### PR TITLE
Fix storybook decorators

### DIFF
--- a/app/.storybook/__mocks__/subscribeToNewsletter.tsx
+++ b/app/.storybook/__mocks__/subscribeToNewsletter.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StoryContext } from "@storybook/addons";
+import { Story, StoryContext } from "@storybook/react";
 
 let nextFn: (email: string) => Promise<void>;
 export default function mockSubscribeToNewsletter(email: string): Promise<void> {
@@ -11,9 +11,9 @@ export default function mockSubscribeToNewsletter(email: string): Promise<void> 
 
 // Decorator for all stories to allow passing a mock function implementation in `parameters.mockSubscribeToNewsletter`
 // Example: https://storybook.js.org/docs/react/workflows/build-pages-with-storybook#mocking-imports
-export function withMockSubscribeToNewsletter(story: Function, { parameters }: StoryContext) {
+export function withMockSubscribeToNewsletter(Story: Story, { parameters }: StoryContext) {
   if (parameters && parameters.mockSubscribeToNewsletter) {
     nextFn = parameters.mockSubscribeToNewsletter;
   }
-  return story();
+  return <Story />;
 }

--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -4,13 +4,17 @@ import { getGlobalConfig } from "@foxglove-studio/app/GlobalConfig";
 import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
 import { withScreenshot } from "storycap";
 import { withMockSubscribeToNewsletter } from "./__mocks__/subscribeToNewsletter";
-import { StoryContext } from "@storybook/react";
+import { Story, StoryContext } from "@storybook/react";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
 
 let loaded = false;
 
-function withTheme(story: Function, { parameters }: StoryContext) {
-  return <ThemeProvider>{story()}</ThemeProvider>;
+function withTheme(Story: Story, { parameters }: StoryContext) {
+  return (
+    <ThemeProvider>
+      <Story />
+    </ThemeProvider>
+  );
 }
 
 export const loaders = [


### PR DESCRIPTION
The _story_ parameter to a decorator is a react component. It should be rendered
as a component rather than called as a function. Calling as a function resulted in
re-mounting all the story components when a hook changed in the story.