### PR TITLE
Lazy Message Reader

### DIFF
--- a/app/dataProviders/ParsedMessageCache.ts
+++ b/app/dataProviders/ParsedMessageCache.ts
@@ -12,8 +12,8 @@
 //   You may not use this file except in compliance with the License.
 
 import { sortBy } from "lodash";
-import { MessageReader } from "rosbag";
 
+import { MessageReader } from "@foxglove-studio/app/dataProviders/types";
 import { Message } from "@foxglove-studio/app/players/types";
 import { deepParse, inaccurateByteSize, isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import filterMap from "@foxglove-studio/app/util/filterMap";

--- a/app/dataProviders/types.ts
+++ b/app/dataProviders/types.ts
@@ -108,6 +108,10 @@ export interface DataProvider {
   close(): Promise<void>;
 }
 
+export interface MessageReader {
+  readMessage<T>(buffer: Uint8Array): T;
+}
+
 export interface DataProviderConstructor {
   new (
     // The arguments to this particular DataProvider; typically an object.

--- a/packages/rosmsg-deser/.eslintrc.yaml
+++ b/packages/rosmsg-deser/.eslintrc.yaml
@@ -1,0 +1,2 @@
+parserOptions:
+  project: packages/rosmsg-deser/tsconfig.json

--- a/packages/rosmsg-deser/README.md
+++ b/packages/rosmsg-deser/README.md
@@ -6,7 +6,7 @@ Deserialize ArrayBuffers using [ROS Message serialization format](http://wiki.ro
 
 Lazy messages provide on-demand access and deserialization to fields of a serialized ROS message. Creating
 a lazy message from a buffer performs no de-serialization during creation. Only accessed fields are
-deserialized. Deserialization occurs at access time.
+deserialized; the deserialization occurs at access time.
 
 ```Typescript
 import { LazyMessageReader } from "@foxglove/rosmsg-deser";
@@ -15,7 +15,7 @@ import { LazyMessageReader } from "@foxglove/rosmsg-deser";
 const reader = new LazyMessageReader(messageDefinition);
 
 // build a new lazy message instance for our serialized message from the Uint8Array
-// Note: the array lifetime should be as long as the message lifetime
+// Note: since deserialization is lazy - avoid-reusing the array you provide for other messages
 const message = reader.readMessage([0x00, 0x00, ...]);
 
 // access message fields

--- a/packages/rosmsg-deser/README.md
+++ b/packages/rosmsg-deser/README.md
@@ -1,0 +1,23 @@
+# rosmsg-deser
+
+Deserialize ArrayBuffers using [ROS Message serialization format](http://wiki.ros.org/msg).
+
+## LazyMessage
+
+Lazy messages provide on-demand access and deserialization to fields of a serialized ROS message. Creating
+a lazy message from a buffer performs no de-serialization during creation. Only accessed fields are
+deserialized. Deserialization occurs at access time.
+
+```Typescript
+import { LazyMessageReader } from "@foxglove/rosmsg-deser";
+
+// message definition comes from rosbag.js
+const reader = new LazyMessageReader(messageDefinition);
+
+// build a new lazy message instance for our serialized message from the Uint8Array
+// Note: the array lifetime should be as long as the message lifetime
+const message = reader.readMessage([0x00, 0x00, ...]);
+
+// access message fields
+message.header.stamp;
+```

--- a/packages/rosmsg-deser/jest.config.ts
+++ b/packages/rosmsg-deser/jest.config.ts
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export default {
+  preset: "ts-jest",
+  testRunner: "jest-circus/runner",
+};

--- a/packages/rosmsg-deser/package.json
+++ b/packages/rosmsg-deser/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@foxglove/rosmsg-deser",
+  "version": "0.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "module": "src/index.ts"
+}

--- a/packages/rosmsg-deser/src/BuiltinDeserialize.ts
+++ b/packages/rosmsg-deser/src/BuiltinDeserialize.ts
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+interface Indexable {
+  [index: number]: unknown;
+}
+
+interface TypedArrayConstructor<T> {
+  new (length?: number): T;
+  new (buffer: ArrayBufferLike, byteOffset?: number, length?: number): T;
+  BYTES_PER_ELEMENT: number;
+}
+
+// Given a TypeArray constructor (Int32Array, Float32Array, etc), create a deserialization function
+// This deserialization function tries to first use aligned access and falls back to iteration
+function MakeTypedArrayDeserialze<T extends Indexable>(
+  TypedArrayConstructor: TypedArrayConstructor<T>,
+  getter:
+    | "getInt8"
+    | "getUint8"
+    | "getInt16"
+    | "getUint16"
+    | "getInt32"
+    | "getUint32"
+    | "getBigInt64"
+    | "getBigUint64"
+    | "getFloat32"
+    | "getFloat64",
+) {
+  return (view: DataView, offset: number, len: number): T => {
+    const totalOffset = view.byteOffset + offset;
+    // aligned access provides for a fast path to typed array construction
+    if (totalOffset % TypedArrayConstructor.BYTES_PER_ELEMENT === 0) {
+      return new TypedArrayConstructor(view.buffer, totalOffset, len);
+    }
+
+    // unaligned access requires additional handling
+
+    // benchmarks indicate for len < ~10 doing each individually is faster than copy
+    if (len < 10) {
+      const arr = new TypedArrayConstructor(len);
+      for (let idx = 0; idx < len; ++idx) {
+        arr[idx] = view[getter](offset, true);
+        offset += TypedArrayConstructor.BYTES_PER_ELEMENT;
+      }
+      return arr;
+    }
+
+    // if the length is > 10, then doing a copy of the data to align it is faster
+    // using _set_ is slightly faster than slice on the array buffer according to today's benchmarks
+    const size = TypedArrayConstructor.BYTES_PER_ELEMENT * len;
+    const copy = new Uint8Array(size);
+    copy.set(new Uint8Array(view.buffer, totalOffset, size));
+    return new TypedArrayConstructor(copy.buffer, copy.byteOffset, len);
+  };
+}
+
+const deserializers = {
+  int8: (view: DataView, offset: number): number => {
+    return view.getInt8(offset);
+  },
+  uint8: (view: DataView, offset: number): number => {
+    return view.getUint8(offset);
+  },
+  bool: (view: DataView, offset: number): boolean => {
+    return view.getUint8(offset) !== 0;
+  },
+  int16: (view: DataView, offset: number): number => {
+    return view.getInt16(offset, true);
+  },
+  uint16: (view: DataView, offset: number): number => {
+    return view.getUint16(offset, true);
+  },
+  int32: (view: DataView, offset: number): number => {
+    return view.getInt32(offset, true);
+  },
+  uint32: (view: DataView, offset: number): number => {
+    return view.getUint32(offset, true);
+  },
+  int64: (view: DataView, offset: number): bigint => {
+    return view.getBigInt64(offset, true);
+  },
+  uint64: (view: DataView, offset: number): bigint => {
+    return view.getBigUint64(offset, true);
+  },
+  float32: (view: DataView, offset: number): number => {
+    return view.getFloat32(offset, true);
+  },
+  float64: (view: DataView, offset: number): number => {
+    return view.getFloat64(offset, true);
+  },
+  time: (view: DataView, offset: number): { sec: number; nsec: number } => {
+    const sec = view.getUint32(offset, true);
+    const nsec = view.getUint32(offset + 4, true);
+    return { sec, nsec };
+  },
+  string: (view: DataView, offset: number): string => {
+    const len = view.getInt32(offset, true);
+    const codePoints = new Uint8Array(view.buffer, view.byteOffset + offset + 4, len);
+    const decoder = new (global as any).TextDecoder("ascii");
+    return decoder.decode(codePoints);
+  },
+  int8Array: MakeTypedArrayDeserialze(Int8Array, "getInt8"),
+  uint8Array: MakeTypedArrayDeserialze(Uint8Array, "getUint8"),
+  int16Array: MakeTypedArrayDeserialze(Int16Array, "getInt16"),
+  uint16Array: MakeTypedArrayDeserialze(Uint16Array, "getUint16"),
+  int32Array: MakeTypedArrayDeserialze(Int32Array, "getInt32"),
+  uint32Array: MakeTypedArrayDeserialze(Uint32Array, "getUint32"),
+  int64Array: MakeTypedArrayDeserialze(BigInt64Array, "getBigInt64"),
+  uint64Array: MakeTypedArrayDeserialze(BigUint64Array, "getBigUint64"),
+  float32Array: MakeTypedArrayDeserialze(Float32Array, "getFloat32"),
+  float64Array: MakeTypedArrayDeserialze(Float64Array, "getFloat64"),
+  timeArray: (view: DataView, offset: number, len: number): { sec: number; nsec: number }[] => {
+    // Time and Duration are actually arrays of int32
+    // If the location of the TimeArray meets Int32Array aligned access requirements, we can use Int32Array
+    // to speed up access to the int32 values.
+    // Otherwise we fall back to individual value reading via DataView
+
+    const timeArr = new Array<{ sec: number; nsec: number }>(len);
+
+    const totalOffset = view.byteOffset + offset;
+    // aligned access provides for a fast path to typed array construction
+    if (totalOffset % Int32Array.BYTES_PER_ELEMENT === 0) {
+      const intArr = new Int32Array(view.buffer, totalOffset, len * 2);
+      for (let i = 0, j = 0; i < len; ++i, j = j + 2) {
+        timeArr[i] = {
+          sec: intArr[j]!,
+          nsec: intArr[j + 1]!,
+        };
+      }
+    } else {
+      for (let idx = 0; idx < len; ++idx) {
+        timeArr[idx] = {
+          sec: view.getInt32(offset, true),
+          nsec: view.getInt32(offset + 4, true),
+        };
+        offset += 8;
+      }
+    }
+
+    return timeArr;
+  },
+  fixedArray: (
+    view: DataView,
+    offset: number,
+    len: number,
+    elementDeser: (view: DataView, offset: number) => unknown,
+    elementSize: (view: DataView, offset: number) => number,
+  ): unknown[] => {
+    const arr = new Array<unknown>(len);
+    for (let idx = 0; idx < len; ++idx) {
+      arr[idx] = elementDeser(view, offset);
+      offset += elementSize(view, offset);
+    }
+    return arr;
+  },
+  dynamicArray: (
+    view: DataView,
+    offset: number,
+    elementDeser: (buff: DataView, offset: number) => unknown,
+    elementSize: (buff: DataView, offset: number) => number,
+  ): unknown[] => {
+    const len = view.getUint32(offset, true);
+    return deserializers.fixedArray(view, offset + 4, len, elementDeser, elementSize);
+  },
+};
+
+export default deserializers;

--- a/packages/rosmsg-deser/src/BuiltinDeserialize.ts
+++ b/packages/rosmsg-deser/src/BuiltinDeserialize.ts
@@ -30,12 +30,11 @@ function MakeTypedArrayDeserialze<T extends Indexable>(
 ) {
   return (view: DataView, offset: number, len: number): T => {
     const totalOffset = view.byteOffset + offset;
-    // aligned access provides for a fast path to typed array construction
+    // new TypedArray(...) will throw if you try to make a typed array on unaligned boundary
+    // but for aligned access we can use a typed array and avoid any extra memory alloc/copy
     if (totalOffset % TypedArrayConstructor.BYTES_PER_ELEMENT === 0) {
       return new TypedArrayConstructor(view.buffer, totalOffset, len);
     }
-
-    // unaligned access requires additional handling
 
     // benchmarks indicate for len < ~10 doing each individually is faster than copy
     if (len < 10) {
@@ -57,39 +56,17 @@ function MakeTypedArrayDeserialze<T extends Indexable>(
 }
 
 const deserializers = {
-  int8: (view: DataView, offset: number): number => {
-    return view.getInt8(offset);
-  },
-  uint8: (view: DataView, offset: number): number => {
-    return view.getUint8(offset);
-  },
-  bool: (view: DataView, offset: number): boolean => {
-    return view.getUint8(offset) !== 0;
-  },
-  int16: (view: DataView, offset: number): number => {
-    return view.getInt16(offset, true);
-  },
-  uint16: (view: DataView, offset: number): number => {
-    return view.getUint16(offset, true);
-  },
-  int32: (view: DataView, offset: number): number => {
-    return view.getInt32(offset, true);
-  },
-  uint32: (view: DataView, offset: number): number => {
-    return view.getUint32(offset, true);
-  },
-  int64: (view: DataView, offset: number): bigint => {
-    return view.getBigInt64(offset, true);
-  },
-  uint64: (view: DataView, offset: number): bigint => {
-    return view.getBigUint64(offset, true);
-  },
-  float32: (view: DataView, offset: number): number => {
-    return view.getFloat32(offset, true);
-  },
-  float64: (view: DataView, offset: number): number => {
-    return view.getFloat64(offset, true);
-  },
+  bool: (view: DataView, offset: number): boolean => view.getUint8(offset) !== 0,
+  int8: (view: DataView, offset: number): number => view.getInt8(offset),
+  uint8: (view: DataView, offset: number): number => view.getUint8(offset),
+  int16: (view: DataView, offset: number): number => view.getInt16(offset, true),
+  uint16: (view: DataView, offset: number): number => view.getUint16(offset, true),
+  int32: (view: DataView, offset: number): number => view.getInt32(offset, true),
+  uint32: (view: DataView, offset: number): number => view.getUint32(offset, true),
+  int64: (view: DataView, offset: number): bigint => view.getBigInt64(offset, true),
+  uint64: (view: DataView, offset: number): bigint => view.getBigUint64(offset, true),
+  float32: (view: DataView, offset: number): number => view.getFloat32(offset, true),
+  float64: (view: DataView, offset: number): number => view.getFloat64(offset, true),
   time: (view: DataView, offset: number): { sec: number; nsec: number } => {
     const sec = view.getUint32(offset, true);
     const nsec = view.getUint32(offset + 4, true);
@@ -98,8 +75,16 @@ const deserializers = {
   string: (view: DataView, offset: number): string => {
     const len = view.getInt32(offset, true);
     const codePoints = new Uint8Array(view.buffer, view.byteOffset + offset + 4, len);
-    const decoder = new (global as any).TextDecoder("ascii");
+    const decoder = new (global as any).TextDecoder("utf8");
     return decoder.decode(codePoints);
+  },
+  boolArray: (view: DataView, offset: number, len: number): boolean[] => {
+    const arr = new Array(len);
+    for (let idx = 0; idx < len; ++idx) {
+      arr[idx] = deserializers.bool(view, offset);
+      offset += 1;
+    }
+    return arr;
   },
   int8Array: MakeTypedArrayDeserialze(Int8Array, "getInt8"),
   uint8Array: MakeTypedArrayDeserialze(Uint8Array, "getUint8"),
@@ -141,6 +126,8 @@ const deserializers = {
 
     return timeArr;
   },
+  durationArray: (view: DataView, offset: number, len: number): { sec: number; nsec: number }[] =>
+    deserializers.timeArray(view, offset, len),
   fixedArray: (
     view: DataView,
     offset: number,

--- a/packages/rosmsg-deser/src/DeserializerFactory.ts
+++ b/packages/rosmsg-deser/src/DeserializerFactory.ts
@@ -1,0 +1,319 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { RosMsgDefinition, RosMsgField } from "rosbag";
+
+import deserializers from "./BuiltinDeserialize";
+
+// Sizes for builtin types - if a type has a fixed size, the deserializer is able to optimize
+const fixedSizeTypes = new Map<string, number>([
+  ["bool", 1],
+  ["int8", 1],
+  ["uint8", 1],
+  ["int16", 2],
+  ["uint16", 2],
+  ["int32", 4],
+  ["uint32", 4],
+  ["int64", 8],
+  ["uint64", 8],
+  ["float32", 4],
+  ["float64", 8],
+  ["time", 8],
+  ["duration", 8],
+]);
+
+const builtinSizes = {
+  // strings are the only builtin type that are variable size
+  string: (view: DataView, offset: number) => {
+    return 4 + view.getInt32(offset, true);
+  },
+  fixedArray: (
+    view: DataView,
+    offset: number,
+    len: number,
+    typeSize: (view: DataView, offset: number) => number,
+  ): number => {
+    let size = 0;
+    for (let idx = 0; idx < len; ++idx) {
+      const elementSize = typeSize(view, offset);
+      size += elementSize;
+      offset += elementSize;
+    }
+    return size;
+  },
+  array: (
+    view: DataView,
+    offset: number,
+    typeSize: (view: DataView, offset: number) => number,
+  ): number => {
+    const len = view.getUint32(offset, true);
+
+    let size = 4;
+    offset += 4;
+    for (let idx = 0; idx < len; ++idx) {
+      const elementSize = typeSize(view, offset);
+      size += elementSize;
+      offset += elementSize;
+    }
+    return size;
+  },
+};
+
+function sanitizeName(name: string): string {
+  return name.replace("/", "_");
+}
+
+interface SerializedMessageReader {
+  build: (view: DataView, offset?: number) => unknown;
+  size: (view: DataView, offset?: number) => number;
+}
+
+// Return a static size function for our @param field
+function sizeFunction(field: RosMsgField): string {
+  const fieldSize = fixedSizeTypes.get(field.type);
+
+  // if the field size is not known, size will be calculated on-demand
+  if (fieldSize == undefined) {
+    // the size function for the field to use in calculating the size on-demand
+    const fieldSizeFn =
+      field.type === "string" ? "sizes.string" : `${sanitizeName(field.type)}.size`;
+
+    if (field.isArray === true) {
+      if (field.arrayLength != undefined) {
+        return `
+          static ${field.name}_size(view /* dataview */, offset) {
+              return sizes.fixedArray(view, offset, ${field.arrayLength}, ${fieldSizeFn});
+          }`;
+      } else {
+        return `
+          static ${field.name}_size(view /* dataview */, offset) {
+              return sizes.array(view, offset, ${fieldSizeFn});
+          }`;
+      }
+    }
+
+    return `
+      static ${field.name}_size(view /* dataview */, offset) {
+          return ${fieldSizeFn}(view, offset);
+      }`;
+  } else {
+    if (field.isArray === true) {
+      if (field.arrayLength != undefined) {
+        return `
+          static ${field.name}_size(view /* dataview */, offset) {
+            return ${fieldSize} * ${field.arrayLength};
+          }`;
+      } else {
+        return `
+          static ${field.name}_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * ${fieldSize};
+          }`;
+      }
+    }
+
+    return `
+      static ${field.name}_size(view /* dataview */, offset) {
+          return ${fieldSize};
+      }`;
+  }
+}
+
+// Return the part of the static size() function for our message class for @param field
+function sizePartForDefinition(field: RosMsgField): string {
+  const fieldSize = fixedSizeTypes.get(field.type);
+  const isFixedArray = field.isArray === true && field.arrayLength != undefined;
+
+  if (fieldSize != undefined && (isFixedArray || field.isArray === false)) {
+    if (field.arrayLength != undefined) {
+      const totalSize = fieldSize * field.arrayLength;
+      return `
+        // ${field.type}[${field.arrayLength}] ${field.name}
+        totalSize += ${totalSize};
+        offset += ${totalSize};
+      `;
+    } else {
+      return `
+        // ${field.type} ${field.name}
+        totalSize += ${fieldSize};
+        offset += ${fieldSize};
+      `;
+    }
+  }
+
+  return `
+    // ${field.type} ${field.name}
+    {
+        const size = this.${field.name}_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    `;
+}
+
+// Create a getter function for the field
+function getterFunction(field: RosMsgField): string {
+  const isBuiltinReader = field.type in deserializers;
+  const isBuiltinSize = field.type in builtinSizes;
+
+  // function to return a read array item
+  const readerFn = isBuiltinReader ? `readers.${field.type}` : `${sanitizeName(field.type)}.build`;
+
+  // function to return size of individual array item
+  const sizeFn = isBuiltinSize ? `sizes.${field.type}` : `${sanitizeName(field.type)}.size`;
+
+  const fieldSize = fixedSizeTypes.get(field.type);
+
+  if (field.isArray === true) {
+    const arrLen = field.arrayLength;
+    if (arrLen != undefined) {
+      // total size is known, which means we should use a builtin array reader
+      if (fieldSize != undefined) {
+        return `
+          // ${field.type}[${arrLen}] ${field.name}
+          get ${field.name}() {
+            const offset = this.${field.name}_offset(this.#view, this.#offset);
+            return readers.${field.type}Array(this.#view, offset, ${arrLen});
+          }`;
+      } else {
+        // fixed size array of complex size items
+        return `
+        // ${field.type}[${arrLen}] ${field.name}
+          get ${field.name}() {
+            const offset = this.${field.name}_offset(this.#view, this.#offset);
+            return readers.fixedArray(this.#view, offset, ${arrLen}, ${readerFn}, ${sizeFn});
+          }`;
+      }
+    } else {
+      // total size is known, which means we should use a builtin array reader
+      if (fieldSize != undefined) {
+        return `
+          // ${field.type}[] ${field.name}
+          get ${field.name}() {
+            const offset = this.${field.name}_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.${field.type}Array(this.#view, offset + 4, len);
+          }`;
+      } else {
+        return `
+          // ${field.type}[] ${field.name}
+          get ${field.name}() {
+            const offset = this.${field.name}_offset(this.#view, this.#offset);
+            return readers.dynamicArray(this.#view, offset, ${readerFn}, ${sizeFn});
+          }`;
+      }
+    }
+  } else {
+    return `get ${field.name}() {
+        const offset = this.${field.name}_offset(this.#view, this.#offset);
+        return ${readerFn}(this.#view, offset);
+      }`;
+  }
+}
+
+// Create a SerializedMessageReader
+//
+// The output is a set of classes - one for each custom message type. Only the root message
+// class is exposed.
+//
+// Each LazyMessage class consists of static _size_ functions, _offset_ methods, and property _getters.
+// The size functions calculate the size of fields within arrays.
+// The offset methods calculate the start byte of the field within the entire message buffer.
+// The getter de-serializes the field from the message buffer.
+export default function buildClass(types: RosMsgDefinition[]): SerializedMessageReader {
+  const classes = new Array<string>();
+
+  // Build the types in reverse order so the root message appears last
+  // Since the root message depends on custom types we want those to be defined
+  for (const type of types.reverse()) {
+    const name = sanitizeName(type.name ?? "__RootMsg");
+
+    const offsetFns = new Array<string>();
+    const fields = new Array<string>();
+
+    // getters need to "look back" at the previous field to create the offset function calls
+    let prevField: RosMsgField | undefined;
+
+    for (const field of type.definitions) {
+      // constants have no impact on deserialization
+      if (field.isConstant === true) {
+        continue;
+      }
+
+      // offsets tell you where the raw data of your field starts (including any length bytes)
+      // they are the size of the offset of the previous field + size of previous field
+      // the first first field is at offset 0
+      if (!prevField) {
+        offsetFns.push(`
+          ${field.name}_offset(view, initOffset) {
+            return initOffset;
+          }`);
+      } else {
+        // offsets tell you where the raw data of your field starts (including any length bytes)
+        // they are the size of the offset of the previous field + size of previous field
+        offsetFns.push(`
+          ${field.name}_offset(view, initOffset) {
+            const prevOffset = this.${prevField.name}_offset(view, initOffset);
+            const totalOffset = prevOffset + ${name}.${prevField.name}_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.${field.name}_offset = () => totalOffset;
+            return totalOffset;
+          }`);
+      }
+
+      fields.push(`${field.name}: this.${field.name}`);
+
+      prevField = field;
+    }
+
+    const messageSrc = `class ${name} {
+        ${type.definitions.map(sizeFunction).join("\n")}
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            ${type.definitions.map(sizePartForDefinition).join("\n")}
+            
+            return totalSize;
+        }
+
+        ${offsetFns.join("\n")}
+
+        // return an instance of ${name} from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new ${name}(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            ${fields.join(",\n")}
+          };
+        }
+
+        ${type.definitions.map(getterFunction).join("\n")}
+    }`;
+
+    classes.push(messageSrc);
+  }
+
+  const src = classes.join("\n\n");
+
+  // close over our builtin deserializers and builtin size functions
+  // eslint-disable-next-line no-new-func
+  const wrapFn = new Function("readers", "sizes", `${src}\nreturn __RootMsg;`);
+  return wrapFn.call(undefined, deserializers, builtinSizes) as SerializedMessageReader;
+}

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { parseMessageDefinition } from "rosbag";
+import { TextDecoder } from "util";
+
+import { LazyMessageReader } from "./LazyMessageReader";
+
+// Jest runs in a node environment, TextDecoder is not available globally.
+// We provide TextDecoder from the uitl module.
+(global as any).TextDecoder = TextDecoder;
+
+const serializeString = (str: string): Uint8Array => {
+  const data = Buffer.from(str, "utf8");
+  const len = Buffer.alloc(4);
+  len.writeInt32LE(data.byteLength, 0);
+  return Uint8Array.from([...len, ...data]);
+};
+
+const Float32Buffer = (floats: number[]): Iterable<number> => {
+  return new Uint8Array(Float32Array.from(floats).buffer);
+};
+
+describe("LazyReader", () => {
+  it.each([
+    [`int8 sample # lowest`, [0x80], { sample: -128 }],
+    [`int8 sample # highest`, [0x7f], { sample: 127 }],
+    [`uint8 sample # lowest`, [0x00], { sample: 0 }],
+    [`uint8 sample # highest`, [0xff], { sample: 255 }],
+    [`int16 sample # lowest`, [0x00, 0x80], { sample: -32768 }],
+    [`int16 sample # highest`, [0xff, 0x7f], { sample: 32767 }],
+    [`uint16 sample # lowest`, [0x00, 0x00], { sample: 0 }],
+    [`uint16 sample # highest`, [0xff, 0xff], { sample: 65535 }],
+    [`int32 sample # lowest`, [0x00, 0x00, 0x00, 0x80], { sample: -2147483648 }],
+    [`int32 sample # highest`, [0xff, 0xff, 0xff, 0x7f], { sample: 2147483647 }],
+    [`uint64 sample # lowest`, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], { sample: 0n }],
+    [
+      `uint64 sample # highest`,
+      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+      { sample: 18446744073709551615n },
+    ],
+    [`float32 sample`, Float32Buffer([5.5]), { sample: 5.5 }],
+    [
+      `float64 sample`,
+      new Uint8Array(Float64Array.of(0.123456789121212121212).buffer),
+      { sample: 0.123456789121212121212 },
+    ],
+    [
+      `time stamp`,
+      [0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00],
+      {
+        stamp: {
+          sec: 0,
+          nsec: 1,
+        },
+      },
+    ],
+    [
+      `int32[] arr`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...new Uint8Array(Int32Array.of(3, 7).buffer),
+      ],
+      { arr: Int32Array.from([3, 7]) },
+    ],
+    [
+      `time[1] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 1, nsec: 2 }] },
+    ],
+    [
+      `time[] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 2, nsec: 3 }] },
+    ],
+    // unaligned access
+    [
+      `uint8 blank\nint32[] arr`,
+      [
+        0x00,
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...new Uint8Array(Int32Array.of(3, 7).buffer),
+      ],
+      { blank: 0, arr: Int32Array.from([3, 7]) },
+    ],
+    [
+      `uint8 blank\ntime[] arr`,
+      [0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      { blank: 0, arr: [{ sec: 2, nsec: 3 }] },
+    ],
+    [`float32[2] arr`, Float32Buffer([5.5, 6.5]), { arr: Float32Array.from([5.5, 6.5]) }],
+    [
+      `uint8 blank\nfloat32[2] arr`,
+      [0x00, ...Float32Buffer([5.5, 6.5])],
+      { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `float32[] arr`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...Float32Buffer([5.5, 6.5]),
+      ],
+      { arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `uint8 blank\nfloat32[] arr`,
+      [0x00, ...[0x02, 0x00, 0x00, 0x00], ...Float32Buffer([5.5, 6.5])],
+      { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `float32[] first\nfloat32[] second`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...Float32Buffer([5.5, 6.5]),
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...Float32Buffer([5.5, 6.5]),
+      ],
+      {
+        first: Float32Array.from([5.5, 6.5]),
+        second: Float32Array.from([5.5, 6.5]),
+      },
+    ],
+    [`string sample # empty string`, serializeString(""), { sample: "" }],
+    [`string sample # some string`, serializeString("some string"), { sample: "some string" }],
+    [`int8[4] first`, [0x00, 0xff, 0x80, 0x7f], { first: new Int8Array([0, -1, -128, 127]) }],
+    [
+      `int8[] first`,
+      [
+        ...[0x04, 0x00, 0x00, 0x00], // length
+        0x00,
+        0xff,
+        0x80,
+        0x7f,
+      ],
+      { first: new Int8Array([0, -1, -128, 127]) },
+    ],
+    [`uint8[4] first`, [0x00, 0xff, 0x80, 0x7f], { first: new Uint8Array([0, -1, -128, 127]) }],
+    [
+      `string[2] first`,
+      [...serializeString("one"), ...serializeString("longer string")],
+      { first: ["one", "longer string"] },
+    ],
+    [
+      `string[] first`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...serializeString("one"),
+        ...serializeString("longer string"),
+      ],
+      { first: ["one", "longer string"] },
+    ],
+    // first size value after fixed size value
+    [`int8 first\nint8 second`, [0x80, 0x7f], { first: -128, second: 127 }],
+    [
+      `string first\nint8 second`,
+      [...serializeString("some string"), 0x80],
+      { first: "some string", second: -128 },
+    ],
+    [
+      `CustomType custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [0x02],
+      {
+        custom: { first: 0x02 },
+      },
+    ],
+    [
+      `CustomType[3] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [0x02, 0x03, 0x04],
+      {
+        custom: [{ first: 0x02 }, { first: 0x03 }, { first: 0x04 }],
+      },
+    ],
+    [
+      `CustomType[] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [
+        ...[0x03, 0x00, 0x00, 0x00], // length
+        0x02,
+        0x03,
+        0x04,
+      ],
+      {
+        custom: [{ first: 0x02 }, { first: 0x03 }, { first: 0x04 }],
+      },
+    ],
+  ])("should deserialize %s", (msgDef: string, arr: Iterable<number>, expected: any) => {
+    const buffer = Uint8Array.from(arr);
+    const reader = new LazyMessageReader(parseMessageDefinition(msgDef));
+    const read = reader.readMessage(buffer);
+
+    // check that our reader expected size matches the buffer size
+    expect(reader.size(buffer)).toEqual(buffer.length);
+
+    // check that our message matches the object
+    expect(read.toJSON()).toMatchObject(expected);
+  });
+});

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -17,7 +17,7 @@ const serializeString = (str: string): Uint8Array => {
   return Uint8Array.from([...len, ...data]);
 };
 
-const float32Buffer = (floats: number[]): Iterable<number> => {
+const float32Buffer = (floats: number[]): Uint8Array => {
   return new Uint8Array(Float32Array.from(floats).buffer);
 };
 
@@ -51,7 +51,7 @@ describe("LazyReader", () => {
       [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
       { sample: 18446744073709551615n },
     ],
-    [`float32 sample`, Float32Buffer([5.5]), { sample: 5.5 }],
+    [`float32 sample`, float32Buffer([5.5]), { sample: 5.5 }],
     [
       `float64 sample`,
       new Uint8Array(Float64Array.of(0.123456789121212121212).buffer),
@@ -100,32 +100,32 @@ describe("LazyReader", () => {
       [0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
       { blank: 0, arr: [{ sec: 2, nsec: 3 }] },
     ],
-    [`float32[2] arr`, Float32Buffer([5.5, 6.5]), { arr: Float32Array.from([5.5, 6.5]) }],
+    [`float32[2] arr`, float32Buffer([5.5, 6.5]), { arr: Float32Array.from([5.5, 6.5]) }],
     [
       `uint8 blank\nfloat32[2] arr`,
-      [0x00, ...Float32Buffer([5.5, 6.5])],
+      [0x00, ...float32Buffer([5.5, 6.5])],
       { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
     ],
     [
       `float32[] arr`,
       [
         ...[0x02, 0x00, 0x00, 0x00], // length
-        ...Float32Buffer([5.5, 6.5]),
+        ...float32Buffer([5.5, 6.5]),
       ],
       { arr: Float32Array.from([5.5, 6.5]) },
     ],
     [
       `uint8 blank\nfloat32[] arr`,
-      [0x00, ...[0x02, 0x00, 0x00, 0x00], ...Float32Buffer([5.5, 6.5])],
+      [0x00, ...[0x02, 0x00, 0x00, 0x00], ...float32Buffer([5.5, 6.5])],
       { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
     ],
     [
       `float32[] first\nfloat32[] second`,
       [
         ...[0x02, 0x00, 0x00, 0x00], // length
-        ...Float32Buffer([5.5, 6.5]),
+        ...float32Buffer([5.5, 6.5]),
         ...[0x02, 0x00, 0x00, 0x00], // length
-        ...Float32Buffer([5.5, 6.5]),
+        ...float32Buffer([5.5, 6.5]),
       ],
       {
         first: Float32Array.from([5.5, 6.5]),

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -33,6 +33,18 @@ describe("LazyReader", () => {
     [`uint16 sample # highest`, [0xff, 0xff], { sample: 65535 }],
     [`int32 sample # lowest`, [0x00, 0x00, 0x00, 0x80], { sample: -2147483648 }],
     [`int32 sample # highest`, [0xff, 0xff, 0xff, 0x7f], { sample: 2147483647 }],
+    [`uint32 sample # lowest`, [0x00, 0x00, 0x00, 0x00], { sample: 0 }],
+    [`uint32 sample # highest`, [0xff, 0xff, 0xff, 0xff], { sample: 4294967295 }],
+    [
+      `int64 sample # lowest`,
+      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+      { sample: -9223372036854775808n },
+    ],
+    [
+      `int64 sample # highest`,
+      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f],
+      { sample: 9223372036854775807n },
+    ],
     [`uint64 sample # lowest`, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], { sample: 0n }],
     [
       `uint64 sample # highest`,
@@ -198,6 +210,9 @@ describe("LazyReader", () => {
 
     // check that our reader expected size matches the buffer size
     expect(reader.size(buffer)).toEqual(buffer.length);
+
+    // allows for easier review of the generated parser source
+    expect(reader.source()).toMatchSnapshot(msgDef);
 
     // check that our message matches the object
     expect(read.toJSON()).toMatchObject(expected);

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -7,7 +7,7 @@ import { TextDecoder } from "util";
 import { LazyMessageReader } from "./LazyMessageReader";
 
 // Jest runs in a node environment, TextDecoder is not available globally.
-// We provide TextDecoder from the uitl module.
+// We provide TextDecoder from the util module.
 (global as any).TextDecoder = TextDecoder;
 
 const serializeString = (str: string): Uint8Array => {

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -17,7 +17,7 @@ const serializeString = (str: string): Uint8Array => {
   return Uint8Array.from([...len, ...data]);
 };
 
-const Float32Buffer = (floats: number[]): Iterable<number> => {
+const float32Buffer = (floats: number[]): Iterable<number> => {
   return new Uint8Array(Float32Array.from(floats).buffer);
 };
 

--- a/packages/rosmsg-deser/src/LazyMessageReader.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.ts
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { RosMsgDefinition } from "rosbag";
+
+import buildClass from "./DeserializerFactory";
+
+function isBigEndian() {
+  const array = new Uint8Array(4);
+  const view = new Uint32Array(array.buffer);
+  view[0] = 1;
+  return array[3] === 1;
+}
+
+// Our fast handling of typed arrays requires that the user be using little endian mode since
+// the browser makes typed arrays use the architecture endianness and ROS messages are little endian
+const isLittleEndian = !isBigEndian();
+if (!isLittleEndian) {
+  throw new Error("Only Little Endian architectures are supported");
+}
+
+type LazyMessage<T> = T & { toJSON: () => T };
+
+export class LazyMessageReader<T = unknown> {
+  parser: ReturnType<typeof buildClass>;
+  definitions: RosMsgDefinition[];
+
+  constructor(definitions: RosMsgDefinition[]) {
+    this.parser = buildClass(definitions);
+    this.definitions = definitions;
+  }
+
+  // Return the size of our message within the buffer
+  size(buffer: Readonly<Uint8Array>): number {
+    const view = new DataView(buffer.buffer, buffer.byteOffset);
+    return this.parser.size(view);
+  }
+
+  // Create a LazyMessage for the buffer
+  // We template on R here for call site type information if the class type information T is not
+  // known or available
+  readMessage<R = T>(buffer: Readonly<Uint8Array>): LazyMessage<R> {
+    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    return this.parser.build(view) as LazyMessage<R>;
+  }
+}

--- a/packages/rosmsg-deser/src/LazyMessageReader.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { RosMsgDefinition } from "rosbag";
 
-import buildClass from "./DeserializerFactory";
+import buildReader from "./LazyMessageReaderFactory";
 
 function isBigEndian() {
   const array = new Uint8Array(4);
@@ -22,18 +22,22 @@ if (!isLittleEndian) {
 type LazyMessage<T> = T & { toJSON: () => T };
 
 export class LazyMessageReader<T = unknown> {
-  parser: ReturnType<typeof buildClass>;
+  readerImpl: ReturnType<typeof buildReader>;
   definitions: RosMsgDefinition[];
 
   constructor(definitions: RosMsgDefinition[]) {
-    this.parser = buildClass(definitions);
+    this.readerImpl = buildReader(definitions);
     this.definitions = definitions;
   }
 
   // Return the size of our message within the buffer
   size(buffer: Readonly<Uint8Array>): number {
     const view = new DataView(buffer.buffer, buffer.byteOffset);
-    return this.parser.size(view);
+    return this.readerImpl.size(view);
+  }
+
+  source(): string {
+    return this.readerImpl.source();
   }
 
   // Create a LazyMessage for the buffer
@@ -41,6 +45,6 @@ export class LazyMessageReader<T = unknown> {
   // known or available
   readMessage<R = T>(buffer: Readonly<Uint8Array>): LazyMessage<R> {
     const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-    return this.parser.build(view) as LazyMessage<R>;
+    return this.readerImpl.build(view) as LazyMessage<R>;
   }
 }

--- a/packages/rosmsg-deser/src/LazyMessageReaderFactory.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReaderFactory.ts
@@ -60,12 +60,13 @@ const builtinSizes = {
 };
 
 function sanitizeName(name: string): string {
-  return name.replace("/", "_");
+  return name.replace(/^[0-9]|[^a-zA-Z0-9_]/g, "_");
 }
 
 interface SerializedMessageReader {
   build: (view: DataView, offset?: number) => unknown;
   size: (view: DataView, offset?: number) => number;
+  source: () => string;
 }
 
 // Return a static size function for our @param field
@@ -220,7 +221,7 @@ function getterFunction(field: RosMsgField): string {
 // The size functions calculate the size of fields within arrays.
 // The offset methods calculate the start byte of the field within the entire message buffer.
 // The getter de-serializes the field from the message buffer.
-export default function buildClass(types: RosMsgDefinition[]): SerializedMessageReader {
+export default function buildReader(types: RosMsgDefinition[]): SerializedMessageReader {
   const classes = new Array<string>();
 
   // Build the types in reverse order so the root message appears last
@@ -315,5 +316,7 @@ export default function buildClass(types: RosMsgDefinition[]): SerializedMessage
   // close over our builtin deserializers and builtin size functions
   // eslint-disable-next-line no-new-func
   const wrapFn = new Function("readers", "sizes", `${src}\nreturn __RootMsg;`);
-  return wrapFn.call(undefined, deserializers, builtinSizes) as SerializedMessageReader;
+  const rootMsg = wrapFn.call(undefined, deserializers, builtinSizes) as SerializedMessageReader;
+  rootMsg.source = () => wrapFn.toString();
+  return rootMsg;
 }

--- a/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -1,0 +1,2877 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LazyReader should deserialize CustomType custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first: CustomType custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first 1`] = `
+"function anonymous(readers,sizes
+) {
+class custom_type_CustomType {
+        
+      static first_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 first
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new custom_type_CustomType(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        get first() {
+        const offset = this.first_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+    }
+
+class __RootMsg {
+        
+      static custom_size(view /* dataview */, offset) {
+          return custom_type_CustomType.size(view, offset);
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // custom_type/CustomType custom
+    {
+        const size = this.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          custom_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            custom: this.custom
+          };
+        }
+
+        get custom() {
+        const offset = this.custom_offset(this.#view, this.#offset);
+        return custom_type_CustomType.build(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize CustomType[] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first: CustomType[] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first 1`] = `
+"function anonymous(readers,sizes
+) {
+class custom_type_CustomType {
+        
+      static first_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 first
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new custom_type_CustomType(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        get first() {
+        const offset = this.first_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+    }
+
+class __RootMsg {
+        
+          static custom_size(view /* dataview */, offset) {
+              return sizes.array(view, offset, custom_type_CustomType.size);
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // custom_type/CustomType custom
+    {
+        const size = this.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          custom_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            custom: this.custom
+          };
+        }
+
+        
+          // custom_type/CustomType[] custom
+          get custom() {
+            const offset = this.custom_offset(this.#view, this.#offset);
+            return readers.dynamicArray(this.#view, offset, custom_type_CustomType.build, custom_type_CustomType.size);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize CustomType[3] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first: CustomType[3] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first 1`] = `
+"function anonymous(readers,sizes
+) {
+class custom_type_CustomType {
+        
+      static first_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 first
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new custom_type_CustomType(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        get first() {
+        const offset = this.first_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+    }
+
+class __RootMsg {
+        
+          static custom_size(view /* dataview */, offset) {
+              return sizes.fixedArray(view, offset, 3, custom_type_CustomType.size);
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // custom_type/CustomType custom
+    {
+        const size = this.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          custom_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            custom: this.custom
+          };
+        }
+
+        
+        // custom_type/CustomType[3] custom
+          get custom() {
+            const offset = this.custom_offset(this.#view, this.#offset);
+            return readers.fixedArray(this.#view, offset, 3, custom_type_CustomType.build, custom_type_CustomType.size);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 4;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // float32 sample
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.float32(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // float32 arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // float32[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.float32Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize float32[] first
+float32[] second: float32[] first
+float32[] second 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+          static second_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // float32 first
+    {
+        const size = this.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+
+    // float32 second
+    {
+        const size = this.second_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          second_offset(view, initOffset) {
+            const prevOffset = this.first_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.second_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first,
+second: this.second
+          };
+        }
+
+        
+          // float32[] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.float32Array(this.#view, offset + 4, len);
+          }
+
+          // float32[] second
+          get second() {
+            const offset = this.second_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.float32Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            return 4 * 2;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // float32[2] arr
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // float32[2] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            return readers.float32Array(this.#view, offset, 2);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // float64 sample
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.float64(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int8 first
+int8 second: int8 first
+int8 second 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static first_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+      static second_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int8 first
+        totalSize += 1;
+        offset += 1;
+      
+
+        // int8 second
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          second_offset(view, initOffset) {
+            const prevOffset = this.first_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.second_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first,
+second: this.second
+          };
+        }
+
+        get first() {
+        const offset = this.first_offset(this.#view, this.#offset);
+        return readers.int8(this.#view, offset);
+      }
+get second() {
+        const offset = this.second_offset(this.#view, this.#offset);
+        return readers.int8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int8 sample # highest: int8 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int8 sample
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int8 sample
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 1;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // int8 first
+    {
+        const size = this.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        
+          // int8[] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.int8Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+            return 1 * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int8[4] first
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        
+          // int8[4] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            return readers.int8Array(this.#view, offset, 4);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int16 sample # highest: int16 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 2;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int16 sample
+        totalSize += 2;
+        offset += 2;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int16(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 2;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int16 sample
+        totalSize += 2;
+        offset += 2;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int16(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int32 sample # highest: int32 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 4;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int32 sample
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int32(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 4;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int32 sample
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int32(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // int32 arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // int32[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.int32Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int64 sample # highest: int64 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int64 sample
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int64(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // int64 sample
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.int64(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize string first
+int8 second: string first
+int8 second 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static first_size(view /* dataview */, offset) {
+          return sizes.string(view, offset);
+      }
+
+      static second_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // string first
+    {
+        const size = this.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+
+        // int8 second
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          second_offset(view, initOffset) {
+            const prevOffset = this.first_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.second_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first,
+second: this.second
+          };
+        }
+
+        get first() {
+        const offset = this.first_offset(this.#view, this.#offset);
+        return readers.string(this.#view, offset);
+      }
+get second() {
+        const offset = this.second_offset(this.#view, this.#offset);
+        return readers.int8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize string sample # empty string: string sample # empty string 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return sizes.string(view, offset);
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // string sample
+    {
+        const size = this.sample_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.string(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize string sample # some string: string sample # some string 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return sizes.string(view, offset);
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // string sample
+    {
+        const size = this.sample_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.string(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+              return sizes.array(view, offset, sizes.string);
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // string first
+    {
+        const size = this.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        
+          // string[] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            return readers.dynamicArray(this.#view, offset, readers.string, sizes.string);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+              return sizes.fixedArray(view, offset, 2, sizes.string);
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // string first
+    {
+        const size = this.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        
+        // string[2] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            return readers.fixedArray(this.#view, offset, 2, readers.string, sizes.string);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static stamp_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // time stamp
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          stamp_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            stamp: this.stamp
+          };
+        }
+
+        get stamp() {
+        const offset = this.stamp_offset(this.#view, this.#offset);
+        return readers.time(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 8;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // time arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // time[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.timeArray(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            return 8 * 1;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // time[1] arr
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // time[1] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            return readers.timeArray(this.#view, offset, 1);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 blank
+float32[] arr: uint8 blank
+float32[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static blank_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 blank
+        totalSize += 1;
+        offset += 1;
+      
+
+    // float32 arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          blank_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          arr_offset(view, initOffset) {
+            const prevOffset = this.blank_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.arr_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            blank: this.blank,
+arr: this.arr
+          };
+        }
+
+        get blank() {
+        const offset = this.blank_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+
+          // float32[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.float32Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 blank
+float32[2] arr: uint8 blank
+float32[2] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static blank_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+          static arr_size(view /* dataview */, offset) {
+            return 4 * 2;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 blank
+        totalSize += 1;
+        offset += 1;
+      
+
+        // float32[2] arr
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          blank_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          arr_offset(view, initOffset) {
+            const prevOffset = this.blank_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.arr_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            blank: this.blank,
+arr: this.arr
+          };
+        }
+
+        get blank() {
+        const offset = this.blank_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+
+          // float32[2] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            return readers.float32Array(this.#view, offset, 2);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 blank
+int32[] arr: uint8 blank
+int32[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static blank_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 blank
+        totalSize += 1;
+        offset += 1;
+      
+
+    // int32 arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          blank_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          arr_offset(view, initOffset) {
+            const prevOffset = this.blank_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.arr_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            blank: this.blank,
+arr: this.arr
+          };
+        }
+
+        get blank() {
+        const offset = this.blank_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+
+          // int32[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.int32Array(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 blank
+time[] arr: uint8 blank
+time[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static blank_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 8;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 blank
+        totalSize += 1;
+        offset += 1;
+      
+
+    // time arr
+    {
+        const size = this.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          blank_offset(view, initOffset) {
+            return initOffset;
+          }
+
+          arr_offset(view, initOffset) {
+            const prevOffset = this.blank_offset(view, initOffset);
+            const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+  
+            // future calls will avoid re-calculating the offset
+            this.arr_offset = () => totalOffset;
+            return totalOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            blank: this.blank,
+arr: this.arr
+          };
+        }
+
+        get blank() {
+        const offset = this.blank_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+
+          // time[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.timeArray(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 sample
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 1;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8 sample
+        totalSize += 1;
+        offset += 1;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint8(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static first_size(view /* dataview */, offset) {
+            return 1 * 4;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint8[4] first
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          first_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            first: this.first
+          };
+        }
+
+        
+          // uint8[4] first
+          get first() {
+            const offset = this.first_offset(this.#view, this.#offset);
+            return readers.uint8Array(this.#view, offset, 4);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 2;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint16 sample
+        totalSize += 2;
+        offset += 2;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint16(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 2;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint16 sample
+        totalSize += 2;
+        offset += 2;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint16(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 4;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint32 sample
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint32(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 4;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint32 sample
+        totalSize += 4;
+        offset += 4;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint32(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # highest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint64 sample
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint64(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # lowest 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static sample_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // uint64 sample
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          sample_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            sample: this.sample
+          };
+        }
+
+        get sample() {
+        const offset = this.sample_offset(this.#view, this.#offset);
+        return readers.uint64(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;

--- a/packages/rosmsg-deser/src/index.ts
+++ b/packages/rosmsg-deser/src/index.ts
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export * from "./LazyMessageReader";

--- a/packages/rosmsg-deser/tsconfig.json
+++ b/packages/rosmsg-deser/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts", "jest.config.ts"],
+  "compilerOptions": {
+    "module": "es2020",
+    "lib": ["es2020"],
+    "rootDir": "./src",
+    "noUnusedParameters": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2204,6 +2204,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@foxglove/rosmsg-deser@workspace:packages/rosmsg-deser":
+  version: 0.0.0-use.local
+  resolution: "@foxglove/rosmsg-deser@workspace:packages/rosmsg-deser"
+  languageName: unknown
+  linkType: soft
+
 "@foxglove/velodyne-cloud@workspace:packages/velodyne-cloud":
   version: 0.0.0-use.local
   resolution: "@foxglove/velodyne-cloud@workspace:packages/velodyne-cloud"


### PR DESCRIPTION
The lazy message reader provides on-demand access and deserialization
of fields within a serialized ROS message.

This PR introduces the LazyMessageReader within the @foxglove/rosmsg-deser package and updates ParseMessageDataProvider to use LazyMessageReader instead of the rosbag.js MessageReader.

Creating a LazyMessage from a Uint8Array incurs little overhead. A `new LazyMessage(buffer);` call occurs and the LazyMessage constructor performs no work. Only during field access does deserialization occur. Deserialization is limited to the accessed fields.