### PR TITLE
Restrict `allowDangerousHtml` to specific parts of the UI

### DIFF
--- a/app/components/ExperimentalFeatureSettings.tsx
+++ b/app/components/ExperimentalFeatureSettings.tsx
@@ -38,7 +38,7 @@ export function ExperimentalFeatureSettings(): React.ReactElement {
             return (
               <tr key={id}>
                 <td style={{ width: "100%", padding: 4 }}>
-                  <TextContent>
+                  <TextContent allowDangerousHtml={true}>
                     <h2>
                       {feature.name} <code style={{ fontSize: 12 }}>{id}</code>
                     </h2>

--- a/app/components/HelpModal.tsx
+++ b/app/components/HelpModal.tsx
@@ -38,7 +38,7 @@ export default function HelpModal({
   return (
     <Modal onRequestClose={onRequestClose}>
       <SRoot {...(rootStyle ? { style: rootStyle } : undefined)}>
-        <TextContent>{children}</TextContent>
+        <TextContent allowDangerousHtml={true}>{children}</TextContent>
       </SRoot>
     </Modal>
   );

--- a/app/components/TextContent.tsx
+++ b/app/components/TextContent.tsx
@@ -21,10 +21,11 @@ import styles from "./TextContent.module.scss";
 
 type Props = {
   style?: CSSProperties;
+  allowDangerousHtml?: boolean;
 };
 
 export default function TextContent(props: PropsWithChildren<Props>): React.ReactElement {
-  const { children, style } = props;
+  const { children, style, allowDangerousHtml } = props;
 
   const handleLink = useContext(LinkHandlerContext);
 
@@ -50,7 +51,7 @@ export default function TextContent(props: PropsWithChildren<Props>): React.Reac
         <ReactMarkdown
           source={children}
           renderers={{ link: linkRenderer }}
-          allowDangerousHtml={true}
+          allowDangerousHtml={allowDangerousHtml}
         />
       ) : (
         children


### PR DESCRIPTION
allowDangerousHtml was set to true recently to allow HTML formatting in Markdown help pages for panels. This PR rolls the setting back from being universally enabled to conditionally enabling in a few parts of the app, to prevent a future problem if we ever start rendering Markdown from user input (such as embedded in a bag).
