### PR TITLE
Add useState snippet for VS Code to reduce typing

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -1,0 +1,14 @@
+{
+  // Place your studio workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  "Insert useState": {
+    "scope": "typescriptreact",
+    "prefix": "useState",
+    "body": "const [${1:thing}, set${1/(.*)/${1:/capitalize}/}] = useState($3);"
+  }
+}


### PR DESCRIPTION
If you type `useState` and press tab (or select the item from the autosuggest popup), it will insert `const [foo, setFoo] = useState()` and let you easily type to change the name.