### PR TITLE
Use esbuild-loader in-place of ts-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "electron-notarize": "1.0.0",
     "electron-squirrel-startup": "1.0.0",
     "electron-updater": "4.3.8",
+    "esbuild-loader": "2.9.2",
     "eslint": "7.21.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-import-resolver-webpack": "0.13.0",

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { ESBuildPlugin } from "esbuild-loader";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import path from "path";
 import { Configuration, ResolveOptions, DefinePlugin, EnvironmentPlugin } from "webpack";
@@ -48,15 +49,10 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
           test: /\.tsx?$/,
           exclude: /node_modules/,
           use: {
-            loader: "ts-loader",
+            loader: "esbuild-loader",
             options: {
-              transpileOnly: true,
-              // https://github.com/TypeStrong/ts-loader#onlycompilebundledfiles
-              // avoid looking at files which are not part of the bundle
-              onlyCompileBundledFiles: true,
-              compilerOptions: {
-                module: "es2020",
-              },
+              loader: "ts",
+              target: "es2020",
             },
           },
         },
@@ -70,6 +66,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     },
 
     plugins: [
+      new ESBuildPlugin(),
       new DefinePlugin({
         MAIN_WINDOW_WEBPACK_ENTRY: rendererEntry,
         // Should match webpack-defines.d.ts

--- a/webpack.preload.config.ts
+++ b/webpack.preload.config.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { ESBuildPlugin } from "esbuild-loader";
 import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import path from "path";
 import { Configuration, EnvironmentPlugin } from "webpack";
@@ -31,12 +32,10 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
           test: /\.tsx?$/,
           exclude: /node_modules/,
           use: {
-            loader: "ts-loader",
+            loader: "esbuild-loader",
             options: {
-              transpileOnly: true,
-              // https://github.com/TypeStrong/ts-loader#onlycompilebundledfiles
-              // avoid looking at files which are not part of the bundle
-              onlyCompileBundledFiles: true,
+              loader: "ts",
+              target: "es2020",
             },
           },
         },
@@ -44,6 +43,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     },
 
     plugins: [
+      new ESBuildPlugin(),
       new EnvironmentPlugin({
         SENTRY_DSN: process.env.SENTRY_DSN ?? null,
       }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -10740,6 +10740,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-loader@npm:2.9.2":
+  version: 2.9.2
+  resolution: "esbuild-loader@npm:2.9.2"
+  dependencies:
+    esbuild: ^0.8.42
+    joycon: ^2.2.5
+    json5: ^2.2.0
+    loader-utils: ^2.0.0
+    type-fest: ^0.20.2
+    webpack-sources: ^2.2.0
+  peerDependencies:
+    webpack: ^4.40.0 || ^5.0.0
+  checksum: a1251dab1ed72f68ce9b50a2b58ffef83594627f1bbf8fc53a098525166d1413f22374eeb966bac2848bc61fbf9f593f170c44e23786ae38f64ff5e5a5ff6724
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.8.42":
+  version: 0.8.57
+  resolution: "esbuild@npm:0.8.57"
+  bin:
+    esbuild: bin/esbuild
+  checksum: 0942950a21a30b57a324380cfedcb425cc1245412e720593415afa0d4f1b7c5f931aa6330937dc1353c754d45c1e5ff7dbc52eb514f54d85517114971300b454
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.0.2, escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -12023,6 +12048,7 @@ __metadata:
     electron-notarize: 1.0.0
     electron-squirrel-startup: 1.0.0
     electron-updater: 4.3.8
+    esbuild-loader: 2.9.2
     eslint: 7.21.0
     eslint-config-prettier: 8.1.0
     eslint-import-resolver-webpack: 0.13.0
@@ -15251,6 +15277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"joycon@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "joycon@npm:2.2.5"
+  checksum: 7908f551e05aa754d1068053ec1304c12f3abc9c812f7c5a58bef7d35d247c3b1da14e508970bd411191099949756e2190e24c24b3382f818e7cda83e8ea1899
+  languageName: node
+  linkType: hard
+
 "jpeg-js@npm:^0.4.2":
   version: 0.4.3
   resolution: "jpeg-js@npm:0.4.3"
@@ -15438,7 +15471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:2.x, json5@npm:^2.1.2, json5@npm:^2.1.3":
+"json5@npm:2.x, json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0":
   version: 2.2.0
   resolution: "json5@npm:2.2.0"
   dependencies:
@@ -25071,7 +25104,7 @@ typescript@4.2.2:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^2.1.1":
+"webpack-sources@npm:^2.1.1, webpack-sources@npm:^2.2.0":
   version: 2.2.0
   resolution: "webpack-sources@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
Using [esbuild](https://github.com/evanw/esbuild) via [esbuild-loader](https://github.com/privatenumber/esbuild-loader) decreases the prod and dev build time and bundle size.

| Build | esbuild | ts-loader |
| --- | --- | --- |
| build:prod | 35.2s | 43.6s |
| prod main.js | 5.94 mb | 23.2 mb |
| prod .webpack | 61mb | 64mb |
| build:dev |  23.4s | 26.3s |

There might be more gains if we also port main and preload over but renderer is the big one.

The biggest benefit of this is less the speedup but the smaller main.js size. A smaller size loads faster in electron.

I've also yet to try using esbuild just for the minification which is something we could try - tho I've not been able to get the minified builds to start typically.