### PR TITLE
Improve PoseMarker type information

### DIFF
--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -22,11 +22,11 @@ import { SLabel, SInput } from "./common";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
-import { PoseStamped } from "@foxglove-studio/app/types/Messages";
+import { Color, PoseStamped } from "@foxglove-studio/app/types/Messages";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
-type PoseSettings = {
-  overrideColor?: string | null | undefined;
+export type PoseSettings = {
+  overrideColor?: Color;
   alpha?: number;
   size?: {
     headLength: number;
@@ -65,7 +65,7 @@ export default function PoseSettingsEditor(
           <>
             <SLabel>Color of outline</SLabel>
             <ColorPickerForTopicSettings
-              color={settings.overrideColor as any}
+              color={settings.overrideColor}
               onChange={(newColor) => onFieldChange("overrideColor", newColor)}
             />
           </>

--- a/app/panels/ThreeDimensionalViz/WorldMarkers.tsx
+++ b/app/panels/ThreeDimensionalViz/WorldMarkers.tsx
@@ -237,7 +237,7 @@ export default function WorldMarkers({
       <Spheres layerIndex={layerIndex}>{[...sphere, ...sphereList]}</Spheres>
       <Cylinders layerIndex={layerIndex}>{cylinder}</Cylinders>
       <Cubes layerIndex={layerIndex}>{[...cube, ...cubeList]}</Cubes>
-      <PoseMarkers layerIndex={layerIndex}>{poseMarker}</PoseMarkers>
+      <PoseMarkers layerIndex={layerIndex} markers={poseMarker} />
       <LaserScans layerIndex={layerIndex}>{laserScan as any}</LaserScans>
       {glTextAtlasInfo.status === "LOADED" && (
         <GLText

--- a/app/panels/ThreeDimensionalViz/commands/PoseMarkers.stories.tsx
+++ b/app/panels/ThreeDimensionalViz/commands/PoseMarkers.stories.tsx
@@ -12,10 +12,12 @@
 //   You may not use this file except in compliance with the License.
 
 import { storiesOf } from "@storybook/react";
-import * as React from "react";
+import { ComponentProps } from "react";
 import { Worldview, DEFAULT_CAMERA_STATE, Color } from "regl-worldview";
 
 import PoseMarkers from "./PoseMarkers";
+
+type PoseMarker = ComponentProps<typeof PoseMarkers>["markers"][0];
 
 const MARKER_DATA = {
   header: { seq: 26967, stamp: { sec: 1516929048, nsec: 413347495 }, frame_id: "" },
@@ -62,7 +64,7 @@ function Example({
       },
     },
   };
-  const markerWithCarModel = {
+  const markerWithCarModel: PoseMarker = {
     ...MARKER_DATA,
     pose: {
       position: { x: -1951.7028138723192, y: 1770.5034239982174, z: 52.870026489273044 },
@@ -85,9 +87,7 @@ function Example({
       cameraMode="perspective"
       hideDebug
     >
-      <PoseMarkers>
-        {[marker, markerWithoutColor, markerWithSettings, markerWithCarModel]}
-      </PoseMarkers>
+      <PoseMarkers markers={[marker, markerWithoutColor, markerWithSettings, markerWithCarModel]} />
     </Worldview>
   );
 }
@@ -95,6 +95,8 @@ function Example({
 storiesOf("<3DViz> / PoseMarkers", module)
   .addParameters({
     screenshot: {
+      // the car-model marker loads the car models asyncronously
+      // we delay screenshot until some time with the hope it has loaded
       delay: 3000,
     },
   })


### PR DESCRIPTION
I also changed how `<PoseMarkers>` accepts the markers. Previously it used children whereas now it uses a property. I prefer conventionally using children for other react components rather than just another property of any type.

I've increased the screenshot delay on PostMarkers.stories with the hope of making it less flaky.