### PR TITLE
Revert "Quit app when all windows closed"

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -350,7 +350,11 @@ app.on("ready", async () => {
   });
 });
 
-// Quit when all windows are closed
+// Quit when all windows are closed, except on macOS. There, it's common
+// for applications and their menu bar to stay active until the user quits
+// explicitly with Cmd + Q.
 app.on("window-all-closed", () => {
-  app.quit();
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
 });

--- a/desktop/menu.ts
+++ b/desktop/menu.ts
@@ -9,6 +9,7 @@ import { simulateUserClick } from "./simulateUserClick";
 // Install handlers for ipc menu add and remove events
 // These handlers allow for the preload/renderer to manage the list of "File Open ..." items.
 export function installMenuInterface(): void {
+  ipcMain.removeHandler("menu.add-input-source");
   ipcMain.handle("menu.add-input-source", (_ev: unknown, ...args) => {
     const name = args[0];
     if (typeof name !== "string") {
@@ -56,6 +57,7 @@ export function installMenuInterface(): void {
     Menu.setApplicationMenu(appMenu);
   });
 
+  ipcMain.removeHandler("menu.remove-input-source");
   ipcMain.handle("menu.remove-input-source", (_ev: unknown, ...args) => {
     const name = args[0];
     if (typeof name !== "string") {


### PR DESCRIPTION
Reverts foxglove/studio#161

Keeping app open when windows are closed is standard / expected behavior for mac apps.