### PR TITLE
Fix window buttons overlapping tooltips

### DIFF
--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -2,7 +2,6 @@ import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
 import { withMockSubscribeToNewsletter } from "./__mocks__/subscribeToNewsletter";
 import { Story, StoryContext } from "@storybook/react";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
-import WindowGeometryContext from "@foxglove-studio/app/context/WindowGeometryContext";
 
 import "@foxglove-studio/app/styles/global.scss";
 import "./styles.scss";
@@ -17,14 +16,6 @@ function withTheme(Story: Story, { parameters }: StoryContext) {
   );
 }
 
-function withWindowGeometry(Story: Story) {
-  return (
-    <WindowGeometryContext.Provider value={{ insetToolbar: false }}>
-      <Story />
-    </WindowGeometryContext.Provider>
-  );
-}
-
 export const loaders = [
   async () => {
     // These loaders are run once for each story when you switch between stories,
@@ -36,7 +27,7 @@ export const loaders = [
   },
 ];
 
-export const decorators = [withTheme, withWindowGeometry, withMockSubscribeToNewsletter];
+export const decorators = [withTheme, withMockSubscribeToNewsletter];
 
 export const parameters = {
   // Disable default padding around the page body

--- a/app/.storybook/preview.tsx
+++ b/app/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
 import { withMockSubscribeToNewsletter } from "./__mocks__/subscribeToNewsletter";
 import { Story, StoryContext } from "@storybook/react";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
+import WindowGeometryContext from "@foxglove-studio/app/context/WindowGeometryContext";
 
 import "@foxglove-studio/app/styles/global.scss";
 import "./styles.scss";
@@ -16,6 +17,14 @@ function withTheme(Story: Story, { parameters }: StoryContext) {
   );
 }
 
+function withWindowGeometry(Story: Story) {
+  return (
+    <WindowGeometryContext.Provider value={{ insetToolbar: false }}>
+      <Story />
+    </WindowGeometryContext.Provider>
+  );
+}
+
 export const loaders = [
   async () => {
     // These loaders are run once for each story when you switch between stories,
@@ -27,7 +36,7 @@ export const loaders = [
   },
 ];
 
-export const decorators = [withTheme, withMockSubscribeToNewsletter];
+export const decorators = [withTheme, withWindowGeometry, withMockSubscribeToNewsletter];
 
 export const parameters = {
   // Disable default padding around the page body

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -12,15 +12,7 @@
 
 import { ActionButton, Modal } from "@fluentui/react";
 import AlertIcon from "@mdi/svg/svg/alert.svg";
-import {
-  ReactElement,
-  useState,
-  CSSProperties,
-  useEffect,
-  useMemo,
-  useRef,
-  useCallback,
-} from "react";
+import { ReactElement, useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
 import { Provider, useDispatch } from "react-redux";

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -63,6 +63,7 @@ import {
   PlayerSourceDefinition,
   usePlayerSelection,
 } from "@foxglove-studio/app/context/PlayerSelectionContext";
+import WindowGeometryContext from "@foxglove-studio/app/context/WindowGeometryContext";
 import experimentalFeatures from "@foxglove-studio/app/experimentalFeatures";
 import welcomeLayout from "@foxglove-studio/app/layouts/welcomeLayout";
 import { PlayerPresence } from "@foxglove-studio/app/players/types";
@@ -114,11 +115,6 @@ function Root() {
     }
   }, [dispatch, setPlayerFromDemoBag, isMounted]);
 
-  // On MacOS we use inset window controls, when the window is full-screen these controls are not present
-  // We detect the full screen state and adjust our rendering accordingly
-  // Note: this does not removed the handlers so should be done at the highest component level
-  const [isFullScreen, setFullScreen] = useState(false);
-
   const handleInternalLink = useCallback((event: React.MouseEvent, href: string) => {
     if (href === "#help:message-path-syntax") {
       event.preventDefault();
@@ -134,9 +130,6 @@ function Root() {
     // Add a hook for integration tests.
     (window as TestableWindow).setPanelLayout = (payload: ImportPanelLayoutPayload) =>
       dispatch(importPanelLayout(payload));
-
-    OsContextSingleton?.addIpcEventListener("enter-full-screen", () => setFullScreen(true));
-    OsContextSingleton?.addIpcEventListener("leave-full-screen", () => setFullScreen(false));
 
     // For undo/redo events, first try the browser's native undo/redo, and if that is disabled, then
     // undo/redo the layout history. Note that in GlobalKeyListener we also handle the keyboard
@@ -163,14 +156,6 @@ function Root() {
     );
     OsContextSingleton?.addIpcEventListener("open-welcome-layout", () => openWelcomeLayout());
   }, [dispatch, openWelcomeLayout]);
-
-  const toolbarStyle = useMemo<CSSProperties | undefined>(() => {
-    const insetWindowControls = OsContextSingleton?.platform === "darwin" && !isFullScreen;
-    if (insetWindowControls) {
-      return { marginLeft: "78px", borderLeft: "2px groove #29292f" };
-    }
-    return undefined;
-  }, [isFullScreen]);
 
   const appConfiguration = useAppConfiguration();
 
@@ -227,7 +212,7 @@ function Root() {
           </RenderToBodyComponent>
         )}
 
-        <Toolbar style={toolbarStyle} onDoubleClick={OsContextSingleton?.handleToolbarDoubleClick}>
+        <Toolbar onDoubleClick={OsContextSingleton?.handleToolbarDoubleClick}>
           <SToolbarItem>
             <TinyConnectionPicker />
           </SToolbarItem>
@@ -294,10 +279,23 @@ export default function App(): ReactElement {
     },
   ];
 
+  // On MacOS we use inset window controls, when the window is full-screen these controls are not present
+  // We detect the full screen state and adjust our rendering accordingly
+  // Note: this does not removed the handlers so should be done at the highest component level
+  const [isFullScreen, setFullScreen] = useState(false);
+  useEffect(() => {
+    OsContextSingleton?.addIpcEventListener("enter-full-screen", () => setFullScreen(true));
+    OsContextSingleton?.addIpcEventListener("leave-full-screen", () => setFullScreen(false));
+  }, []);
+
+  const insetToolbar = OsContextSingleton?.platform === "darwin" && !isFullScreen;
+  const windowGeometry = useMemo(() => ({ insetToolbar }), [insetToolbar]);
+
   const providers = [
     /* eslint-disable react/jsx-key */
     <OsContextAppConfigurationProvider />,
     <OsContextLayoutStorageProvider />,
+    <WindowGeometryContext.Provider value={windowGeometry} />,
     <Provider store={globalStore} />,
     <AnalyticsProvider />,
     <ExperimentalFeaturesLocalStorageProvider features={experimentalFeatures} />,

--- a/app/components/Panel.module.scss
+++ b/app/components/Panel.module.scss
@@ -1,5 +1,5 @@
 @import "@foxglove-studio/app/styles/colors.module.scss";
-@import "@foxglove-studio/app/styles/variables.scss";
+@import "@foxglove-studio/app/styles/variables.module.scss";
 
 .root {
   z-index: 1;

--- a/app/components/PlaybackControls/index.module.scss
+++ b/app/components/PlaybackControls/index.module.scss
@@ -13,7 +13,7 @@
 
 @import "@foxglove-studio/app/styles/mixins.module.scss";
 @import "@foxglove-studio/app/styles/colors.module.scss";
-@import "@foxglove-studio/app/styles/variables.scss";
+@import "@foxglove-studio/app/styles/variables.module.scss";
 
 .container {
   padding: 16px;

--- a/app/components/Toolbar.module.scss
+++ b/app/components/Toolbar.module.scss
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 @import "@foxglove-studio/app/styles/colors.module.scss";
-@import "@foxglove-studio/app/styles/variables.scss";
+@import "@foxglove-studio/app/styles/variables.module.scss";
 
 .toolbar {
   padding: 0 0 0 8px;
@@ -25,4 +25,15 @@
   justify-content: flex-end;
   background-color: $dark2;
   -webkit-app-region: drag; // make electron window draggable
+}
+
+$toolbar-inset-width: 78px;
+
+.insetToolbar {
+  margin-left: $toolbar-inset-width;
+  border-left: 2px groove #29292f;
+}
+
+:export {
+  toolbarInsetWidth: $toolbar-inset-width;
 }

--- a/app/components/Toolbar.stories.tsx
+++ b/app/components/Toolbar.stories.tsx
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Toolbar from "@foxglove-studio/app/components/Toolbar";
+import WindowGeometryContext from "@foxglove-studio/app/context/WindowGeometryContext";
+
+export default {
+  title: "<Toolbar>",
+  component: Toolbar,
+};
+
+export function Default(): JSX.Element {
+  return (
+    <WindowGeometryContext.Provider value={{ insetToolbar: false }}>
+      <Toolbar>
+        <span style={{ flexGrow: 1 }}>Hello</span>
+        <span>There</span>
+      </Toolbar>
+    </WindowGeometryContext.Provider>
+  );
+}
+
+export function Inset(): JSX.Element {
+  return (
+    <WindowGeometryContext.Provider value={{ insetToolbar: true }}>
+      <Toolbar>
+        <span style={{ flexGrow: 1 }}>Hello</span>
+        <span>There</span>
+      </Toolbar>
+    </WindowGeometryContext.Provider>
+  );
+}

--- a/app/components/Toolbar.stories.tsx
+++ b/app/components/Toolbar.stories.tsx
@@ -12,10 +12,12 @@ export default {
 export function Default(): JSX.Element {
   return (
     <WindowGeometryContext.Provider value={{ insetToolbar: false }}>
-      <Toolbar>
-        <span style={{ flexGrow: 1 }}>Hello</span>
-        <span>There</span>
-      </Toolbar>
+      <div style={{ width: 400 }}>
+        <Toolbar>
+          <span style={{ flexGrow: 1 }}>Hello</span>
+          <span>There</span>
+        </Toolbar>
+      </div>
     </WindowGeometryContext.Provider>
   );
 }
@@ -23,10 +25,12 @@ export function Default(): JSX.Element {
 export function Inset(): JSX.Element {
   return (
     <WindowGeometryContext.Provider value={{ insetToolbar: true }}>
-      <Toolbar>
-        <span style={{ flexGrow: 1 }}>Hello</span>
-        <span>There</span>
-      </Toolbar>
+      <div style={{ width: 400 }}>
+        <Toolbar>
+          <span style={{ flexGrow: 1 }}>Hello</span>
+          <span>There</span>
+        </Toolbar>
+      </div>
     </WindowGeometryContext.Provider>
   );
 }

--- a/app/components/Toolbar.tsx
+++ b/app/components/Toolbar.tsx
@@ -11,19 +11,24 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import cx from "classnames";
 import { ReactNode, useCallback } from "react";
+
+import { useWindowGeometry } from "@foxglove-studio/app/context/WindowGeometryContext";
 
 import styles from "./Toolbar.module.scss";
 
 type Props = {
   children: ReactNode;
-  style?: React.CSSProperties;
   className?: string;
   onDoubleClick?: () => void;
 };
 
 function Toolbar(props: Props): React.ReactElement {
-  const { style, className = "", onDoubleClick } = props;
+  const { className = "", onDoubleClick } = props;
+
+  const { insetToolbar } = useWindowGeometry();
+
   const clickHandler = useCallback(
     (event: React.MouseEvent) => {
       // Only process the click event if the toolbar itself was clicked, not e.g. a button
@@ -34,7 +39,12 @@ function Toolbar(props: Props): React.ReactElement {
     [onDoubleClick],
   );
   return (
-    <div className={`${styles.toolbar} ${className}`} style={style} onDoubleClick={clickHandler}>
+    <div
+      className={cx(styles.toolbar, className, {
+        [styles.insetToolbar as string]: insetToolbar,
+      })}
+      onDoubleClick={clickHandler}
+    >
       {props.children}
     </div>
   );

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -11,6 +11,10 @@ import {
 } from "@fluentui/react";
 import { useCallback, useRef, useState } from "react";
 
+import toolbarStyles from "@foxglove-studio/app/components/Toolbar.module.scss";
+import { useWindowGeometry } from "@foxglove-studio/app/context/WindowGeometryContext";
+import styles from "@foxglove-studio/app/styles/variables.module.scss";
+
 type Contents = React.ReactNode | (() => React.ReactNode);
 
 export type Props = {
@@ -49,6 +53,7 @@ export function useTooltip({
     [contents],
   );
   const theme = useTheme();
+  const { insetToolbar } = useWindowGeometry();
 
   // Styles which ideally we would be able to set in the theme for all Tooltips:
   // https://github.com/microsoft/fluentui/discussions/17772
@@ -62,6 +67,27 @@ export function useTooltip({
       beak: { background: theme.palette.neutralDark },
       beakCurtain: { background: theme.palette.neutralDark },
       calloutMain: { background: theme.palette.neutralDark },
+    },
+    // Customize bounds to leave space for the window traffic light icons
+    bounds: (target, win) => {
+      if (!win) {
+        return undefined;
+      }
+      const rect = {
+        top: 8,
+        left: 8,
+        bottom: win.innerHeight - 8,
+        right: win.innerWidth - 8,
+        width: win.innerWidth - 2 * 8,
+        height: win.innerHeight - 2 * 8,
+      };
+      if (insetToolbar && target instanceof Element) {
+        const targetRect = target.getBoundingClientRect();
+        if (targetRect.left < parseInt(toolbarStyles.toolbarInsetWidth as string)) {
+          rect.top = parseInt(styles.topBarHeight as string);
+        }
+      }
+      return rect;
     },
   };
 

--- a/app/context/WindowGeometryContext.ts
+++ b/app/context/WindowGeometryContext.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+type WindowGeometry = {
+  // Whether the toolbar should be inset on the left side to allow space for "traffic light" buttons
+  insetToolbar: boolean;
+};
+const WindowGeometryContext = createContext<WindowGeometry | undefined>(undefined);
+
+export function useWindowGeometry(): WindowGeometry {
+  const storage = useContext(WindowGeometryContext);
+  if (!storage) {
+    throw new Error("An WindowGeometryContext provider is required to useWindowGeometry");
+  }
+  return storage;
+}
+
+export default WindowGeometryContext;

--- a/app/context/WindowGeometryContext.ts
+++ b/app/context/WindowGeometryContext.ts
@@ -8,14 +8,10 @@ type WindowGeometry = {
   // Whether the toolbar should be inset on the left side to allow space for "traffic light" buttons
   insetToolbar: boolean;
 };
-const WindowGeometryContext = createContext<WindowGeometry | undefined>(undefined);
+const WindowGeometryContext = createContext<WindowGeometry>({ insetToolbar: false });
 
 export function useWindowGeometry(): WindowGeometry {
-  const storage = useContext(WindowGeometryContext);
-  if (!storage) {
-    throw new Error("An WindowGeometryContext provider is required to useWindowGeometry");
-  }
-  return storage;
+  return useContext(WindowGeometryContext);
 }
 
 export default WindowGeometryContext;

--- a/app/styles/variables.module.scss
+++ b/app/styles/variables.module.scss
@@ -1,2 +1,5 @@
 $topBarHeight: 40px;
 $playbackControlHeight: 60px;
+:export {
+  topBarHeight: $topBarHeight;
+}


### PR DESCRIPTION
Conditionally change the tooltip's callout `bounds` so that the top boundary can be lowered if the tooltip target is near the window icons.

This isn't perfect because it doesn't take the tooltip's size into account, but seems to handle some basic cases I tested.

<img width="233" alt="Screen Shot 2021-04-13 at 10 31 09 AM" src="https://user-images.githubusercontent.com/14237/114620091-f0692b00-9c46-11eb-8df2-0cec875e10dc.png">
<img width="345" alt="Screen Shot 2021-04-13 at 10 31 07 AM" src="https://user-images.githubusercontent.com/14237/114620096-f232ee80-9c46-11eb-8cad-e4f58fd2b12c.png">

Fullscreen mode / non-macOS:
<img width="223" alt="image" src="https://user-images.githubusercontent.com/14237/114620373-3cb46b00-9c47-11eb-96e1-a820eada8ebe.png">
