### PR TITLE
CI: Run yarn build:packages on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - windows-2019
         config:
           # Specify names so that the GitHub branch protection settings for
           # required checks don't need to change if we ever change the commands used.
@@ -27,12 +28,11 @@ jobs:
             command: yarn run test --maxWorkers=100%
           - name: storybook
             command: yarn workspace @foxglove-studio/app run chromatic
-        include:
-          - os: windows-2019
-            config:
-              name: lint
-              command: echo complete
         exclude:
+          - os: windows-2019
+            config: { name: lint }
+          - os: windows-2019
+            config: { name: test }
           - os: windows-2019
             config: { name: storybook }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "clean": "tsc --build --clean packages/*/tsconfig.json && rimraf .webpack dist app/storybook-static",
     "clean:package": "yarn && yarn clean && yarn build:prod && yarn package",
     "start": "electron .webpack",
-    "build:packages": "tsc --build packages/*/tsconfig.json",
+    "build:packages": "tsc --build --verbose packages/*/tsconfig.json",
     "build:prod": "webpack --mode production --progress",
     "build:dev": "webpack --mode development --progress",
     "serve": "webpack serve --mode development --progress",


### PR DESCRIPTION
- Build packages on Windows CI
- Remove `lint` step on Windows CI since it only existed to ensure that `yarn install` continued to work, and the `packages` step does that for us now. 