### PR TITLE
Add layout management

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -58,7 +58,9 @@ rules:
   react/prop-types: off # Unnecessary with typescript validation
   react/no-unused-prop-types: error
   react-hooks/rules-of-hooks: error
-  react-hooks/exhaustive-deps: error
+  react-hooks/exhaustive-deps:
+    - error
+    - additionalHooks: "(useAsync)"
   no-new-func: error
   header/header:
     - error

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -27,6 +27,7 @@ import GlobalKeyListener from "@foxglove-studio/app/components/GlobalKeyListener
 import GlobalVariablesMenu from "@foxglove-studio/app/components/GlobalVariablesMenu";
 import { WrappedIcon } from "@foxglove-studio/app/components/Icon";
 import LayoutMenu from "@foxglove-studio/app/components/LayoutMenu";
+import LayoutStorageReduxAdapter from "@foxglove-studio/app/components/LayoutStorageReduxAdapter";
 import { NativeFileMenuPlayerSelection } from "@foxglove-studio/app/components/NativeFileMenuPlayerSelection";
 import NotificationDisplay from "@foxglove-studio/app/components/NotificationDisplay";
 import PanelLayout from "@foxglove-studio/app/components/PanelLayout";
@@ -37,6 +38,7 @@ import ShortcutsModal from "@foxglove-studio/app/components/ShortcutsModal";
 import TinyConnectionPicker from "@foxglove-studio/app/components/TinyConnectionPicker";
 import Toolbar from "@foxglove-studio/app/components/Toolbar";
 import ExperimentalFeaturesLocalStorageProvider from "@foxglove-studio/app/context/ExperimentalFeaturesLocalStorageProvider";
+import OsContextLayoutStorageProvider from "@foxglove-studio/app/context/OsContextLayoutStorageProvider";
 import {
   PlayerSourceDefinition,
   usePlayerSelection,
@@ -145,6 +147,8 @@ function Root() {
 }
 
 export default function App(): ReactElement {
+  const globalStore = getGlobalStore();
+
   const playerSources: PlayerSourceDefinition[] = [
     {
       name: "Bag File",
@@ -161,13 +165,16 @@ export default function App(): ReactElement {
   ];
 
   return (
-    <Provider store={getGlobalStore()}>
+    <Provider store={globalStore}>
       <ExperimentalFeaturesLocalStorageProvider features={experimentalFeatures}>
         <ErrorBoundary>
           <PlayerManager playerSources={playerSources}>
             <NativeFileMenuPlayerSelection />
             <DndProvider backend={HTML5Backend}>
-              <Root />
+              <OsContextLayoutStorageProvider>
+                <Root />
+                <LayoutStorageReduxAdapter />
+              </OsContextLayoutStorageProvider>
             </DndProvider>
           </PlayerManager>
         </ErrorBoundary>

--- a/app/components/ExperimentalLayoutMenu.tsx
+++ b/app/components/ExperimentalLayoutMenu.tsx
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import path from "path";
+import { useCallback, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useMountedState } from "react-use";
+import { v4 as uuidv4 } from "uuid";
+
+import { loadLayout } from "@foxglove-studio/app/actions/panels";
+import LayoutIcon from "@foxglove-studio/app/assets/layout.svg";
+import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
+import Flex from "@foxglove-studio/app/components/Flex";
+import { WrappedIcon } from "@foxglove-studio/app/components/Icon";
+import { Layout, useLayoutStorage } from "@foxglove-studio/app/context/LayoutStorageContext";
+import { usePrompt } from "@foxglove-studio/app/hooks/usePrompt";
+import { PanelsState } from "@foxglove-studio/app/reducers/panels";
+import { downloadTextFile } from "@foxglove-studio/app/util";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import LayoutsContextMenu from "./LayoutsContextMenu";
+
+// A Wrapper around window.showOpenFilePicker that handles the error thrown on "cancel"
+// Why the api is designed this was is beyond me
+async function showOpenFilePicker(): Promise<FileSystemFileHandle | undefined> {
+  const result = await window
+    .showOpenFilePicker({
+      multiple: false,
+      excludeAcceptAllOption: false,
+      types: [
+        {
+          description: "JSON Files",
+          accept: {
+            "application/json": [".json"],
+          },
+        },
+      ],
+    })
+    .catch((err) => {
+      if (err.message !== "The user aborted a request.") {
+        throw err;
+      }
+    });
+
+  if (!result) {
+    return;
+  }
+
+  return result[0];
+}
+
+// Show the list of available layouts for user selection
+// The context menu is implemented as a separate component to avoid fetching the layout list
+// and re-rendering when panel layouts change if the menu is not open
+export default function ExperimentalLayoutMenu(props: { isOpen?: boolean }) {
+  const [isOpen, setIsOpen] = useState(props.isOpen ?? false);
+  const prompt = usePrompt();
+  const dispatch = useDispatch();
+  const isMounted = useMountedState();
+
+  const layoutStorage = useLayoutStorage();
+
+  const renameAction = useCallback(
+    async (layout: Layout) => {
+      const value = await prompt({
+        value: layout.name,
+      });
+      if (!isMounted()) {
+        return;
+      }
+      if (value !== undefined && value.length > 0 && layout.state) {
+        layout.name = value;
+        layout.state.name = value;
+        dispatch(loadLayout(layout.state));
+      }
+    },
+    [dispatch, isMounted, prompt],
+  );
+
+  const exportAction = useCallback((layout: Layout) => {
+    const name = layout.name ?? "unnamed";
+    const content = JSON.stringify(layout.state, undefined, 2);
+    downloadTextFile(content, `${name}.json`);
+  }, []);
+
+  const importAction = useCallback(async () => {
+    const fileHandle = await showOpenFilePicker();
+    if (!fileHandle) {
+      return;
+    }
+
+    const file = await fileHandle.getFile();
+    const layoutName = path.basename(file.name, path.extname(file.name));
+    const content = await file.text();
+    const parsedState: unknown = JSON.parse(content);
+
+    if (!isMounted()) {
+      return;
+    }
+
+    if (typeof parsedState !== "object") {
+      sendNotification(`${file} is not a valid layout`, Error, "user", "error");
+      return;
+    }
+
+    const state = parsedState as PanelsState;
+    state.id = uuidv4();
+    state.name = layoutName;
+
+    dispatch(loadLayout(state));
+  }, [dispatch, isMounted]);
+
+  const newAction = useCallback(
+    (layout: Layout) => {
+      if (layout.state) {
+        dispatch(loadLayout(layout.state));
+      }
+    },
+    [dispatch],
+  );
+
+  const selectAction = useCallback(
+    (layout: Layout) => {
+      if (layout.state) {
+        dispatch(loadLayout(layout.state));
+      }
+    },
+    [dispatch],
+  );
+
+  const deleteLayout = useCallback(
+    async (layout: Layout) => {
+      await layoutStorage.delete(layout.id);
+    },
+    [layoutStorage],
+  );
+
+  return (
+    <ChildToggle position="below" onToggle={setIsOpen} isOpen={isOpen}>
+      <Flex>
+        <WrappedIcon medium fade active={isOpen} tooltip="Layouts">
+          <LayoutIcon />
+        </WrappedIcon>
+      </Flex>
+      <LayoutsContextMenu
+        onSelectAction={selectAction}
+        onRenameAction={renameAction}
+        onNewAction={newAction}
+        onExportAction={exportAction}
+        onImportAction={importAction}
+        onDeleteAction={deleteLayout}
+        onClose={() => setIsOpen(false)}
+      />
+    </ChildToggle>
+  );
+}

--- a/app/components/LayoutMenu.tsx
+++ b/app/components/LayoutMenu.tsx
@@ -15,12 +15,15 @@ import { useState } from "react";
 
 import LayoutIcon from "@foxglove-studio/app/assets/layout.svg";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
+import ExperimentalLayoutMenu from "@foxglove-studio/app/components/ExperimentalLayoutMenu";
 import Flex from "@foxglove-studio/app/components/Flex";
 import { WrappedIcon } from "@foxglove-studio/app/components/Icon";
 import LayoutModal from "@foxglove-studio/app/components/LayoutModal";
 import Menu, { Item } from "@foxglove-studio/app/components/Menu";
+import { useExperimentalFeature } from "@foxglove-studio/app/context/ExperimentalFeaturesContext";
 
-export default function LayoutMenu() {
+// default import/export menu with no layout management
+function ImportExportMenu() {
   const [isOpen, setIsOpen] = useState(false);
   const [showLayoutModal, setShowLayoutModal] = useState(false);
 
@@ -47,4 +50,15 @@ export default function LayoutMenu() {
       </ChildToggle>
     </>
   );
+}
+
+export default function LayoutMenu() {
+  const enableLayoutManagement = useExperimentalFeature("layoutManagement");
+
+  // show existing import/export menu
+  if (!enableLayoutManagement) {
+    return <ImportExportMenu />;
+  }
+
+  return <ExperimentalLayoutMenu />;
 }

--- a/app/components/LayoutStorageReduxAdapter.tsx
+++ b/app/components/LayoutStorageReduxAdapter.tsx
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useAsync } from "react-use";
+import { v4 as uuidv4 } from "uuid";
+
+import { loadLayout } from "@foxglove-studio/app/actions/panels";
+import { useExperimentalFeature } from "@foxglove-studio/app/context/ExperimentalFeaturesContext";
+import { useLayoutStorage } from "@foxglove-studio/app/context/LayoutStorageContext";
+import { State } from "@foxglove-studio/app/reducers";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+// LayoutStorageReduxAdapter persists the current panel state from redux to the current LayoutStorage context
+export default function LayoutStorageReduxAdapter() {
+  const { panels } = useSelector((state: State) => ({ panels: state.persistedState.panels }));
+  const dispatch = useDispatch();
+
+  const layoutStorage = useLayoutStorage();
+  const enableLayoutManagement = useExperimentalFeature("layoutManagement");
+
+  // save panel state to our storage
+  const { error } = useAsync(async () => {
+    if (!enableLayoutManagement) {
+      return;
+    }
+
+    if (panels.id === undefined) {
+      return;
+    }
+
+    const layout = {
+      id: panels.id,
+      name: panels.name ?? "unnamed",
+      state: panels,
+    };
+
+    // save to our storage
+    await layoutStorage.put(layout);
+  }, [enableLayoutManagement, layoutStorage, panels]);
+
+  // set an id if panel is missing one
+  useEffect(() => {
+    if (!enableLayoutManagement) {
+      return;
+    }
+
+    if (panels.id === undefined) {
+      panels.id = uuidv4();
+      panels.name = panels.name ?? "unnamed";
+      dispatch(loadLayout(panels));
+    }
+  }, [dispatch, enableLayoutManagement, panels]);
+
+  useEffect(() => {
+    if (error) {
+      sendNotification(error.message, Error, "app", "error");
+    }
+  }, [error]);
+
+  return ReactNull;
+}

--- a/app/components/LayoutsContextMenu.stories.tsx
+++ b/app/components/LayoutsContextMenu.stories.tsx
@@ -45,11 +45,13 @@ export function Empty(): JSX.Element {
   const store = useMemo(() => configureStore(createRootReducer(createMemoryHistory())), []);
 
   return (
-    <Provider store={store}>
-      <LayoutStorageContext.Provider value={storage}>
-        <LayoutsContextMenu />
-      </LayoutStorageContext.Provider>
-    </Provider>
+    <div style={{ display: "flex" }}>
+      <Provider store={store}>
+        <LayoutStorageContext.Provider value={storage}>
+          <LayoutsContextMenu />
+        </LayoutStorageContext.Provider>
+      </Provider>
+    </div>
   );
 }
 
@@ -86,10 +88,12 @@ export function LayoutList(): JSX.Element {
   }, []);
 
   return (
-    <Provider store={store}>
-      <LayoutStorageContext.Provider value={storage}>
-        <LayoutsContextMenu />
-      </LayoutStorageContext.Provider>
-    </Provider>
+    <div style={{ display: "flex" }}>
+      <Provider store={store}>
+        <LayoutStorageContext.Provider value={storage}>
+          <LayoutsContextMenu />
+        </LayoutStorageContext.Provider>
+      </Provider>
+    </div>
   );
 }

--- a/app/components/LayoutsContextMenu.stories.tsx
+++ b/app/components/LayoutsContextMenu.stories.tsx
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createMemoryHistory } from "history";
+import { useMemo } from "react";
+import { Provider } from "react-redux";
+
+import LayoutStorageContext, {
+  Layout,
+  LayoutStorage,
+} from "@foxglove-studio/app/context/LayoutStorageContext";
+import createRootReducer from "@foxglove-studio/app/reducers";
+import configureStore from "@foxglove-studio/app/store/configureStore.testing";
+
+import LayoutsContextMenu from "./LayoutsContextMenu";
+
+class FakeLayoutStorage implements LayoutStorage {
+  #layouts: Layout[];
+
+  constructor(layouts: Layout[] = []) {
+    this.#layouts = layouts;
+  }
+  list(): Promise<Layout[]> {
+    return Promise.resolve(this.#layouts);
+  }
+  get(_id: string): Promise<Layout | undefined> {
+    throw new Error("Method not implemented.");
+  }
+  put(_layout: unknown): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  delete(_id: string): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export default {
+  title: "LayoutsContextMenu",
+  component: LayoutsContextMenu,
+};
+
+export function Empty(): JSX.Element {
+  const storage = useMemo(() => new FakeLayoutStorage(), []);
+  const store = useMemo(() => configureStore(createRootReducer(createMemoryHistory())), []);
+
+  return (
+    <Provider store={store}>
+      <LayoutStorageContext.Provider value={storage}>
+        <LayoutsContextMenu />
+      </LayoutStorageContext.Provider>
+    </Provider>
+  );
+}
+
+export function LayoutList(): JSX.Element {
+  const storage = useMemo(
+    () =>
+      new FakeLayoutStorage([
+        {
+          id: "not-current",
+          name: "Another Layout",
+          state: undefined,
+        },
+        {
+          id: "test-id",
+          name: "Current Layout",
+          state: undefined,
+        },
+        {
+          id: "short-id",
+          name: "Short",
+          state: undefined,
+        },
+      ]),
+    [],
+  );
+  const store = useMemo(() => {
+    const newStore = configureStore(createRootReducer(createMemoryHistory()));
+
+    // set an id for the current panel state so we can see it highlited in the menu
+    const state = newStore.getState();
+    state.persistedState.panels.id = "test-id";
+
+    return newStore;
+  }, []);
+
+  return (
+    <Provider store={store}>
+      <LayoutStorageContext.Provider value={storage}>
+        <LayoutsContextMenu />
+      </LayoutStorageContext.Provider>
+    </Provider>
+  );
+}

--- a/app/components/LayoutsContextMenu.tsx
+++ b/app/components/LayoutsContextMenu.tsx
@@ -27,12 +27,18 @@ type LayoutsContextMenuProps = {
   onRenameAction?: (layout: Layout) => void;
 };
 
+// Wrap Item with styled so we can reference it in ShowHoverParent
 const HoverItem = styled(Item)``;
 
+// ShowsHoverParent shows its content when the user hovers over HoverItem
+// We use it to display the rename/delete icons on item hover
+// Use visibility so the icons occupy their space while hidden
+// This avoids the menu width jumping changing when icons are shown on hover
 const ShowHoverParent = styled.div`
-  display: none;
+  display: flex;
+  visibility: hidden;
   ${HoverItem}:hover & {
-    display: flex;
+    visibility: visible;
   }
 `;
 

--- a/app/components/LayoutsContextMenu.tsx
+++ b/app/components/LayoutsContextMenu.tsx
@@ -1,0 +1,179 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import DeleteSvg from "@mdi/svg/svg/delete-forever.svg";
+import PencilSvg from "@mdi/svg/svg/pencil.svg";
+import { useCallback, useEffect, useMemo } from "react";
+import { useSelector } from "react-redux";
+import { useAsync } from "react-use";
+import styled from "styled-components";
+import { v4 as uuidv4 } from "uuid";
+
+import Icon from "@foxglove-studio/app/components/Icon";
+import Menu, { Item } from "@foxglove-studio/app/components/Menu";
+import { Layout, useLayoutStorage } from "@foxglove-studio/app/context/LayoutStorageContext";
+import { State } from "@foxglove-studio/app/reducers";
+import { PanelsState } from "@foxglove-studio/app/reducers/panels";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+type LayoutsContextMenuProps = {
+  onClose?: () => void;
+  onSelectAction?: (layout: Layout) => void;
+  onNewAction?: (layout: Layout) => void;
+  onDeleteAction?: (layout: Layout) => void;
+  onExportAction?: (layout: Layout) => void;
+  onImportAction?: () => void;
+  onRenameAction?: (layout: Layout) => void;
+};
+
+const HoverItem = styled(Item)``;
+
+const ShowHoverParent = styled.div`
+  display: none;
+  ${HoverItem}:hover & {
+    display: flex;
+  }
+`;
+
+// LayoutSubMenu is a separate component so we only load the storage list and listen to currentPanelsState
+// when the sub menu is mounted (open)
+export default function LayoutsContextMenu(props: LayoutsContextMenuProps) {
+  const layoutStorage = useLayoutStorage();
+  const currentPanelsState = useSelector((state: State) => state.persistedState.panels);
+
+  const { value: layouts, error, loading } = useAsync(() => layoutStorage.list(), [layoutStorage]);
+
+  const exportToFile = useCallback(() => {
+    props.onClose?.();
+    props.onExportAction?.({
+      id: currentPanelsState.id ?? uuidv4(),
+      name: currentPanelsState.name ?? "unnamed",
+      state: currentPanelsState,
+    });
+  }, [currentPanelsState, props]);
+
+  const importFromFile = useCallback(async () => {
+    props.onClose?.();
+    props.onImportAction?.();
+  }, [props]);
+
+  const duplicateLayout = useCallback(() => {
+    const name = `${currentPanelsState.name ?? "unnamed"} copy`;
+    const id = uuidv4();
+
+    const newState: PanelsState = {
+      ...currentPanelsState,
+      id: id,
+      name: name,
+    };
+
+    props.onNewAction?.({
+      id: id,
+      name: name,
+      state: newState,
+    });
+    props.onClose?.();
+  }, [currentPanelsState, props]);
+
+  const deleteLayout = useCallback(
+    async (layout: Layout) => {
+      // to avoid figuring out which layout to select or what to do when the user deletes the last layout
+      // we pevent deleting the current layout
+      if (layout.id === currentPanelsState.id) {
+        return;
+      }
+
+      props.onDeleteAction?.(layout);
+      props.onClose?.();
+    },
+    [currentPanelsState, props],
+  );
+
+  const layoutItems = useMemo(() => {
+    if (loading || layouts === undefined) {
+      return;
+    }
+
+    // Panel state may not have an ID yet. To make highlighting current layout work we need the ID.
+    // Here we set one locally until the currentPanelState has one
+    const currentId = currentPanelsState.id ?? uuidv4();
+    currentPanelsState.id = currentId;
+
+    const currentIdx = layouts.findIndex((layout) => {
+      return layout.id === currentId;
+    });
+
+    // current panel state is not in our storage layouts list
+    if (currentIdx < 0) {
+      layouts.push({
+        id: currentId,
+        name: currentPanelsState.name ?? "unnamed",
+        state: currentPanelsState,
+      });
+    }
+
+    return layouts.map((layout) => (
+      <HoverItem
+        key={layout.id}
+        highlighted={layout.id === currentId}
+        onClick={() => {
+          props.onClose?.();
+          props.onSelectAction?.(layout);
+        }}
+      >
+        <span style={{ flexGrow: 1 }}>{layout.name}</span>
+        <ShowHoverParent>
+          <Icon xxsmall style={{ marginLeft: "10px", paddingRight: "20px" }} fade>
+            <PencilSvg
+              onClick={(ev) => {
+                // prevent the layout from changing via the Item onClick
+                ev.stopPropagation();
+                props.onClose?.();
+                props.onRenameAction?.(layout);
+              }}
+            />
+          </Icon>
+          {/* delete only available for non-current layouts to avoid "what happens when I delete last layout" */}
+          {layout.id !== currentId && (
+            <Icon xxsmall fade>
+              <DeleteSvg
+                onClick={(ev) => {
+                  // prevent the layout from changing via the Item onClick
+                  ev.stopPropagation();
+                  deleteLayout(layout);
+                }}
+              />
+            </Icon>
+          )}
+          {layout.id === currentId && (
+            <Icon clickable={false} xxsmall style={{ opacity: 0.2 }}>
+              <DeleteSvg />
+            </Icon>
+          )}
+        </ShowHoverParent>
+      </HoverItem>
+    ));
+  }, [loading, layouts, currentPanelsState, props, deleteLayout]);
+
+  useEffect(() => {
+    if (error) {
+      sendNotification(error.message, error, "app", "error");
+    }
+  }, [error]);
+
+  // avoid showing a flash of empty menu while loading
+  if (loading) {
+    return ReactNull;
+  }
+
+  return (
+    <Menu>
+      {layoutItems}
+      <hr style={{ marginTop: "8px", marginBottom: "8px" }} />
+      <Item onClick={duplicateLayout}>New</Item>
+      <Item onClick={exportToFile}>Export</Item>
+      <Item onClick={importFromFile}>Import</Item>
+    </Menu>
+  );
+}

--- a/app/context/LayoutStorageContext.ts
+++ b/app/context/LayoutStorageContext.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+import { PanelsState } from "@foxglove-studio/app/reducers/panels";
+
+export type Layout = {
+  id: string;
+  name: string;
+  state?: PanelsState;
+};
+
+export interface LayoutStorage {
+  list(): Promise<Layout[]>;
+  get(id: string): Promise<Layout | undefined>;
+  put(layout: unknown): Promise<void>;
+  delete(id: string): Promise<void>;
+}
+
+const LayoutStorageContext = createContext<LayoutStorage | undefined>(undefined);
+
+export function useLayoutStorage(): LayoutStorage {
+  const ctx = useContext(LayoutStorageContext);
+  if (ctx === undefined) {
+    throw new Error("A LayoutStorage provider is required to useLayoutStorage");
+  }
+  return ctx;
+}
+
+export default LayoutStorageContext;

--- a/app/context/OsContextLayoutStorageProvider.tsx
+++ b/app/context/OsContextLayoutStorageProvider.tsx
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useMemo } from "react";
+
+import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
+import LayoutStorageContext from "@foxglove-studio/app/context/LayoutStorageContext";
+import OsContextLayoutStorage from "@foxglove-studio/app/services/OsContextLayoutStorage";
+
+// Provide an instance of the OsContextLayoutStorage
+export default function OsContextLayoutStorageProvider(props: PropsWithChildren<unknown>) {
+  const provider = useMemo(() => {
+    if (!OsContextSingleton) {
+      return undefined;
+    }
+
+    return new OsContextLayoutStorage(OsContextSingleton);
+  }, []);
+
+  return (
+    <LayoutStorageContext.Provider value={provider}>{props.children}</LayoutStorageContext.Provider>
+  );
+}

--- a/app/experimentalFeatures.tsx
+++ b/app/experimentalFeatures.tsx
@@ -28,4 +28,10 @@ export default {
     developmentDefault: false,
     productionDefault: false,
   },
+  layoutManagement: {
+    name: "Manage Layouts",
+    description: `Manage layouts via the layout menu. Add/Remove/Copy layouts. Import/Export layouts to files.`,
+    developmentDefault: false,
+    productionDefault: false,
+  },
 } as FeatureDescriptions;

--- a/app/package.json
+++ b/app/package.json
@@ -123,6 +123,7 @@
     "@types/tinycolor2": "1.4.2",
     "@types/url-search-params": "1.1.0",
     "@types/uuid": "8.3.0",
+    "@types/wicg-file-system-access": "2020.9.1",
     "@types/ws": "7.4.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.4.1",
     "argparse": "2.0.1",

--- a/app/reducers/panels.ts
+++ b/app/reducers/panels.ts
@@ -92,6 +92,8 @@ export const defaultPlaybackConfig: PlaybackConfig = {
 };
 
 export type PanelsState = {
+  id?: string;
+  name?: string;
   layout?: MosaicNode;
   // We store config for each panel in a hash keyed by the panel id.
   // This should at some point be renamed to `config` or `configById` or so,

--- a/app/services/OsContextLayoutStorage.ts
+++ b/app/services/OsContextLayoutStorage.ts
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { OsContext } from "@foxglove-studio/app/OsContext";
+import { Layout, LayoutStorage } from "@foxglove-studio/app/context/LayoutStorageContext";
+
+function assertLayout(value: unknown): asserts value is Layout {
+  if (typeof value !== "object" || value == undefined) {
+    throw new Error("Invariant violation - layout item is not an object");
+  }
+
+  if (!("id" in value)) {
+    throw new Error("Invariant violation - layout item is missing an id");
+  }
+}
+
+// Implement a LayoutStorage interface over OsContext
+export default class OsContextLayoutStorage implements LayoutStorage {
+  private static STORE_NAME = "layouts";
+
+  #ctx: OsContext;
+
+  constructor(osContext: OsContext) {
+    this.#ctx = osContext;
+  }
+
+  async list(): Promise<Layout[]> {
+    const items = await this.#ctx.storage.all(OsContextLayoutStorage.STORE_NAME);
+
+    const layouts: Layout[] = [];
+    for (const item of items) {
+      if (!(item instanceof Uint8Array)) {
+        throw new Error("Invariant violation - layout item is not a buffer");
+      }
+
+      const str = new TextDecoder().decode(item);
+      const parsed = JSON.parse(str);
+      assertLayout(parsed);
+      layouts.push(parsed);
+    }
+
+    return layouts;
+  }
+
+  async get(id: string): Promise<Layout | undefined> {
+    const item = await this.#ctx.storage.get(OsContextLayoutStorage.STORE_NAME, id);
+    if (!(item instanceof Uint8Array)) {
+      throw new Error("Invariant violation - layout item is not a buffer");
+    }
+
+    const str = new TextDecoder().decode(item);
+    const parsed = JSON.parse(str);
+    assertLayout(parsed);
+
+    return parsed;
+  }
+
+  async put(layout: Layout): Promise<void> {
+    const content = JSON.stringify(layout);
+    return this.#ctx.storage.put(OsContextLayoutStorage.STORE_NAME, layout.id, content);
+  }
+
+  async delete(id: string): Promise<void> {
+    return this.#ctx.storage.delete(OsContextLayoutStorage.STORE_NAME, id);
+  }
+}

--- a/preload/LocalFileStorage.ts
+++ b/preload/LocalFileStorage.ts
@@ -82,9 +82,18 @@ export default class LocalFileStorage implements Storage {
       throw new Error(`datastore (${datastore}) contains invalid characters`);
     }
 
+    const datastoresDir = path.join(basePath, "studio-datastores");
+    try {
+      await fs.mkdir(datastoresDir);
+    } catch (err) {
+      if (err.code !== "EEXIST") {
+        throw err;
+      }
+    }
+
     // There are other files and folders in the userDataPath. To avoid conflict we
     // store our datastores under a studio specific directory
-    const datastoreDir = path.join(basePath, "studio-datastores", datastore);
+    const datastoreDir = path.join(datastoresDir, datastore);
     try {
       await fs.mkdir(datastoreDir);
     } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,6 +1815,7 @@ __metadata:
     "@types/tinycolor2": 1.4.2
     "@types/url-search-params": 1.1.0
     "@types/uuid": 8.3.0
+    "@types/wicg-file-system-access": 2020.9.1
     "@types/ws": 7.4.0
     "@wojtekmaj/enzyme-adapter-react-17": 0.4.1
     argparse: 2.0.1
@@ -4991,6 +4992,13 @@ __metadata:
   version: 1.3.2
   resolution: "@types/which@npm:1.3.2"
   checksum: ffb779f93f76c0f79c0c1d7f9f36f5c396a8b04b5214cd905a0c22a16555f41d689940aa642fb23fd040e648a5ae7e15e5dcc2fd7d6c44608f5c3dabec9e02e7
+  languageName: node
+  linkType: hard
+
+"@types/wicg-file-system-access@npm:2020.9.1":
+  version: 2020.9.1
+  resolution: "@types/wicg-file-system-access@npm:2020.9.1"
+  checksum: 9703bed51ac2c9755bb89cedbc2efe9bb275c9de8e9d94a2e254d14bc03227385afe59a3e0c55c62f5a40a42e2012602c96a7f3409e977bd585f850a5708b752
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add experimental feature for layout management. Layout management changes the "layout" menu to support:

* Adding new layouts
* Changing between layouts
* Rename layout
* Export/Import layouts to/from json files

See the Storybook LayoutsContextMenu story to play with the component.