### PR TITLE
Add jest transform to support `?raw` import syntax

### DIFF
--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -5,7 +5,7 @@
 export default {
   preset: "ts-jest",
   transform: {
-    "\\.tsx?$": "<rootDir>/test/transformers/webpacker",
+    "\\.tsx?$": "<rootDir>/test/transformers/rawImportPreprocessor.ts",
     "\\.ne$": "<rootDir>/test/transformers/neTransformer.js",
     "\\.(bin|template|wasm)$": "<rootDir>/test/transformers/rawTransformer.js",
   },

--- a/app/jest.config.ts
+++ b/app/jest.config.ts
@@ -2,9 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Shared configuration used by all jest projects
-const sharedConfig = {
+export default {
   preset: "ts-jest",
+  transform: {
+    "\\.tsx?$": "<rootDir>/test/transformers/webpacker",
+    "\\.ne$": "<rootDir>/test/transformers/neTransformer.js",
+    "\\.(bin|template|wasm)$": "<rootDir>/test/transformers/rawTransformer.js",
+  },
   globals: {
     "ts-jest": {
       tsconfig: "<rootDir>/tsconfig.jest.json",
@@ -13,45 +17,12 @@ const sharedConfig = {
   setupFiles: ["<rootDir>/test/setup.ts", "<rootDir>/test/setupEnzyme.ts", "jest-canvas-mock"],
   setupFilesAfterEnv: ["<rootDir>/test/setupTestFramework.ts"],
   restoreMocks: true,
-  transform: {
-    "\\.ne$": "<rootDir>/test/transformers/neTransformer.js",
-    "\\.(bin|template|wasm)$": "<rootDir>/test/transformers/rawTransformer.js",
-  },
   moduleNameMapper: {
     "worker-loader.*!.*/UserNodePlayer/.+Worker": "<rootDir>/players/UserNodePlayer/worker.mock.ts",
     "worker-loader.*!.*": "<rootDir>/test/mocks/MockWorker.ts",
-    "(.*)\\?raw$": "$1",
     "\\.svg$": "<rootDir>/test/mocks/MockSvg.tsx",
     "react-monaco-editor": "<rootDir>/test/stubs/MonacoEditor.tsx",
     "\\.(glb|md|png)$": "<rootDir>/test/mocks/fileMock.ts",
     "\\.(css|scss)$": "<rootDir>/test/mocks/styleMock.ts",
   },
-};
-
-export default {
-  projects: [
-    // Configuration used by root jest project only
-    {
-      ...sharedConfig,
-      transform: {
-        ...sharedConfig.transform,
-        "[\\/]nodeTransformerWorker[\\/]typescript[\\/]userUtils[\\/].+\\.ts":
-          "<rootDir>/test/transformers/rawTransformer.js",
-      },
-      testPathIgnorePatterns: [
-        "/node_modules/",
-        // Ignore userUtils tests - they are run in the nested jest project
-        "[\\/]nodeTransformerWorker[\\/]typescript[\\/]userUtils[\\/]",
-      ],
-    },
-
-    // Custom config to support running userUtils tests, which import typescript files
-    // as ordinary modules (in all other tests they are imported as strings).
-    // Outside of jest, webpack handles this for us using "?raw" in the module name.
-    {
-      ...sharedConfig,
-      displayName: "Node Playground userUtils tests",
-      testRegex: "[\\/]nodeTransformerWorker[\\/]typescript[\\/]userUtils[\\/].+\\.test\\.tsx?$",
-    },
-  ],
 };

--- a/app/package.json
+++ b/app/package.json
@@ -2,8 +2,8 @@
   "name": "@foxglove-studio/app",
   "private": true,
   "scripts": {
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "NODE_OPTIONS='-r ts-node/register' jest",
+    "test:watch": "NODE_OPTIONS='-r ts-node/register' jest --watch"
   },
   "dependencies": {
     "@mdi/svg": "5.9.55",

--- a/app/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils.ts
+++ b/app/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils.ts
@@ -2,16 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import markers from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/markers?raw";
-import pointClouds from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/pointClouds?raw";
-import readers from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/readers?raw";
-import time from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time?raw";
-import types from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/types?raw";
-import vectors from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/vectors?raw";
-
-if (markers === undefined) {
-  throw new Error("markers?raw import failed");
-}
+import markers from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/markers.ts?raw";
+import pointClouds from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/pointClouds.ts?raw";
+import readers from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/readers.ts?raw";
+import time from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time.ts?raw";
+import types from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/types.ts?raw";
+import vectors from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/vectors.ts?raw";
 
 export default [
   { fileName: "pointClouds.ts", sourceCode: pointClouds },

--- a/app/test/transformers/rawImportPreprocessor.ts
+++ b/app/test/transformers/rawImportPreprocessor.ts
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createTransformer } from "ts-jest";
-import type { Config } from "@jest/types";
 import type { CacheKeyOptions, TransformOptions } from "@jest/transform";
+import type { Config } from "@jest/types";
 import fs from "fs";
+import { createTransformer } from "ts-jest";
 
 const transformer = createTransformer();
 

--- a/app/test/transformers/rawImportPreprocessor.ts
+++ b/app/test/transformers/rawImportPreprocessor.ts
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import fs from "fs";
 import { createTransformer } from "ts-jest";
 import type { Config } from "@jest/types";
 import type { CacheKeyOptions, TransformOptions } from "@jest/transform";
+import fs from "fs";
 
 const transformer = createTransformer();
 

--- a/app/test/transformers/rawImportPreprocessor.ts
+++ b/app/test/transformers/rawImportPreprocessor.ts
@@ -2,30 +2,36 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-const fs = require("fs");
-const tsjest = require("ts-jest");
+import fs from "fs";
+import tsjest from "ts-jest";
+import type { Config } from "@jest/types";
+import type { CacheKeyOptions, TransformOptions } from "@jest/transform";
 
 const transformer = tsjest.createTransformer();
 
 // look for `?raw` import statements
 // re-write these into `const variable = "string source";`;
 const importRegEx = /^import (.*) from "(.*)\?raw";$/gm;
-const importReplacer = (_, p1, p2) => {
+const importReplacer = (_: unknown, p1: string, p2: string) => {
   const resolved = require.resolve(p2);
   const rawFile = fs.readFileSync(resolved, { encoding: "utf-8" });
   return `const ${p1} = ${JSON.stringify(rawFile.toString())};`;
 };
 
-function rewriteSource(source) {
-  return importRegEx[Symbol.replace](source, importReplacer);
+function rewriteSource(source: string) {
+  return source.replace(importRegEx, importReplacer);
 }
 
 module.exports = {
-  process(source, filePath, config, options) {
+  process(
+    source: string,
+    filePath: string,
+    config: Config.ProjectConfig,
+    options?: TransformOptions,
+  ) {
     return transformer.process(rewriteSource(source), filePath, config, options);
   },
-  getCacheKey(source, filePath, config, options) {
+  getCacheKey(source: string, filePath: string, config: string, options: CacheKeyOptions) {
     return transformer.getCacheKey(rewriteSource(source), filePath, config, options);
   },
 };

--- a/app/test/transformers/rawImportPreprocessor.ts
+++ b/app/test/transformers/rawImportPreprocessor.ts
@@ -3,11 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import fs from "fs";
-import tsjest from "ts-jest";
+import { createTransformer } from "ts-jest";
 import type { Config } from "@jest/types";
 import type { CacheKeyOptions, TransformOptions } from "@jest/transform";
 
-const transformer = tsjest.createTransformer();
+const transformer = createTransformer();
 
 // look for `?raw` import statements
 // re-write these into `const variable = "string source";`;

--- a/app/test/transformers/webpacker.js
+++ b/app/test/transformers/webpacker.js
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require("fs");
+const tsjest = require("ts-jest");
+
+const transformer = tsjest.createTransformer();
+
+// look for `?raw` import statements
+// re-write these into `const variable = "string source";`;
+const importRegEx = /^import (.*) from "(.*)\?raw";$/gm;
+const importReplacer = (_, p1, p2) => {
+  const resolved = require.resolve(p2);
+  const rawFile = fs.readFileSync(resolved, { encoding: "utf-8" });
+  return `const ${p1} = ${JSON.stringify(rawFile.toString())};`;
+};
+
+function rewriteSource(source) {
+  return importRegEx[Symbol.replace](source, importReplacer);
+}
+
+module.exports = {
+  process(source, filePath, config, options) {
+    return transformer.process(rewriteSource(source), filePath, config, options);
+  },
+  getCacheKey(source, filePath, config, options) {
+    return transformer.getCacheKey(rewriteSource(source), filePath, config, options);
+  },
+};


### PR DESCRIPTION
`?raw` indicates to webpack that an import statement should be treated as the raw content of the file. Jest doesn't know how to properly import this because it wants to resolve the entire module name (including the `?raw` string). This does not resolve to an actual file on disk and jest complains. Using `moduleNameMapper` in jest.config is also incorrect since it still has jest perform a resolution on the aliased string. Jest will try to transform it with the appropriate transformer for that file type. In the case of our raw imports in nodePlayground that file type is `.ts` and it will try the ts-jest loader. We do not want that - we want such an import to be loaded as raw content so we need to prevent jest from ever trying to resolve it to the typescript loader.

The more robust solution is to use the typescript ast rather than regex for import statements. The even more robust solution is to write a transform which uses webpack to compile the test file since all our code is written with the assumption it will run through a bundler. This solution is not currently possible since jest transforms must be sync and I think webpack compilation is async. There are some discussions within jest to add support for async transforms. If/when that does land this is a possible way forward.