### PR TITLE
Fix CSS color inheritance by adding <!doctype html> to index.html

### DIFF
--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -215,6 +215,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
   config.plugins?.push(
     new HtmlWebpackPlugin({
       templateContent: `
+        <!doctype html>
         <html>
           <head><meta charset="utf-8"></head>
           <script>global = globalThis;</script>


### PR DESCRIPTION
Apparently tables were not inheriting text color from their parent div because we were missing `<!doctype html>`, which causes the browser to use quirks-mode rendering: https://stackoverflow.com/a/24259068/23649 Truly we live in an age of wonders.