### PR TITLE
Fix webpack build failure detection for integration tests

### DIFF
--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -6,28 +6,33 @@ import webpack from "webpack";
 import { WebpackArgv } from "../WebpackArgv";
 import webpackConfig from "../webpack.config";
 
-const webpackArgs: WebpackArgv = { mode: "production" };
-const compiler = webpack(
-  webpackConfig.map((config) => {
-    if (typeof config === "function") {
-      return config(undefined, webpackArgs);
-    }
-
-    return config;
-  }),
-);
-
 // global jest test setup builds the webpack build before running any integration tests
 export default async (): Promise<void> => {
   if ((process.env.INTEGRATION_SKIP_BUILD ?? "") !== "") {
     return;
   }
+
+  const webpackArgs: WebpackArgv = { mode: "production" };
+  const compiler = webpack(
+    webpackConfig.map((config) => {
+      if (typeof config === "function") {
+        return config(undefined, webpackArgs);
+      }
+
+      return config;
+    }),
+  );
+
   return new Promise<void>((resolve, reject) => {
     // eslint-disable-next-line no-restricted-syntax
     console.info("Building Webpack");
-    compiler.run((err) => {
+    compiler.run((err, result) => {
       if (err) {
         reject(err);
+        return;
+      }
+      if (!result || result.hasErrors()) {
+        reject(new Error("webpack build failed"));
         return;
       }
       // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
Integration tests would stall if the webpack build failed with errors
because the _err_ for compiler.run is insufficient to detect build errors.
We also need to check result.hasErrors() to see if the build error'd.

Now the integration test fails when the build fails rather than trying
to launch the app and timing out.