### PR TITLE
Fix typo in PoseMarkers TS conversion

### DIFF
--- a/app/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
+++ b/app/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
@@ -142,11 +142,10 @@ export default React.memo<Props>(function PoseMarkers({ children, layerIndex }):
       <FilledPolygons layerIndex={layerIndex} key={`cruise-pose`}>
         {filledPolygons}
       </FilledPolygons>
-      , ...models,
+      {...models}
       <Arrows layerIndex={layerIndex} key="arrows">
         {arrowMarkers}
       </Arrows>
-      ,
     </>
   );
 });


### PR DESCRIPTION
The car model now shows up correctly in Storybook.
<img width="167" alt="image" src="https://user-images.githubusercontent.com/14237/109881410-da2a8100-7c3d-11eb-9914-a199ea44ac01.png">
