### PR TITLE
Include source in source maps

### DIFF
--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -35,7 +35,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     context: path.resolve("./desktop"),
     entry: "./index.ts",
     target: "electron-main",
-    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
+    devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
       publicPath: "",

--- a/webpack.preload.config.ts
+++ b/webpack.preload.config.ts
@@ -15,7 +15,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     context: path.resolve("./preload"),
     entry: "./index.ts",
     target: "electron-preload",
-    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
+    devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
       publicPath: "",

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -40,7 +40,7 @@ export function makeConfig(_: unknown, argv: WebpackArgv): Configuration {
     target: "web",
     context: path.resolve("./app"),
     entry: "./index.tsx",
-    devtool: isDev ? "eval-cheap-module-source-map" : "nosources-source-map",
+    devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     optimization: {
       minimize: false,


### PR DESCRIPTION
This will make source maps in production builds usable, and hopefully improve sentry errors too.