### PR TITLE
Fix NoHeaderTopicsButton in storybook; switch NotificationDisplay to RenderToBodyComponent

### DIFF
--- a/app/components/NoHeaderTopicsButton.tsx
+++ b/app/components/NoHeaderTopicsButton.tsx
@@ -12,14 +12,14 @@
 //   You may not use this file except in compliance with the License.
 import InformationIcon from "@mdi/svg/svg/information.svg";
 import { groupBy } from "lodash";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import styled from "styled-components";
 
 import Icon from "@foxglove-studio/app/components/Icon";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import Modal, { Title } from "@foxglove-studio/app/components/Modal";
 import TextContent from "@foxglove-studio/app/components/TextContent";
-import renderToBody from "@foxglove-studio/app/components/renderToBody";
+import { RenderToBodyComponent } from "@foxglove-studio/app/components/renderToBody";
 
 const SRoot = styled.div`
   max-width: calc(100vw - 30px);
@@ -54,6 +54,7 @@ function useTopicsWithoutHeaders() {
 
 export default function NoHeaderTopicsButton() {
   const topicsWithoutHeaders = useTopicsWithoutHeaders();
+  const [showingModal, setShowingModal] = useState(false);
   return useMemo(() => {
     if (!topicsWithoutHeaders.length) {
       return null;
@@ -72,9 +73,13 @@ export default function NoHeaderTopicsButton() {
     return (
       <Icon
         tooltip={tooltip}
-        onClick={() => {
-          const modal = renderToBody(
-            <Modal onRequestClose={() => modal.remove()}>
+        onClick={() => setShowingModal(true)}
+        style={{ color, paddingRight: "6px" }}
+        dataTest="missing-headers-icon"
+      >
+        {showingModal && (
+          <RenderToBodyComponent>
+            <Modal onRequestClose={() => setShowingModal(false)}>
               <SRoot>
                 <Title>Topics without headers</Title>
                 <TextContent>
@@ -92,14 +97,11 @@ export default function NoHeaderTopicsButton() {
                   </table>
                 </TextContent>
               </SRoot>
-            </Modal>,
-          );
-        }}
-        style={{ color, paddingRight: "6px" }}
-        dataTest="missing-headers-icon"
-      >
+            </Modal>
+          </RenderToBodyComponent>
+        )}
         <InformationIcon />
       </Icon>
     );
-  }, [topicsWithoutHeaders]);
+  }, [topicsWithoutHeaders, showingModal]);
 }

--- a/app/components/NotificationDisplay.stories.tsx
+++ b/app/components/NotificationDisplay.stories.tsx
@@ -206,6 +206,7 @@ storiesOf("<NotificationDisplay>", module)
   .add("Error Modal", () => {
     return (
       <NotificationModal
+        onRequestClose={() => {}}
         notification={{
           id: "1",
           message: "Error 1",
@@ -220,6 +221,7 @@ storiesOf("<NotificationDisplay>", module)
   .add("Warning Modal", () => {
     return (
       <NotificationModal
+        onRequestClose={() => {}}
         notification={{
           id: "1",
           message: "Warning 1",
@@ -234,6 +236,7 @@ storiesOf("<NotificationDisplay>", module)
   .add("Error Modal without details", () => {
     return (
       <NotificationModal
+        onRequestClose={() => {}}
         notification={{
           id: "1",
           message: "Error 1",
@@ -253,6 +256,7 @@ storiesOf("<NotificationDisplay>", module)
     });
     return (
       <NotificationModal
+        onRequestClose={() => {}}
         notification={{
           id: "1",
           message: "Error Modal without details",
@@ -267,6 +271,7 @@ storiesOf("<NotificationDisplay>", module)
   .add("Error Modal with details in React.Node type", () => {
     return (
       <NotificationModal
+        onRequestClose={() => {}}
         notification={{
           id: "1",
           message: "Error 1",

--- a/app/components/NotificationDisplay.tsx
+++ b/app/components/NotificationDisplay.tsx
@@ -25,7 +25,7 @@ import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Menu from "@foxglove-studio/app/components/Menu";
 import Modal, { Title } from "@foxglove-studio/app/components/Modal";
-import renderToBody from "@foxglove-studio/app/components/renderToBody";
+import { RenderToBodyComponent } from "@foxglove-studio/app/components/renderToBody";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { nbsp } from "@foxglove-studio/app/util/entities";
 import minivizAPI from "@foxglove-studio/app/util/minivizAPI";
@@ -183,26 +183,23 @@ const ModalBody = styled.div`
 `;
 
 // Exporting for tests.
-export function NotificationModal({ notification }: { notification: NotificationMessage }): null {
-  useLayoutEffect(() => {
-    const { renderNotificationDetails } = getGlobalHooks() as any;
-    let details = renderNotificationDetails
-      ? renderNotificationDetails(notification.details)
-      : notification.details;
-    if (details instanceof Error) {
-      details = details.stack;
-    }
-
-    let removed = false;
-    function remove() {
-      if (!removed) {
-        modal.remove();
-        removed = true;
-      }
-    }
-
-    const modal = renderToBody(
-      <Modal onRequestClose={remove}>
+export function NotificationModal({
+  notification,
+  onRequestClose,
+}: {
+  notification: NotificationMessage;
+  onRequestClose: () => void;
+}): React.ReactElement {
+  const { renderNotificationDetails } = getGlobalHooks() as any;
+  let details = renderNotificationDetails
+    ? renderNotificationDetails(notification.details)
+    : notification.details;
+  if (details instanceof Error) {
+    details = details.stack;
+  }
+  return (
+    <RenderToBodyComponent>
+      <Modal onRequestClose={onRequestClose}>
         <Title style={{ color: getColorForSeverity(notification.severity) }}>
           {notification.message}
         </Title>
@@ -214,12 +211,9 @@ export function NotificationModal({ notification }: { notification: Notification
             details || "No details provided"
           )}
         </ModalBody>
-      </Modal>,
-    );
-    return remove;
-  }, [notification]);
-
-  return null;
+      </Modal>
+    </RenderToBodyComponent>
+  );
 }
 
 export default function NotificationDisplay(): React.ReactElement {
@@ -279,7 +273,12 @@ export default function NotificationDisplay(): React.ReactElement {
 
   return (
     <Container flash={showMostRecent} unread={hasUnread} color={color}>
-      {clickedNotification && <NotificationModal notification={clickedNotification} />}
+      {clickedNotification && (
+        <NotificationModal
+          notification={clickedNotification}
+          onRequestClose={() => setClickedNotification(undefined)}
+        />
+      )}
       {firstNotification && (
         <ChildToggle position="below" onToggle={toggleNotificationList}>
           <div style={{ display: "flex", flex: "1 1 auto", alignItems: "center" }}>

--- a/app/components/renderToBody.tsx
+++ b/app/components/renderToBody.tsx
@@ -11,11 +11,12 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import * as React from "react";
+import { useLayoutEffect, useRef } from "react";
 import { render, unmountComponentAtNode } from "react-dom";
 import { Provider } from "react-redux";
 import { Router } from "react-router-dom";
 
+import useCleanup from "@foxglove-studio/app/hooks/useCleanup";
 import getGlobalStore from "@foxglove-studio/app/store/getGlobalStore";
 import history from "@foxglove-studio/app/util/history";
 
@@ -55,26 +56,18 @@ export default function renderToBody(element: any): RenderedToBodyHandle {
   };
 }
 
-export class RenderToBodyComponent extends React.Component<{ children: React.ReactElement<any> }> {
-  _renderedToBodyHandle: RenderedToBodyHandle | null | undefined;
+export function RenderToBodyComponent({ children }: { children: React.ReactElement }): null {
+  const handle = useRef<RenderedToBodyHandle | null>(null);
 
-  componentDidMount() {
-    this._renderedToBodyHandle = renderToBody(this.props.children);
-  }
-
-  componentDidUpdate() {
-    if (this._renderedToBodyHandle) {
-      this._renderedToBodyHandle.update(this.props.children);
+  useLayoutEffect(() => {
+    if (handle.current) {
+      handle.current.update(children);
+    } else {
+      handle.current = renderToBody(children);
     }
-  }
+  }, [children]);
 
-  componentWillUnmount() {
-    if (this._renderedToBodyHandle) {
-      this._renderedToBodyHandle.remove();
-    }
-  }
+  useCleanup(() => handle.current?.remove());
 
-  render() {
-    return null;
-  }
+  return null;
 }

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -170,7 +170,7 @@ export function makeConfig(_: unknown, argv: WebpackArgv): Configuration {
       new CircularDependencyPlugin({
         exclude: /node_modules/,
         onDetected({ paths, compilation }) {
-          if (paths.includes("app/GlobalConfig.ts")) {
+          if (paths.some((filePath) => filePath.match(/(^|[\\/])GlobalConfig.ts/))) {
             return;
           }
           compilation.warnings.push(new Error(paths.join(" -> ")));


### PR DESCRIPTION
Turns out we already had RenderToBodyComponent to manage automatic removal. Switch NotificationDisplay and NoHeaderTopicsButton to use that.

Also ignore GlobalConfig import cycles in build-storybook, where the prefix is different.