### PR TITLE
Fix misleading ImageCanvas story

### DIFF
--- a/app/panels/ImageView/ImageCanvas.stories.tsx
+++ b/app/panels/ImageView/ImageCanvas.stories.tsx
@@ -312,7 +312,7 @@ function Mono16Story({ bigEndian }: { bigEndian: boolean }) {
   for (let r = 0; r < height; r++) {
     for (let c = 0; c < width; c++) {
       const val = Math.round(Math.min(1, Math.hypot(c / width, r / height)) * 10000);
-      view.setUint16(2 * (r * width + c), val, true);
+      view.setUint16(2 * (r * width + c), val, !bigEndian);
     }
   }
   return (


### PR DESCRIPTION
Instead of the story being correct when it looks "wrong", make it look "right".

Before:
![](https://open-source-webviz-ui.s3.amazonaws.com/75a84499621bcb4dc4c8362ee8a277c05cc985d0/actual/ImageCanvas/mono16%20big%20endian.png)

After:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/14237/109851889-cec55e80-7c19-11eb-8fad-c15dbf2ac484.png">
