### PR TITLE
Fix up some comment formatting from flow-to-ts conversion

### DIFF
--- a/app/components/MessagePathSyntax/constants.ts
+++ b/app/components/MessagePathSyntax/constants.ts
@@ -63,12 +63,12 @@ export type MessagePathStructureItemMessage = {
   structureType: "message";
   nextByName: {
     [key: string]: MessagePathStructureItem;
-  }; // eslint-disable-line no-use-before-define
+  };
   datatype: string;
 };
 type MessagePathStructureItemArray = {
   structureType: "array";
-  next: MessagePathStructureItem; // eslint-disable-line no-use-before-define
+  next: MessagePathStructureItem;
   datatype: string;
 };
 type MessagePathStructureItemPrimitive = {

--- a/app/dataProviders/RpcDataProviderRemote.ts
+++ b/app/dataProviders/RpcDataProviderRemote.ts
@@ -19,6 +19,7 @@ import {
 import { NotifyPlayerManagerData } from "@foxglove-studio/app/players/types";
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { setupWorker } from "@foxglove-studio/app/util/RpcWorkerUtils";
+
 // The "other side" of `RpcDataProvider`. Instantiates a `DataProviderDescriptor` tree underneath,
 // in the context of wherever this is instantiated (e.g. a Web Worker, or the server side of a
 // WebSocket).

--- a/app/dataProviders/types.ts
+++ b/app/dataProviders/types.ts
@@ -114,10 +114,12 @@ export interface DataProvider {
 export interface DataProviderConstructor {
   new (
     // The arguments to this particular DataProvider; typically an object.
-    args: any, // The children we should instantiate below. Many DataProviders cannot have any children (leaf
+    args: any,
+    // The children we should instantiate below. Many DataProviders cannot have any children (leaf
     // nodes in the tree), many require exactly one child, and the `CombinedDataProvider` can take
     // an arbitrary number of children.
-    children: DataProviderDescriptor[], // The function to instantiate the children (different in e.g. Web Workers).
+    children: DataProviderDescriptor[],
+    // The function to instantiate the children (different in e.g. Web Workers).
     getDataProvider: GetDataProvider,
   ): DataProvider;
 }

--- a/app/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
@@ -390,7 +390,8 @@ function TopicTree({
               diffModeEnabled: hasFeatureColumn && diffModeEnabled,
             })}
             height={treeHeight}
-            itemHeight={ROW_HEIGHT} // Disable motion because it seems to cause a bug in the `rc-tree` (used under the hood by `antd` for
+            itemHeight={ROW_HEIGHT}
+            // Disable motion because it seems to cause a bug in the `rc-tree` (used under the hood by `antd` for
             // the tree). This bug would result in nodes no longer being rendered after a search.
             motion={null}
             selectable={false}

--- a/app/types/BinaryMessages.ts
+++ b/app/types/BinaryMessages.ts
@@ -126,8 +126,7 @@ export type BinaryOccupancyGrid = Readonly<{
 
 export type BinaryWebvizMarker = Readonly<
   BinaryMarker & {
-    id(): string;
-    // overridden type,
+    id(): string; // overridden type
     metadata(): any; // JSON
   }
 >;


### PR DESCRIPTION
Some comments were moved around by flow-to-ts. Thanks to recent work in https://github.com/Khan/flow-to-ts/issues/230, running it again produced better results in some of these cases (although worse in others), so I manually pulled in a handful of useful changes to get us closer to the original comment formatting. I also fixed a couple things found using a project grep.

For future reference, replacing TS files with their original JS equivalents:
```
for f in $(find app -name \*.ts ! -path \*node_modules\* ! -name \*.d.ts); do jsf=~/webviz/packages/webviz-core/src/${${f#app/}%.ts}.js; if [[ -e $jsf ]]; then cp $jsf ${f%.ts}.js; rm $f; fi; done
```
Re-running flow-to-ts:
```
yarn dlx @khanacademy/flow-to-ts@github:Khan/flow-to-ts#9affc366d6d1b1b8b307262311938ba5c0a85cd7 --write --delete-source app/**/*.js
```