### PR TITLE
Basic support for unknown diagnostic status levels

### DIFF
--- a/UncheckedIndexAccess.json
+++ b/UncheckedIndexAccess.json
@@ -111,7 +111,6 @@
   "app/panels/TwoDimensionalPlot/index.stories.tsx",
   "app/panels/diagnostics/DiagnosticStatus.tsx",
   "app/panels/diagnostics/DiagnosticSummary.tsx",
-  "app/panels/diagnostics/util.test.ts",
   "app/players/NodePlayer.test.ts",
   "app/players/OrderedStampPlayer.test.ts",
   "app/players/RandomAccessPlayer.test.ts",

--- a/app/panels/diagnostics/DiagnosticStatus.tsx
+++ b/app/panels/diagnostics/DiagnosticStatus.tsx
@@ -102,7 +102,6 @@ type FormattedKeyValue = {
 };
 
 const allowedTags = [
-  // this comment forces the array onto multiple lines :)
   "b",
   "br",
   "center",
@@ -328,7 +327,7 @@ class DiagnosticStatus extends React.Component<Props, any> {
       openSiblingPanel,
       topicToRender,
     } = this.props;
-    const statusClass = style[`status-${LEVEL_NAMES[status.level] || "unknown"}`];
+    const statusClass = style[`status-${LEVEL_NAMES[status.level] ?? "unknown"}`];
 
     return (
       <div>

--- a/app/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/app/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import DiagnosticStatusPanel from "@foxglove-studio/app/panels/diagnostics/DiagnosticStatusPanel";
+import { makeDiagnosticMessage } from "@foxglove-studio/app/panels/diagnostics/DiagnosticSummary.stories";
+import { LEVELS } from "@foxglove-studio/app/panels/diagnostics/util";
+import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+export default {
+  title: "<DiagnosticStatusPanel>",
+};
+
+const fixture = {
+  topics: [{ name: "/diagnostics", datatype: "diagnostic_msgs/DiagnosticArray" }],
+  frame: {
+    "/diagnostics": [
+      makeDiagnosticMessage(LEVELS.OK, "name1", "hardware_id1", ["message 1", "message 2"]),
+      makeDiagnosticMessage(
+        LEVELS.OK,
+        "name2",
+        "hardware_id1",
+        ["message 3"],
+        [
+          { key: "key", value: "value" },
+          { key: "key <b>with html</b>", value: "value <tt>with html</tt>" },
+        ],
+      ),
+    ],
+  },
+};
+
+export function Empty(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticStatusPanel />
+    </PanelSetup>
+  );
+}
+
+export function SelectedHardwareIDOnly(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticStatusPanel
+        config={{
+          topicToRender: "/diagnostics",
+          selectedHardwareId: "hardware_id1",
+          selectedName: null,
+          collapsedSections: [],
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function SelectedName(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticStatusPanel
+        config={{
+          topicToRender: "/diagnostics",
+          selectedHardwareId: "hardware_id1",
+          selectedName: "name2",
+          collapsedSections: [],
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function MovedDivider(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticStatusPanel
+        config={{
+          topicToRender: "/diagnostics",
+          selectedHardwareId: "hardware_id1",
+          selectedName: null,
+          splitFraction: 0.25,
+          collapsedSections: [],
+        }}
+      />
+    </PanelSetup>
+  );
+}

--- a/app/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/app/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import DiagnosticSummary from "@foxglove-studio/app/panels/diagnostics/DiagnosticSummary";
+import {
+  DiagnosticStatusArrayMsg,
+  getDiagnosticId,
+  KeyValue,
+  LEVELS,
+} from "@foxglove-studio/app/panels/diagnostics/util";
+import { TypedMessage } from "@foxglove-studio/app/players/types";
+import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+export default {
+  title: "<DiagnosticSummary>",
+};
+
+export function makeDiagnosticMessage(
+  level: number,
+  name: string,
+  hardware_id: string,
+  messages: string[],
+  values: KeyValue[] = [],
+): TypedMessage<DiagnosticStatusArrayMsg> {
+  return {
+    topic: "/diagnostics",
+    receiveTime: { sec: 2, nsec: 0 },
+    message: {
+      header: { frame_id: "", stamp: { sec: 1, nsec: 500_000_000 } },
+      status: messages.map((message) => ({ level, name, hardware_id, message, values })),
+    },
+  };
+}
+
+const fixture = {
+  topics: [{ name: "/diagnostics", datatype: "diagnostic_msgs/DiagnosticArray" }],
+  frame: {
+    "/diagnostics": [
+      makeDiagnosticMessage(LEVELS.OK, "name1", "hardware_id1", ["ok"]),
+      makeDiagnosticMessage(42, "name4", "hardware_id4/filter", ["unknown level"]),
+      makeDiagnosticMessage(LEVELS.ERROR, "name3", "hardware_id3/filter", ["error"]),
+      makeDiagnosticMessage(LEVELS.STALE, "name5", "hardware_id5", ["stale"]),
+      makeDiagnosticMessage(LEVELS.WARN, "name2", "hardware_id2/filter", ["warn"]),
+    ],
+  },
+};
+
+export function Empty(): JSX.Element {
+  return (
+    <PanelSetup fixture={{ ...fixture, frame: {} }}>
+      <DiagnosticSummary />
+    </PanelSetup>
+  );
+}
+
+export function Basic(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary />
+    </PanelSetup>
+  );
+}
+
+export function WithPinnedNodes(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        config={{
+          pinnedIds: [
+            getDiagnosticId("hardware_id1", "name1"),
+            getDiagnosticId("hardware_id4", "name4"),
+          ],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "",
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function WithoutSorting(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        config={{
+          pinnedIds: [],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "",
+          sortByLevel: false,
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function Filtered(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        config={{
+          pinnedIds: [],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "filter",
+          sortByLevel: false,
+        }}
+      />
+    </PanelSetup>
+  );
+}

--- a/app/panels/diagnostics/DiagnosticSummary.tsx
+++ b/app/panels/diagnostics/DiagnosticSummary.tsx
@@ -25,11 +25,11 @@ import { Config as DiagnosticStatusConfig } from "./DiagnosticStatusPanel";
 import helpContent from "./DiagnosticSummary.help.md";
 import styles from "./DiagnosticSummary.module.scss";
 import {
-  LEVELS,
   DiagnosticId,
   DiagnosticInfo,
   getDiagnosticsByLevel,
-  getSortedDiagnostics,
+  filterAndSortDiagnostics,
+  LEVEL_NAMES,
 } from "./util";
 import EmptyState from "@foxglove-studio/app/components/EmptyState";
 import Flex from "@foxglove-studio/app/components/Flex";
@@ -45,13 +45,6 @@ import { PanelConfig } from "@foxglove-studio/app/types/panels";
 import filterMap from "@foxglove-studio/app/util/filterMap";
 import { DIAGNOSTIC_TOPIC } from "@foxglove-studio/app/util/globalConstants";
 import toggle from "@foxglove-studio/app/util/toggle";
-
-const LevelClasses = {
-  [LEVELS.OK]: styles.ok,
-  [LEVELS.WARN]: styles.warn,
-  [LEVELS.ERROR]: styles.error,
-  [LEVELS.STALE]: styles.stale,
-};
 
 type NodeRowProps = {
   info: DiagnosticInfo;
@@ -71,10 +64,11 @@ class NodeRow extends React.PureComponent<NodeRowProps> {
 
   render() {
     const { info, isPinned } = this.props;
+    const levelName = LEVEL_NAMES[info.status.level];
 
     return (
       <div
-        className={cx(LevelClasses[info.status.level], styles.nodeRow)}
+        className={cx(levelName ? styles[levelName] : null, styles.nodeRow)}
         onClick={this.onClick}
         data-test-diagnostic-row
       >
@@ -223,18 +217,19 @@ class DiagnosticSummary extends React.Component<Props> {
               });
 
               const nodesByLevel = getDiagnosticsByLevel(buffer);
+              const levels = Array.from(nodesByLevel.keys()).sort().reverse();
               const sortedNodes = sortByLevel
-                ? [].concat(
-                    ...([LEVELS.STALE, LEVELS.ERROR, LEVELS.WARN, LEVELS.OK].map((level) =>
-                      getSortedDiagnostics(nodesByLevel[level], hardwareIdFilter, pinnedIds),
-                    ) as any),
-                  )
-                : getSortedDiagnostics(
-                    [].concat(
-                      ...([LEVELS.STALE, LEVELS.ERROR, LEVELS.WARN, LEVELS.OK].map(
-                        (level) => nodesByLevel[level],
-                      ) as any),
+                ? ([] as DiagnosticInfo[]).concat(
+                    ...levels.map((level) =>
+                      filterAndSortDiagnostics(
+                        nodesByLevel.get(level) ?? [],
+                        hardwareIdFilter,
+                        pinnedIds,
+                      ),
                     ),
+                  )
+                : filterAndSortDiagnostics(
+                    ([] as DiagnosticInfo[]).concat(...nodesByLevel.values()),
                     hardwareIdFilter,
                     pinnedIds,
                   );

--- a/app/panels/diagnostics/DiagnosticsHistory.test.ts
+++ b/app/panels/diagnostics/DiagnosticsHistory.test.ts
@@ -12,10 +12,10 @@
 //   You may not use this file except in compliance with the License.
 
 import { addMessages, defaultDiagnosticsBuffer } from "./DiagnosticsHistory";
-import { computeDiagnosticInfo, Level, DiagnosticInfo, LEVELS } from "./util";
+import { computeDiagnosticInfo, DiagnosticInfo, LEVELS } from "./util";
 import { Message } from "@foxglove-studio/app/players/types";
 
-const messageAtLevel = (level: Level): Message => ({
+const messageAtLevel = (level: number): Message => ({
   message: {
     status: [
       {
@@ -32,7 +32,7 @@ const messageAtLevel = (level: Level): Message => ({
   receiveTime: { sec: 1547062466, nsec: 1674890 },
 });
 
-const diagnosticInfoAtLevel = (level: Level): DiagnosticInfo => {
+const diagnosticInfoAtLevel = (level: number): DiagnosticInfo => {
   const { message } = messageAtLevel(level);
   return computeDiagnosticInfo(message.status[0], message.header.stamp);
 };


### PR DESCRIPTION
Fixes a crash when a custom level was added.

Adds some basic stories for Diagnostic Summary & Detail panels, since the existing stories were not available in the open source webviz repo.