### PR TITLE
Add an HttpServer to electron-socket

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -78,6 +78,7 @@ async function createWindow(): Promise<void> {
       contextIsolation: true,
       preload: preloadPath,
       nodeIntegration: false,
+      webSecurity: false,
     },
     backgroundColor: colors.background,
   };

--- a/packages/electron-socket/preloader/HttpServerElectron.ts
+++ b/packages/electron-socket/preloader/HttpServerElectron.ts
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import http from "http";
+
+import { HttpRequest, HttpResponse } from "../shared/HttpTypes";
+import { Cloneable, RpcCall, RpcHandler, RpcResponse } from "../shared/Rpc";
+import { TcpAddress } from "../shared/TcpTypes";
+
+export class HttpServerElectron {
+  readonly id: number;
+  #server: http.Server;
+  #messagePort: MessagePort;
+  #nextRequestId = 0;
+  #requests = new Map<number, (response: HttpResponse) => Promise<void>>();
+  #api = new Map<string, RpcHandler>([
+    ["address", (callId) => this.#apiResponse([callId, this.address()])],
+    [
+      "listen",
+      (callId, args) => {
+        const port = args[0] as number | undefined;
+        const hostname = args[1] as string | undefined;
+        const backlog = args[2] as number | undefined;
+        this.listen(port, hostname, backlog)
+          .then(() => this.#apiResponse([callId, undefined]))
+          .catch((err) => this.#apiResponse([callId, String(err.stack ?? err)]));
+      },
+    ],
+    [
+      "response",
+      (callId, args) => {
+        const requestId = args[0] as number;
+        const response = args[1] as HttpResponse;
+        const handler = this.#requests.get(requestId);
+        if (handler == undefined) {
+          this.#apiResponse([callId, `unknown requestId ${requestId}`]);
+          return;
+        }
+        this.#requests.delete(requestId);
+        handler(response)
+          .then(() => this.#apiResponse([callId, undefined]))
+          .catch((err) => this.#apiResponse([callId, String(err.stack ?? err)]));
+      },
+    ],
+    ["close", (callId) => this.#apiResponse([callId, this.close()])],
+    ["dispose", (callId) => this.#apiResponse([callId, this.dispose()])],
+  ]);
+
+  constructor(id: number, messagePort: MessagePort) {
+    this.id = id;
+    this.#server = http.createServer(this.#handleRequest);
+    this.#messagePort = messagePort;
+
+    this.#server.on("close", () => this.#emit("close"));
+    this.#server.on("error", (err) => this.#emit("error", String(err.stack ?? err)));
+
+    messagePort.onmessage = (ev: MessageEvent<RpcCall>) => {
+      const [methodName, callId] = ev.data;
+      const args = ev.data.slice(2);
+      const handler = this.#api.get(methodName);
+      handler?.(callId, args);
+    };
+    messagePort.start();
+  }
+
+  address(): TcpAddress | undefined {
+    const addr = this.#server.address();
+    if (addr == undefined || typeof addr === "string") {
+      // Address will only be a string for an IPC (named pipe) server, which
+      // should never happen here
+      return undefined;
+    }
+    return addr;
+  }
+
+  listen(port?: number, hostname?: string, backlog?: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.#server.listen(port, hostname, backlog, () => {
+        this.#server.removeListener("error", reject);
+        resolve();
+      });
+    });
+  }
+
+  close(): void {
+    this.#server.close();
+  }
+
+  dispose(): void {
+    this.#server.removeAllListeners();
+    this.close();
+    this.#messagePort.close();
+  }
+
+  #apiResponse = (message: RpcResponse, transfer?: Transferable[]): void => {
+    if (transfer != undefined) {
+      this.#messagePort.postMessage(message, transfer);
+    } else {
+      this.#messagePort.postMessage(message);
+    }
+  };
+
+  #emit = (eventName: string, ...args: Cloneable[]): void => {
+    const msg = [eventName, ...args];
+    this.#messagePort.postMessage(msg);
+  };
+
+  #handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+    const chunks: Uint8Array[] = [];
+    req.on("data", (chunk: Uint8Array) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString();
+
+      const requestId = this.#nextRequestId++;
+      this.#requests.set(
+        requestId,
+        (incomingRes): Promise<void> => {
+          res.chunkedEncoding = incomingRes.chunkedEncoding ?? res.chunkedEncoding;
+          res.shouldKeepAlive = incomingRes.shouldKeepAlive ?? res.shouldKeepAlive;
+          res.useChunkedEncodingByDefault =
+            incomingRes.useChunkedEncodingByDefault ?? res.useChunkedEncodingByDefault;
+          res.sendDate = incomingRes.sendDate ?? res.sendDate;
+
+          res.writeHead(incomingRes.statusCode, incomingRes.statusMessage, incomingRes.headers);
+          return new Promise((resolve) => res.end(incomingRes.body, resolve));
+        },
+      );
+
+      const request: HttpRequest = {
+        body,
+        aborted: req.aborted,
+        httpVersion: req.httpVersion,
+        httpVersionMajor: req.httpVersionMajor,
+        httpVersionMinor: req.httpVersionMinor,
+        complete: req.complete,
+        headers: req.headers,
+        rawHeaders: req.rawHeaders,
+        trailers: req.trailers,
+        rawTrailers: req.rawTrailers,
+        method: req.method,
+        url: req.url,
+      };
+      this.#emit("request", requestId, request);
+    });
+  };
+}

--- a/packages/electron-socket/preloader/PreloaderSockets.ts
+++ b/packages/electron-socket/preloader/PreloaderSockets.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Cloneable, RpcCall } from "../shared/Rpc";
-import { createServer, createSocket } from "./api";
+import { createHttpServer, createServer, createSocket } from "./api";
 
 export class PreloaderSockets {
   // The preloader ("isolated world") side of the original message channel
@@ -13,6 +13,13 @@ export class PreloaderSockets {
   #messagePort: MessagePort;
   // The API exposed to the renderer
   #functionHandlers = new Map<string, (callId: number, args: Cloneable[]) => void>([
+    [
+      "createHttpServer",
+      (callId, _) => {
+        const port = createHttpServer();
+        this.#messagePort.postMessage([callId], [port]);
+      },
+    ],
     [
       "createSocket",
       (callId, args) => {

--- a/packages/electron-socket/preloader/api.ts
+++ b/packages/electron-socket/preloader/api.ts
@@ -4,11 +4,20 @@
 
 import { Socket } from "net";
 
+import { HttpServerElectron } from "./HttpServerElectron";
 import { TcpServerElectron } from "./TcpServerElectron";
 import { TcpSocketElectron } from "./TcpSocketElectron";
 import { getTransform, nextId, registerEntity } from "./registry";
 
 export { registerTransform } from "./registry";
+
+export function createHttpServer(): MessagePort {
+  const channel = new MessageChannel();
+  const id = nextId();
+  const server = new HttpServerElectron(id, channel.port2);
+  registerEntity(id, server);
+  return channel.port1;
+}
 
 export function createSocket(transformName?: string): MessagePort {
   const channel = new MessageChannel();

--- a/packages/electron-socket/renderer/HttpServerRenderer.ts
+++ b/packages/electron-socket/renderer/HttpServerRenderer.ts
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import EventEmitter from "eventemitter3";
+
+import { HttpHandler, HttpRequest, HttpResponse } from "../shared/HttpTypes";
+import { Cloneable, RpcCall, RpcEvent, RpcResponse } from "../shared/Rpc";
+import { TcpAddress } from "../shared/TcpTypes";
+
+export class HttpServerRenderer extends EventEmitter {
+  #messagePort: MessagePort;
+  #handler: HttpHandler;
+  #callbacks = new Map<number, (result: Cloneable[]) => void>();
+  #nextCallId = 0;
+  #events = new Map<string, (args: Cloneable[], ports?: readonly MessagePort[]) => void>([
+    ["close", () => this.emit("close")],
+    [
+      "request",
+      async (args) => {
+        const requestId = args[0] as number;
+        const req = args[1] as HttpRequest;
+        let res: HttpResponse | undefined;
+        try {
+          res = await this.#handler(req);
+        } catch (err) {
+          res = { statusCode: 500, statusMessage: String(err) };
+        }
+        this.#apiCall("response", requestId, res);
+      },
+    ],
+    ["error", (args) => this.emit("error", new Error(args[0] as string))],
+  ]);
+
+  constructor(messagePort: MessagePort, requestHandler: HttpHandler) {
+    super();
+    this.#messagePort = messagePort;
+    this.#handler = requestHandler;
+
+    messagePort.onmessage = (ev: MessageEvent<RpcResponse | RpcEvent>) => {
+      const args = ev.data.slice(1);
+      if (typeof ev.data[0] === "number") {
+        // RpcResponse
+        const callId = ev.data[0];
+        const callback = this.#callbacks.get(callId);
+        if (callback !== undefined) {
+          this.#callbacks.delete(callId);
+          callback(args);
+        }
+      } else {
+        // RpcEvent
+        const eventName = ev.data[0];
+        const handler = this.#events.get(eventName);
+        handler?.(args, ev.ports);
+      }
+    };
+    messagePort.start();
+  }
+
+  async address(): Promise<TcpAddress | undefined> {
+    const res = await this.#apiCall("address");
+    return res[0] as TcpAddress | undefined;
+  }
+
+  async listen(port?: number, hostname?: string, backlog?: number): Promise<void> {
+    const res = await this.#apiCall("listen", port, hostname, backlog);
+    if (res[0] != undefined) {
+      return Promise.reject(new Error(res[0] as string));
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.#apiCall("close");
+  }
+
+  async dispose(): Promise<void> {
+    await this.#apiCall("dispose");
+    // eslint-disable-next-line no-restricted-syntax
+    this.#messagePort.onmessage = null;
+    this.#messagePort.close();
+    this.#callbacks.clear();
+  }
+
+  #apiCall = (methodName: string, ...args: Cloneable[]): Promise<Cloneable[]> => {
+    return new Promise((resolve) => {
+      const callId = this.#nextCallId++;
+      this.#callbacks.set(callId, (result) => {
+        this.#callbacks.delete(callId);
+        resolve(result);
+      });
+      const msg: RpcCall = [methodName, callId, ...args];
+      this.#messagePort.postMessage(msg);
+    });
+  };
+}

--- a/packages/electron-socket/renderer/index.ts
+++ b/packages/electron-socket/renderer/index.ts
@@ -3,5 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export * from "./Sockets";
+export * from "./HttpServerRenderer";
 export * from "./TcpServerRenderer";
 export * from "./TcpSocketRenderer";

--- a/packages/electron-socket/shared/HttpTypes.ts
+++ b/packages/electron-socket/shared/HttpTypes.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type HttpHeaders = Record<string, number | string | string[]>;
+
+export type IncomingHttpHeaders = Record<string, string | string[] | undefined>;
+
+export type HttpRequest = {
+  body: string;
+  aborted: boolean;
+  httpVersion: string;
+  httpVersionMajor: number;
+  httpVersionMinor: number;
+  complete: boolean;
+  headers: IncomingHttpHeaders;
+  rawHeaders: string[];
+  trailers: IncomingHttpHeaders;
+  rawTrailers: string[];
+  method?: string;
+  url?: string;
+};
+
+export type HttpResponse = {
+  statusCode: number;
+  statusMessage?: string;
+  headers?: HttpHeaders;
+  body?: string;
+  chunkedEncoding?: boolean;
+  shouldKeepAlive?: boolean;
+  useChunkedEncodingByDefault?: boolean;
+  sendDate?: boolean;
+};
+
+export type HttpHandler = (req: HttpRequest) => Promise<HttpResponse>;


### PR DESCRIPTION
Because you can't spell XMLRPC without HTTP﻿
