### PR TITLE
Help modal, keyboard shortcut, and undo/redo menu improvements

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -8,7 +8,10 @@ export type OsContextForwardedEvent =
   | "leave-full-screen"
   | "open-preferences"
   | "open-keyboard-shortcuts"
-  | "open-welcome-layout";
+  | "open-message-path-syntax-help"
+  | "open-welcome-layout"
+  | "undo"
+  | "redo";
 
 export type StorageContent = string | Uint8Array;
 

--- a/app/components/GlobalKeyListener.test.tsx
+++ b/app/components/GlobalKeyListener.test.tsx
@@ -29,11 +29,6 @@ function Context(props: any) {
     <MockMessagePipelineProvider store={props.store}> {props.children}</MockMessagePipelineProvider>
   );
 }
-const mockHistory = {
-  push: () => {
-    // no-op
-  },
-};
 describe("GlobalKeyListener", () => {
   let redoActionCreator: any;
   let undoActionCreator: any;
@@ -48,7 +43,7 @@ describe("GlobalKeyListener", () => {
         <div data-nativeundoredo="true">
           <textarea id="some-text-area" />
         </div>
-        <GlobalKeyListener history={mockHistory} />
+        <GlobalKeyListener />
         <textarea id="other-text-area" />
       </Context>,
       { attachTo: wrapper },
@@ -90,94 +85,5 @@ describe("GlobalKeyListener", () => {
     );
     expect(undoActionCreator).not.toHaveBeenCalled();
     expect(redoActionCreator).not.toHaveBeenCalled();
-  });
-
-  it("calls openSaveLayoutModal after pressing cmd/ctrl + s/S keys", async () => {
-    const wrapper = document.createElement("div");
-    const openSaveLayoutModal = jest.fn();
-    mount(
-      <Context store={getStore()}>
-        <GlobalKeyListener history={mockHistory} openSaveLayoutModal={openSaveLayoutModal} />
-      </Context>,
-      { attachTo: wrapper },
-    );
-
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true }));
-    expect(openSaveLayoutModal).toHaveBeenCalledTimes(1);
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "S", metaKey: true }));
-    expect(openSaveLayoutModal).toHaveBeenCalledTimes(2);
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "S", ctrlKey: true }));
-    expect(openSaveLayoutModal).toHaveBeenCalledTimes(3);
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "s", metaKey: true }));
-    expect(openSaveLayoutModal).toHaveBeenCalledTimes(4);
-  });
-
-  it("does not call openSaveLayoutModal if the events were fired from editable fields", () => {
-    const wrapper = document.createElement("div");
-    const openSaveLayoutModal = jest.fn();
-    mount(
-      <Context store={getStore()}>
-        <GlobalKeyListener history={mockHistory} openSaveLayoutModal={openSaveLayoutModal} />
-        <textarea id="some-text-area" />
-      </Context>,
-      { attachTo: wrapper },
-    );
-
-    const textarea = document.getElementById("some-text-area");
-    if (!textarea) {
-      throw new Error("could not find textarea.");
-    }
-    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "s", ctrlKey: true }));
-    expect(openSaveLayoutModal).toHaveBeenCalledTimes(0);
-  });
-
-  it("opens shortcuts modal after pressing cmd/ctrl + / keys", async () => {
-    const wrapper = document.createElement("div");
-    const openShortcutsModal = jest.fn();
-
-    mount(
-      <Context store={getStore()}>
-        <GlobalKeyListener openShortcutsModal={openShortcutsModal} history={mockHistory} />
-      </Context>,
-      { attachTo: wrapper },
-    );
-
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "/", ctrlKey: true }));
-    expect(openShortcutsModal).toHaveBeenCalledTimes(1);
-  });
-
-  it("pushes help route to history after pressing ?", async () => {
-    const wrapper = document.createElement("div");
-    const mockHistoryPush = jest.fn();
-
-    mount(
-      <Context store={getStore()}>
-        <GlobalKeyListener history={{ push: mockHistoryPush }} />
-      </Context>,
-      { attachTo: wrapper },
-    );
-
-    document.dispatchEvent(new KeyboardEvent("keydown", { key: "?" }));
-    expect(mockHistoryPush).toHaveBeenNthCalledWith(1, "/help");
-  });
-
-  it("does not push shortcuts route if the events were fired from editable fields", () => {
-    const wrapper = document.createElement("div");
-    const mockHistoryPush = jest.fn();
-
-    mount(
-      <Context store={getStore()}>
-        <GlobalKeyListener history={{ push: mockHistoryPush }} />
-        <textarea id="some-text-area" />
-      </Context>,
-      { attachTo: wrapper },
-    );
-
-    const textarea = document.getElementById("some-text-area");
-    if (!textarea) {
-      throw new Error("could not find textarea.");
-    }
-    textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "?" }));
-    expect(mockHistoryPush).not.toHaveBeenCalled();
   });
 });

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -52,13 +52,11 @@ import MosaicDragHandle from "./MosaicDragHandle";
 import styles from "./index.module.scss";
 
 type Props = {
-  // eslint-disable-next-line react/no-unused-prop-types
   children?: React.ReactNode;
   floating?: boolean;
   helpContent?: React.ReactNode;
   menuContent?: React.ReactNode;
   additionalIcons?: React.ReactNode;
-  // eslint-disable-next-line react/no-unused-prop-types
   hideToolbars?: boolean;
   showHiddenControlsOnHover?: boolean;
   isUnknownPanel?: boolean;
@@ -234,7 +232,10 @@ function StandardMenuItems({
   );
 }
 
-type PanelToolbarControlsProps = Props & {
+type PanelToolbarControlsProps = Pick<
+  Props,
+  "additionalIcons" | "floating" | "menuContent" | "showHiddenControlsOnHover"
+> & {
   isRendered: boolean;
   onDragStart: () => void;
   onDragEnd: () => void;

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -18,6 +18,7 @@ import CodeJsonIcon from "@mdi/svg/svg/code-json.svg";
 import CogIcon from "@mdi/svg/svg/cog.svg";
 import DragIcon from "@mdi/svg/svg/drag.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
+import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import TrashCanOutlineIcon from "@mdi/svg/svg/trash-can-outline.svg";
 import cx from "classnames";
 import { useContext, useState, useCallback, useMemo } from "react";
@@ -35,6 +36,7 @@ import {
 import ChildToggle from "@foxglove-studio/app/components/ChildToggle";
 import Dimensions from "@foxglove-studio/app/components/Dimensions";
 import Dropdown from "@foxglove-studio/app/components/Dropdown";
+import HelpModal from "@foxglove-studio/app/components/HelpModal";
 import Icon from "@foxglove-studio/app/components/Icon";
 import { Item, SubMenu } from "@foxglove-studio/app/components/Menu";
 import PanelContext, { usePanelContext } from "@foxglove-studio/app/components/PanelContext";
@@ -46,7 +48,6 @@ import frameless from "@foxglove-studio/app/util/frameless";
 import { TAB_PANEL_TYPE } from "@foxglove-studio/app/util/globalConstants";
 import logEvent, { getEventNames, getEventTags } from "@foxglove-studio/app/util/logEvent";
 
-import HelpButton from "./HelpButton";
 import MosaicDragHandle from "./MosaicDragHandle";
 import styles from "./index.module.scss";
 
@@ -247,7 +248,6 @@ type PanelToolbarControlsProps = Props & {
 const PanelToolbarControls = React.memo(function PanelToolbarControls({
   additionalIcons,
   floating,
-  helpContent,
   isRendered,
   isUnknownPanel,
   menuContent,
@@ -266,7 +266,6 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
     >
       {showPanelName && panelData && <div className={styles.panelName}>{panelData.title}</div>}
       {additionalIcons}
-      {helpContent && <HelpButton>{helpContent}</HelpButton>}
       <Dropdown
         flatEdges={!floating}
         toggleComponent={
@@ -316,6 +315,7 @@ export default React.memo<Props>(function PanelToolbar({
   const onDragEnd = useCallback(() => setIsDragging(false), []);
   const [containsOpen, setContainsOpen] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
   const dispatch = useDispatch();
 
   const { store } = useContext(ReactReduxContext);
@@ -336,6 +336,21 @@ export default React.memo<Props>(function PanelToolbar({
     );
   }, [id, showShareModal, store, dispatch]);
 
+  // Help-shown state must be hoisted outside the controls container so the modal can remain visible
+  // when the panel is no longer hovered.
+  const additionalIconsWithHelp = useMemo(() => {
+    return helpContent ? (
+      <>
+        {additionalIcons}
+        <Icon tooltip="Help" fade onClick={() => setShowHelp(true)}>
+          <HelpCircleOutlineIcon className={styles.icon} />
+        </Icon>
+      </>
+    ) : (
+      additionalIcons
+    );
+  }, [additionalIcons, helpContent]);
+
   if (frameless() || hideToolbars) {
     return ReactNull;
   }
@@ -346,6 +361,9 @@ export default React.memo<Props>(function PanelToolbar({
       {({ width }) => (
         <ChildToggle.ContainsOpen onChange={setContainsOpen}>
           {shareModal}
+          {showHelp && (
+            <HelpModal onRequestClose={() => setShowHelp(false)}>{helpContent}</HelpModal>
+          )}
           <div
             className={cx(styles.panelToolbarContainer, {
               [styles.floating!]: floating,
@@ -359,10 +377,9 @@ export default React.memo<Props>(function PanelToolbar({
                 isRendered={isRendered}
                 showHiddenControlsOnHover={showHiddenControlsOnHover}
                 floating={floating}
-                helpContent={helpContent}
                 menuContent={menuContent}
                 showPanelName={width > 360}
-                additionalIcons={additionalIcons}
+                additionalIcons={additionalIconsWithHelp}
                 onDragStart={onDragStart}
                 onDragEnd={onDragEnd}
                 isUnknownPanel={!!isUnknownPanel}

--- a/app/components/TextContent.tsx
+++ b/app/components/TextContent.tsx
@@ -11,30 +11,38 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { PropsWithChildren, useMemo } from "react";
+import { PropsWithChildren, useCallback, useContext } from "react";
 import ReactMarkdown from "react-markdown";
 import { CSSProperties } from "styled-components";
+
+import LinkHandlerContext from "@foxglove-studio/app/context/LinkHandlerContext";
 
 import styles from "./TextContent.module.scss";
 
 type Props = {
-  linkTarget?: string;
   style?: CSSProperties;
 };
 
-export default function TextContent(props: PropsWithChildren<Props>) {
+export default function TextContent(props: PropsWithChildren<Props>): React.ReactElement {
   const { children, style } = props;
-  const linkTarget = props.linkTarget;
 
-  const linkRenderer = useMemo(() => {
-    return function RenderLink(renderLinkProps: any) {
+  const handleLink = useContext(LinkHandlerContext);
+
+  const linkRenderer = useCallback(
+    (linkProps: { href: string; children: React.ReactNode }) => {
       return (
-        <a href={renderLinkProps.href} target={linkTarget}>
-          {renderLinkProps.children}
+        <a
+          href={linkProps.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(event) => handleLink(event, linkProps.href)}
+        >
+          {linkProps.children}
         </a>
       );
-    };
-  }, [linkTarget]);
+    },
+    [handleLink],
+  );
 
   return (
     <div className={styles.root} style={style}>

--- a/app/context/LinkHandlerContext.ts
+++ b/app/context/LinkHandlerContext.ts
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { createContext } from "react";
+
+// This context provides a function that handles link clicks, for example to handle app-internal
+// links by showing a modal dialog rather than actualy navigating.
+export default createContext<(event: React.MouseEvent, href: string) => void>(() => {});

--- a/app/panels/GlobalVariables/index.help.md
+++ b/app/panels/GlobalVariables/index.help.md
@@ -1,6 +1,6 @@
 # Global Variables
 
-Allows you to read and set global variables for any panel that uses the [message path syntax](/help/message-path-syntax) (e.g. Plot, State Transitions, Raw Messages, etc.).
+Allows you to read and set global variables for any panel that uses the [message path syntax](#help:message-path-syntax) (e.g. Plot, State Transitions, Raw Messages, etc.).
 
 For example, instead of having to change a particular object ID that you want to see visualizations for across panels, you can:
 

--- a/app/panels/NodePlayground/Sidebar.tsx
+++ b/app/panels/NodePlayground/Sidebar.tsx
@@ -224,14 +224,12 @@ const Sidebar = ({
       docs: (
         <SFlex>
           <SidebarTitle title={"docs"} collapse={() => updateExplorer(undefined)} />
-          <TextContent style={{ backgroundColor: "transparent" }} linkTarget="_blank">
+          <TextContent style={{ backgroundColor: "transparent" }}>
             {otherMarkdownDocsForTest ?? nodePlaygroundDocs}
           </TextContent>
           <br />
           <br />
-          <TextContent style={{ backgroundColor: "transparent" }} linkTarget="_blank">
-            {userUtilsReadMe}
-          </TextContent>
+          <TextContent style={{ backgroundColor: "transparent" }}>{userUtilsReadMe}</TextContent>
         </SFlex>
       ),
       utils: (

--- a/app/panels/Plot/index.help.md
+++ b/app/panels/Plot/index.help.md
@@ -2,7 +2,7 @@
 
 Plots arbitrary values from topics, similar to [rqt_plot](http://wiki.ros.org/rqt_plot).
 
-The values plotted are specified through Webviz's [message path syntax](/help/message-path-syntax).
+The values plotted are specified through Webviz's [message path syntax](#help:message-path-syntax).
 
 In the options menu, you can set a minimum and maximum Y-value. By default, the plot will use those bounds unless the data you're looking at extends above the max Y-value or below the min Y-value; in those cases it will automatically expand. If you want to disable this behavior and force the plot to use the exact minimum and maximum Y-values entered, you can "lock" the y-axis in the options menu as well.
 

--- a/app/panels/RawMessages/index.help.md
+++ b/app/panels/RawMessages/index.help.md
@@ -2,6 +2,6 @@
 
 Displays the data from a specific topic in an easier to read format. As new messages are received the structure shows the latest data, but doesn't reset the view (e.g if you unfold a specific key - it'll stay that way with the values under it updating as messages come in).
 
-You can drill down the message and filter arrays to specific messages using the [message path syntax](/help/message-path-syntax).
+You can drill down the message and filter arrays to specific messages using the [message path syntax](#help:message-path-syntax).
 
 If you need to understand the data structure of the messages, a link is provided at the top.

--- a/app/panels/StateTransitions/index.help.md
+++ b/app/panels/StateTransitions/index.help.md
@@ -2,7 +2,7 @@
 
 Shows when values change. Can be used for any primitive value, but is most useful for "enums" (even though ROS does not have that as a formal concept). If you put constants in your ROS message definition, those constant names will be shown. You can only have one "enum" per message definition, otherwise we don't know which constant name to show (if there are multiple matches).
 
-The values plotted are specified through Webviz's [message path syntax](/help/message-path-syntax).
+The values plotted are specified through Webviz's [message path syntax](#help:message-path-syntax).
 
 You can zoom by scrolling, and pan by dragging. Double-click to reset.
 

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -145,8 +145,16 @@ async function createWindow(): Promise<void> {
     role: "editMenu",
     label: "Edit",
     submenu: [
-      { role: "undo" },
-      { role: "redo" },
+      {
+        label: "Undo",
+        accelerator: "CommandOrControl+Z",
+        click: () => mainWindow.webContents.send("undo"),
+      },
+      {
+        label: "Redo",
+        accelerator: "CommandOrControl+Shift+Z",
+        click: () => mainWindow.webContents.send("redo"),
+      },
       { type: "separator" },
       { role: "cut" },
       { role: "copy" },
@@ -187,6 +195,10 @@ async function createWindow(): Promise<void> {
       {
         label: "Welcome",
         click: () => mainWindow.webContents.send("open-welcome-layout"),
+      },
+      {
+        label: "Message Path Syntax",
+        click: () => mainWindow.webContents.send("open-message-path-syntax-help"),
       },
       {
         label: "Keyboard Shortcuts",


### PR DESCRIPTION
- Hook up undo/redo menu items to layout history. Sadly, we now have both undo/redo menu item actions **and** also a key listener in GlobalKeyListener.tsx. Both are necessary because we want to maintain the ability to use native undo/redo in text fields, and there's no API to hook into the native undo/redo stack (WebKit used to support it, but no longer does; Firefox might, but W3C still has not produced a current standard for this: see https://github.com/w3c/editing/issues/150).
- Provide help menu item for Message Path Syntax modal, which used to be accessible through a `/help...` link via react-router (which we later removed). The top level `/help` from the webviz project is not particularly relevant to Foxglove Studio so I didn't bring it back.
- Remove help modals from GlobalKeyListener and handle them in App. Introduced a LinkHandlerContext so we can use `[link](#help:message-path-syntax)` in Markdown files, and App can hook into TextContent and handle these links.
- Fix an issue where moving the mouse outside the window would close help modals because it closes the panel toolbar.