### PR TITLE
Avoid loading app configuration value twice

### DIFF
--- a/app/hooks/useAsyncAppConfigurationValue.test.tsx
+++ b/app/hooks/useAsyncAppConfigurationValue.test.tsx
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook } from "@testing-library/react-hooks";
+import { PropsWithChildren } from "react";
+
+import AppConfigurationContext, {
+  AppConfiguration,
+} from "@foxglove-studio/app/context/AppConfigurationContext";
+import { useAsyncAppConfigurationValue } from "@foxglove-studio/app/hooks/useAsyncAppConfigurationValue";
+
+class FakeProvider implements AppConfiguration {
+  async get(key: string): Promise<unknown> {
+    return key;
+  }
+  async set(_key: string, _value: unknown): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+describe("useAsyncAppConfigurationValue", () => {
+  it("gets the value", async () => {
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <AppConfigurationContext.Provider value={new FakeProvider()}>
+          {children}
+        </AppConfigurationContext.Provider>
+      );
+    };
+
+    const { result, unmount, waitForNextUpdate } = renderHook(
+      () => useAsyncAppConfigurationValue("test.value"),
+      {
+        wrapper,
+      },
+    );
+
+    // immediately on mount loading should be true
+    expect(result.current[0]).toMatchObject({ loading: true, retry: undefined });
+
+    await waitForNextUpdate();
+    expect(result.current[0]).toMatchObject({
+      loading: false,
+      value: "test.value",
+      retry: undefined,
+    });
+
+    unmount();
+  });
+});

--- a/app/hooks/useAsyncAppConfigurationValue.ts
+++ b/app/hooks/useAsyncAppConfigurationValue.ts
@@ -1,9 +1,9 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { useLayoutEffect } from "react";
-import { useAsyncFn } from "react-use";
-import { AsyncState } from "react-use/lib/useAsyncFn";
+import { useMemo } from "react";
+import { useAsyncFn, useAsyncRetry } from "react-use";
+import type { AsyncState } from "react-use/lib/useAsyncFn";
 
 import { useAppConfiguration } from "@foxglove-studio/app/context/AppConfigurationContext";
 
@@ -13,25 +13,26 @@ export function useAsyncAppConfigurationValue<T>(
   key: string,
 ): [state: AsyncState<T>, setter: (value: T) => Promise<void>] {
   const appConfiguration = useAppConfiguration();
-  const [getterState, getter] = useAsyncFn(async () => (await appConfiguration.get(key)) as T, [
+
+  // async retry will start loading the value on mount
+  const getterState = useAsyncRetry(async () => (await appConfiguration.get(key)) as T, [
     appConfiguration,
     key,
   ]);
 
-  // Start loading the current value on first render
-  useLayoutEffect(() => {
-    getter();
-  }, [getter]);
-
   const [setterState, setter] = useAsyncFn(
     async (value: T) => {
       await appConfiguration.set(key, value);
-      getter(); // re-trigger the getter so the new value is displayed
+      getterState.retry(); // re-trigger the getter so the new value is displayed
     },
-    [appConfiguration, key, getter],
+    [appConfiguration, key, getterState],
   );
 
-  const state =
-    setterState.loading || setterState.error ? { ...setterState, value: undefined } : getterState;
+  const state = useMemo(() => {
+    return setterState.loading || setterState.error
+      ? { ...setterState, value: undefined }
+      : { ...getterState, retry: undefined };
+  }, [setterState, getterState]);
+
   return [state, setter];
 }


### PR DESCRIPTION
useAsyncFn does not set the loading state to _true_ by default
and the first render results in callers thinking the value is loaded.

useAsyncRetry will start loading immediately and set the loading state
to _true_.