### PR TITLE
Introduce a ScreenshotContext for stories to signal when the scene is ready.

### DIFF
--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -1,41 +1,14 @@
-import "@foxglove-studio/app/styles/global.scss";
-import "./styles.scss";
 import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
 import { withScreenshot } from "storycap";
 import { withMockSubscribeToNewsletter } from "./__mocks__/subscribeToNewsletter";
 import { Story, StoryContext } from "@storybook/react";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
-import signal from "@foxglove-studio/app/shared/signal";
-import ScreenshotContext from "@foxglove-studio/app/stories/ScreenshotContext";
-import { useCallback, useRef, useState } from "react";
+
+import "@foxglove-studio/app/styles/global.scss";
+import "./styles.scss";
+import withScreenshotSignal from "@foxglove-studio/app/.storybook/withScreenshotSignal";
 
 let loaded = false;
-
-function withScreenshotSignal(Story: Story, { parameters }: StoryContext) {
-  const signalRef = useRef(signal());
-  const callCount = useRef(0);
-  const [error, setError] = useState<Error | undefined>(undefined);
-  parameters.screenshot.waitFor = signalRef.current;
-
-  const sceneReady = useCallback(() => {
-    if (callCount.current > 0) {
-      setError(new Error("withScreenshotSignal: called scene ready more than once"));
-      return;
-    }
-    ++callCount.current;
-    signalRef.current.resolve();
-  }, []);
-
-  if (error) {
-    throw error;
-  }
-
-  return (
-    <ScreenshotContext.Provider value={sceneReady}>
-      <Story />
-    </ScreenshotContext.Provider>
-  );
-}
 
 function withTheme(Story: Story, { parameters }: StoryContext) {
   return (

--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -5,8 +5,37 @@ import { withScreenshot } from "storycap";
 import { withMockSubscribeToNewsletter } from "./__mocks__/subscribeToNewsletter";
 import { Story, StoryContext } from "@storybook/react";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
+import signal from "@foxglove-studio/app/shared/signal";
+import ScreenshotContext from "@foxglove-studio/app/stories/ScreenshotContext";
+import { useCallback, useRef, useState } from "react";
 
 let loaded = false;
+
+function withScreenshotSignal(Story: Story, { parameters }: StoryContext) {
+  const signalRef = useRef(signal());
+  const callCount = useRef(0);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  parameters.screenshot.waitFor = signalRef.current;
+
+  const sceneReady = useCallback(() => {
+    if (callCount.current > 0) {
+      setError(new Error("withScreenshotSignal: called scene ready more than once"));
+      return;
+    }
+    ++callCount.current;
+    signalRef.current.resolve();
+  }, []);
+
+  if (error) {
+    throw error;
+  }
+
+  return (
+    <ScreenshotContext.Provider value={sceneReady}>
+      <Story />
+    </ScreenshotContext.Provider>
+  );
+}
 
 function withTheme(Story: Story, { parameters }: StoryContext) {
   return (
@@ -27,7 +56,12 @@ export const loaders = [
   },
 ];
 
-export const decorators = [withTheme, withScreenshot, withMockSubscribeToNewsletter];
+export const decorators = [
+  withTheme,
+  withScreenshot,
+  withScreenshotSignal,
+  withMockSubscribeToNewsletter,
+];
 
 export const parameters = {
   // Disable default padding around the page body

--- a/app/.storybook/withScreenshotSignal.tsx
+++ b/app/.storybook/withScreenshotSignal.tsx
@@ -1,0 +1,37 @@
+import { Story, StoryContext } from "@storybook/react";
+import { useCallback, useRef, useState } from "react";
+
+import signal from "@foxglove-studio/app/shared/signal";
+import ScreenshotReadyContext from "@foxglove-studio/app/stories/ScreenshotReadyContext";
+
+export default function withScreenshotSignal(Story: Story, { parameters }: StoryContext) {
+  const signalRef = useRef(signal());
+  const callCount = useRef(0);
+  const [error, setError] = useState<Error | undefined>(undefined);
+
+  if (parameters.screenshot?.waitFor == undefined) {
+    parameters.screenshot.waitFor = signalRef.current;
+  } else {
+    // if the user has a waitFor defined, use that rather than our signal
+    signalRef.current = parameters.screenshot.waitFor;
+  }
+
+  const sceneReady = useCallback(() => {
+    if (callCount.current > 0) {
+      setError(new Error("withScreenshotSignal: called scene ready more than once"));
+      return;
+    }
+    ++callCount.current;
+    signalRef.current.resolve();
+  }, []);
+
+  if (error) {
+    throw error;
+  }
+
+  return (
+    <ScreenshotReadyContext.Provider value={sceneReady}>
+      <Story />
+    </ScreenshotReadyContext.Provider>
+  );
+}

--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -116,21 +116,12 @@ export const Simple = () => {
 // zoom and update without resetting zoom
 export const CanZoomAndUpdate = () => {
   const sceneReady = useScreenshotReady();
+  const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
+  const callCountRef = useRef(0);
 
   const okTrigger = useRef(false);
-  const pauseFrame = useCallback(() => {
-    return () => {
-      if (okTrigger.current) {
-        sceneReady();
-      }
-    };
-  }, [sceneReady]);
 
-  const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
-
-  const refFn = useCallback(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
+  const doScroll = useCallback(async () => {
     const canvasEl = document.querySelector("canvas");
     if (!canvasEl) {
       return;
@@ -138,24 +129,40 @@ export const CanZoomAndUpdate = () => {
 
     // Zoom is a continuous event, so we need to simulate wheel multiple times
     for (let i = 0; i < 5; i++) {
-      triggerWheel(canvasEl, 1);
+      triggerWheel(canvasEl, 2);
+      await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 100));
     setChartProps((oldProps) => {
-      // the next chart render will trigger our screenshot signal
-      okTrigger.current = true;
-
       const newProps = cloneDeep(oldProps);
       const newDataPoint = cloneDeep(newProps.data.datasets[0]!.data[0]!);
       newDataPoint.x = 20;
       newProps.data.datasets[0]!.data[1] = newDataPoint;
+
+      // the next chart render will trigger our screenshot signal
+      okTrigger.current = true;
       return newProps;
     });
   }, []);
 
+  const pauseFrame = useCallback(() => {
+    return () => {
+      // first render of the chart triggers scrolling
+      if (callCountRef.current === 0) {
+        doScroll();
+      }
+
+      if (okTrigger.current) {
+        sceneReady();
+      }
+
+      ++callCountRef.current;
+    };
+  }, [doScroll, sceneReady]);
+
   return (
-    <div style={{ width: 800, height: 800, background: "black" }} ref={refFn}>
+    <div style={{ width: 800, height: 800, background: "black" }}>
       <MockMessagePipelineProvider pauseFrame={pauseFrame}>
         <TimeBasedChart {...chartProps} width={800} height={800} />
       </MockMessagePipelineProvider>

--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -16,6 +16,7 @@ import { useState, useCallback, useRef } from "react";
 import MockMessagePipelineProvider from "@foxglove-studio/app/components/MessagePipeline/MockMessagePipelineProvider";
 import signal from "@foxglove-studio/app/shared/signal";
 import { triggerWheel } from "@foxglove-studio/app/stories/PanelSetup";
+import { useScreenshotReady } from "@foxglove-studio/app/stories/ScreenshotReadyContext";
 
 import TimeBasedChart, { TimeBasedChartTooltipData } from "./index";
 import type { Props } from "./index";
@@ -96,13 +97,13 @@ export default {
   },
 };
 
-const simpleSignal = signal();
 export const Simple = () => {
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
-      simpleSignal.resolve();
+      sceneReady();
     };
-  }, []);
+  }, [sceneReady]);
 
   return (
     <div style={{ width: "100%", height: "100%", background: "black" }}>
@@ -113,23 +114,18 @@ export const Simple = () => {
   );
 };
 
-Simple.parameters = {
-  screenshot: {
-    waitFor: simpleSignal,
-  },
-};
-
 // zoom and update without resetting zoom
-const zoomAndUpdateSignal = signal();
 export const CanZoomAndUpdate = () => {
+  const sceneReady = useScreenshotReady();
+
   const okTrigger = useRef(false);
   const pauseFrame = useCallback(() => {
     return () => {
       if (okTrigger.current) {
-        zoomAndUpdateSignal.resolve();
+        sceneReady();
       }
     };
-  }, []);
+  }, [sceneReady]);
 
   const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
 
@@ -167,9 +163,10 @@ export const CanZoomAndUpdate = () => {
     </div>
   );
 };
-CanZoomAndUpdate.parameters = { screenshot: { waitFor: zoomAndUpdateSignal } };
 
 export const CleansUpTooltipOnUnmount = () => {
+  const sceneReady = useScreenshotReady();
+
   const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
   const refFn = useCallback(async () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
@@ -181,7 +178,8 @@ export const CleansUpTooltipOnUnmount = () => {
     );
     await new Promise((resolve) => setTimeout(resolve, 100));
     setHasRenderedOnce(true);
-  }, []);
+    sceneReady();
+  }, [sceneReady]);
 
   if (hasRenderedOnce) {
     return ReactNull;
@@ -197,12 +195,14 @@ export const CleansUpTooltipOnUnmount = () => {
 };
 
 export const CallPauseOnInitialMount = () => {
+  const sceneReady = useScreenshotReady();
   const [unpauseFrameCount, setUnpauseFrameCount] = useState(0);
   const pauseFrame = useCallback(() => {
     return () => {
       setUnpauseFrameCount((old) => old + 1);
+      sceneReady();
     };
-  }, [setUnpauseFrameCount]);
+  }, [sceneReady]);
 
   return (
     <div style={{ width: "100%", height: "100%", background: "black" }}>

--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -14,7 +14,6 @@ import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, useRef } from "react";
 
 import MockMessagePipelineProvider from "@foxglove-studio/app/components/MessagePipeline/MockMessagePipelineProvider";
-import signal from "@foxglove-studio/app/shared/signal";
 import { triggerWheel } from "@foxglove-studio/app/stories/PanelSetup";
 import { useScreenshotReady } from "@foxglove-studio/app/stories/ScreenshotReadyContext";
 

--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -133,28 +133,30 @@ export const CanZoomAndUpdate = () => {
 
   const [chartProps, setChartProps] = useState(cloneDeep(commonProps));
 
-  const refFn = useCallback(() => {
-    setTimeout(() => {
-      const canvasEl = document.querySelector("canvas");
-      // Zoom is a continuous event, so we need to simulate wheel multiple times
-      if (canvasEl) {
-        for (let i = 0; i < 5; i++) {
-          triggerWheel(canvasEl, 1);
-        }
-        setTimeout(() => {
-          setChartProps((oldProps) => {
-            // the next chart render will trigger our screenshot signal
-            okTrigger.current = true;
+  const refFn = useCallback(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
-            const newProps = cloneDeep(oldProps);
-            const newDataPoint = cloneDeep(newProps.data.datasets[0]!.data[0]!);
-            newDataPoint.x = 20;
-            newProps.data.datasets[0]!.data[1] = newDataPoint;
-            return newProps;
-          });
-        }, 50);
-      }
-    }, 200);
+    const canvasEl = document.querySelector("canvas");
+    if (!canvasEl) {
+      return;
+    }
+
+    // Zoom is a continuous event, so we need to simulate wheel multiple times
+    for (let i = 0; i < 5; i++) {
+      triggerWheel(canvasEl, 1);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    setChartProps((oldProps) => {
+      // the next chart render will trigger our screenshot signal
+      okTrigger.current = true;
+
+      const newProps = cloneDeep(oldProps);
+      const newDataPoint = cloneDeep(newProps.data.datasets[0]!.data[0]!);
+      newDataPoint.x = 20;
+      newProps.data.datasets[0]!.data[1] = newDataPoint;
+      return newProps;
+    });
   }, []);
 
   return (
@@ -169,22 +171,26 @@ CanZoomAndUpdate.parameters = { screenshot: { waitFor: zoomAndUpdateSignal } };
 
 export const CleansUpTooltipOnUnmount = () => {
   const [hasRenderedOnce, setHasRenderedOnce] = useState<boolean>(false);
-  const refFn = useCallback(() => {
-    setTimeout(() => {
-      const [canvas] = document.getElementsByTagName("canvas");
-      const { top, left } = canvas!.getBoundingClientRect();
-      document.dispatchEvent(
-        new MouseEvent("mousemove", { clientX: 363 + left, clientY: 650 + top }),
-      );
-      setTimeout(() => {
-        setHasRenderedOnce(true);
-      }, 100);
-    }, 200);
+  const refFn = useCallback(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const [canvas] = document.getElementsByTagName("canvas");
+    const { top, left } = canvas!.getBoundingClientRect();
+    document.dispatchEvent(
+      new MouseEvent("mousemove", { clientX: 363 + left, clientY: 650 + top }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    setHasRenderedOnce(true);
   }, []);
+
+  if (hasRenderedOnce) {
+    return ReactNull;
+  }
+
   return (
     <div style={{ width: "100%", height: "100%", background: "black" }} ref={refFn}>
       <MockMessagePipelineProvider>
-        {!hasRenderedOnce && <TimeBasedChart {...commonProps} />}
+        <TimeBasedChart {...commonProps} />
       </MockMessagePipelineProvider>
     </div>
   );

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -279,8 +279,13 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   // since we render in a web-worker we need to pause/resume the message pipeline to keep
   // our plot rendeirng in-sync with data rendered elsewhere in the app
   const onChartUpdate = useCallback(() => {
-    resumeFrame.current?.();
+    const current = resumeFrame.current;
     resumeFrame.current = undefined;
+
+    if (current) {
+      // allow the chart offscreen canvas to render to screen
+      requestAnimationFrame(current);
+    }
   }, []);
 
   const hoverBar = useRef<HTMLDivElement>(ReactNull);
@@ -299,10 +304,9 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
 
     // cleanup pased frames on unmount or dataset changes
     return () => {
-      resumeFrame.current?.();
-      resumeFrame.current = undefined;
+      onChartUpdate();
     };
-  }, [pauseFrame, datasets]);
+  }, [pauseFrame, datasets, onChartUpdate]);
 
   // some callbacks don't need to re-create when the current scales change, so we keep a ref
   const currentScalesRef = useRef<RpcScales | undefined>(currentScales);

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -765,6 +765,12 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     onHover,
   };
 
+  // avoid rendering if width/height are 0 - usually on initial mount
+  // so we don't trigger onChartUpdate if we know we will immediately resize
+  if (width === 0 || height === 0) {
+    return ReactNull;
+  }
+
   return (
     <div style={{ display: "flex", width: "100%" }}>
       <div style={{ display: "flex", width }}>

--- a/app/package.json
+++ b/app/package.json
@@ -85,10 +85,10 @@
     "wasm-lz4": "1.0.0"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "6.2.3",
-    "@storybook/addon-essentials": "6.2.3",
-    "@storybook/builder-webpack5": "6.2.3",
-    "@storybook/react": "6.2.3",
+    "@storybook/addon-actions": "6.2.5",
+    "@storybook/addon-essentials": "6.2.5",
+    "@storybook/builder-webpack5": "6.2.5",
+    "@storybook/react": "6.2.5",
     "@testing-library/react": "11.2.6",
     "@testing-library/react-hooks": "5.1.1",
     "@types/argparse": "^2",

--- a/app/panels/StateTransitions/index.stories.tsx
+++ b/app/panels/StateTransitions/index.stories.tsx
@@ -11,10 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { storiesOf } from "@storybook/react";
+import { useCallback } from "react";
 import TestUtils from "react-dom/test-utils";
 
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
+import { useScreenshot } from "@foxglove-studio/app/stories/ScreenshotContext";
 
 import StateTransitions from "./index";
 
@@ -86,107 +87,154 @@ const fixture = {
   },
 };
 
-storiesOf("<StateTransitions>", module)
-  .addParameters({
-    screenshot: {
-      // Wait for chart workers to render
-      delay: 1000,
-    },
-  })
-  .add("one path", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <StateTransitions
-          config={{
-            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("multiple paths", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <StateTransitions
-          config={{
-            paths: new Array(5).fill({
-              value: "/some/topic/with/state.state",
-              timestampMethod: "receiveTime",
-            }),
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("multiple paths with hover", () => {
-    return (
-      <PanelSetup
-        fixture={fixture}
-        onMount={() => {
-          const mouseEnterContainer = document.querySelectorAll(
-            "[data-test~=panel-mouseenter-container",
-          )[0]!;
-          TestUtils.Simulate.mouseEnter(mouseEnterContainer);
+export default {
+  title: "<StateTransitions>",
+  component: StateTransitions,
+};
+
+export const OnePath = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
+      <StateTransitions
+        config={{
+          paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
         }}
-        style={{ width: 370 }}
-      >
-        <StateTransitions
-          config={{
-            paths: new Array(5).fill({
-              value: "/some/topic/with/state.state",
-              timestampMethod: "receiveTime",
-            }),
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("long path", () => {
-    return (
-      <PanelSetup fixture={fixture} style={{ maxWidth: 100 }}>
-        <StateTransitions
-          config={{
-            paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("json path", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <StateTransitions
-          config={{
-            paths: [{ value: "/some/topic/with/state.data.value", timestampMethod: "receiveTime" }],
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("With a hovered tooltip", () => {
-    return (
-      <PanelSetup
-        fixture={fixture}
-        onMount={() => {
-          setTimeout(() => {
-            const [canvas] = document.getElementsByTagName("canvas");
-            const x = 163;
-            const y = 266;
-            canvas?.dispatchEvent(
-              new MouseEvent("mousemove", { screenX: x, clientX: x, screenY: y, clientY: y }),
-            );
-          }, 100);
+      />
+    </PanelSetup>
+  );
+};
+
+export const MultiplePaths = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
+      <StateTransitions
+        config={{
+          paths: new Array(5).fill({
+            value: "/some/topic/with/state.state",
+            timestampMethod: "receiveTime",
+          }),
         }}
-        style={{ width: 370 }}
-      >
-        <StateTransitions
-          config={{
-            paths: new Array(5).fill({
-              value: "/some/topic/with/state.state",
-              timestampMethod: "receiveTime",
-            }),
-          }}
-        />
-      </PanelSetup>
-    );
-  });
+      />
+    </PanelSetup>
+  );
+};
+
+export const MultiplePathsWithHover = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup
+      pauseFrame={pauseFrame}
+      fixture={fixture}
+      onMount={() => {
+        const mouseEnterContainer = document.querySelectorAll(
+          "[data-test~=panel-mouseenter-container",
+        )[0]!;
+        TestUtils.Simulate.mouseEnter(mouseEnterContainer);
+      }}
+      style={{ width: 370 }}
+    >
+      <StateTransitions
+        config={{
+          paths: new Array(5).fill({
+            value: "/some/topic/with/state.state",
+            timestampMethod: "receiveTime",
+          }),
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+export const LongPath = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup pauseFrame={pauseFrame} fixture={fixture} style={{ maxWidth: 100 }}>
+      <StateTransitions
+        config={{
+          paths: [{ value: "/some/topic/with/state.state", timestampMethod: "receiveTime" }],
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+export const JsonPath = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
+      <StateTransitions
+        config={{
+          paths: [{ value: "/some/topic/with/state.data.value", timestampMethod: "receiveTime" }],
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+export const WithAHoveredTooltip = () => {
+  const sceneReady = useScreenshot();
+  const pauseFrame = useCallback(() => {
+    return () => {
+      sceneReady();
+    };
+  }, [sceneReady]);
+
+  return (
+    <PanelSetup
+      pauseFrame={pauseFrame}
+      fixture={fixture}
+      onMount={() => {
+        setTimeout(() => {
+          const [canvas] = document.getElementsByTagName("canvas");
+          const x = 163;
+          const y = 266;
+          canvas?.dispatchEvent(
+            new MouseEvent("mousemove", { screenX: x, clientX: x, screenY: y, clientY: y }),
+          );
+        }, 100);
+      }}
+      style={{ width: 370 }}
+    >
+      <StateTransitions
+        config={{
+          paths: new Array(5).fill({
+            value: "/some/topic/with/state.state",
+            timestampMethod: "receiveTime",
+          }),
+        }}
+      />
+    </PanelSetup>
+  );
+};

--- a/app/panels/StateTransitions/index.stories.tsx
+++ b/app/panels/StateTransitions/index.stories.tsx
@@ -15,7 +15,7 @@ import { useCallback } from "react";
 import TestUtils from "react-dom/test-utils";
 
 import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
-import { useScreenshot } from "@foxglove-studio/app/stories/ScreenshotContext";
+import { useScreenshotReady } from "@foxglove-studio/app/stories/ScreenshotReadyContext";
 
 import StateTransitions from "./index";
 
@@ -93,7 +93,7 @@ export default {
 };
 
 export const OnePath = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();
@@ -112,7 +112,7 @@ export const OnePath = () => {
 };
 
 export const MultiplePaths = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();
@@ -134,7 +134,7 @@ export const MultiplePaths = () => {
 };
 
 export const MultiplePathsWithHover = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();
@@ -166,7 +166,7 @@ export const MultiplePathsWithHover = () => {
 };
 
 export const LongPath = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();
@@ -185,7 +185,7 @@ export const LongPath = () => {
 };
 
 export const JsonPath = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();
@@ -204,7 +204,7 @@ export const JsonPath = () => {
 };
 
 export const WithAHoveredTooltip = () => {
-  const sceneReady = useScreenshot();
+  const sceneReady = useScreenshotReady();
   const pauseFrame = useCallback(() => {
     return () => {
       sceneReady();

--- a/app/stories/PanelSetup.tsx
+++ b/app/stories/PanelSetup.tsx
@@ -13,6 +13,7 @@
 
 import { createMemoryHistory } from "history";
 import { flatten, partition } from "lodash";
+import { ComponentProps } from "react";
 import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { Mosaic, MosaicNode, MosaicWindow } from "react-mosaic-component";
@@ -83,6 +84,7 @@ type Props = {
   fixture?: Fixture;
   panelCatalog?: PanelCatalog;
   omitDragAndDrop?: boolean;
+  pauseFrame?: ComponentProps<typeof MockMessagePipelineProvider>["pauseFrame"];
   onMount?: (arg0: HTMLDivElement, store: Store) => void;
   onFirstMount?: (arg0: HTMLDivElement) => void;
   store?: Store;
@@ -263,6 +265,7 @@ export default class PanelSetup extends React.PureComponent<Props, State> {
           topics={topics}
           datatypes={dTypes}
           messages={messages}
+          pauseFrame={this.props.pauseFrame}
           bobjects={bobjects.length > 0 ? bobjects : undefined}
           activeData={activeData}
           progress={progress}

--- a/app/stories/ScreenshotContext.ts
+++ b/app/stories/ScreenshotContext.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+// indicate that screenshot is ready for capture
+type ScreenshotSignal = () => void;
+
+const ScreenshotContext = createContext<ScreenshotSignal | undefined>(undefined);
+
+export function useScreenshot(): ScreenshotSignal {
+  const ctx = useContext(ScreenshotContext);
+  if (!ctx) {
+    throw new Error("ScreenshotContext Provider is required to useScreenshot");
+  }
+
+  return ctx;
+}
+
+export default ScreenshotContext;

--- a/app/stories/ScreenshotReadyContext.ts
+++ b/app/stories/ScreenshotReadyContext.ts
@@ -12,7 +12,7 @@ const ScreenshotReadyContext = createContext<ScreenshotReady | undefined>(undefi
 export function useScreenshotReady(): ScreenshotReady {
   const ctx = useContext(ScreenshotReadyContext);
   if (!ctx) {
-    throw new Error("ScreenshotContext Provider is required to useScreenshot");
+    throw new Error("ScreenshotContext Provider is required to useScreenshotReady");
   }
 
   return ctx;

--- a/app/stories/ScreenshotReadyContext.ts
+++ b/app/stories/ScreenshotReadyContext.ts
@@ -5,12 +5,12 @@
 import { createContext, useContext } from "react";
 
 // indicate that screenshot is ready for capture
-type ScreenshotSignal = () => void;
+type ScreenshotReady = () => void;
 
-const ScreenshotContext = createContext<ScreenshotSignal | undefined>(undefined);
+const ScreenshotReadyContext = createContext<ScreenshotReady | undefined>(undefined);
 
-export function useScreenshot(): ScreenshotSignal {
-  const ctx = useContext(ScreenshotContext);
+export function useScreenshotReady(): ScreenshotReady {
+  const ctx = useContext(ScreenshotReadyContext);
   if (!ctx) {
     throw new Error("ScreenshotContext Provider is required to useScreenshot");
   }
@@ -18,4 +18,4 @@ export function useScreenshot(): ScreenshotSignal {
   return ctx;
 }
 
-export default ScreenshotContext;
+export default ScreenshotReadyContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,10 +2014,10 @@ __metadata:
     "@fluentui/react": 8.9.0
     "@fluentui/react-icons-mdl2": 1.0.3
     "@mdi/svg": 5.9.55
-    "@storybook/addon-actions": 6.2.3
-    "@storybook/addon-essentials": 6.2.3
-    "@storybook/builder-webpack5": 6.2.3
-    "@storybook/react": 6.2.3
+    "@storybook/addon-actions": 6.2.5
+    "@storybook/addon-essentials": 6.2.5
+    "@storybook/builder-webpack5": 6.2.5
+    "@storybook/react": 6.2.5
     "@testing-library/react": 11.2.6
     "@testing-library/react-hooks": 5.1.1
     "@types/argparse": ^2
@@ -3055,16 +3055,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-actions@npm:6.2.3"
+"@storybook/addon-actions@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-actions@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/theming": 6.2.5
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
     global: ^4.4.0
@@ -3084,20 +3084,20 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 5915d71f431db624d47638ec84bebe977b1c5f2457a409e1236ca4b1265b306e9de58aca87d433d9a9f487f404aadecbf1bbd63df93a776cdc492485a7fdcd91
+  checksum: 44f3883736a8667d489e0cdefe2ff8ad5904f828962d08bd961ddb803bb99857bfef74fb5c41154966971aa8ac63018fd176d9c694cc0bc3480efd8eb2c958cc
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-backgrounds@npm:6.2.3"
+"@storybook/addon-backgrounds@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-backgrounds@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/theming": 6.2.5
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -3112,20 +3112,20 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 390c8578db8a54153cbee974c658a26dfa89010c7d2150d440f32233a914ef84126ba238e22484714256f0f4849172d9ce1f3fe7a7f5edcb6a8870c041ee8bce
+  checksum: efcc19f4789bce49cd399c99df0d3e0f5d37f1643d90281d1258a1e8a68f2d42cb68df588a66efd86f39624bf601fc9c633048351400e6c0d363c5761615123d
   languageName: node
   linkType: hard
 
-"@storybook/addon-controls@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-controls@npm:6.2.3"
+"@storybook/addon-controls@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-controls@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/node-logger": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/node-logger": 6.2.5
+    "@storybook/theming": 6.2.5
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
   peerDependencies:
@@ -3136,13 +3136,13 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 551cb89a60a8bb85a840c7ab87c317e9423eb4d14c5689f8bbfe4d2c55d3d8ffcb00c462e1bb36c65cdc898d16fa9cff702744a8878cc90054625e21133dc8c6
+  checksum: e73d9931bc75ff8a7b187926dd64a49ecf5c2acad4ff3ababfcdb4a66e280f8cd62920ae24971cb70dfad48ec32e005cc65b1673a7117c09b79eb57bc92d39bb
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-docs@npm:6.2.3"
+"@storybook/addon-docs@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-docs@npm:6.2.5"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/generator": ^7.12.11
@@ -3153,19 +3153,19 @@ __metadata:
     "@mdx-js/loader": ^1.6.22
     "@mdx-js/mdx": ^1.6.22
     "@mdx-js/react": ^1.6.22
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/builder-webpack4": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core": 6.2.3
-    "@storybook/core-events": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/builder-webpack4": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core": 6.2.5
+    "@storybook/core-events": 6.2.5
     "@storybook/csf": 0.0.1
-    "@storybook/node-logger": 6.2.3
-    "@storybook/postinstall": 6.2.3
-    "@storybook/source-loader": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/node-logger": 6.2.5
+    "@storybook/postinstall": 6.2.5
+    "@storybook/source-loader": 6.2.5
+    "@storybook/theming": 6.2.5
     acorn: ^7.4.1
     acorn-jsx: ^5.3.1
     acorn-walk: ^7.2.0
@@ -3188,9 +3188,9 @@ __metadata:
     util-deprecate: ^1.0.2
   peerDependencies:
     "@babel/core": ^7.11.5
-    "@storybook/angular": 6.2.3
-    "@storybook/vue": 6.2.3
-    "@storybook/vue3": 6.2.3
+    "@storybook/angular": 6.2.5
+    "@storybook/vue": 6.2.5
+    "@storybook/vue3": 6.2.5
     babel-loader: ^8.0.0
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
@@ -3217,29 +3217,29 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 6e95f08217a891cbbe5b47ce7d1d1f7cb5ab7beefdc2e3f0555472bb72f3b050ba6fe3de384e054e5c3917539902c1e3bb5609a3cd34b580477d9d527deb7073
+  checksum: a7b19357efc87e98cd3ca68c3112106113c3cc060b574a2868973b11c56697aef32ab74d6bc912784ed1b79a547268ad53a1111d8511c7e191fda72799aaf1e5
   languageName: node
   linkType: hard
 
-"@storybook/addon-essentials@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-essentials@npm:6.2.3"
+"@storybook/addon-essentials@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-essentials@npm:6.2.5"
   dependencies:
-    "@storybook/addon-actions": 6.2.3
-    "@storybook/addon-backgrounds": 6.2.3
-    "@storybook/addon-controls": 6.2.3
-    "@storybook/addon-docs": 6.2.3
-    "@storybook/addon-toolbars": 6.2.3
-    "@storybook/addon-viewport": 6.2.3
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/node-logger": 6.2.3
+    "@storybook/addon-actions": 6.2.5
+    "@storybook/addon-backgrounds": 6.2.5
+    "@storybook/addon-controls": 6.2.5
+    "@storybook/addon-docs": 6.2.5
+    "@storybook/addon-toolbars": 6.2.5
+    "@storybook/addon-viewport": 6.2.5
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/node-logger": 6.2.5
     core-js: ^3.8.2
     regenerator-runtime: ^0.13.7
     ts-dedent: ^2.0.0
   peerDependencies:
     "@babel/core": ^7.9.6
-    "@storybook/vue": 6.2.3
+    "@storybook/vue": 6.2.5
     babel-loader: ^8.0.0
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
@@ -3253,18 +3253,18 @@ __metadata:
       optional: true
     webpack:
       optional: true
-  checksum: 97dcdb9570fc173a47d93f01d8c3e1b609cab356678d8f339368bc92df4e6ded9cd26e5f6c15b0d2e8522ac4ebc72c03a76ef407d4b26f82f904f8088a511cb3
+  checksum: 363a34d7544cc01d9b520cb7bfc0a050448f0890b360521f947c18c969732ad972d0e0cbdc5ec37e7017ae645faec7485bac25ba8eb43f1d3605e6deb0d082e2
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-toolbars@npm:6.2.3"
+"@storybook/addon-toolbars@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-toolbars@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/components": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/components": 6.2.5
     core-js: ^3.8.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
@@ -3274,20 +3274,20 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 34c5a84e2ad1e530cf53fe14f3c33d0dd244ee153489ee5d6bc86e85a98e7271c14d6615fc5e13b482f0f9eee2eaf0cdaf364c22f313d9676cda30e6afd97bea
+  checksum: a70ee2a3a08e90b3b03a072b249a63da4427d231b60f7de373c40a425cf543799d777f3f248f75188c5a4200b6085a6561fc594b6834d22f0bb637a46d325d4a
   languageName: node
   linkType: hard
 
-"@storybook/addon-viewport@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addon-viewport@npm:6.2.3"
+"@storybook/addon-viewport@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addon-viewport@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/theming": 6.2.5
     core-js: ^3.8.2
     global: ^4.4.0
     memoizerific: ^1.11.3
@@ -3301,42 +3301,42 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: e8178443c819c5e73c59e2d663231cc25abe99c80dfa7a662e3f4ef748e821e95561641800ce70f84cf72c8882a455b369339d3085e653feb1d225e3b697b220
+  checksum: bd7e71a62f015e1179e41d34ef6f222d5a4e1dfc147303874a6f629ada8417ee04ae64a331bca53160b39d20a609683542b58fa8769747c999fdd3ba71c2fa92
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/addons@npm:6.2.3"
+"@storybook/addons@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/addons@npm:6.2.5"
   dependencies:
-    "@storybook/api": 6.2.3
-    "@storybook/channels": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/router": 6.2.3
-    "@storybook/theming": 6.2.3
+    "@storybook/api": 6.2.5
+    "@storybook/channels": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/router": 6.2.5
+    "@storybook/theming": 6.2.5
     core-js: ^3.8.2
     global: ^4.4.0
     regenerator-runtime: ^0.13.7
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 5e7cd819f0295f0d37fa5b2111068fb8b00ae791a04da91d9b7a1745ee7b9ea6e6fbad906e17b97d7a172f7da8985f35ce38e70890418b11f1338787bbaadb9d
+  checksum: 2a7f0074ac11be4fd2611b75930874ef3937bb18820eadcc2192f22b041b9befcd9e36ec289e0b2dd0f3a5c7f0b3accafb34092de83143b8bac59becaafaf435
   languageName: node
   linkType: hard
 
-"@storybook/api@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/api@npm:6.2.3"
+"@storybook/api@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/api@npm:6.2.5"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/channels": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/core-events": 6.2.3
+    "@storybook/channels": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/core-events": 6.2.5
     "@storybook/csf": 0.0.1
-    "@storybook/router": 6.2.3
+    "@storybook/router": 6.2.5
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.2.3
+    "@storybook/theming": 6.2.5
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -3352,13 +3352,13 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 5ba07e5188ba327e36f73f455d923f350db6e1caa25a5d4329b03c0f057ef2cbbb16870e107547fc3cd21e94f190156ce51b532f99b66258c81674cbe485e965
+  checksum: 6d317b32e7de08c81ad2c10aaa82d8f6c1a7ca0da0cdfe89d49814a6cdf521d69d9e7b74223030721f4ecbbb67e84e3c0cfc992ef4065808446ffc408c7fcdbf
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack4@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/builder-webpack4@npm:6.2.3"
+"@storybook/builder-webpack4@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/builder-webpack4@npm:6.2.5"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -3381,20 +3381,20 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/channel-postmessage": 6.2.3
-    "@storybook/channels": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-common": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/node-logger": 6.2.3
-    "@storybook/router": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/channel-postmessage": 6.2.5
+    "@storybook/channels": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-common": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/node-logger": 6.2.5
+    "@storybook/router": 6.2.5
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.2.3
-    "@storybook/ui": 6.2.3
+    "@storybook/theming": 6.2.5
+    "@storybook/ui": 6.2.5
     "@types/node": ^14.0.10
     "@types/webpack": ^4.41.26
     autoprefixer: ^9.8.6
@@ -3436,13 +3436,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 934045c4b1546d4b71aa758b0b80632a5ed1a15f2c782267e02f7631c24f0351d61b390ade016c76f6eaa6895e2d651303fcf9db1bc05692e6cc08df87c7afef
+  checksum: 3589aae7ea84b78c0c4527b3570ebcc166b843399a21db1fedd8ebd28ebf7c619f91b979d3272196b07926de36d7d9a60c6b4dcad7bd4a051d937b2d83ca0543
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack5@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/builder-webpack5@npm:6.2.3"
+"@storybook/builder-webpack5@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/builder-webpack5@npm:6.2.5"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -3464,19 +3464,19 @@ __metadata:
     "@babel/preset-env": ^7.12.11
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/channel-postmessage": 6.2.3
-    "@storybook/channels": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-common": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/node-logger": 6.2.3
-    "@storybook/router": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/channel-postmessage": 6.2.5
+    "@storybook/channels": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-common": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/node-logger": 6.2.5
+    "@storybook/router": 6.2.5
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.2.3
+    "@storybook/theming": 6.2.5
     "@types/node": ^14.0.10
     babel-loader: ^8.2.2
     babel-plugin-macros: ^3.0.1
@@ -3510,45 +3510,45 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 31ce491f5f7c087f6e396cbc1127aafb04e18893a2598543f9470ef417c38489f729506593089a45f301348c2bc7085e53df530cd740523cda8a7fe988d4292f
+  checksum: d52902e43d3851c4ff7b00d832297cf47fe77dccb5bb5ca5c74bca816ef754dca3359a47fed72df081b559b08276b7a0631fc002d3dcd8685ef02763b1ebb8ae
   languageName: node
   linkType: hard
 
-"@storybook/channel-postmessage@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/channel-postmessage@npm:6.2.3"
+"@storybook/channel-postmessage@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/channel-postmessage@npm:6.2.5"
   dependencies:
-    "@storybook/channels": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/core-events": 6.2.3
+    "@storybook/channels": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/core-events": 6.2.5
     core-js: ^3.8.2
     global: ^4.4.0
     qs: ^6.10.0
     telejson: ^5.1.0
-  checksum: fec79ca7fefbad6a04ee29dc500449495878390729d84b1a30beb4fc37e151d95e285b0c3d393daaee2c35840922a00d3ebcfd51cd1f2650570894e5277cb742
+  checksum: 49df4d52175667277b39740ddca7580ea6446ae4a8dedae58382e49096e90de216a34741a8ffeec90c609c808c7de8371588db0a14318169b67ae6902a38dc6f
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/channels@npm:6.2.3"
+"@storybook/channels@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/channels@npm:6.2.5"
   dependencies:
     core-js: ^3.8.2
     ts-dedent: ^2.0.0
     util-deprecate: ^1.0.2
-  checksum: 006918732b0bd07a069c787cece672ebbeb8b439ddc46abe30d801dc36130da937887a8a03e4aed8a73de538a84f27374ad05da72e46219653e07947fa0d8528
+  checksum: 6aeafd868cac6761aee4f75fb982b80300b3ef52938b2c5fdbf956c6899d08bd7be02c3a93ef8a40909dd78b163e0b229486833a484020b5d92e5435cd788885
   languageName: node
   linkType: hard
 
-"@storybook/client-api@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/client-api@npm:6.2.3"
+"@storybook/client-api@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/client-api@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/channel-postmessage": 6.2.3
-    "@storybook/channels": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/core-events": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/channel-postmessage": 6.2.5
+    "@storybook/channels": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/core-events": 6.2.5
     "@storybook/csf": 0.0.1
     "@types/qs": ^6.9.5
     "@types/webpack-env": ^1.16.0
@@ -3565,28 +3565,28 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 02955ac9ad359bb3bb385ce2ffaf64ab250ecfae6e23559cf0840c6174cfee11e5c2db4a9d2f906f713fb29425abf3a2f79a8f6e9688e853e448ef2543a9b798
+  checksum: e7d8440b5cc34b3d363ba66b8cf6bf7f3934885dfe359c2d8f71a19b991ea481634d47000cba69172413dbcb10a46892e02f1dc97680004fe0a93603357b8266
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/client-logger@npm:6.2.3"
+"@storybook/client-logger@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/client-logger@npm:6.2.5"
   dependencies:
     core-js: ^3.8.2
     global: ^4.4.0
-  checksum: bebd516179b2a8ebe26b3d8a3b4b7e857f31ebc8fb9bc291d2e4f834bd2f8228728854938cadb657683e0d46d770196560640f897809804c864b49261ebdadaf
+  checksum: bf6ca38ceba30bb40c69540076b052702ae87516a74c853830b6b84bc32171a9844d9e7800e5f9b37f83b9a7e7f99b82f24c1003675f0f10a05b28b6fc10e598
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/components@npm:6.2.3"
+"@storybook/components@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/components@npm:6.2.5"
   dependencies:
     "@popperjs/core": ^2.6.0
-    "@storybook/client-logger": 6.2.3
+    "@storybook/client-logger": 6.2.5
     "@storybook/csf": 0.0.1
-    "@storybook/theming": 6.2.3
+    "@storybook/theming": 6.2.5
     "@types/color-convert": ^2.0.0
     "@types/overlayscrollbars": ^1.12.0
     "@types/react-syntax-highlighter": 11.0.5
@@ -3610,21 +3610,21 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: eccbb75e9f8ac040f72c139b2e8aa658a78470bee56d5107808976fb52ddf6d42a8df5dde7085ec71ae4d206e967afb2433179e0895ec0d42c96e1cb3f58a231
+  checksum: ef2b0a0a3648a466b53a34d92993e783b480701aaf461170616f797eca531945149d0f053478506a285cdb2e468e0a8cb386d4400edd4c5bb45e889e5568b89d
   languageName: node
   linkType: hard
 
-"@storybook/core-client@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/core-client@npm:6.2.3"
+"@storybook/core-client@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/core-client@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/channel-postmessage": 6.2.3
-    "@storybook/client-api": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/core-events": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/channel-postmessage": 6.2.5
+    "@storybook/client-api": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/core-events": 6.2.5
     "@storybook/csf": 0.0.1
-    "@storybook/ui": 6.2.3
+    "@storybook/ui": 6.2.5
     ansi-to-html: ^0.6.11
     core-js: ^3.8.2
     global: ^4.4.0
@@ -3641,13 +3641,13 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 5c25d788affa9b7dbfb840f5ba4cda74f60415b26c77324cf20ba759b7bb9fc9176649baa85b29dd1dff253f646e138aea6378c4903675307d3f5a582291a714
+  checksum: 7f3031bfcfadef311f65eb9d625f7190adb7bf22488f9d83189cc6a9ebd88f73f3b146686530b5ae22f4ab3cddfe2ea089ff644f93cb891647aa11917a344674
   languageName: node
   linkType: hard
 
-"@storybook/core-common@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/core-common@npm:6.2.3"
+"@storybook/core-common@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/core-common@npm:6.2.5"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-proposal-class-properties": ^7.12.1
@@ -3670,7 +3670,7 @@ __metadata:
     "@babel/preset-react": ^7.12.10
     "@babel/preset-typescript": ^7.12.7
     "@babel/register": ^7.12.1
-    "@storybook/node-logger": 6.2.3
+    "@storybook/node-logger": 6.2.5
     "@storybook/semver": ^7.3.2
     "@types/glob-base": ^0.3.0
     "@types/micromatch": ^4.0.1
@@ -3703,34 +3703,34 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ad3eca4a984d1ef6bfcdb3a42152419cb81bd2a9f6126a2ec4b5757f9015aa140a399362f99896f463dc8e59a6f42fb6f117961531d64288da8cf758e7fb2eea
+  checksum: 974dbf614be17a54268ccf2c5d6b36f4dd14547862e10eb0d8054898a102aee8873d6ee598f6b5d60b185847535e7fc8949e9065eefb83f68dcc1a66fa8eeb61
   languageName: node
   linkType: hard
 
-"@storybook/core-events@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/core-events@npm:6.2.3"
+"@storybook/core-events@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/core-events@npm:6.2.5"
   dependencies:
     core-js: ^3.8.2
-  checksum: 7a9e52a4e2cff471604a81460da873ac41fa4e3e837e4229567a1342476bef09ea3251f42f4cfb142e83c05deb0c75f62ff5da83ab99de442add65a66430fff9
+  checksum: c6eecab7ba1431ccb28b806008a8cd948b2c4c57962c48e7e4ee0b0a296d743bf3b17d2486d4e3b5944115148414ceb405b400c44e458324e112afbf127cf427
   languageName: node
   linkType: hard
 
-"@storybook/core-server@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/core-server@npm:6.2.3"
+"@storybook/core-server@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/core-server@npm:6.2.5"
   dependencies:
     "@babel/core": ^7.12.10
     "@babel/plugin-transform-template-literals": ^7.12.1
     "@babel/preset-react": ^7.12.10
-    "@storybook/addons": 6.2.3
-    "@storybook/builder-webpack4": 6.2.3
-    "@storybook/core-client": 6.2.3
-    "@storybook/core-common": 6.2.3
-    "@storybook/node-logger": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/builder-webpack4": 6.2.5
+    "@storybook/core-client": 6.2.5
+    "@storybook/core-common": 6.2.5
+    "@storybook/node-logger": 6.2.5
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.2.3
-    "@storybook/ui": 6.2.3
+    "@storybook/theming": 6.2.5
+    "@storybook/ui": 6.2.5
     "@types/node": ^14.0.10
     "@types/node-fetch": ^2.5.7
     "@types/pretty-hrtime": ^1.0.0
@@ -3774,7 +3774,7 @@ __metadata:
     webpack-dev-middleware: ^3.7.3
     webpack-virtual-modules: ^0.2.2
   peerDependencies:
-    "@storybook/builder-webpack5": 6.2.3
+    "@storybook/builder-webpack5": 6.2.5
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -3782,18 +3782,18 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 21d522a5df2e935fa3ceeab43ae277faf89fab7d2f74fde1d3ff2e62a8d3cbcb018e20c01c00f07e927162838d5d008837a61d82ec0ea80ca47789bea1accbee
+  checksum: a20221e9d54f4a0af127f1fbf9ef5b3bab59b5579476ab0f6cf24ad69b3fa8ae7574818aa4466599dfb3cbe82b17d83592096043b481c50ca3e80420962ac93b
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/core@npm:6.2.3"
+"@storybook/core@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/core@npm:6.2.5"
   dependencies:
-    "@storybook/core-client": 6.2.3
-    "@storybook/core-server": 6.2.3
+    "@storybook/core-client": 6.2.5
+    "@storybook/core-server": 6.2.5
   peerDependencies:
-    "@storybook/builder-webpack5": 6.2.3
+    "@storybook/builder-webpack5": 6.2.5
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   peerDependenciesMeta:
@@ -3801,7 +3801,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: f749e6e79b38e50b5ccae3d28b4d09674ecc940a1b8771b75b93d652db229a2284a9486593a47f9426bcfb51f50285d15e36cf0edd70c52b2f64a9223b9cace4
+  checksum: 92781fb221adae1e5a474b11b14f15122c67d14f9fa459d56c4a4d8947be0058460737d32fa463870288b815d0710ba9cc18c3b00ea497797b41f2b8d69b770a
   languageName: node
   linkType: hard
 
@@ -3814,39 +3814,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/node-logger@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/node-logger@npm:6.2.3"
+"@storybook/node-logger@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/node-logger@npm:6.2.5"
   dependencies:
     "@types/npmlog": ^4.1.2
     chalk: ^4.1.0
     core-js: ^3.8.2
     npmlog: ^4.1.2
     pretty-hrtime: ^1.0.3
-  checksum: 1b2e037fb8840085c1b395d7af94a2b3040028a506971146fadb3a05019b1487e8e3695a2512500cfd03eb2a4671a9526f936156cae630cc9f3703ef631fd006
+  checksum: 972253b81508cb899531f7cafcd7288ea22bb7ce41c8656c74d4022945385076c377d90f359ce89b12301953313cd9aeb368ed46854de95d18e599a50b809d44
   languageName: node
   linkType: hard
 
-"@storybook/postinstall@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/postinstall@npm:6.2.3"
+"@storybook/postinstall@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/postinstall@npm:6.2.5"
   dependencies:
     core-js: ^3.8.2
-  checksum: 99b50b29149a7d0be943f4ac76ad84db56971e9eeccc9b69274d653d84950281a5723898299f9c74cc39e8c042d771b9d64c65c99bc557e58052f30975ba0e94
+  checksum: 85cbaf18671a1173b5ad75507b8764c971205df8967949c5010226b6af5ad05370242bd196e8e4082a32488cc913307232d300f3bf786a1339a253e34e7d99e5
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/react@npm:6.2.3"
+"@storybook/react@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/react@npm:6.2.5"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
     "@pmmmwh/react-refresh-webpack-plugin": ^0.4.3
-    "@storybook/addons": 6.2.3
-    "@storybook/core": 6.2.3
-    "@storybook/core-common": 6.2.3
-    "@storybook/node-logger": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/core": 6.2.5
+    "@storybook/core-common": 6.2.5
+    "@storybook/node-logger": 6.2.5
     "@storybook/semver": ^7.3.2
     "@types/webpack-env": ^1.16.0
     babel-plugin-add-react-displayname: ^0.0.5
@@ -3876,16 +3876,16 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 62ba43f639863439d55df91af6caba3ca8f05abacf3401bdd1441b7c9d91977e312be627413bd039a06225d84cd19d8f498295ed7cd869414224eac2794afb8e
+  checksum: f3fb3226a768613dcd3f7c8aa4c450d01338b050c78278fb3bf182e4694f15e2fcde34768e071ff75327947c740741596acd17567e877a884989f5b8077006b6
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/router@npm:6.2.3"
+"@storybook/router@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/router@npm:6.2.5"
   dependencies:
     "@reach/router": ^1.3.4
-    "@storybook/client-logger": 6.2.3
+    "@storybook/client-logger": 6.2.5
     "@types/reach__router": ^1.3.7
     core-js: ^3.8.2
     fast-deep-equal: ^3.1.3
@@ -3897,7 +3897,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 2df2f27337b152c860a85ce8d55aabe6fbe97bf1bee1e94c851e345a01ae0929c46e9ddf30b572f8600d345256bb6951ed9192fb9418396794394b31e42ed129
+  checksum: 050eb19a98dab8dd0a36c7debc17f6b128ccf19b2c354b1ff4d45f5f4490a3b6974a0081606a457cfa62323c1c79f9816b7f2745a727487bcdc6521b437692e6
   languageName: node
   linkType: hard
 
@@ -3913,12 +3913,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/source-loader@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/source-loader@npm:6.2.3"
+"@storybook/source-loader@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/source-loader@npm:6.2.5"
   dependencies:
-    "@storybook/addons": 6.2.3
-    "@storybook/client-logger": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/client-logger": 6.2.5
     "@storybook/csf": 0.0.1
     core-js: ^3.8.2
     estraverse: ^5.2.0
@@ -3930,18 +3930,18 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: e06526fbf68cd56379c797831568323c7ec88534eacf4c385b7fea283b7c210d4957849ce38d2e3c19074cf62e5625dc7bf94672276707ab84fb52ef56a7c788
+  checksum: e1daa4b84050a06100704b0d74c6eb576477b37e994a68f5d3a75065dc7080ee61cc743f649e1df59621d0ab1b7a2a9913ad578da402499e49bd70c0a9ce66e2
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/theming@npm:6.2.3"
+"@storybook/theming@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/theming@npm:6.2.5"
   dependencies:
     "@emotion/core": ^10.1.1
     "@emotion/is-prop-valid": ^0.8.6
     "@emotion/styled": ^10.0.27
-    "@storybook/client-logger": 6.2.3
+    "@storybook/client-logger": 6.2.5
     core-js: ^3.8.2
     deep-object-diff: ^1.1.0
     emotion-theming: ^10.0.27
@@ -3953,24 +3953,24 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 5493fd2ad8817ec2033847abb8def7d2c7017bba58b3ebc4cc2f58998c5f4f4e77cd612ee63c9f0b6d18bccbddfef51eff5bd99cfe0f481e96eaef242cdfd725
+  checksum: c969d5fe8101a8a9366c9831aa5ec33820bfcd5eab832a3b7c8dd09dd35853e94c96e684351df6cb8f3542f4a270ef01edcf800c8e523f84559973ddd137594a
   languageName: node
   linkType: hard
 
-"@storybook/ui@npm:6.2.3":
-  version: 6.2.3
-  resolution: "@storybook/ui@npm:6.2.3"
+"@storybook/ui@npm:6.2.5":
+  version: 6.2.5
+  resolution: "@storybook/ui@npm:6.2.5"
   dependencies:
     "@emotion/core": ^10.1.1
-    "@storybook/addons": 6.2.3
-    "@storybook/api": 6.2.3
-    "@storybook/channels": 6.2.3
-    "@storybook/client-logger": 6.2.3
-    "@storybook/components": 6.2.3
-    "@storybook/core-events": 6.2.3
-    "@storybook/router": 6.2.3
+    "@storybook/addons": 6.2.5
+    "@storybook/api": 6.2.5
+    "@storybook/channels": 6.2.5
+    "@storybook/client-logger": 6.2.5
+    "@storybook/components": 6.2.5
+    "@storybook/core-events": 6.2.5
+    "@storybook/router": 6.2.5
     "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.2.3
+    "@storybook/theming": 6.2.5
     "@types/markdown-to-jsx": ^6.11.3
     copy-to-clipboard: ^3.3.1
     core-js: ^3.8.2
@@ -3993,7 +3993,7 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
-  checksum: 444eb56b4eb3657a575dbbfa195e0175b38202dbec54fbb8baa422588fbb5d089b5561ed71b76d81089905909095dec19d2d3fa47a2f946cdee5d893ec2d36c0
+  checksum: 678cb85d5dd16af07e012281316542d4e4f9108b87a347f307e257ce2ca2bb8c71679fba44cd5581a055cecfd3e428340f61d5d1faf37cd3d128702bfa05fba8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stories which test several interactions or have delayed rendering are not always
ready at a fixed delay from mounting. The scene ready signal provides the story author
more control over when a screenshot can be taken of the story.