### PR TITLE
Fix PanelLayout stories

### DIFF
--- a/app/.storybook/preview.ts
+++ b/app/.storybook/preview.ts
@@ -1,1 +1,17 @@
 import "@foxglove-studio/app/styles/global.scss";
+import { getGlobalConfig } from "@foxglove-studio/app/GlobalConfig";
+import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
+
+let loaded = false;
+
+export const loaders = [
+  async () => {
+    // These loaders are run once for each story when you switch between stories,
+    // but the global config can't be safely loaded more than once.
+    if (!loaded) {
+      await waitForFonts();
+      await getGlobalConfig().load();
+      loaded = true;
+    }
+  },
+];

--- a/app/GlobalConfig.ts
+++ b/app/GlobalConfig.ts
@@ -22,7 +22,6 @@ import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
 let importedPanelsByCategory: any;
 const importedPerPanelHooks = perPanelHooks();
 const defaultHooks = {
-  areHooksImported: () => importedPanelsByCategory && importedPerPanelHooks,
   getLayoutFromUrl: async (search: string) => {
     const params = new URLSearchParams(search);
     const layoutUrl = params.get(LAYOUT_URL_QUERY_KEY);

--- a/app/components/PanelLayout.tsx
+++ b/app/components/PanelLayout.tsx
@@ -30,16 +30,12 @@ import {
 } from "@foxglove-studio/app/actions/panels";
 import { useExperimentalFeature } from "@foxglove-studio/app/components/ExperimentalFeatures";
 import Flex from "@foxglove-studio/app/components/Flex";
-import Icon from "@foxglove-studio/app/components/Icon";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
-import SpinningLoadingIcon from "@foxglove-studio/app/components/SpinningLoadingIcon";
-import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import PanelList from "@foxglove-studio/app/panels/PanelList";
 import { EmptyDropTarget } from "@foxglove-studio/app/panels/Tab/EmptyDropTarget";
 import { State, Dispatcher } from "@foxglove-studio/app/reducers";
 import { MosaicNode, SaveConfigsPayload } from "@foxglove-studio/app/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove-studio/app/util/layout";
-import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
 type Props = {
   layout: MosaicNode | null | undefined;
@@ -80,20 +76,6 @@ export function UnconnectedPanelLayout(props: Props) {
     removeRootDropTarget,
     mosaicId,
   } = props;
-  const [hooksImported, setHooksImported] = useState(getGlobalHooks().areHooksImported());
-
-  if (importHooks && !hooksImported) {
-    const globalHooks = getGlobalHooks();
-    globalHooks
-      .importHooksAsync()
-      .then(() => {
-        setHooksImported({ hooksImported: true });
-      })
-      .catch((reason) => {
-        console.error(`Import failed ${reason}`);
-      });
-  }
-
   const createTile = useCallback(
     (config: any) => {
       const defaultPanelType = "RosOut";
@@ -114,8 +96,22 @@ export function UnconnectedPanelLayout(props: Props) {
         return;
       }
       const type = getPanelTypeFromId(id);
-      const MosaicWindowComponent: any = type === "Tab" ? MosaicDumbWindow : MosaicWindow;
 
+      const PanelComponent = PanelList.getComponentForType(type);
+      const panel = PanelComponent ? (
+        <PanelComponent childId={id} tabId={tabId} />
+      ) : (
+        // If we haven't found a panel of the given type, render the panel selector
+        // @ts-ignore typings say title is required property?
+        <MosaicWindow path={path} createNode={createTile} renderPreview={() => null}>
+          <Flex col center>
+            <PanelToolbar floating isUnknownPanel />
+            Unknown panel type: {type}.
+          </Flex>
+        </MosaicWindow>
+      );
+
+      const MosaicWindowComponent: any = type === "Tab" ? MosaicDumbWindow : MosaicWindow;
       return (
         <MosaicWindowComponent
           key={path}
@@ -124,55 +120,11 @@ export function UnconnectedPanelLayout(props: Props) {
           renderPreview={() => null}
           tabId={tabId}
         >
-          {(() => {
-            if (!hooksImported) {
-              return null;
-            }
-            // If we haven't found a panel of the given type, render the panel selector
-            const PanelComponent = PanelList.getComponentForType(type);
-            if (!PanelComponent) {
-              return (
-                // @ts-ignore typings say title is required property?
-                <MosaicWindow
-                  path={path}
-                  createNode={createTile}
-                  renderPreview={() => {
-                    return <></>;
-                  }}
-                >
-                  <Flex col center>
-                    <PanelToolbar floating isUnknownPanel />
-                    Unknown panel type: {type}.
-                  </Flex>
-                </MosaicWindow>
-              );
-            }
-            return <PanelComponent childId={id} tabId={tabId} />;
-          })()}
-          <div
-            style={{
-              top: 0,
-              left: 0,
-              width: "100%",
-              height: "100%",
-              position: "absolute",
-              background: colors.DARK2,
-              opacity: hooksImported ? 0 : 1,
-              pointerEvents: "none",
-              zIndex: 1,
-              transition: `all ${0.35}s ease-out ${Math.random() + 0.25}s`,
-            }}
-          >
-            <Flex center style={{ width: "100%", height: "100%" }}>
-              <Icon large>
-                <SpinningLoadingIcon />
-              </Icon>
-            </Flex>
-          </div>
+          {panel}
         </MosaicWindowComponent>
       );
     },
-    [createTile, hooksImported, tabId],
+    [createTile, tabId],
   );
   const isDemoMode = useExperimentalFeature("demoMode");
   const bodyToRender = useMemo(

--- a/app/components/PanelLayout.tsx
+++ b/app/components/PanelLayout.tsx
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import React, { useCallback, useMemo, useState, forwardRef, ElementRef } from "react";
+import React, { useCallback, useMemo, forwardRef, ElementRef } from "react";
 import {
   MosaicWithoutDragDropContext,
   MosaicWindow,
@@ -42,7 +42,6 @@ type Props = {
   onChange: (panels: any) => void;
   setMosaicId: (mosaicId: string) => void;
   savePanelConfigs: (arg0: SaveConfigsPayload) => Dispatcher<SAVE_PANEL_CONFIGS>;
-  importHooks: boolean;
   forwardedRef?: ElementRef<any>;
   mosaicId?: string;
   tabId?: string;
@@ -68,7 +67,6 @@ class MosaicRoot extends MosaicWithoutDragDropContext {
 
 export function UnconnectedPanelLayout(props: Props) {
   const {
-    importHooks,
     layout,
     onChange,
     savePanelConfigs: saveConfigs,
@@ -159,7 +157,7 @@ export function UnconnectedPanelLayout(props: Props) {
   return <ErrorBoundary ref={props.forwardedRef as any}>{bodyToRender}</ErrorBoundary>;
 }
 
-const ConnectedPanelLayout = ({ importHooks = true }: { importHooks?: boolean }, ref: any) => {
+const ConnectedPanelLayout = (_: any, ref: any) => {
   const layout = useSelector((state: State) => state.persistedState.panels.layout);
   const dispatch = useDispatch();
   const actions = React.useMemo(
@@ -175,7 +173,6 @@ const ConnectedPanelLayout = ({ importHooks = true }: { importHooks?: boolean },
   return (
     <UnconnectedPanelLayout
       forwardedRef={ref}
-      importHooks={importHooks}
       layout={layout}
       onChange={onChange}
       savePanelConfigs={actions.savePanelConfigs}
@@ -183,6 +180,6 @@ const ConnectedPanelLayout = ({ importHooks = true }: { importHooks?: boolean },
     />
   );
 };
-export default forwardRef<{ importHooks?: boolean }, any>(function PanelLayout(props, ref) {
+export default forwardRef(function PanelLayout(props, ref) {
   return ConnectedPanelLayout(props, ref);
 });

--- a/app/panels/Tab/index.tsx
+++ b/app/panels/Tab/index.tsx
@@ -131,7 +131,6 @@ function Tab({ config, saveConfig }: Props) {
         {activeLayout ? (
           <TabDndContext.Provider value={{ preventTabDrop }}>
             <UnconnectedPanelLayout
-              importHooks={false}
               layout={activeLayout}
               savePanelConfigs={savePanelConfigsFn}
               onChange={onChangeLayout}


### PR DESCRIPTION
The core problem was that globalConfig was not loaded in stories. Added a loader which does a similar thing to the main() function in our main index.ts.

Also clean up some old logic around lazy importing of hooks, which we no longer have.

Also fixes FG-140 and FG-142.