### PR TITLE
Add storycap addon to storybook

### DIFF
--- a/app/.storybook/main.ts
+++ b/app/.storybook/main.ts
@@ -3,7 +3,7 @@ import { makeConfig } from "../../webpack.renderer.config";
 
 module.exports = {
   stories: ["../**/*.stories.@(ts|tsx)"],
-  addons: ["@storybook/addon-essentials", "@storybook/addon-actions"],
+  addons: ["@storybook/addon-essentials", "@storybook/addon-actions", "storycap"],
 
   core: {
     builder: "webpack5",

--- a/app/.storybook/preview.ts
+++ b/app/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import "@foxglove-studio/app/styles/global.scss";
 import { getGlobalConfig } from "@foxglove-studio/app/GlobalConfig";
 import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
+import { withScreenshot } from "storycap";
 
 let loaded = false;
 
@@ -15,6 +16,8 @@ export const loaders = [
     }
   },
 ];
+
+export const decorators = [withScreenshot];
 
 export const parameters = {
   // Disable default padding around the page body

--- a/app/components/NotificationDisplay.stories.tsx
+++ b/app/components/NotificationDisplay.stories.tsx
@@ -51,7 +51,7 @@ const AddMoreButtons = () => (
 storiesOf("<NotificationDisplay>", module)
   .addParameters({
     screenshot: {
-      delay: 5000,
+      delay: 1000,
     },
   })
   .add("No errors", () => {


### PR DESCRIPTION
The storycap addon and withScreenshot decorator are required to support
storycap features like delays, variants, etc within stories.