### PR TITLE
Disallow `#member` in favor of `private _member`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -142,6 +142,9 @@ rules:
         `// eslint-disable-next-line no-restricted-syntax`. For rationale, see:
         https://github.com/sindresorhus/meta/discussions/7"
 
+    - selector: "TSPrivateIdentifier"
+      message: "Use private instead of #"
+
   "@typescript-eslint/strict-boolean-expressions":
     - error
       # Force explicit checks that strings are empty

--- a/app/components/LayoutsContextMenu.stories.tsx
+++ b/app/components/LayoutsContextMenu.stories.tsx
@@ -16,13 +16,13 @@ import configureStore from "@foxglove-studio/app/store/configureStore.testing";
 import LayoutsContextMenu from "./LayoutsContextMenu";
 
 class FakeLayoutStorage implements LayoutStorage {
-  #layouts: Layout[];
+  private _layouts: Layout[];
 
   constructor(layouts: Layout[] = []) {
-    this.#layouts = layouts;
+    this._layouts = layouts;
   }
   list(): Promise<Layout[]> {
-    return Promise.resolve(this.#layouts);
+    return Promise.resolve(this._layouts);
   }
   get(_id: string): Promise<Layout | undefined> {
     throw new Error("Method not implemented.");

--- a/app/panels/ThreeDimensionalViz/Transforms.ts
+++ b/app/panels/ThreeDimensionalViz/Transforms.ts
@@ -132,25 +132,25 @@ export class Transform {
 }
 
 class TfStore {
-  #storage = new Map<string, Transform>();
+  private _storage = new Map<string, Transform>();
 
   get(key: string): Transform {
     key = stripLeadingSlash(key);
-    let result = this.#storage.get(key);
+    let result = this._storage.get(key);
     if (result) {
       return result;
     }
     result = new Transform(key);
-    this.#storage.set(key, result);
+    this._storage.set(key, result);
     return result;
   }
 
   has(key: string): boolean {
-    return this.#storage.has(key);
+    return this._storage.has(key);
   }
 
   values(): Array<Transform> {
-    return Array.from(this.#storage.values());
+    return Array.from(this._storage.values());
   }
 }
 

--- a/app/players/RosbridgePlayer.test.ts
+++ b/app/players/RosbridgePlayer.test.ts
@@ -89,14 +89,14 @@ class MockRosClient {
 }
 
 class MockRosTopic {
-  #name: string = "";
+  private _name: string = "";
 
   constructor({ name }: { name: string }) {
-    this.#name = name;
+    this._name = name;
   }
 
   subscribe(callback: (arg: unknown) => void) {
-    workerInstance.getMessagesByTopicName(this.#name).forEach(({ message }) => callback(message));
+    workerInstance.getMessagesByTopicName(this._name).forEach(({ message }) => callback(message));
   }
 }
 

--- a/app/services/OsContextLayoutStorage.ts
+++ b/app/services/OsContextLayoutStorage.ts
@@ -19,14 +19,14 @@ function assertLayout(value: unknown): asserts value is Layout {
 export default class OsContextLayoutStorage implements LayoutStorage {
   private static STORE_NAME = "layouts";
 
-  #ctx: OsContext;
+  private _ctx: OsContext;
 
   constructor(osContext: OsContext) {
-    this.#ctx = osContext;
+    this._ctx = osContext;
   }
 
   async list(): Promise<Layout[]> {
-    const items = await this.#ctx.storage.all(OsContextLayoutStorage.STORE_NAME);
+    const items = await this._ctx.storage.all(OsContextLayoutStorage.STORE_NAME);
 
     const layouts: Layout[] = [];
     for (const item of items) {
@@ -44,7 +44,7 @@ export default class OsContextLayoutStorage implements LayoutStorage {
   }
 
   async get(id: string): Promise<Layout | undefined> {
-    const item = await this.#ctx.storage.get(OsContextLayoutStorage.STORE_NAME, id);
+    const item = await this._ctx.storage.get(OsContextLayoutStorage.STORE_NAME, id);
     if (!(item instanceof Uint8Array)) {
       throw new Error("Invariant violation - layout item is not a buffer");
     }
@@ -58,10 +58,10 @@ export default class OsContextLayoutStorage implements LayoutStorage {
 
   async put(layout: Layout): Promise<void> {
     const content = JSON.stringify(layout);
-    return this.#ctx.storage.put(OsContextLayoutStorage.STORE_NAME, layout.id, content);
+    return this._ctx.storage.put(OsContextLayoutStorage.STORE_NAME, layout.id, content);
   }
 
   async delete(id: string): Promise<void> {
-    return this.#ctx.storage.delete(OsContextLayoutStorage.STORE_NAME, id);
+    return this._ctx.storage.delete(OsContextLayoutStorage.STORE_NAME, id);
   }
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "module": "esnext",
+    "module": "es2020",
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "es2020"],
     "paths": {
       "micro-memoize": ["../typings/micro-memoize"],
       "@foxglove-studio/app/*": ["*"]

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "module": "es2020",
+    "module": "esnext",
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "paths": {

--- a/packages/electron-socket/preloader/HttpServerElectron.ts
+++ b/packages/electron-socket/preloader/HttpServerElectron.ts
@@ -10,12 +10,12 @@ import { TcpAddress } from "../shared/TcpTypes";
 
 export class HttpServerElectron {
   readonly id: number;
-  #server: http.Server;
-  #messagePort: MessagePort;
-  #nextRequestId = 0;
-  #requests = new Map<number, (response: HttpResponse) => Promise<void>>();
-  #api = new Map<string, RpcHandler>([
-    ["address", (callId) => this.#apiResponse([callId, this.address()])],
+  private _server: http.Server;
+  private _messagePort: MessagePort;
+  private _nextRequestId = 0;
+  private _requests = new Map<number, (response: HttpResponse) => Promise<void>>();
+  private _api = new Map<string, RpcHandler>([
+    ["address", (callId) => this._apiResponse([callId, this.address()])],
     [
       "listen",
       (callId, args) => {
@@ -23,8 +23,8 @@ export class HttpServerElectron {
         const hostname = args[1] as string | undefined;
         const backlog = args[2] as number | undefined;
         this.listen(port, hostname, backlog)
-          .then(() => this.#apiResponse([callId, undefined]))
-          .catch((err) => this.#apiResponse([callId, String(err.stack ?? err)]));
+          .then(() => this._apiResponse([callId, undefined]))
+          .catch((err) => this._apiResponse([callId, String(err.stack ?? err)]));
       },
     ],
     [
@@ -32,40 +32,40 @@ export class HttpServerElectron {
       (callId, args) => {
         const requestId = args[0] as number;
         const response = args[1] as HttpResponse;
-        const handler = this.#requests.get(requestId);
+        const handler = this._requests.get(requestId);
         if (handler == undefined) {
-          this.#apiResponse([callId, `unknown requestId ${requestId}`]);
+          this._apiResponse([callId, `unknown requestId ${requestId}`]);
           return;
         }
-        this.#requests.delete(requestId);
+        this._requests.delete(requestId);
         handler(response)
-          .then(() => this.#apiResponse([callId, undefined]))
-          .catch((err) => this.#apiResponse([callId, String(err.stack ?? err)]));
+          .then(() => this._apiResponse([callId, undefined]))
+          .catch((err) => this._apiResponse([callId, String(err.stack ?? err)]));
       },
     ],
-    ["close", (callId) => this.#apiResponse([callId, this.close()])],
-    ["dispose", (callId) => this.#apiResponse([callId, this.dispose()])],
+    ["close", (callId) => this._apiResponse([callId, this.close()])],
+    ["dispose", (callId) => this._apiResponse([callId, this.dispose()])],
   ]);
 
   constructor(id: number, messagePort: MessagePort) {
     this.id = id;
-    this.#server = http.createServer(this.#handleRequest);
-    this.#messagePort = messagePort;
+    this._server = http.createServer(this._handleRequest);
+    this._messagePort = messagePort;
 
-    this.#server.on("close", () => this.#emit("close"));
-    this.#server.on("error", (err) => this.#emit("error", String(err.stack ?? err)));
+    this._server.on("close", () => this._emit("close"));
+    this._server.on("error", (err) => this._emit("error", String(err.stack ?? err)));
 
     messagePort.onmessage = (ev: MessageEvent<RpcCall>) => {
       const [methodName, callId] = ev.data;
       const args = ev.data.slice(2);
-      const handler = this.#api.get(methodName);
+      const handler = this._api.get(methodName);
       handler?.(callId, args);
     };
     messagePort.start();
   }
 
   address(): TcpAddress | undefined {
-    const addr = this.#server.address();
+    const addr = this._server.address();
     if (addr == undefined || typeof addr === "string") {
       // Address will only be a string for an IPC (named pipe) server, which
       // should never happen here
@@ -76,44 +76,44 @@ export class HttpServerElectron {
 
   listen(port?: number, hostname?: string, backlog?: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.#server.listen(port, hostname, backlog, () => {
-        this.#server.removeListener("error", reject);
+      this._server.listen(port, hostname, backlog, () => {
+        this._server.removeListener("error", reject);
         resolve();
       });
     });
   }
 
   close(): void {
-    this.#server.close();
+    this._server.close();
   }
 
   dispose(): void {
-    this.#server.removeAllListeners();
+    this._server.removeAllListeners();
     this.close();
-    this.#messagePort.close();
+    this._messagePort.close();
   }
 
-  #apiResponse = (message: RpcResponse, transfer?: Transferable[]): void => {
+  private _apiResponse(message: RpcResponse, transfer?: Transferable[]): void {
     if (transfer != undefined) {
-      this.#messagePort.postMessage(message, transfer);
+      this._messagePort.postMessage(message, transfer);
     } else {
-      this.#messagePort.postMessage(message);
+      this._messagePort.postMessage(message);
     }
-  };
+  }
 
-  #emit = (eventName: string, ...args: Cloneable[]): void => {
+  private _emit(eventName: string, ...args: Cloneable[]): void {
     const msg = [eventName, ...args];
-    this.#messagePort.postMessage(msg);
-  };
+    this._messagePort.postMessage(msg);
+  }
 
-  #handleRequest = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+  private _handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const chunks: Uint8Array[] = [];
     req.on("data", (chunk: Uint8Array) => chunks.push(chunk));
     req.on("end", () => {
       const body = Buffer.concat(chunks).toString();
 
-      const requestId = this.#nextRequestId++;
-      this.#requests.set(
+      const requestId = this._nextRequestId++;
+      this._requests.set(
         requestId,
         (incomingRes): Promise<void> => {
           res.chunkedEncoding = incomingRes.chunkedEncoding ?? res.chunkedEncoding;
@@ -141,7 +141,7 @@ export class HttpServerElectron {
         method: req.method,
         url: req.url,
       };
-      this.#emit("request", requestId, request);
+      this._emit("request", requestId, request);
     });
-  };
+  }
 }

--- a/packages/electron-socket/preloader/TcpServerElectron.ts
+++ b/packages/electron-socket/preloader/TcpServerElectron.ts
@@ -11,10 +11,10 @@ import { nextId, registerEntity } from "./registry";
 
 export class TcpServerElectron {
   readonly id: number;
-  #server: net.Server;
-  #messagePort: MessagePort;
-  #api = new Map<string, RpcHandler>([
-    ["address", (callId) => this.#apiResponse([callId, this.address()])],
+  private _server: net.Server;
+  private _messagePort: MessagePort;
+  private _api = new Map<string, RpcHandler>([
+    ["address", (callId) => this._apiResponse([callId, this.address()])],
     [
       "listen",
       (callId, args) => {
@@ -22,34 +22,34 @@ export class TcpServerElectron {
         const hostname = args[1] as string | undefined;
         const backlog = args[2] as number | undefined;
         this.listen(port, hostname, backlog)
-          .then(() => this.#apiResponse([callId, undefined]))
-          .catch((err) => this.#apiResponse([callId, String(err.stack ?? err)]));
+          .then(() => this._apiResponse([callId, undefined]))
+          .catch((err) => this._apiResponse([callId, String(err.stack ?? err)]));
       },
     ],
-    ["close", (callId) => this.#apiResponse([callId, this.close()])],
-    ["dispose", (callId) => this.#apiResponse([callId, this.dispose()])],
+    ["close", (callId) => this._apiResponse([callId, this.close()])],
+    ["dispose", (callId) => this._apiResponse([callId, this.dispose()])],
   ]);
 
   constructor(id: number, messagePort: MessagePort) {
     this.id = id;
-    this.#server = net.createServer();
-    this.#messagePort = messagePort;
+    this._server = net.createServer();
+    this._messagePort = messagePort;
 
-    this.#server.on("close", () => this.#emit("close"));
-    this.#server.on("connection", (socket) => this.#emitConnection(socket));
-    this.#server.on("error", (err) => this.#emit("error", String(err.stack ?? err)));
+    this._server.on("close", () => this._emit("close"));
+    this._server.on("connection", (socket) => this._emitConnection(socket));
+    this._server.on("error", (err) => this._emit("error", String(err.stack ?? err)));
 
     messagePort.onmessage = (ev: MessageEvent<RpcCall>) => {
       const [methodName, callId] = ev.data;
       const args = ev.data.slice(2);
-      const handler = this.#api.get(methodName);
+      const handler = this._api.get(methodName);
       handler?.(callId, args);
     };
     messagePort.start();
   }
 
   address(): TcpAddress | undefined {
-    const addr = this.#server.address();
+    const addr = this._server.address();
     if (addr == undefined || typeof addr === "string") {
       // Address will only be a string for an IPC (named pipe) server, which
       // should never happen here
@@ -60,43 +60,43 @@ export class TcpServerElectron {
 
   listen(port?: number, hostname?: string, backlog?: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.#server.listen(port, hostname, backlog, () => {
-        this.#server.removeListener("error", reject);
+      this._server.listen(port, hostname, backlog, () => {
+        this._server.removeListener("error", reject);
         resolve();
       });
     });
   }
 
   close(): void {
-    this.#server.close();
+    this._server.close();
   }
 
   dispose(): void {
-    this.#server.removeAllListeners();
+    this._server.removeAllListeners();
     this.close();
-    this.#messagePort.close();
+    this._messagePort.close();
   }
 
-  #apiResponse = (message: RpcResponse, transfer?: Transferable[]): void => {
+  private _apiResponse(message: RpcResponse, transfer?: Transferable[]): void {
     if (transfer != undefined) {
-      this.#messagePort.postMessage(message, transfer);
+      this._messagePort.postMessage(message, transfer);
     } else {
-      this.#messagePort.postMessage(message);
+      this._messagePort.postMessage(message);
     }
-  };
+  }
 
-  #emit = (eventName: string, ...args: Cloneable[]): void => {
+  private _emit(eventName: string, ...args: Cloneable[]): void {
     const msg = [eventName, ...args];
-    this.#messagePort.postMessage(msg);
-  };
+    this._messagePort.postMessage(msg);
+  }
 
-  #emitConnection = (socket: net.Socket): void => {
+  private _emitConnection(socket: net.Socket): void {
     const id = nextId();
     const channel = new MessageChannel();
     const host = socket.remoteAddress as string;
     const port = socket.remotePort as number;
     const electronSocket = new TcpSocketElectron(id, channel.port2, host, port, socket);
     registerEntity(id, electronSocket);
-    this.#messagePort.postMessage(["connection"], [channel.port1]);
-  };
+    this._messagePort.postMessage(["connection"], [channel.port1]);
+  }
 }

--- a/packages/electron-socket/tsconfig.json
+++ b/packages/electron-socket/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": ["preloader/*.ts", "renderer/*.ts", "shared/*.ts"],
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
-    "lib": ["es2020", "dom"],
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext", "dom"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/electron-socket/tsconfig.json
+++ b/packages/electron-socket/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["preloader/*.ts", "renderer/*.ts", "shared/*.ts"],
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["esnext", "dom"],
+    "module": "es2020",
+    "lib": ["es2020", "dom"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/just-fetch/browser/tsconfig.json
+++ b/packages/just-fetch/browser/tsconfig.json
@@ -3,9 +3,8 @@
   "include": ["index.ts"],
   "compilerOptions": {
     "outDir": "../dist/browser",
-    "target": "esnext",
     "module": "commonjs",
-    "lib": ["esnext", "dom"],
+    "lib": ["es2020", "dom"],
     "declaration": true,
     "rootDir": "."
   }

--- a/packages/just-fetch/browser/tsconfig.json
+++ b/packages/just-fetch/browser/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["index.ts"],
   "compilerOptions": {
     "outDir": "../dist/browser",
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
-    "lib": ["es2020", "dom"],
+    "lib": ["esnext", "dom"],
     "declaration": true,
     "rootDir": "."
   }

--- a/packages/just-fetch/tsconfig.json
+++ b/packages/just-fetch/tsconfig.json
@@ -3,9 +3,8 @@
   "include": ["index.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "esnext",
     "module": "commonjs",
-    "lib": ["esnext"],
+    "lib": ["es2020"],
     "declaration": true,
     "rootDir": "."
   }

--- a/packages/just-fetch/tsconfig.json
+++ b/packages/just-fetch/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["index.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["esnext"],
     "declaration": true,
     "rootDir": "."
   }

--- a/packages/ros1-turtlesim-test/tsconfig.json
+++ b/packages/ros1-turtlesim-test/tsconfig.json
@@ -3,9 +3,8 @@
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "esnext",
     "module": "commonjs",
-    "lib": ["esnext"],
+    "lib": ["es2020"],
     "declaration": true,
     "rootDir": "./src",
     "noUnusedParameters": true,

--- a/packages/ros1-turtlesim-test/tsconfig.json
+++ b/packages/ros1-turtlesim-test/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["esnext"],
     "declaration": true,
     "rootDir": "./src",
     "noUnusedParameters": true,

--- a/packages/ros1/src/Publication.ts
+++ b/packages/ros1/src/Publication.ts
@@ -15,7 +15,7 @@ export class Publication {
   readonly name: string;
   readonly md5sum: string;
   readonly dataType: string;
-  #subscribers = new Map<number, SubscriberLink>();
+  private _subscribers = new Map<number, SubscriberLink>();
 
   constructor(name: string, md5sum: string, dataType: string) {
     this.name = name;
@@ -24,14 +24,14 @@ export class Publication {
   }
 
   close(): void {
-    for (const sub of this.#subscribers.values()) {
+    for (const sub of this._subscribers.values()) {
       sub.connection.close();
     }
-    this.#subscribers.clear();
+    this._subscribers.clear();
   }
 
   getInfo(): SubscriberInfo[] {
-    return Array.from(this.#subscribers.values()).map(
+    return Array.from(this._subscribers.values()).map(
       (sub): SubscriberInfo => {
         return [
           sub.connectionId,
@@ -47,7 +47,7 @@ export class Publication {
   }
 
   getStats(): [string, SubscriberStats[]] {
-    const subStats = Array.from(this.#subscribers.values()).map(
+    const subStats = Array.from(this._subscribers.values()).map(
       (sub): SubscriberStats => {
         const stats = sub.connection.stats();
         return [sub.connectionId, stats.bytesSent, stats.bytesSent, stats.messagesSent, 0];

--- a/packages/ros1/src/RosFollower.ts
+++ b/packages/ros1/src/RosFollower.ts
@@ -33,34 +33,34 @@ function TcpRequested(protocols: XmlRpcValue[]): boolean {
 }
 
 export class RosFollower {
-  #rosNode: RosNode;
-  #server: XmlRpcServer;
+  private _rosNode: RosNode;
+  private _server: XmlRpcServer;
 
   constructor(rosNode: RosNode, httpServer: HttpServer) {
-    this.#rosNode = rosNode;
-    this.#server = new XmlRpcServer(httpServer);
+    this._rosNode = rosNode;
+    this._server = new XmlRpcServer(httpServer);
   }
 
   async start(hostname: string, port?: number): Promise<void> {
-    await this.#server.listen(port, hostname, 10);
+    await this._server.listen(port, hostname, 10);
 
-    this.#server.setHandler("getBusStats", this.getBusStats);
-    this.#server.setHandler("getBusInfo", this.getBusInfo);
-    this.#server.setHandler("shutdown", this.shutdown);
-    this.#server.setHandler("getPid", this.getPid);
-    this.#server.setHandler("getSubscriptions", this.getSubscriptions);
-    this.#server.setHandler("getPublications", this.getPublications);
-    this.#server.setHandler("paramUpdate", this.paramUpdate);
-    this.#server.setHandler("publisherUpdate", this.publisherUpdate);
-    this.#server.setHandler("requestTopic", this.requestTopic);
+    this._server.setHandler("getBusStats", this.getBusStats);
+    this._server.setHandler("getBusInfo", this.getBusInfo);
+    this._server.setHandler("shutdown", this.shutdown);
+    this._server.setHandler("getPid", this.getPid);
+    this._server.setHandler("getSubscriptions", this.getSubscriptions);
+    this._server.setHandler("getPublications", this.getPublications);
+    this._server.setHandler("paramUpdate", this.paramUpdate);
+    this._server.setHandler("publisherUpdate", this.publisherUpdate);
+    this._server.setHandler("requestTopic", this.requestTopic);
   }
 
   close(): void {
-    this.#server.close();
+    this._server.close();
   }
 
   url(): string | undefined {
-    return this.#server.url();
+    return this._server.url();
   }
 
   getBusStats = (_: string, args: XmlRpcValue[]): Promise<RosXmlRpcResponse> => {
@@ -69,8 +69,8 @@ export class RosFollower {
       return Promise.reject(err);
     }
 
-    const publications = this.#rosNode.publications.values();
-    const subscriptions = this.#rosNode.subscriptions.values();
+    const publications = this._rosNode.publications.values();
+    const subscriptions = this._rosNode.subscriptions.values();
 
     const publishStats: XmlRpcValue[] = Array.from(publications, (pub, __) => pub.getStats());
     const subscribeStats: XmlRpcValue[] = Array.from(subscriptions, (sub, __) => sub.getStats());
@@ -100,7 +100,7 @@ export class RosFollower {
     }
 
     const msg = args[1] as string | undefined;
-    this.#rosNode.shutdown(msg);
+    this._rosNode.shutdown(msg);
 
     return Promise.resolve([1, "", 0]);
   };
@@ -111,7 +111,7 @@ export class RosFollower {
       return Promise.reject(err);
     }
 
-    return [1, "", this.#rosNode.pid];
+    return [1, "", this._rosNode.pid];
   };
 
   getSubscriptions = (_: string, args: XmlRpcValue[]): Promise<RosXmlRpcResponse> => {
@@ -121,7 +121,7 @@ export class RosFollower {
     }
 
     const subs: [string, string][] = [];
-    this.#rosNode.subscriptions.forEach((sub) => subs.push([sub.name, sub.dataType]));
+    this._rosNode.subscriptions.forEach((sub) => subs.push([sub.name, sub.dataType]));
     return Promise.resolve([1, "subscriptions", subs]);
   };
 
@@ -132,7 +132,7 @@ export class RosFollower {
     }
 
     const pubs: [string, string][] = [];
-    this.#rosNode.publications.forEach((pub) => pubs.push([pub.name, pub.dataType]));
+    this._rosNode.publications.forEach((pub) => pubs.push([pub.name, pub.dataType]));
     return Promise.resolve([1, "publications", pubs]);
   };
 
@@ -168,7 +168,7 @@ export class RosFollower {
       return Promise.resolve([0, "unsupported protocol", []]);
     }
 
-    const addr = this.#rosNode.tcpServerAddress();
+    const addr = this._rosNode.tcpServerAddress();
     if (!addr) {
       return Promise.resolve([0, "cannot receive incoming connections", []]);
     }

--- a/packages/ros1/src/RosTcpMessageStream.ts
+++ b/packages/ros1/src/RosTcpMessageStream.ts
@@ -15,44 +15,44 @@ export declare interface RosTcpMessageStream {
 // TCPROS format of 4 byte length prefixes followed by message payloads into one
 // complete message per "message" event, discarding the length prefix
 export class RosTcpMessageStream extends EventEmitter {
-  #inMessage = false;
-  #bytesNeeded = 4;
-  #chunks: Uint8Array[] = [];
+  private _inMessage = false;
+  private _bytesNeeded = 4;
+  private _chunks: Uint8Array[] = [];
 
   addData(chunk: Uint8Array): void {
     let idx = 0;
     while (idx < chunk.length) {
-      if (chunk.length - idx < this.#bytesNeeded) {
+      if (chunk.length - idx < this._bytesNeeded) {
         // If we didn't receive enough bytes to complete the current message or
         // message length field, store this chunk and continue on
-        this.#chunks.push(new Uint8Array(chunk.buffer, chunk.byteOffset + idx));
-        this.#bytesNeeded -= chunk.length - idx;
+        this._chunks.push(new Uint8Array(chunk.buffer, chunk.byteOffset + idx));
+        this._bytesNeeded -= chunk.length - idx;
         return;
       }
 
       // Store the final chunk needed to complete the current message or message
       // length field
-      this.#chunks.push(new Uint8Array(chunk.buffer, chunk.byteOffset + idx, this.#bytesNeeded));
-      idx += this.#bytesNeeded;
+      this._chunks.push(new Uint8Array(chunk.buffer, chunk.byteOffset + idx, this._bytesNeeded));
+      idx += this._bytesNeeded;
 
-      const payload = concatData(this.#chunks);
-      this.#chunks = [];
+      const payload = concatData(this._chunks);
+      this._chunks = [];
 
-      if (this.#inMessage) {
+      if (this._inMessage) {
         // Produce a Uint8Array representing a single message and transition to
         // reading a message length field
-        this.#bytesNeeded = 4;
+        this._bytesNeeded = 4;
         this.emit("message", payload);
       } else {
         // Decoded the message length field and transition to reading a message
-        this.#bytesNeeded = new DataView(
+        this._bytesNeeded = new DataView(
           payload.buffer,
           payload.byteOffset,
           payload.byteLength,
         ).getUint32(0, true);
       }
 
-      this.#inMessage = !this.#inMessage;
+      this._inMessage = !this._inMessage;
     }
   }
 }

--- a/packages/ros1/src/RosXmlRpcClient.ts
+++ b/packages/ros1/src/RosXmlRpcClient.ts
@@ -7,21 +7,21 @@ import { XmlRpcClient, XmlRpcValue } from "@foxglove/xmlrpc";
 import { RosXmlRpcResponse } from "./XmlRpcTypes";
 
 export class RosXmlRpcClient {
-  #client: XmlRpcClient;
+  private _client: XmlRpcClient;
 
   constructor(url: string) {
-    this.#client = new XmlRpcClient(url, { encoding: "utf8" });
+    this._client = new XmlRpcClient(url, { encoding: "utf8" });
   }
 
   url(): string {
-    return this.#client.url;
+    return this._client.url;
   }
 
   protected _methodCall = async (
     methodName: string,
     args: XmlRpcValue[],
   ): Promise<RosXmlRpcResponse> => {
-    const res = await this.#client.methodCall(methodName, args);
+    const res = await this._client.methodCall(methodName, args);
     if (!Array.isArray(res) || res.length !== 3) {
       throw new Error(`malformed XML-RPC response`);
     }

--- a/packages/ros1/src/mock/MockTcp.ts
+++ b/packages/ros1/src/mock/MockTcp.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from "eventemitter3";
 import { TcpAddress, TcpServer, TcpSocket } from "../TcpTypes";
 
 export class MockTcpSocket extends EventEmitter implements TcpSocket {
-  #connected = true;
+  private _connected = true;
 
   constructor() {
     super();
@@ -17,13 +17,13 @@ export class MockTcpSocket extends EventEmitter implements TcpSocket {
     return Promise.resolve({
       address: "192.168.1.2",
       port: 40000,
-      family: this.#connected ? "IPv4" : undefined,
+      family: this._connected ? "IPv4" : undefined,
     });
   }
 
   localAddress(): Promise<TcpAddress | undefined> {
     return Promise.resolve(
-      this.#connected ? { address: "127.0.0.1", port: 30000, family: "IPv4" } : undefined,
+      this._connected ? { address: "127.0.0.1", port: 30000, family: "IPv4" } : undefined,
     );
   }
 
@@ -32,7 +32,7 @@ export class MockTcpSocket extends EventEmitter implements TcpSocket {
   }
 
   connected(): Promise<boolean> {
-    return Promise.resolve(this.#connected);
+    return Promise.resolve(this._connected);
   }
 
   connect(): Promise<void> {
@@ -40,7 +40,7 @@ export class MockTcpSocket extends EventEmitter implements TcpSocket {
   }
 
   close(): Promise<void> {
-    this.#connected = false;
+    this._connected = false;
     return Promise.resolve();
   }
 

--- a/packages/ros1/src/nodejs/TcpServerNode.ts
+++ b/packages/ros1/src/nodejs/TcpServerNode.ts
@@ -10,11 +10,11 @@ import { TcpAddress, TcpServer } from "@foxglove/ros1";
 import { TcpSocketNode } from "./TcpSocketNode";
 
 export class TcpServerNode extends EventEmitter implements TcpServer {
-  #server: net.Server;
+  private _server: net.Server;
 
   constructor(server: net.Server) {
     super();
-    this.#server = server;
+    this._server = server;
 
     server.on("close", () => this.emit("close"));
     server.on("connection", (socket) => {
@@ -28,7 +28,7 @@ export class TcpServerNode extends EventEmitter implements TcpServer {
   }
 
   address(): TcpAddress | undefined {
-    const addr = this.#server.address();
+    const addr = this._server.address();
     if (addr == undefined || typeof addr === "string") {
       // Address will only be a string for an IPC (named pipe) server, which
       // should never happen in TcpServerNode
@@ -38,7 +38,7 @@ export class TcpServerNode extends EventEmitter implements TcpServer {
   }
 
   close(): void {
-    this.#server.close();
+    this._server.close();
   }
 
   static Listen(options: { host?: string; port?: number; backlog?: number }): Promise<TcpServer> {

--- a/packages/ros1/tsconfig.json
+++ b/packages/ros1/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["esnext"],
+    "module": "es2020",
+    "lib": ["es2020"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/ros1/tsconfig.json
+++ b/packages/ros1/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
-    "lib": ["es2020"],
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/rosmsg-bobject/tsconfig.json
+++ b/packages/rosmsg-bobject/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "test/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
-    "module": "es2020"
+    "module": "esnext"
   }
 }

--- a/packages/rosmsg-bobject/tsconfig.json
+++ b/packages/rosmsg-bobject/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts", "test/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
-    "module": "esnext"
+    "module": "es2020"
   }
 }

--- a/packages/velodyne-cloud/tsconfig.json
+++ b/packages/velodyne-cloud/tsconfig.json
@@ -3,9 +3,8 @@
   "include": ["src/**/*.ts", "src/**/*.json", "fixtures/**/*", "jest.config.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "esnext",
     "module": "commonjs",
-    "lib": ["esnext"],
+    "lib": ["es2020"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true

--- a/packages/velodyne-cloud/tsconfig.json
+++ b/packages/velodyne-cloud/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src/**/*.ts", "src/**/*.json", "fixtures/**/*", "jest.config.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["esnext"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true

--- a/packages/wasm-bz2/tsconfig.json
+++ b/packages/wasm-bz2/tsconfig.json
@@ -2,9 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["*.ts", "src/*.ts", "test/*.ts"],
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "lib": ["esnext", "DOM"],
+    "module": "es2020",
+    "lib": ["es2020", "DOM"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/wasm-bz2/tsconfig.json
+++ b/packages/wasm-bz2/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": ["*.ts", "src/*.ts", "test/*.ts"],
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
-    "lib": ["es2020", "DOM"],
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext", "DOM"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true,

--- a/packages/xmlrpc/src/DateFormatter.ts
+++ b/packages/xmlrpc/src/DateFormatter.ts
@@ -9,18 +9,18 @@ export type DateFormatterOptions = {
 };
 
 export class DateFormatter {
-  #colons = true;
-  #hyphens = true;
-  #ms = true;
+  private _colons = true;
+  private _hyphens = true;
+  private _ms = true;
 
   // Regular Expression that dissects an ISO 8601 formatted string into an array of parts
   static ISO8601 = /([0-9]{4})([-]?([0-9]{2}))([-]?([0-9]{2}))(T-?([0-9]{2})(((:?([0-9]{2}))?((:?([0-9]{2}))?(\.([0-9]+))?))?)(Z|([+-]([0-9]{2}(:?([0-9]{2}))?)))?)?/;
 
   constructor(options?: DateFormatterOptions) {
     if (options) {
-      this.#colons = options.colons ?? this.#colons;
-      this.#hyphens = options.hyphens ?? this.#hyphens;
-      this.#ms = options.ms ?? this.#ms;
+      this._colons = options.colons ?? this._colons;
+      this._hyphens = options.hyphens ?? this._hyphens;
+      this._ms = options.ms ?? this._ms;
     }
   }
 
@@ -63,10 +63,10 @@ export class DateFormatter {
     const parts = DateFormatter.getUTCDateParts(date);
 
     return [
-      [parts[0], parts[1], parts[2]].join(this.#hyphens ? "-" : ""),
+      [parts[0], parts[1], parts[2]].join(this._hyphens ? "-" : ""),
       "T",
-      [parts[3], parts[4], parts[5]].join(this.#colons ? ":" : ""),
-      this.#ms ? "." + parts[6] : "",
+      [parts[3], parts[4], parts[5]].join(this._colons ? ":" : ""),
+      this._ms ? "." + parts[6] : "",
       "Z",
     ].join("");
   }

--- a/packages/xmlrpc/src/Deserializer.ts
+++ b/packages/xmlrpc/src/Deserializer.ts
@@ -15,170 +15,170 @@ type ResponseType = "params" | "fault";
 export class Deserializer {
   dateFormatter = new DateFormatter();
 
-  #type?: DeserializerType;
-  #responseType?: ResponseType;
-  #stack: XmlRpcValue[] = [];
-  #marks: number[] = [];
-  #data: string[] = [];
-  #methodname?: string;
-  #encoding: Encoding;
-  #value: boolean = false;
-  #callback: (err?: Error, res?: XmlRpcValue[]) => void = () => {};
-  #error?: Error;
-  #parser: sax.SAXStream;
+  private _type?: DeserializerType;
+  private _responseType?: ResponseType;
+  private _stack: XmlRpcValue[] = [];
+  private _marks: number[] = [];
+  private _data: string[] = [];
+  private _methodname?: string;
+  private _encoding: Encoding;
+  private _value: boolean = false;
+  private _callback: (err?: Error, res?: XmlRpcValue[]) => void = () => {};
+  private _error?: Error;
+  private _parser: sax.SAXStream;
 
   static isInteger = /^-?\d+$/;
 
   constructor(encoding: Encoding = "utf8") {
-    this.#encoding = encoding;
-    this.#parser = sax.createStream();
-    this.#parser.on("opentag", this.#onOpentag);
-    this.#parser.on("closetag", this.#onClosetag);
-    this.#parser.on("text", this.#onText);
-    this.#parser.on("cdata", this.#onCDATA);
-    this.#parser.on("end", this.#onDone);
-    this.#parser.on("error", this.#onError);
+    this._encoding = encoding;
+    this._parser = sax.createStream();
+    this._parser.on("opentag", this._onOpentag);
+    this._parser.on("closetag", this._onClosetag);
+    this._parser.on("text", this._onText);
+    this._parser.on("cdata", this._onCDATA);
+    this._parser.on("end", this._onDone);
+    this._parser.on("error", this._onError);
   }
 
   deserializeMethodResponse(data: string | ArrayBuffer): Promise<XmlRpcValue> {
     return new Promise((resolve, reject) => {
-      this.#callback = (error, result) => {
+      this._callback = (error, result) => {
         if (error) {
           reject(error);
         } else if (result != undefined && result.length > 1) {
           reject(new Error("Response has more than one param"));
-        } else if (this.#type !== "methodresponse") {
+        } else if (this._type !== "methodresponse") {
           reject(new Error("Not a method response"));
-        } else if (this.#responseType == undefined) {
+        } else if (this._responseType == undefined) {
           reject(new Error("Invalid method response"));
         } else {
           resolve(result?.[0]);
         }
       };
 
-      this.#parser.end(data, this.#encoding);
+      this._parser.end(data, this._encoding);
     });
   }
 
   deserializeMethodCall(data: string): Promise<[methodName: string, args: XmlRpcValue[]]> {
     return new Promise((resolve, reject) => {
-      this.#callback = (error, result) => {
+      this._callback = (error, result) => {
         if (error) {
           reject(error);
-        } else if (this.#type !== "methodcall") {
+        } else if (this._type !== "methodcall") {
           reject(new Error("Not a method call"));
-        } else if (this.#methodname == undefined) {
+        } else if (this._methodname == undefined) {
           reject(new Error("Method call did not contain a method name"));
         } else {
-          resolve([this.#methodname, result ?? []]);
+          resolve([this._methodname, result ?? []]);
         }
       };
 
-      this.#parser.end(data, this.#encoding);
+      this._parser.end(data, this._encoding);
     });
   }
 
-  #onDone = (): void => {
-    if (!this.#error) {
-      if (this.#type == undefined || this.#marks.length !== 0) {
-        this.#callback(new Error("Invalid XML-RPC message"));
-      } else if (this.#responseType === "fault") {
+  private _onDone = (): void => {
+    if (!this._error) {
+      if (this._type == undefined || this._marks.length !== 0) {
+        this._callback(new Error("Invalid XML-RPC message"));
+      } else if (this._responseType === "fault") {
         const createFault = (fault: XmlRpcStruct) => {
           const faultString = typeof fault.faultString === "string" ? fault.faultString : undefined;
           const faultCode = typeof fault.faultCode === "number" ? fault.faultCode : undefined;
           return new XmlRpcFault(faultString, faultCode);
         };
-        this.#callback(createFault(this.#stack[0] as XmlRpcStruct));
+        this._callback(createFault(this._stack[0] as XmlRpcStruct));
       } else {
-        this.#callback(undefined, this.#stack);
+        this._callback(undefined, this._stack);
       }
     }
   };
 
-  #onError = (err: Error): void => {
-    if (!this.#error) {
-      this.#error = err;
-      this.#callback?.(this.#error);
+  private _onError = (err: Error): void => {
+    if (!this._error) {
+      this._error = err;
+      this._callback?.(this._error);
     }
   };
 
-  #push = (value: XmlRpcValue): void => {
-    this.#stack.push(value);
+  private _push = (value: XmlRpcValue): void => {
+    this._stack.push(value);
   };
 
   //==============================================================================
   // SAX Handlers
   //==============================================================================
 
-  #onOpentag = (node: XmlNode): void => {
+  private _onOpentag = (node: XmlNode): void => {
     if (node.name === "ARRAY" || node.name === "STRUCT") {
-      this.#marks.push(this.#stack.length);
+      this._marks.push(this._stack.length);
     }
-    this.#data = [];
-    this.#value = node.name === "VALUE";
+    this._data = [];
+    this._value = node.name === "VALUE";
   };
 
-  #onText = (text: string): void => {
-    this.#data.push(text);
+  private _onText = (text: string): void => {
+    this._data.push(text);
   };
 
-  #onCDATA = (cdata: string): void => {
-    this.#data.push(cdata);
+  private _onCDATA = (cdata: string): void => {
+    this._data.push(cdata);
   };
 
-  #onClosetag = (el: string): void => {
-    const data = this.#data.join("");
+  private _onClosetag = (el: string): void => {
+    const data = this._data.join("");
     try {
       switch (el) {
         case "BOOLEAN":
-          this.#endBoolean(data);
+          this._endBoolean(data);
           break;
         case "INT":
         case "I4":
-          this.#endInt(data);
+          this._endInt(data);
           break;
         case "I8":
-          this.#endI8(data);
+          this._endI8(data);
           break;
         case "DOUBLE":
-          this.#endDouble(data);
+          this._endDouble(data);
           break;
         case "STRING":
         case "NAME":
-          this.#endString(data);
+          this._endString(data);
           break;
         case "ARRAY":
-          this.#endArray(data);
+          this._endArray(data);
           break;
         case "STRUCT":
-          this.#endStruct(data);
+          this._endStruct(data);
           break;
         case "BASE64":
-          this.#endBase64(data);
+          this._endBase64(data);
           break;
         case "DATETIME.ISO8601":
-          this.#endDateTime(data);
+          this._endDateTime(data);
           break;
         case "VALUE":
-          this.#endValue(data);
+          this._endValue(data);
           break;
         case "PARAMS":
-          this.#endParams(data);
+          this._endParams(data);
           break;
         case "FAULT":
-          this.#endFault(data);
+          this._endFault(data);
           break;
         case "METHODRESPONSE":
-          this.#endMethodResponse(data);
+          this._endMethodResponse(data);
           break;
         case "METHODNAME":
-          this.#endMethodName(data);
+          this._endMethodName(data);
           break;
         case "METHODCALL":
-          this.#endMethodCall(data);
+          this._endMethodCall(data);
           break;
         case "NIL":
-          this.#endNil(data);
+          this._endNil(data);
           break;
         case "DATA":
         case "PARAM":
@@ -186,116 +186,116 @@ export class Deserializer {
           // Ignored by design
           break;
         default:
-          this.#onError(new Error(`Unknown XML-RPC tag "${el}"`));
+          this._onError(new Error(`Unknown XML-RPC tag "${el}"`));
           break;
       }
     } catch (e) {
-      this.#onError(e);
+      this._onError(e);
     }
   };
 
-  #endNil = (_data: string): void => {
-    this.#push(undefined);
-    this.#value = false;
+  private _endNil = (_data: string): void => {
+    this._push(undefined);
+    this._value = false;
   };
 
-  #endBoolean = (data: string): void => {
+  private _endBoolean = (data: string): void => {
     if (data === "1") {
-      this.#push(true);
+      this._push(true);
     } else if (data === "0") {
-      this.#push(false);
+      this._push(false);
     } else {
       throw new Error("Illegal boolean value '" + data + "'");
     }
-    this.#value = false;
+    this._value = false;
   };
 
-  #endInt = (data: string): void => {
+  private _endInt = (data: string): void => {
     const value = parseInt(data, 10);
     if (isNaN(value)) {
       throw new Error("Expected an integer but got '" + data + "'");
     } else {
-      this.#push(value);
-      this.#value = false;
+      this._push(value);
+      this._value = false;
     }
   };
 
-  #endDouble = (data: string): void => {
+  private _endDouble = (data: string): void => {
     const value = parseFloat(data);
     if (isNaN(value)) {
       throw new Error("Expected a double but got '" + data + "'");
     } else {
-      this.#push(value);
-      this.#value = false;
+      this._push(value);
+      this._value = false;
     }
   };
 
-  #endString = (data: string): void => {
-    this.#push(data);
-    this.#value = false;
+  private _endString = (data: string): void => {
+    this._push(data);
+    this._value = false;
   };
 
-  #endArray = (_data: string): void => {
-    const mark = this.#marks.pop() ?? 0;
-    this.#stack.splice(mark, this.#stack.length - mark, this.#stack.slice(mark));
-    this.#value = false;
+  private _endArray = (_data: string): void => {
+    const mark = this._marks.pop() ?? 0;
+    this._stack.splice(mark, this._stack.length - mark, this._stack.slice(mark));
+    this._value = false;
   };
 
-  #endStruct = (_data: string): void => {
-    const mark = this.#marks.pop() ?? 0;
+  private _endStruct = (_data: string): void => {
+    const mark = this._marks.pop() ?? 0;
     const struct: XmlRpcStruct = {};
-    const items = this.#stack.slice(mark);
+    const items = this._stack.slice(mark);
     for (let i = 0; i < items.length; i += 2) {
       const key = String(items[i]);
       struct[key] = items[i + 1];
     }
-    this.#stack.splice(mark, this.#stack.length - mark, struct);
-    this.#value = false;
+    this._stack.splice(mark, this._stack.length - mark, struct);
+    this._value = false;
   };
 
-  #endBase64 = (data: string): void => {
+  private _endBase64 = (data: string): void => {
     const buffer = Buffer.from(data, "base64");
-    this.#push(buffer);
-    this.#value = false;
+    this._push(buffer);
+    this._value = false;
   };
 
-  #endDateTime = (data: string): void => {
+  private _endDateTime = (data: string): void => {
     const date = this.dateFormatter.decodeIso8601(data);
-    this.#push(date);
-    this.#value = false;
+    this._push(date);
+    this._value = false;
   };
 
-  #endI8 = (data: string): void => {
+  private _endI8 = (data: string): void => {
     if (!Deserializer.isInteger.test(data)) {
       throw new Error(`Expected integer (I8) value but got "${data}"`);
     } else {
-      this.#endString(data);
+      this._endString(data);
     }
   };
 
-  #endValue = (data: string): void => {
-    if (this.#value) {
-      this.#endString(data);
+  private _endValue = (data: string): void => {
+    if (this._value) {
+      this._endString(data);
     }
   };
 
-  #endParams = (_data: string): void => {
-    this.#responseType = "params";
+  private _endParams = (_data: string): void => {
+    this._responseType = "params";
   };
 
-  #endFault = (_data: string): void => {
-    this.#responseType = "fault";
+  private _endFault = (_data: string): void => {
+    this._responseType = "fault";
   };
 
-  #endMethodResponse = (_data: string): void => {
-    this.#type = "methodresponse";
+  private _endMethodResponse = (_data: string): void => {
+    this._type = "methodresponse";
   };
 
-  #endMethodName = (data: string): void => {
-    this.#methodname = data;
+  private _endMethodName = (data: string): void => {
+    this._methodname = data;
   };
 
-  #endMethodCall = (_data: string): void => {
-    this.#type = "methodcall";
+  private _endMethodCall = (_data: string): void => {
+    this._type = "methodcall";
   };
 }

--- a/packages/xmlrpc/src/HttpServerNodejs.ts
+++ b/packages/xmlrpc/src/HttpServerNodejs.ts
@@ -8,11 +8,11 @@ import { HttpHandler, HttpServer } from "@foxglove/xmlrpc";
 
 export class HttpServerNodejs implements HttpServer {
   handler: HttpHandler;
-  #server: http.Server;
+  private _server: http.Server;
 
   constructor() {
     this.handler = () => Promise.resolve({ statusCode: 404 });
-    this.#server = new http.Server((req, res) => {
+    this._server = new http.Server((req, res) => {
       // Read the full request body into a string
       const chunks: Uint8Array[] = [];
       req.on("data", (chunk: Uint8Array) => chunks.push(chunk));
@@ -32,7 +32,7 @@ export class HttpServerNodejs implements HttpServer {
   }
 
   url(): string | undefined {
-    const addr = this.#server.address();
+    const addr = this._server.address();
     if (addr == undefined || typeof addr === "string") {
       return addr ?? undefined;
     }
@@ -42,15 +42,15 @@ export class HttpServerNodejs implements HttpServer {
 
   listen(port?: number, hostname?: string, backlog?: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.#server.on("error", reject);
-      this.#server.listen(port, hostname, backlog, () => {
-        this.#server.removeListener("error", reject);
+      this._server.on("error", reject);
+      this._server.listen(port, hostname, backlog, () => {
+        this._server.removeListener("error", reject);
         resolve();
       });
     });
   }
 
   close(): void {
-    this.#server.close();
+    this._server.close();
   }
 }

--- a/packages/xmlrpc/src/XmlRpcServer.ts
+++ b/packages/xmlrpc/src/XmlRpcServer.ts
@@ -17,7 +17,7 @@ export class XmlRpcServer {
 
   constructor(server: HttpServer) {
     this.server = server;
-    server.handler = this.#requestHandler; // Our HTTP handler
+    server.handler = this._requestHandler; // Our HTTP handler
   }
 
   url(): string | undefined {
@@ -36,7 +36,7 @@ export class XmlRpcServer {
     this.xmlRpcHandlers.set(methodName, handler);
   }
 
-  #requestHandler = async (req: HttpRequest): Promise<HttpResponse> => {
+  private _requestHandler = async (req: HttpRequest): Promise<HttpResponse> => {
     const deserializer = new Deserializer();
     const [methodName, args] = await deserializer.deserializeMethodCall(req.body);
     const handler = this.xmlRpcHandlers.get(methodName);

--- a/packages/xmlrpc/tsconfig.json
+++ b/packages/xmlrpc/tsconfig.json
@@ -3,9 +3,8 @@
   "include": ["src/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "esnext",
     "module": "commonjs",
-    "lib": ["esnext"],
+    "lib": ["es2020"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true

--- a/packages/xmlrpc/tsconfig.json
+++ b/packages/xmlrpc/tsconfig.json
@@ -3,9 +3,9 @@
   "include": ["src/**/*.ts", "jest.config.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["esnext"],
     "declaration": true,
     "rootDir": ".",
     "noUnusedParameters": true

--- a/preload/LocalFileStorage.ts
+++ b/preload/LocalFileStorage.ts
@@ -9,7 +9,7 @@ import path from "path";
 import type { Storage, StorageContent } from "@foxglove-studio/app/OsContext";
 
 export default class LocalFileStorage implements Storage {
-  #userDataPath = ipcRenderer.invoke("getUserDataPath");
+  private _userDataPath = ipcRenderer.invoke("getUserDataPath");
 
   async list(datastore: string): Promise<string[]> {
     const datastoreDir = await this.ensureDatastorePath(datastore);
@@ -89,7 +89,7 @@ export default class LocalFileStorage implements Storage {
   }
 
   private async ensureDatastorePath(datastore: string): Promise<string> {
-    const basePath = await this.#userDataPath;
+    const basePath = await this._userDataPath;
     // check that datastore matches regex [a-z]*
     // since datastore becomes a path under our userDataPath, we use this to sanitize
     if (!/[a-z-]/.test(datastore)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2020",
     "module": "commonjs",
     "newLine": "lf",
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "commonjs",
     "newLine": "lf",
     "skipLibCheck": true,

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -55,7 +55,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
               // avoid looking at files which are not part of the bundle
               onlyCompileBundledFiles: true,
               compilerOptions: {
-                module: "es2020",
+                module: "esnext",
               },
             },
           },

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -55,7 +55,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
               // avoid looking at files which are not part of the bundle
               onlyCompileBundledFiles: true,
               compilerOptions: {
-                module: "esnext",
+                module: "es2020",
               },
             },
           },


### PR DESCRIPTION
`#member` access is rewritten to a slow double hashmap lookup when targeting ES2020. It is passed through without transformation when targeting ESNext, but that causes other webpack and babel failures with `??=` usage and it would still cause a big perf hit if we target non-Chrome browsers at some point (dashboard feature). The current direct impact is a 2x slowdown in Velodyne packet -> point cloud transform, and could affect more hot paths if the usage proliferates.

This PR disables `#member` usage via an ESLint rule.