### PR TITLE
Fix double-click to open bag desktop integration.

### DIFF
--- a/app/components/PlayerManager.tsx
+++ b/app/components/PlayerManager.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { PropsWithChildren, useCallback, useEffect, useRef, useState } from "react";
+import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useMountedState } from "react-use";
 
@@ -322,10 +322,15 @@ function PlayerManager({
     [setDiagnostics, setLogs, setRosLib, initialMessageOrder],
   );
 
+  const analytics = useAnalytics();
+  const metricsCollector = useMemo(() => {
+    return new AnalyticsMetricsCollector(analytics);
+  }, [analytics]);
+
   const buildPlayerOptions: BuildPlayerOptions = useShallowMemo({
     diskBagCaching: useExperimentalFeature("diskBagCaching"),
     unlimitedMemoryCache: useExperimentalFeature("unlimitedMemoryCache"),
-    metricsCollector: new AnalyticsMetricsCollector(useAnalytics()),
+    metricsCollector: metricsCollector,
   });
 
   useEffect(() => {

--- a/app/hooks/useElectronFilesToOpen.ts
+++ b/app/hooks/useElectronFilesToOpen.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 // Hook to get any files the main thread has told us to open
 // See the comments in main thread implementation on how the files are injected into this input
 export default function useElectronFilesToOpen(): FileList | undefined {
-  const [files, setFiles] = useState<FileList>();
+  const [fileList, setFileList] = useState<FileList>();
 
   useEffect(() => {
     const input = document.querySelector<HTMLInputElement>("#electron-open-file-input");
@@ -20,19 +20,20 @@ export default function useElectronFilesToOpen(): FileList | undefined {
 
     const update = () => {
       if (input.files) {
-        setFiles(input.files);
+        setFileList(input.files);
       }
     };
 
     // handle any new file open requests
-    input.onchange = update;
+    input.addEventListener("change", update);
 
+    // trigger initial set list
     update();
+
     return () => {
-      // eslint-disable-next-line no-restricted-syntax
-      input.onchange = null;
+      input.removeEventListener("change", update);
     };
   }, []);
 
-  return files;
+  return fileList;
 }

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -217,12 +217,6 @@ async function createWindow(): Promise<void> {
   Menu.setApplicationMenu(Menu.buildFromTemplate(appMenuTemplate));
   installMenuInterface();
 
-  mainWindow.loadURL(rendererPath);
-
-  if (!isProduction) {
-    mainWindow.webContents.openDevTools();
-  }
-
   // Open all new windows in an external browser
   // Note: this API is supposed to be superseded by webContents.setWindowOpenHandler,
   // but using that causes the app to freeze when a new window is opened.
@@ -279,18 +273,30 @@ async function createWindow(): Promise<void> {
     }
   }
 
+  // indicates the preloader has setup the file input used to inject which files to open
+  let preloaderFileInputIsReady = false;
+
   // This handles user dropping files on the doc icon or double clicking a file when the app
   // is already open.
   //
   // The open-file handler registered earlier will handle adding the file to filesToOpen
   app.on("open-file", async (_ev) => {
-    await loadFilesToOpen();
+    if (preloaderFileInputIsReady) {
+      await loadFilesToOpen();
+    }
   });
 
-  // When the window content has loaded, the input is available, we can open our files now
-  mainWindow.webContents.on("did-finish-load", () => {
-    loadFilesToOpen();
+  // preload will tell us when it is ready to process the pending open file requests
+  ipcMain.handle("load-pending-files", async () => {
+    await loadFilesToOpen();
+    preloaderFileInputIsReady = true;
   });
+
+  mainWindow.loadURL(rendererPath);
+
+  if (!isProduction) {
+    mainWindow.webContents.openDevTools();
+  }
 }
 
 // This method will be called when Electron has finished

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -24,15 +24,22 @@ const menuClickListeners = new Map<string, IpcListener>();
 // Initialize the RPC channel for electron-socket
 PreloaderSockets.Create();
 
-window.addEventListener("DOMContentLoaded", () => {
-  // This input element receives generated dom events from main thread to inject File objects
-  // See the comments in desktop/index.ts regarding this feature
-  const input = document.createElement("input");
-  input.setAttribute("hidden", "true");
-  input.setAttribute("type", "file");
-  input.setAttribute("id", "electron-open-file-input");
-  document.body.appendChild(input);
-});
+window.addEventListener(
+  "DOMContentLoaded",
+  async () => {
+    // This input element receives generated dom events from main thread to inject File objects
+    // See the comments in desktop/index.ts regarding this feature
+    const input = document.createElement("input");
+    input.setAttribute("hidden", "true");
+    input.setAttribute("type", "file");
+    input.setAttribute("id", "electron-open-file-input");
+    document.body.appendChild(input);
+
+    // let main know we are ready to accept open-file requests
+    await ipcRenderer.invoke("load-pending-files");
+  },
+  { once: true },
+);
 
 const localFileStorage = new LocalFileStorage();
 


### PR DESCRIPTION
* Fix identity memo for builderOptions which resulted in constantly re-running the hook in a tight loop.
* Tidy up the order for informing main about the hidden file-open input.