### PR TITLE
Change eslint import/order to put @foxglove before relative imports

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -38,7 +38,7 @@ parserOptions:
 settings:
   react:
     version: detect
-  import/internal-regex: "^@foxglove-studio/"
+  import/internal-regex: "^@foxglove"
 
 rules:
   file-progress/activate: 1
@@ -86,13 +86,12 @@ rules:
   import/no-mutable-exports: error
   import/newline-after-import: error
   import/no-duplicates: error # https://github.com/benmosher/eslint-plugin-import/issues/242#issuecomment-230118951
-  # Group imports into two groups: packages and files. Sort alphabetically
-  # within those groups.
+  # Group imports into three groups [external, @foxglove, relative] and sort alphabetically within each group
   import/order:
     - error
     - alphabetize: { order: asc }
       newlines-between: always
-      groups: [[builtin, external], [internal, parent, sibling, index]]
+      groups: [[builtin, external], [internal], [parent, sibling, index]]
 
   # we let typescript and webpack handle whether imports exist or not
   import/namespace: off

--- a/app/PanelAPI/useBlocksByTopic.test.tsx
+++ b/app/PanelAPI/useBlocksByTopic.test.tsx
@@ -15,8 +15,9 @@ import { mount } from "enzyme";
 import { cloneDeep } from "lodash";
 import { MessageReader, parseMessageDefinition } from "rosbag";
 
-import * as PanelAPI from ".";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
+
+import * as PanelAPI from ".";
 
 describe("useBlocksByTopic", () => {
   // Create a helper component that exposes the results of the hook for mocking.

--- a/app/PanelAPI/useDataSourceInfo.test.tsx
+++ b/app/PanelAPI/useDataSourceInfo.test.tsx
@@ -13,8 +13,9 @@
 
 import { mount } from "enzyme";
 
-import * as PanelAPI from ".";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
+
+import * as PanelAPI from ".";
 
 describe("useDataSourceInfo", () => {
   const topics = [{ name: "/foo", datatype: "Foo" }];

--- a/app/PanelAPI/useMessageReducer.test.tsx
+++ b/app/PanelAPI/useMessageReducer.test.tsx
@@ -14,9 +14,10 @@
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 
-import * as PanelAPI from ".";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+
+import * as PanelAPI from ".";
 
 describe("useMessageReducer", () => {
   // Create a helper component that exposes restore, addMessage, and the results of the hook for mocking

--- a/app/PanelAPI/useMessagesByTopic.test.tsx
+++ b/app/PanelAPI/useMessagesByTopic.test.tsx
@@ -13,11 +13,12 @@
 
 import { mount } from "enzyme";
 
-import * as PanelAPI from ".";
-import { concatAndTruncate } from "./useMessagesByTopic";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { MessageFormat } from "@foxglove-studio/app/players/types";
 import { wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+
+import * as PanelAPI from ".";
+import { concatAndTruncate } from "./useMessagesByTopic";
 
 describe("useMessagesByTopic", () => {
   // Create a helper component that exposes the results of the hook for mocking.

--- a/app/PanelAPI/useMessagesByTopic.ts
+++ b/app/PanelAPI/useMessagesByTopic.ts
@@ -14,9 +14,10 @@
 import { groupBy } from "lodash";
 import { useCallback } from "react";
 
-import { useMessageReducer } from "./useMessageReducer";
 import { TypedMessage, MessageFormat } from "@foxglove-studio/app/players/types";
 import { useDeepMemo } from "@foxglove-studio/app/util/hooks";
+
+import { useMessageReducer } from "./useMessageReducer";
 
 // Exported for tests
 // Equivalent to array1.concat(array2).slice(-limit), but somewhat faster. Also works with limit=0.

--- a/app/components/Autocomplete.tsx
+++ b/app/components/Autocomplete.tsx
@@ -18,8 +18,9 @@ import ReactAutocomplete from "react-autocomplete";
 import { createPortal } from "react-dom";
 import textWidth from "text-width";
 
-import styles from "./Autocomplete.module.scss";
 import fuzzyFilter from "@foxglove-studio/app/util/fuzzyFilter";
+
+import styles from "./Autocomplete.module.scss";
 
 const fontFamily = "'Inter UI', -apple-system, BlinkMacSystemFont, sans-serif";
 const fontSize = 12;

--- a/app/components/ChildToggle/index.tsx
+++ b/app/components/ChildToggle/index.tsx
@@ -24,9 +24,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-import styles from "./index.module.scss";
 import Flex from "@foxglove-studio/app/components/Flex";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
+
+import styles from "./index.module.scss";
 
 type ContainsOpenProps = {
   onChange: (containsOpen: boolean) => void;

--- a/app/components/Dropdown/index.tsx
+++ b/app/components/Dropdown/index.tsx
@@ -15,11 +15,12 @@ import ChevronDownIcon from "@mdi/svg/svg/chevron-down.svg";
 import cx from "classnames";
 import { ReactNode, CSSProperties, ReactElement } from "react";
 
+import Tooltip from "@foxglove-studio/app/components/Tooltip";
+
 import ChildToggle from "../ChildToggle";
 import Icon from "../Icon";
 import Menu, { Item } from "../Menu";
 import styles from "./index.module.scss";
-import Tooltip from "@foxglove-studio/app/components/Tooltip";
 
 type Props = {
   children?: ReactNode;

--- a/app/components/ExpandingToolbar.tsx
+++ b/app/components/ExpandingToolbar.tsx
@@ -15,10 +15,11 @@ import ArrowCollapseIcon from "@mdi/svg/svg/arrow-collapse.svg";
 import cx from "classnames";
 import styled from "styled-components";
 
-import styles from "./ExpandingToolbar.module.scss";
 import Button from "@foxglove-studio/app/components/Button";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
+
+import styles from "./ExpandingToolbar.module.scss";
 
 const PANE_WIDTH = 268;
 const PANE_HEIGHT = 240;

--- a/app/components/GlobalVariablesMenu.stories.tsx
+++ b/app/components/GlobalVariablesMenu.stories.tsx
@@ -17,9 +17,10 @@ import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { Provider } from "react-redux";
 
-import GlobalVariablesMenu from "./GlobalVariablesMenu";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
+
+import GlobalVariablesMenu from "./GlobalVariablesMenu";
 
 storiesOf("<GlobalVariablesMenu>", module)
   .add("closed", () => {

--- a/app/components/GlobalVariablesTable.tsx
+++ b/app/components/GlobalVariablesTable.tsx
@@ -16,7 +16,6 @@ import { partition, pick, union, without } from "lodash";
 import { useEffect, useMemo, useCallback, useRef, useState, ReactElement } from "react";
 import styled, { css, keyframes } from "styled-components";
 
-import { usePreviousValue } from "../util/hooks";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
@@ -28,6 +27,8 @@ import useGlobalVariables, { GlobalVariables } from "@foxglove-studio/app/hooks/
 import { memoizedGetLinkedGlobalVariablesKeyByName } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/interactionUtils";
 import useLinkedGlobalVariables from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
 import { colors as sharedColors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { usePreviousValue } from "../util/hooks";
 
 // The minimum amount of time to wait between showing the global variable update animation again
 export const ANIMATION_RESET_DELAY_MS = 3000;

--- a/app/components/Icon.tsx
+++ b/app/components/Icon.tsx
@@ -13,8 +13,9 @@
 
 import cx from "classnames";
 
-import styles from "./icon.module.scss";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
+
+import styles from "./icon.module.scss";
 
 type Props = {
   children: React.ReactNode;

--- a/app/components/Menu/ExpandableMenu.tsx
+++ b/app/components/Menu/ExpandableMenu.tsx
@@ -16,8 +16,9 @@ import ChevronUpIcon from "@mdi/svg/svg/chevron-up.svg";
 import { ReactNode } from "react";
 import styled from "styled-components";
 
-import Item from "./Item";
 import Icon from "@foxglove-studio/app/components/Icon";
+
+import Item from "./Item";
 
 const STitleWrapper = styled.div`
   line-height: 15px;

--- a/app/components/Menu/Item.tsx
+++ b/app/components/Menu/Item.tsx
@@ -19,9 +19,10 @@ import cx from "classnames";
 import { noop } from "lodash";
 import styled from "styled-components";
 
-import styles from "./index.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
+
+import styles from "./index.module.scss";
 
 const SContentWrapper = styled.div`
   flex: 1 1 auto;

--- a/app/components/Menu/SubMenu.tsx
+++ b/app/components/Menu/SubMenu.tsx
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
+
 import Item from "./Item";
 import Menu from "./Menu";
-import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 
 type State = {
   open: boolean;

--- a/app/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/app/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -13,10 +13,11 @@
 
 import { storiesOf } from "@storybook/react";
 
-import MessagePathInput from "./MessagePathInput";
 import Flex from "@foxglove-studio/app/components/Flex";
 import MockPanelContextProvider from "@foxglove-studio/app/components/MockPanelContextProvider";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import MessagePathInput from "./MessagePathInput";
 
 const fixture = {
   datatypes: {

--- a/app/components/MessagePathSyntax/MessagePathInput.test.ts
+++ b/app/components/MessagePathSyntax/MessagePathInput.test.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
+
 import { tryToSetDefaultGlobalVar, getFirstInvalidVariableFromRosPath } from "./MessagePathInput";
 import { RosPath } from "./constants";
-import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 
 const defaultGlobalVars = getGlobalHooks().getDefaultPersistedState().panels.globalVariables;
 

--- a/app/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/app/components/MessagePathSyntax/MessagePathInput.tsx
@@ -15,16 +15,6 @@ import MenuDownIcon from "@mdi/svg/svg/menu-down.svg";
 import cx from "classnames";
 import { flatten, flatMap, partition } from "lodash";
 
-import styles from "./MessagePathInput.module.scss";
-import { RosPath, RosPrimitive } from "./constants";
-import {
-  StructureTraversalResult,
-  traverseStructure,
-  messagePathStructures,
-  messagePathsForDatatype,
-  validTerminatingStructureItem,
-} from "./messagePathsForDatatype";
-import parseRosPath from "./parseRosPath";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import Autocomplete from "@foxglove-studio/app/components/Autocomplete";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
@@ -36,6 +26,17 @@ import { Topic } from "@foxglove-studio/app/players/types";
 import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
 import { getTopicNames, getTopicsByTopicName } from "@foxglove-studio/app/util/selectors";
 import { TimestampMethod } from "@foxglove-studio/app/util/time";
+
+import styles from "./MessagePathInput.module.scss";
+import { RosPath, RosPrimitive } from "./constants";
+import {
+  StructureTraversalResult,
+  traverseStructure,
+  messagePathStructures,
+  messagePathsForDatatype,
+  validTerminatingStructureItem,
+} from "./messagePathsForDatatype";
+import parseRosPath from "./parseRosPath";
 
 // To show an input field with an autocomplete so the user can enter message paths, use:
 //

--- a/app/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/app/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -13,13 +13,14 @@
 
 import { cloneDeep } from "lodash";
 
+import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
+
 import {
   traverseStructure,
   messagePathsForDatatype,
   messagePathStructures,
   validTerminatingStructureItem,
 } from "./messagePathsForDatatype";
-import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
 
 const datatypes: RosDatatypes = {
   "pose_msgs/PoseDebug": {

--- a/app/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/app/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -14,6 +14,10 @@
 import { memoize } from "lodash";
 import memoizeWeak from "memoize-weak";
 
+import { isTypicalFilterName } from "@foxglove-studio/app/components/MessagePathSyntax/isTypicalFilterName";
+import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
+import naturalSort from "@foxglove-studio/app/util/naturalSort";
+
 import {
   MessagePathPart,
   rosPrimitives,
@@ -21,9 +25,6 @@ import {
   MessagePathStructureItem,
   MessagePathStructureItemMessage,
 } from "./constants";
-import { isTypicalFilterName } from "@foxglove-studio/app/components/MessagePathSyntax/isTypicalFilterName";
-import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
-import naturalSort from "@foxglove-studio/app/util/naturalSort";
 
 // Generate an easily navigable flat structure given some `datatypes`. We cache
 // this loosely as `datatypes` don't change after the player has connected.

--- a/app/components/MessagePathSyntax/parseRosPath.ts
+++ b/app/components/MessagePathSyntax/parseRosPath.ts
@@ -14,10 +14,11 @@
 import { memoize, uniq } from "lodash";
 import { Parser, Grammar } from "nearley";
 
+import filterMap from "@foxglove-studio/app/util/filterMap";
+
 import { RosPath } from "./constants";
 // @ts-expect-error grammar.ne files currently imported with any type
 import grammar from "./grammar.ne";
-import filterMap from "@foxglove-studio/app/util/filterMap";
 
 const grammarObj = Grammar.fromCompiled(grammar);
 

--- a/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -14,12 +14,6 @@ import { mount } from "enzyme";
 import { createMemoryHistory } from "history";
 import { cloneDeep } from "lodash";
 
-import {
-  fillInGlobalVariablesInPath,
-  getMessagePathDataItems,
-  useCachedGetMessagePathDataItems,
-  useDecodeMessagePathsForMessagesByTopic,
-} from "./useCachedGetMessagePathDataItems";
 import { setGlobalVariables } from "@foxglove-studio/app/actions/panels";
 import parseRosPath from "@foxglove-studio/app/components/MessagePathSyntax/parseRosPath";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
@@ -29,6 +23,13 @@ import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 import { wrapMessages } from "@foxglove-studio/app/test/datatypes";
 import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
 import { deepParse, isBobject } from "@foxglove-studio/app/util/binaryObjects";
+
+import {
+  fillInGlobalVariablesInPath,
+  getMessagePathDataItems,
+  useCachedGetMessagePathDataItems,
+  useDecodeMessagePathsForMessagesByTopic,
+} from "./useCachedGetMessagePathDataItems";
 
 function addValuesWithPathsToItems(
   messages: any,

--- a/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -14,8 +14,6 @@
 import { isEqual } from "lodash";
 import { useCallback, useMemo, useRef } from "react";
 
-import { MessagePathFilter, MessagePathStructureItem, RosPath } from "./constants";
-import { messagePathStructures } from "./messagePathsForDatatype";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import { isTypicalFilterName } from "@foxglove-studio/app/components/MessagePathSyntax/isTypicalFilterName";
 import parseRosPath from "@foxglove-studio/app/components/MessagePathSyntax/parseRosPath";
@@ -28,6 +26,9 @@ import {
   enumValuesByDatatypeAndField,
   getTopicsByTopicName,
 } from "@foxglove-studio/app/util/selectors";
+
+import { MessagePathFilter, MessagePathStructureItem, RosPath } from "./constants";
+import { messagePathStructures } from "./messagePathsForDatatype";
 
 export type MessagePathDataItem = {
   value: unknown; // The actual value.

--- a/app/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
+++ b/app/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
@@ -12,10 +12,11 @@
 //   You may not use this file except in compliance with the License.
 import { mount } from "enzyme";
 
-import { useLatestMessageDataItem } from "./useLatestMessageDataItem";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { Message, MessageFormat } from "@foxglove-studio/app/players/types";
 import { deepParse } from "@foxglove-studio/app/util/binaryObjects";
+
+import { useLatestMessageDataItem } from "./useLatestMessageDataItem";
 
 const topics = [{ name: "/topic", datatype: "datatype" }];
 const datatypes = {

--- a/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
+++ b/app/components/MessagePathSyntax/useLatestMessageDataItem.ts
@@ -13,15 +13,16 @@
 
 import { useCallback, useMemo } from "react";
 
+import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
+import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
+import { Message, MessageFormat } from "@foxglove-studio/app/players/types";
+import { useChangeDetector } from "@foxglove-studio/app/util/hooks";
+
 import parseRosPath from "./parseRosPath";
 import {
   useCachedGetMessagePathDataItems,
   MessageAndData,
 } from "./useCachedGetMessagePathDataItems";
-import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
-import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
-import { Message, MessageFormat } from "@foxglove-studio/app/players/types";
-import { useChangeDetector } from "@foxglove-studio/app/util/hooks";
 
 // Get the last message for a path, but *after* applying filters. In other words, we'll keep the
 // last message that matched.

--- a/app/components/MessagePathSyntax/useMessagesByPath.test.tsx
+++ b/app/components/MessagePathSyntax/useMessagesByPath.test.tsx
@@ -15,12 +15,13 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import { createMemoryHistory } from "history";
 import React, { PropsWithChildren } from "react";
 
-import * as fixture from "./fixture";
 import { setGlobalVariables } from "@foxglove-studio/app/actions/panels";
 import useMessagesByPath from "@foxglove-studio/app/components/MessagePathSyntax/useMessagesByPath";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
+
+import * as fixture from "./fixture";
 
 const singleTopic = [{ name: "/some/topic", datatype: "some/datatype" }];
 

--- a/app/components/MessagePipeline/index.test.tsx
+++ b/app/components/MessagePipeline/index.test.tsx
@@ -15,6 +15,12 @@ import { mount } from "enzyme";
 import { last } from "lodash";
 import { act } from "react-dom/test-utils";
 
+import { PlayerStateActiveData } from "@foxglove-studio/app/players/types";
+import delay from "@foxglove-studio/app/shared/delay";
+import signal from "@foxglove-studio/app/shared/signal";
+import tick from "@foxglove-studio/app/shared/tick";
+import { initializeLogEvent, resetLogEventForTests } from "@foxglove-studio/app/util/logEvent";
+
 import {
   MessagePipelineProvider,
   MessagePipelineConsumer,
@@ -22,11 +28,6 @@ import {
 } from ".";
 import FakePlayer from "./FakePlayer";
 import { MAX_PROMISE_TIMEOUT_TIME_MS } from "./pauseFrameForPromise";
-import { PlayerStateActiveData } from "@foxglove-studio/app/players/types";
-import delay from "@foxglove-studio/app/shared/delay";
-import signal from "@foxglove-studio/app/shared/signal";
-import tick from "@foxglove-studio/app/shared/tick";
-import { initializeLogEvent, resetLogEventForTests } from "@foxglove-studio/app/util/logEvent";
 
 jest.setTimeout(MAX_PROMISE_TIMEOUT_TIME_MS * 3);
 

--- a/app/components/MessagePipeline/index.tsx
+++ b/app/components/MessagePipeline/index.tsx
@@ -15,8 +15,6 @@ import { debounce, flatten, groupBy, isEqual } from "lodash";
 import { ReactElement } from "react";
 import { Time, TimeUtil } from "rosbag";
 
-import { pauseFrameForPromises, FramePromise } from "./pauseFrameForPromise";
-import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
 import { GlobalVariables } from "@foxglove-studio/app/hooks/useGlobalVariables";
 import {
   AdvertisePayload,
@@ -43,6 +41,9 @@ import {
 } from "@foxglove-studio/app/util/hooks";
 import naturalSort from "@foxglove-studio/app/util/naturalSort";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import { pauseFrameForPromises, FramePromise } from "./pauseFrameForPromise";
+import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
 
 export const WARN_ON_SUBSCRIPTIONS_WITHIN_TIME_MS = 1000;
 

--- a/app/components/MessagePipeline/pauseFrameForPromise.test.ts
+++ b/app/components/MessagePipeline/pauseFrameForPromise.test.ts
@@ -11,12 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { pauseFrameForPromises, MAX_PROMISE_TIMEOUT_TIME_MS } from "./pauseFrameForPromise";
 import delay from "@foxglove-studio/app/shared/delay";
 import signal from "@foxglove-studio/app/shared/signal";
 import inAutomatedRunMode from "@foxglove-studio/app/util/inAutomatedRunMode";
 import { initializeLogEvent, resetLogEventForTests } from "@foxglove-studio/app/util/logEvent";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import { pauseFrameForPromises, MAX_PROMISE_TIMEOUT_TIME_MS } from "./pauseFrameForPromise";
 
 const sendNotificationAny: any = sendNotification;
 

--- a/app/components/MessagePipeline/warnOnOutOfSyncMessages.test.ts
+++ b/app/components/MessagePipeline/warnOnOutOfSyncMessages.test.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
 import { Message, PlayerState } from "@foxglove-studio/app/players/types";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
 
 let lastSeekTimeCounter = 1;
 const lastSeekTime = () => {

--- a/app/components/NotificationDisplay.stories.tsx
+++ b/app/components/NotificationDisplay.stories.tsx
@@ -15,13 +15,14 @@ import { storiesOf } from "@storybook/react";
 import moment from "moment";
 import { useRef } from "react";
 
-import { setHooks } from "../loadWebviz";
 import NotificationDisplay, {
   NotificationList,
   NotificationModal,
   NotificationMessage,
 } from "@foxglove-studio/app/components/NotificationDisplay";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import { setHooks } from "../loadWebviz";
 
 const randomNum = () => Math.floor(Math.random() * 1000);
 const addError = () =>

--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -35,7 +35,6 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 import { bindActionCreators } from "redux";
 
-import styles from "./Panel.module.scss";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import {
   addSelectedPanelId,
@@ -80,6 +79,8 @@ import {
 } from "@foxglove-studio/app/util/layout";
 import logEvent, { getEventTags, getEventNames } from "@foxglove-studio/app/util/logEvent";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import styles from "./Panel.module.scss";
 
 type Props<Config> = {
   childId?: string;

--- a/app/components/PanelLayout.stories.tsx
+++ b/app/components/PanelLayout.stories.tsx
@@ -16,12 +16,13 @@ import { createMemoryHistory } from "history";
 import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 
-import PanelLayout from "./PanelLayout";
 import { changePanelLayout } from "@foxglove-studio/app/actions/panels";
 import MockPanelContextProvider from "@foxglove-studio/app/components/MockPanelContextProvider";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import PanelLayout from "./PanelLayout";
 
 const DEFAULT_CLICK_DELAY = 100;
 storiesOf("<PanelLayout>", module)

--- a/app/components/PanelLayout.tsx
+++ b/app/components/PanelLayout.tsx
@@ -20,7 +20,6 @@ import { useSelector, useDispatch } from "react-redux";
 import "react-mosaic-component/react-mosaic-component.css";
 import { bindActionCreators } from "redux";
 
-import ErrorBoundary from "./ErrorBoundary";
 import "./PanelLayout.scss";
 import { setMosaicId } from "@foxglove-studio/app/actions/mosaic";
 import {
@@ -36,6 +35,8 @@ import { EmptyDropTarget } from "@foxglove-studio/app/panels/Tab/EmptyDropTarget
 import { State, Dispatcher } from "@foxglove-studio/app/reducers";
 import { MosaicNode, SaveConfigsPayload } from "@foxglove-studio/app/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove-studio/app/util/layout";
+
+import ErrorBoundary from "./ErrorBoundary";
 
 type Props = {
   layout?: MosaicNode;

--- a/app/components/PanelToolbar/HelpButton.tsx
+++ b/app/components/PanelToolbar/HelpButton.tsx
@@ -14,9 +14,10 @@
 import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import { CSSProperties, PropsWithChildren, useState } from "react";
 
-import styles from "./index.module.scss";
 import HelpModal from "@foxglove-studio/app/components/HelpModal";
 import Icon from "@foxglove-studio/app/components/Icon";
+
+import styles from "./index.module.scss";
 
 type Props = {
   iconStyle?: CSSProperties;

--- a/app/components/PanelToolbar/index.stories.tsx
+++ b/app/components/PanelToolbar/index.stories.tsx
@@ -17,12 +17,13 @@ import { createMemoryHistory } from "history";
 import { Mosaic, MosaicWindow } from "react-mosaic-component";
 import { Provider } from "react-redux";
 
-import PanelToolbar from "./index";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import MockPanelContextProvider from "@foxglove-studio/app/components/MockPanelContextProvider";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
+
+import PanelToolbar from "./index";
 
 class MosaicWrapper extends React.Component<{
   layout?: any;

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -25,9 +25,6 @@ import { MosaicContext, MosaicWindowContext } from "react-mosaic-component";
 import { useDispatch, useSelector, ReactReduxContext } from "react-redux";
 import { bindActionCreators } from "redux";
 
-import HelpButton from "./HelpButton";
-import MosaicDragHandle from "./MosaicDragHandle";
-import styles from "./index.module.scss";
 import {
   savePanelConfigs,
   changePanelLayout,
@@ -48,6 +45,10 @@ import { State } from "@foxglove-studio/app/reducers";
 import frameless from "@foxglove-studio/app/util/frameless";
 import { TAB_PANEL_TYPE } from "@foxglove-studio/app/util/globalConstants";
 import logEvent, { getEventNames, getEventTags } from "@foxglove-studio/app/util/logEvent";
+
+import HelpButton from "./HelpButton";
+import MosaicDragHandle from "./MosaicDragHandle";
+import styles from "./index.module.scss";
 
 type Props = {
   children?: React.ReactNode;

--- a/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -13,7 +13,6 @@
 import React, { useMemo, useState } from "react";
 import styled, { css } from "styled-components";
 
-import { ScaleBounds } from "../ReactChartjs/zoomAndPanHelpers";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
 import {
   MessagePipelineContext,
@@ -21,6 +20,8 @@ import {
 } from "@foxglove-studio/app/components/MessagePipeline";
 import HoverBar from "@foxglove-studio/app/components/TimeBasedChart/HoverBar";
 import { toSec } from "@foxglove-studio/app/util/time";
+
+import { ScaleBounds } from "../ReactChartjs/zoomAndPanHelpers";
 
 const sharedTickStyles = css`
   position: absolute;

--- a/app/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/app/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -15,7 +15,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { Time } from "rosbag";
 import styled from "styled-components";
 
-import styles from "./index.module.scss";
 import { setPlaybackConfig } from "@foxglove-studio/app/actions/panels";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
 import DropdownItem from "@foxglove-studio/app/components/Dropdown/DropdownItem";
@@ -28,6 +27,8 @@ import {
 } from "@foxglove-studio/app/util/formatTime";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { formatTimeRaw, isTimeInRangeInclusive } from "@foxglove-studio/app/util/time";
+
+import styles from "./index.module.scss";
 
 const MAX_WIDTH = 200;
 

--- a/app/components/PlaybackControls/index.stories.tsx
+++ b/app/components/PlaybackControls/index.stories.tsx
@@ -16,8 +16,6 @@ import { storiesOf } from "@storybook/react";
 import { createMemoryHistory } from "history";
 import TestUtils from "react-dom/test-utils";
 
-import { UnconnectedPlaybackControls } from ".";
-import styles from "./index.module.scss";
 import { setPlaybackConfig } from "@foxglove-studio/app/actions/panels";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import {
@@ -27,6 +25,9 @@ import {
 } from "@foxglove-studio/app/players/types";
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
+
+import { UnconnectedPlaybackControls } from ".";
+import styles from "./index.module.scss";
 
 const START_TIME = 1531761690;
 

--- a/app/components/PlaybackControls/index.tsx
+++ b/app/components/PlaybackControls/index.tsx
@@ -22,9 +22,6 @@ import { Time } from "rosbag";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 
-import PlaybackBarHoverTicks from "./PlaybackBarHoverTicks";
-import { ProgressPlot } from "./ProgressPlot";
-import styles from "./index.module.scss";
 import { clearHoverValue, setHoverValue } from "@foxglove-studio/app/actions/hoverValue";
 import Button from "@foxglove-studio/app/components/Button";
 import Flex from "@foxglove-studio/app/components/Flex";
@@ -50,6 +47,10 @@ import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { formatTime } from "@foxglove-studio/app/util/formatTime";
 import { colors as sharedColors } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { subtractTimes, toSec, fromSec, formatTimeRaw } from "@foxglove-studio/app/util/time";
+
+import PlaybackBarHoverTicks from "./PlaybackBarHoverTicks";
+import { ProgressPlot } from "./ProgressPlot";
+import styles from "./index.module.scss";
 
 const cx = classnames.bind(styles);
 

--- a/app/components/Radio.tsx
+++ b/app/components/Radio.tsx
@@ -15,9 +15,10 @@ import RadioButtonCheckedIcon from "@mdi/svg/svg/radiobox-marked.svg";
 import { ReactElement } from "react";
 import styled from "styled-components";
 
+import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
 import Icon from "./Icon";
 import { colorToAlpha } from "./SegmentedControl";
-import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
 export type RadioOption = {
   id: string;

--- a/app/components/ReactChartjs/ChartJSWorker.ts
+++ b/app/components/ReactChartjs/ChartJSWorker.ts
@@ -13,12 +13,13 @@
 
 import Chart from "chart.js";
 
-import ChartJSManager from "./ChartJSManager";
 import { RpcLike } from "@foxglove-studio/app/util/FakeRpc";
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { setupWorker } from "@foxglove-studio/app/util/RpcWorkerUtils";
 import installChartjs from "@foxglove-studio/app/util/installChartjs";
 import { inWebWorker } from "@foxglove-studio/app/util/workers";
+
+import ChartJSManager from "./ChartJSManager";
 
 let hasInstalledChartjs = false;
 

--- a/app/components/ReactChartjs/ChartJSWorker.worker.ts
+++ b/app/components/ReactChartjs/ChartJSWorker.worker.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import ChartJSWorker from "./ChartJSWorker";
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { inWebWorker } from "@foxglove-studio/app/util/workers";
+
+import ChartJSWorker from "./ChartJSWorker";
 
 if (inWebWorker()) {
   // @ts-expect-error not yet using TS Worker lib: FG-64

--- a/app/components/ReactChartjs/index.tsx
+++ b/app/components/ReactChartjs/index.tsx
@@ -24,13 +24,14 @@
 import Hammer from "hammerjs";
 import { v4 as uuidv4 } from "uuid";
 
-import { ScaleOptions as ManagerScaleOptions } from "./ChartJSManager";
-import { ScaleBounds, ZoomOptions, PanOptions, wheelZoomHandler } from "./zoomAndPanHelpers";
 import { objectValues } from "@foxglove-studio/app/util";
 import { getFakeRpcs, RpcLike } from "@foxglove-studio/app/util/FakeRpc";
 import WebWorkerManager from "@foxglove-studio/app/util/WebWorkerManager";
 import supportsOffscreenCanvas from "@foxglove-studio/app/util/supportsOffscreenCanvas";
 import ChartJSWorker from "worker-loader!./ChartJSWorker.worker.ts";
+
+import { ScaleOptions as ManagerScaleOptions } from "./ChartJSManager";
+import { ScaleBounds, ZoomOptions, PanOptions, wheelZoomHandler } from "./zoomAndPanHelpers";
 
 const getMainThreadChartJSWorker = () =>
   import(

--- a/app/components/Select/Option.tsx
+++ b/app/components/Select/Option.tsx
@@ -13,8 +13,9 @@
 
 import cx from "classnames";
 
-import styles from "./Option.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
+
+import styles from "./Option.module.scss";
 
 type Props = {
   // value is used by the Select component

--- a/app/components/Select/Select.tsx
+++ b/app/components/Select/Select.tsx
@@ -15,9 +15,10 @@ import MenuDownIcon from "@mdi/svg/svg/menu-down.svg";
 import { createPortal } from "react-dom";
 import styled from "styled-components";
 
-import styles from "./Select.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
+
+import styles from "./Select.module.scss";
 
 const SEmpty = styled.div`
   padding: 8px 12px;

--- a/app/components/ShareJsonModal.tsx
+++ b/app/components/ShareJsonModal.tsx
@@ -15,12 +15,13 @@ import cx from "classnames";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMountedState } from "react-use";
 
-import styles from "./ShareJsonModal.module.scss";
 import Button from "@foxglove-studio/app/components/Button";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Modal from "@foxglove-studio/app/components/Modal";
 import { downloadTextFile } from "@foxglove-studio/app/util";
 import clipboard from "@foxglove-studio/app/util/clipboard";
+
+import styles from "./ShareJsonModal.module.scss";
 
 type Props = {
   onRequestClose: () => void;

--- a/app/components/TextField.stories.tsx
+++ b/app/components/TextField.stories.tsx
@@ -13,10 +13,11 @@
 
 import { storiesOf } from "@storybook/react";
 
-import TextField from "./TextField";
 import Flex from "@foxglove-studio/app/components/Flex";
 import { createPrimitiveValidator, hasLen } from "@foxglove-studio/app/shared/validators";
 import { triggerInputChange, triggerInputBlur } from "@foxglove-studio/app/stories/PanelSetup";
+
+import TextField from "./TextField";
 
 const validator = createPrimitiveValidator([hasLen(4)]);
 

--- a/app/components/TimeBasedChart/TimeBasedChartTooltip.tsx
+++ b/app/components/TimeBasedChart/TimeBasedChartTooltip.tsx
@@ -11,11 +11,12 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import styles from "./TimeBasedChartTooltip.module.scss";
-import { TimeBasedChartTooltipData } from "./index";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import { formatTime } from "@foxglove-studio/app/util/formatTime";
 import { subtractTimes, toSec, formatTimeRaw } from "@foxglove-studio/app/util/time";
+
+import styles from "./TimeBasedChartTooltip.module.scss";
+import { TimeBasedChartTooltipData } from "./index";
 
 type Props = {
   children: React.ReactElement<any>;

--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -14,10 +14,11 @@ import { storiesOf } from "@storybook/react";
 import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback } from "react";
 
-import TimeBasedChart from "./index";
-import type { Props } from "./index";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { triggerWheel } from "@foxglove-studio/app/stories/PanelSetup";
+
+import TimeBasedChart from "./index";
+import type { Props } from "./index";
 
 const dataX = 0.000057603000000000004;
 const dataY = 5.544444561004639;

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -20,8 +20,6 @@ import { Time } from "rosbag";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 
-import HoverBar from "./HoverBar";
-import TimeBasedChartTooltip from "./TimeBasedChartTooltip";
 import { clearHoverValue, setHoverValue } from "@foxglove-studio/app/actions/hoverValue";
 import Button from "@foxglove-studio/app/components/Button";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
@@ -47,6 +45,9 @@ import { isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import { useDeepChangeDetector } from "@foxglove-studio/app/util/hooks";
 import { defaultGetHeaderStamp } from "@foxglove-studio/app/util/synchronizeMessages";
 import { maybeGetBobjectHeaderStamp } from "@foxglove-studio/app/util/time";
+
+import HoverBar from "./HoverBar";
+import TimeBasedChartTooltip from "./TimeBasedChartTooltip";
 
 type Bounds = { minX?: number; maxX?: number };
 const SyncTimeAxis = createSyncingComponent<Bounds, Bounds>(

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import styles from "./Tooltip.module.scss";
 import BaseTooltip from "@foxglove-studio/app/components/TooltipBase";
+
+import styles from "./Tooltip.module.scss";
 
 type BaseProps = React.ComponentProps<typeof BaseTooltip>;
 type Props = Omit<BaseProps, "offset" | "fixed" | "contents"> & {

--- a/app/components/Tree/TreeNode.tsx
+++ b/app/components/Tree/TreeNode.tsx
@@ -25,11 +25,12 @@ import LeadPencilIcon from "@mdi/svg/svg/lead-pencil.svg";
 import cx from "classnames";
 import React, { Component } from "react";
 
-import { Node } from "./Node";
-import styles from "./index.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
+
+import { Node } from "./Node";
+import styles from "./index.module.scss";
 
 type Props = {
   node: Node;

--- a/app/components/ValidatedInput.stories.tsx
+++ b/app/components/ValidatedInput.stories.tsx
@@ -14,7 +14,6 @@
 import { storiesOf } from "@storybook/react";
 import { DEFAULT_CAMERA_STATE } from "regl-worldview";
 
-import ValidatedInput, { EDIT_FORMAT, EditFormat } from "./ValidatedInput";
 import Flex from "@foxglove-studio/app/components/Flex";
 import {
   createValidator,
@@ -22,6 +21,8 @@ import {
   ValidationResult,
 } from "@foxglove-studio/app/shared/validators";
 import { triggerInputChange, triggerInputBlur } from "@foxglove-studio/app/stories/PanelSetup";
+
+import ValidatedInput, { EDIT_FORMAT, EditFormat } from "./ValidatedInput";
 
 const INPUT_OBJ = { id: 1, name: "foo" };
 const INPUT_OBJ1 = { id: 2, name: "bar" };

--- a/app/components/WssErrorModal.tsx
+++ b/app/components/WssErrorModal.tsx
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import imageSrc from "./WssErrorModal.png";
 import HelpModal from "@foxglove-studio/app/components/HelpModal";
+
+import imageSrc from "./WssErrorModal.png";
 
 export default function WssErrorModal(props: { onRequestClose: () => void }) {
   return (

--- a/app/components/useConfirm.tsx
+++ b/app/components/useConfirm.tsx
@@ -13,11 +13,12 @@
 
 import React, { useState, useCallback } from "react";
 
-import styles from "./Confirm.module.scss";
 import Button from "@foxglove-studio/app/components/Button";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Modal, { Title } from "@foxglove-studio/app/components/Modal";
 import { RenderToBodyComponent } from "@foxglove-studio/app/components/RenderToBodyComponent";
+
+import styles from "./Confirm.module.scss";
 
 type ConfirmStyle = "danger" | "primary";
 

--- a/app/dataProviders/CombinedDataProvider.ts
+++ b/app/dataProviders/CombinedDataProvider.ts
@@ -15,7 +15,6 @@ import { assign, flatten, isEqual } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { TimeUtil, Time, RosMsgField } from "rosbag";
 
-import rawMessageDefinitionsToParsed from "./rawMessageDefinitionsToParsed";
 import {
   BlockCache,
   MemoryCacheBlock,
@@ -37,6 +36,8 @@ import filterMap from "@foxglove-studio/app/util/filterMap";
 import { deepIntersect } from "@foxglove-studio/app/util/ranges";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import { clampTime } from "@foxglove-studio/app/util/time";
+
+import rawMessageDefinitionsToParsed from "./rawMessageDefinitionsToParsed";
 
 const sortTimes = (times: Time[]) => times.sort(TimeUtil.compare);
 const emptyGetMessagesResult = {

--- a/app/dataProviders/IdbCacheReaderDataProvider.test.ts
+++ b/app/dataProviders/IdbCacheReaderDataProvider.test.ts
@@ -11,13 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import IdbCacheReaderDataProvider from "./IdbCacheReaderDataProvider";
-import IdbCacheWriterDataProvider from "./IdbCacheWriterDataProvider";
 import MemoryDataProvider from "@foxglove-studio/app/dataProviders/MemoryDataProvider";
 import { CoreDataProviders } from "@foxglove-studio/app/dataProviders/constants";
 import { mockExtensionPoint } from "@foxglove-studio/app/dataProviders/mockExtensionPoint";
 import { TypedMessage } from "@foxglove-studio/app/players/types";
 import { getDatabasesInTests } from "@foxglove-studio/app/util/indexeddb/getDatabasesInTests";
+
+import IdbCacheReaderDataProvider from "./IdbCacheReaderDataProvider";
+import IdbCacheWriterDataProvider from "./IdbCacheWriterDataProvider";
 
 function generateMessages(): TypedMessage<ArrayBuffer>[] {
   return [

--- a/app/dataProviders/IdbCacheReaderDataProvider.ts
+++ b/app/dataProviders/IdbCacheReaderDataProvider.ts
@@ -14,6 +14,11 @@
 import microMemoize from "micro-memoize";
 import { Time } from "rosbag";
 
+import { Progress } from "@foxglove-studio/app/players/types";
+import Database from "@foxglove-studio/app/util/indexeddb/Database";
+import { Range, deepIntersect, isRangeCoveredByRanges } from "@foxglove-studio/app/util/ranges";
+import { subtractTimes, toNanoSec } from "@foxglove-studio/app/util/time";
+
 import {
   MESSAGES_STORE_NAME,
   getIdbCacheDataProviderDatabase,
@@ -28,10 +33,6 @@ import {
   GetMessagesResult,
   GetMessagesTopics,
 } from "./types";
-import { Progress } from "@foxglove-studio/app/players/types";
-import Database from "@foxglove-studio/app/util/indexeddb/Database";
-import { Range, deepIntersect, isRangeCoveredByRanges } from "@foxglove-studio/app/util/ranges";
-import { subtractTimes, toNanoSec } from "@foxglove-studio/app/util/time";
 
 // Can take a few ms, so worth memoizing.
 const deeplyIntersectedTopics = microMemoize(

--- a/app/dataProviders/IdbCacheWriterDataProvider.test.ts
+++ b/app/dataProviders/IdbCacheWriterDataProvider.test.ts
@@ -14,17 +14,18 @@
 import { flatten } from "lodash";
 import { TimeUtil } from "rosbag";
 
+import MemoryDataProvider from "@foxglove-studio/app/dataProviders/MemoryDataProvider";
+import { mockExtensionPoint } from "@foxglove-studio/app/dataProviders/mockExtensionPoint";
+import { Message, TypedMessage } from "@foxglove-studio/app/players/types";
+import { getDatabasesInTests } from "@foxglove-studio/app/util/indexeddb/getDatabasesInTests";
+import naturalSort from "@foxglove-studio/app/util/naturalSort";
+
 import {
   getIdbCacheDataProviderDatabase,
   MESSAGES_STORE_NAME,
   TIMESTAMP_INDEX,
 } from "./IdbCacheDataProviderDatabase";
 import IdbCacheWriterDataProvider, { BLOCK_SIZE_NS } from "./IdbCacheWriterDataProvider";
-import MemoryDataProvider from "@foxglove-studio/app/dataProviders/MemoryDataProvider";
-import { mockExtensionPoint } from "@foxglove-studio/app/dataProviders/mockExtensionPoint";
-import { Message, TypedMessage } from "@foxglove-studio/app/players/types";
-import { getDatabasesInTests } from "@foxglove-studio/app/util/indexeddb/getDatabasesInTests";
-import naturalSort from "@foxglove-studio/app/util/naturalSort";
 
 function sortMessages(messages: Message[]) {
   return messages.sort(

--- a/app/dataProviders/IdbCacheWriterDataProvider.ts
+++ b/app/dataProviders/IdbCacheWriterDataProvider.ts
@@ -17,14 +17,6 @@ import { TimeUtil, Time } from "rosbag";
 import { v4 as uuidv4 } from "uuid";
 
 import {
-  MESSAGES_STORE_NAME,
-  TIMESTAMP_KEY,
-  TOPIC_RANGES_KEY,
-  TOPIC_RANGES_STORE_NAME,
-  getIdbCacheDataProviderDatabase,
-  PRIMARY_KEY,
-} from "./IdbCacheDataProviderDatabase";
-import {
   DataProvider,
   DataProviderDescriptor,
   ExtensionPoint,
@@ -44,6 +36,15 @@ import {
 } from "@foxglove-studio/app/util/ranges";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import { fromNanoSec, subtractTimes, toNanoSec } from "@foxglove-studio/app/util/time";
+
+import {
+  MESSAGES_STORE_NAME,
+  TIMESTAMP_KEY,
+  TOPIC_RANGES_KEY,
+  TOPIC_RANGES_STORE_NAME,
+  getIdbCacheDataProviderDatabase,
+  PRIMARY_KEY,
+} from "./IdbCacheDataProviderDatabase";
 
 const log = new Logger(__filename);
 

--- a/app/dataProviders/MemoryCacheDataProvider.test.ts
+++ b/app/dataProviders/MemoryCacheDataProvider.test.ts
@@ -14,12 +14,6 @@
 import { first, flatten, last } from "lodash";
 import { TimeUtil } from "rosbag";
 
-import MemoryCacheDataProvider, {
-  getBlocksToKeep,
-  getPrefetchStartPoint,
-  MAX_BLOCK_SIZE_BYTES,
-  MAX_BLOCKS,
-} from "./MemoryCacheDataProvider";
 import MemoryDataProvider from "@foxglove-studio/app/dataProviders/MemoryDataProvider";
 import { CoreDataProviders } from "@foxglove-studio/app/dataProviders/constants";
 import { mockExtensionPoint } from "@foxglove-studio/app/dataProviders/mockExtensionPoint";
@@ -28,6 +22,13 @@ import delay from "@foxglove-studio/app/shared/delay";
 import { getObject } from "@foxglove-studio/app/util/binaryObjects";
 import naturalSort from "@foxglove-studio/app/util/naturalSort";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import MemoryCacheDataProvider, {
+  getBlocksToKeep,
+  getPrefetchStartPoint,
+  MAX_BLOCK_SIZE_BYTES,
+  MAX_BLOCKS,
+} from "./MemoryCacheDataProvider";
 
 function sortMessages(messages: Message[]) {
   return messages.sort(

--- a/app/dataProviders/ParseMessagesDataProvider.ts
+++ b/app/dataProviders/ParseMessagesDataProvider.ts
@@ -14,6 +14,11 @@
 import { uniq } from "lodash";
 import { Time, MessageReader } from "rosbag";
 
+import ParsedMessageCache from "@foxglove-studio/app/dataProviders/ParsedMessageCache";
+import { ParsedMessageDefinitionsByTopic } from "@foxglove-studio/app/players/types";
+import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
+import { FREEZE_MESSAGES } from "@foxglove-studio/app/util/globalConstants";
+
 import {
   DataProvider,
   InitializationResult,
@@ -23,10 +28,6 @@ import {
   GetMessagesResult,
   GetMessagesTopics,
 } from "./types";
-import ParsedMessageCache from "@foxglove-studio/app/dataProviders/ParsedMessageCache";
-import { ParsedMessageDefinitionsByTopic } from "@foxglove-studio/app/players/types";
-import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
-import { FREEZE_MESSAGES } from "@foxglove-studio/app/util/globalConstants";
 
 // Parses raw messages as returned by `BagDataProvider`. To make it fast to seek back and forth, we keep
 // a small cache here, which maps messages from the underlying DataProvider to parsed messages. This assumes

--- a/app/dataProviders/RewriteBinaryDataProvider.ts
+++ b/app/dataProviders/RewriteBinaryDataProvider.ts
@@ -13,7 +13,6 @@
 import { groupBy } from "lodash";
 import { Time, TimeUtil } from "rosbag";
 
-import rawMessageDefinitionsToParsed from "./rawMessageDefinitionsToParsed";
 import {
   DataProviderDescriptor,
   DataProvider,
@@ -29,6 +28,8 @@ import { getContentBasedDatatypes } from "@foxglove-studio/app/util/datatypes";
 import naturalSort from "@foxglove-studio/app/util/naturalSort";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import { BinaryMessageWriter } from "@foxglove/rosmsg-bobject";
+
+import rawMessageDefinitionsToParsed from "./rawMessageDefinitionsToParsed";
 
 export default class RewriteBinaryDataProvider implements DataProvider {
   _provider: DataProvider;

--- a/app/dataProviders/RpcDataProvider.test.ts
+++ b/app/dataProviders/RpcDataProvider.test.ts
@@ -11,12 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import RpcDataProvider from "./RpcDataProvider";
-import RpcDataProviderRemote from "./RpcDataProviderRemote";
 import MemoryDataProvider from "@foxglove-studio/app/dataProviders/MemoryDataProvider";
 import { mockExtensionPoint } from "@foxglove-studio/app/dataProviders/mockExtensionPoint";
 import { DataProviderMetadata } from "@foxglove-studio/app/dataProviders/types";
 import Rpc, { createLinkedChannels } from "@foxglove-studio/app/util/Rpc";
+
+import RpcDataProvider from "./RpcDataProvider";
+import RpcDataProviderRemote from "./RpcDataProviderRemote";
 
 const data = {
   messages: {

--- a/app/dataProviders/WorkerDataProvider.ts
+++ b/app/dataProviders/WorkerDataProvider.ts
@@ -13,6 +13,11 @@
 
 import { Time } from "rosbag";
 
+import RpcDataProvider from "@foxglove-studio/app/dataProviders/RpcDataProvider";
+import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
+import Rpc from "@foxglove-studio/app/util/Rpc";
+import WorkerDataProviderWorker from "worker-loader!@foxglove-studio/app/dataProviders/WorkerDataProvider.worker";
+
 import {
   DataProvider,
   InitializationResult,
@@ -21,10 +26,6 @@ import {
   GetMessagesResult,
   GetMessagesTopics,
 } from "./types";
-import RpcDataProvider from "@foxglove-studio/app/dataProviders/RpcDataProvider";
-import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
-import Rpc from "@foxglove-studio/app/util/Rpc";
-import WorkerDataProviderWorker from "worker-loader!@foxglove-studio/app/dataProviders/WorkerDataProvider.worker";
 
 const params = new URLSearchParams(window.location.search);
 const secondSourceUrlParams = getGlobalHooks().getSecondSourceUrlParams();

--- a/app/dataProviders/rawMessageDefinitionsToParsed.ts
+++ b/app/dataProviders/rawMessageDefinitionsToParsed.ts
@@ -13,10 +13,11 @@
 
 import { fromPairs, uniq } from "lodash";
 
-import { MessageDefinitions, ParsedMessageDefinitions } from "./types";
 import { Topic, ParsedMessageDefinitionsByTopic } from "@foxglove-studio/app/players/types";
 import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
 import parseMessageDefinitionsCache from "@foxglove-studio/app/util/parseMessageDefinitionsCache";
+
+import { MessageDefinitions, ParsedMessageDefinitions } from "./types";
 
 // Extract one big list of datatypes from the individual connections.
 function parsedMessageDefinitionsToDatatypes(

--- a/app/dataProviders/util.test.ts
+++ b/app/dataProviders/util.test.ts
@@ -11,10 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { mockExtensionPoint } from "./mockExtensionPoint";
-import { getReportMetadataForChunk } from "./util";
 import delay from "@foxglove-studio/app/shared/delay";
 import { toSec } from "@foxglove-studio/app/util/time";
+
+import { mockExtensionPoint } from "./mockExtensionPoint";
+import { getReportMetadataForChunk } from "./util";
 
 describe("getReportMetadataForChunk", () => {
   it("logs a stall", async () => {

--- a/app/panels/GlobalVariables/index.stories.tsx
+++ b/app/panels/GlobalVariables/index.stories.tsx
@@ -13,10 +13,11 @@
 
 import { storiesOf } from "@storybook/react";
 
-import GlobalVariables from "./index";
 import { LinkedGlobalVariable } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
 import delay from "@foxglove-studio/app/shared/delay";
 import PanelSetup, { triggerInputChange } from "@foxglove-studio/app/stories/PanelSetup";
+
+import GlobalVariables from "./index";
 
 const exampleVariables = {
   someNum: 0,

--- a/app/panels/GlobalVariables/index.tsx
+++ b/app/panels/GlobalVariables/index.tsx
@@ -14,10 +14,11 @@
 import { ReactElement } from "react";
 import styled from "styled-components";
 
-import helpContent from "./index.help.md";
 import GlobalVariablesTable from "@foxglove-studio/app/components/GlobalVariablesTable";
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
+
+import helpContent from "./index.help.md";
 
 const SGlobalVariablesPanel = styled.div`
   display: flex;

--- a/app/panels/ImageView/ImageCanvas.tsx
+++ b/app/panels/ImageView/ImageCanvas.tsx
@@ -22,10 +22,6 @@ import shallowequal from "shallowequal";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 
-import styles from "./ImageCanvas.module.scss";
-import { ImageViewPanelHooks, Config, SaveImagePanelConfig } from "./index";
-import { renderImage } from "./renderImage";
-import { checkOutOfBounds, Dimensions } from "./util";
 import ContextMenu from "@foxglove-studio/app/components/ContextMenu";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
 import Menu, { Item } from "@foxglove-studio/app/components/Menu";
@@ -39,6 +35,11 @@ import debouncePromise from "@foxglove-studio/app/util/debouncePromise";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import supportsOffscreenCanvas from "@foxglove-studio/app/util/supportsOffscreenCanvas";
 import ImageCanvasWorker from "worker-loader!./ImageCanvas.worker";
+
+import styles from "./ImageCanvas.module.scss";
+import { ImageViewPanelHooks, Config, SaveImagePanelConfig } from "./index";
+import { renderImage } from "./renderImage";
+import { checkOutOfBounds, Dimensions } from "./util";
 
 type OnFinishRenderImage = () => void;
 type Props = {

--- a/app/panels/ImageView/ImageCanvas.worker.ts
+++ b/app/panels/ImageView/ImageCanvas.worker.ts
@@ -11,11 +11,12 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { renderImage } from "./renderImage";
-import { Dimensions, RawMarkerData, OffscreenCanvas } from "./util";
 import { Message } from "@foxglove-studio/app/players/types";
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { setupWorker } from "@foxglove-studio/app/util/RpcWorkerUtils";
+
+import { renderImage } from "./renderImage";
+import { Dimensions, RawMarkerData, OffscreenCanvas } from "./util";
 
 export default class ImageCanvasWorker {
   _idToCanvas: {

--- a/app/panels/ImageView/index.tsx
+++ b/app/panels/ImageView/index.tsx
@@ -20,17 +20,6 @@ import cx from "classnames";
 import { last, uniq } from "lodash";
 import styled from "styled-components";
 
-import ImageCanvas from "./ImageCanvas";
-import imageCanvasStyles from "./ImageCanvas.module.scss";
-import helpContent from "./index.help.md";
-import style from "./index.module.scss";
-import {
-  getCameraInfoTopic,
-  getCameraNamespace,
-  getRelatedMarkerTopics,
-  getMarkerOptions,
-  groupTopics,
-} from "./util";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import Autocomplete from "@foxglove-studio/app/components/Autocomplete";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
@@ -58,6 +47,18 @@ import { colors as sharedColors } from "@foxglove-studio/app/util/sharedStyleCon
 import { getSynchronizingReducers } from "@foxglove-studio/app/util/synchronizeMessages";
 import { formatTimeRaw } from "@foxglove-studio/app/util/time";
 import toggle from "@foxglove-studio/app/util/toggle";
+
+import ImageCanvas from "./ImageCanvas";
+import imageCanvasStyles from "./ImageCanvas.module.scss";
+import helpContent from "./index.help.md";
+import style from "./index.module.scss";
+import {
+  getCameraInfoTopic,
+  getCameraNamespace,
+  getRelatedMarkerTopics,
+  getMarkerOptions,
+  groupTopics,
+} from "./util";
 
 const { useMemo, useCallback } = React;
 

--- a/app/panels/ImageView/renderImage.ts
+++ b/app/panels/ImageView/renderImage.ts
@@ -11,6 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Message } from "@foxglove-studio/app/players/types";
+import { ImageMarker, Color, Point } from "@foxglove-studio/app/types/Messages";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
 import CameraModel from "./CameraModel";
 import {
   decodeYUV,
@@ -25,9 +29,6 @@ import {
   decodeMono16,
 } from "./decodings";
 import { buildMarkerData, Dimensions, RawMarkerData, MarkerData, OffscreenCanvas } from "./util";
-import { Message } from "@foxglove-studio/app/players/types";
-import { ImageMarker, Color, Point } from "@foxglove-studio/app/types/Messages";
-import sendNotification from "@foxglove-studio/app/util/sendNotification";
 
 // Just globally keep track of if we've shown an error in rendering, since typically when you get
 // one error, you'd then get a whole bunch more, which is spammy.

--- a/app/panels/ImageView/util.test.ts
+++ b/app/panels/ImageView/util.test.ts
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Topic } from "@foxglove-studio/app/players/types";
+
 import {
   getCameraInfoTopic,
   getMarkerOptions,
@@ -19,7 +21,6 @@ import {
   buildMarkerData,
   getCameraNamespace,
 } from "./util";
-import { Topic } from "@foxglove-studio/app/players/types";
 
 describe("ImageView", () => {
   describe("getCameraInfoTopic", () => {

--- a/app/panels/ImageView/util.ts
+++ b/app/panels/ImageView/util.ts
@@ -13,9 +13,10 @@
 
 import clamp from "lodash/clamp";
 
-import CameraModel from "./CameraModel";
 import { Topic, Message } from "@foxglove-studio/app/players/types";
 import { CameraInfo } from "@foxglove-studio/app/types/Messages";
+
+import CameraModel from "./CameraModel";
 
 // The OffscreenCanvas type is not yet in Flow. It's similar to, but more restrictive than HTMLCanvasElement.
 // TODO: change this to the Flow definition once it's been added.

--- a/app/panels/Internals.test.tsx
+++ b/app/panels/Internals.test.tsx
@@ -13,11 +13,12 @@
 
 import { mount } from "enzyme";
 
-import { MessagePipelineConsumer } from "../components/MessagePipeline";
-import Internals from "./Internals";
 import { useMessagesByTopic } from "@foxglove-studio/app/PanelAPI";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
 import { downloadTextFile, objectValues } from "@foxglove-studio/app/util";
+
+import { MessagePipelineConsumer } from "../components/MessagePipeline";
+import Internals from "./Internals";
 
 const mockDownloadTextFile: any = downloadTextFile;
 (objectValues as any).mockImplementation(Object.values); // broken by module mock

--- a/app/panels/NodePlayground/index.tsx
+++ b/app/panels/NodePlayground/index.tsx
@@ -20,7 +20,6 @@ import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 
-import { Script } from "./script";
 import { setUserNodes as setUserNodesAction } from "@foxglove-studio/app/actions/panels";
 import Button from "@foxglove-studio/app/components/Button";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
@@ -37,6 +36,8 @@ import Playground from "@foxglove-studio/app/panels/NodePlayground/playground-ic
 import { UserNodes } from "@foxglove-studio/app/types/panels";
 import { DEFAULT_WEBVIZ_NODE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { Script } from "./script";
 
 const Editor = React.lazy(() => import("@foxglove-studio/app/panels/NodePlayground/Editor"));
 

--- a/app/panels/Note/index.stories.tsx
+++ b/app/panels/Note/index.stories.tsx
@@ -13,8 +13,9 @@
 
 import { storiesOf } from "@storybook/react";
 
-import Note from "./index";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import Note from "./index";
 
 storiesOf("<Note>", module)
   .add("empty", () => {

--- a/app/panels/Note/index.tsx
+++ b/app/panels/Note/index.tsx
@@ -14,11 +14,12 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
 
-import helpContent from "./index.help.md";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import { SaveConfig } from "@foxglove-studio/app/types/panels";
+
+import helpContent from "./index.help.md";
 
 const STextArea = styled.textarea`
   width: 100%;

--- a/app/panels/PanelList/index.tsx
+++ b/app/panels/PanelList/index.tsx
@@ -18,7 +18,6 @@ import { MosaicDragType } from "react-mosaic-component";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
-import styles from "./index.module.scss";
 import { dropPanel } from "@foxglove-studio/app/actions/panels";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
@@ -34,6 +33,8 @@ import {
 } from "@foxglove-studio/app/types/panels";
 import { objectValues } from "@foxglove-studio/app/util";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import styles from "./index.module.scss";
 
 const StickyDiv = styled.div`
   color: ${colors.LIGHT};

--- a/app/panels/PlaybackPerformance/index.stories.tsx
+++ b/app/panels/PlaybackPerformance/index.stories.tsx
@@ -13,8 +13,9 @@
 
 import { storiesOf } from "@storybook/react";
 
-import { UnconnectedPlaybackPerformance, UnconnectedPlaybackPerformanceProps } from ".";
 import { PlayerStateActiveData } from "@foxglove-studio/app/players/types";
+
+import { UnconnectedPlaybackPerformance, UnconnectedPlaybackPerformanceProps } from ".";
 
 const defaultActiveData: PlayerStateActiveData = {
   messages: [],

--- a/app/panels/PlaybackPerformance/index.tsx
+++ b/app/panels/PlaybackPerformance/index.tsx
@@ -14,7 +14,6 @@
 import { last, sumBy } from "lodash";
 import { ReactElement } from "react";
 
-import helpContent from "./index.help.md";
 import Flex from "@foxglove-studio/app/components/Flex";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import Panel from "@foxglove-studio/app/components/Panel";
@@ -22,6 +21,8 @@ import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import { Sparkline, SparklinePoint } from "@foxglove-studio/app/components/Sparkline";
 import { PlayerStateActiveData } from "@foxglove-studio/app/players/types";
 import { subtractTimes, toSec } from "@foxglove-studio/app/util/time";
+
+import helpContent from "./index.help.md";
 
 const TIME_RANGE = 5000;
 

--- a/app/panels/Plot/PlotChart.tsx
+++ b/app/panels/Plot/PlotChart.tsx
@@ -18,8 +18,6 @@ import { createSelector } from "reselect";
 import { Time } from "rosbag";
 import { v4 as uuidv4 } from "uuid";
 
-import styles from "./PlotChart.module.scss";
-import { PlotXAxisVal } from "./index";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
 import { ScaleOptions } from "@foxglove-studio/app/components/ReactChartjs";
 import TimeBasedChart, {
@@ -49,6 +47,9 @@ import {
   formatTimeRaw,
   TimestampMethod,
 } from "@foxglove-studio/app/util/time";
+
+import styles from "./PlotChart.module.scss";
+import { PlotXAxisVal } from "./index";
 
 export type PlotChartPoint = {
   x: number;

--- a/app/panels/Plot/PlotLegend.tsx
+++ b/app/panels/Plot/PlotLegend.tsx
@@ -17,8 +17,6 @@ import cx from "classnames";
 import { last } from "lodash";
 import { Fragment, useCallback, useMemo } from "react";
 
-import styles from "./PlotLegend.module.scss";
-import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
 import DropdownItem from "@foxglove-studio/app/components/Dropdown/DropdownItem";
 import Icon from "@foxglove-studio/app/components/Icon";
@@ -31,6 +29,9 @@ import {
 import { lineColors } from "@foxglove-studio/app/util/plotColors";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { TimestampMethod } from "@foxglove-studio/app/util/time";
+
+import styles from "./PlotLegend.module.scss";
+import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
 
 type PlotLegendProps = {
   paths: PlotPath[];

--- a/app/panels/Plot/PlotMenu.test.ts
+++ b/app/panels/Plot/PlotMenu.test.ts
@@ -13,8 +13,9 @@
 
 import { flatten } from "lodash";
 
-import { getCSVData } from "./PlotMenu";
 import { getDatasetsAndTooltips } from "@foxglove-studio/app/panels/Plot/PlotChart";
+
+import { getCSVData } from "./PlotMenu";
 
 const {
   tooltips: trackedObjectsTooltips,

--- a/app/panels/Plot/PlotMenu.tsx
+++ b/app/panels/Plot/PlotMenu.tsx
@@ -15,7 +15,6 @@ import cx from "classnames";
 import { useMemo, useRef } from "react";
 import styled from "styled-components";
 
-import styles from "./PlotMenu.module.scss";
 import Item from "@foxglove-studio/app/components/Menu/Item";
 import { TimeBasedChartTooltipData } from "@foxglove-studio/app/components/TimeBasedChart";
 import { PlotConfig, PlotXAxisVal } from "@foxglove-studio/app/panels/Plot";
@@ -23,6 +22,8 @@ import { DataSet, PlotChartPoint } from "@foxglove-studio/app/panels/Plot/PlotCh
 import { PanelToolbarInput } from "@foxglove-studio/app/shared/panelToolbarStyles";
 import { downloadFiles } from "@foxglove-studio/app/util";
 import { formatTimeRaw } from "@foxglove-studio/app/util/time";
+
+import styles from "./PlotMenu.module.scss";
 
 const SLabel = styled.div`
   flex-grow: 1;

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -16,8 +16,6 @@ import memoizeWeak from "memoize-weak";
 import { useEffect, useCallback, useMemo, useRef } from "react";
 import { Time, TimeUtil } from "rosbag";
 
-import helpContent from "./index.help.md";
-import { PlotConfig } from "./types";
 import {
   useBlocksByTopic,
   useDataSourceInfo,
@@ -45,6 +43,9 @@ import PlotMenu from "@foxglove-studio/app/panels/Plot/PlotMenu";
 import { PanelConfig } from "@foxglove-studio/app/types/panels";
 import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
 import { fromSec, subtractTimes, toSec } from "@foxglove-studio/app/util/time";
+
+import helpContent from "./index.help.md";
+import { PlotConfig } from "./types";
 
 export { plotableRosTypes } from "./types";
 export type { PlotConfig, PlotXAxisVal } from "./types";

--- a/app/panels/Plot/transformPlotRange.test.ts
+++ b/app/panels/Plot/transformPlotRange.test.ts
@@ -11,13 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { TimeBasedChartTooltipData } from "@foxglove-studio/app/components/TimeBasedChart";
+
 import {
   derivative,
   applyToDataOrTooltips,
   mathFunctions,
   MathFunction,
 } from "./transformPlotRange";
-import { TimeBasedChartTooltipData } from "@foxglove-studio/app/components/TimeBasedChart";
 
 describe("transformPlotRange", () => {
   describe("derivative", () => {

--- a/app/panels/Publish/index.tsx
+++ b/app/panels/Publish/index.tsx
@@ -15,7 +15,6 @@ import CheckboxBlankOutlineIcon from "@mdi/svg/svg/checkbox-blank-outline.svg";
 import CheckboxMarkedIcon from "@mdi/svg/svg/checkbox-marked.svg";
 import styled from "styled-components";
 
-import buildSampleMessage from "./buildSampleMessage";
 import Autocomplete from "@foxglove-studio/app/components/Autocomplete";
 import Button from "@foxglove-studio/app/components/Button";
 import Flex from "@foxglove-studio/app/components/Flex";
@@ -30,6 +29,8 @@ import {
 } from "@foxglove-studio/app/shared/panelToolbarStyles";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
+
+import buildSampleMessage from "./buildSampleMessage";
 
 type Config = {
   topicName: string;

--- a/app/panels/RawMessages/Metadata.tsx
+++ b/app/panels/RawMessages/Metadata.tsx
@@ -15,12 +15,13 @@ import { cloneDeepWith } from "lodash";
 import React, { useCallback } from "react";
 import styled from "styled-components";
 
-import { getMessageDocumentationLink } from "./utils";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { Message } from "@foxglove-studio/app/players/types";
 import { deepParse, isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import clipboard from "@foxglove-studio/app/util/clipboard";
 import { formatTimeRaw } from "@foxglove-studio/app/util/time";
+
+import { getMessageDocumentationLink } from "./utils";
 
 const SMetadata = styled.div`
   margin-top: 4px;

--- a/app/panels/RawMessages/RawMessagesIcons.tsx
+++ b/app/panels/RawMessages/RawMessagesIcons.tsx
@@ -16,8 +16,6 @@ import DotsHorizontalIcon from "@mdi/svg/svg/dots-horizontal.svg";
 import TargetIcon from "@mdi/svg/svg/target.svg";
 import { ReactElement, useCallback } from "react";
 
-import { ValueAction } from "./getValueActionForValue";
-import styles from "./index.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { openSiblingPlotPanel, plotableRosTypes } from "@foxglove-studio/app/panels/Plot";
 import {
@@ -25,6 +23,9 @@ import {
   transitionableRosTypes,
 } from "@foxglove-studio/app/panels/StateTransitions";
 import { PanelConfig } from "@foxglove-studio/app/types/panels";
+
+import { ValueAction } from "./getValueActionForValue";
+import styles from "./index.module.scss";
 
 type Props = {
   valueAction: ValueAction;

--- a/app/panels/RawMessages/getValueActionForValue.test.ts
+++ b/app/panels/RawMessages/getValueActionForValue.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { getValueActionForValue, getStructureItemForPath } from "./getValueActionForValue";
 import { wrapMessage } from "@foxglove-studio/app/test/datatypes";
+
+import { getValueActionForValue, getStructureItemForPath } from "./getValueActionForValue";
 
 describe.each(["parsedMessages", "bobjects"])("getValueActionForValue %s", (format) => {
   const getAction = (data: any, structureItem: any, keyPath: any) => {

--- a/app/panels/RawMessages/index.stories.tsx
+++ b/app/panels/RawMessages/index.stories.tsx
@@ -13,6 +13,13 @@
 
 import { storiesOf } from "@storybook/react";
 
+import RawMessages, {
+  PREV_MSG_METHOD,
+  OTHER_SOURCE_METHOD,
+} from "@foxglove-studio/app/panels/RawMessages";
+import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+
 import {
   fixture,
   enumFixture,
@@ -22,12 +29,6 @@ import {
   topicsWithIdsToDiffFixture,
   multipleNumberMessagesFixture,
 } from "./fixture";
-import RawMessages, {
-  PREV_MSG_METHOD,
-  OTHER_SOURCE_METHOD,
-} from "@foxglove-studio/app/panels/RawMessages";
-import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
-import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 
 const noDiffConfig = {
   diffMethod: "custom",

--- a/app/panels/RawMessages/index.tsx
+++ b/app/panels/RawMessages/index.tsx
@@ -23,17 +23,6 @@ import { useState, useCallback, useMemo } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
 
-import { HighlightedValue, SDiffSpan, MaybeCollapsedValue } from "./Diff";
-import Metadata from "./Metadata";
-import RawMessagesIcons from "./RawMessagesIcons";
-import {
-  ValueAction,
-  getValueActionForValue,
-  getStructureItemForPath,
-} from "./getValueActionForValue";
-import helpContent from "./index.help.md";
-import styles from "./index.module.scss";
-import { DATA_ARRAY_PREVIEW_LIMIT, getItemString, getItemStringForDiff } from "./utils";
 import { useDataSourceInfo, useMessagesByTopic } from "@foxglove-studio/app/PanelAPI";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
 import DropdownItem from "@foxglove-studio/app/components/Dropdown/DropdownItem";
@@ -76,6 +65,18 @@ import {
 } from "@foxglove-studio/app/util/binaryObjects";
 import { jsonTreeTheme, SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 import { enumValuesByDatatypeAndField } from "@foxglove-studio/app/util/selectors";
+
+import { HighlightedValue, SDiffSpan, MaybeCollapsedValue } from "./Diff";
+import Metadata from "./Metadata";
+import RawMessagesIcons from "./RawMessagesIcons";
+import {
+  ValueAction,
+  getValueActionForValue,
+  getStructureItemForPath,
+} from "./getValueActionForValue";
+import helpContent from "./index.help.md";
+import styles from "./index.module.scss";
+import { DATA_ARRAY_PREVIEW_LIMIT, getItemString, getItemStringForDiff } from "./utils";
 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";

--- a/app/panels/Rosout/LogMessage.tsx
+++ b/app/panels/Rosout/LogMessage.tsx
@@ -14,9 +14,10 @@
 import _ from "lodash";
 import { Time } from "rosbag";
 
+import { RosgraphMsgs$Log } from "@foxglove-studio/app/types/Messages";
+
 import LevelToString from "./LevelToString";
 import style from "./LogMessage.module.scss";
-import { RosgraphMsgs$Log } from "@foxglove-studio/app/types/Messages";
 
 // pad the start of `val` with 0's to make the total string length `count` size
 function PadStart(val: any, count: number) {

--- a/app/panels/Rosout/index.tsx
+++ b/app/panels/Rosout/index.tsx
@@ -17,11 +17,6 @@ import { Creatable as ReactSelectCreatable } from "react-select";
 import VirtualizedSelect from "react-virtualized-select";
 import { createSelector } from "reselect";
 
-import LevelToString, { KNOWN_LOG_LEVELS } from "./LevelToString";
-import LogMessage from "./LogMessage";
-import logStyle from "./LogMessage.module.scss";
-import helpContent from "./index.help.md";
-import styles from "./index.module.scss";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
@@ -33,6 +28,12 @@ import { cast, ReflectiveMessage, Topic, TypedMessage } from "@foxglove-studio/a
 import { RosgraphMsgs$Log } from "@foxglove-studio/app/types/Messages";
 import clipboard from "@foxglove-studio/app/util/clipboard";
 import { ROSOUT_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+
+import LevelToString, { KNOWN_LOG_LEVELS } from "./LevelToString";
+import LogMessage from "./LogMessage";
+import logStyle from "./LogMessage.module.scss";
+import helpContent from "./index.help.md";
+import styles from "./index.module.scss";
 
 // Remove creatable warning https://github.com/JedWatson/react-select/issues/2181
 class Creatable extends React.Component {

--- a/app/panels/SourceInfo/index.stories.tsx
+++ b/app/panels/SourceInfo/index.stories.tsx
@@ -14,9 +14,10 @@
 import { storiesOf } from "@storybook/react";
 import styled from "styled-components";
 
-import SourceInfo from "./index";
 import PanelSetupWithBag from "@foxglove-studio/app/stories/PanelSetupWithBag";
 import bagFile from "@foxglove-studio/app/test/fixtures/example.bag";
+
+import SourceInfo from "./index";
 
 const SNarrow = styled.div`
   width: 200px;

--- a/app/panels/StateTransitions/index.stories.tsx
+++ b/app/panels/StateTransitions/index.stories.tsx
@@ -14,8 +14,9 @@
 import { storiesOf } from "@storybook/react";
 import TestUtils from "react-dom/test-utils";
 
-import StateTransitions from "./index";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import StateTransitions from "./index";
 
 const systemStateMessages = [
   { header: { stamp: { sec: 1526191539, nsec: 574635076 } }, state: 0 },

--- a/app/panels/StateTransitions/index.tsx
+++ b/app/panels/StateTransitions/index.tsx
@@ -17,7 +17,6 @@ import stringHash from "string-hash";
 import styled, { css } from "styled-components";
 import tinycolor from "tinycolor2";
 
-import helpContent from "./index.help.md";
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import Button from "@foxglove-studio/app/components/Button";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
@@ -38,6 +37,8 @@ import { darkColor, lineColors } from "@foxglove-studio/app/util/plotColors";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { TimestampMethod, subtractTimes, toSec } from "@foxglove-studio/app/util/time";
 import { grey } from "@foxglove-studio/app/util/toolsColorScheme";
+
+import helpContent from "./index.help.md";
 
 export const transitionableRosTypes = [
   "bool",

--- a/app/panels/SubscribeToList.stories.tsx
+++ b/app/panels/SubscribeToList.stories.tsx
@@ -12,8 +12,9 @@
 //   You may not use this file except in compliance with the License.
 import { storiesOf } from "@storybook/react";
 
-import SubscribeToList from "./SubscribeToList";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import SubscribeToList from "./SubscribeToList";
 
 storiesOf("<SubscribeToList>", module).add("shows a topic list", () => {
   return (

--- a/app/panels/Tab/ToolbarTab.tsx
+++ b/app/panels/Tab/ToolbarTab.tsx
@@ -18,11 +18,12 @@ import React, { Ref as ReactRef, useCallback, useEffect, useMemo, useRef, useSta
 import styled from "styled-components";
 import textWidth from "text-width";
 
-import styles from "./Tab.module.scss";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import { TabActions } from "@foxglove-studio/app/panels/Tab/TabDndContext";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import styles from "./Tab.module.scss";
 
 const FONT_SIZE = 12;
 const FONT_FAMILY = "'Inter UI', -apple-system, BlinkMacSystemFont, sans-serif";

--- a/app/panels/Tab/index.stories.tsx
+++ b/app/panels/Tab/index.stories.tsx
@@ -15,7 +15,6 @@ import { storiesOf } from "@storybook/react";
 import { createBrowserHistory } from "history";
 import TestUtils from "react-dom/test-utils";
 
-import Tab from "./index";
 import PanelLayout from "@foxglove-studio/app/components/PanelLayout";
 import nestedTabLayoutFixture from "@foxglove-studio/app/panels/Tab/nestedTabLayoutFixture";
 import createRootReducer from "@foxglove-studio/app/reducers";
@@ -24,6 +23,8 @@ import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
 import { SExpectedResult } from "@foxglove-studio/app/stories/storyHelpers";
 import { dragAndDrop } from "@foxglove-studio/app/test/dragAndDropHelper";
+
+import Tab from "./index";
 
 const rootReducer = createRootReducer(createBrowserHistory());
 

--- a/app/panels/Table/index.tsx
+++ b/app/panels/Table/index.tsx
@@ -17,7 +17,6 @@ import _ from "lodash";
 import { useTable, usePagination, useExpanded, useSortBy } from "react-table";
 import styled from "styled-components";
 
-import helpContent from "./index.help.md";
 import { useMessagesByTopic } from "@foxglove-studio/app/PanelAPI";
 import EmptyState from "@foxglove-studio/app/components/EmptyState";
 import Flex from "@foxglove-studio/app/components/Flex";
@@ -38,6 +37,8 @@ import { RosObject } from "@foxglove-studio/app/players/types";
 import { SaveConfig } from "@foxglove-studio/app/types/panels";
 import { ROBOTO_MONO } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { toolsColorScheme } from "@foxglove-studio/app/util/toolsColorScheme";
+
+import helpContent from "./index.help.md";
 
 const STable = styled.table`
   border: none;

--- a/app/panels/ThreeDimensionalViz/DrawingTools/index.stories.tsx
+++ b/app/panels/ThreeDimensionalViz/DrawingTools/index.stories.tsx
@@ -14,8 +14,9 @@
 import { storiesOf } from "@storybook/react";
 import { PolygonBuilder } from "regl-worldview";
 
-import DrawingTools, { POLYGON_TAB_TYPE } from "./index";
 import { pointsToPolygons } from "@foxglove-studio/app/panels/ThreeDimensionalViz/utils/drawToolUtils";
+
+import DrawingTools, { POLYGON_TAB_TYPE } from "./index";
 
 const polygons = pointsToPolygons([
   [

--- a/app/panels/ThreeDimensionalViz/DrawingTools/index.tsx
+++ b/app/panels/ThreeDimensionalViz/DrawingTools/index.tsx
@@ -13,12 +13,13 @@
 import PencilIcon from "@mdi/svg/svg/pencil.svg";
 import { PolygonBuilder, Polygon } from "regl-worldview";
 
-import Polygons from "./Polygons";
 import ExpandingToolbar, { ToolGroup } from "@foxglove-studio/app/components/ExpandingToolbar";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { EDIT_FORMAT, EditFormat } from "@foxglove-studio/app/components/ValidatedInput";
 import styles from "@foxglove-studio/app/panels/ThreeDimensionalViz/Layout.module.scss";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
+
+import Polygons from "./Polygons";
 
 export const POLYGON_TAB_TYPE = "Polygons";
 export type DrawingTabType = typeof POLYGON_TAB_TYPE;

--- a/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -20,13 +20,14 @@ import React, { memo, createRef, useCallback, useState } from "react";
 import shallowequal from "shallowequal";
 import styled from "styled-components";
 
-import { Transform } from "./Transforms";
 import Autocomplete from "@foxglove-studio/app/components/Autocomplete";
 import Button from "@foxglove-studio/app/components/Button";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { objectValues } from "@foxglove-studio/app/util";
+
+import { Transform } from "./Transforms";
 
 type TfTreeNode = {
   tf: Transform;

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
@@ -15,10 +15,11 @@ import { mount } from "enzyme";
 import { last } from "lodash";
 import { act } from "react-dom/test-utils";
 
-import { FrameCompatibilityDEPRECATED } from "./FrameCompatibility";
-import { datatypes, messages } from "./FrameCompatibilityFixture";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { deepParse } from "@foxglove-studio/app/util/binaryObjects";
+
+import { FrameCompatibilityDEPRECATED } from "./FrameCompatibility";
+import { datatypes, messages } from "./FrameCompatibilityFixture";
 
 const unBobjectifyMessage = ({ message, receiveTime, topic }: any) => ({
   message: deepParse(message),

--- a/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/LinkToGlobalVariable.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/LinkToGlobalVariable.tsx
@@ -15,15 +15,16 @@ import LinkPlusIcon from "@mdi/svg/svg/link-plus.svg";
 import classNames from "classnames";
 import React, { FormEvent } from "react";
 
-import useLinkedGlobalVariables from "../useLinkedGlobalVariables";
-import SGlobalVariableForm from "./SGlobalVariableForm";
-import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
 import Button from "@foxglove-studio/app/components/Button";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import useGlobalVariables from "@foxglove-studio/app/hooks/useGlobalVariables";
 import GlobalVariableName from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableName";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
+
+import useLinkedGlobalVariables from "../useLinkedGlobalVariables";
+import SGlobalVariableForm from "./SGlobalVariableForm";
+import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
 
 type AddToLinkedGlobalVariable = {
   topic: string;

--- a/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariable.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariable.tsx
@@ -14,11 +14,12 @@
 import { isEqual } from "lodash";
 import styled from "styled-components";
 
+import Button from "@foxglove-studio/app/components/Button";
+import GlobalVariableName from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableName";
+
 import { getPath } from "../interactionUtils";
 import useLinkedGlobalVariables, { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
 import SGlobalVariableForm from "./SGlobalVariableForm";
-import Button from "@foxglove-studio/app/components/Button";
-import GlobalVariableName from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableName";
 
 const SPath = styled.span`
   opacity: 0.8;

--- a/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariables.stories.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariables.stories.tsx
@@ -13,8 +13,9 @@
 
 import { storiesOf } from "@storybook/react";
 
-import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+
+import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
 
 const linkedGlobalVariables = [
   {

--- a/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariables.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkGlobalVariables.tsx
@@ -14,13 +14,14 @@
 import { isEqual } from "lodash";
 import styled from "styled-components";
 
+import Button from "@foxglove-studio/app/components/Button";
+import GlobalVariableName from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableName";
+import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
 import { getPath, memoizedGetLinkedGlobalVariablesKeyByName } from "../interactionUtils";
 import useLinkedGlobalVariables, { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
 import SGlobalVariableLink from "./SGlobalVariableLink";
 import UnlinkWrapper from "./UnlinkWrapper";
-import Button from "@foxglove-studio/app/components/Button";
-import GlobalVariableName from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableName";
-import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
 const SPath = styled.span`
   opacity: 0.8;

--- a/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkWrapper.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/GlobalVariableLink/UnlinkWrapper.tsx
@@ -16,10 +16,11 @@ import LinkVariantIcon from "@mdi/svg/svg/link-variant.svg";
 import { useState, ReactNode } from "react";
 import styled from "styled-components";
 
-import GlobalVariableName from "../GlobalVariableName";
-import { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
+
+import GlobalVariableName from "../GlobalVariableName";
+import { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
 
 const SIconWrapper = styled.span`
   .icon {

--- a/app/panels/ThreeDimensionalViz/Interactions/Interaction.stories.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/Interaction.stories.tsx
@@ -14,8 +14,6 @@
 import { storiesOf } from "@storybook/react";
 import styled from "styled-components";
 
-import Interactions, { OBJECT_TAB_TYPE, LINKED_VARIABLES_TAB_TYPE } from "./index";
-import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
 import Flex from "@foxglove-studio/app/components/Flex";
 import MockPanelContextProvider from "@foxglove-studio/app/components/MockPanelContextProvider";
 import useGlobalVariables from "@foxglove-studio/app/hooks/useGlobalVariables";
@@ -31,6 +29,9 @@ import PanelSetup, { triggerInputChange } from "@foxglove-studio/app/stories/Pan
 import { ScreenshotSizedContainer } from "@foxglove-studio/app/stories/storyHelpers";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { simulateDragClick } from "@foxglove-studio/app/test/mouseEventsHelper";
+
+import Interactions, { OBJECT_TAB_TYPE, LINKED_VARIABLES_TAB_TYPE } from "./index";
+import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
 
 const SWrapper = styled.div`
   background: #2d2c33;

--- a/app/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
@@ -14,10 +14,6 @@
 import CursorDefault from "@mdi/svg/svg/cursor-default.svg";
 import { MouseEventObject } from "regl-worldview";
 
-import LinkedGlobalVariableList from "./LinkedGlobalVariableList";
-import PointCloudDetails from "./PointCloudDetails";
-import { SEmptyState, SRow, SValue } from "./styling";
-import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
 import Checkbox from "@foxglove-studio/app/components/Checkbox";
 import ExpandingToolbar, {
   ToolGroup,
@@ -31,6 +27,11 @@ import styles from "@foxglove-studio/app/panels/ThreeDimensionalViz/Layout.modul
 import { decodeAdditionalFields } from "@foxglove-studio/app/panels/ThreeDimensionalViz/commands/PointClouds/selection";
 import { getInteractionData } from "@foxglove-studio/app/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import { SaveConfig, PanelConfig } from "@foxglove-studio/app/types/panels";
+
+import LinkedGlobalVariableList from "./LinkedGlobalVariableList";
+import PointCloudDetails from "./PointCloudDetails";
+import { SEmptyState, SRow, SValue } from "./styling";
+import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
 
 export const OBJECT_TAB_TYPE = "Selected object";
 export const LINKED_VARIABLES_TAB_TYPE = "Linked variables";

--- a/app/panels/ThreeDimensionalViz/Interactions/LinkedGlobalVariableList.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/LinkedGlobalVariableList.tsx
@@ -14,12 +14,13 @@
 import LinkPlusIcon from "@mdi/svg/svg/link-plus.svg";
 import styled from "styled-components";
 
+import Icon from "@foxglove-studio/app/components/Icon";
+
 import GlobalVariableLink from "./GlobalVariableLink/index";
 import GlobalVariableName from "./GlobalVariableName";
 import { getPath } from "./interactionUtils";
 import { SEmptyState } from "./styling";
 import { LinkedGlobalVariables } from "./useLinkedGlobalVariables";
-import Icon from "@foxglove-studio/app/components/Icon";
 
 const SPath = styled.span`
   opacity: 0.8;

--- a/app/panels/ThreeDimensionalViz/Interactions/ObjectDetails.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/ObjectDetails.tsx
@@ -16,14 +16,15 @@ import Tree from "react-json-tree";
 import { MouseEventObject } from "regl-worldview";
 import styled from "styled-components";
 
-import GlobalVariableLink from "./GlobalVariableLink/index";
-import { InteractionData } from "./types";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
 import DropdownItem from "@foxglove-studio/app/components/Dropdown/DropdownItem";
 import { getInstanceObj } from "@foxglove-studio/app/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import { deepParse, isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import { jsonTreeTheme } from "@foxglove-studio/app/util/globalConstants";
 import logEvent, { getEventNames, getEventTags } from "@foxglove-studio/app/util/logEvent";
+
+import GlobalVariableLink from "./GlobalVariableLink/index";
+import { InteractionData } from "./types";
 
 // Sort the keys of objects to make their presentation more predictable
 const PREFERRED_OBJECT_KEY_ORDER = [

--- a/app/panels/ThreeDimensionalViz/Interactions/PointCloudDetails.tsx
+++ b/app/panels/ThreeDimensionalViz/Interactions/PointCloudDetails.tsx
@@ -16,7 +16,6 @@ import { useMemo, useState, useCallback } from "react";
 import { MouseEventObject } from "regl-worldview";
 import styled from "styled-components";
 
-import { SValue, SLabel } from "./styling";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Menu from "@foxglove-studio/app/components/Menu";
@@ -27,6 +26,8 @@ import {
 } from "@foxglove-studio/app/panels/ThreeDimensionalViz/commands/PointClouds/selection";
 import { downloadFiles } from "@foxglove-studio/app/util";
 import clipboard from "@foxglove-studio/app/util/clipboard";
+
+import { SValue, SLabel } from "./styling";
 
 const SRow = styled.div`
   display: flex;

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import MessageCollector from "./MessageCollector";
 import { Interactive } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/types";
 import { BaseMarker } from "@foxglove-studio/app/types/Messages";
+
+import MessageCollector from "./MessageCollector";
 
 const makeMarker = (namespace: string, id: string): Interactive<BaseMarker> => {
   const originalMessage = {

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ThreeDimensionalVizHooks } from "./types";
 import { TF_DATATYPE } from "@foxglove-studio/app/util/globalConstants";
+
+import { ThreeDimensionalVizHooks } from "./types";
 
 const sceneBuilderHooks: ThreeDimensionalVizHooks = {
   getSelectionState: () => {

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -14,7 +14,6 @@ import _, { flatten, groupBy, isEqual, keyBy, mapValues, some, xor } from "lodas
 import { Time } from "rosbag";
 import shallowequal from "shallowequal";
 
-import { SkipTransformSpec, ThreeDimensionalVizHooks } from "./types";
 import { GlobalVariables } from "@foxglove-studio/app/hooks/useGlobalVariables";
 import MessageCollector from "@foxglove-studio/app/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector";
 import { MarkerMatcher } from "@foxglove-studio/app/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
@@ -59,6 +58,8 @@ import {
 import naturalSort from "@foxglove-studio/app/util/naturalSort";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import { fromSec } from "@foxglove-studio/app/util/time";
+
+import { SkipTransformSpec, ThreeDimensionalVizHooks } from "./types";
 
 export type TopicSettingsCollection = {
   [topicOrNamespaceKey: string]: any;

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonDecaySettings.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonDecaySettings.tsx
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { SLabel, SDescription, SInput } from "./common";
 import Flex from "@foxglove-studio/app/components/Flex";
+
+import { SLabel, SDescription, SInput } from "./common";
 
 export default function CommonDecaySettings({
   settings,

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
@@ -13,9 +13,10 @@
 
 import { upperFirst } from "lodash";
 
-import { SLabel, SInput } from "./common";
 import Flex from "@foxglove-studio/app/components/Flex";
 import { Select, Option } from "@foxglove-studio/app/components/Select";
+
+import { SLabel, SInput } from "./common";
 
 export default function CommonPointSettings({
   defaultPointSize,

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/LaserScanSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/LaserScanSettingsEditor.tsx
@@ -13,13 +13,14 @@
 
 import { Color } from "regl-worldview";
 
+import Flex from "@foxglove-studio/app/components/Flex";
+import { LaserScan } from "@foxglove-studio/app/types/Messages";
+
 import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
 import CommonDecaySettings from "./CommonDecaySettings";
 import CommonPointSettings from "./CommonPointSettings";
 import { SLabel } from "./common";
 import { TopicSettingsEditorProps } from "./types";
-import Flex from "@foxglove-studio/app/components/Flex";
-import { LaserScan } from "@foxglove-studio/app/types/Messages";
 
 type LaserScanSettings = {
   pointSize?: number;

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/MarkerSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/MarkerSettingsEditor.tsx
@@ -13,13 +13,14 @@
 
 import { Color } from "regl-worldview";
 
-import { TopicSettingsEditorProps } from ".";
-import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
-import { SLabel, SDescription } from "./common";
 import Checkbox from "@foxglove-studio/app/components/Checkbox";
 import Flex from "@foxglove-studio/app/components/Flex";
 import { Marker, MarkerArray } from "@foxglove-studio/app/types/Messages";
 import { LINED_CONVEX_HULL_RENDERING_SETTING } from "@foxglove-studio/app/util/globalConstants";
+
+import { TopicSettingsEditorProps } from ".";
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+import { SLabel, SDescription } from "./common";
 
 type MarkerSettings = {
   overrideColor?: Color;

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
@@ -15,9 +15,6 @@ import React, { useCallback } from "react";
 import { Color } from "regl-worldview";
 import styled from "styled-components";
 
-import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
-import CommonDecaySettings from "./CommonDecaySettings";
-import { SLabel, SInput } from "./common";
 import Flex from "@foxglove-studio/app/components/Flex";
 import GradientPicker from "@foxglove-studio/app/components/GradientPicker";
 import Radio from "@foxglove-studio/app/components/Radio";
@@ -26,6 +23,10 @@ import { Select, Option } from "@foxglove-studio/app/components/Select";
 import CommonPointSettings from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings";
 import { TopicSettingsEditorProps } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/types";
 import { PointCloud2 } from "@foxglove-studio/app/types/Messages";
+
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+import CommonDecaySettings from "./CommonDecaySettings";
+import { SLabel, SInput } from "./common";
 
 export type ColorMode =
   | { mode: "rgb" }

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -15,14 +15,15 @@ import CheckboxBlankOutlineIcon from "@mdi/svg/svg/checkbox-blank-outline.svg";
 import CheckboxMarkedIcon from "@mdi/svg/svg/checkbox-marked.svg";
 import InformationIcon from "@mdi/svg/svg/information.svg";
 
-import { TopicSettingsEditorProps } from ".";
-import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
-import { SLabel, SInput } from "./common";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { Color, PoseStamped } from "@foxglove-studio/app/types/Messages";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { TopicSettingsEditorProps } from ".";
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+import { SLabel, SInput } from "./common";
 
 export type PoseSettings = {
   overrideColor?: Color;

--- a/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
@@ -13,11 +13,6 @@
 
 import React, { useCallback, ComponentType } from "react";
 
-import LaserScanSettingsEditor from "./LaserScanSettingsEditor";
-import MarkerSettingsEditor from "./MarkerSettingsEditor";
-import PointCloudSettingsEditor from "./PointCloudSettingsEditor";
-import PoseSettingsEditor from "./PoseSettingsEditor";
-import styles from "./TopicSettingsEditor.module.scss";
 import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { TopicSettingsEditorProps } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/types";
@@ -28,6 +23,12 @@ import {
   SENSOR_MSGS_LASER_SCAN_DATATYPE,
   WEBVIZ_MARKER_DATATYPE,
 } from "@foxglove-studio/app/util/globalConstants";
+
+import LaserScanSettingsEditor from "./LaserScanSettingsEditor";
+import MarkerSettingsEditor from "./MarkerSettingsEditor";
+import PointCloudSettingsEditor from "./PointCloudSettingsEditor";
+import PoseSettingsEditor from "./PoseSettingsEditor";
+import styles from "./TopicSettingsEditor.module.scss";
 
 export const LINED_CONVEX_HULL_RENDERING_SETTING = "LinedConvexHull";
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/DiffModeSettings.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/DiffModeSettings.tsx
@@ -13,10 +13,11 @@
 
 import styled from "styled-components";
 
-import { Save3DConfig } from "../index";
 import Switch from "@foxglove-studio/app/components/Switch";
 import logEvent, { getEventNames } from "@foxglove-studio/app/util/logEvent";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { Save3DConfig } from "../index";
 
 type Props = {
   enabled: boolean;

--- a/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -33,7 +33,6 @@ import {
 import { Time } from "rosbag";
 import { useDebouncedCallback } from "use-debounce";
 
-import useTopicTree, { TopicTreeContext } from "./useTopicTree";
 import useDataSourceInfo from "@foxglove-studio/app/PanelAPI/useDataSourceInfo";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
@@ -91,6 +90,8 @@ import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
 import { inVideoRecordingMode } from "@foxglove-studio/app/util/inAutomatedRunMode";
 import { getTopicsByTopicName } from "@foxglove-studio/app/util/selectors";
 import { joinTopics } from "@foxglove-studio/app/util/topicUtils";
+
+import useTopicTree, { TopicTreeContext } from "./useTopicTree";
 
 const { sceneBuilderHooks } = (getGlobalHooks() as any).perPanelHooks().ThreeDimensionalViz;
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/NamespaceMenu.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/NamespaceMenu.tsx
@@ -16,8 +16,6 @@ import UndoVariantIcon from "@mdi/svg/svg/undo-variant.svg";
 import { useState } from "react";
 import styled from "styled-components";
 
-import { SDotMenuPlaceholder } from "./TreeNodeRow";
-import { OnNamespaceOverrideColorChange, SetEditingNamespace } from "./types";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import KeyboardShortcut from "@foxglove-studio/app/components/KeyboardShortcut";
@@ -31,6 +29,9 @@ import { TopicTreeContext } from "@foxglove-studio/app/panels/ThreeDimensionalVi
 import clipboard from "@foxglove-studio/app/util/clipboard";
 import { useGuaranteedContext } from "@foxglove-studio/app/util/hooks";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { SDotMenuPlaceholder } from "./TreeNodeRow";
+import { OnNamespaceOverrideColorChange, SetEditingNamespace } from "./types";
 
 const DISABLED_STYLE = { cursor: "not-allowed", color: colors.TEXT_MUTED };
 const ICON_SIZE = 18; // The width of the small icon.

--- a/app/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
@@ -13,10 +13,11 @@
 
 import styled from "styled-components";
 
-import TextHighlight from "./TextHighlight";
-import TextMiddleTruncate from "./TextMiddleTruncate";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+
+import TextHighlight from "./TextHighlight";
+import TextMiddleTruncate from "./TextMiddleTruncate";
 
 // Extra text length to make sure text such as `1000 visible topics` don't get truncated.
 const DEFAULT_END_TEXT_LENGTH = 22;

--- a/app/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -16,7 +16,6 @@ import Tabs, { TabPane } from "rc-tabs";
 import React, { useCallback } from "react";
 import styled from "styled-components";
 
-import { Save3DConfig } from "../index";
 import Button from "@foxglove-studio/app/components/Button";
 import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
 import Modal from "@foxglove-studio/app/components/Modal";
@@ -26,6 +25,8 @@ import { topicSettingsEditorForDatatype } from "@foxglove-studio/app/panels/Thre
 import { Topic } from "@foxglove-studio/app/players/types";
 import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { Save3DConfig } from "../index";
 
 const STopicSettingsEditor = styled.div`
   background: ${colors.DARK2};

--- a/app/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
@@ -22,6 +22,12 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSpring, animated } from "react-spring";
 import styled from "styled-components";
 
+import Dimensions from "@foxglove-studio/app/components/Dimensions";
+import Icon from "@foxglove-studio/app/components/Icon";
+import useLinkedGlobalVariables from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
+import { useChangeDetector } from "@foxglove-studio/app/util/hooks";
+import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
 import { Save3DConfig } from "../index";
 import DiffModeSettings from "./DiffModeSettings";
 import TopicTreeSwitcher, { SWITCHER_HEIGHT } from "./TopicTreeSwitcher";
@@ -43,11 +49,6 @@ import {
   TreeNode,
   VisibleTopicsCountByKey,
 } from "./types";
-import Dimensions from "@foxglove-studio/app/components/Dimensions";
-import Icon from "@foxglove-studio/app/components/Icon";
-import useLinkedGlobalVariables from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
-import { useChangeDetector } from "@foxglove-studio/app/util/hooks";
-import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
 const CONTAINER_SPACING = 15;
 const DEFAULT_WIDTH = 360;

--- a/app/panels/ThreeDimensionalViz/TopicTree/TopicTreeSwitcher.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TopicTreeSwitcher.tsx
@@ -16,11 +16,12 @@ import PinIcon from "@mdi/svg/svg/pin.svg";
 import { useCallback } from "react";
 import styled from "styled-components";
 
-import { Save3DConfig } from "../index";
 import Icon from "@foxglove-studio/app/components/Icon";
 import KeyboardShortcut from "@foxglove-studio/app/components/KeyboardShortcut";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { Save3DConfig } from "../index";
 
 export const SWITCHER_HEIGHT = 30;
 const STopicTreeSwitcher = styled.div`

--- a/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector.tsx
@@ -13,8 +13,9 @@
 
 import styled from "styled-components";
 
-import { Save3DConfig } from "..";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
+
+import { Save3DConfig } from "..";
 
 export const TOPIC_DISPLAY_MODES = {
   SHOW_ALL: {

--- a/app/panels/ThreeDimensionalViz/TopicTree/TreeNodeMenu.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TreeNodeMenu.tsx
@@ -15,7 +15,6 @@ import DotsVerticalIcon from "@mdi/svg/svg/dots-vertical.svg";
 import { useState } from "react";
 import styled from "styled-components";
 
-import { SetCurrentEditingTopic } from "./types";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import KeyboardShortcut from "@foxglove-studio/app/components/KeyboardShortcut";
@@ -25,6 +24,8 @@ import { TopicTreeContext } from "@foxglove-studio/app/panels/ThreeDimensionalVi
 import clipboard from "@foxglove-studio/app/util/clipboard";
 import { useGuaranteedContext } from "@foxglove-studio/app/util/hooks";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { SetCurrentEditingTopic } from "./types";
 
 const DISABLED_STYLE = { cursor: "not-allowed", color: colors.TEXT_MUTED };
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
@@ -16,10 +16,6 @@ import LeadPencilIcon from "@mdi/svg/svg/lead-pencil.svg";
 import { useCallback, useContext, useMemo } from "react";
 import styled from "styled-components";
 
-import NodeName from "./NodeName";
-import TreeNodeMenu, { DOT_MENU_WIDTH } from "./TreeNodeMenu";
-import VisibilityToggle, { TOGGLE_WRAPPER_SIZE, TOPIC_ROW_PADDING } from "./VisibilityToggle";
-import { DerivedCustomSettings, SetCurrentEditingTopic, TreeNode } from "./types";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
 import { ThreeDimensionalVizContext } from "@foxglove-studio/app/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
@@ -33,6 +29,11 @@ import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants"
 import { useGuaranteedContext } from "@foxglove-studio/app/util/hooks";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 import { joinTopics } from "@foxglove-studio/app/util/topicUtils";
+
+import NodeName from "./NodeName";
+import TreeNodeMenu, { DOT_MENU_WIDTH } from "./TreeNodeMenu";
+import VisibilityToggle, { TOGGLE_WRAPPER_SIZE, TOPIC_ROW_PADDING } from "./VisibilityToggle";
+import { DerivedCustomSettings, SetCurrentEditingTopic, TreeNode } from "./types";
 
 export const ICON_SIZE = 22;
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
@@ -17,10 +17,11 @@ import { Color } from "regl-worldview";
 import styled from "styled-components";
 import tinyColor from "tinycolor2";
 
-import { ROW_HEIGHT } from "./constants";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { getHexFromColorSettingWithDefault } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/ColorPickerForTopicSettings";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import { ROW_HEIGHT } from "./constants";
 
 export const TOPIC_ROW_PADDING = 3;
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
@@ -13,6 +13,13 @@
 
 import { useCallback, useContext, useMemo } from "react";
 
+import { ThreeDimensionalVizContext } from "@foxglove-studio/app/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
+import { TREE_SPACING } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/constants";
+import { TopicTreeContext } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree";
+import { SECOND_SOURCE_PREFIX, TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+import { useGuaranteedContext } from "@foxglove-studio/app/util/hooks";
+import { joinTopics } from "@foxglove-studio/app/util/topicUtils";
+
 import NamespaceMenu from "./NamespaceMenu";
 import NodeName from "./NodeName";
 import TooltipRow from "./TooltipRow";
@@ -26,12 +33,6 @@ import {
   TreeTopicNode,
   TreeUINode,
 } from "./types";
-import { ThreeDimensionalVizContext } from "@foxglove-studio/app/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
-import { TREE_SPACING } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/constants";
-import { TopicTreeContext } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree";
-import { SECOND_SOURCE_PREFIX, TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
-import { useGuaranteedContext } from "@foxglove-studio/app/util/hooks";
-import { joinTopics } from "@foxglove-studio/app/util/topicUtils";
 
 const OUTER_LEFT_MARGIN = 12;
 const INNER_LEFT_MARGIN = 8;

--- a/app/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
@@ -17,9 +17,6 @@ import { groupBy, defaults } from "lodash";
 import { useCallback, useContext, useMemo, useState } from "react";
 import styled from "styled-components";
 
-import { SLeft, SRightActions, SToggles, STreeNodeRow } from "./TreeNodeRow";
-import VisibilityToggle from "./VisibilityToggle";
-import { TREE_SPACING, ROW_HEIGHT } from "./constants";
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Menu, { Item } from "@foxglove-studio/app/components/Menu";
@@ -42,6 +39,10 @@ import { Color } from "@foxglove-studio/app/types/Messages";
 import filterMap from "@foxglove-studio/app/util/filterMap";
 import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 import { joinTopics } from "@foxglove-studio/app/util/topicUtils";
+
+import { SLeft, SRightActions, SToggles, STreeNodeRow } from "./TreeNodeRow";
+import VisibilityToggle from "./VisibilityToggle";
+import { TREE_SPACING, ROW_HEIGHT } from "./constants";
 
 // TODO: Dedupe from renderNamespaceNodes
 const OUTER_LEFT_MARGIN = 12;

--- a/app/panels/ThreeDimensionalViz/TopicTree/renderTreeNodes.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/renderTreeNodes.tsx
@@ -14,6 +14,13 @@
 import { uniq } from "lodash";
 import styled from "styled-components";
 
+import { LinkedGlobalVariable } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
+import { canEditNamespaceOverrideColorDatatype } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index";
+import { TOPIC_DISPLAY_MODES } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector";
+import filterMap from "@foxglove-studio/app/util/filterMap";
+import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+import naturalSort from "@foxglove-studio/app/util/naturalSort";
+
 import TooltipRow from "./TooltipRow";
 import TooltipTable from "./TooltipTable";
 import TreeNodeRow from "./TreeNodeRow";
@@ -36,12 +43,6 @@ import {
   VisibleTopicsCountByKey,
 } from "./types";
 import { generateNodeKey } from "./useTopicTree";
-import { LinkedGlobalVariable } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
-import { canEditNamespaceOverrideColorDatatype } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/index";
-import { TOPIC_DISPLAY_MODES } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector";
-import filterMap from "@foxglove-studio/app/util/filterMap";
-import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
-import naturalSort from "@foxglove-studio/app/util/naturalSort";
 
 export const SWITCHER_WIDTH = 24;
 

--- a/app/panels/ThreeDimensionalViz/TopicTree/types.ts
+++ b/app/panels/ThreeDimensionalViz/TopicTree/types.ts
@@ -12,10 +12,11 @@
 //   You may not use this file except in compliance with the License.
 import { Color } from "regl-worldview";
 
-import { Save3DConfig } from "../index";
-import { TopicDisplayMode as DisplayMode } from "./TopicViewModeSelector";
 import { Topic } from "@foxglove-studio/app/players/types";
 import { Namespace } from "@foxglove-studio/app/types/Messages";
+
+import { Save3DConfig } from "../index";
+import { TopicDisplayMode as DisplayMode } from "./TopicViewModeSelector";
 
 export type TopicDisplayMode = DisplayMode;
 export type TopicTreeConfig = {

--- a/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
@@ -14,11 +14,12 @@
 import { mount } from "enzyme";
 import { omit } from "lodash";
 
-import { UseSceneBuilderAndTransformsDataInput } from "./types";
-import useSceneBuilderAndTransformsData from "./useSceneBuilderAndTransformsData";
 import { MockMessagePipelineProvider } from "@foxglove-studio/app/components/MessagePipeline";
 import { Namespace } from "@foxglove-studio/app/types/Messages";
 import { TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+
+import { UseSceneBuilderAndTransformsDataInput } from "./types";
+import useSceneBuilderAndTransformsData from "./useSceneBuilderAndTransformsData";
 
 type ErrorsByTopic = {
   [topicName: string]: string[];

--- a/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
@@ -14,14 +14,15 @@
 import { mapKeys, difference } from "lodash";
 import { useMemo, useRef } from "react";
 
+import useDataSourceInfo from "@foxglove-studio/app/PanelAPI/useDataSourceInfo";
+import { TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+import { useChangeDetector, useDeepMemo } from "@foxglove-studio/app/util/hooks";
+
 import {
   UseSceneBuilderAndTransformsDataInput,
   UseSceneBuilderAndTransformsDataOutput,
 } from "./types";
 import { generateNodeKey } from "./useTopicTree";
-import useDataSourceInfo from "@foxglove-studio/app/PanelAPI/useDataSourceInfo";
-import { TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
-import { useChangeDetector, useDeepMemo } from "@foxglove-studio/app/util/hooks";
 
 // Derived namespace and error information for TopicTree from sceneBuilder and transforms.
 export default function useSceneBuilderAndTransformsData({

--- a/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.test.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.test.tsx
@@ -13,9 +13,10 @@
 
 import { mount } from "enzyme";
 
+import { Topic } from "@foxglove-studio/app/players/types";
+
 import { UseTreeInput } from "./types";
 import useTopicTree, { generateNodeKey, getBaseKey } from "./useTopicTree";
-import { Topic } from "@foxglove-studio/app/players/types";
 
 const TREE_CONFIG = {
   name: "root",

--- a/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -15,6 +15,11 @@ import { difference, keyBy, uniq, mapValues, xor, isEqual, flatten, omit } from 
 import { useMemo, useCallback, useRef, createContext } from "react";
 import { useDebounce } from "use-debounce";
 
+import { TOPIC_DISPLAY_MODES } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector";
+import filterMap from "@foxglove-studio/app/util/filterMap";
+import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
+
 import {
   TreeNode,
   TopicTreeConfig,
@@ -22,10 +27,6 @@ import {
   UseTreeOutput,
   DerivedCustomSettingsByKey,
 } from "./types";
-import { TOPIC_DISPLAY_MODES } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector";
-import filterMap from "@foxglove-studio/app/util/filterMap";
-import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
-import { useShallowMemo } from "@foxglove-studio/app/util/hooks";
 
 const DEFAULT_TOPICS_COUNT_BY_KEY = {};
 // TODO(Audrey): opaque type for node keys: https://flow.org/en/docs/types/opaque-types/

--- a/app/panels/ThreeDimensionalViz/WorldMarkers.tsx
+++ b/app/panels/ThreeDimensionalViz/WorldMarkers.tsx
@@ -28,8 +28,6 @@ import {
 } from "regl-worldview";
 import styled from "styled-components";
 
-import glTextAtlasLoader, { TextAtlas } from "./utils/glTextAtlasLoader";
-import { groupLinesIntoInstancedLineLists } from "./utils/groupingUtils";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { Interactive } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/types";
 import { GLTextMarker } from "@foxglove-studio/app/panels/ThreeDimensionalViz/SearchText";
@@ -59,6 +57,9 @@ import {
 } from "@foxglove-studio/app/types/Messages";
 import { deepParse, isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import glTextAtlasLoader, { TextAtlas } from "./utils/glTextAtlasLoader";
+import { groupLinesIntoInstancedLineLists } from "./utils/groupingUtils";
 
 const ICON_WRAPPER_SIZE = 24;
 const ICON_SIZE = 14;

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
@@ -11,11 +11,12 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { FieldReader, Uint8Reader, getReader } from "./readers";
-import { DATATYPE, VertexBuffer } from "./types";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { ColorMode } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor";
 import { PointField } from "@foxglove-studio/app/types/Messages";
+
+import { FieldReader, Uint8Reader, getReader } from "./readers";
+import { DATATYPE, VertexBuffer } from "./types";
 
 export type FieldOffsetsAndReaders = {
   [name: string]: { datatype: string; offset: number; reader?: FieldReader };

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
@@ -12,6 +12,11 @@
 //   You may not use this file except in compliance with the License.
 
 import {
+  DEFAULT_FLAT_COLOR,
+  ColorMode,
+} from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor";
+
+import {
   getFieldOffsetsAndReaders,
   createPositionBuffer,
   createColorBuffer,
@@ -19,10 +24,6 @@ import {
   getVertexValue,
 } from "./buffers";
 import { PointCloudMarker } from "./types";
-import {
-  DEFAULT_FLAT_COLOR,
-  ColorMode,
-} from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor";
 
 // Decode a marker and generate position and color buffers for rendering
 // The resulting marker should be memoized for better performance

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -22,11 +22,6 @@ import {
   vec4ToRGBA,
 } from "regl-worldview";
 
-import VertexBufferCache from "./VertexBufferCache";
-import { FLOAT_SIZE } from "./buffers";
-import { decodeMarker } from "./decodeMarker";
-import { updateMarkerCache } from "./memoization";
-import { MemoizedMarker, MemoizedVertexBuffer, VertexBuffer } from "./types";
 import {
   DEFAULT_FLAT_COLOR,
   DEFAULT_MIN_COLOR,
@@ -35,6 +30,12 @@ import {
 import { toRgba } from "@foxglove-studio/app/panels/ThreeDimensionalViz/commands/PointClouds/selection";
 import { PointCloud } from "@foxglove-studio/app/types/Messages";
 import filterMap from "@foxglove-studio/app/util/filterMap";
+
+import VertexBufferCache from "./VertexBufferCache";
+import { FLOAT_SIZE } from "./buffers";
+import { decodeMarker } from "./decodeMarker";
+import { updateMarkerCache } from "./memoization";
+import { MemoizedMarker, MemoizedVertexBuffer, VertexBuffer } from "./types";
 
 const COLOR_MODE_FLAT = 0;
 const COLOR_MODE_RGB = 1;

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/readers.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/readers.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { DATATYPE } from "./types";
 import log from "@foxglove-studio/app/panels/ThreeDimensionalViz/logger";
+
+import { DATATYPE } from "./types";
 
 export interface FieldReader {
   read(data: number[] | Uint8Array, index: number): number;

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/selection.test.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/selection.test.ts
@@ -11,10 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { PointCloud2 } from "@foxglove-studio/app/types/Messages";
+
 import { decodeMarker } from "./decodeMarker";
 import { POINT_CLOUD_MESSAGE, POINT_CLOUD_WITH_ADDITIONAL_FIELDS } from "./fixture/pointCloudData";
 import { getClickedInfo, getAllPoints, decodeAdditionalFields } from "./selection";
-import { PointCloud2 } from "@foxglove-studio/app/types/Messages";
 
 describe("<PointClouds />", () => {
   console.info = () => {

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
@@ -15,18 +15,19 @@ import { omit, difference, isEmpty, isNil } from "lodash";
 import { MouseEventObject, toRGBA, Color } from "regl-worldview";
 
 import {
-  getVertexValues,
-  getVertexValue,
-  getFieldOffsetsAndReaders,
-  getVertexCount,
-} from "./buffers";
-import {
   DEFAULT_FLAT_COLOR,
   DEFAULT_MIN_COLOR,
   DEFAULT_MAX_COLOR,
 } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor";
 import { PointCloud2, PointField } from "@foxglove-studio/app/types/Messages";
 import { lerp } from "@foxglove-studio/app/util";
+
+import {
+  getVertexValues,
+  getVertexValue,
+  getFieldOffsetsAndReaders,
+  getVertexCount,
+} from "./buffers";
 
 export type ClickedInfo = {
   clickedPoint: number[];

--- a/app/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
+++ b/app/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
@@ -22,13 +22,14 @@ import {
   Pose,
 } from "regl-worldview";
 
-import CarModel from "./CarModel";
-import carOutlinePoints from "./CarModel/carOutline.json";
 import { useExperimentalFeature } from "@foxglove-studio/app/context/ExperimentalFeaturesContext";
 import { getGlobalHooks } from "@foxglove-studio/app/loadWebviz";
 import { InteractionData } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/types";
 import { PoseSettings } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor";
 import { Color, Header, Scale } from "@foxglove-studio/app/types/Messages";
+
+import CarModel from "./CarModel";
+import carOutlinePoints from "./CarModel/carOutline.json";
 
 const { originalScaling, updatedScaling } = getGlobalHooks().getPoseErrorScaling();
 

--- a/app/panels/ThreeDimensionalViz/index.tsx
+++ b/app/panels/ThreeDimensionalViz/index.tsx
@@ -15,7 +15,6 @@ import hoistNonReactStatics from "hoist-non-react-statics";
 import { omit, debounce } from "lodash";
 import React, { useCallback, useMemo, useState, useRef, useEffect } from "react";
 
-import { FrameCompatibilityDEPRECATED } from "./FrameCompatibility";
 import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelContext from "@foxglove-studio/app/components/PanelContext";
@@ -32,6 +31,8 @@ import withTransforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/with
 import { Frame, Topic } from "@foxglove-studio/app/players/types";
 import { SaveConfig } from "@foxglove-studio/app/types/panels";
 import { TRANSFORM_TOPIC, TRANSFORM_STATIC_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+
+import { FrameCompatibilityDEPRECATED } from "./FrameCompatibility";
 
 // The amount of time to wait before dispatching the saveConfig action to save the cameraState into the layout
 export const CAMERA_STATE_UPDATE_DEBOUNCE_DELAY_MS = 250;

--- a/app/panels/ThreeDimensionalViz/utils/diffModeUtils.test.ts
+++ b/app/panels/ThreeDimensionalViz/utils/diffModeUtils.test.ts
@@ -11,6 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Interactive } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/types";
+import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+
 import {
   getDiffBySource,
   BASE_COLOR,
@@ -20,8 +23,6 @@ import {
   SOURCE_1_COLOR_RGBA,
   SOURCE_2_COLOR_RGBA,
 } from "./diffModeUtils";
-import { Interactive } from "@foxglove-studio/app/panels/ThreeDimensionalViz/Interactions/types";
-import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
 
 const marker = (topic: string): Interactive<any> => {
   return {

--- a/app/panels/ThreeDimensionalViz/utils/drawToolUtils.test.ts
+++ b/app/panels/ThreeDimensionalViz/utils/drawToolUtils.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { polygonsToPoints, pointsToPolygons, getFormattedString } from "./drawToolUtils";
 import { EDIT_FORMAT } from "@foxglove-studio/app/components/ValidatedInput";
+
+import { polygonsToPoints, pointsToPolygons, getFormattedString } from "./drawToolUtils";
 
 const points = [
   [

--- a/app/panels/ThreeDimensionalViz/utils/groupingUtils.test.ts
+++ b/app/panels/ThreeDimensionalViz/utils/groupingUtils.test.ts
@@ -11,10 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { groupLinesIntoInstancedLineLists } from "./groupingUtils";
 import { Color, Point, LineStripMarker, LineListMarker } from "@foxglove-studio/app/types/Messages";
 import { emptyPose } from "@foxglove-studio/app/util/Pose";
 import { COLORS, MARKER_MSG_TYPES } from "@foxglove-studio/app/util/globalConstants";
+
+import { groupLinesIntoInstancedLineLists } from "./groupingUtils";
 
 const DUMMY_POINT_COLOR = { r: 0, g: 0, b: 0, a: 0 };
 

--- a/app/panels/ThreeDimensionalViz/withTransforms.tsx
+++ b/app/panels/ThreeDimensionalViz/withTransforms.tsx
@@ -14,11 +14,12 @@
 import hoistNonReactStatics from "hoist-non-react-statics";
 import PropTypes from "prop-types";
 
-import { getGlobalHooks } from "../../loadWebviz";
 import Transforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/Transforms";
 import { Frame } from "@foxglove-studio/app/players/types";
 import { isBobject, deepParse } from "@foxglove-studio/app/util/binaryObjects";
 import { TRANSFORM_STATIC_TOPIC, TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+
+import { getGlobalHooks } from "../../loadWebviz";
 
 type State = { transforms: Transforms };
 

--- a/app/panels/TwoDimensionalPlot/index.stories.tsx
+++ b/app/panels/TwoDimensionalPlot/index.stories.tsx
@@ -13,8 +13,9 @@
 import { storiesOf } from "@storybook/react";
 import { useState } from "react";
 
-import TwoDimensionalPlot from "./index";
 import PanelSetup, { triggerWheel } from "@foxglove-studio/app/stories/PanelSetup";
+
+import TwoDimensionalPlot from "./index";
 
 const example0 = {
   title: "This is Plot A",

--- a/app/panels/TwoDimensionalPlot/index.tsx
+++ b/app/panels/TwoDimensionalPlot/index.tsx
@@ -16,7 +16,6 @@ import DocumentEvents from "react-document-events";
 import ReactDOM from "react-dom";
 import styled from "styled-components";
 
-import helpContent from "./index.help.md";
 import Button from "@foxglove-studio/app/components/Button";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
 import EmptyState from "@foxglove-studio/app/components/EmptyState";
@@ -38,6 +37,8 @@ import {
 import { deepParse, isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import { useDeepChangeDetector } from "@foxglove-studio/app/util/hooks";
 import { colors, ROBOTO_MONO } from "@foxglove-studio/app/util/sharedStyleConstants";
+
+import helpContent from "./index.help.md";
 
 const SResetZoom = styled.div`
   position: absolute;

--- a/app/panels/diagnostics/DiagnosticStatus.tsx
+++ b/app/panels/diagnostics/DiagnosticStatus.tsx
@@ -21,8 +21,6 @@ import { createSelector } from "reselect";
 import sanitizeHtml from "sanitize-html";
 import styled from "styled-components";
 
-import style from "./DiagnosticStatus.module.scss";
-import { LEVEL_NAMES, DiagnosticInfo, KeyValue, DiagnosticStatusMessage } from "./util";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
 import Tooltip from "@foxglove-studio/app/components/Tooltip";
@@ -31,6 +29,9 @@ import { openSiblingStateTransitionsPanel } from "@foxglove-studio/app/panels/St
 import { Config } from "@foxglove-studio/app/panels/diagnostics/DiagnosticStatusPanel";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { PanelConfig } from "@foxglove-studio/app/types/panels";
+
+import style from "./DiagnosticStatus.module.scss";
+import { LEVEL_NAMES, DiagnosticInfo, KeyValue, DiagnosticStatusMessage } from "./util";
 
 const MIN_SPLIT_FRACTION = 0.1;
 

--- a/app/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/app/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -13,10 +13,6 @@
 
 import { sortBy } from "lodash";
 
-import DiagnosticStatus from "./DiagnosticStatus";
-import helpContent from "./DiagnosticStatusPanel.help.md";
-import DiagnosticsHistory, { DiagnosticAutocompleteEntry } from "./DiagnosticsHistory";
-import { getDisplayName, trimHardwareId } from "./util";
 import Autocomplete from "@foxglove-studio/app/components/Autocomplete";
 import EmptyState from "@foxglove-studio/app/components/EmptyState";
 import Flex from "@foxglove-studio/app/components/Flex";
@@ -26,6 +22,11 @@ import TopicToRenderMenu from "@foxglove-studio/app/components/TopicToRenderMenu
 import { Topic } from "@foxglove-studio/app/players/types";
 import { PanelConfig } from "@foxglove-studio/app/types/panels";
 import { DIAGNOSTIC_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+
+import DiagnosticStatus from "./DiagnosticStatus";
+import helpContent from "./DiagnosticStatusPanel.help.md";
+import DiagnosticsHistory, { DiagnosticAutocompleteEntry } from "./DiagnosticsHistory";
+import { getDisplayName, trimHardwareId } from "./util";
 
 export type Config = {
   selectedHardwareId?: string;

--- a/app/panels/diagnostics/DiagnosticSummary.tsx
+++ b/app/panels/diagnostics/DiagnosticSummary.tsx
@@ -18,16 +18,6 @@ import cx from "classnames";
 import { compact } from "lodash";
 import { List, AutoSizer } from "react-virtualized";
 
-import { Config as DiagnosticStatusConfig } from "./DiagnosticStatusPanel";
-import helpContent from "./DiagnosticSummary.help.md";
-import styles from "./DiagnosticSummary.module.scss";
-import {
-  DiagnosticId,
-  DiagnosticInfo,
-  getDiagnosticsByLevel,
-  filterAndSortDiagnostics,
-  LEVEL_NAMES,
-} from "./util";
 import EmptyState from "@foxglove-studio/app/components/EmptyState";
 import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
@@ -42,6 +32,17 @@ import { PanelConfig } from "@foxglove-studio/app/types/panels";
 import filterMap from "@foxglove-studio/app/util/filterMap";
 import { DIAGNOSTIC_TOPIC } from "@foxglove-studio/app/util/globalConstants";
 import toggle from "@foxglove-studio/app/util/toggle";
+
+import { Config as DiagnosticStatusConfig } from "./DiagnosticStatusPanel";
+import helpContent from "./DiagnosticSummary.help.md";
+import styles from "./DiagnosticSummary.module.scss";
+import {
+  DiagnosticId,
+  DiagnosticInfo,
+  getDiagnosticsByLevel,
+  filterAndSortDiagnostics,
+  LEVEL_NAMES,
+} from "./util";
 
 type NodeRowProps = {
   info: DiagnosticInfo;

--- a/app/panels/diagnostics/DiagnosticsHistory.test.ts
+++ b/app/panels/diagnostics/DiagnosticsHistory.test.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Message } from "@foxglove-studio/app/players/types";
+
 import { addMessages, defaultDiagnosticsBuffer } from "./DiagnosticsHistory";
 import { computeDiagnosticInfo, DiagnosticInfo, LEVELS } from "./util";
-import { Message } from "@foxglove-studio/app/players/types";
 
 const messageAtLevel = (level: number): Message => ({
   message: {

--- a/app/panels/diagnostics/DiagnosticsHistory.ts
+++ b/app/panels/diagnostics/DiagnosticsHistory.ts
@@ -13,6 +13,9 @@
 
 import { sortedIndexBy } from "lodash";
 
+import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
+import { Message } from "@foxglove-studio/app/players/types";
+
 import {
   DiagnosticStatusArrayMsg,
   DiagnosticsById,
@@ -21,8 +24,6 @@ import {
   getDiagnosticId,
   trimHardwareId,
 } from "./util";
-import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
-import { Message } from "@foxglove-studio/app/players/types";
 
 export type DiagnosticAutocompleteEntry = {
   name?: string; // undefined for "combined hardware_id" entries for showing diagnostics with any name.

--- a/app/players/NodePlayer.test.ts
+++ b/app/players/NodePlayer.test.ts
@@ -11,8 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import NodePlayer from "./NodePlayer";
-import { NodeDefinition } from "./nodes";
 import FakePlayer from "@foxglove-studio/app/components/MessagePipeline/FakePlayer";
 import {
   SubscribePayload,
@@ -22,6 +20,9 @@ import {
 } from "@foxglove-studio/app/players/types";
 import signal from "@foxglove-studio/app/shared/signal";
 import { deepParse, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+
+import NodePlayer from "./NodePlayer";
+import { NodeDefinition } from "./nodes";
 
 const testMessageDefinition = {
   fields: [

--- a/app/players/OrderedStampPlayer.test.ts
+++ b/app/players/OrderedStampPlayer.test.ts
@@ -13,7 +13,6 @@
 
 import { TimeUtil } from "rosbag";
 
-import OrderedStampPlayer, { BUFFER_DURATION_SECS } from "./OrderedStampPlayer";
 import FakePlayer from "@foxglove-studio/app/components/MessagePipeline/FakePlayer";
 import UserNodePlayer from "@foxglove-studio/app/players/UserNodePlayer";
 import {
@@ -25,6 +24,8 @@ import signal from "@foxglove-studio/app/shared/signal";
 import { deepParse, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
 import { basicDatatypes } from "@foxglove-studio/app/util/datatypes";
 import { fromSec, TimestampMethod } from "@foxglove-studio/app/util/time";
+
+import OrderedStampPlayer, { BUFFER_DURATION_SECS } from "./OrderedStampPlayer";
 
 function makeMessage(
   headerStamp: number | undefined,

--- a/app/players/RandomAccessPlayer.test.ts
+++ b/app/players/RandomAccessPlayer.test.ts
@@ -14,12 +14,6 @@
 import { omit } from "lodash";
 import { TimeUtil, Time } from "rosbag";
 
-import RandomAccessPlayer, {
-  RandomAccessPlayerOptions,
-  SEEK_BACK_NANOSECONDS,
-  SEEK_START_DELAY_MS,
-} from "./RandomAccessPlayer";
-import TestProvider from "./TestProvider";
 import { GetMessagesResult, GetMessagesTopics } from "@foxglove-studio/app/dataProviders/types";
 import {
   BobjectMessage,
@@ -33,6 +27,13 @@ import delay from "@foxglove-studio/app/shared/delay";
 import signal from "@foxglove-studio/app/shared/signal";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
 import { fromNanoSec, getSeekToTime, SEEK_ON_START_NS } from "@foxglove-studio/app/util/time";
+
+import RandomAccessPlayer, {
+  RandomAccessPlayerOptions,
+  SEEK_BACK_NANOSECONDS,
+  SEEK_START_DELAY_MS,
+} from "./RandomAccessPlayer";
+import TestProvider from "./TestProvider";
 
 // By default seek to the start of the bag, since that makes things a bit simpler to reason about.
 const playerOptions: RandomAccessPlayerOptions = {

--- a/app/players/StoryPlayer.ts
+++ b/app/players/StoryPlayer.ts
@@ -13,7 +13,6 @@
 
 import { partition } from "lodash";
 
-import { SECOND_SOURCE_PREFIX } from "../util/globalConstants";
 import BagDataProvider from "@foxglove-studio/app/dataProviders/BagDataProvider";
 import CombinedDataProvider from "@foxglove-studio/app/dataProviders/CombinedDataProvider";
 import ParseMessagesDataProvider from "@foxglove-studio/app/dataProviders/ParseMessagesDataProvider";
@@ -25,6 +24,8 @@ import {
   Player,
   NotifyPlayerManagerReplyData,
 } from "@foxglove-studio/app/players/types";
+
+import { SECOND_SOURCE_PREFIX } from "../util/globalConstants";
 
 const noop = () => {
   // no-op

--- a/app/players/UserNodePlayer/nodeTransformerWorker/typescript/projectConfig.ts
+++ b/app/players/UserNodePlayer/nodeTransformerWorker/typescript/projectConfig.ts
@@ -13,7 +13,6 @@
 
 // @ts-nocheck
 
-import { lib_filename, lib_es6_dts } from "./lib";
 import {
   DEPRECATED__ros_lib_dts,
   DEPRECATED__ros_lib_filename,
@@ -24,6 +23,8 @@ import {
   ros_lib_dts,
 } from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/ros";
 import { DEFAULT_WEBVIZ_NODE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+
+import { lib_filename, lib_es6_dts } from "./lib";
 
 export type NodeProjectFile = {
   fileName: string;

--- a/app/players/automatedRun/AutomatedRunPlayer.test.ts
+++ b/app/players/automatedRun/AutomatedRunPlayer.test.ts
@@ -11,14 +11,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Progress } from "@foxglove-studio/app/players/types";
+import delay from "@foxglove-studio/app/shared/delay";
+import signal from "@foxglove-studio/app/shared/signal";
+
 import TestProvider from "../TestProvider";
 import AutomatedRunPlayer, {
   AutomatedRunClient,
   AUTOMATED_RUN_START_DELAY,
 } from "./AutomatedRunPlayer";
-import { Progress } from "@foxglove-studio/app/players/types";
-import delay from "@foxglove-studio/app/shared/delay";
-import signal from "@foxglove-studio/app/shared/signal";
 
 class TestRunClient implements AutomatedRunClient {
   speed = 1;

--- a/app/players/automatedRun/performanceMeasuringClient.test.ts
+++ b/app/players/automatedRun/performanceMeasuringClient.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import PerformanceMeasuringClient from "./performanceMeasuringClient";
 import Database from "@foxglove-studio/app/util/indexeddb/Database";
+
+import PerformanceMeasuringClient from "./performanceMeasuringClient";
 
 describe("performanceMeasuringClient", () => {
   let onPlaybackFinished: any;

--- a/app/players/nodes.test.ts
+++ b/app/players/nodes.test.ts
@@ -11,6 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { deepParse, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+import { basicDatatypes } from "@foxglove-studio/app/util/datatypes";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
 import {
   validateNodeDefinitions,
   makeNodeMessage,
@@ -19,9 +23,6 @@ import {
   getNodeSubscriptions,
   NodeDefinition,
 } from "./nodes";
-import { deepParse, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
-import { basicDatatypes } from "@foxglove-studio/app/util/datatypes";
-import sendNotification from "@foxglove-studio/app/util/sendNotification";
 
 const EmptyNode: Partial<NodeDefinition<void>> = {
   inputs: [],

--- a/app/reducers/recentLayouts.test.ts
+++ b/app/reducers/recentLayouts.test.ts
@@ -13,11 +13,12 @@
 
 import fetchMock from "fetch-mock";
 
-import { maybeStoreNewRecentLayout, getRecentLayouts } from "./recentLayouts";
 import { fetchLayout } from "@foxglove-studio/app/actions/panels";
 import delay from "@foxglove-studio/app/shared/delay";
 import { getGlobalStoreForTest } from "@foxglove-studio/app/store/getGlobalStore";
 import Storage from "@foxglove-studio/app/util/Storage";
+
+import { maybeStoreNewRecentLayout, getRecentLayouts } from "./recentLayouts";
 
 const storage = new Storage();
 

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -15,8 +15,9 @@ import UrlSearchParams from "url-search-params";
 import util from "util";
 import ws from "ws";
 
-import MemoryStorage from "./MemoryStorage";
 import { resetLogEventForTests } from "@foxglove-studio/app/util/logEvent";
+
+import MemoryStorage from "./MemoryStorage";
 
 process.env.WASM_LZ4_ENVIRONMENT = "NODE";
 

--- a/app/util/CachedFilelike.test.ts
+++ b/app/util/CachedFilelike.test.ts
@@ -13,8 +13,9 @@
 
 import buffer from "buffer";
 
-import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
 import delay from "@foxglove-studio/app/shared/delay";
+
+import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
 
 class InMemoryFileReader implements FileReader {
   _buffer: Buffer;

--- a/app/util/CachedFilelike.ts
+++ b/app/util/CachedFilelike.ts
@@ -13,10 +13,11 @@
 import { round } from "lodash";
 import { Callback, Filelike } from "rosbag";
 
+import Logger from "@foxglove-studio/app/util/Logger";
+
 import VirtualLRUBuffer from "./VirtualLRUBuffer";
 import { getNewConnection } from "./getNewConnection";
 import { Range } from "./ranges";
-import Logger from "@foxglove-studio/app/util/Logger";
 
 // CachedFilelike is a `Filelike` that attempts to do as much caching of the file in memory as
 // possible. It takes in 3 named arguments to its constructor:

--- a/app/util/Rpc.test.ts
+++ b/app/util/Rpc.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import Rpc, { ChannelImpl, createLinkedChannels } from "./Rpc";
 import delay from "@foxglove-studio/app/shared/delay";
+
+import Rpc, { ChannelImpl, createLinkedChannels } from "./Rpc";
 
 describe("Rpc", () => {
   it("only allows setting Rpc once per channel", () => {

--- a/app/util/RpcMainThreadUtils.ts
+++ b/app/util/RpcMainThreadUtils.ts
@@ -11,9 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import Rpc from "./Rpc";
 import logEvent from "@foxglove-studio/app/util/logEvent";
 import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
+import Rpc from "./Rpc";
 
 // This function should be called inside the parent thread; it sets up receiving a message from the worker thread and
 // calling sendNotification.

--- a/app/util/RpcUtils.test.ts
+++ b/app/util/RpcUtils.test.ts
@@ -11,9 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import Rpc, { createLinkedChannels } from "./Rpc";
-import { setupReceiveReportErrorHandler, setupReceiveLogEventHandler } from "./RpcMainThreadUtils";
-import { setupSendReportNotificationHandler, setupLogEventHandler } from "./RpcWorkerUtils";
 import delay from "@foxglove-studio/app/shared/delay";
 import logEvent, {
   initializeLogEvent,
@@ -22,6 +19,10 @@ import logEvent, {
 import sendNotification, {
   setNotificationHandler,
 } from "@foxglove-studio/app/util/sendNotification";
+
+import Rpc, { createLinkedChannels } from "./Rpc";
+import { setupReceiveReportErrorHandler, setupReceiveLogEventHandler } from "./RpcMainThreadUtils";
+import { setupSendReportNotificationHandler, setupLogEventHandler } from "./RpcWorkerUtils";
 
 describe("RpcWorkerUtils and RpcMainThreadUtils", () => {
   describe("sendNotification", () => {

--- a/app/util/RpcWorkerUtils.ts
+++ b/app/util/RpcWorkerUtils.ts
@@ -11,8 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import Rpc from "./Rpc";
-import overwriteFetch from "./overwriteFetch";
 import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
 import {
   setNotificationHandler,
@@ -20,6 +18,9 @@ import {
   NotificationType,
   NotificationSeverity,
 } from "@foxglove-studio/app/util/sendNotification";
+
+import Rpc from "./Rpc";
+import overwriteFetch from "./overwriteFetch";
 
 export function setupSendReportNotificationHandler(rpc: Rpc) {
   setNotificationHandler(

--- a/app/util/Storage.test.ts
+++ b/app/util/Storage.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import Storage, { clearBustStorageFnsMap } from "./Storage";
 import MemoryStorage from "@foxglove-studio/app/test/MemoryStorage";
+
+import Storage, { clearBustStorageFnsMap } from "./Storage";
 
 describe("Storage", () => {
   beforeEach(() => {

--- a/app/util/bags.test.ts
+++ b/app/util/bags.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { getBagChunksOverlapCount } from "./bags";
 import { fromSec } from "@foxglove-studio/app/util/time";
+
+import { getBagChunksOverlapCount } from "./bags";
 
 function* getPermutations<T>(values: T[]): Iterable<T[]> {
   if (values.length < 2) {

--- a/app/util/binaryObjects/binaryWrapperObjects.test.ts
+++ b/app/util/binaryObjects/binaryWrapperObjects.test.ts
@@ -11,13 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { definitions } from "./messageDefinitionTestTypes";
 import {
   printFieldDefinition,
   printGetClassForView,
   printSingularExpression,
   PointerExpression,
 } from "@foxglove-studio/app/util/binaryObjects/binaryWrapperObjects";
+
+import { definitions } from "./messageDefinitionTestTypes";
 
 describe("PointerExpression", () => {
   it("prints a constructed expression nicely", () => {

--- a/app/util/binaryObjects/index.test.ts
+++ b/app/util/binaryObjects/index.test.ts
@@ -13,6 +13,9 @@
 
 import { cloneDeep } from "lodash";
 
+import { cast } from "@foxglove-studio/app/players/types";
+import { BinaryHeader, BinaryTime } from "@foxglove-studio/app/types/BinaryMessages";
+
 import {
   deepParse,
   getField,
@@ -36,8 +39,6 @@ import {
   HasInt64s,
 } from "./messageDefinitionTestTypes";
 import { typeSize } from "./messageDefinitionUtils";
-import { cast } from "@foxglove-studio/app/players/types";
-import { BinaryHeader, BinaryTime } from "@foxglove-studio/app/types/BinaryMessages";
 
 describe("getObjects", () => {
   it("can compile everything", () => {

--- a/app/util/binaryObjects/jsWrapperObjects.test.ts
+++ b/app/util/binaryObjects/jsWrapperObjects.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { definitions } from "./messageDefinitionTestTypes";
 import { printClasses } from "@foxglove-studio/app/util/binaryObjects/jsWrapperObjects";
+
+import { definitions } from "./messageDefinitionTestTypes";
 
 describe("printClasses", () => {
   it("prints the expected function definition", () => {

--- a/app/util/debouncePromise.test.ts
+++ b/app/util/debouncePromise.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import debouncePromise from "./debouncePromise";
 import signal from "@foxglove-studio/app/shared/signal";
+
+import debouncePromise from "./debouncePromise";
 
 describe("debouncePromise", () => {
   it("debounces with resolved and rejected signals", async () => {

--- a/app/util/index.test.ts
+++ b/app/util/index.test.ts
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { encodeURLQueryParamValue, positiveModulo, debounceReduce } from "./index";
 import delay from "@foxglove-studio/app/shared/delay";
+
+import { encodeURLQueryParamValue, positiveModulo, debounceReduce } from "./index";
 
 describe("util", () => {
   describe("encodeURLQueryParamValue()", () => {

--- a/app/util/layout.test.ts
+++ b/app/util/layout.test.ts
@@ -14,6 +14,8 @@ import CBOR from "cbor-js";
 import { MosaicNode, MosaicParent, updateTree } from "react-mosaic-component";
 import zlib from "zlib";
 
+import { defaultPlaybackConfig } from "@foxglove-studio/app/reducers/panels";
+
 import {
   getPanelTypeFromId,
   getSaveConfigsPayloadForAddedPanel,
@@ -32,7 +34,6 @@ import {
   stringifyParams,
   dictForPatchCompression,
 } from "./layout";
-import { defaultPlaybackConfig } from "@foxglove-studio/app/reducers/panels";
 
 const tabConfig = {
   title: "First tab",

--- a/app/util/layout.ts
+++ b/app/util/layout.ts
@@ -24,8 +24,6 @@ import {
 } from "react-mosaic-component";
 import zlib from "zlib";
 
-import Logger from "./Logger";
-import { isInIFrame } from "./iframeUtils";
 import { PanelsState } from "@foxglove-studio/app/reducers/panels";
 import { TabLocation, TabPanelConfig } from "@foxglove-studio/app/types/layouts";
 import {
@@ -43,6 +41,9 @@ import {
   LAYOUT_URL_QUERY_KEY,
   PATCH_QUERY_KEY,
 } from "@foxglove-studio/app/util/globalConstants";
+
+import Logger from "./Logger";
+import { isInIFrame } from "./iframeUtils";
 
 const jsondiffpatch = JsonDiffCreate({});
 

--- a/app/util/parseMessageDefinitionsCache.test.ts
+++ b/app/util/parseMessageDefinitionsCache.test.ts
@@ -11,14 +11,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import Storage, { clearBustStorageFnsMap } from "@foxglove-studio/app/util/Storage";
+import sendNotification from "@foxglove-studio/app/util/sendNotification";
+
 import {
   CacheForTesting as ParseMessageDefinitionsCache,
   setStorageForTest,
   getStorageForTest,
   restoreStorageForTest,
 } from "./parseMessageDefinitionsCache";
-import Storage, { clearBustStorageFnsMap } from "@foxglove-studio/app/util/Storage";
-import sendNotification from "@foxglove-studio/app/util/sendNotification";
 
 const storage = new Storage();
 

--- a/app/util/rosDatatypesToMessageDefinitions.test.ts
+++ b/app/util/rosDatatypesToMessageDefinitions.test.ts
@@ -13,12 +13,13 @@
 
 import { uniqBy } from "lodash";
 
-import { basicDatatypes } from "./datatypes";
-import rosDatatypesToMessageDefinition from "./rosDatatypesToMessageDefinition";
 import {
   WEBVIZ_MARKER_ARRAY_DATATYPE,
   WEBVIZ_MARKER_DATATYPE,
 } from "@foxglove-studio/app/util/globalConstants";
+
+import { basicDatatypes } from "./datatypes";
+import rosDatatypesToMessageDefinition from "./rosDatatypesToMessageDefinition";
 
 describe("rosDatatypesToMessageDefinition", () => {
   it(`Includes all of the definitions for "visualization_msgs/WebvizMarkerArray"`, () => {

--- a/app/util/time.test.ts
+++ b/app/util/time.test.ts
@@ -11,10 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import * as time from "./time";
 import { cast } from "@foxglove-studio/app/players/types";
 import { BinaryTime } from "@foxglove-studio/app/types/BinaryMessages";
 import { deepParse, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+
+import * as time from "./time";
 
 const { fromSecondStamp } = time;
 describe("time.toDate & time.fromDate", () => {

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -26,9 +26,10 @@ import { autoUpdater } from "electron-updater";
 import fs from "fs";
 import path from "path";
 
+import colors from "@foxglove-studio/app/styles/colors.module.scss";
+
 import packageJson from "../package.json";
 import { installMenuInterface } from "./menu";
-import colors from "@foxglove-studio/app/styles/colors.module.scss";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 

--- a/packages/ros1-nodejs/src/TcpServerNode.ts
+++ b/packages/ros1-nodejs/src/TcpServerNode.ts
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { TcpAddress, TcpServer } from "@foxglove/ros1";
 import EventEmitter from "eventemitter3";
 import net from "net";
+
+import { TcpAddress, TcpServer } from "@foxglove/ros1";
 
 import { TcpSocketNode } from "./TcpSocketNode";
 

--- a/packages/ros1-nodejs/src/TcpSocketNode.ts
+++ b/packages/ros1-nodejs/src/TcpSocketNode.ts
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { TcpAddress, TcpSocket } from "@foxglove/ros1";
 import EventEmitter from "eventemitter3";
 import net from "net";
+
+import { TcpAddress, TcpSocket } from "@foxglove/ros1";
 
 import { TcpMessageStream } from "./TcpMessageStream";
 

--- a/packages/ros1-nodejs/src/XmlRpcNode.ts
+++ b/packages/ros1-nodejs/src/XmlRpcNode.ts
@@ -5,6 +5,10 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../typings/xmlrpc-rosnodejs.d.ts" />
 
+import EventEmitter from "eventemitter3";
+import { URL } from "whatwg-url";
+import { default as xmlrpc } from "xmlrpc-rosnodejs";
+
 import type {
   XmlRpcClient,
   XmlRpcValue,
@@ -12,9 +16,6 @@ import type {
   XmlRpcServer,
   HttpAddress,
 } from "@foxglove/ros1";
-import EventEmitter from "eventemitter3";
-import { URL } from "whatwg-url";
-import { default as xmlrpc } from "xmlrpc-rosnodejs";
 
 export class XmlRpcClientNode implements XmlRpcClient {
   readonly serverUrl: URL;

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -5,8 +5,9 @@
 import { init as initSentry } from "@sentry/electron";
 import { contextBridge, ipcRenderer } from "electron";
 
-import LocalFileStorage from "./LocalFileStorage";
 import type { OsContext, OsContextForwardedEvent } from "@foxglove-studio/app/OsContext";
+
+import LocalFileStorage from "./LocalFileStorage";
 
 if (typeof process.env.SENTRY_DSN === "string") {
   initSentry({ dsn: process.env.SENTRY_DSN });


### PR DESCRIPTION
Stylistic organization to put @foxglove imports before relative path imports. @foxglove imports are between "external" and "local" since they could one day reference published packages. I find this import organization helps me when reading which imports are where.