### PR TITLE
Remove some webviz references in panel docs

### DIFF
--- a/app/panels/ImageView/index.help.md
+++ b/app/panels/ImageView/index.help.md
@@ -4,9 +4,9 @@ The Image View panel displays images from `sensor_msgs/Image` or `sensor_msgs/Co
 
 16-bit images (`16UC1`) are currently displayed assuming the values fall into the 0&ndash;10000 range, consistent with the defaults of the ROS `image_view` tool.
 
-The **markers** dropdown can be used to toggle on and off topics with type `visualization_msgs/ImageMarker`, which will be overlayed on top of the selected image topic. Note that markers are only available if the `CameraInfo` for the selected camera is being published. If the image is unrectified, the markers will be transformed by webviz based on `CameraInfo`.
+The **markers** dropdown can be used to toggle on and off topics with type `visualization_msgs/ImageMarker`, which will be overlayed on top of the selected image topic. Note that markers are only available if the `CameraInfo` for the selected camera is being published. If the image is unrectified, the markers will be transformed based on `CameraInfo`.
 
-The **scale** dropdown allows you to adjust the scale of the image.  Since the images are fairly large, it is recommended to use the smallest scale you need to conserve bandwidth.  Currently using `scale 1.0` can negatively impact rendering speed, particularly if you have a limited bandwidth connection. (Note: only applies to streaming connections, which is not part of the open source version yet.)
+The **scale** dropdown allows you to adjust the scale of the image. Since the images are fairly large, it is recommended to use the smallest scale you need to conserve bandwidth. Currently using `scale 1.0` can negatively impact rendering speed, particularly if you have a limited bandwidth connection. (Note: only applies to streaming connections, which is not part of the open source version yet.)
 
 Shortcuts:
 

--- a/app/panels/NodePlayground/index.help.md
+++ b/app/panels/NodePlayground/index.help.md
@@ -1,6 +1,6 @@
 # Node Playground
 
-Node Playground is a code editor sandbox in which you can write pseudo-ROS topics that get published within Webviz. Node Playground allows you to manipulate, reduce, and filter existing ROS messages and output them in a way that is useful to you.
+Node Playground is a code editor sandbox in which you can write pseudo-ROS topics that get published internally. Node Playground allows you to manipulate, reduce, and filter existing ROS messages and output them in a way that is useful to you.
 
 ## Getting Started
 
@@ -17,9 +17,9 @@ Here are some resources to get yourself ramped up:
 
 Post in #typescript for TypeScript questions.
 
-### Writing Your First Webviz Node
+### Writing Your First Node
 
-Every Webviz node must declare 3 exports that determine how it should execute:
+Every node must declare 3 exports that determine how it should execute:
 
 - An inputs array of topic names.
 - An output topic with an enforced prefix: `/webviz_node/`.
@@ -75,7 +75,7 @@ As for the `Output` type, you can either manually type out your output with the 
 
 The `GlobalVariables` type is used to specify the types of any global variables you'd like to access in your node. It is not required.
 
-Strictly typing your nodes will help you debug issues at compile time rather than at runtime. It's not always obvious in Webviz how message properties are affecting the visualized output, and so the more you strictly type your nodes, the less likely you will make mistakes.
+Strictly typing your nodes will help you debug issues at compile time rather than at runtime. It's not always obvious how message properties are affecting the visualized output, and so the more you strictly type your nodes, the less likely you will make mistakes.
 
 With that said, you can disable Typescript checks while getting a rough draft of your node working by adding `// @ts-expect-error` on the line above the one you want to ignore.
 
@@ -142,7 +142,7 @@ export default publisher;
 
 #### Using Global Variables
 
-The publisher function will receive all of the Webviz global variables as an object every time it is called. If the global variables change, the publisher function will automatically re-run with the new values:
+The publisher function will receive all of the global variables as an object every time it is called. If the global variables change, the publisher function will automatically re-run with the new values:
 
 ```typescript
 import { Input, Messages } from "ros";
@@ -163,7 +163,7 @@ const publisher = (message: Input<"/foo_marker">, globalVars: GlobalVariables): 
 
 ## Debugging
 
-For easier debugging, invoke `log(someValue)` anywhere in your Webviz node code to print values to the `Logs` section at the bottom of the panel. The only value you cannot `log()` is one that is, or contains, a function definition.
+For easier debugging, invoke `log(someValue)` anywhere in your node code to print values to the `Logs` section at the bottom of the panel. The only value you cannot `log()` is one that is, or contains, a function definition.
 
 ```typescript
 const add = (a: number, b: number): number => a + b;

--- a/app/panels/PlaybackPerformance/index.help.md
+++ b/app/panels/PlaybackPerformance/index.help.md
@@ -14,7 +14,7 @@ The number of frames played per second. Though the player can play back at up to
 
 ## Bag frame time
 
-The duration in bag-time for the rendered frames in milliseconds. To "keep up" with playback, Webviz will often emit "larger" frames.
+The duration in bag-time for the rendered frames in milliseconds. To "keep up" with playback, Studio will often emit "larger" frames.
 
 ## Data throughput
 

--- a/app/panels/Plot/index.help.md
+++ b/app/panels/Plot/index.help.md
@@ -2,7 +2,7 @@
 
 Plots arbitrary values from topics, similar to [rqt_plot](http://wiki.ros.org/rqt_plot).
 
-The values plotted are specified through Webviz's [message path syntax](#help:message-path-syntax).
+The values plotted are specified through the [message path syntax](#help:message-path-syntax).
 
 In the options menu, you can set a minimum and maximum Y-value. By default, the plot will use those bounds unless the data you're looking at extends above the max Y-value or below the min Y-value; in those cases it will automatically expand. If you want to disable this behavior and force the plot to use the exact minimum and maximum Y-values entered, you can "lock" the y-axis in the options menu as well.
 

--- a/app/panels/StateTransitions/index.help.md
+++ b/app/panels/StateTransitions/index.help.md
@@ -2,7 +2,7 @@
 
 Shows when values change. Can be used for any primitive value, but is most useful for "enums" (even though ROS does not have that as a formal concept). If you put constants in your ROS message definition, those constant names will be shown. You can only have one "enum" per message definition, otherwise we don't know which constant name to show (if there are multiple matches).
 
-The values plotted are specified through Webviz's [message path syntax](#help:message-path-syntax).
+The values plotted are specified through the [message path syntax](#help:message-path-syntax).
 
 You can zoom by scrolling, and pan by dragging. Double-click to reset.
 

--- a/app/panels/Tab/index.help.md
+++ b/app/panels/Tab/index.help.md
@@ -1,6 +1,6 @@
 # Tab
 
-Allows users to group multiple Webviz panels in a mini layout, each nested under a tab.
+Allows users to group multiple panels in a mini layout, each nested under a tab.
 
 ## Selecting Panels to Group
 


### PR DESCRIPTION
Using _webviz_ in docs will be confusing to readers since the product is not _webviz_. I tried to change the language to avoid any product name (since you are already in the product).