### PR TITLE
Enhance some redux store types

### DIFF
--- a/app/GlobalConfig.ts
+++ b/app/GlobalConfig.ts
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { perPanelHooks } from "@foxglove-studio/app/BuiltinPanelHooks";
-import { PersistedState, Store } from "@foxglove-studio/app/reducers";
+import { PersistedState } from "@foxglove-studio/app/reducers";
 import {
   LAYOUT_URL_QUERY_KEY,
   REMOTE_BAG_URL_2_QUERY_KEY,
@@ -130,10 +130,6 @@ const defaultHooks = {
   linkMessagePathSyntaxToHelpPage: () => true,
   getSecondSourceUrlParams() {
     return [REMOTE_BAG_URL_2_QUERY_KEY];
-  },
-  updateUrlToTrackLayoutChanges: async (_opt: { store: Store; skipPatch: boolean }) => {
-    // Persist the layout state in URL or remote storage if needed.
-    await Promise.resolve();
   },
   getPoseErrorScaling() {
     const scaling = {

--- a/app/actions/layoutHistory.ts
+++ b/app/actions/layoutHistory.ts
@@ -11,13 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-export type REDO_LAYOUT_CHANGE = { type: "REDO_LAYOUT_CHANGE" };
+export type REDO_LAYOUT_CHANGE = { type: "REDO_LAYOUT_CHANGE"; payload?: never };
 
 export const redoLayoutChange = (): REDO_LAYOUT_CHANGE => ({
   type: "REDO_LAYOUT_CHANGE",
 });
 
-export type UNDO_LAYOUT_CHANGE = { type: "UNDO_LAYOUT_CHANGE" };
+export type UNDO_LAYOUT_CHANGE = { type: "UNDO_LAYOUT_CHANGE"; payload?: never };
 
 export const undoLayoutChange = (): UNDO_LAYOUT_CHANGE => ({
   type: "UNDO_LAYOUT_CHANGE",

--- a/app/actions/mosaic.ts
+++ b/app/actions/mosaic.ts
@@ -16,7 +16,7 @@ export type SET_MOSAIC_ID = { type: "SET_MOSAIC_ID"; payload: string };
 export type ADD_SELECTED_PANEL_ID = { type: "ADD_SELECTED_PANEL_ID"; payload: string };
 export type REMOVE_SELECTED_PANEL_ID = { type: "REMOVE_SELECTED_PANEL_ID"; payload: string };
 export type SET_SELECTED_PANEL_IDS = { type: "SET_SELECTED_PANEL_IDS"; payload: string[] };
-export type SELECT_ALL_PANELS = { type: "SELECT_ALL_PANELS" };
+export type SELECT_ALL_PANELS = { type: "SELECT_ALL_PANELS"; payload?: never };
 
 export const setMosaicId = (payload: string): SET_MOSAIC_ID => ({
   type: "SET_MOSAIC_ID",

--- a/app/actions/panels.ts
+++ b/app/actions/panels.ts
@@ -125,7 +125,10 @@ export const loadLayout = (layout: PanelsState): Dispatcher<LOAD_LAYOUT> => (dis
   return dispatch({ type: PANELS_ACTION_TYPES.LOAD_LAYOUT, payload: layout });
 };
 
-type CLEAR_LAYOUT_URL_REPLACED_BY_DEFAULT = { type: "CLEAR_LAYOUT_URL_REPLACED_BY_DEFAULT" };
+type CLEAR_LAYOUT_URL_REPLACED_BY_DEFAULT = {
+  type: "CLEAR_LAYOUT_URL_REPLACED_BY_DEFAULT";
+  payload?: never;
+};
 export const clearLayoutUrlReplacedByDefault = (): Dispatcher<CLEAR_LAYOUT_URL_REPLACED_BY_DEFAULT> => (
   dispatch,
 ) => {

--- a/app/panels/ThreeDimensionalViz/stories/storyComponents.tsx
+++ b/app/panels/ThreeDimensionalViz/stories/storyComponents.tsx
@@ -31,9 +31,10 @@ import PanelSetupWithBag from "@foxglove-studio/app/stories/PanelSetupWithBag";
 import inScreenshotTests from "@foxglove-studio/app/stories/inScreenshotTests";
 import { ScreenshotSizedContainer } from "@foxglove-studio/app/stories/storyHelpers";
 import { createRosDatatypesFromFrame } from "@foxglove-studio/app/test/datatypes";
-import { Store } from "@foxglove-studio/app/types/Store";
 import { objectValues } from "@foxglove-studio/app/util";
 import { isBobject, wrapJsObject } from "@foxglove-studio/app/util/binaryObjects";
+
+type Store = ReturnType<typeof configureStore>;
 
 export type FixtureExampleData = {
   topics: {

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -11,6 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Reducer } from "redux";
+import { ThunkAction } from "redux-thunk";
+
 import { ActionTypes } from "@foxglove-studio/app/actions";
 import { ros_lib_dts } from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typescript/ros";
 import hoverValue from "@foxglove-studio/app/reducers/hoverValue";
@@ -29,7 +32,6 @@ import recentLayouts, {
 import tests from "@foxglove-studio/app/reducers/tests";
 import userNodes, { UserNodeDiagnostics } from "@foxglove-studio/app/reducers/userNodes";
 import { Auth as AuthState } from "@foxglove-studio/app/types/Auth";
-import { Dispatch, GetState } from "@foxglove-studio/app/types/Store";
 import { HoverValue } from "@foxglove-studio/app/types/hoverValue";
 import { MosaicKey, SetFetchedLayoutPayload } from "@foxglove-studio/app/types/panels";
 
@@ -49,7 +51,7 @@ export type PersistedState = {
   search?: string;
 };
 
-export type Dispatcher<T extends ActionTypes> = (dispatch: Dispatch<T>, getState: GetState) => void;
+export type Dispatcher<A extends ActionTypes> = ThunkAction<void, State, undefined, A>;
 
 export type State = {
   persistedState: PersistedState;
@@ -65,9 +67,10 @@ export type State = {
   };
 };
 
-export type Store = { dispatch: Dispatch<unknown>; getState: () => State };
-
-export default function createRootReducer(history: any, args?: { testAuth?: any }) {
+export default function createRootReducer(
+  history: any,
+  args?: { testAuth?: any },
+): Reducer<State, ActionTypes> {
   const persistedState = getInitialPersistedStateAndMaybeUpdateLocalStorageAndURL(history);
   maybeStoreNewRecentLayout(persistedState);
   const initialState: State = {
@@ -85,7 +88,7 @@ export default function createRootReducer(history: any, args?: { testAuth?: any 
     layoutHistory: initialLayoutHistoryState,
     commenting: { fetchedCommentsBase: [], fetchedCommentsFeature: [], sourceToShow: "Both" },
   };
-  return (state: State, action: ActionTypes): State => {
+  return (state: State | undefined, action: ActionTypes): State => {
     const oldPersistedState: PersistedState | undefined = state?.persistedState;
     const reducers: Array<
       (arg0: State, arg1: ActionTypes, arg2?: PersistedState) => State

--- a/app/store/configureStore.testing.ts
+++ b/app/store/configureStore.testing.ts
@@ -11,16 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { createStore, applyMiddleware } from "redux";
-import thunk from "redux-thunk";
-import type { ThunkMiddleware } from "redux-thunk";
+import { createStore, applyMiddleware, Reducer } from "redux";
+import thunk, { ThunkDispatch } from "redux-thunk";
 
 import { ActionTypes } from "@foxglove-studio/app/actions";
 import { State } from "@foxglove-studio/app/reducers";
-import { Store } from "@foxglove-studio/app/types/Store";
 
 const configureStore = (
-  reducer: (arg0: any, arg1: any) => any,
+  reducer: Reducer<State, ActionTypes>,
   middleware: Array<any> = [],
   history?: any,
   preloadedState?: State,
@@ -28,7 +26,7 @@ const configureStore = (
   const store = createStore(
     reducer,
     preloadedState,
-    applyMiddleware(thunk as ThunkMiddleware<Store, ActionTypes>, ...middleware),
+    applyMiddleware<ThunkDispatch<State, undefined, ActionTypes>>(thunk, ...middleware),
   );
 
   return store;

--- a/app/store/configureStore.ts
+++ b/app/store/configureStore.ts
@@ -12,14 +12,16 @@
 //   You may not use this file except in compliance with the License.
 
 import { createStore, applyMiddleware, Reducer } from "redux";
-import thunk from "redux-thunk";
-import type { ThunkMiddleware } from "redux-thunk";
+import thunk, { ThunkDispatch } from "redux-thunk";
 
 import { ActionTypes } from "@foxglove-studio/app/actions";
-import { Store } from "@foxglove-studio/app/types/Store";
+import { State } from "@foxglove-studio/app/reducers";
 
-const configureStore = (reducer: Reducer<any, ActionTypes>, middleware: Array<any> = []) => {
-  let enhancer = applyMiddleware(thunk as ThunkMiddleware<Store, ActionTypes>, ...middleware);
+const configureStore = (reducer: Reducer<State, ActionTypes>, middleware: Array<any> = []) => {
+  let enhancer = applyMiddleware<ThunkDispatch<State, undefined, ActionTypes>>(
+    thunk,
+    ...middleware,
+  );
   if (process.env.NODE_ENV !== "production") {
     // Unclear whether this require can be safely moved to an import
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/app/store/getGlobalStore.ts
+++ b/app/store/getGlobalStore.ts
@@ -16,8 +16,9 @@ import updateUrlAndLocalStorageMiddleware from "@foxglove-studio/app/middleware/
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store";
 import configureTestingStore from "@foxglove-studio/app/store/configureStore.testing";
-import { Store } from "@foxglove-studio/app/types/Store";
 import history from "@foxglove-studio/app/util/history";
+
+type Store = ReturnType<typeof configureStore>;
 
 interface TestStore extends Store {
   push?: (path: string) => void;

--- a/app/stories/PanelSetup.tsx
+++ b/app/stories/PanelSetup.tsx
@@ -40,10 +40,11 @@ import { Frame, Topic, PlayerStateActiveData, Progress } from "@foxglove-studio/
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 import { RosDatatypes } from "@foxglove-studio/app/types/RosDatatypes";
-import { Store } from "@foxglove-studio/app/types/Store";
 import { MosaicNode, SavedProps, UserNodes } from "@foxglove-studio/app/types/panels";
 import { objectValues } from "@foxglove-studio/app/util";
 import { isBobject } from "@foxglove-studio/app/util/binaryObjects";
+
+type Store = ReturnType<typeof configureStore>;
 
 export type Fixture = {
   frame: Frame;
@@ -185,7 +186,7 @@ export default class PanelSetup extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      store: props.store || configureStore(createRootReducer(createMemoryHistory())),
+      store: props.store ?? configureStore(createRootReducer(createMemoryHistory())),
     };
   }
 

--- a/app/stories/StoreSetup.tsx
+++ b/app/stories/StoreSetup.tsx
@@ -17,7 +17,8 @@ import { Provider } from "react-redux";
 
 import createRootReducer from "@foxglove-studio/app/reducers";
 import configureStore from "@foxglove-studio/app/store/configureStore";
-import { Store } from "@foxglove-studio/app/types/Store";
+
+type Store = ReturnType<typeof configureStore>;
 
 type Props = {
   children: ReactNode;
@@ -25,7 +26,7 @@ type Props = {
 };
 
 export default function StoreSetup(props: Props) {
-  const storeRef = useRef(props.store || configureStore(createRootReducer(createMemoryHistory())));
+  const storeRef = useRef(props.store ?? configureStore(createRootReducer(createMemoryHistory())));
 
   return <Provider store={storeRef.current}>{props.children}</Provider>;
 }

--- a/app/types/Store.ts
+++ b/app/types/Store.ts
@@ -11,16 +11,12 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import type { Store as ReduxStore } from "redux";
+import type { Action, Store as ReduxStore } from "redux";
 import type { ThunkDispatch } from "redux-thunk";
 
 import { ActionTypes } from "@foxglove-studio/app/actions";
 import { State } from "@foxglove-studio/app/reducers";
 
-export type Store = ReduxStore<State, ActionTypes> & {
-  dispatch: ThunkDispatch<State, undefined, ActionTypes>;
+export type Store<S = State, A extends Action<unknown> = ActionTypes> = ReduxStore<S, A> & {
+  dispatch: ThunkDispatch<S, undefined, A>;
 };
-
-export type GetState = () => State;
-
-export type Dispatch<T> = (arg0: T | ((arg0: Dispatch<T>, arg1: GetState) => State)) => void;


### PR DESCRIPTION
Improve some type information for redux store creation and dispatch. I was sent down this road because I wanted to make a `createStore` in a story and found that some of our existing type specifications were at odds with building a store using the basic primitives.