### PR TITLE
Fix WebSocket connections; allow URL.createObjectURL for worker CSP

### DIFF
--- a/app/players/RosbridgePlayer.tsx
+++ b/app/players/RosbridgePlayer.tsx
@@ -339,23 +339,25 @@ export default class RosbridgePlayer implements Player {
   }
 
   setPublishers(publishers: AdvertisePayload[]): void {
-    if (!this._rosClient) {
-      throw new Error("RosbridgePlayer not connected");
-    }
-
     // Since `setPublishers` is rarely called, we can get away with just throwing away the old
     // Roslib.Topic objects and creating new ones.
     for (const publisher of objectValues(this._topicPublishers)) {
       publisher.unadvertise();
     }
     this._topicPublishers = {};
-    for (const { topic, datatype } of publishers) {
-      this._topicPublishers[topic] = new roslib.Topic({
-        ros: this._rosClient,
-        name: topic,
-        messageType: datatype,
-        queue_size: 0,
-      });
+
+    if (publishers.length > 0) {
+      if (!this._rosClient) {
+        throw new Error("RosbridgePlayer not connected");
+      }
+      for (const { topic, datatype } of publishers) {
+        this._topicPublishers[topic] = new roslib.Topic({
+          ros: this._rosClient,
+          name: topic,
+          messageType: datatype,
+          queue_size: 0,
+        });
+      }
     }
   }
 

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -233,6 +233,7 @@ app.on("ready", async () => {
   const contentSecurtiyPolicy: Record<string, string> = {
     "default-src": "'self'",
     "script-src": `'self' 'unsafe-inline' 'unsafe-eval'`,
+    "worker-src": `'self' blob:`,
     "style-src": "'self' 'unsafe-inline'",
     "connect-src": "'self' ws: wss: http: https:", // Required for rosbridge connections
     "font-src": "'self' data:",


### PR DESCRIPTION
Add `blob:` to allowed sources for workers, since roslib uses URL.createObjectURL.

There was an overly aggressive `throw` upon connection failure/disconnect, added during TS conversion, which caused a normally harmless `setPublishers([])` to crash.