### PR TITLE
Reset old highlighted markers

### DIFF
--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -997,6 +997,10 @@ export default class SceneBuilder implements MarkerProvider {
               }),
           );
           marker.interactionData.highlighted = markerMatches;
+        } else {
+          // Markers that are not re-processed on this frame (i.e. older markers whose lifetime has
+          // not expired) do not get a new copy of interactionData, so they need to be reset.
+          marker.interactionData.highlighted = false;
         }
 
         // TODO(bmc): once we support more topic settings

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -988,20 +988,16 @@ export default class SceneBuilder implements MarkerProvider {
         }
 
         // Highlight if marker matches any of this topic's highlightMarkerMatchers; dim other markers
-        if (Object.keys(this._highlightMarkerMatchersByTopic).length > 0) {
-          const markerMatches = (this._highlightMarkerMatchersByTopic[topic.name] || []).some(
-            ({ checks = [] }) =>
-              checks.every(({ markerKeyPath, value }) => {
-                const markerValue = _.get(message, markerKeyPath as any);
-                return value === markerValue;
-              }),
-          );
-          marker.interactionData.highlighted = markerMatches;
-        } else {
-          // Markers that are not re-processed on this frame (i.e. older markers whose lifetime has
-          // not expired) do not get a new copy of interactionData, so they need to be reset.
-          marker.interactionData.highlighted = false;
-        }
+        // Markers that are not re-processed on this frame (i.e. older markers whose lifetime has
+        // not expired) do not get a new copy of interactionData, so they always need to be reset.
+        const markerMatches = (this._highlightMarkerMatchersByTopic[topic.name] || []).some(
+          ({ checks = [] }) =>
+            checks.every(({ markerKeyPath, value }) => {
+              const markerValue = _.get(message, markerKeyPath as any);
+              return value === markerValue;
+            }),
+        );
+        marker.interactionData.highlighted = markerMatches;
 
         // TODO(bmc): once we support more topic settings
         // flesh this out to be more marker type agnostic


### PR DESCRIPTION
There was a bug where markers from previous frames (whose lifetime had not expired) were not getting new `interactionData` because they weren't passing through `_consumeMarker` again. This meant that after clicking the background to deselect these objects, they would still have `highlighted: true`.

Clicking recent markers (in the current `frame`) didn't exhibit the same problem because it is always re-processed on each frame: https://github.com/foxglove/studio/blob/4e771b6b74b6aed277fdcfdc42f492cc931eb963/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts#L943

Generally markers and other messages should be treated as immutable — ideally `interactionData` would not be attached to markers and mutated between frames in this way — but this is an easy quick fix.

Thanks @jackma for the bug report!