### PR TITLE
Re-add monaco-editor-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "html-webpack-plugin": "5.2.0",
     "jest": "26.6.3",
     "jest-canvas-mock": "2.3.1",
+    "monaco-editor-webpack-plugin": "3.0.0",
     "nearley": "2.20.1",
     "nearley-loader": "2.0.0",
     "path-browserify": "1.0.1",

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -6,6 +6,7 @@ import rehypePrism from "@mapbox/rehype-prism";
 import CircularDependencyPlugin from "circular-dependency-plugin";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
+import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
 import path from "path";
 import retext from "retext";
 import retextSmartypants from "retext-smartypants";
@@ -196,6 +197,10 @@ export function makeConfig(_: unknown, argv: WebpackArgv): Configuration {
       new webpack.IgnorePlugin({
         resourceRegExp: /^\.[\\/]locale$/,
         contextRegExp: /moment$/,
+      }),
+      new MonacoWebpackPlugin({
+        // available options: https://github.com/Microsoft/monaco-editor-webpack-plugin#options
+        languages: ["typescript", "javascript"],
       }),
       // We use two ForkTsCheckers to ignore known files which fail noUncheckedIndexedAccess
       // The first checker disables the compiler option and is used for all files

--- a/yarn.lock
+++ b/yarn.lock
@@ -11263,6 +11263,7 @@ __metadata:
     html-webpack-plugin: 5.2.0
     jest: 26.6.3
     jest-canvas-mock: 2.3.1
+    monaco-editor-webpack-plugin: 3.0.0
     nearley: 2.20.1
     nearley-loader: 2.0.0
     path-browserify: 1.0.1
@@ -15884,6 +15885,18 @@ __metadata:
   version: 2.29.1
   resolution: "moment@npm:2.29.1"
   checksum: 86729013febf7160de5b93da69273dd304d674b0224f9544b3abd09a87671ddd2cdd57598261ce57588910d63747ffd5590965e83c790d8bf327083c0e0a06e0
+  languageName: node
+  linkType: hard
+
+"monaco-editor-webpack-plugin@npm:3.0.0":
+  version: 3.0.0
+  resolution: "monaco-editor-webpack-plugin@npm:3.0.0"
+  dependencies:
+    loader-utils: ^2.0.0
+  peerDependencies:
+    monaco-editor: 0.22.x
+    webpack: ^4.5.0 || 5.x
+  checksum: 8efe6f33b7ad2ab276c12e44428c75a1baa7e5cb0963a34a865586c87b825ca8c2cf5a4d46c7f7161e69f02d17ddad5090e94368a09a62beb4afa667c181bbeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is necessary for the editor in Node Playground, otherwise we get runtime errors about it not being able to load a worker. Configuration taken from https://github.com/cruise-automation/webviz/blob/d46c633949a923cbc016aa504c562c6279dd35b8/webpack.config.js#L198-L201