### PR TITLE
Bump screenshot delay for TimeBasedChart tooltip

### DIFF
--- a/app/components/TimeBasedChart/index.stories.tsx
+++ b/app/components/TimeBasedChart/index.stories.tsx
@@ -191,7 +191,7 @@ export const CleansUpTooltipOnUnmount = () => {
 
 CleansUpTooltipOnUnmount.parameters = {
   chromatic: {
-    delay: 500,
+    delay: 2000,
   },
 };
 


### PR DESCRIPTION
I apparently made this screenshot more flaky in #553.