### PR TITLE
Convert StateTransitions panel to hooks

### DIFF
--- a/app/PanelAPI/useDataSourceInfo.ts
+++ b/app/PanelAPI/useDataSourceInfo.ts
@@ -27,7 +27,7 @@ export type DataSourceInfo = {
   topics: ReadonlyArray<Topic>;
   datatypes: RosDatatypes;
   capabilities: string[];
-  startTime: Time | undefined; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
+  startTime?: Time; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
   playerId: string;
 };
 

--- a/app/PanelAPI/useDataSourceInfo.ts
+++ b/app/PanelAPI/useDataSourceInfo.ts
@@ -27,7 +27,7 @@ export type DataSourceInfo = {
   topics: ReadonlyArray<Topic>;
   datatypes: RosDatatypes;
   capabilities: string[];
-  startTime: Time | null | undefined; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
+  startTime: Time | undefined; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
   playerId: string;
 };
 
@@ -43,8 +43,7 @@ export default function useDataSourceInfo(): DataSourceInfo {
   );
   const startTime = useMessagePipeline(
     useCallback(
-      ({ playerState: { activeData } }: MessagePipelineContext) =>
-        activeData && activeData.startTime,
+      ({ playerState: { activeData } }: MessagePipelineContext) => activeData?.startTime,
       [],
     ),
   );

--- a/app/components/MessageHistoryDEPRECATED/index.ts
+++ b/app/components/MessageHistoryDEPRECATED/index.ts
@@ -15,25 +15,11 @@ import React, { ReactElement, useMemo } from "react";
 import { Time } from "rosbag";
 
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
-import { getTopicsFromPaths } from "@foxglove-studio/app/components/MessagePathSyntax/parseRosPath";
-import {
-  MessagePathDataItem,
-  useDecodeMessagePathsForMessagesByTopic,
-} from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import { Message } from "@foxglove-studio/app/players/types";
-import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
+import { MessageDataItemsByPath } from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import useMessagesByPath from "@foxglove-studio/app/components/MessagePathSyntax/useMessagesByPath";
 
-export type MessageHistoryItem = {
-  queriedData: MessagePathDataItem[];
-  message: Message;
-};
-
-export type MessageHistoryItemsByPath = Readonly<{
-  [key: string]: ReadonlyArray<MessageHistoryItem>;
-}>;
-
-export type MessageHistoryData = {
-  itemsByPath: MessageHistoryItemsByPath;
+type MessageHistoryData = {
+  itemsByPath: MessageDataItemsByPath;
   startTime: Time;
 };
 
@@ -59,23 +45,8 @@ export default React.memo<Props>(function MessageHistoryDEPRECATED({
   historySize,
 }: Props) {
   const { startTime } = PanelAPI.useDataSourceInfo();
-  const memoizedPaths: string[] = useShallowMemo<string[]>(paths);
-  const subscribeTopics = useMemo(() => getTopicsFromPaths(memoizedPaths), [memoizedPaths]);
-
-  const messagesByTopic = PanelAPI.useMessagesByTopic({
-    topics: subscribeTopics,
-    historySize: historySize || Infinity,
-  });
-
-  const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(
-    memoizedPaths,
-  );
-  const itemsByPath = useMemo(() => decodeMessagePathsForMessagesByTopic(messagesByTopic), [
-    decodeMessagePathsForMessagesByTopic,
-    messagesByTopic,
-  ]);
-
-  return useMemo(() => children({ itemsByPath, startTime: startTime || ZERO_TIME }), [
+  const itemsByPath = useMessagesByPath(paths, historySize);
+  return useMemo(() => children({ itemsByPath, startTime: startTime ?? ZERO_TIME }), [
     children,
     itemsByPath,
     startTime,

--- a/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
+++ b/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
@@ -16,14 +16,12 @@ import { useCallback, useMemo } from "react";
 import parseRosPath from "./parseRosPath";
 import {
   useCachedGetMessagePathDataItems,
-  MessagePathDataItem,
+  MessageAndData,
 } from "./useCachedGetMessagePathDataItems";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import { Message, MessageFormat } from "@foxglove-studio/app/players/types";
 import { useChangeDetector } from "@foxglove-studio/app/util/hooks";
-
-type MessageAndData = { message: Message; queriedData: MessagePathDataItem[] };
 
 // Get the last message for a path, but *after* applying filters. In other words, we'll keep the
 // last message that matched.
@@ -35,10 +33,7 @@ export function useLatestMessageDataItem(
   const topics = useMemo(() => (rosPath ? [rosPath.topicName] : []), [rosPath]);
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems([path]);
 
-  const addMessages: (
-    arg0: MessageAndData | null | undefined,
-    arg1: ReadonlyArray<Message>,
-  ) => MessageAndData | null | undefined = useCallback(
+  const addMessages = useCallback(
     (prevMessageAndData: MessageAndData | null | undefined, messages: ReadonlyArray<Message>) => {
       // Iterate in reverse so we can early-return and not process all messages.
       for (let i = messages.length - 1; i >= 0; --i) {

--- a/app/components/MessagePathSyntax/useMessagesByPath.ts
+++ b/app/components/MessagePathSyntax/useMessagesByPath.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { useMemo } from "react";
+
+import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
+import { getTopicsFromPaths } from "@foxglove-studio/app/components/MessagePathSyntax/parseRosPath";
+import {
+  MessageDataItemsByPath,
+  useDecodeMessagePathsForMessagesByTopic,
+} from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
+
+// Given a set of message paths, subscribe to the appropriate topics and return
+// messages with their queried data decoded for each path.
+export default function useMessagesByPath(
+  paths: string[],
+  historySize: number = Infinity,
+): MessageDataItemsByPath {
+  const memoizedPaths: string[] = useShallowMemo(paths);
+  const subscribeTopics = useMemo(() => getTopicsFromPaths(memoizedPaths), [memoizedPaths]);
+
+  const messagesByTopic = PanelAPI.useMessagesByTopic({
+    topics: subscribeTopics,
+    historySize,
+  });
+
+  const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(
+    memoizedPaths,
+  );
+  return useMemo(() => decodeMessagePathsForMessagesByTopic(messagesByTopic), [
+    decodeMessagePathsForMessagesByTopic,
+    messagesByTopic,
+  ]);
+}

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -25,8 +25,10 @@ import TimeBasedChartTooltip from "./TimeBasedChartTooltip";
 import { clearHoverValue, setHoverValue } from "@foxglove-studio/app/actions/hoverValue";
 import Button from "@foxglove-studio/app/components/Button";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
-import { MessageHistoryItem } from "@foxglove-studio/app/components/MessageHistoryDEPRECATED";
-import { MessagePathDataItem } from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import {
+  MessageAndData,
+  MessagePathDataItem,
+} from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import ChartComponent, {
   HoveredElement,
@@ -61,7 +63,7 @@ export type TooltipItem = {
   headerStamp: Time | null | undefined;
 };
 
-export const getTooltipItemForMessageHistoryItem = (item: MessageHistoryItem): TooltipItem => {
+export const getTooltipItemForMessageHistoryItem = (item: MessageAndData): TooltipItem => {
   const { message } = item.message;
   const headerStamp = isBobject(message)
     ? maybeGetBobjectHeaderStamp(message)

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -24,9 +24,11 @@ import {
   useMessagesByTopic,
 } from "@foxglove-studio/app/PanelAPI";
 import Flex from "@foxglove-studio/app/components/Flex";
-import { MessageHistoryItemsByPath } from "@foxglove-studio/app/components/MessageHistoryDEPRECATED";
 import { getTopicsFromPaths } from "@foxglove-studio/app/components/MessagePathSyntax/parseRosPath";
-import { useDecodeMessagePathsForMessagesByTopic } from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import {
+  MessageDataItemsByPath,
+  useDecodeMessagePathsForMessagesByTopic,
+} from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
@@ -101,7 +103,7 @@ type Props = {
 
 // messagePathItems contains the whole parsed message, and we don't need to cache all of that.
 // Instead, throw away everything but what we need (the timestamps).
-const getPlotDataByPath = (itemsByPath: MessageHistoryItemsByPath): PlotDataByPath => {
+const getPlotDataByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
   const ret: PlotDataByPath = {};
   Object.keys(itemsByPath).forEach((path) => {
     ret[path] = [itemsByPath[path].map(getTooltipItemForMessageHistoryItem)];


### PR DESCRIPTION
Removes its use of MessageHistoryDEPRECATED.

Most of the logic from MessageHistoryDEPRECATED is moved into a new hook, `useMessagesByPath`. Some of the logic in the Plot panel is similar, but I think it's different because Plot can handle discontiguous ranges and preloading. Still, perhaps could be consolidated in the future.