### PR TITLE
Change Icon to useTooltip hook to fix tooltip positioning

### DIFF
--- a/app/components/Icon.tsx
+++ b/app/components/Icon.tsx
@@ -13,7 +13,7 @@
 
 import cx from "classnames";
 
-import Tooltip from "@foxglove-studio/app/components/Tooltip";
+import Tooltip, { useTooltip } from "@foxglove-studio/app/components/Tooltip";
 
 import styles from "./icon.module.scss";
 
@@ -80,12 +80,22 @@ const Icon = (props: Props) => {
     }
   };
 
+  const { ref: tooltipRef, tooltip: tooltipNode } = useTooltip({
+    contents: tooltip,
+    ...tooltipProps,
+  });
+
   return (
-    <Tooltip contents={tooltip} {...tooltipProps}>
-      <span className={classNames} onClick={clickHandler} style={style} data-test={dataTest}>
-        {children}
-      </span>
-    </Tooltip>
+    <span
+      ref={tooltipRef}
+      className={classNames}
+      onClick={clickHandler}
+      style={style}
+      data-test={dataTest}
+    >
+      {children}
+      {tooltipNode}
+    </span>
   );
 };
 

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -1,15 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
 import {
   DirectionalHint,


### PR DESCRIPTION
Unfortunately the fluentui Tooltip renders an extra `<span>` around its portal, which can mess up the layout wherever it's rendered. By using the useTooltip hook here we can move the extra span inside the icon's span.

Another solution may be to style .ms-layer as display:none, but I'm not sure whether this might have unintended consequences, and using the hook here fixes the immediate issue for Icon.

Remove license header per https://github.com/foxglove/studio/pull/553/files#r612098082