### PR TITLE
Support ROS topics that do not start with `/`

### DIFF
--- a/app/components/MessagePathSyntax/grammar.ne
+++ b/app/components/MessagePathSyntax/grammar.ne
@@ -41,9 +41,9 @@ value -> integer  {% (d) => d[0] %}
        | "false" {% (d) => ({ value: false, repr: "false" }) %}
 	   | variable {% (d) => d[0] %}
 
-## Topic part. Basically an id but with slashes.
-topicName -> slashID:+
-  {% (d) => d[0].join("") %}
+## Topic part. Basically an id but with (optional) slashes.
+topicName -> slashID:+     {% (d) => d[0].join("") %}
+           | id slashID:*  {% (d) => d[0] + d[1].join("") %}
 slashID -> "/" id:?
   {% (d) => d.join("") %}
 

--- a/app/components/MessagePathSyntax/parseRosPath.test.ts
+++ b/app/components/MessagePathSyntax/parseRosPath.test.ts
@@ -39,6 +39,21 @@ describe("parseRosPath", () => {
       ],
       modifier: "derivative",
     });
+    expect(parseRosPath("some0/nice_topic.with[99].stuff[0]")).toEqual({
+      topicName: "some0/nice_topic",
+      messagePath: [
+        { type: "name", name: "with" },
+        { type: "slice", start: 99, end: 99 },
+        { type: "name", name: "stuff" },
+        { type: "slice", start: 0, end: 0 },
+      ],
+      modifier: MISSING,
+    });
+    expect(parseRosPath("some_nice_topic")).toEqual({
+      topicName: "some_nice_topic",
+      messagePath: [],
+      modifier: MISSING,
+    });
   });
 
   it("parses slices", () => {
@@ -370,13 +385,16 @@ describe("parseRosPath", () => {
     });
   });
 
+  it("parses simple valid strings", () => {
+    expect(parseRosPath("blah")).toBeDefined();
+    expect(parseRosPath("100")).toBeDefined();
+    expect(parseRosPath("blah.blah")).toBeDefined();
+  });
+
   it("returns undefined for invalid strings", () => {
-    expect(parseRosPath("blah")).toBeUndefined();
-    expect(parseRosPath("100")).toBeUndefined();
     expect(parseRosPath("-100")).toBeUndefined();
     expect(parseRosPath("[100]")).toBeUndefined();
     expect(parseRosPath("[-100]")).toBeUndefined();
-    expect(parseRosPath("blah.blah")).toBeUndefined();
     expect(parseRosPath("/topic.no.2d.arrays[0][1]")).toBeUndefined();
     expect(parseRosPath("/topic.foo[].bar")).toBeUndefined();
     expect(parseRosPath("/topic.foo[bar]")).toBeUndefined();


### PR DESCRIPTION
Simple grammar file fix for message path parsing
