### PR TITLE
Bump up delays on TimeBasedChart and 2D Plot stories

### DIFF
--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -276,7 +276,9 @@ storiesOf("<TimeBasedChart>", module)
       </div>
     );
   })
-  .add("can zoom and then update with new data without resetting the zoom", () => <ZoomExample />)
+  .add("can zoom and then update with new data without resetting the zoom", () => <ZoomExample />, {
+    screenshot: { delay: 3000 },
+  })
   .add("cleans up the tooltip when removing the panel", () => <CleansUpTooltipExample />)
   .add("should call pauseFrame twice", () => <PauseFrameExample {...commonProps} />)
   .add(

--- a/app/panels/TwoDimensionalPlot/index.stories.tsx
+++ b/app/panels/TwoDimensionalPlot/index.stories.tsx
@@ -234,19 +234,23 @@ storiesOf("<TwoDimensionalPlot>", module)
       <TwoDimensionalPlot config={{ path: { value: "/plot_a.versions[0]" } }} />
     </PanelSetup>
   ))
-  .add("resets zoom", () => (
-    <PanelSetup
-      fixture={fixture}
-      onMount={(el: any) => {
-        setTimeout(zoomOut, 200);
-        setTimeout(() => {
-          const resetZoomBtn = el.querySelector("button");
-          if (resetZoomBtn) {
-            resetZoomBtn.click();
-          }
-        }, 400);
-      }}
-    >
-      <TwoDimensionalPlot config={{ path: { value: "/plot_a.versions[0]" } }} />
-    </PanelSetup>
-  ));
+  .add(
+    "resets zoom",
+    () => (
+      <PanelSetup
+        fixture={fixture}
+        onMount={(el: any) => {
+          setTimeout(zoomOut, 200);
+          setTimeout(() => {
+            const resetZoomBtn = el.querySelector("button");
+            if (resetZoomBtn) {
+              resetZoomBtn.click();
+            }
+          }, 400);
+        }}
+      >
+        <TwoDimensionalPlot config={{ path: { value: "/plot_a.versions[0]" } }} />
+      </PanelSetup>
+    ),
+    { screenshot: { delay: 4000 } },
+  );

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "package:darwin": "yarn package --mac",
     "package:linux": "yarn package --linux",
     "package": "NODE_OPTIONS='-r ts-node/register' electron-builder",
-    "storybook": "yarn workspace @foxglove-studio/app run start-storybook",
+    "storybook": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn workspace @foxglove-studio/app run start-storybook",
     "storybook-script": "cd ci && node --loader ts-node/esm --experimental-specifier-resolution=node storybook.ts",
     "storybook:ci": "yarn storybook-script build capture publish",
     "storybook:local-capture": "yarn storybook-script capture"


### PR DESCRIPTION
These are still flaky. Both of them involve fake input events and delays, so I don't know what we can really do other than bump up the delays.

Also fix node args passed to local storybook runs.