### PR TITLE
Reinstate some styled.attrs that were removed in TS conversion

### DIFF
--- a/app/components/PlaybackControls/index.tsx
+++ b/app/components/PlaybackControls/index.tsx
@@ -62,14 +62,15 @@ export const StyledFullWidthBar = styled.div<{ activeData?: PlayerStateActiveDat
   height: 4px;
 `;
 
-export const StyledMarker = styled.div<{ width: number }>`
+export const StyledMarker = styled.div.attrs<{ width: number }>(({ width }) => ({
+  style: { left: `calc(${(width || 0) * 100}% - 2px)` },
+}))<{ width: number }>`
   background-color: white;
   position: absolute;
   height: 36%;
   border: 1px solid ${colors.divider};
   width: 2px;
   top: 32%;
-  left: ${({ width }) => `calc(${(width || 0) * 100}% - 2px)`};
 `;
 
 export type PlaybackControlProps = {

--- a/app/components/Slider.tsx
+++ b/app/components/Slider.tsx
@@ -49,12 +49,13 @@ const StyledSlider = styled.div<{ disabled?: boolean }>`
   border-radius: 2px;
 `;
 
-export const StyledRange = styled.div<{ width: number }>`
+export const StyledRange = styled.div.attrs<{ width: number }>(({ width }) => ({
+  style: { width: `${(width || 0) * 100}%` },
+}))<{ width: number }>`
   background-color: rgba(255, 255, 255, 0.2);
   position: absolute;
   height: 100%;
   border-radius: 2px;
-  width: ${({ width }) => `${(width || 0) * 100}%`};
 `;
 
 function defaultRenderSlider(value: number | undefined): React.ReactNode {

--- a/app/panels/diagnostics/DiagnosticStatus.tsx
+++ b/app/panels/diagnostics/DiagnosticStatus.tsx
@@ -46,14 +46,15 @@ type Props = {
   saveConfig: (arg0: $Shape<Config>) => void;
 };
 
-const ResizeHandle = styled.div<{ splitFraction: number }>`
+const ResizeHandle = styled.div.attrs<{ splitFraction: number }>(({ splitFraction }) => ({
+  style: { left: `${100 * splitFraction}%` },
+}))<{ splitFraction: number }>`
   position: absolute;
   top: 0;
   bottom: 0;
   width: 12px;
   margin-left: -6px;
   cursor: col-resize;
-  left: ${({ splitFraction }) => `${100 * splitFraction}%`}
   :hover,
   :active,
   :focus {


### PR DESCRIPTION
Using `attrs` is a performance optimization, because styled-components creates a new class name eaach time the props change.

Revert a few of these back to .attrs with proper TS types, thanks to https://github.com/DefinitelyTyped/DefinitelyTyped/issues/28597.