### PR TITLE
Publish macOS universal binaries

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -39,7 +39,7 @@
   "mac": {
     "target": {
       "target": "default",
-      "arch": ["x64", "arm64"]
+      "arch": ["universal"]
     },
     "category": "public.app-category.developer-tools",
     "icon": "resources/icon/icon.icns",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "package:win": "yarn package --win",
     "package:darwin": "yarn package --mac",
     "package:linux": "yarn package --linux",
-    "package": "NODE_OPTIONS='-r ts-node/register' electron-builder",
+    "package": "NODE_OPTIONS='-r ts-node/register' electron-builder build --publish never",
     "storybook": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn workspace @foxglove-studio/app run start-storybook",
     "storybook-script": "cd ci && node --loader ts-node/esm --experimental-specifier-resolution=node storybook.ts",
     "storybook:ci": "yarn storybook-script build capture publish",


### PR DESCRIPTION
Replace the separate `x64` and `arm64` builds with a `universal` macOS build. It's a little bit larger:

```
-rw-r--r--@  91M Mar 15 20:19 dist/foxglove-studio-0.1.3-dev-mac.dmg
-rw-r--r--@  92M Mar 15 20:19 dist/foxglove-studio-0.1.3-dev-mac-arm64.dmg
-rw-r--r--@ 159M Mar 15 20:20 dist/foxglove-studio-0.1.3-dev-mac-universal.dmg

-rw-r--r--   87M Mar 15 20:19 dist/foxglove-studio-0.1.3-dev-mac.zip
-rw-r--r--   88M Mar 15 20:19 dist/foxglove-studio-0.1.3-dev-mac-arm64.zip
-rw-r--r--  153M Mar 15 20:21 dist/foxglove-studio-0.1.3-dev-mac-universal.zip
```

I think the package size trade-off is justified by the simplicity of installation, and meeting expectations of macOS users for things to just work.