### PR TITLE
Enable vscode debugger

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "debug.javascript.autoAttachFilter": "onlyWithFlag",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
This setting alone isn't as useful as I originally thought, but it is still helpful.

You can now easily debug dev tools by running `yarn run --inspect foo` from the vscode terminal. Breakpoints inside `node_modules` work as expected. Note that you need to run commands directly (i.e. not run a script that delegates to another yarn instance).

Right now this doesn't work for electron code, but I learned a few things along the way and will see if I can get that working nicely later.