### PR TITLE
Update electron-builder artifactName to {name}

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -7,6 +7,7 @@
     "app": ".webpack",
     "buildResources": "resources"
   },
+  "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
   "afterSign": "resources/notarize.ts",
   "linux": {
     "target": [
@@ -27,7 +28,6 @@
       "target": "default",
       "arch": ["x64", "arm64"]
     },
-    "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "category": "public.app-category.developer-tools",
     "icon": "resources/icon/icon.icns",
     "entitlements": "resources/mac/entitlements.plist",


### PR DESCRIPTION
Our product name contains a space. Github releases doesn't allow
files with spaces and sanitizes the name replacing the spaces with ".".

Electron-builder sanitizes names using a "-" to replace spaces. This
creates a discrepancy between which files electron-updater (the auto update
part of builder) expects to be available for download from the latest
github release.

This change uses "name" which does not have spaces.