### PR TITLE
Always call `menuRemoveInputSource` before `menuAddInputSource`

### DIFF
--- a/app/components/NativeFileMenuPlayerSelection.tsx
+++ b/app/components/NativeFileMenuPlayerSelection.tsx
@@ -13,6 +13,7 @@ export function NativeFileMenuPlayerSelection(): ReactElement {
 
   useEffect(() => {
     for (const item of availableSources) {
+      OsContextSingleton?.menuRemoveInputSource(item.name);
       OsContextSingleton?.menuAddInputSource(item.name, () => {
         selectSource(item);
       });


### PR DESCRIPTION
This should hopefully address Sentry errors about adding native file menu handlers multiple times