### PR TITLE
Enable lint error on `await`ing non-Promises

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -57,6 +57,7 @@ rules:
   "@typescript-eslint/no-inferrable-types": off
   "@typescript-eslint/no-empty-function": off
   "@typescript-eslint/prefer-nullish-coalescing": warn
+  "@typescript-eslint/await-thenable": error
   react/jsx-uses-react: off
   react/react-in-jsx-scope: off
   react/prop-types: off # Unnecessary with typescript validation

--- a/app/context/PlayerSelectionContext.ts
+++ b/app/context/PlayerSelectionContext.ts
@@ -12,7 +12,7 @@ export type PlayerSourceDefinition = {
 // PlayerSelection provides the user with a select function and the items to select
 export interface PlayerSelection {
   selectSource: (definition: PlayerSourceDefinition) => void;
-  setPlayerFromDemoBag: () => void;
+  setPlayerFromDemoBag: () => Promise<void>;
   availableSources: PlayerSourceDefinition[];
   currentSourceName?: string;
 }

--- a/app/panels/ThreeDimensionalViz/SearchText.test.tsx
+++ b/app/panels/ThreeDimensionalViz/SearchText.test.tsx
@@ -26,16 +26,6 @@ import Transforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/Transfor
 import { TextMarker } from "@foxglove-studio/app/types/Messages";
 import { MARKER_MSG_TYPES } from "@foxglove-studio/app/util/globalConstants";
 
-jest.mock("lodash", () => {
-  // Require the original module to not be mocked...
-  const originalModule = jest.requireActual("lodash");
-  return {
-    __esModule: true, // Use it when dealing with esModules
-    ...originalModule,
-    debounce: (fn: any) => fn,
-  };
-});
-
 export const ROOT_FRAME_ID = "root_frame";
 export const CHILD_FRAME_ID = "child_frame";
 
@@ -65,7 +55,7 @@ const createMarker = (text: string): Interactive<TextMarker> | Interactive<GLTex
   }) as any;
 };
 
-const runUseGLTextTest = async (
+const runUseGLTextTest = (
   text: Interactive<TextMarker>[],
   searchText: string,
   searchTextMatches: Interactive<GLTextMarker>[],
@@ -85,7 +75,7 @@ const runUseGLTextTest = async (
     } as any);
     return ReactNull;
   };
-  const root = await mount(<Wrapper />);
+  const root = mount(<Wrapper />);
   root.update();
   root.unmount();
   return glTextMarkers;
@@ -103,7 +93,7 @@ describe("<SearchText />", () => {
   describe("useGLText", () => {
     it("updates the text markers to include highlighted indices", async () => {
       const setSearchTextMatches = jest.fn();
-      const glTextMarkers = await runUseGLTextTest(
+      const glTextMarkers = runUseGLTextTest(
         [createMarker("hello")],
         "hello",
         [],
@@ -115,12 +105,7 @@ describe("<SearchText />", () => {
     });
     it("works with empy text markers", async () => {
       const setSearchTextMatches = jest.fn();
-      const glTextMarkers = await runUseGLTextTest(
-        [createMarker("")],
-        "hello",
-        [],
-        setSearchTextMatches,
-      );
+      const glTextMarkers = runUseGLTextTest([createMarker("")], "hello", [], setSearchTextMatches);
       expect(glTextMarkers.length).toEqual(1);
       expect(glTextMarkers[0].highlightedIndices).toEqual(undefined);
       expect(setSearchTextMatches).not.toHaveBeenCalled();
@@ -128,7 +113,7 @@ describe("<SearchText />", () => {
     it("updates matches to empty", async () => {
       const setSearchTextMatches = jest.fn();
       const marker = createMarker("hello");
-      const glTextMarkers = await runUseGLTextTest(
+      const glTextMarkers = runUseGLTextTest(
         [marker],
         "bye",
         [marker as any],
@@ -145,7 +130,7 @@ describe("<SearchText />", () => {
         createMarker("hello cruies"),
         createMarker("hello future"),
       ];
-      const glTextMarkers = await runUseGLTextTest(markers, "hello", [], setSearchTextMatches, 2);
+      const glTextMarkers = runUseGLTextTest(markers, "hello", [], setSearchTextMatches, 2);
       expect(glTextMarkers.length).toEqual(3);
       expect(glTextMarkers[2].highlightColor).toEqual(ORANGE);
     });
@@ -164,7 +149,7 @@ describe("<SearchText />", () => {
         });
         return <span>{searchText}</span>;
       };
-      const root = await mount(<Wrapper searchText={"hello"} />);
+      const root = mount(<Wrapper searchText={"hello"} />);
       root.update();
       const originalGlText = glTextMarkers;
       root.setProps({ searchText: "bye" });
@@ -187,7 +172,7 @@ describe("<SearchText />", () => {
         });
         return <span>{randomNum}</span>;
       };
-      const root = await mount(<Wrapper randomNum={1} />);
+      const root = mount(<Wrapper randomNum={1} />);
       root.update();
       const originalGlText = glTextMarkers;
       root.setProps({ randomNum: 2 });

--- a/app/players/RandomAccessPlayer.test.ts
+++ b/app/players/RandomAccessPlayer.test.ts
@@ -104,7 +104,7 @@ describe("RandomAccessPlayer", () => {
       playerOptions,
     );
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     const messages = await store.done;
     expect(messages).toEqual([
       {
@@ -154,7 +154,7 @@ describe("RandomAccessPlayer", () => {
       { ...playerOptions, seekToTime: getSeekToTime() },
     );
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     const messages: any = await store.done;
     expect(messages[1].activeData.currentTime).toEqual(
       TimeUtil.add({ sec: 10, nsec: 0 }, fromNanoSec(SEEK_ON_START_NS)),
@@ -170,7 +170,7 @@ describe("RandomAccessPlayer", () => {
       playerOptions,
     );
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     // make getMessages do nothing since we're going to start reading
     provider.getMessages = () =>
       new Promise(() => {
@@ -228,7 +228,7 @@ describe("RandomAccessPlayer", () => {
       playerOptions,
     );
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     // allow initialization messages to come in
     await store.done;
     // wait for each playback speed change
@@ -321,7 +321,8 @@ describe("RandomAccessPlayer", () => {
       playerOptions,
     );
     const store = new MessageStore(5);
-    await source.setListener(store.add);
+    source.setListener(store.add);
+    await Promise.resolve();
 
     source.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
@@ -366,7 +367,7 @@ describe("RandomAccessPlayer", () => {
       playerOptions,
     );
     const store = new MessageStore(5);
-    await source.setListener(store.add);
+    source.setListener(store.add);
 
     source.setSubscriptions([]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
@@ -426,7 +427,8 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(4);
-    await source.setListener(store.add);
+    source.setListener(store.add);
+    await Promise.resolve();
     source.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
     source.startPlayback();
@@ -503,7 +505,8 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(5);
-    await source.setListener(store.add);
+    source.setListener(store.add);
+    await Promise.resolve();
     source.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
 
@@ -591,7 +594,8 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(4);
-    await source.setListener(store.add);
+    source.setListener(store.add);
+    await Promise.resolve();
     source.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
     source.startPlayback();
@@ -1014,9 +1018,8 @@ describe("RandomAccessPlayer", () => {
     };
     provider.getMessages = getMessages;
 
-    await source.setListener(async () => {
-      // no-op
-    });
+    source.setListener(async () => {});
+    await Promise.resolve();
     source.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     source.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
 
@@ -1097,7 +1100,7 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(9);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     await delay(1);
     source.setSubscriptions([
       { topic: "/foo/bar", format: "parsedMessages" },
@@ -1176,7 +1179,7 @@ describe("RandomAccessPlayer", () => {
     );
     const messagesReceived: Message[] = [];
     const bobjectsReceived: BobjectMessage[] = [];
-    await source.setListener((msg) => {
+    source.setListener((msg) => {
       messagesReceived.push(
         ...((
           msg.activeData ?? {
@@ -1236,10 +1239,9 @@ describe("RandomAccessPlayer", () => {
       { name: "TestProvider", args: { provider }, children: [] },
       playerOptions,
     );
-    await source.setListener(async () => {
-      // no-op
-    });
-    await source.close();
+    source.setListener(async () => {});
+    await Promise.resolve();
+    source.close();
     expect(provider.closed).toBe(true);
   });
 
@@ -1256,7 +1258,7 @@ describe("RandomAccessPlayer", () => {
     );
 
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     expect(provider.closed).toBe(false);
 
     source.close();
@@ -1332,7 +1334,8 @@ describe("RandomAccessPlayer", () => {
     });
 
     const store = new MessageStore(2);
-    await player.setListener(store.add);
+    player.setListener(store.add);
+    await Promise.resolve();
     player.startPlayback();
 
     await firstGetMessagesCall;
@@ -1598,7 +1601,8 @@ describe("RandomAccessPlayer", () => {
     });
 
     const store = new MessageStore(3);
-    await player.setListener(store.add);
+    player.setListener(store.add);
+    await Promise.resolve();
     player.startPlayback();
 
     await firstGetMessagesCall;
@@ -1652,7 +1656,7 @@ describe("RandomAccessPlayer", () => {
     const store = new MessageStore(2);
     player.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     player.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
-    await player.setListener(store.add);
+    player.setListener(store.add);
     const firstMessages = await store.done;
     expect(firstMessages).toEqual([
       expect.objectContaining({ activeData: undefined }), // isPlaying is set to false to begin
@@ -1679,7 +1683,8 @@ describe("RandomAccessPlayer", () => {
     player.seekPlayback({ sec: 10, nsec: 0 });
     expect(provider.getMessages).not.toHaveBeenCalled();
 
-    await player.setListener(store.add);
+    player.setListener(store.add);
+    await Promise.resolve();
     player.seekPlayback({ sec: 10, nsec: 0 });
     expect(provider.getMessages).toHaveBeenCalled();
 
@@ -1696,7 +1701,7 @@ describe("RandomAccessPlayer", () => {
     const store = new MessageStore(2);
     player.setSubscriptions([{ topic: "/foo/bar", format: "parsedMessages" }]);
     player.requestBackfill(); // We always get a `requestBackfill` after each `setSubscriptions`.
-    await player.setListener(store.add);
+    player.setListener(store.add);
     await store.done;
 
     // Seek to just before the end.
@@ -1762,7 +1767,7 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     source.setSubscriptions([
       { topic: "/unknown_topic", format: "parsedMessages" }, // Shouldn't appear in getMessages at all!
       { topic: "/parsed_topic", format: "parsedMessages" },
@@ -1803,7 +1808,7 @@ describe("RandomAccessPlayer", () => {
     };
 
     const store = new MessageStore(2);
-    await source.setListener(store.add);
+    source.setListener(store.add);
     source.setSubscriptions([
       { topic: "/unknown_topic", format: "parsedMessages" }, // Shouldn't appear in getMessages at all!
       { topic: "/streaming_parsed", format: "parsedMessages" },
@@ -1831,7 +1836,7 @@ describe("RandomAccessPlayer", () => {
         { name: "TestProvider", args: { provider }, children: [] },
         playerOptions,
       );
-      await player.setListener(async () => {
+      player.setListener(async () => {
         // no-op
       });
       provider.extensionPoint?.progressCallback({});
@@ -1847,9 +1852,8 @@ describe("RandomAccessPlayer", () => {
         { name: "TestProvider", args: { provider }, children: [] },
         playerOptions,
       );
-      await player.setListener(async () => {
-        // no-op
-      });
+      player.setListener(async () => {});
+      await Promise.resolve();
 
       // Provider start/end is 10s/100s. Load from 55s to 100s.
       provider.extensionPoint?.progressCallback({

--- a/app/players/RandomAccessPlayer.ts
+++ b/app/players/RandomAccessPlayer.ts
@@ -593,7 +593,7 @@ export default class RandomAccessPlayer implements Player {
         this._messages = messages;
         this._bobjects = bobjects;
         this._lastSeekEmitTime = seekTime;
-        await this._emitState();
+        this._emitState();
       }
     } else {
       // If we are playing, make sure we set this emit time so that consumers will know that we seeked.

--- a/app/util/indexeddb/Database.test.ts
+++ b/app/util/indexeddb/Database.test.ts
@@ -36,7 +36,7 @@ describe("Database", () => {
     expect(await tx2.objectStore("bar").get(2)).toEqual("two");
     expect(await tx2.objectStore("bar").get(3)).toEqual(undefined);
     await tx2.complete;
-    await db.close();
+    db.close();
   });
 
   it("can do crud operations", async () => {

--- a/app/util/indexeddb/Database.ts
+++ b/app/util/indexeddb/Database.ts
@@ -83,7 +83,7 @@ export default class Database {
     this.db = db;
   }
 
-  close() {
+  close(): void {
     return this.db.close();
   }
 

--- a/app/util/indexeddb/MetaDatabase.test.ts
+++ b/app/util/indexeddb/MetaDatabase.test.ts
@@ -34,7 +34,7 @@ describe("MetaDatabase", () => {
     it("deletes databases if over max", async () => {
       async function createAndClose(name: string) {
         const db = await Database.get({ name, version: 1, objectStores: [{ name: "foo" }] });
-        await db.close();
+        db.close();
         await updateMetaDatabases(name, 3, METADATABASE_NAME);
       }
       await createAndClose("foo");

--- a/app/util/indexeddb/MetaDatabase.ts
+++ b/app/util/indexeddb/MetaDatabase.ts
@@ -158,7 +158,7 @@ export async function updateMetaDatabases(
     });
     await Promise.all(promises);
   } finally {
-    await metadataDatabase.close();
+    metadataDatabase.close();
   }
 }
 
@@ -168,7 +168,7 @@ export async function doesDatabaseExist(
 ): Promise<boolean> {
   const metadataDatabase = await Database.get(getConfig(metadataDatabaseName));
   const entry = await metadataDatabase.get(metadataObjectStoreName, databaseName);
-  await metadataDatabase.close();
+  metadataDatabase.close();
   log.info(`Checking if database exists returned ${!!entry} with...`, { databaseName });
   return !!entry;
 }

--- a/eslint-test.ts
+++ b/eslint-test.ts
@@ -14,6 +14,12 @@
   set x(newX) {},
 });
 
+(async () => {
+  await 1; // eslint-disable-line @typescript-eslint/await-thenable
+  await (function () {})(); // eslint-disable-line @typescript-eslint/await-thenable
+  await (async function () {})();
+})();
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (str: string, num: number, wut: any) => {
   str ? 0 : 1; // eslint-disable-line @typescript-eslint/strict-boolean-expressions

--- a/packages/ros1/src/RosFollower.ts
+++ b/packages/ros1/src/RosFollower.ts
@@ -111,8 +111,7 @@ export class RosFollower {
       return Promise.reject(err);
     }
 
-    const pid = await this.#rosNode.pid;
-    return [1, "", pid];
+    return [1, "", this.#rosNode.pid];
   };
 
   getSubscriptions = (_: string, args: XmlRpcValue[]): Promise<RosXmlRpcResponse> => {


### PR DESCRIPTION
Enables `@typescript-eslint/await-thenable` and fixes outstanding errors.