### PR TITLE
Send telemetry events to Sentry as breadcrumbs when crash reporting is enabled

### DIFF
--- a/app/context/AnalyticsProvider.tsx
+++ b/app/context/AnalyticsProvider.tsx
@@ -14,6 +14,7 @@ export default function AnalyticsProvider(
   const analytics = useMemo(() => {
     return new Analytics({
       optOut: !(OsContextSingleton?.isTelemetryEnabled() ?? true),
+      crashReportingOptOut: !(OsContextSingleton?.isCrashReportingEnabled() ?? true),
       amplitudeApiKey: props.amplitudeApiKey ?? process.env.AMPLITUDE_API_KEY,
     });
   }, [props.amplitudeApiKey]);

--- a/app/context/AnalyticsProvider.tsx
+++ b/app/context/AnalyticsProvider.tsx
@@ -14,7 +14,10 @@ export default function AnalyticsProvider(
   const analytics = useMemo(() => {
     return new Analytics({
       optOut: !(OsContextSingleton?.isTelemetryEnabled() ?? true),
-      crashReportingOptOut: !(OsContextSingleton?.isCrashReportingEnabled() ?? true),
+      crashReportingOptOut: !(
+        (OsContextSingleton?.isCrashReportingEnabled() ?? true) &&
+        typeof process.env.SENTRY_DSN === "string"
+      ),
       amplitudeApiKey: props.amplitudeApiKey ?? process.env.AMPLITUDE_API_KEY,
     });
   }, [props.amplitudeApiKey]);


### PR DESCRIPTION
This change reports HTTP requests, responses, and user interaction events as Sentry.io breadcrumbs when crash reporting is enabled. It also uses consistent userIds and deviceIds across Amplitude and Sentry, which may improve the unique users affected per error metrics.
