### PR TITLE
vscode: Remove hardcoded yarn version from launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,12 +15,15 @@
       "type": "node",
       "name": "vscode-jest-tests",
       "request": "launch",
-      "args": ["run", "jest", "--runInBand"],
-      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand"],
+      "cwd": "${workspaceFolder}/app",
+      "env": {
+        "NODE_OPTIONS": "--require ts-node/register"
+      },
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
-      "program": "${workspaceFolder}/.yarn/releases/yarn-2.4.1.cjs"
+      "disableOptimisticBPs": true
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "debug.javascript.autoAttachFilter": "onlyWithFlag",
+  "debug.toolBarLocation": "docked",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
This was broken due to jest config being moved into the `app/` directory.

It's faster & easier to call jest directly rather than through yarn (one debugger attaches instead of 3).

Unfortunately I need to set `cwd` to `app/` due to the way we have configured jest & typescript.