### PR TITLE
Create identity transforms for unseen TFs referenced by header.frame_id, always select a rootTf if we can

### DIFF
--- a/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -72,7 +72,9 @@ import TopicTree from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree
 import { TOPIC_DISPLAY_MODES } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/TopicViewModeSelector";
 import { TopicDisplayMode } from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/types";
 import useSceneBuilderAndTransformsData from "@foxglove-studio/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData";
-import Transforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/Transforms";
+import Transforms, {
+  DEFAULT_ROOT_FRAME_IDS,
+} from "@foxglove-studio/app/panels/ThreeDimensionalViz/Transforms";
 import TransformsBuilder from "@foxglove-studio/app/panels/ThreeDimensionalViz/TransformsBuilder";
 import World from "@foxglove-studio/app/panels/ThreeDimensionalViz/World";
 import {
@@ -405,13 +407,27 @@ export default function Layout({
   }, [colorOverrideBySourceIdxByVariable, globalVariables, linkedGlobalVariables]);
 
   const rootTf = useMemo(() => {
-    // If the user specified a followTf, we give priority to the root frame from their followTf
-    if (followTf && transforms.has(followTf)) {
-      return transforms.rootOfTransform(followTf).id;
+    // If the user specified a followTf we will only return the root frame from their followTf
+    if (followTf) {
+      if (transforms.has(followTf)) {
+        return transforms.rootOfTransform(followTf).id;
+      }
+      return undefined;
     }
 
-    // Otherwise, fall back to the default tf selection logic
-    return transforms.defaultTf()?.id;
+    const tfStore = transforms.storage.entries();
+
+    // Try the conventional list of root frame transform ids
+    for (const frameId of DEFAULT_ROOT_FRAME_IDS) {
+      const tf = tfStore.get(frameId);
+      if (tf != undefined) {
+        return tf.id;
+      }
+    }
+
+    // Fall back to the root of the first transform (lexicographically), if any
+    const firstFrameId = Array.from(tfStore.keys()).sort()[0];
+    return firstFrameId != undefined ? tfStore.get(firstFrameId)?.rootTransform().id : undefined;
   }, [transforms, followTf]);
 
   useEffect(() => {

--- a/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -405,22 +405,13 @@ export default function Layout({
   }, [colorOverrideBySourceIdxByVariable, globalVariables, linkedGlobalVariables]);
 
   const rootTf = useMemo(() => {
-    // REP 105 specifies a set of conventional root frame transform ids
-    // We try these in order
-    // https://www.ros.org/reps/rep-0105.html
-    const possibleRootFrames = ["base_link", "odom", "map", "earth"];
-
     // If the user specified a followTf, we give priority to the root frame from their followTf
-    if (followTf) {
-      possibleRootFrames.unshift(followTf);
+    if (followTf && transforms.has(followTf)) {
+      return transforms.rootOfTransform(followTf).id;
     }
 
-    for (const possibleRoot of possibleRootFrames) {
-      if (transforms.has(possibleRoot)) {
-        return transforms.rootOfTransform(possibleRoot).id;
-      }
-    }
-    return undefined;
+    // Otherwise, fall back to the default tf selection logic
+    return transforms.defaultTf()?.id;
   }, [transforms, followTf]);
 
   useEffect(() => {

--- a/app/panels/ThreeDimensionalViz/Transforms.ts
+++ b/app/panels/ThreeDimensionalViz/Transforms.ts
@@ -27,6 +27,10 @@ function stripLeadingSlash(name: string) {
   return name.startsWith("/") ? name.slice(1) : name;
 }
 
+// REP 105 specifies a set of conventional root frame transform ids
+// https://www.ros.org/reps/rep-0105.html
+export const DEFAULT_ROOT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
+
 export class Transform {
   id: string;
   matrix: mat4 = mat4.create();
@@ -132,8 +136,6 @@ export class Transform {
 }
 
 class TfStore {
-  static DEFAULT_FRAMES = ["base_link", "odom", "map", "earth"];
-
   private _storage = new Map<string, Transform>();
 
   get(key: string): Transform {
@@ -155,20 +157,8 @@ class TfStore {
     return Array.from(this._storage.values());
   }
 
-  default(): Transform | undefined {
-    // REP 105 specifies a set of conventional root frame transform ids
-    // We try these in order
-    // https://www.ros.org/reps/rep-0105.html
-    for (const frameId of TfStore.DEFAULT_FRAMES) {
-      const tf = this._storage.get(frameId);
-      if (tf != undefined) {
-        return tf;
-      }
-    }
-
-    // Fall back to the root of the first transform (lexicographically), if any
-    const firstFrameId = Array.from(this._storage.keys()).sort()[0];
-    return firstFrameId != undefined ? this._storage.get(firstFrameId)?.rootTransform() : undefined;
+  entries(): Readonly<Map<string, Transform>> {
+    return this._storage;
   }
 }
 
@@ -226,9 +216,5 @@ export default class Transforms {
 
   values(): Array<Transform> {
     return this.storage.values();
-  }
-
-  defaultTf(): Transform | undefined {
-    return this.storage.default();
   }
 }

--- a/app/panels/ThreeDimensionalViz/Transforms.ts
+++ b/app/panels/ThreeDimensionalViz/Transforms.ts
@@ -37,7 +37,7 @@ export class Transform {
     this.id = stripLeadingSlash(id);
   }
 
-  set(position: Point, orientation: Orientation) {
+  set(position: Point, orientation: Orientation): void {
     mat4.fromRotationTranslation(
       this.matrix,
       quat.set(tempOrient, orientation.x, orientation.y, orientation.z, orientation.w),
@@ -46,7 +46,7 @@ export class Transform {
     this._hasValidMatrix = true;
   }
 
-  isValid(rootId: string) {
+  isValid(rootId: string): boolean {
     return this._hasValidMatrix || this.id === rootId;
   }
 
@@ -132,6 +132,8 @@ export class Transform {
 }
 
 class TfStore {
+  static DEFAULT_FRAMES = ["base_link", "odom", "map", "earth"];
+
   private _storage = new Map<string, Transform>();
 
   get(key: string): Transform {
@@ -146,11 +148,27 @@ class TfStore {
   }
 
   has(key: string): boolean {
-    return this._storage.has(key);
+    return this._storage.has(stripLeadingSlash(key));
   }
 
   values(): Array<Transform> {
     return Array.from(this._storage.values());
+  }
+
+  default(): Transform | undefined {
+    // REP 105 specifies a set of conventional root frame transform ids
+    // We try these in order
+    // https://www.ros.org/reps/rep-0105.html
+    for (const frameId of TfStore.DEFAULT_FRAMES) {
+      const tf = this._storage.get(frameId);
+      if (tf != undefined) {
+        return tf;
+      }
+    }
+
+    // Fall back to the root of the first transform (lexicographically), if any
+    const firstFrameId = Array.from(this._storage.keys()).sort()[0];
+    return firstFrameId != undefined ? this._storage.get(firstFrameId)?.rootTransform() : undefined;
   }
 }
 
@@ -159,7 +177,7 @@ export default class Transforms {
   empty = true;
 
   // consume a tf message
-  consume(tfMessage: TF) {
+  consume(tfMessage: TF): void {
     // child_frame_id is the id of the tf
     const id = tfMessage.child_frame_id;
     const parentId = tfMessage.header.frame_id;
@@ -167,6 +185,12 @@ export default class Transforms {
     const { rotation, translation } = tfMessage.transform;
     tf.set(translation, rotation);
     tf.parent = this.storage.get(parentId);
+    this.empty = false;
+  }
+
+  // create a placeholder tf if we have not seen this frameId yet
+  register(frameId: string): void {
+    this.storage.get(frameId);
     this.empty = false;
   }
 
@@ -192,15 +216,19 @@ export default class Transforms {
   }
 
   // Return true if a transform with id _key_ exists in our transforms
-  has(key: string) {
+  has(key: string): boolean {
     return this.storage.has(key);
   }
 
-  get(key: string) {
+  get(key: string): Transform {
     return this.storage.get(key);
   }
 
   values(): Array<Transform> {
     return this.storage.values();
+  }
+
+  defaultTf(): Transform | undefined {
+    return this.storage.default();
   }
 }


### PR DESCRIPTION
Rendering is skipped entirely if there is no rootTf. Therefore, we should always select a rootTf unless there is absolutely no renderable data that could be shown
