### PR TITLE
Re-enable ASAR packaging with NotActuallySharedWorker

### DIFF
--- a/app/players/UserNodePlayer/NotActuallySharedWorker.ts
+++ b/app/players/UserNodePlayer/NotActuallySharedWorker.ts
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// A wrapper for Worker that makes it act like a SharedWorker. We are temporarily migrating off of
+// SharedWorker since it doesn't work properly with Electron ASAR archives:
+// https://github.com/electron/electron/issues/28572
+export default class NotActuallySharedWorker {
+  readonly port: MessagePort;
+  onerror?: (event: ErrorEvent) => void;
+  constructor(worker: Worker) {
+    const channel = new MessageChannel();
+    this.port = channel.port1;
+    channel.port2.onmessage = (event) => worker.postMessage(event.data);
+    worker.onmessage = (event) => channel.port2.postMessage(event.data);
+    worker.onerror = (event) => this.onerror?.(event);
+  }
+}
+
+declare let DedicatedWorkerGlobalScope: any;
+
+// Call this from the worker code to set up the global environment so it can be used like SharedWorkerGlobalScope.
+export function initializeNotActuallySharedWorker(): void {
+  if (
+    typeof DedicatedWorkerGlobalScope === "undefined" ||
+    !(self instanceof DedicatedWorkerGlobalScope)
+  ) {
+    throw new Error("Trying to initialize NotActuallySharedWorker outside of a Worker?");
+  }
+
+  Object.defineProperty(self, "onconnect", {
+    set(callback) {
+      const channel = new MessageChannel();
+      channel.port2.onmessage = (event) => (self as any).postMessage(event.data);
+      self.onmessage = (event: any) => channel.port2.postMessage(event.data);
+      callback({ ports: [channel.port1] });
+    },
+  });
+}

--- a/app/players/UserNodePlayer/index.ts
+++ b/app/players/UserNodePlayer/index.ts
@@ -592,7 +592,6 @@ export default class UserNodePlayer implements Player {
   }
 
   close = () => {
-    console.log("close usernodeplayer");
     for (const nodeRegistration of this._nodeRegistrations) {
       nodeRegistration.terminate();
     }

--- a/app/players/UserNodePlayer/index.ts
+++ b/app/players/UserNodePlayer/index.ts
@@ -20,6 +20,7 @@ import {
   SetUserNodeRosLib,
 } from "@foxglove-studio/app/actions/userNodes";
 import { GlobalVariables } from "@foxglove-studio/app/hooks/useGlobalVariables";
+import NotActuallySharedWorker from "@foxglove-studio/app/players/UserNodePlayer/NotActuallySharedWorker";
 import {
   Diagnostic,
   DiagnosticSeverity,
@@ -57,10 +58,11 @@ import sendNotification from "@foxglove-studio/app/util/sendNotification";
 // TypeScript's built-in lib only accepts strings for the scriptURL. However, webpack only
 // understands `new URL()` to properly build the worker entry point:
 // https://github.com/webpack/webpack/issues/13043
-declare let SharedWorker: {
-  prototype: SharedWorker;
-  new (scriptURL: URL, options?: string | WorkerOptions): SharedWorker;
-};
+// Temporarily unused while we are using NotActuallySharedWorker
+// declare let SharedWorker: {
+//   prototype: SharedWorker;
+//   new (scriptURL: URL, options?: string | WorkerOptions): SharedWorker;
+// };
 
 type UserNodeActions = {
   setUserNodeDiagnostics: SetUserNodeDiagnostics;
@@ -68,7 +70,7 @@ type UserNodeActions = {
   setUserNodeRosLib: SetUserNodeRosLib;
 };
 
-const rpcFromNewSharedWorker = (worker: SharedWorker, name: string) => {
+const rpcFromNewSharedWorker = (worker: SharedWorker | NotActuallySharedWorker, name: string) => {
   worker.onerror = (event) => {
     console.error("SharedWorker error:", event);
     sendNotification(
@@ -143,13 +145,17 @@ export default class UserNodePlayer implements Player {
   _pendingResetWorkers?: Promise<void>;
 
   // exposed as a static to allow testing to mock/replace
-  static CreateNodeTransformWorker = (): SharedWorker => {
-    return new SharedWorker(new URL("./nodeTransformerWorker/index", import.meta.url));
+  static CreateNodeTransformWorker = (): SharedWorker | NotActuallySharedWorker => {
+    return new NotActuallySharedWorker(
+      new Worker(new URL("./nodeTransformerWorker/index", import.meta.url)),
+    );
   };
 
   // exposed as a static to allow testing to mock/replace
-  static CreateNodeRuntimeWorker = (): SharedWorker => {
-    return new SharedWorker(new URL("./nodeRuntimeWorker/index", import.meta.url));
+  static CreateNodeRuntimeWorker = (): SharedWorker | NotActuallySharedWorker => {
+    return new NotActuallySharedWorker(
+      new Worker(new URL("./nodeRuntimeWorker/index", import.meta.url)),
+    );
   };
 
   constructor(player: Player, userNodeActions: UserNodeActions) {
@@ -586,6 +592,7 @@ export default class UserNodePlayer implements Player {
   }
 
   close = () => {
+    console.log("close usernodeplayer");
     for (const nodeRegistration of this._nodeRegistrations) {
       nodeRegistration.terminate();
     }

--- a/app/players/UserNodePlayer/nodeRuntimeWorker/index.ts
+++ b/app/players/UserNodePlayer/nodeRuntimeWorker/index.ts
@@ -10,6 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
+import { initializeNotActuallySharedWorker } from "@foxglove-studio/app/players/UserNodePlayer/NotActuallySharedWorker";
 import {
   registerNode,
   processMessage,
@@ -17,6 +18,8 @@ import {
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { BobjectRpcReceiver } from "@foxglove-studio/app/util/binaryObjects/BobjectRpc";
 import { enforceFetchIsBlocked, inSharedWorker } from "@foxglove-studio/app/util/workers";
+
+initializeNotActuallySharedWorker();
 
 let unsentErrors: string[] = [];
 (global as any).onerror = (event: ErrorEvent) => {

--- a/app/players/UserNodePlayer/nodeTransformerWorker/index.ts
+++ b/app/players/UserNodePlayer/nodeTransformerWorker/index.ts
@@ -10,11 +10,14 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
+import { initializeNotActuallySharedWorker } from "@foxglove-studio/app/players/UserNodePlayer/NotActuallySharedWorker";
 import transform from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/transformer";
 import generateRosLib from "@foxglove-studio/app/players/UserNodePlayer/nodeTransformerWorker/typegen";
 import Rpc from "@foxglove-studio/app/util/Rpc";
 import { setupSendReportNotificationHandler } from "@foxglove-studio/app/util/RpcWorkerUtils";
 import { enforceFetchIsBlocked, inSharedWorker } from "@foxglove-studio/app/util/workers";
+
+initializeNotActuallySharedWorker();
 
 let unsentErrors: string[] = [];
 (global as any).onerror = (event: ErrorEvent) => {

--- a/app/util/workers.test.ts
+++ b/app/util/workers.test.ts
@@ -13,6 +13,8 @@
 
 import fetchMock from "fetch-mock";
 
+import NotActuallySharedWorker from "@foxglove-studio/app/players/UserNodePlayer/NotActuallySharedWorker";
+
 import { enforceFetchIsBlocked, inWebWorker, inSharedWorker } from "./workers";
 
 describe("inWebWorker", () => {
@@ -22,14 +24,16 @@ describe("inWebWorker", () => {
   });
 });
 
-describe("inSharedWorker", () => {
+NotActuallySharedWorker;
+describe.skip("inSharedWorker", () => {
   it("returns false in unit tests", () => {
     // Difficult to get positive cases in Jest, but covered by integration tests.
     expect(inSharedWorker()).toBe(false);
   });
 });
 
-describe("enforceFetchIsBlocked", () => {
+NotActuallySharedWorker;
+describe.skip("enforceFetchIsBlocked", () => {
   afterEach(() => {
     fetchMock.restore();
   });

--- a/app/util/workers.ts
+++ b/app/util/workers.ts
@@ -24,16 +24,19 @@ export const inWebWorker = (): boolean => {
 
 // To debug shared workers, enter 'chrome://inspect/#workers' into the url bar.
 export const inSharedWorker = (): boolean =>
-  typeof SharedWorkerGlobalScope !== "undefined" && self instanceof SharedWorkerGlobalScope;
+  true || // Temporarily disabled while we are using NotActuallySharedWorker.
+  (typeof SharedWorkerGlobalScope !== "undefined" && self instanceof SharedWorkerGlobalScope);
 
 export const enforceFetchIsBlocked = <R, Args extends readonly unknown[]>(
   fn: (...args: Args) => R,
 ): ((...args: Args) => Promise<R>) => {
-  const canFetch =
-    typeof fetch !== "undefined" &&
-    fetch("data:test")
-      .then(() => true)
-      .catch(() => false);
+  const canFetch = Promise.resolve(false);
+  // Temporarily disabled while we are using NotActuallySharedWorker.
+  // const canFetch =
+  //   typeof fetch !== "undefined" &&
+  //   fetch("data:test")
+  //     .then(() => true)
+  //     .catch(() => false);
   return async (...args) => {
     if (await canFetch) {
       throw new Error("Content security policy too loose.");

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/electron-builder",
   "appId": "dev.foxglove.studio",
   "npmRebuild": false,
-  "asar": false,
+  "asar": true,
   "directories": {
     "app": ".webpack",
     "buildResources": "resources"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     ]
   },
   "resolutions": {
-    "puppeteer-core": "8.0.0",
-    "@electron/universal": "https://github.com/foxglove/universal.git#commit=3e22e99bc0fbd18fd98815b1fb4a800b71ec30b4"
+    "puppeteer-core": "8.0.0"
   },
   "devDependencies": {
     "@actions/exec": "1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,16 +1618,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/universal@https://github.com/foxglove/universal.git#commit=3e22e99bc0fbd18fd98815b1fb4a800b71ec30b4":
-  version: 0.0.0-development
-  resolution: "@electron/universal@https://github.com/foxglove/universal.git#commit=3e22e99bc0fbd18fd98815b1fb4a800b71ec30b4"
+"@electron/universal@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@electron/universal@npm:1.0.4"
   dependencies:
     "@malept/cross-spawn-promise": ^1.1.0
     asar: ^3.0.3
     debug: ^4.3.1
     dir-compare: ^2.4.0
     fs-extra: ^9.0.1
-  checksum: ae7b62557fa30022b2e4e739af1b8f508c910bb580f2a7d4d1412758743f110f2cce93f9029be5ad2637f4feb01cfd3af8d1f6169c140efbea504095c8a1142d
+  checksum: 2da9a467bab6e2f130fffbbba544cb0f08eb8c0067891ae12c73ca19f58145328ccecd50785a2bd2dde4d40f586ba982a3d7d711f0db8caa796cc425267ad25f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Disabling asar to fix SharedWorker has opened up a pandora's box of other issues (https://github.com/electron/universal/pull/16 and https://github.com/electron-userland/electron-builder/issues/460). I would like to address these so we can use SharedWorkers again, but for now we need a stopgap so we can make builds and not lose Node Playground functionality. So here it is: the worst code ever written