### PR TITLE
Don't initialize telemetry until `telemetry.telemetryEnabled` setting has been read

### DIFF
--- a/app/context/AnalyticsContext.ts
+++ b/app/context/AnalyticsContext.ts
@@ -13,6 +13,7 @@ export function useAnalytics(): Analytics {
   if (analytics == undefined) {
     throw new Error("An AnalyticsContext provider is required to useAnalytics");
   }
+  analytics.init();
   return analytics;
 }
 

--- a/app/services/Analytics.ts
+++ b/app/services/Analytics.ts
@@ -28,13 +28,25 @@ export enum AppEvent {
 }
 
 export class Analytics {
+  private _initialized = false;
   private _amplitude?: amplitude.AmplitudeClient;
   private _storage = new Storage();
+  private _optOut: boolean;
+  private _amplitudeApiKey?: string;
 
   constructor(options: { optOut?: boolean; amplitudeApiKey: string | undefined }) {
-    const amplitudeApiKey = options.amplitudeApiKey;
-    const optOut = options.optOut ?? false;
-    if (!optOut && amplitudeApiKey != undefined && amplitudeApiKey.length > 0) {
+    this._optOut = options.optOut ?? false;
+    this._amplitudeApiKey = options.amplitudeApiKey;
+  }
+
+  init(): void {
+    if (this._initialized) {
+      return;
+    }
+    this._initialized = true;
+
+    const amplitudeApiKey = this._amplitudeApiKey;
+    if (!this._optOut && amplitudeApiKey != undefined && amplitudeApiKey.length > 0) {
       const userId = this.getUserId();
       const deviceId = this.getDeviceId();
       const appVersion = this.getAppVersion();


### PR DESCRIPTION
This prevents the APP_INIT telemetry event from being recorded if the user has set `telemetry.telemetryEnabled = false`
