### PR TITLE
Add typescript-plugin-styled-components

### DIFF
--- a/app/.storybook/main.ts
+++ b/app/.storybook/main.ts
@@ -7,7 +7,7 @@ import { makeConfig } from "../../webpack.renderer.config";
 
 module.exports = {
   stories: ["../**/*.stories.@(ts|tsx)"],
-  addons: ["@storybook/addon-essentials", "@storybook/addon-actions", "storycap"],
+  addons: ["@storybook/addon-essentials", "@storybook/addon-actions"],
 
   core: {
     builder: "webpack5",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.2",
     "typescript-plugin-css-modules": "3.2.0",
+    "typescript-plugin-styled-components": "1.5.0",
     "universal-url": "2.0.0",
     "webpack": "5.31.0",
     "webpack-cli": "4.6.0",

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -21,7 +21,7 @@ import packageJson from "./package.json";
 
 const styledComponentsTransformer = createStyledComponentsTransformer({
   getDisplayName: (filename, bindingName) => {
-    const sanitizedFilename = path.relative(__dirname, filename).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
+    const sanitizedFilename = path.relative(__dirname, filename).replace(/[^a-zA-Z0-9_-]/g, "_");
     return bindingName != undefined ? `${bindingName}__${sanitizedFilename}` : sanitizedFilename;
   },
 });

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -8,6 +8,7 @@ import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
 import path from "path";
+import createStyledComponentsTransformer from "typescript-plugin-styled-components";
 import webpack, {
   Configuration,
   EnvironmentPlugin,
@@ -17,6 +18,13 @@ import webpack, {
 
 import { WebpackArgv } from "./WebpackArgv";
 import packageJson from "./package.json";
+
+const styledComponentsTransformer = createStyledComponentsTransformer({
+  getDisplayName: (filename, bindingName) => {
+    const sanitizedFilename = path.relative(__dirname, filename).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
+    return bindingName != undefined ? `${bindingName}__${sanitizedFilename}` : sanitizedFilename;
+  },
+});
 
 type Options = {
   // During hot reloading and development it is useful to comment out code while iterating.
@@ -106,6 +114,7 @@ export function makeConfig(_: unknown, argv: WebpackArgv, options?: Options): Co
                 // avoid looking at files which are not part of the bundle
                 onlyCompileBundledFiles: true,
                 configFile: isDev ? "tsconfig.dev.json" : "tsconfig.json",
+                getCustomTransformers: () => ({ before: [styledComponentsTransformer] }),
               },
             },
           ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12090,6 +12090,7 @@ __metadata:
     ts-node: 9.1.1
     typescript: 4.2.2
     typescript-plugin-css-modules: 3.2.0
+    typescript-plugin-styled-components: 1.5.0
     universal-url: 2.0.0
     webpack: 5.31.0
     webpack-cli: 4.6.0
@@ -23385,6 +23386,15 @@ resolve@^2.0.0-next.3:
   peerDependencies:
     typescript: ">=3.0.0"
   checksum: a3dabdd5c97bd2f2fc392263c54193b6838981de72f63d7d5586f4aca3225322ae5ccab150b842f3d9827c96a19ab368e314554fcd2574663ca9092f0509d601
+  languageName: node
+  linkType: hard
+
+"typescript-plugin-styled-components@npm:1.5.0":
+  version: 1.5.0
+  resolution: "typescript-plugin-styled-components@npm:1.5.0"
+  peerDependencies:
+    typescript: ^2.5.2 || ^3.0 || ^4.0
+  checksum: d4a44cbfe200c7f7a10d7277454f3847f066c44018751581492bca13d3c7b595f3c223d90ff0cb7be55002e39d925c0a5ab2f3b8ac2f78f5c6b5a8a48c67e8d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Makes the CSS class names used by styled-components readable.

![](https://user-images.githubusercontent.com/14237/114780356-ff1d1400-9d12-11eb-863f-f30be47570a3.png)
