### PR TITLE
Fix sentry sourcemap warnings in development

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,7 +13,7 @@ import installDevtoolsFormatters from "@foxglove-studio/app/util/installDevtools
 import overwriteFetch from "@foxglove-studio/app/util/overwriteFetch";
 import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
 
-if (process.env.SENTRY_DSN) {
+if (typeof process.env.SENTRY_DSN === "string") {
   initSentry({ dsn: process.env.SENTRY_DSN });
 }
 

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -29,7 +29,7 @@ import { installMenuInterface } from "./menu";
 import type { OsContextWindowEvent } from "@foxglove-studio/app/OsContext";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 
-if (process.env.SENTRY_DSN !== undefined) {
+if (typeof process.env.SENTRY_DSN === "string") {
   initSentry({ dsn: process.env.SENTRY_DSN });
 }
 

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -2,14 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// @sentry/electron isn't able to detect that the renderer should be loaded when in the preload script
-// instead if tries to load esm/main which is only applicable for the main script
-import { init as initSentry } from "@sentry/electron/esm/renderer";
+import { init as initSentry } from "@sentry/electron";
 import { contextBridge, ipcRenderer } from "electron";
 
 import { OsContext, OsContextWindowEvent } from "@foxglove-studio/app/OsContext";
 
-if (process.env.SENTRY_DSN !== undefined) {
+if (typeof process.env.SENTRY_DSN === "string") {
   initSentry({ dsn: process.env.SENTRY_DSN });
 }
 

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -35,6 +35,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     context: path.resolve("./desktop"),
     entry: "./index.ts",
     target: "electron-main",
+    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
 
     output: {
       publicPath: "",

--- a/webpack.preload.config.ts
+++ b/webpack.preload.config.ts
@@ -8,11 +8,14 @@ import { Configuration, EnvironmentPlugin } from "webpack";
 
 import { WebpackArgv } from "./WebpackArgv";
 
-export default (_: unknown, _argv: WebpackArgv): Configuration => {
+export default (_: unknown, argv: WebpackArgv): Configuration => {
+  const isDev = argv.mode === "development";
+
   return {
     context: path.resolve("./preload"),
     entry: "./index.ts",
     target: "electron-preload",
+    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
 
     output: {
       publicPath: "",
@@ -49,6 +52,9 @@ export default (_: unknown, _argv: WebpackArgv): Configuration => {
 
     resolve: {
       extensions: [".js", ".ts", ".tsx", ".json"],
+      alias: {
+        "@sentry/electron": "@sentry/electron/esm/renderer",
+      },
     },
   };
 };

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -41,7 +41,7 @@ export function makeConfig(_: unknown, argv: WebpackArgv): Configuration {
     target: "web",
     context: path.resolve("./app"),
     entry: "./index.tsx",
-    devtool: isDev ? "eval-cheap-source-map" : "source-map",
+    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
 
     optimization: {
       minimize: false,
@@ -191,7 +191,6 @@ export function makeConfig(_: unknown, argv: WebpackArgv): Configuration {
       new webpack.DefinePlugin({
         // Should match webpack-defines.d.ts
         APP_NAME: JSON.stringify("Foxglove Studio"),
-        SENTRY_DSN: process.env.SENTRY_DSN,
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({


### PR DESCRIPTION
Use a better devTool source map which doesn't produce the warnings.