### PR TITLE
Load the Roboto Mono font on chart.js worker thread explicitly

### DIFF
--- a/app/components/Chart/index.stories.tsx
+++ b/app/components/Chart/index.stories.tsx
@@ -71,7 +71,7 @@ const props: ComponentProps<typeof ChartComponent> = {
       y: {
         ticks: {
           font: {
-            family: `"Roboto Mono", Menlo, Inconsolata, "Courier New", Courier, monospace`,
+            family: `"Roboto Mono"`,
             size: 10,
           },
           color: "#eee",
@@ -86,7 +86,7 @@ const props: ComponentProps<typeof ChartComponent> = {
       x: {
         ticks: {
           font: {
-            family: `"Roboto Mono", Menlo, Inconsolata, "Courier New", Courier, monospace`,
+            family: `"Roboto Mono"`,
             size: 10,
           },
           color: "#eee",

--- a/app/components/Chart/worker/ChartJSManager.ts
+++ b/app/components/Chart/worker/ChartJSManager.ts
@@ -15,7 +15,6 @@ import { Chart, ChartData, ChartOptions, ChartType } from "chart.js";
 import type { Context as DatalabelContext } from "chartjs-plugin-datalabels";
 import DatalabelPlugin from "chartjs-plugin-datalabels";
 import { Zoom as ZoomPlugin } from "chartjs-plugin-zoom";
-import { FontFaceSet } from "css-font-loading-module";
 import EventEmitter from "eventemitter3";
 import merge from "lodash/merge";
 

--- a/app/components/Chart/worker/ChartJSManager.ts
+++ b/app/components/Chart/worker/ChartJSManager.ts
@@ -19,7 +19,6 @@ import EventEmitter from "eventemitter3";
 import merge from "lodash/merge";
 
 import { RpcElement, RpcScales } from "@foxglove-studio/app/components/Chart/types";
-import RobotoMono from "@foxglove-studio/app/styles/assets/latin-roboto-mono.woff2";
 import Logger from "@foxglove/log";
 
 const log = Logger.getLogger(__filename);
@@ -44,14 +43,6 @@ function removeEventListener(emitter: EventEmitter) {
   };
 }
 
-// Explicitly load the "Roboto Mono" font, since custom fonts from the main renderer are not
-// inherited by web workers
-async function loadDefaultFont(): Promise<FontFace> {
-  const fontFace = new FontFace("Roboto Mono", `url(${RobotoMono}) format('woff2')`);
-  ((self as unknown) as WorkerGlobalScope).fonts.add(fontFace);
-  return fontFace.load();
-}
-
 type InitOpts = {
   id: string;
   node: OffscreenCanvas;
@@ -59,6 +50,7 @@ type InitOpts = {
   data: ChartData;
   options: ChartOptions;
   devicePixelRatio: number;
+  fontLoaded: Promise<FontFace>;
 };
 
 export default class ChartJSManager {
@@ -72,9 +64,17 @@ export default class ChartJSManager {
     this.init(initOpts);
   }
 
-  async init({ id, node, type, data, options, devicePixelRatio }: InitOpts): Promise<void> {
-    const font = await loadDefaultFont();
-    log.info(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
+  async init({
+    id,
+    node,
+    type,
+    data,
+    options,
+    devicePixelRatio,
+    fontLoaded,
+  }: InitOpts): Promise<void> {
+    const font = await fontLoaded;
+    log.debug(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
 
     const fakeNode = {
       addEventListener: addEventListener(this._fakeNodeEvents),
@@ -100,7 +100,7 @@ export default class ChartJSManager {
     const fullOptions: ChartOptions = {
       ...this.addFunctionsToConfig(options),
       devicePixelRatio,
-      font: { family: "Roboto Mono" },
+      font: { family: "'Roboto Mono'" },
     };
 
     const chartInstance = new Chart(node, {

--- a/app/components/Chart/worker/ChartJSManager.ts
+++ b/app/components/Chart/worker/ChartJSManager.ts
@@ -15,10 +15,15 @@ import { Chart, ChartData, ChartOptions, ChartType } from "chart.js";
 import type { Context as DatalabelContext } from "chartjs-plugin-datalabels";
 import DatalabelPlugin from "chartjs-plugin-datalabels";
 import { Zoom as ZoomPlugin } from "chartjs-plugin-zoom";
+import { FontFaceSet } from "css-font-loading-module";
 import EventEmitter from "eventemitter3";
 import merge from "lodash/merge";
 
 import { RpcElement, RpcScales } from "@foxglove-studio/app/components/Chart/types";
+import RobotoMono from "@foxglove-studio/app/styles/assets/latin-roboto-mono.woff2";
+import Logger from "@foxglove/log";
+
+const log = Logger.getLogger(__filename);
 
 // allows us to override the chart.ctx instance field which zoom plugin uses for adding event listeners
 type MutableContext = Omit<Chart, "ctx"> & { ctx: any };
@@ -40,26 +45,38 @@ function removeEventListener(emitter: EventEmitter) {
   };
 }
 
+// Explicitly load the "Roboto Mono" font, since custom fonts from the main renderer are not
+// inherited by web workers
+async function loadDefaultFont(): Promise<FontFace> {
+  const fontFace = new FontFace("Roboto Mono", `url(${RobotoMono}) format('woff2')`);
+  ((self as unknown) as WorkerGlobalScope).fonts.add(fontFace);
+  return fontFace.load();
+}
+
+type InitOpts = {
+  id: string;
+  node: OffscreenCanvas;
+  type: ChartType;
+  data: ChartData;
+  options: ChartOptions;
+  devicePixelRatio: number;
+};
+
 export default class ChartJSManager {
-  private _chartInstance: Chart;
+  private _chartInstance?: Chart;
   private _fakeNodeEvents = new EventEmitter();
   private _fakeDocumentEvents = new EventEmitter();
-  private _lastDatalabelClickContext?: DatalabelContext = undefined;
+  private _lastDatalabelClickContext?: DatalabelContext;
 
-  constructor({
-    node,
-    type,
-    data,
-    options,
-    devicePixelRatio,
-  }: {
-    id: string;
-    node: OffscreenCanvas;
-    type: ChartType;
-    data: ChartData;
-    options: ChartOptions;
-    devicePixelRatio: number;
-  }) {
+  constructor(initOpts: InitOpts) {
+    log.info(`new ChartJSManager(id=${initOpts.id})`);
+    this.init(initOpts);
+  }
+
+  async init({ id, node, type, data, options, devicePixelRatio }: InitOpts): Promise<void> {
+    const font = await loadDefaultFont();
+    log.info(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
+
     const fakeNode = {
       addEventListener: addEventListener(this._fakeNodeEvents),
       removeEventListener: removeEventListener(this._fakeNodeEvents),
@@ -81,9 +98,10 @@ export default class ChartJSManager {
       return res;
     };
 
-    const fullOptions = {
+    const fullOptions: ChartOptions = {
       ...this.addFunctionsToConfig(options),
       devicePixelRatio,
+      font: { family: "Roboto Mono" },
     };
 
     const chartInstance = new Chart(node, {
@@ -123,19 +141,19 @@ export default class ChartJSManager {
 
   panstart(event: any) {
     event.target.getBoundingClientRect = () => event.target.boundingClientRect;
-    (this._chartInstance as any).$zoom.panStartHandler(event);
+    (this._chartInstance as any)?.$zoom.panStartHandler(event);
     return this.getScales();
   }
 
   panmove(event: any) {
     event.target.getBoundingClientRect = () => event.target.boundingClientRect;
-    (this._chartInstance as any).$zoom.panHandler(event);
+    (this._chartInstance as any)?.$zoom.panHandler(event);
     return this.getScales();
   }
 
   panend(event: any) {
     event.target.getBoundingClientRect = () => event.target.boundingClientRect;
-    (this._chartInstance as any).$zoom.panEndHandler(event);
+    (this._chartInstance as any)?.$zoom.panEndHandler(event);
     return this.getScales();
   }
 
@@ -149,8 +167,11 @@ export default class ChartJSManager {
     options: ChartOptions;
     width: number;
     height: number;
-  }) {
+  }): RpcScales {
     const instance = this._chartInstance;
+    if (instance == undefined) {
+      return {};
+    }
 
     instance.options.plugins = this.addFunctionsToConfig(options).plugins;
 
@@ -182,17 +203,18 @@ export default class ChartJSManager {
 
     // ev is cast to any because the typings for getElementsAtEventForMode are wrong
     // ev is specified as a dom Event - but the implementation does not require it for the basic platform
-    const elements = this._chartInstance.getElementsAtEventForMode(
-      ev as any,
-      this._chartInstance.options.hover?.mode ?? "intersect",
-      this._chartInstance.options.hover ?? {},
-      false,
-    );
+    const elements =
+      this._chartInstance?.getElementsAtEventForMode(
+        ev as any,
+        this._chartInstance.options.hover?.mode ?? "intersect",
+        this._chartInstance.options.hover ?? {},
+        false,
+      ) ?? [];
 
     const out = new Array<RpcElement>();
 
     for (const element of elements) {
-      const data = this._chartInstance.data.datasets[element.datasetIndex]?.data[element.index];
+      const data = this._chartInstance?.data.datasets[element.datasetIndex]?.data[element.index];
       if (data == undefined || typeof data === "number") {
         continue;
       }
@@ -211,8 +233,7 @@ export default class ChartJSManager {
   }
 
   getDatalabelAtEvent({ event }: { event: Event }): unknown {
-    const chartInstance = this._chartInstance;
-    chartInstance.notifyPlugins("beforeEvent", { event });
+    this._chartInstance?.notifyPlugins("beforeEvent", { event });
 
     // clear the stored click context - we have consumed it
     const context = this._lastDatalabelClickContext;
@@ -227,7 +248,7 @@ export default class ChartJSManager {
     const scales: RpcScales = {};
 
     // fill our rpc scales - we only support x and y scales for now
-    const xScale = this._chartInstance.scales.x;
+    const xScale = this._chartInstance?.scales.x;
     if (xScale) {
       scales.x = {
         pixelMin: xScale.left,
@@ -237,7 +258,7 @@ export default class ChartJSManager {
       };
     }
 
-    const yScale = this._chartInstance.scales.y;
+    const yScale = this._chartInstance?.scales.y;
     if (yScale) {
       scales.y = {
         pixelMin: yScale.bottom,

--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -48,9 +48,12 @@ import { isBobject } from "@foxglove-studio/app/util/binaryObjects";
 import filterMap from "@foxglove-studio/app/util/filterMap";
 import { defaultGetHeaderStamp } from "@foxglove-studio/app/util/synchronizeMessages";
 import { maybeGetBobjectHeaderStamp } from "@foxglove-studio/app/util/time";
+import Logger from "@foxglove/log";
 
 import HoverBar from "./HoverBar";
 import TimeBasedChartTooltip from "./TimeBasedChartTooltip";
+
+const log = Logger.getLogger(__filename);
 
 export type TooltipItem = {
   queriedData: MessagePathDataItem[];
@@ -763,6 +766,8 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     onChartUpdate,
     onHover,
   };
+
+  useEffect(() => log.debug(`<TimeBasedChart> (datasetId=${datasetId})`), [datasetId]);
 
   // avoid rendering if width/height are 0 - usually on initial mount
   // so we don't trigger onChartUpdate if we know we will immediately resize

--- a/app/styles/mixins.module.scss
+++ b/app/styles/mixins.module.scss
@@ -77,14 +77,14 @@ $control-margin: 0 0.2em;
   background-color: $dark5;
 }
 
-$sans-serif-font: "Inter UI", -apple-system, BlinkMacSystemFont, sans-serif;
+$sans-serif-font: "Inter UI";
 
 @mixin sans-serif {
   font-family: $sans-serif-font;
   font-feature-settings: "tnum";
 }
 
-$monospace-font: "Roboto Mono", Menlo, Inconsolata, "Courier New", Courier, monospace;
+$monospace-font: "Roboto Mono";
 @mixin monospace {
   font-family: $monospace-font;
 }

--- a/typings/extensions.d.ts
+++ b/typings/extensions.d.ts
@@ -50,6 +50,11 @@ declare module "*.wasm" {
   export default url;
 }
 
+declare module "*.woff2" {
+  const url: string;
+  export default url;
+}
+
 declare module "*.ne" {
   import type { CompiledRules } from "nearley";
 


### PR DESCRIPTION
A large portion of Windows users are affected by a rendering thread crash in [skia](https://skia.org/) that seems to happen when chart.js renders a custom font to a <canvas> element when the system display scaling is set >100%.

This PR directly fixes a related issue, the Roboto Mono font is specified for chart axis labels but is not actually available in the worker thread where `ctx.fillText()` is called. By waiting for the custom font to be loaded before rendering the chart, it also appears to fix the DirectWrite font crash in my testing so far.

Fixes https://github.com/foxglove/studio/issues/495
