### PR TITLE
Fix panel settings json modal closing when clicked

### DIFF
--- a/app/components/ErrorBoundary.stories.tsx
+++ b/app/components/ErrorBoundary.stories.tsx
@@ -15,6 +15,8 @@ import { storiesOf } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 
+import StoreSetup from "@foxglove-studio/app/stories/StoreSetup";
+
 import ErrorBoundary from "./ErrorBoundary";
 
 class Broken extends React.Component {
@@ -33,9 +35,11 @@ class Broken extends React.Component {
 storiesOf("<ErrorBoundary>", module).add("examples", () => {
   return (
     <DndProvider backend={HTML5Backend}>
-      <ErrorBoundary hideSourceLocations>
-        <Broken />
-      </ErrorBoundary>
+      <StoreSetup>
+        <ErrorBoundary hideSourceLocations>
+          <Broken />
+        </ErrorBoundary>
+      </StoreSetup>
     </DndProvider>
   );
 });

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -68,11 +68,11 @@ type Props = {
 function StandardMenuItems({
   tabId,
   isUnknownPanel,
-  setShowShareModal,
+  onEditPanelConfig,
 }: {
   tabId?: string;
   isUnknownPanel: boolean;
-  setShowShareModal: (_: boolean) => void;
+  onEditPanelConfig: () => void;
 }) {
   const { mosaicActions } = useContext(MosaicContext);
   const { mosaicWindowActions } = useContext(MosaicWindowContext);
@@ -203,7 +203,7 @@ function StandardMenuItems({
       {!isUnknownPanel && (
         <Item
           icon={<CodeJsonIcon />}
-          onClick={() => setShowShareModal(true)}
+          onClick={onEditPanelConfig}
           disabled={type === TAB_PANEL_TYPE}
           dataTest="panel-settings-config"
         >
@@ -220,7 +220,7 @@ type PanelToolbarControlsProps = Props & {
   onDragEnd: () => void;
   showPanelName?: boolean;
   isUnknownPanel: boolean;
-  setShowShareModal: (_: boolean) => void;
+  onEditPanelConfig: () => void;
 };
 
 // Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
@@ -236,7 +236,7 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
   onDragStart,
   showHiddenControlsOnHover,
   showPanelName,
-  setShowShareModal,
+  onEditPanelConfig,
 }: PanelToolbarControlsProps) {
   const panelData = useContext(PanelContext);
 
@@ -259,7 +259,7 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
         <StandardMenuItems
           tabId={panelData?.tabId}
           isUnknownPanel={isUnknownPanel}
-          setShowShareModal={setShowShareModal}
+          onEditPanelConfig={onEditPanelConfig}
         />
         {menuContent && <hr />}
         {menuContent}
@@ -347,7 +347,7 @@ export default React.memo<Props>(function PanelToolbar({
                 onDragStart={onDragStart}
                 onDragEnd={onDragEnd}
                 isUnknownPanel={!!isUnknownPanel}
-                setShowShareModal={setShowShareModal}
+                onEditPanelConfig={() => setShowShareModal(true)}
               />
             )}
           </div>

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -65,7 +65,15 @@ type Props = {
 
 // separated into a sub-component so it can always skip re-rendering
 // it never changes after it initially mounts
-function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string; isUnknownPanel: boolean }) {
+function StandardMenuItems({
+  tabId,
+  isUnknownPanel,
+  setShowShareModal,
+}: {
+  tabId?: string;
+  isUnknownPanel: boolean;
+  setShowShareModal: (_: boolean) => void;
+}) {
   const { mosaicActions } = useContext(MosaicContext);
   const { mosaicWindowActions } = useContext(MosaicWindowContext);
   const savedProps = useSelector((state: State) => state.persistedState.panels.savedProps);
@@ -138,26 +146,6 @@ function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string; isUnknow
 
   const { store } = useContext(ReactReduxContext);
   const panelContext = usePanelContext();
-  const [showShareModal, setShowShareModal] = useState<boolean>(false);
-
-  const shareModal = useMemo(() => {
-    const id = panelContext?.id;
-    if (!id || !showShareModal) {
-      return ReactNull;
-    }
-
-    const panelConfigById = store.getState().persistedState.panels.savedProps;
-    return (
-      <ShareJsonModal
-        onRequestClose={() => setShowShareModal(false)}
-        value={panelConfigById[id] ?? {}}
-        onChange={(config) =>
-          actions.savePanelConfigs({ configs: [{ id, config, override: true }] })
-        }
-        noun="panel configuration"
-      />
-    );
-  }, [panelContext?.id, showShareModal, store, actions]);
 
   const type = getPanelType();
   if (!type) {
@@ -222,7 +210,6 @@ function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string; isUnknow
           Import/export panel settings
         </Item>
       )}
-      {shareModal}
     </>
   );
 }
@@ -233,6 +220,7 @@ type PanelToolbarControlsProps = Props & {
   onDragEnd: () => void;
   showPanelName?: boolean;
   isUnknownPanel: boolean;
+  setShowShareModal: (_: boolean) => void;
 };
 
 // Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
@@ -248,6 +236,7 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
   onDragStart,
   showHiddenControlsOnHover,
   showPanelName,
+  setShowShareModal,
 }: PanelToolbarControlsProps) {
   const panelData = useContext(PanelContext);
 
@@ -267,7 +256,11 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
           </Icon>
         }
       >
-        <StandardMenuItems tabId={panelData?.tabId} isUnknownPanel={isUnknownPanel} />
+        <StandardMenuItems
+          tabId={panelData?.tabId}
+          isUnknownPanel={isUnknownPanel}
+          setShowShareModal={setShowShareModal}
+        />
         {menuContent && <hr />}
         {menuContent}
       </Dropdown>
@@ -298,11 +291,31 @@ export default React.memo<Props>(function PanelToolbar({
   menuContent,
   showHiddenControlsOnHover,
 }: Props) {
-  const { isHovered = false } = useContext(PanelContext) || {};
+  const { isHovered = false, id } = useContext(PanelContext) ?? {};
   const [isDragging, setIsDragging] = useState(false);
   const onDragStart = useCallback(() => setIsDragging(true), []);
   const onDragEnd = useCallback(() => setIsDragging(false), []);
   const [containsOpen, setContainsOpen] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
+  const dispatch = useDispatch();
+
+  const { store } = useContext(ReactReduxContext);
+  const shareModal = useMemo(() => {
+    if (!id || !showShareModal) {
+      return ReactNull;
+    }
+    const panelConfigById = store.getState().persistedState.panels.savedProps;
+    return (
+      <ShareJsonModal
+        onRequestClose={() => setShowShareModal(false)}
+        value={panelConfigById[id] ?? {}}
+        onChange={(config) =>
+          dispatch(savePanelConfigs({ configs: [{ id, config, override: true }] }))
+        }
+        noun="panel configuration"
+      />
+    );
+  }, [id, showShareModal, store, dispatch]);
 
   if (frameless() || hideToolbars) {
     return ReactNull;
@@ -313,6 +326,7 @@ export default React.memo<Props>(function PanelToolbar({
     <Dimensions>
       {({ width }) => (
         <ChildToggle.ContainsOpen onChange={setContainsOpen}>
+          {shareModal}
           <div
             className={cx(styles.panelToolbarContainer, {
               [styles.floating]: floating,
@@ -333,6 +347,7 @@ export default React.memo<Props>(function PanelToolbar({
                 onDragStart={onDragStart}
                 onDragEnd={onDragEnd}
                 isUnknownPanel={!!isUnknownPanel}
+                setShowShareModal={setShowShareModal}
               />
             )}
           </div>

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -299,9 +299,9 @@ export default React.memo<Props>(function PanelToolbar({
   const [showShareModal, setShowShareModal] = useState(false);
   const dispatch = useDispatch();
 
-  const { store } = useContext(ReactReduxContext);
+  const { store } = useContext(ReactReduxContext) ?? {};
   const shareModal = useMemo(() => {
-    if (!id || !showShareModal) {
+    if (!id || !showShareModal || !store) {
       return ReactNull;
     }
     const panelConfigById = store.getState().persistedState.panels.savedProps;

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -299,9 +299,9 @@ export default React.memo<Props>(function PanelToolbar({
   const [showShareModal, setShowShareModal] = useState(false);
   const dispatch = useDispatch();
 
-  const { store } = useContext(ReactReduxContext) ?? {};
+  const { store } = useContext(ReactReduxContext);
   const shareModal = useMemo(() => {
-    if (!id || !showShareModal || !store) {
+    if (!id || !showShareModal) {
       return ReactNull;
     }
     const panelConfigById = store.getState().persistedState.panels.savedProps;

--- a/app/panels/PlaybackPerformance/index.stories.tsx
+++ b/app/panels/PlaybackPerformance/index.stories.tsx
@@ -14,6 +14,7 @@
 import { storiesOf } from "@storybook/react";
 
 import { PlayerStateActiveData } from "@foxglove-studio/app/players/types";
+import StoreSetup from "@foxglove-studio/app/stories/StoreSetup";
 
 import { UnconnectedPlaybackPerformance, UnconnectedPlaybackPerformanceProps } from ".";
 
@@ -41,7 +42,11 @@ function Example({ states }: { states: UnconnectedPlaybackPerformanceProps[] }) 
       setState(state.slice(1));
     }
   }, [state]);
-  return <UnconnectedPlaybackPerformance {...state[0]} />;
+  return (
+    <StoreSetup>
+      <UnconnectedPlaybackPerformance {...state[0]} />
+    </StoreSetup>
+  );
 }
 
 storiesOf("<PlaybackPerformance>", module).add("simple example", () => {


### PR DESCRIPTION
The modal was closing whenever its parent ChildToggle closed, since the RenderToBody was being hosted inside the menu (as of #233). Hoist the modal to the top level PanelToolbar so it is not removed when the menu closes.