### PR TITLE
Convert "==/!= null" to "==/!= undefined"

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -42,12 +42,6 @@ settings:
 
 rules:
   file-progress/activate: 1
-  # https://eslint.org/docs/rules/eqeqeq
-  # Use smart mode until we change "T | null | undefined" to "T | undefined"
-  # For user input, we could make an isNullish function or leverage schema validation
-  eqeqeq:
-    - error
-    - smart
   no-console: off # configured in no-restricted-syntax
   "@typescript-eslint/ban-ts-comment":
     - error
@@ -117,6 +111,17 @@ rules:
     # We disable console methods here rather than using no-console so that it doesn't prohibit overrides such as "console.info = ..."
     - selector: "CallExpression[callee.object.name='console'][callee.property.name!=/^(warn|error|debug|assert)$/]"
       message: "Unexpected property on console object was called"
+
+    # Ban `null [!=]= x` and `x [!=]= null`
+    - selector: "BinaryExpression:matches([operator='=='], [operator='!=']):matches([left.type=Literal][left.raw=null], [right.type=Literal][right.raw=null])"
+      message: 'Prefer "x == undefined" or "x != undefined" to check for both null and undefined.'
+    # Ban `undefined [!=]= x`
+    - selector: "BinaryExpression:matches([operator='=='], [operator='!='])[left.type=Identifier][left.name=undefined]"
+      message: 'Prefer "x == undefined" or "x != undefined" to check for both null and undefined.'
+    # Ban `==` and `!=` unless RHS is undefined
+    - selector: "BinaryExpression:matches([operator='=='], [operator='!=']):not([right.type=Identifier][right.name=undefined]):not([right.type=Literal][right.raw=null])"
+      message: 'Use strict equality operators "===" and "!==", except when checking for null or undefined.'
+
   "@typescript-eslint/strict-boolean-expressions":
     - error
       # Force explicit checks that strings are empty

--- a/app/PanelAPI/useMessageReducer.ts
+++ b/app/PanelAPI/useMessageReducer.ts
@@ -176,7 +176,7 @@ export function useMessageReducer<T>(props: Props<T>): T {
     () => new Set(requestedTopics.map((req) => (typeof req === "object" ? req.topic : req))),
     [requestedTopics],
   );
-  const format = props.addBobjects != null ? "bobjects" : "parsedMessages";
+  const format = props.addBobjects != undefined ? "bobjects" : "parsedMessages";
   const subscriptions = useSubscriptions({
     requestedTopics,
     panelType,

--- a/app/components/Autocomplete.tsx
+++ b/app/components/Autocomplete.tsx
@@ -268,7 +268,7 @@ export default class Autocomplete extends PureComponent<AutocompleteProps, Autoc
       this._ignoreBlur = false;
     }
 
-    const selectedItemValue = selectedItem != null ? getItemValue(selectedItem) : undefined;
+    const selectedItemValue = selectedItem != undefined ? getItemValue(selectedItem) : undefined;
     return (
       <ReactAutocomplete
         open={open}
@@ -283,7 +283,8 @@ export default class Autocomplete extends PureComponent<AutocompleteProps, Autoc
               data-test-auto-item
               className={cx(styles.autocompleteItem, {
                 [styles.highlighted]: isHighlighted,
-                [styles.selected]: selectedItemValue != null && itemValue === selectedItemValue,
+                [styles.selected]:
+                  selectedItemValue != undefined && itemValue === selectedItemValue,
               })}
             >
               {getItemText(item)}

--- a/app/components/Dimensions.tsx
+++ b/app/components/Dimensions.tsx
@@ -87,7 +87,7 @@ export default function Dimensions(props: Props): React.ReactElement | null {
   }, [parentElement, resizeObserver]);
 
   // This only happens during the first render - we use it to grab the parentElement of this div.
-  if (dimensions == null) {
+  if (dimensions == undefined) {
     return <div ref={setParentElementRef} />;
   }
   if ("children" in props && typeof props.children === "function") {

--- a/app/components/Dropdown/index.tsx
+++ b/app/components/Dropdown/index.tsx
@@ -89,7 +89,7 @@ export default class Dropdown extends React.Component<Props, State> {
       if (child === null) {
         return null;
       }
-      const inner = (child as any).props.value != null ? this.renderItem(child as any) : child;
+      const inner = (child as any).props.value != undefined ? this.renderItem(child as any) : child;
       return <span key={i}>{inner}</span>;
     });
   }

--- a/app/components/Flex.tsx
+++ b/app/components/Flex.tsx
@@ -69,7 +69,7 @@ const Flex = (props: Props) => {
     onMouseMove,
     dataTest,
   } = props;
-  if (col != null && col === row) {
+  if (col != undefined && col === row) {
     throw new Error("Flex col and row are mutually exclusive");
   }
 

--- a/app/components/GlobalKeyListener.test.tsx
+++ b/app/components/GlobalKeyListener.test.tsx
@@ -74,7 +74,7 @@ describe("GlobalKeyListener", () => {
 
   it("does not fire undo/redo events from editable fields", () => {
     const shareTextarea = document.getElementById("some-text-area");
-    if (shareTextarea == null) {
+    if (shareTextarea == undefined) {
       throw new Error("could not find shareTextArea.");
     }
     shareTextarea.dispatchEvent(

--- a/app/components/GlobalVariablesTable.tsx
+++ b/app/components/GlobalVariablesTable.tsx
@@ -352,7 +352,7 @@ function GlobalVariablesTable(): ReactElement {
       </table>
       <Flex style={{ margin: "20px 16px 16px", justifyContent: "flex-end" }}>
         <button
-          disabled={globalVariables[""] != null}
+          disabled={globalVariables[""] != undefined}
           onClick={() => setGlobalVariables({ "": "" })}
           data-test="add-variable-btn"
         >

--- a/app/components/Icon.tsx
+++ b/app/components/Icon.tsx
@@ -58,7 +58,7 @@ const Icon = (props: Props) => {
   } = props;
   const classNames = cx("icon", styles.icon, className, {
     [styles.fade]: fade,
-    [styles.clickable]: !!onClick || clickable == null || clickable,
+    [styles.clickable]: !!onClick || clickable == undefined || clickable,
     [styles.active]: active,
     [styles.xlarge]: xlarge,
     [styles.large]: large,

--- a/app/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/app/components/MessagePathSyntax/MessagePathInput.tsx
@@ -106,7 +106,7 @@ export function getFirstInvalidVariableFromRosPath(
         messagePathParts.push({ variableName, loc });
       }
       if (
-        path.end != null &&
+        path.end != undefined &&
         typeof path.end === "object" &&
         !globalVars.includes(path.end.variableName)
       ) {

--- a/app/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/app/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -233,7 +233,7 @@ export const traverseStructure = memoizeWeak(
         if (
           structureItem.structureType !== "message" ||
           msgPathPart.path.length === 0 ||
-          msgPathPart.value == null
+          msgPathPart.value == undefined
         ) {
           return { valid: false, msgPathPart, structureItem };
         }
@@ -243,7 +243,7 @@ export const traverseStructure = memoizeWeak(
             return { valid: false, msgPathPart, structureItem };
           }
           currentItem = currentItem.nextByName[name];
-          if (currentItem == null) {
+          if (currentItem == undefined) {
             return { valid: false, msgPathPart, structureItem };
           }
         }

--- a/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -129,7 +129,7 @@ function filterMatches(filter: MessagePathFilter, value: any) {
   let currentValue = value;
   for (const name of filter.path) {
     currentValue = getField(currentValue, name);
-    if (currentValue == null) {
+    if (currentValue == undefined) {
       return false;
     }
   }
@@ -283,7 +283,7 @@ export function getMessagePathDataItems(
       for (let i = startIdx; i <= Math.min(endIdx, arrayLength - 1); i++) {
         const index = i >= 0 ? i : arrayLength + i;
         const arrayElement = getIndex(value, index);
-        if (arrayElement == null) {
+        if (arrayElement == undefined) {
           continue;
         }
         // Ideally show something like `/topic.object[:]{some_id=123}` for the path, but fall

--- a/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -136,7 +136,7 @@ function filterMatches(filter: MessagePathFilter, value: any) {
 
   // Test equality using `==` so we can be forgiving for comparing booleans with integers,
   // comparing numbers with strings, and so on.
-  // eslint-disable-next-line eqeqeq
+  // eslint-disable-next-line no-restricted-syntax
   return currentValue == filter.value;
 }
 

--- a/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
+++ b/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
@@ -39,7 +39,7 @@ export function useLatestMessageDataItem(
       for (let i = messages.length - 1; i >= 0; --i) {
         const message = messages[i];
         const queriedData = cachedGetMessagePathDataItems(path, message);
-        if (queriedData == null) {
+        if (queriedData == undefined) {
           // Invalid path.
           return;
         }

--- a/app/components/MessagePipeline/index.tsx
+++ b/app/components/MessagePipeline/index.tsx
@@ -412,7 +412,7 @@ export function MockMessagePipelineProvider(props: {
 
   const playerState = useMemo(
     () => ({
-      isPresent: props.isPresent == null ? true : props.isPresent,
+      isPresent: props.isPresent == undefined ? true : props.isPresent,
       playerId: props.playerId || "1",
       progress: props.progress || {},
       showInitializing: !!props.showInitializing,

--- a/app/components/MessagePipeline/warnOnOutOfSyncMessages.test.ts
+++ b/app/components/MessagePipeline/warnOnOutOfSyncMessages.test.ts
@@ -58,10 +58,10 @@ const message = (
 ): Message => ({
   topic: "/foo",
   receiveTime:
-    receiveTimeSeconds == null ? undefined : ({ sec: receiveTimeSeconds, nsec: 1 } as any),
+    receiveTimeSeconds == undefined ? undefined : ({ sec: receiveTimeSeconds, nsec: 1 } as any),
   message: {
     header:
-      headerStampSeconds == null ? undefined : { stamp: { sec: headerStampSeconds, nsec: 1 } },
+      headerStampSeconds == undefined ? undefined : { stamp: { sec: headerStampSeconds, nsec: 1 } },
   },
 });
 

--- a/app/components/NoHeaderTopicsButton.tsx
+++ b/app/components/NoHeaderTopicsButton.tsx
@@ -32,7 +32,7 @@ const DEFAULT_TOPICS = Object.freeze({ topicsWithoutHeaderStamps: [], topics: []
 const COLOR_THRESHOLD = 5; // show the icon yellow when too many headers are missing
 
 function getTopics({ playerState: { activeData } }: any) {
-  if (activeData == null) {
+  if (activeData == undefined) {
     return DEFAULT_TOPICS;
   }
   const {

--- a/app/components/Panel.test.tsx
+++ b/app/components/Panel.test.tsx
@@ -41,7 +41,7 @@ function getStore() {
 }
 
 function Context(props: { children: React.ReactNode; store?: any }) {
-  const extraProps = props.store == null ? undefined : { store: props.store };
+  const extraProps = props.store == undefined ? undefined : { store: props.store };
   return (
     <PanelSetup
       fixture={{

--- a/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -47,7 +47,7 @@ const BottomTick = styled.div`
 `;
 
 function getStartAndEndTime({ playerState: { activeData } }: MessagePipelineContext) {
-  if (activeData == null) {
+  if (activeData == undefined) {
     return { startTime: undefined, endTime: undefined };
   }
   return { startTime: activeData.startTime, endTime: activeData.endTime };
@@ -62,7 +62,7 @@ export default React.memo<Props>(function PlaybackBarHoverTicks({ componentId }:
   const [width, setWidth] = useState<number | undefined>();
 
   const scaleBounds = useMemo<{ current: readonly ScaleBounds[] | undefined }>(() => {
-    if (width == null || startTime == null || endTime == null) {
+    if (width == undefined || startTime == undefined || endTime == undefined) {
       return { current: undefined };
     }
     return {

--- a/app/components/PlaybackControls/index.tsx
+++ b/app/components/PlaybackControls/index.tsx
@@ -121,7 +121,7 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
           return;
         }
         const { startTime, endTime } = activeData || {};
-        if (!startTime || !endTime || el.current == null || slider.current == null) {
+        if (!startTime || !endTime || el.current == undefined || slider.current == undefined) {
           return;
         }
         const currentEl = el.current;
@@ -170,7 +170,7 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
 
     const min = (startTime && toSec(startTime)) ?? 0;
     const max = (endTime && toSec(endTime)) ?? 0;
-    const value = currentTime == null ? undefined : toSec(currentTime);
+    const value = currentTime == undefined ? undefined : toSec(currentTime);
     const step = (max - min) / 500;
 
     const seekControls = useMemo(
@@ -224,12 +224,12 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
               ref={slider}
               min={min || 0}
               max={max || 100}
-              disabled={min == null || max == null}
+              disabled={min == undefined || max == undefined}
               step={step}
               value={value}
               draggable
               onChange={onChange}
-              renderSlider={(val) => (val == null ? null : <StyledMarker width={val} />)}
+              renderSlider={(val) => (val == undefined ? null : <StyledMarker width={val} />)}
             />
           </div>
           <PlaybackBarHoverTicks componentId={hoverComponentId} />

--- a/app/components/ReactChartjs/ChartJSManager.ts
+++ b/app/components/ReactChartjs/ChartJSManager.ts
@@ -353,7 +353,7 @@ export default class ChartJSManager {
         const label = value?.label;
         // We have to return "null" if we don't want this label to be displayed. Returning "undefined" falls back to the
         // default formatting.
-        return label != null ? label : null;
+        return label != undefined ? label : null;
       };
       // Override color so that it can be set per-dataset.
       const staticColor = config.plugins.datalabels.color || "white";
@@ -365,7 +365,7 @@ export default class ChartJSManager {
 
     if (scaleOptions) {
       for (const scale of config.scales.yAxes) {
-        if (scaleOptions.fixedYAxisWidth != null) {
+        if (scaleOptions.fixedYAxisWidth != undefined) {
           scale.afterFit = (scaleInstance: any) => {
             scaleInstance.width = scaleOptions.fixedYAxisWidth;
           };

--- a/app/components/ReactChartjs/zoomAndPanHelpers.ts
+++ b/app/components/ReactChartjs/zoomAndPanHelpers.ts
@@ -417,7 +417,7 @@ export function getChartValue(
   bounds: ScaleBounds | undefined,
   canvasPx: number,
 ): number | undefined {
-  if (bounds == null) {
+  if (bounds == undefined) {
     return;
   }
   const { min, max, minAlongAxis, maxAlongAxis } = bounds;
@@ -426,7 +426,7 @@ export function getChartValue(
 }
 
 export function getChartPx(bounds: ScaleBounds | undefined, value: number): number | undefined {
-  if (bounds == null) {
+  if (bounds == undefined) {
     return;
   }
   const { min, max, minAlongAxis, maxAlongAxis } = bounds;
@@ -437,7 +437,7 @@ export function getChartPx(bounds: ScaleBounds | undefined, value: number): numb
 }
 
 export function inBounds(position: number, bounds?: ScaleBounds): boolean {
-  if (bounds == null) {
+  if (bounds == undefined) {
     return false;
   }
   // The position of the minimum value may not be the minimum coordinate if the axis is reversed.

--- a/app/components/Slider.tsx
+++ b/app/components/Slider.tsx
@@ -58,7 +58,7 @@ export const StyledRange = styled.div.attrs<{ width: number }>(({ width }) => ({
 `;
 
 function defaultRenderSlider(value: number | undefined): React.ReactNode {
-  if (value == null || isNaN(value)) {
+  if (value == undefined || isNaN(value)) {
     return null;
   }
   return <StyledRange width={value} />;
@@ -182,7 +182,7 @@ export default class Slider extends React.Component<Props> {
           enabled={mouseDown && draggable}
           onMouseUp={this._onMouseUp}
         />
-        {renderSlider(value != null && min !== max ? (value - min) / (max - min) : undefined)}
+        {renderSlider(value != undefined && min !== max ? (value - min) / (max - min) : undefined)}
       </StyledSlider>
     );
   }

--- a/app/components/TimeBasedChart/HoverBar.tsx
+++ b/app/components/TimeBasedChart/HoverBar.tsx
@@ -50,7 +50,7 @@ function showBar(wrapper: any, position: any) {
 }
 
 function shouldShowBar(hoverValue: any, componentId: any, isTimestampScale: boolean) {
-  if (hoverValue == null) {
+  if (hoverValue == undefined) {
     return false;
   }
   if (hoverValue.type === "PLAYBACK_SECONDS" && isTimestampScale) {
@@ -75,14 +75,14 @@ export default React.memo<Props>(function HoverBar({
   // We avoid putting the visibility and transforms into react state to try to keep updates snappy.
   // Mouse interactions are frequent, and adding/removing the bar from the DOM would slow things
   // down a lot more than mutating the style props does.
-  if (wrapper.current != null) {
+  if (wrapper.current != undefined) {
     const { current } = wrapper;
-    if (xBounds == null || hoverValue == null) {
+    if (xBounds == undefined || hoverValue == undefined) {
       hideBar(current);
     }
     if (shouldShowBar(hoverValue, componentId, isTimestampScale)) {
       const position = getChartPx(xBounds, hoverValue.value);
-      if (position == null) {
+      if (position == undefined) {
         hideBar(current);
       } else {
         showBar(current, position);

--- a/app/components/TimeBasedChart/TimeBasedChartTooltip.tsx
+++ b/app/components/TimeBasedChart/TimeBasedChartTooltip.tsx
@@ -36,7 +36,7 @@ export default class TimeBasedChartTooltip extends React.PureComponent<Props> {
           <span className={styles.title}>Path:&nbsp;</span>
           {tooltip.path}
         </div>
-        {tooltip.source != null && (
+        {tooltip.source != undefined && (
           <div>
             <span className={styles.title}>Source:&nbsp;</span>
             {tooltip.source}

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -52,8 +52,8 @@ type Bounds = { minX?: number; maxX?: number };
 const SyncTimeAxis = createSyncingComponent<Bounds, Bounds>(
   "SyncTimeAxis",
   (dataItems: Bounds[]) => ({
-    minX: min(dataItems.map(({ minX }) => (minX == null ? undefined : minX))),
-    maxX: max(dataItems.map(({ maxX }) => (maxX == null ? undefined : maxX))),
+    minX: min(dataItems.map(({ minX }) => (minX == undefined ? undefined : minX))),
+    maxX: max(dataItems.map(({ maxX }) => (maxX == undefined ? undefined : maxX))),
   }),
 );
 
@@ -302,7 +302,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       ) {
         saveCurrentView(firstYScale.min, firstYScale.max, width);
       }
-      if (firstYScale != null && hoverBar.current != null) {
+      if (firstYScale != undefined && hoverBar.current != undefined) {
         const { current } = hoverBar;
         const topPx = Math.min(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
         const bottomPx = Math.max(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
@@ -337,7 +337,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
             ? ev.clientX - (ev.target as Element).getBoundingClientRect().x
             : ev.clientY - (ev.target as Element).getBoundingClientRect().y;
         const value = getChartValue(bounds, chartPx);
-        if (value == null) {
+        if (value == undefined) {
           return;
         }
         values[bounds.id] = value;
@@ -359,10 +359,10 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       // initial "zoom to fit" state. Subsequent zooms/pans adjust the offsets.
       const bounds = newScaleBounds.find(({ axes }) => axes === "xAxes");
       if (
-        bounds != null &&
-        bounds.min != null &&
-        bounds.max != null &&
-        currentTimeRef.current != null
+        bounds != undefined &&
+        bounds.min != undefined &&
+        bounds.max != undefined &&
+        currentTimeRef.current != undefined
       ) {
         const currentTime = currentTimeRef.current;
         setFollowPlaybackState({
@@ -388,7 +388,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     if (hasUserPannedOrZoomed) {
       setHasUserPannedOrZoomed(false);
     }
-    if (followPlaybackState != null) {
+    if (followPlaybackState != undefined) {
       setFollowPlaybackState(undefined);
     }
   }
@@ -534,7 +534,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       }
 
       const value = getChartValue(xBounds, xMousePosition);
-      if (value != null) {
+      if (value != undefined) {
         setGlobalHoverTime(value);
       } else {
         clearGlobalHoverTime();
@@ -592,7 +592,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
           },
         }))
       : [defaultXAxis];
-    if (currentTime != null) {
+    if (currentTime != undefined) {
       annotations.push({
         type: "line",
         drawTime: "beforeDatasetsDraw",
@@ -644,12 +644,12 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     };
     const firstXAxisTicks = options.scales?.xAxes?.[0]?.ticks;
     if (firstXAxisTicks) {
-      if (followPlaybackState != null) {
+      if (followPlaybackState != undefined) {
         // Follow playback, but don't force it if the user has recently panned or zoomed -- playback
         // will fight with the user's action.
         if (
-          currentTime != null &&
-          (lastPanTime.current == null ||
+          currentTime != undefined &&
+          (lastPanTime.current == undefined ||
             // @ts-expect-error while valid js we should fix this arithmatic operation on dates
             new Date() - lastPanTime.current > FOLLOW_PLAYBACK_PAN_THRESHOLD_MS)
         ) {
@@ -683,7 +683,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   );
   let minX: number;
   let maxX: number;
-  if (defaultView == null || (defaultView.type === "following" && currentTime == null)) {
+  if (defaultView == undefined || (defaultView.type === "following" && currentTime == undefined)) {
     // Zoom to fit if the view is "following" but there's no playback cursor. Unlikely.
     minX = min(xVals) ?? 0;
     maxX = max(xVals) ?? 0;
@@ -692,15 +692,17 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     maxX = defaultView.maxXValue;
   } else {
     // Following with non-null currentTime.
-    if (currentTime == null) {
-      throw new Error("Flow doesn't know that currentTime != null");
+    if (currentTime == undefined) {
+      throw new Error("Flow doesn't know that currentTime != undefined");
     }
     minX = currentTime - defaultView.width / 2;
     maxX = currentTime + defaultView.width / 2;
   }
 
   const scaleOptions =
-    xScaleOptions != null ? { ...props.scaleOptions, xAxisTicks: "follow" } : props.scaleOptions;
+    xScaleOptions != undefined
+      ? { ...props.scaleOptions, xAxisTicks: "follow" }
+      : props.scaleOptions;
 
   const chartProps = {
     type,
@@ -744,13 +746,13 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
           </HoverBar>
 
           {/* only sync when using x-axis timestamp and actually plotting data. */}
-          {isSynced && currentTime == null && xAxisIsPlaybackTime && hasData ? (
+          {isSynced && currentTime == undefined && xAxisIsPlaybackTime && hasData ? (
             <SyncTimeAxis data={{ minX, maxX }}>
               {(syncedMinMax) => {
                 const syncedMinX =
-                  syncedMinMax.minX != null ? min([minX, syncedMinMax.minX]) : minX;
+                  syncedMinMax.minX != undefined ? min([minX, syncedMinMax.minX]) : minX;
                 const syncedMaxX =
-                  syncedMinMax.maxX != null ? max([maxX, syncedMinMax.maxX]) : maxX;
+                  syncedMinMax.maxX != undefined ? max([maxX, syncedMinMax.maxX]) : maxX;
                 return (
                   // @ts-expect-error fix properties
                   <ChartComponent

--- a/app/dataProviders/ApiCheckerDataProvider.ts
+++ b/app/dataProviders/ApiCheckerDataProvider.ts
@@ -184,7 +184,7 @@ export default class ApiCheckerDataProvider implements DataProvider {
 
     for (const messageType of MESSAGE_FORMATS) {
       const messages = providerResult[messageType];
-      if (messages == null) {
+      if (messages == undefined) {
         continue;
       }
       const topics = (subscriptions as any)[messageType] ?? [];

--- a/app/dataProviders/BagDataProvider.test.ts
+++ b/app/dataProviders/BagDataProvider.test.ts
@@ -145,7 +145,7 @@ describe("BagDataProvider", () => {
     });
     expect(bobjects).toBe(undefined);
     expect(parsedMessages).toBe(undefined);
-    if (rosBinaryMessages == null) {
+    if (rosBinaryMessages == undefined) {
       throw new Error("Satisfy flow");
     }
     const timestamps = rosBinaryMessages.map(({ receiveTime }) => receiveTime);

--- a/app/dataProviders/BagDataProvider.ts
+++ b/app/dataProviders/BagDataProvider.ts
@@ -224,7 +224,7 @@ export default class BagDataProvider implements DataProvider {
   }
 
   _logStats() {
-    if (this._extensionPoint == null || this._lastPerformanceStatsToLog == null) {
+    if (this._extensionPoint == undefined || this._lastPerformanceStatsToLog == undefined) {
       return;
     }
     this._extensionPoint.reportMetadataCallback(this._lastPerformanceStatsToLog.data);
@@ -236,7 +236,7 @@ export default class BagDataProvider implements DataProvider {
 
   _queueStats(stats: TimedDataThroughput) {
     if (
-      this._lastPerformanceStatsToLog != null &&
+      this._lastPerformanceStatsToLog != undefined &&
       statsAreAdjacent(this._lastPerformanceStatsToLog, stats)
     ) {
       // The common case: The next bit of data will be next to the last one. For remote bags we'll

--- a/app/dataProviders/CombinedDataProvider.test.ts
+++ b/app/dataProviders/CombinedDataProvider.test.ts
@@ -146,7 +146,7 @@ function getCombinedDataProvider(data: any[]) {
     const { provider, prefix } = item;
     providerInfos.push({});
     const childProvider =
-      prefix == null
+      prefix == undefined
         ? provider
         : new RenameDataProvider({ prefix }, [provider], (child: any) => child);
     children.push({ name: "TestProvider", args: { provider: childProvider }, children: [] });
@@ -937,7 +937,7 @@ describe("mergedBlocks", () => {
       { startTime: { sec: 0, nsec: 0 }, blocks: [lhs] },
       { startTime: { sec: 0, nsec: 0 }, blocks: [rhs] },
     );
-    if (mergedValue == null) {
+    if (mergedValue == undefined) {
       throw new Error("satisfy flow");
     }
     const combinedBlocks = mergedValue.blocks;
@@ -953,7 +953,7 @@ describe("mergedBlocks", () => {
       { startTime: { sec: 0, nsec: 0 }, blocks: [lhs] },
       { startTime: { sec: 0, nsec: 0 }, blocks: [rhs] },
     );
-    if (newMergedValue == null) {
+    if (newMergedValue == undefined) {
       throw new Error("satisfy flow");
     }
     const newCombinedBlocks = newMergedValue.blocks;

--- a/app/dataProviders/CombinedDataProvider.ts
+++ b/app/dataProviders/CombinedDataProvider.ts
@@ -46,10 +46,10 @@ const emptyGetMessagesResult = {
 };
 
 const memoizedMergedBlock = memoizeWeak((block1?: MemoryCacheBlock, block2?: MemoryCacheBlock) => {
-  if (block1 == null) {
+  if (block1 == undefined) {
     return block2;
   }
-  if (block2 == null) {
+  if (block2 == undefined) {
     return block1;
   }
   return {
@@ -63,10 +63,10 @@ export const mergedBlocks = (
   cache1: BlockCache | undefined,
   cache2: BlockCache | undefined,
 ): BlockCache | undefined => {
-  if (cache1 == null) {
+  if (cache1 == undefined) {
     return cache2;
   }
-  if (cache2 == null) {
+  if (cache2 == undefined) {
     return cache1;
   }
   if (!TimeUtil.areSame(cache1.startTime, cache2.startTime)) {
@@ -86,10 +86,10 @@ const merge = (
   messages1: readonly Message[] | undefined,
   messages2: readonly Message[] | undefined,
 ) => {
-  if (messages1 == null) {
+  if (messages1 == undefined) {
     return messages2;
   }
-  if (messages2 == null) {
+  if (messages2 == undefined) {
     return messages1;
   }
   const messages = [];
@@ -210,7 +210,7 @@ function intersectProgress(progresses: Progress[]): Progress {
     fullyLoadedFractionRanges: deepIntersect(
       filterMap(progresses, (p) => p.fullyLoadedFractionRanges),
     ),
-    ...(messageCache != null ? { messageCache } : undefined),
+    ...(messageCache != undefined ? { messageCache } : undefined),
   };
 }
 function emptyProgress() {
@@ -314,7 +314,7 @@ export default class CombinedDataProvider implements DataProvider {
     const messagesPerProvider = await Promise.all(
       this._providers.map(async (provider, index) => {
         const initializationResult = this._initializationResultsPerProvider[index];
-        if (initializationResult == null) {
+        if (initializationResult == undefined) {
           return { bobjects: undefined, parsedMessages: undefined, rosBinaryMessages: undefined };
         }
         const availableTopics = initializationResult.topicSet;
@@ -350,7 +350,7 @@ export default class CombinedDataProvider implements DataProvider {
           filteredTopicsByFormat,
         );
         for (const messages of objectValues(providerResult)) {
-          if (messages == null) {
+          if (messages == undefined) {
             continue;
           }
           for (const message of messages) {

--- a/app/dataProviders/FetchReader.ts
+++ b/app/dataProviders/FetchReader.ts
@@ -102,7 +102,7 @@ export default class FetchReader extends Readable {
             return this.push(null);
           }
           // Flow doesn't know that value is only undefined when value done is true.
-          if (value != null) {
+          if (value != undefined) {
             this.push(Buffer.from(value.buffer));
           }
         })

--- a/app/dataProviders/IdbCacheWriterDataProvider.ts
+++ b/app/dataProviders/IdbCacheWriterDataProvider.ts
@@ -302,7 +302,7 @@ export default class IdbCacheWriterDataProvider implements DataProvider {
           rosBinaryMessages: topics,
         },
       );
-      if (bobjects != null || parsedMessages != null || rosBinaryMessages == null) {
+      if (bobjects != undefined || parsedMessages != undefined || rosBinaryMessages == undefined) {
         sendNotification("IdbCacheWriter should only have ROS binary messages", "", "app", "error");
         return;
       }

--- a/app/dataProviders/MemoryCacheDataProvider.ts
+++ b/app/dataProviders/MemoryCacheDataProvider.ts
@@ -102,7 +102,7 @@ export function getBlocksToKeep({
     for (let blockIndex = badEvictionRange.start; blockIndex < badEvictionRange.end; ++blockIndex) {
       const sizeInBytes = blockSizesInBytes[blockIndex];
 
-      if (sizeInBytes != null && !blockIndexesToKeep.has(blockIndex)) {
+      if (sizeInBytes != undefined && !blockIndexesToKeep.has(blockIndex)) {
         blockIndexesToKeep.add(blockIndex);
         cacheSizeInBytes += sizeInBytes;
       }
@@ -148,7 +148,7 @@ export function getBlocksToKeep({
               },
         ];
         const newRecentRanges =
-          badEvictionRange == null
+          badEvictionRange == undefined
             ? newRecentRangesExcludingBadEvictionRange
             : mergeNewRangeIntoUnsortedNonOverlappingList(
                 badEvictionRange,
@@ -183,7 +183,7 @@ function getBlocksToKeepDirection(
   increment: number;
 } {
   if (
-    badEvictionLocation != null &&
+    badEvictionLocation != undefined &&
     Math.abs(badEvictionLocation - blockRange.start) <
       Math.abs(badEvictionLocation - blockRange.end)
   ) {
@@ -600,9 +600,9 @@ export default class MemoryCacheDataProvider implements DataProvider {
           };
       const { bobjects, rosBinaryMessages, parsedMessages } = messages;
 
-      if (rosBinaryMessages != null || parsedMessages != null) {
+      if (rosBinaryMessages != undefined || parsedMessages != undefined) {
         const types = (Object.keys(messages) as (keyof typeof messages)[])
-          .filter((type) => messages[type] != null)
+          .filter((type) => messages[type] != undefined)
           .join("\n");
         sendNotification("MemoryCacheDataProvider got bad message types", types, "app", "error");
         // Do not retry.
@@ -739,7 +739,7 @@ export default class MemoryCacheDataProvider implements DataProvider {
     // playback cursor) because we'll automatically try to refetch that data immediately after.
     let badEvictionRange = this._readRequests[0]?.blockRange;
 
-    if (!badEvictionRange && this._lastResolvedCallbackEnd != null) {
+    if (!badEvictionRange && this._lastResolvedCallbackEnd != undefined) {
       badEvictionRange = {
         start: this._lastResolvedCallbackEnd,
         end: this._lastResolvedCallbackEnd + this._readAheadBlocks,

--- a/app/dataProviders/MemoryDataProvider.ts
+++ b/app/dataProviders/MemoryDataProvider.ts
@@ -36,7 +36,7 @@ function filterMessages(
   topics: readonly string[],
   messages: readonly Message[] | undefined,
 ) {
-  if (messages == null) {
+  if (messages == undefined) {
     return undefined;
   }
   const ret = [];
@@ -89,7 +89,7 @@ export default class MemoryDataProvider implements DataProvider {
     this.messageDefinitionsByTopic = messageDefinitionsByTopic || {};
     this.parsedMessageDefinitionsByTopic = parsedMessageDefinitionsByTopic;
     this.initiallyLoaded = !!initiallyLoaded;
-    this.providesParsedMessages = providesParsedMessages ?? messages.parsedMessages != null;
+    this.providesParsedMessages = providesParsedMessages ?? messages.parsedMessages != undefined;
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {

--- a/app/dataProviders/ParseMessagesDataProvider.ts
+++ b/app/dataProviders/ParseMessagesDataProvider.ts
@@ -111,7 +111,7 @@ export default class ParseMessagesDataProvider implements DataProvider {
     const getMessagesPromise = this._provider.getMessages(start, end, childTopics);
     const readersByTopic = this._getReadersByTopic(readerTopics);
     const { bobjects } = await getMessagesPromise;
-    if (bobjects == null) {
+    if (bobjects == undefined) {
       throw new Error("Child of ParseMessagesProvider must provide binary messages");
     }
     const messagesToParse = bobjects.filter(({ topic }) => requestedParsedTopics.has(topic));

--- a/app/dataProviders/ParsedMessageCache.test.ts
+++ b/app/dataProviders/ParsedMessageCache.test.ts
@@ -51,7 +51,7 @@ describe("parsedMessageCache", () => {
     const { rosBinaryMessages } = await provider.getMessages(start, end, {
       rosBinaryMessages: ["/tf"],
     });
-    if (rosBinaryMessages == null) {
+    if (rosBinaryMessages == undefined) {
       throw new Error("Satisfy flow");
     }
 

--- a/app/dataProviders/RpcDataProviderRemote.ts
+++ b/app/dataProviders/RpcDataProviderRemote.ts
@@ -44,7 +44,7 @@ export default class RpcDataProviderRemote {
       const messages = await provider.getMessages(start, end, { rosBinaryMessages: topics });
       const { parsedMessages, rosBinaryMessages, bobjects } = messages;
       const messagesToSend = rosBinaryMessages ?? [];
-      if (parsedMessages != null || bobjects != null) {
+      if (parsedMessages != undefined || bobjects != undefined) {
         throw new Error(
           "RpcDataProvider only accepts raw messages (that still need to be parsed with ParseMessagesDataProvider)",
         );

--- a/app/dataProviders/util.ts
+++ b/app/dataProviders/util.ts
@@ -29,10 +29,10 @@ const getMaybeLogStall = (
   const startOfRequest = Date.now();
   return (buffer: Buffer) => {
     const now = Date.now();
-    if (firstDataReceivedTime == null) {
+    if (firstDataReceivedTime == undefined) {
       firstDataReceivedTime = now;
     }
-    if (lastDataReceivedTime != null && now - lastDataReceivedTime > stallThresholdMs) {
+    if (lastDataReceivedTime != undefined && now - lastDataReceivedTime > stallThresholdMs) {
       const stallDuration = fromMillis(now - lastDataReceivedTime);
       const requestTimeUntilStall = fromMillis(lastDataReceivedTime - startOfRequest);
       const transferTimeUntilStall = fromMillis(lastDataReceivedTime - firstDataReceivedTime);

--- a/app/panels/ImageView/renderImage.ts
+++ b/app/panels/ImageView/renderImage.ts
@@ -178,10 +178,10 @@ function paintBitmap(
 
   const { markers, cameraModel } = markerData;
   let { originalWidth, originalHeight } = markerData;
-  if (originalWidth == null) {
+  if (originalWidth == undefined) {
     originalWidth = bitmap.width;
   }
-  if (originalHeight == null) {
+  if (originalHeight == undefined) {
     originalHeight = bitmap.height;
   }
 

--- a/app/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
+++ b/app/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
@@ -44,7 +44,7 @@ const DiagnosticsSection = ({ diagnostics }: Props) => {
       {diagnostics.map(({ severity, message, source, startColumn, startLineNumber }, i) => {
         const severityLabel = invert(DiagnosticSeverity)[severity];
         const errorLoc =
-          startLineNumber != null && startColumn != null
+          startLineNumber != undefined && startColumn != undefined
             ? `[${startLineNumber + 1},${startColumn + 1}]`
             : undefined;
         return (

--- a/app/panels/NodePlayground/BottomBar/LogsSection.tsx
+++ b/app/panels/NodePlayground/BottomBar/LogsSection.tsx
@@ -69,7 +69,7 @@ const LogsSection = ({ nodeId, logs, clearLogs }: Props) => {
       </button>
       <ul>
         {logs.map(({ source, value }, idx) => {
-          const renderTreeObj = value != null && typeof value === "object";
+          const renderTreeObj = value != undefined && typeof value === "object";
           return (
             <SListItem
               key={`${idx}${source}`}
@@ -79,7 +79,7 @@ const LogsSection = ({ nodeId, logs, clearLogs }: Props) => {
                 <Tree hideRoot data={value} invertTheme={false} theme={jsonTreeTheme} />
               ) : (
                 <span style={{ color: (valueColorMap as any)[typeof value] || colors.LIGHT }}>
-                  {value == null || value === false ? String(value) : value}
+                  {value == undefined || value === false ? String(value) : value}
                 </span>
               )}
               <div style={{ color: colors.DARK9, textDecoration: "underline" }}>{source}</div>

--- a/app/panels/PanelList/index.tsx
+++ b/app/panels/PanelList/index.tsx
@@ -322,15 +322,15 @@ function PanelList(props: Props) {
   ]);
 
   const highlightedPanel = React.useMemo(
-    () => (highlightedPanelIdx != null ? filteredItems[highlightedPanelIdx] : null),
+    () => (highlightedPanelIdx != undefined ? filteredItems[highlightedPanelIdx] : null),
     [filteredItems, highlightedPanelIdx],
   );
 
   const onKeyDown = React.useCallback(
     (e) => {
-      if (e.key === "ArrowDown" && highlightedPanelIdx != null) {
+      if (e.key === "ArrowDown" && highlightedPanelIdx != undefined) {
         setHighlightedPanelIdx((highlightedPanelIdx + 1) % filteredItems.length);
-      } else if (e.key === "ArrowUp" && highlightedPanelIdx != null) {
+      } else if (e.key === "ArrowUp" && highlightedPanelIdx != undefined) {
         const newIdx = (highlightedPanelIdx - 1) % (filteredItems.length - 1);
         setHighlightedPanelIdx(newIdx >= 0 ? newIdx : filteredItems.length + newIdx);
       } else if (e.key === "Enter" && highlightedPanel) {

--- a/app/panels/Plot/PlotChart.tsx
+++ b/app/panels/Plot/PlotChart.tsx
@@ -198,7 +198,7 @@ function getDatasetAndTooltipsFromMessagePlotPath(
 
   let hasMismatchedData =
     isCustomScale(xAxisVal) &&
-    xAxisRanges != null &&
+    xAxisRanges != undefined &&
     (yAxisRanges.length !== xAxisRanges.length ||
       xAxisRanges.every((range, rangeIndex) => range.length !== yAxisRanges[rangeIndex]?.length));
   let rangesOfTooltips: TimeBasedChartTooltipData[][] = [];

--- a/app/panels/Plot/PlotLegend.tsx
+++ b/app/panels/Plot/PlotLegend.tsx
@@ -71,7 +71,7 @@ export default function PlotLegend(props: PlotLegendProps) {
 
   const onInputChange = useCallback(
     (value: string, index?: number) => {
-      if (index == null) {
+      if (index == undefined) {
         throw new Error("index not set");
       }
       const newPaths = paths.slice();
@@ -83,7 +83,7 @@ export default function PlotLegend(props: PlotLegendProps) {
 
   const onInputTimestampMethodChange = useCallback(
     (value: TimestampMethod, index?: number) => {
-      if (index == null) {
+      if (index == undefined) {
         throw new Error("index not set");
       }
       const newPaths = paths.slice();

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -142,7 +142,7 @@ function Plot(props: Props) {
     () =>
       saveConfig({
         followingViewWidth:
-          currentViewWidth.current != null ? currentViewWidth.current.toString() : "",
+          currentViewWidth.current != undefined ? currentViewWidth.current.toString() : "",
       }),
     [saveConfig],
   );
@@ -150,8 +150,8 @@ function Plot(props: Props) {
   const setMinMax = useCallback(
     () =>
       saveConfig({
-        minYValue: currentMinY.current != null ? currentMinY.current.toString() : "",
-        maxYValue: currentMaxY.current != null ? currentMaxY.current.toString() : "",
+        minYValue: currentMinY.current != undefined ? currentMinY.current.toString() : "",
+        maxYValue: currentMaxY.current != undefined ? currentMaxY.current.toString() : "",
       }),
     [currentMaxY, currentMinY, saveConfig],
   );
@@ -200,7 +200,7 @@ function Plot(props: Props) {
   // If every streaming key is in the blocks, just use the blocks object for a stable identity.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const mergedItems = Object.keys(streamedItemsByPath).every(
-    (path) => (blockItemsByPath as any)[path] != null,
+    (path) => (blockItemsByPath as any)[path] != undefined,
   )
     ? blockItemsByPath
     : { ...streamedItemsByPath, ...blockItemsByPath };
@@ -238,18 +238,18 @@ function Plot(props: Props) {
   const preloadingStartTime = timeToXValueForPreloading(startTime); // zero or undefined
   const preloadingEndTime = timeToXValueForPreloading(endTime);
   let defaultView;
-  if (preloadingDisplayTime != null) {
-    if (followingViewWidth != null && parseFloat(followingViewWidth) > 0) {
+  if (preloadingDisplayTime != undefined) {
+    if (followingViewWidth != undefined && parseFloat(followingViewWidth) > 0) {
       // Will be ignored in TimeBasedChart for non-preloading plots and non-timestamp plots.
       defaultView = { type: "following", width: parseFloat(followingViewWidth) };
-    } else if (preloadingStartTime != null && preloadingEndTime != null) {
+    } else if (preloadingStartTime != undefined && preloadingEndTime != undefined) {
       defaultView = { type: "fixed", minXValue: preloadingStartTime, maxXValue: preloadingEndTime };
     }
   }
 
   const onClick = useCallback(
     (_, __, { X_AXIS_ID: seekSeconds }) => {
-      if (!startTime || seekSeconds == null || !seek || xAxisVal !== "timestamp") {
+      if (!startTime || seekSeconds == undefined || !seek || xAxisVal !== "timestamp") {
         return;
       }
       // The player validates and clamps the time.

--- a/app/panels/Publish/buildSampleMessage.ts
+++ b/app/panels/Publish/buildSampleMessage.ts
@@ -35,7 +35,7 @@ export default function buildSampleMessage(
   datatype: string,
 ): any | undefined {
   const builtin = (builtinSampleValues as any)[datatype];
-  if (builtin != null) {
+  if (builtin != undefined) {
     return builtin;
   }
   const fields = datatypes[datatype].fields;
@@ -49,7 +49,7 @@ export default function buildSampleMessage(
     }
     const sample = buildSampleMessage(datatypes, field.type);
     if (field.isArray) {
-      if (field.arrayLength != null) {
+      if (field.arrayLength != undefined) {
         obj[field.name] = new Array(field.arrayLength).fill(sample);
       } else {
         obj[field.name] = [sample];

--- a/app/panels/Publish/index.tsx
+++ b/app/panels/Publish/index.tsx
@@ -150,9 +150,9 @@ class Publish extends React.PureComponent<Props, PanelState> {
     // the user's message just because state.cachedProps.config hasn't been initialized.
     if (
       props.config.datatype &&
-      state.cachedProps?.config?.datatype != null &&
+      state.cachedProps?.config?.datatype != undefined &&
       props.config.datatype !== state.cachedProps?.config?.datatype &&
-      props.datatypes[props.config.datatype] != null
+      props.datatypes[props.config.datatype] != undefined
     ) {
       const sampleMessage = buildSampleMessage(props.datatypes, props.config.datatype);
       if (sampleMessage) {

--- a/app/panels/RawMessages/getDiff.ts
+++ b/app/panels/RawMessages/getDiff.ts
@@ -47,7 +47,7 @@ export default function getDiff(
     const allItems = before.concat(after);
     if (allItems[0] && typeof allItems[0] === "object") {
       let candidateIdsToCompareWith: any = {};
-      if (allItems[0].id != null) {
+      if (allItems[0].id != undefined) {
         candidateIdsToCompareWith.id = { before: [], after: [] };
       }
       for (const key in allItems[0]) {
@@ -60,14 +60,14 @@ export default function getDiff(
       }
       for (const idKey in candidateIdsToCompareWith) {
         for (const beforeItem of before) {
-          if (beforeItem[idKey] != null) {
+          if (beforeItem[idKey] != undefined) {
             candidateIdsToCompareWith[idKey].before.push(beforeItem[idKey]);
           }
         }
       }
       for (const idKey in candidateIdsToCompareWith) {
         for (const afterItem of after) {
-          if (afterItem[idKey] != null) {
+          if (afterItem[idKey] != undefined) {
             candidateIdsToCompareWith[idKey].after.push(afterItem[idKey]);
           }
         }

--- a/app/panels/RawMessages/getValueActionForValue.ts
+++ b/app/panels/RawMessages/getValueActionForValue.ts
@@ -55,7 +55,7 @@ export function getValueActionForValue(
   let structureItem: MessagePathStructureItem | undefined = rootStructureItem;
   // Walk down the keyPath, while updating `value` and `structureItem`
   for (const pathItem of keyPath) {
-    if (structureItem == null || value == null) {
+    if (structureItem == undefined || value == undefined) {
       break;
     } else if (isObjectElement(value, pathItem, structureItem)) {
       structureItem =
@@ -89,7 +89,11 @@ export function getValueActionForValue(
           isTypicalFilterName(key),
         );
       }
-      if (typeof value === "object" && value != null && typeof typicalFilterName === "string") {
+      if (
+        typeof value === "object" &&
+        value != undefined &&
+        typeof typicalFilterName === "string"
+      ) {
         singleSlicePath += `[:]{${typicalFilterName}==${
           JSON.stringify(getField(value, typicalFilterName)) || ""
         }}`;
@@ -105,7 +109,7 @@ export function getValueActionForValue(
     }
   }
   // At this point we should be looking at a primitive. If not, just return nothing.
-  if (structureItem && structureItem.structureType === "primitive" && value != null) {
+  if (structureItem && structureItem.structureType === "primitive" && value != undefined) {
     if (pivotPath && isTypicalFilterName((last(keyPath) as any).toString())) {
       return { type: "pivot", pivotPath };
     }
@@ -138,7 +142,7 @@ export const getStructureItemForPath = memoizeWeak(
     let structureItem: MessagePathStructureItem | undefined = rootStructureItem;
     // Walk down the keyPath, while updating `value` and `structureItem`
     for (const pathItem of keyPath) {
-      if (structureItem == null) {
+      if (structureItem == undefined) {
         break;
       } else if (structureItem.structureType === "message" && typeof pathItem === "string") {
         structureItem = structureItem.nextByName[pathItem];

--- a/app/panels/RawMessages/index.tsx
+++ b/app/panels/RawMessages/index.tsx
@@ -99,7 +99,7 @@ const isSingleElemArray = (obj: any) => {
     return false;
   }
   const arr = isArrayView(obj) ? cast<ArrayView<any>>(obj).toArray() : cast<any[]>(obj);
-  return arr.filter((a) => a != null).length === 1;
+  return arr.filter((a) => a != undefined).length === 1;
 };
 const dataWithoutWrappingArray = (data: any) => {
   return isSingleElemArray(data) && typeof getIndex(data, 0) === "object"
@@ -318,7 +318,7 @@ function RawMessages(props: Props) {
 
   const renderSingleTopicOrDiffOutput = useCallback(() => {
     let shouldExpandNode;
-    if (expandAll != null) {
+    if (expandAll != undefined) {
       shouldExpandNode = () => expandAll;
     } else {
       shouldExpandNode = (keypath: any) => {
@@ -349,7 +349,7 @@ function RawMessages(props: Props) {
     const shouldDisplaySingleVal =
       (data !== undefined && typeof data !== "object") ||
       (isSingleElemArray(data) &&
-        getIndex(data, 0) != null &&
+        getIndex(data, 0) != undefined &&
         typeof getIndex(data, 0) !== "object");
     const singleVal = isSingleElemArray(data) ? getIndex(data, 0) : data;
 
@@ -413,7 +413,7 @@ function RawMessages(props: Props) {
               postprocessValue={(rawVal: unknown) => {
                 const val = maybeShallowParse(rawVal);
                 if (
-                  val != null &&
+                  val != undefined &&
                   typeof val === "object" &&
                   Object.keys(val as any).length === 1 &&
                   diffLabelTexts.includes(Object.keys(val as any)[0])

--- a/app/panels/RawMessages/utils.tsx
+++ b/app/panels/RawMessages/utils.tsx
@@ -46,7 +46,7 @@ export function getItemString(type: string, data: any, itemType: string, itemStr
   const keys = Object.keys(data);
   if (keys.length === 2) {
     const { sec, nsec } = data;
-    if (sec != null && nsec != null) {
+    if (sec != undefined && nsec != undefined) {
       // Values "too small" to be absolute epoch-based times are probably relative durations.
       return sec < DURATION_20_YEARS_SEC ? formatDuration(data) : <span>{format(data)}</span>;
     }
@@ -55,7 +55,7 @@ export function getItemString(type: string, data: any, itemType: string, itemStr
   // for vectors/points display length
   if (keys.length === 2) {
     const { x, y } = data;
-    if (x != null && y != null) {
+    if (x != undefined && y != undefined) {
       const length = Math.sqrt(x * x + y * y);
       return (
         <span>
@@ -67,7 +67,7 @@ export function getItemString(type: string, data: any, itemType: string, itemStr
 
   if (keys.length === 3) {
     const { x, y, z } = data;
-    if (x != null && y != null && z != null) {
+    if (x != undefined && y != undefined && z != undefined) {
       const length = Math.sqrt(x * x + y * y + z * z);
       return (
         <span>

--- a/app/panels/SourceInfo/index.tsx
+++ b/app/panels/SourceInfo/index.tsx
@@ -146,7 +146,7 @@ function SourceInfo(): ReactNode {
               >
                 {t.datatype}
               </SCell>
-              {t.numMessages != null ? (
+              {t.numMessages != undefined ? (
                 <SCell>
                   {t.numMessages} msgs ({(t.numMessages / toSec(duration)).toFixed(2)} Hz)
                 </SCell>

--- a/app/panels/StateTransitions/index.tsx
+++ b/app/panels/StateTransitions/index.tsx
@@ -193,7 +193,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const { config, saveConfig, isHovered } = props;
 
   const onInputChange = (value: string, index?: number) => {
-    if (index == null) {
+    if (index == undefined) {
       throw new Error("index not set");
     }
     const newPaths = config.paths.slice();
@@ -202,7 +202,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   };
 
   const onInputTimestampMethodChange = (value: TimestampMethod, index: number | undefined) => {
-    if (index == null) {
+    if (index == undefined) {
       throw new Error("index not set");
     }
     const newPaths = config.paths.slice();

--- a/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -208,7 +208,8 @@ const FollowTFControl = memo<Props>((props: Props) => {
   }, [onMouseLeaveDebounced, setHovering]);
 
   const followingCustomFrame = tfToFollow && tfToFollow !== getDefaultFollowTransformFrame();
-  const showFrameList = lastSelectedFrame != null || forceShowFrameList || followingCustomFrame;
+  const showFrameList =
+    lastSelectedFrame != undefined || forceShowFrameList || followingCustomFrame;
   const selectedFrameId = tfToFollow || lastSelectedFrame;
   const selectedItem = selectedFrameId ? { tf: { id: selectedFrameId }, depth: 0 } : undefined;
 

--- a/app/panels/ThreeDimensionalViz/PositionControl.tsx
+++ b/app/panels/ThreeDimensionalViz/PositionControl.tsx
@@ -37,7 +37,7 @@ export function parsePosition(input: string): Vec3 | undefined {
   if (parts.length === 2 || parts.length === 3) {
     const x = parseMatch(parts[0]);
     const y = parseMatch(parts[1]);
-    if (x != null && y != null) {
+    if (x != undefined && y != undefined) {
       return [x, y, 0];
     }
   }

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
@@ -50,7 +50,7 @@ class MessageWithLifetime {
     if (!currentTime) {
       return false;
     }
-    if (this.lifetime == null) {
+    if (this.lifetime == undefined) {
       // Do not expire markers if we can't tell what their lifetime is.
       // They'll be flushed later if needed (see flush below)
       return false;
@@ -98,7 +98,7 @@ export default class MessageCollector {
   flush() {
     // clear out all undefined lifetime markers
     this.markers.forEach((marker, key) => {
-      if (marker.lifetime == null) {
+      if (marker.lifetime == undefined) {
         this.markers.delete(key);
       }
     });
@@ -138,7 +138,7 @@ export default class MessageCollector {
     // Topics are expected to have data in one of these two "modes" at a time.
     // Non-marker messages are not expected to have names, as they have no "delete" operation.
 
-    if (lifetime != null) {
+    if (lifetime != undefined) {
       // Assuming that all future messages will have a decay time set,
       // we need to immediately expire any pre-existing message that didn't have a decay time.
       this.markers.delete(topic);

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -109,7 +109,7 @@ const missingTransformMessage = (
   transforms: Transforms,
   skipTransform: SkipTransformSpec | undefined,
 ): string => {
-  if (skipTransform != null && error.frameIds.has(skipTransform.frameId)) {
+  if (skipTransform != undefined && error.frameIds.has(skipTransform.frameId)) {
     return `missing transform. Is ${skipTransform.sourceTopic} present?`;
   }
   if (transforms.empty) {
@@ -452,7 +452,7 @@ export default class SceneBuilder implements MarkerProvider {
       return (
         (this.selectedNamespacesByTopic[topic] &&
           this.selectedNamespacesByTopic[topic].has(name)) ||
-        this.selectedNamespacesByTopic[topic] == null
+        this.selectedNamespacesByTopic[topic] == undefined
       );
     }
     return some(this.enabledNamespaces, (ns) => ns.topic === topic && ns.name === name);

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -44,7 +44,7 @@ export default function PoseSettingsEditor(
   const settingsByCarType = React.useMemo(() => {
     switch (settings.modelType) {
       case "car-model": {
-        const alpha = settings.alpha != null ? settings.alpha : 1;
+        const alpha = settings.alpha != undefined ? settings.alpha : 1;
         return (
           <Flex col>
             <SLabel>Alpha</SLabel>

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
@@ -49,7 +49,7 @@ export function topicSettingsEditorForDatatype(
 }
 
 export function canEditDatatype(datatype: string): boolean {
-  return topicSettingsEditorForDatatype(datatype) != null;
+  return topicSettingsEditorForDatatype(datatype) != undefined;
 }
 
 export function canEditNamespaceOverrideColorDatatype(datatype: string): boolean {

--- a/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -684,12 +684,12 @@ export default function useTree({
         return false;
       } else if (node.type === "group") {
         // Group node
-        return node.name != null && node.name.toLowerCase().includes(searchText);
+        return node.name != undefined && node.name.toLowerCase().includes(searchText);
       }
       // Topic node, without namespace
       return (
         node.topicName.toLowerCase().includes(searchText) ||
-        (node.name != null && node.name.toLowerCase().includes(searchText)) ||
+        (node.name != undefined && node.name.toLowerCase().includes(searchText)) ||
         (hasFeatureColumn &&
           `${SECOND_SOURCE_PREFIX}${node.topicName}`.toLowerCase().includes(searchText))
       );

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
@@ -105,7 +105,7 @@ function extractValues({
     for (let j = 0; j < readers.length; j++) {
       const reader = readers[j];
       let value = Number.NaN;
-      if (reader != null) {
+      if (reader != undefined) {
         value = reader.read(data, pointStart);
       }
       buffer[i * COMPONENT_COUNT + j] = value;

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
@@ -45,7 +45,7 @@ export function decodeMarker(marker: PointCloudMarker) {
 
   const colorMode: ColorMode = settings.colorMode
     ? settings.colorMode
-    : rgbOffset != null
+    : rgbOffset != undefined
     ? { mode: "rgb" }
     : { mode: "flat", flatColor: DEFAULT_FLAT_COLOR };
 
@@ -80,12 +80,12 @@ export function decodeMarker(marker: PointCloudMarker) {
   // These calculations can be ignored if we're rendering to the hitmap
   if (colorBuffer && !isHitmap && (colorMode.mode === "gradient" || colorMode.mode === "rainbow")) {
     let hasMinValue = false;
-    if (colorMode.minValue != null) {
+    if (colorMode.minValue != undefined) {
       hasMinValue = true;
       minColorValue = colorMode.minValue;
     }
     let hasMaxValue = false;
-    if (colorMode.maxValue != null) {
+    if (colorMode.maxValue != undefined) {
       hasMaxValue = true;
       maxColorValue = colorMode.maxValue;
     }

--- a/app/panels/ThreeDimensionalViz/stories/storyComponents.tsx
+++ b/app/panels/ThreeDimensionalViz/stories/storyComponents.tsx
@@ -147,7 +147,7 @@ export class FixtureExample extends React.Component<FixtureExampleProps, Fixture
             config={this.state.config as any}
             saveConfig={(config) => this.setState({ config: { ...this.state.config, ...config } })}
           />
-          {this.props.futureTime != null && (
+          {this.props.futureTime != undefined && (
             <div style={{ height: "100px" }}>
               <GlobalVariableSliderPanel
                 config={{

--- a/app/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
+++ b/app/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
@@ -92,7 +92,7 @@ export function useTransformedCameraState({
     }
   }
   // Read the distance from URL when World is first loaded with empty cameraState distance in savedProps
-  if (configCameraState?.distance == null) {
+  if (configCameraState?.distance == undefined) {
     transformedCameraState.distance = getZoomDistanceFromURLParam();
   }
 

--- a/app/panels/TwoDimensionalPlot/index.tsx
+++ b/app/panels/TwoDimensionalPlot/index.tsx
@@ -81,7 +81,7 @@ const keysToPick = [
 const messagePathInputStyle = { height: "100%" };
 
 const isValidMinMaxVal = (val?: string) => {
-  return val == null || val === "" || !isNaN(parseFloat(val));
+  return val == undefined || val === "" || !isNaN(parseFloat(val));
 };
 
 type Path = { value: string };
@@ -171,9 +171,9 @@ const HoverBar = React.memo<HoverBarProps>(function HoverBar({
   // We avoid putting the visibility and transforms into react state to try to keep updates snappy.
   // Mouse interactions are frequent, and adding/removing the bar from the DOM would slow things
   // down a lot more than mutating the style props does.
-  if (wrapper.current != null) {
+  if (wrapper.current != undefined) {
     const { current } = wrapper;
-    if (mousePosition != null) {
+    if (mousePosition != undefined) {
       showBar(current, mousePosition.x);
     } else {
       hideBar(current);
@@ -462,7 +462,7 @@ function TwoDimensionalPlot(props: Props) {
     (scales) => {
       scaleBounds.current = scales;
       const firstYScale = scales.find(({ axes }: any) => axes === "yAxes");
-      if (firstYScale != null && hoverBar.current != null) {
+      if (firstYScale != undefined && hoverBar.current != undefined) {
         const { current } = hoverBar;
         const topPx = Math.min(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);
         const bottomPx = Math.max(firstYScale.minAlongAxis, firstYScale.maxAlongAxis);

--- a/app/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/app/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -85,7 +85,7 @@ class DiagnosticStatusPanel extends React.Component<Props> {
     } = config;
 
     const selectedDisplayName =
-      selectedHardwareId != null
+      selectedHardwareId != undefined
         ? getDisplayName(selectedHardwareId, selectedName || "")
         : undefined;
     return (
@@ -94,16 +94,16 @@ class DiagnosticStatusPanel extends React.Component<Props> {
           {(buffer) => {
             let selectedItem; // selected by name+hardware_id
             let selectedItems; // [selectedItem], or all diagnostics with selectedHardwareId if no name is selected
-            if (selectedHardwareId != null) {
+            if (selectedHardwareId != undefined) {
               const items = [];
               const diagnosticsByName = buffer.diagnosticsByNameByTrimmedHardwareId.get(
                 trimHardwareId(selectedHardwareId),
               );
-              if (diagnosticsByName != null) {
+              if (diagnosticsByName != undefined) {
                 for (const diagnostic of diagnosticsByName.values()) {
-                  if (selectedName == null || selectedName === diagnostic.status.name) {
+                  if (selectedName == undefined || selectedName === diagnostic.status.name) {
                     items.push(diagnostic);
-                    if (selectedName != null) {
+                    if (selectedName != undefined) {
                       selectedItem = diagnostic;
                     }
                   }

--- a/app/panels/diagnostics/DiagnosticSummary.tsx
+++ b/app/panels/diagnostics/DiagnosticSummary.tsx
@@ -207,7 +207,7 @@ class DiagnosticSummary extends React.Component<Props> {
                 const diagnosticsByName = buffer.diagnosticsByNameByTrimmedHardwareId.get(
                   trimmedHardwareId,
                 );
-                if (diagnosticsByName == null) {
+                if (diagnosticsByName == undefined) {
                   return;
                 }
                 return diagnosticsByName.get(name);

--- a/app/panels/diagnostics/DiagnosticsHistory.ts
+++ b/app/panels/diagnostics/DiagnosticsHistory.ts
@@ -57,7 +57,7 @@ function maybeAddMessageToBuffer(buffer: DiagnosticsBuffer, message: Message): b
     const hardwareDiagnosticsByName = buffer.diagnosticsByNameByTrimmedHardwareId.get(
       trimmedHardwareId,
     );
-    if (hardwareDiagnosticsByName == null) {
+    if (hardwareDiagnosticsByName == undefined) {
       newHardwareId = true;
       newDiagnostic = true;
       buffer.diagnosticsByNameByTrimmedHardwareId.set(

--- a/app/panels/diagnostics/util.ts
+++ b/app/panels/diagnostics/util.ts
@@ -79,7 +79,7 @@ export function trimHardwareId(hardwareId: string): string {
 
 export function getDiagnosticId(hardwareId: string, name?: string): DiagnosticId {
   const trimmedHardwareId = trimHardwareId(hardwareId);
-  return name != null ? `|${trimmedHardwareId}|${name}|` : `|${trimmedHardwareId}|`;
+  return name != undefined ? `|${trimmedHardwareId}|${name}|` : `|${trimmedHardwareId}|`;
 }
 
 export function getDisplayName(hardwareId: string, name: string) {

--- a/app/players/OrderedStampPlayer.test.ts
+++ b/app/players/OrderedStampPlayer.test.ts
@@ -35,7 +35,7 @@ function makeMessage(
     topic,
     message: {
       header: {
-        stamp: headerStamp == null ? undefined : fromSec(headerStamp),
+        stamp: headerStamp == undefined ? undefined : fromSec(headerStamp),
       },
     },
     receiveTime: fromSec(receiveTime),
@@ -52,7 +52,7 @@ function makeBobject(
     receiveTime: fromSec(receiveTime),
     message: wrapJsObject(basicDatatypes, "geometry_msgs/PoseStamped", {
       header: {
-        stamp: headerStamp == null ? undefined : fromSec(headerStamp),
+        stamp: headerStamp == undefined ? undefined : fromSec(headerStamp),
       },
       pose: { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 0 } },
     }),
@@ -171,7 +171,7 @@ describe("OrderedStampPlayer", () => {
     const bobjects = states[0].activeData?.bobjects;
     const topics = states[0].activeData?.topics;
 
-    if (bobjects == null) {
+    if (bobjects == undefined) {
       throw new Error("Satisfy flow.");
     }
     expect(

--- a/app/players/RandomAccessPlayer.ts
+++ b/app/players/RandomAccessPlayer.ts
@@ -363,7 +363,7 @@ export default class RandomAccessPlayer implements Player {
     // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
     // cause the next frame to also be unnecessarily slow by increasing the frame size.
     let rangeMillis = Math.min(durationMillis * this._speed, 300);
-    if (this._lastRangeMillis != null) {
+    if (this._lastRangeMillis != undefined) {
       rangeMillis = this._lastRangeMillis * 0.9 + rangeMillis * 0.1;
     }
     this._lastRangeMillis = rangeMillis;
@@ -457,9 +457,9 @@ export default class RandomAccessPlayer implements Player {
       parsedMessages: parsedTopics,
     });
     const { parsedMessages, bobjects } = messages;
-    if (parsedMessages == null || bobjects == null) {
+    if (parsedMessages == undefined || bobjects == undefined) {
       const messageTypes = Object.keys(messages)
-        .filter((type) => (messages as any)[type] != null)
+        .filter((type) => (messages as any)[type] != undefined)
         .join("\n");
       sendNotification(
         "Bad set of message types in RandomAccessPlayer",

--- a/app/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
+++ b/app/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
@@ -36,7 +36,7 @@ export const containsFuncDeclaration = (args: any[]) => {
   for (const arg of args) {
     if (typeof arg === "function") {
       return true;
-    } else if (arg != null && typeof arg === "object") {
+    } else if (arg != undefined && typeof arg === "object") {
       for (const value of Object.values(arg)) {
         if (containsFuncDeclaration([value])) {
           return true;
@@ -50,7 +50,7 @@ export const containsFuncDeclaration = (args: any[]) => {
 export const stringifyFuncsInObject = (arg: any) => {
   if (typeof arg === "function") {
     return `${arg}`;
-  } else if (arg != null && typeof arg === "object") {
+  } else if (arg != undefined && typeof arg === "object") {
     const newArg = { ...arg };
     for (const [key, value] of Object.entries(arg)) {
       newArg[key] = stringifyFuncsInObject(value);

--- a/app/players/automatedRun/AutomatedRunPlayer.ts
+++ b/app/players/automatedRun/AutomatedRunPlayer.ts
@@ -158,7 +158,7 @@ export default class AutomatedRunPlayer implements Player {
       bobjects: bobjectTopics,
     });
     const { parsedMessages, rosBinaryMessages, bobjects } = messages;
-    if (rosBinaryMessages?.length || bobjects == null || parsedMessages == null) {
+    if (rosBinaryMessages?.length || bobjects == undefined || parsedMessages == undefined) {
       const messageTypes = Object.keys(messages)
         .filter((kind) => (messages as any)[kind]?.length)
         .join(",");
@@ -314,7 +314,7 @@ export default class AutomatedRunPlayer implements Player {
   }
 
   async _onUpdateProgress() {
-    if (this._client.shouldLoadDataBeforePlaying && this._providerResult != null) {
+    if (this._client.shouldLoadDataBeforePlaying && this._providerResult != undefined) {
       // Update the view and do preloading calculations. Not necessary if we're already playing.
       this._emitState([], [], this._providerResult.start);
     }
@@ -328,7 +328,7 @@ export default class AutomatedRunPlayer implements Player {
   }
 
   _readyToPlay() {
-    if (!this._startCalled || this._providerResult == null) {
+    if (!this._startCalled || this._providerResult == undefined) {
       return false;
     }
     if (!this._client.shouldLoadDataBeforePlaying) {

--- a/app/players/automatedRun/performanceMeasuringClient.ts
+++ b/app/players/automatedRun/performanceMeasuringClient.ts
@@ -122,7 +122,7 @@ class PerformanceMeasuringClient {
 
   markFrameRenderEnd() {
     const frameRenderStart = this.frameRenderStart;
-    if (frameRenderStart == null) {
+    if (frameRenderStart == undefined) {
       throw new Error("Called markFrameRenderEnd without calling markFrameRenderStart");
     }
     if (this.enablePerformanceMarks) {
@@ -144,7 +144,7 @@ class PerformanceMeasuringClient {
 
   markPreloadEnd() {
     const { preloadStart } = this;
-    if (preloadStart == null) {
+    if (preloadStart == undefined) {
       throw new Error("Called markPreloadEnd without calling markPreloadStart");
     }
     if (this.enablePerformanceMarks) {
@@ -163,7 +163,7 @@ class PerformanceMeasuringClient {
 
   markTotalFrameEnd() {
     const totalFrameMs = this.totalFrameMs;
-    if (totalFrameMs == null) {
+    if (totalFrameMs == undefined) {
       throw new Error("Called markTotalFrameEnd without calling markTotalFrameStart");
     }
     this.totalFrameTimes.push(round(performance.now() - totalFrameMs));
@@ -211,7 +211,7 @@ class PerformanceMeasuringClient {
     const bagLengthMs = this.bagLengthMs;
     const preloadTimeMs = this.preloadTimeMs;
 
-    if (startTime == null || bagLengthMs == null) {
+    if (startTime == undefined || bagLengthMs == undefined) {
       throw new Error("Cannot call finish() without calling start()");
     }
 

--- a/app/players/nodes.ts
+++ b/app/players/nodes.ts
@@ -89,7 +89,7 @@ function validateDatatypes({ output, datatypes }: NodeDefinition<any>) {
       }
     }
   }
-  if (datatypes[output.datatype] == null) {
+  if (datatypes[output.datatype] == undefined) {
     throw new Error(`The datatype "${output.datatype}" is not defined for node "${output.name}"`);
   }
 }

--- a/app/reducers/panels.ts
+++ b/app/reducers/panels.ts
@@ -117,7 +117,7 @@ let initialPersistedState: PersistedState | undefined = undefined;
 export function getInitialPersistedStateAndMaybeUpdateLocalStorageAndURL(
   history: any,
 ): PersistedState {
-  if (initialPersistedState == null) {
+  if (initialPersistedState == undefined) {
     const defaultPersistedState = Object.freeze(getGlobalHooks().getDefaultPersistedState());
     const oldPersistedState: any = storage.getItem(GLOBAL_STATE_STORAGE_KEY);
 
@@ -600,7 +600,7 @@ const dragWithinSameTab = (
         ...sourceTabChildConfigs,
       ],
     });
-  } else if (currentTabLayout != null) {
+  } else if (currentTabLayout != undefined) {
     const updates = createDragToUpdates(currentTabLayout, ownPath, destinationPath, position);
     const newTree = updateTree(currentTabLayout, updates);
 
@@ -874,7 +874,7 @@ const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsS
     return changePanelLayout(panelsState, { layout: originalLayout, trimSavedProps: false });
   }
 
-  if (position != null && destinationPath != null && !isEqual(destinationPath, ownPath)) {
+  if (position != undefined && destinationPath != undefined && !isEqual(destinationPath, ownPath)) {
     const updates = createDragToUpdates(originalLayout, ownPath, destinationPath, position);
     const newLayout = updateTree(originalLayout, updates);
     return changePanelLayout(panelsState, { layout: newLayout, trimSavedProps: false });

--- a/app/reducers/recentLayouts.ts
+++ b/app/reducers/recentLayouts.ts
@@ -36,7 +36,7 @@ export function getRecentLayouts(): RecentLayoutId[] {
 export function maybeStoreNewRecentLayout(newPersistedState: PersistedState) {
   const oldRecentLayouts = getRecentLayouts();
   const newestRecentLayout = recentLayoutFromPersistedState(newPersistedState);
-  if (newestRecentLayout == null || oldRecentLayouts[0] === newestRecentLayout) {
+  if (newestRecentLayout == undefined || oldRecentLayouts[0] === newestRecentLayout) {
     return;
   }
 

--- a/app/shared/validators.ts
+++ b/app/shared/validators.ts
@@ -20,7 +20,7 @@ type Rules = {
 const layoutNameRegex = /[@%]/; // Don't allow these characters in layoutName.
 
 function isEmpty(value: any) {
-  return value == null;
+  return value == undefined;
 }
 
 export const isEmail = (value?: unknown): boolean => {
@@ -29,7 +29,7 @@ export const isEmail = (value?: unknown): boolean => {
 };
 
 export const isRequired = (value: any): string | undefined =>
-  value == null ? "is required" : undefined;
+  value == undefined ? "is required" : undefined;
 
 export const isNumber = (value: any): string | undefined =>
   !isEmpty(value) && typeof value !== "number" ? "must be a number" : undefined;
@@ -179,7 +179,7 @@ export const cameraStateValidator = (jsonData: any): ValidationResult | undefine
 const isXYPointArray = (value: any): string | undefined => {
   if (Array.isArray(value)) {
     for (const item of value) {
-      if (!item || item.x == null || item.y == null) {
+      if (!item || item.x == undefined || item.y == undefined) {
         return `must contain x and y points`;
       }
       if (typeof item.x !== "number" || typeof item.y !== "number") {

--- a/app/test/datatypes.ts
+++ b/app/test/datatypes.ts
@@ -37,7 +37,7 @@ const maybeInferJsonFieldType = (value: any, fieldName: string): FieldType | und
   // to make this pluggable in the future.
   // "Markers" sometimes have some missing fields, but these ones always seem to be present:
   const hasMarkerFields = ["header", "ns", "id", "type", "action", "pose"].every(
-    (field) => value[field] != null,
+    (field) => value[field] != undefined,
   );
   if (!hasMarkerFields) {
     return;
@@ -72,7 +72,7 @@ export const inferDatatypes = (fieldType: FieldType, value: any): FieldType => {
     return { isArray: fieldType.isArray, type: "bool" };
   } else if (ArrayBuffer.isView(value)) {
     return { isArray: true, type: "float64" };
-  } else if (value == null) {
+  } else if (value == undefined) {
     // Shouldn't happen, but we should be robust against it. Keep whatever information we have.
     return fieldType;
   } else if (value instanceof Array) {
@@ -90,7 +90,7 @@ export const inferDatatypes = (fieldType: FieldType, value: any): FieldType => {
   const inferredObject: any = ret.object;
   Object.keys(value).forEach((fieldName) => {
     const fieldValue = value[fieldName];
-    if (inferredObject[fieldName] == null) {
+    if (inferredObject[fieldName] == undefined) {
       const jsonFieldType = maybeInferJsonFieldType(value, fieldName);
       inferredObject[fieldName] = jsonFieldType ?? {
         type: "unknown",
@@ -143,7 +143,7 @@ export const createRosDatatypesFromFrame = (
   const ret = {};
   topics.forEach(({ name, datatype }) => {
     const messages = frame[name];
-    if (messages == null) {
+    if (messages == undefined) {
       return;
     }
     // We run type inference on every message because some messages may contain empty arrays,

--- a/app/test/setupTestFramework.ts
+++ b/app/test/setupTestFramework.ts
@@ -107,7 +107,7 @@ expect.extend({
   // This custom matcher is necessary because the standard `toEqual()` does not behave
   // like ==, and considers null/undefined to be unequal.
   toBeNullOrUndefined(received: unknown) {
-    const pass = received == null;
+    const pass = received == undefined;
     return {
       pass,
       actual: received,

--- a/app/util/addMessageDefaults.ts
+++ b/app/util/addMessageDefaults.ts
@@ -52,7 +52,7 @@ export default function addMessageDefaults(
   }
   for (const { name, type, isConstant, isArray } of datatypes[datatypeName].fields) {
     // Don't set any constant fields - they are not written anyways.
-    if (!isConstant && object[name] == null) {
+    if (!isConstant && object[name] == undefined) {
       if (isArray) {
         object[name] = [];
       } else if (rosPrimitiveTypes.has(type)) {
@@ -75,7 +75,7 @@ export default function addMessageDefaults(
       }
     } else if (!isConstant && isArray) {
       for (const index in object[name]) {
-        if (object[name][index] == null) {
+        if (object[name][index] == undefined) {
           object[name][index] = getPrimitiveDefault(type);
         }
       }

--- a/app/util/binaryObjects/BobjectRpc.ts
+++ b/app/util/binaryObjects/BobjectRpc.ts
@@ -73,19 +73,19 @@ export class BobjectRpcSender {
     additionalTransferables?: any,
   ): Promise<T> {
     const messageDatatypeInfo = getDatatypes(Object.getPrototypeOf(message).constructor);
-    if (messageDatatypeInfo == null) {
+    if (messageDatatypeInfo == undefined) {
       throw new Error("Missing datatypes for message. Likely not a bobject.");
     }
     const [datatypes, datatype] = messageDatatypeInfo;
     let datatypesIndex = this._datatypesIndices.get(datatypes);
-    if (datatypesIndex == null) {
+    if (datatypesIndex == undefined) {
       datatypesIndex = this._numberOfDatatypesSent;
       this._datatypesIndices.set(datatypes, datatypesIndex);
       this._numberOfDatatypesSent += 1;
       await this._rpc.send("$$transferDatatypes", datatypes);
     }
     const binaryData = getBinaryData(message);
-    if (binaryData == null) {
+    if (binaryData == undefined) {
       // Reverse-wrapped bobject. Deep parse to transfer.
       const data = {
         action,
@@ -141,7 +141,7 @@ export class BobjectRpcReceiver {
     });
     rpc.receive("$$transferBobject", async (transferData: TransferData) => {
       const receiveFunction = this._receiveFunctions[transferData.action];
-      if (receiveFunction == null) {
+      if (receiveFunction == undefined) {
         throw new Error(`action ${transferData.action} not registered`);
       }
       return receiveFunction(transferData);

--- a/app/util/binaryObjects/__snapshots__/jsWrapperObjects.test.ts.snap
+++ b/app/util/binaryObjects/__snapshots__/jsWrapperObjects.test.ts.snap
@@ -14,7 +14,7 @@ class std_msgs_Header {
   }
   stamp() {
     const $fieldValue = this[$value].stamp;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new time($fieldValue);
@@ -38,14 +38,14 @@ class fake_msgs_HasComplexAndArray {
   }
   header() {
     const $fieldValue = this[$value].header;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new std_msgs_Header($fieldValue);
   }
   stringArray() {
     const $fieldValue = this[$value].stringArray;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new $PrimitiveArrayView($fieldValue);
@@ -65,7 +65,7 @@ class fake_msgs_HasComplexArray {
   }
   complexArray() {
     const $fieldValue = this[$value].complexArray;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasComplexAndArray$Array($fieldValue);
@@ -148,7 +148,7 @@ class fake_msgs_HasArrayOfEmpties {
   }
   arr() {
     const $fieldValue = this[$value].arr;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasConstant$Array($fieldValue);
@@ -167,56 +167,56 @@ class fake_msgs_ContainsEverything {
   }
   first() {
     const $fieldValue = this[$value].first;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new std_msgs_Header($fieldValue);
   }
   second() {
     const $fieldValue = this[$value].second;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasComplexAndArray($fieldValue);
   }
   third() {
     const $fieldValue = this[$value].third;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasComplexArray($fieldValue);
   }
   fourth() {
     const $fieldValue = this[$value].fourth;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasConstant($fieldValue);
   }
   fifth() {
     const $fieldValue = this[$value].fifth;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasByteArray($fieldValue);
   }
   sixth() {
     const $fieldValue = this[$value].sixth;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasJson($fieldValue);
   }
   seventh() {
     const $fieldValue = this[$value].seventh;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasInt64s($fieldValue);
   }
   eighth() {
     const $fieldValue = this[$value].eighth;
-    if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+    if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
       return $fieldValue;
     }
     return new fake_msgs_HasArrayOfEmpties($fieldValue);

--- a/app/util/binaryObjects/binaryWrapperObjects.ts
+++ b/app/util/binaryObjects/binaryWrapperObjects.ts
@@ -100,7 +100,7 @@ const printFieldDefinitionBody = (
 ): string => {
   if (field.isConstant) {
     const value = JSON.stringify(field.value);
-    if (value == null) {
+    if (value == undefined) {
       throw new Error(`Could not serialize constant value for field ${field.name}`);
     }
     return `return ${value};`;
@@ -170,7 +170,7 @@ const printDeepParseField = (
 
 const printDeepParseFunction = (typesByName: RosDatatypes, typeName: string): string => {
   const type = typesByName[typeName];
-  if (type == null) {
+  if (type == undefined) {
     throw new Error(`Unknown type "${typeName}"`);
   }
 
@@ -196,7 +196,7 @@ const printDeepParseMethod = (typeName: string): string => {
 const printClassDefinition = (typesByName: RosDatatypes, typeName: string): string => {
   let pointer = new PointerExpression("this[$offset]");
   const type = typesByName[typeName];
-  if (type == null) {
+  if (type == undefined) {
     throw new Error(`Unknown type "${typeName}"`);
   }
   const fieldDefinitions = type.fields.map((field) => {
@@ -230,7 +230,7 @@ const getTypesUsed = (typesByName: RosDatatypes, typeName: string): TypesUsed =>
     const nextFrontier: string[] = [];
     for (const nextTypeName of frontier) {
       const nextType = typesByName[nextTypeName];
-      if (nextType == null) {
+      if (nextType == undefined) {
         throw new Error(`Unknown type ${nextTypeName}`);
       }
       nextType.fields.forEach((field) => {

--- a/app/util/binaryObjects/index.ts
+++ b/app/util/binaryObjects/index.ts
@@ -105,7 +105,7 @@ export const getObjects = (
 export { deepParse, isBobject } from "./messageDefinitionUtils";
 
 export const isArrayView = (object: any): boolean => {
-  return isBobject(object) && object[Symbol.iterator] != null;
+  return isBobject(object) && object[Symbol.iterator] != undefined;
 };
 
 export const wrapJsObject = <T>(typesByName: RosDatatypes, typeName: string, object: any): T => {
@@ -125,7 +125,7 @@ export const wrapJsObject = <T>(typesByName: RosDatatypes, typeName: string, obj
 // so the shared storage is clear.
 export const inaccurateByteSize = (obj: any): number => {
   const data = getBinaryData(obj);
-  if (data != null) {
+  if (data != undefined) {
     return data.approximateSize;
   }
   if (reverseWrappedBobjects.has(obj)) {
@@ -143,7 +143,7 @@ export function bobjectFieldNames(bobject: any): string[] {
     throw new Error("Unknown constructor in bobjectFieldNames");
   }
   const datatype = typeInfo[0][typeInfo[1]];
-  if (datatype == null) {
+  if (datatype == undefined) {
     if (typeInfo[1] === "time" || typeInfo[1] === "duration") {
       return ["sec", "nsec"];
     }
@@ -177,7 +177,7 @@ export const merge = <T extends any>(
     shallow[field] = bobject[field]();
   });
   const datatypes = getDatatypes(Object.getPrototypeOf(bobject).constructor);
-  if (datatypes == null) {
+  if (datatypes == undefined) {
     throw new Error("Unknown type in merge");
   }
   return cast<T>(wrapJsObject(datatypes[0], datatypes[1], { ...shallow, ...overrides }));

--- a/app/util/binaryObjects/jsWrapperObjects.ts
+++ b/app/util/binaryObjects/jsWrapperObjects.ts
@@ -33,13 +33,13 @@ const arrayTypeName = (typeName: string): string => `${friendlyTypeName(typeName
 const printFieldDefinitionBody = (field: RosMsgField): string => {
   if (field.isConstant) {
     const value = JSON.stringify(field.value);
-    if (value == null) {
+    if (value == undefined) {
       throw new Error(`Could not serialize constant value for field ${field.name}`);
     }
     return `return ${value};`;
   }
   const complexExpression = (type: string) => `const $fieldValue = this[$value].${field.name};
-if ($fieldValue == null || $fieldValue[$deepParse] != null) {
+if ($fieldValue == undefined || $fieldValue[$deepParse] != undefined) {
   return $fieldValue;
 }
 return new ${type}($fieldValue);`;
@@ -82,7 +82,7 @@ const deepParseFieldExpression = ({
 
 const printClassDefinition = (typesByName: RosDatatypes, typeName: string): string => {
   const type = typesByName[typeName];
-  if (type == null) {
+  if (type == undefined) {
     throw new Error(`Unknown type "${typeName}"`);
   }
   const fieldDefinitions = type.fields.map((field) => indent(printFieldDefinition(field), 2));

--- a/app/util/binaryObjects/messageDefinitionUtils.ts
+++ b/app/util/binaryObjects/messageDefinitionUtils.ts
@@ -38,11 +38,11 @@ const primitiveSizes: Record<string, number> = {
 export const primitiveList: Set<string> = new Set(Object.keys(primitiveSizes));
 
 export const typeSize = memoize((typesByName: RosDatatypes, typeName: string): number => {
-  if (primitiveSizes[typeName] != null) {
+  if (primitiveSizes[typeName] != undefined) {
     return primitiveSizes[typeName];
   }
   const messageType = typesByName[typeName];
-  if (messageType == null) {
+  if (messageType == undefined) {
     throw new Error(`Unknown type: ${typeName}`);
   }
   // We add field sizes here, not type sizes. If the type has a field that's an array of strings,
@@ -102,11 +102,11 @@ export const isComplex = (typeName: string) => !primitiveList.has(typeName);
 
 // True for "object bobjects" and array views.
 export const isBobject = (object?: any): boolean => {
-  return object?.[deepParseSymbol] != null;
+  return object?.[deepParseSymbol] != undefined;
 };
 
 export const deepParse = (object?: any): any => {
-  if (object == null) {
+  if (object == undefined) {
     // Missing submessage fields are unfortunately common for constructed markers. This is not
     // principled, but it is pragmatic.
     return object;

--- a/app/util/datatypes.ts
+++ b/app/util/datatypes.ts
@@ -38,12 +38,12 @@ export const getTransitiveSubsetForDatatypes = (
     const nextDatatypesToExplore = new Set<string>();
     for (const datatype of datatypesToExplore) {
       const definition = allDatatypes[datatype];
-      if (definition == null) {
+      if (definition == undefined) {
         throw new Error(`Definition missing for type ${datatype}`);
       }
       ret[datatype] = definition;
       for (const field of definition.fields) {
-        if (isComplex(field.type) && ret[field.type] == null) {
+        if (isComplex(field.type) && ret[field.type] == undefined) {
           nextDatatypesToExplore.add(field.type);
         }
       }
@@ -218,7 +218,7 @@ function getGetDatatypeName() {
   let count = 0;
   const names: Record<string, unknown> = {};
   return (key: string) => {
-    if (names[key] == null) {
+    if (names[key] == undefined) {
       names[key] = `${prefix}_${count++}`;
     }
     return names[key];
@@ -285,7 +285,8 @@ export const getContentBasedDatatypes = (
     const definition = messageDefinitionsByTopic[topic];
     const parsedDefinition = parsedMessageDefinitionsByTopic[topic];
     // This "key" is just used to group topics with identical sets of datatypes.
-    const stringDefinitionKey = definition != null ? definition : JSON.stringify(parsedDefinition);
+    const stringDefinitionKey =
+      definition != undefined ? definition : JSON.stringify(parsedDefinition);
     if (topicsByStringDefinition[stringDefinitionKey]) {
       // Already generated datatypes for these message types.
       topicsByStringDefinition[stringDefinitionKey].push(topic);

--- a/app/util/getNewConnection.ts
+++ b/app/util/getNewConnection.ts
@@ -123,7 +123,7 @@ function getNewConnectionWithoutExistingConnection({
     } else {
       readAheadRange = { start: 0, end: fileSize };
     }
-  } else if (lastResolvedCallbackEnd != null) {
+  } else if (lastResolvedCallbackEnd != undefined) {
     // Otherwise, if we have a limited cache, we want to read the data right after the last
     // read request, because usually read requests are sequential without gaps.
     readAheadRange = {

--- a/app/util/logEvent.ts
+++ b/app/util/logEvent.ts
@@ -28,7 +28,7 @@ let eventTags: { readonly [key: string]: string } | undefined;
 export function getEventNames(): {
   readonly [key: string]: string;
 } {
-  if (eventNames == null) {
+  if (eventNames == undefined) {
     throw new Error(
       "Tried to get event names before they were set or tried to get event names in a web worker",
     );
@@ -38,7 +38,7 @@ export function getEventNames(): {
 export function getEventTags(): {
   readonly [key: string]: string;
 } {
-  if (eventTags == null) {
+  if (eventTags == undefined) {
     throw new Error(
       "Tried to get event tags before they were set or tried to get event tags in a web worker",
     );

--- a/app/util/minivizAPI.ts
+++ b/app/util/minivizAPI.ts
@@ -43,7 +43,7 @@ export type IframeEvent =
 
 function createMessageHandler(handleMessage: (eventData: IframeEvent) => void) {
   return (event: any) => {
-    if (!isInIFrame() || event.data == null || typeof event.data !== "object") {
+    if (!isInIFrame() || event.data == undefined || typeof event.data !== "object") {
       return;
     }
     handleMessage(event.data);

--- a/app/util/parseMessageDefinitionsCache.ts
+++ b/app/util/parseMessageDefinitionsCache.ts
@@ -88,7 +88,7 @@ class ParseMessageDefinitionCache {
     // What if we already have this message definition stored?
     if (md5Sum) {
       const storedDefinition = this.getStoredDefinition(md5Sum);
-      if (storedDefinition != null) {
+      if (storedDefinition != undefined) {
         return storedDefinition;
       }
     }

--- a/app/util/synchronizeMessages.ts
+++ b/app/util/synchronizeMessages.ts
@@ -20,7 +20,7 @@ import { StampedMessage } from "@foxglove-studio/app/types/Messages";
 export const defaultGetHeaderStamp = (
   message: Readonly<RosObject> | undefined,
 ): Time | undefined => {
-  if (message != null && message.header != null) {
+  if (message != undefined && message.header != undefined) {
     return cast<StampedMessage>(message).header.stamp;
   }
 };
@@ -65,7 +65,7 @@ function messagesMatchingStamp(
         : defaultGetHeaderStamp(message.message);
       return thisStamp && TimeUtil.areSame(stamp, thisStamp);
     });
-    if (synchronizedMessage != null) {
+    if (synchronizedMessage != undefined) {
       synchronizedMessagesByTopic[topic] = [synchronizedMessage];
     } else {
       return undefined;
@@ -94,7 +94,7 @@ export default function synchronizeMessages(
       messagesByTopic,
       getHeaderStamp,
     );
-    if (synchronizedMessagesByTopic != null) {
+    if (synchronizedMessagesByTopic != undefined) {
       return synchronizedMessagesByTopic;
     }
   }

--- a/app/util/time.ts
+++ b/app/util/time.ts
@@ -295,19 +295,19 @@ export function getSeekToTime(): SeekToTimeSpec {
     type: "relative",
     startOffset: fromNanoSec(SEEK_ON_START_NS),
   };
-  if (absoluteSeek != null) {
+  if (absoluteSeek != undefined) {
     return isNaN(+absoluteSeek)
       ? defaultResult
       : { type: "absolute", time: fromMillis(parseInt(absoluteSeek)) };
   }
   const relativeSeek = params.get(SEEK_TO_RELATIVE_MS_QUERY_KEY);
-  if (relativeSeek != null) {
+  if (relativeSeek != undefined) {
     return isNaN(+relativeSeek)
       ? defaultResult
       : { type: "relative", startOffset: fromMillis(parseInt(relativeSeek)) };
   }
   const seekFraction = params.get(SEEK_TO_FRACTION_QUERY_KEY);
-  if (seekFraction != null) {
+  if (seekFraction != undefined) {
     return isNaN(+seekFraction)
       ? defaultResult
       : { type: "fraction", fraction: parseFloat(seekFraction) };
@@ -333,7 +333,10 @@ export function getTimestampForMessage(
   timestampMethod?: TimestampMethod,
 ): Time | undefined {
   if (timestampMethod === "headerStamp") {
-    if (message.message.header?.stamp?.sec != null && message.message.header?.stamp?.nsec != null) {
+    if (
+      message.message.header?.stamp?.sec != undefined &&
+      message.message.header?.stamp?.nsec != undefined
+    ) {
       return message.message.header.stamp;
     }
     return undefined;
@@ -351,7 +354,7 @@ type MaybeStampedBobject = Readonly<{
 }>;
 
 export const maybeGetBobjectHeaderStamp = (message: Bobject | undefined): Time | undefined => {
-  if (message == null) {
+  if (message == undefined) {
     return;
   }
   const maybeStamped = cast<MaybeStampedBobject>(message);


### PR DESCRIPTION
These are functionally identical. Since the eslint `eqeqeq` rule doesn't support this style, I used some `no-restricted-syntax` selectors to ban `!= null`. While I was at it I enforce that we use `x == undefined` instead of `undefined == x`.