### PR TITLE
Re-enable webSecurity to fix integration test

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -78,7 +78,6 @@ async function createWindow(): Promise<void> {
       contextIsolation: true,
       preload: preloadPath,
       nodeIntegration: false,
-      webSecurity: false,
     },
     backgroundColor: colors.background,
   };


### PR DESCRIPTION
Introduced by https://github.com/foxglove/studio/pull/313, but appears to be causing failures in our integration test ([example](https://github.com/foxglove/studio/runs/2146528962)).