### PR TITLE
Always use dark mode

### DIFF
--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -17,6 +17,7 @@ import {
   session,
   shell,
   systemPreferences,
+  nativeTheme,
 } from "electron";
 import installExtension, {
   REACT_DEVELOPER_TOOLS,
@@ -295,6 +296,8 @@ async function createWindow(): Promise<void> {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on("ready", async () => {
+  nativeTheme.themeSource = "dark";
+
   autoUpdater.checkForUpdatesAndNotify().catch((err) => {
     captureException(err);
   });


### PR DESCRIPTION
If macOS is in light mode, the app looks inconsistent because the file open dialog is light but the main window is dark. Just always use dark mode since we don't really support light mode.