### PR TITLE
Close webpack after compiling for integration testing

### DIFF
--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -27,6 +27,7 @@ export default async (): Promise<void> => {
     // eslint-disable-next-line no-restricted-syntax
     console.info("Building Webpack");
     compiler.run((err, result) => {
+      compiler.close();
       if (err) {
         reject(err);
         return;

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -27,7 +27,7 @@ export default async (): Promise<void> => {
     // eslint-disable-next-line no-restricted-syntax
     console.info("Building Webpack");
     compiler.run((err, result) => {
-      compiler.close();
+      compiler.close(() => {});
       if (err) {
         reject(err);
         return;


### PR DESCRIPTION
This should fix the integration test not cleanly exiting in some cases