### PR TITLE
Add a yarn plugin to enforce the node engine req during `yarn install` and disallow npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/.yarn/plugins/@foxglove/node-version-check.cjs
+++ b/.yarn/plugins/@foxglove/node-version-check.cjs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35fb380afeb2e3ca19dc10f03c66a6e9efa178f1b4fab761dccafab8cd9760b4
+size 455

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,6 +3,8 @@ defaultSemverRangePrefix: ""
 nodeLinker: node-modules
 
 plugins:
+  - path: .yarn/plugins/@foxglove/node-version-check.cjs
+    spec: "@foxglove/node-version-check"
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "name": "Foxglove Technologies",
     "email": "support@foxglove.dev"
   },
+  "engines": {
+    "npm": "please-use-yarn",
+    "node": ">= 14.0.0"
+  },
   "scripts": {
     "clean": "rimraf .webpack dist app/storybook-static",
     "start": "electron .webpack",


### PR DESCRIPTION
I need to compile `semver` into the `.cjs` file before this will actually work.