### PR TITLE
reg-suit: don't set commit status on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,5 @@ jobs:
       - run: yarn run ${{ matrix.config.command }}
         env:
           REG_SUIT_GITHUB_CLIENT_ID: ${{ secrets.REG_SUIT_GITHUB_CLIENT_ID }}
-          REG_SUIT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          REG_SUIT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+          REG_SUIT_HEAD_SHA: ${{ github.sha }}
+          REG_SUIT_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "storybook": "yarn workspace @foxglove-studio/app run start-storybook",
     "storybook:build": "yarn workspace @foxglove-studio/app run build-storybook",
     "storybook:storycap": "yarn workspace @foxglove-studio/app run storycap http://localhost:9001 --serverCmd \"yarn http-server storybook-static -p 9001\" --outDir \"storybook-screenshots\"",
-    "storybook:reg-suit": "yarn workspace @foxglove-studio/app run reg-suit run",
     "storybook:ci": "ci/storybook.sh"
   },
   "workspaces": {


### PR DESCRIPTION
Two changes:

- The reg-suit snapshot is now uploaded under the merge commit sha (rather than PR branch head sha), which is more accurate since github actions actually run against a merge of the PR with main.
- Reg-suit is now configured to not set a commit status when it runs on main. I don't think it is helpful setting red status checks on commits to main since a change does not mean "failed" there. We will still get status checks and comments on PRs.