### PR TITLE
Handle bobjects when registering unseen TF frames

### DIFF
--- a/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/app/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -93,7 +93,7 @@ type Props = {
   onFollowChange: (tfId?: string | false, followOrientation?: boolean) => void;
 };
 
-function* getDescendants(nodes: TfTreeNode[]): any {
+function* getDescendants(nodes: TfTreeNode[]): Iterable<TfTreeNode> {
   for (const node of nodes) {
     yield node;
     yield* getDescendants(node.children);
@@ -130,7 +130,7 @@ const FollowTFControl = memo<Props>((props: Props) => {
   const [lastSelectedFrame, setLastSelectedFrame] = useState(undefined);
 
   const tfTree = buildTfTree(transforms.values());
-  const allNodes: any = Array.from(getDescendants(tfTree.roots));
+  const allNodes = Array.from(getDescendants(tfTree.roots));
   const nodesWithoutDefaultFollowTfFrame = allNodes?.length;
   const newFollowTfFrame = allNodes?.[0]?.tf?.id;
 

--- a/app/panels/ThreeDimensionalViz/withTransforms.tsx
+++ b/app/panels/ThreeDimensionalViz/withTransforms.tsx
@@ -62,7 +62,9 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
       // that topic) and transform frames (coordinate frames)
       for (const topic in frame) {
         for (const msg of frame[topic] as Message[]) {
-          const frameId = msg.message.header?.frame_id as string | undefined;
+          const frameId: string | undefined = isBobject(msg.message)
+            ? msg.message.header?.().frame_id?.()
+            : msg.message.header?.frame_id;
           if (frameId != undefined) {
             transforms.register(frameId);
           }


### PR DESCRIPTION
Updates the logic added in #442 to handle bobjects. Fixes an issue where visualizing point clouds was impossible when there was no /tf topic because the root frame couldn't be selected automatically.