### PR TITLE
Keep layout menu open after deleting a layout

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -277,15 +277,15 @@ export default function App(): ReactElement {
       <Provider store={globalStore}>
         <ExperimentalFeaturesLocalStorageProvider features={experimentalFeatures}>
           <ErrorBoundary>
-            <PlayerManager playerSources={playerSources}>
-              <NativeFileMenuPlayerSelection />
-              <DndProvider backend={HTML5Backend}>
-                <OsContextLayoutStorageProvider>
+            <OsContextLayoutStorageProvider>
+              <LayoutStorageReduxAdapter />
+              <PlayerManager playerSources={playerSources}>
+                <NativeFileMenuPlayerSelection />
+                <DndProvider backend={HTML5Backend}>
                   <Root />
-                  <LayoutStorageReduxAdapter />
-                </OsContextLayoutStorageProvider>
-              </DndProvider>
-            </PlayerManager>
+                </DndProvider>
+              </PlayerManager>
+            </OsContextLayoutStorageProvider>
           </ErrorBoundary>
         </ExperimentalFeaturesLocalStorageProvider>
       </Provider>

--- a/app/reducers/panels.ts
+++ b/app/reducers/panels.ts
@@ -897,6 +897,7 @@ const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsS
 
 const panelsReducer = function (state: State, action: ActionTypes): State {
   // Make a copy of the persistedState before mutation.
+  // Only return the copy if we mutated persistedState, otherwise we return the old state
   let newState = {
     ...state,
     persistedState: { ...state.persistedState, panels: { ...state.persistedState.panels } },
@@ -1034,7 +1035,8 @@ const panelsReducer = function (state: State, action: ActionTypes): State {
       break;
 
     default:
-      break;
+      // avoid returning a copy of the state if we did not handle the action
+      return state;
   }
 
   return newState;


### PR DESCRIPTION
Keeping the layout menu open after deleting a layout provides visual feedback
that the action succeeded. The user can then delete or rename other layouts.