### PR TITLE
Fix root tf frame selection in TopicTree

### DIFF
--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -118,7 +118,7 @@ const missingTransformMessage = (
   }
   const frameIds = [...error.frameIds].sort().join(",");
   const s = error.frameIds.size === 1 ? "" : "s"; // for plural
-  return `missing transforms to root frame ${rootTransformId} from frame${s} ${frameIds}.`;
+  return `missing transforms from frame${s} (${frameIds}) to root frame (${rootTransformId})`;
 };
 
 export function getSceneErrorsByTopic(
@@ -422,9 +422,13 @@ export default class SceneBuilder implements MarkerProvider {
 
   // Update the field anytime the errors change in order to generate a new object to trigger TopicTree to rerender.
   _updateErrorsByTopic() {
+    if (!this.transforms) {
+      return;
+    }
+
     const errorsByTopic = getSceneErrorsByTopic(
       this.errors,
-      this.transforms as any,
+      this.transforms,
       this._hooks.skipTransformFrame,
     );
     if (!isEqual(this.errorsByTopic, errorsByTopic)) {

--- a/app/panels/ThreeDimensionalViz/Transforms.ts
+++ b/app/panels/ThreeDimensionalViz/Transforms.ts
@@ -14,7 +14,6 @@
 import { mat4, vec3, quat, vec4 } from "gl-matrix";
 
 import { TF, MutablePose, Pose, Point, Orientation } from "@foxglove-studio/app/types/Messages";
-import { objectValues } from "@foxglove-studio/app/util";
 
 // allocate some temporary variables
 // so we can copy/in out of them during tf application
@@ -133,19 +132,26 @@ export class Transform {
 }
 
 class TfStore {
-  storage: any = {};
+  #storage = new Map<string, Transform>();
+
   get(key: string): Transform {
     key = stripLeadingSlash(key);
-    let result = this.storage[key];
+    let result = this.#storage.get(key);
     if (result) {
       return result;
     }
     result = new Transform(key);
-    this.storage[key] = result;
+    this.#storage.set(key, result);
     return result;
   }
 
-  values = (): Array<Transform> => objectValues(this.storage);
+  has(key: string): boolean {
+    return this.#storage.has(key);
+  }
+
+  values(): Array<Transform> {
+    return Array.from(this.#storage.values());
+  }
 }
 
 export default class Transforms {
@@ -185,6 +191,16 @@ export default class Transforms {
     return this.get(transformID).rootTransform();
   }
 
-  get = (key: string) => this.storage.get(key);
-  values = (): Array<Transform> => this.storage.values();
+  // Return true if a transform with id _key_ exists in our transforms
+  has(key: string) {
+    return this.storage.has(key);
+  }
+
+  get(key: string) {
+    return this.storage.get(key);
+  }
+
+  values(): Array<Transform> {
+    return this.storage.values();
+  }
 }


### PR DESCRIPTION
REP 105 defines a set of naming conventions for coordinate frames.
In addition to trying to find a root tf from the user's selected follow frame,
we try the tf frame ids from this naming convention.

The result is that bag files with tf frames that follow this convention are likely
to load without errors for missing tf root frames and also likely to have the 3d view
focus on an area with something to display.