### PR TITLE
Strict typing for icon names

### DIFF
--- a/app/components/LayoutMenu.tsx
+++ b/app/components/LayoutMenu.tsx
@@ -113,7 +113,7 @@ export default function LayoutMenu({
     downloadTextFile(content, `${name}.json`);
   }, [store]);
 
-  const importAction = useCallback(async () => {
+  const importAction = useCallback<() => void>(async () => {
     const fileHandle = await showOpenFilePicker();
     if (!fileHandle) {
       return;
@@ -202,7 +202,7 @@ export default function LayoutMenu({
             selectAction(layout);
           }
         },
-        iconProps: layout.id === currentLayoutId ? { iconName: "Checkmark" } : undefined,
+        iconProps: layout.id === currentLayoutId ? { iconName: "CheckMark" } : undefined,
         subMenuProps: {
           items: [
             {

--- a/app/components/TinyConnectionPicker.tsx
+++ b/app/components/TinyConnectionPicker.tsx
@@ -43,7 +43,7 @@ export default function TinyConnectionPicker({
       onRenderMenuIcon={() => ReactNull}
       menuProps={{
         items: availableSources.map((source) => {
-          let iconName: string;
+          let iconName: RegisteredIconNames;
           switch (source.type) {
             case "file":
               iconName = "OpenFile";

--- a/app/theme/useIcons.tsx
+++ b/app/theme/useIcons.tsx
@@ -1,58 +1,34 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import {
-  AddIcon,
-  CheckMarkIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  CirclePlusIcon,
-  DataManagementSettingsIcon,
-  DeleteIcon,
-  EditIcon,
-  FileASPXIcon,
-  FiveTileGridIcon,
-  FlowIcon,
-  MoreVerticalIcon,
-  OpenFileIcon,
-  SettingsIcon,
-  ShareIcon,
-  Variable2Icon,
-} from "@fluentui/react-icons-mdl2";
+import * as Icons from "@fluentui/react-icons-mdl2";
 import { registerIcons, unregisterIcons } from "@fluentui/style-utilities";
 import { useLayoutEffect, useRef } from "react";
 
 import RosIcon from "@foxglove-studio/app/components/RosIcon";
 
-const iconComponents = [
-  AddIcon,
-  CheckMarkIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  CirclePlusIcon,
-  DataManagementSettingsIcon,
-  DeleteIcon,
-  EditIcon,
-  FileASPXIcon,
-  FiveTileGridIcon,
-  FlowIcon,
-  MoreVerticalIcon,
-  OpenFileIcon,
-  SettingsIcon,
-  ShareIcon,
-  Variable2Icon,
-];
-
-const icons: Record<string, React.ReactElement> = {};
-for (const Component of iconComponents) {
-  const { displayName = "" } = Component;
-  if (!displayName.endsWith("Icon")) {
-    throw new Error("Names must end with Icon");
-  }
-  icons[displayName.replace(/Icon$/, "")] = <Component />;
-}
-
-icons["studio.ROS"] = <RosIcon />;
+const icons: {
+  // This makes it a type error to forget to add an icon here once it has been added to RegisteredIconNames.
+  [N in RegisteredIconNames]: React.ReactElement;
+} = {
+  Add: <Icons.AddIcon />,
+  CheckMark: <Icons.CheckMarkIcon />,
+  ChevronDown: <Icons.ChevronDownIcon />,
+  ChevronRight: <Icons.ChevronRightIcon />,
+  CirclePlus: <Icons.CirclePlusIcon />,
+  DataManagementSettings: <Icons.DataManagementSettingsIcon />,
+  Delete: <Icons.DeleteIcon />,
+  Edit: <Icons.EditIcon />,
+  FileASPX: <Icons.FileASPXIcon />,
+  FiveTileGrid: <Icons.FiveTileGridIcon />,
+  Flow: <Icons.FlowIcon />,
+  MoreVertical: <Icons.MoreVerticalIcon />,
+  OpenFile: <Icons.OpenFileIcon />,
+  Settings: <Icons.SettingsIcon />,
+  Share: <Icons.ShareIcon />,
+  Variable2: <Icons.Variable2Icon />,
+  "studio.ROS": <RosIcon />,
+};
 
 export default function useIcons(): void {
   const registered = useRef(false);

--- a/typings/fluentui.d.ts
+++ b/typings/fluentui.d.ts
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IStyleFunctionOrObject, IIconStyleProps, IIconStyles } from "@fluentui/react";
+
+// Restrict TS types for icons to allow only the icon names we've registered.
+declare global {
+  type CustomIconNames = "studio.ROS";
+  type RegisteredIconNames =
+    | CustomIconNames
+    | "Add"
+    | "CheckMark"
+    | "ChevronDown"
+    | "ChevronRight"
+    | "CirclePlus"
+    | "DataManagementSettings"
+    | "Delete"
+    | "Edit"
+    | "FileASPX"
+    | "FiveTileGrid"
+    | "Flow"
+    | "MoreVertical"
+    | "OpenFile"
+    | "Settings"
+    | "Share"
+    | "Variable2";
+}
+
+declare module "@fluentui/react/lib/Icon" {
+  export interface IIconProps {
+    iconName?: RegisteredIconNames;
+    styles?: IStyleFunctionOrObject<IIconStyleProps, IIconStyles>;
+  }
+}
+declare module "@fluentui/react" {
+  export interface IIconProps {
+    iconName?: RegisteredIconNames;
+    styles?: IStyleFunctionOrObject<IIconStyleProps, IIconStyles>;
+  }
+}


### PR DESCRIPTION
Prevent us from using `iconName: "doesnotexist"`, or forgetting to register icons when we add new ones to the known types.