### PR TITLE
Fix for unaligned reinterpretBufferToFloat()

### DIFF
--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.test.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.test.ts
@@ -36,5 +36,19 @@ describe("<PointClouds />", () => {
       expect(Math.floor(buffer[17]!)).toBe(225);
       expect(Math.floor(buffer[18]!)).toBe(127);
     });
+
+    it("handles odd sizes", () => {
+      const srcBuffer = new ArrayBuffer(11);
+      const data = new Uint8Array(srcBuffer);
+      const buffer = reinterpretBufferToFloat(data);
+      expect(buffer).toHaveLength(2);
+    });
+
+    it("handles odd offsets", () => {
+      const srcBuffer = new ArrayBuffer(15);
+      const data = new Uint8Array(srcBuffer, 5, 8);
+      const buffer = reinterpretBufferToFloat(data);
+      expect(buffer).toHaveLength(2);
+    });
   });
 });

--- a/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
+++ b/app/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
@@ -41,11 +41,14 @@ export const FLOAT_SIZE = Float32Array.BYTES_PER_ELEMENT;
 
 // Reinterpret a buffer of bytes as a buffer of float values
 export function reinterpretBufferToFloat(buffer: Uint8Array): Float32Array {
-  return new Float32Array(
-    buffer.buffer,
-    buffer.byteOffset,
-    buffer.length / Float32Array.BYTES_PER_ELEMENT,
-  );
+  if (buffer.byteOffset % FLOAT_SIZE === 0) {
+    // Fast path when byteOffset is aligned with FLOAT_SIZE
+    return new Float32Array(buffer.buffer, buffer.byteOffset, buffer.length / FLOAT_SIZE);
+  } else {
+    // Bad alignment, we have to copy a section of the ArrayBuffer
+    const end = buffer.byteOffset + buffer.length;
+    return new Float32Array(buffer.buffer.slice(buffer.byteOffset, end));
+  }
 }
 
 // Expand a buffer of byte values, transforming each value into a float


### PR DESCRIPTION
Float32Array byteOffset must be a multiple of 4. Another bag is working now:

![os1-lidar](https://user-images.githubusercontent.com/195374/113630721-2f7ef700-961d-11eb-9283-894e47cf12de.PNG)
