### PR TITLE
Add img-src: self to security policy

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -236,6 +236,7 @@ app.on("ready", async () => {
     "style-src": "'self' 'unsafe-inline'",
     "connect-src": "'self' ws: wss: http: https:", // Required for rosbridge connections
     "font-src": "'self' data:",
+    "img-src": "'self' data:",
   };
 
   // Set default http headers


### PR DESCRIPTION
Was getting some console errors about data URLs being used by canvas.