### PR TITLE
Remove reg-suit from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - name: test
             command: yarn run test --maxWorkers=100%
           - name: storybook
-            command: yarn run storybook:ci
-          - name: chromatic
             command: yarn workspace @foxglove-studio/app run chromatic
 
     name: ${{ matrix.config.name }}
@@ -46,22 +44,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Configure Google Cloud
-        if: matrix.config.name == 'storybook'
-        uses: google-github-actions/setup-gcloud@v0.2.1
-        with:
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-          export_default_credentials: true
       - run: yarn install --immutable
       - run: ${{ matrix.config.command }}
         env:
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref }}
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          REG_SUIT_GITHUB_CLIENT_ID: ${{ secrets.REG_SUIT_GITHUB_CLIENT_ID }}
-          REG_SUIT_HEAD_SHA: ${{ github.sha }}
-          # `base.sha` works for pull request events, `before` works for pushes to main
-          REG_SUIT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
   integration:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Leaving the scripts in repo for now in case we want to go back to it, but for now this will significantly speed up the long pole in CI and reduce visual clutter (no more merging failed PRs).

I renamed the existing `chromatic` CI job to `storybook` which I think is clearer.