### PR TITLE
Select the initial value when displaying a prompt

### DIFF
--- a/app/hooks/usePrompt.tsx
+++ b/app/hooks/usePrompt.tsx
@@ -36,6 +36,11 @@ function ModalPrompt({ onComplete, placeholder, value: initialValue }: ModalProm
   const [value, setValue] = useState<string>(initialValue ?? "");
   const inputRef = useRef<HTMLInputElement>(ReactNull);
 
+  // select any existing input text on first display
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
   return (
     <Modal onRequestClose={() => onComplete(undefined)}>
       <ModalContent>


### PR DESCRIPTION
The common use case for displaying a prompt with an initial value
is for the user to change that value. We pre-select the string
so they user can start typing their new value without having to first
select the pre-filled value.