### PR TITLE
Fix dragging panels from Add Panel menu

### DIFF
--- a/app/components/AddPanelMenu/index.tsx
+++ b/app/components/AddPanelMenu/index.tsx
@@ -41,7 +41,14 @@ function MenuContent(menuProps: IContextualMenuProps) {
     [dispatch, layout],
   );
   return (
-    <Callout {...menuProps}>
+    <Callout
+      {...menuProps}
+      directionalHintFixed
+      layerProps={{
+        // Allow dragging panels from the menu into the layout
+        eventBubblingEnabled: true,
+      }}
+    >
       <Menu>
         <PanelList onPanelSelect={onPanelSelect} />
       </Menu>


### PR DESCRIPTION
Drag events were not passing through the Layer. Also fix the menu position (making sure it always points down).