### PR TITLE
Fix TimeBasedChart vertical bar CSS

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,12 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
   // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "orta.vscode-jest"],
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "orta.vscode-jest",
+    "jpoissonnier.vscode-styled-components"
+  ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []
 }

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -119,8 +119,8 @@ const SBar = styled.div<{ xAxisIsPlaybackTime: boolean }>`
   border-style: solid;
   border-color: #f7be00 transparent;
   background: ${(props) =>
-    props.xAxisIsPlaybackTime ? "#F7BE00 padding-box" : "#248EFF padding-box"},
-  borderWidth: ${(props) => (props.xAxisIsPlaybackTime ? "4px" : "0px 4px")},
+    props.xAxisIsPlaybackTime ? "#F7BE00 padding-box" : "#248EFF padding-box"};
+  border-width: ${(props) => (props.xAxisIsPlaybackTime ? "4px" : "0px 4px")};
 `;
 
 // Sometimes a click gets fired at the end of a pan. Probably subtle touchpad stuff. Ignore "clicks"


### PR DESCRIPTION
There was a CSS syntax error resulting from the removal of `styled.*.attrs` during TS conversion. We may need to do an audit of other places that used to use styled.attrs since it can be a performance optimization.