### PR TITLE
Remove Storybook padding around body

### DIFF
--- a/app/.storybook/preview.ts
+++ b/app/.storybook/preview.ts
@@ -15,3 +15,8 @@ export const loaders = [
     }
   },
 ];
+
+export const parameters = {
+  // Disable default padding around the page body
+  layout: "fullscreen",
+};


### PR DESCRIPTION
This caused some stories such as UnlinkGlobalVariables to behave differently than in the webviz repo due to different element positioning.