### PR TITLE
Add GlobalVariablesMenu

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -120,7 +120,6 @@ overrides:
       - "app/PanelAPI/useMessageReducer.ts"
       - "app/PanelAPI/useMessagesByTopic.ts"
       - "app/actions/panels.ts"
-      - "app/components/AppMenu/index.tsx"
       - "app/components/AutoSizingCanvas/index.stories.tsx"
       - "app/components/AutoSizingCanvas/index.tsx"
       - "app/components/Autocomplete.tsx"

--- a/UncheckedIndexAccess.json
+++ b/UncheckedIndexAccess.json
@@ -2,7 +2,7 @@
   "app/PanelAPI/useBlocksByTopic.ts",
   "app/PanelAPI/useDataSourceInfo.test.tsx",
   "app/PanelAPI/useMessagesByTopic.ts",
-  "app/components/AppMenu/index.tsx",
+  "app/components/AddPanelMenu/index.tsx",
   "app/components/Autocomplete.tsx",
   "app/components/ExpandingToolbar.tsx",
   "app/components/ExperimentalFeatures.tsx",

--- a/app/components/AddPanelMenu/index.stories.tsx
+++ b/app/components/AddPanelMenu/index.stories.tsx
@@ -18,11 +18,11 @@ import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { Provider } from "react-redux";
 
-import AppMenu from "@foxglove-studio/app/components/AppMenu";
+import AddPanelMenu from "@foxglove-studio/app/components/AddPanelMenu";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 
-storiesOf("<AppMenu>", module)
+storiesOf("<AddPanelMenu>", module)
   .addParameters({
     screenshot: {
       delay: 500,
@@ -33,7 +33,7 @@ storiesOf("<AppMenu>", module)
       <div style={{ margin: 30, paddingLeft: 300 }}>
         <DndProvider backend={HTML5Backend}>
           <Provider store={configureStore(createRootReducer(createMemoryHistory()))}>
-            <AppMenu defaultIsOpen />
+            <AddPanelMenu defaultIsOpen />
           </Provider>
         </DndProvider>
       </div>

--- a/app/components/AddPanelMenu/index.tsx
+++ b/app/components/AddPanelMenu/index.tsx
@@ -28,7 +28,7 @@ type Props = {
 };
 
 function AddPanelMenu(props: Props) {
-  const [isOpen, setIsOpen] = useState<boolean>(props.defaultIsOpen || false);
+  const [isOpen, setIsOpen] = useState<boolean>(props.defaultIsOpen ?? false);
   const onToggle = useCallback(() => setIsOpen((open) => !open), []);
   const dispatch = useDispatch();
 

--- a/app/components/AddPanelMenu/index.tsx
+++ b/app/components/AddPanelMenu/index.tsx
@@ -27,7 +27,7 @@ type Props = {
   defaultIsOpen?: boolean; // just for testing
 };
 
-function AppMenu(props: Props) {
+function AddPanelMenu(props: Props) {
   const [isOpen, setIsOpen] = useState<boolean>(props.defaultIsOpen || false);
   const onToggle = useCallback(() => setIsOpen((open) => !open), []);
   const dispatch = useDispatch();
@@ -53,4 +53,4 @@ function AppMenu(props: Props) {
   );
 }
 
-export default AppMenu;
+export default AddPanelMenu;

--- a/app/components/Icon.tsx
+++ b/app/components/Icon.tsx
@@ -102,7 +102,7 @@ export const WrappedIcon = (props: Props) => {
         minWidth: "40px",
         ...props.style,
       }}
-      className={styles.wrappedIcon}
+      className={cx(styles.wrappedIcon, props.className)}
     />
   );
 };

--- a/app/components/Root.tsx
+++ b/app/components/Root.tsx
@@ -21,8 +21,9 @@ import { Route } from "react-router";
 import styles from "./Root.module.scss";
 import { redoLayoutChange, undoLayoutChange } from "@foxglove-studio/app/actions/layoutHistory";
 import { importPanelLayout } from "@foxglove-studio/app/actions/panels";
-import AppMenu from "@foxglove-studio/app/components/AppMenu";
+import AddPanelMenu from "@foxglove-studio/app/components/AddPanelMenu";
 import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
+import GlobalVariablesMenu from "@foxglove-studio/app/components/GlobalVariablesMenu";
 import LayoutMenu from "@foxglove-studio/app/components/LayoutMenu";
 import NotificationDisplay from "@foxglove-studio/app/components/NotificationDisplay";
 import PanelLayout from "@foxglove-studio/app/components/PanelLayout";
@@ -83,7 +84,10 @@ function App({ importPanelLayout: importPanelLayoutProp, onToolbarDoubleClick }:
                 <LayoutMenu />
               </div>
               <div className={styles.toolbarItem}>
-                <AppMenu />
+                <AddPanelMenu />
+              </div>
+              <div className={styles.toolbarItem}>
+                <GlobalVariablesMenu />
               </div>
               <div className={styles.toolbarItem}>
                 <TinyConnectionPicker inputDescription={inputDescription} />


### PR DESCRIPTION
 I found that GlobalVariablesMenu was unused in the open-source webviz. It was easy to add to the top bar so I added it. While testing this I discovered that its animation was broken. Fixed by passing through `className` prop correctly. Also renamed `AppMenu` to `AddPanelMenu` which makes more sense.

<img width="401" alt="image" src="https://user-images.githubusercontent.com/14237/109912435-ae28f300-7c71-11eb-8ce7-25b895b9bf28.png">