### PR TITLE
Support TFs on all topics, not just /tf and /tf_static

### DIFF
--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
@@ -16,15 +16,13 @@ import { uniq } from "lodash";
 
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
 import useChangeDetector from "@foxglove-studio/app/hooks/useChangeDetector";
-import { Message, Topic } from "@foxglove-studio/app/players/types";
+import { Frame, Message, Topic } from "@foxglove-studio/app/players/types";
 
 const useFrame = (
   topics: string[],
 ): {
-  cleared: boolean;
-  frame: {
-    [topic: string]: readonly Message[];
-  };
+  cleared?: boolean;
+  frame: Frame;
 } => {
   // NOTE(JP): This is a huge abuse of the `useMessageReducer` API. Never use `useMessageReducer`
   // in this way yourself!! `restore` and `addMessage` should be pure functions and not have

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -47,8 +47,6 @@ import {
   POSE_MARKER_SCALE,
   LINED_CONVEX_HULL_RENDERING_SETTING,
   MARKER_ARRAY_DATATYPES,
-  TRANSFORM_STATIC_TOPIC,
-  TRANSFORM_TOPIC,
   WEBVIZ_MARKER_DATATYPE,
   WEBVIZ_MARKER_ARRAY_DATATYPE,
   VISUALIZATION_MSGS_MARKER_DATATYPE,
@@ -123,7 +121,7 @@ const missingTransformMessage = (
       ? `missing transforms from frame${s} <${frameIds}> to root frame <${rootTransformId}>`
       : `missing transform <${rootTransformId}>`;
   if (transforms.empty) {
-    return msg + `. Is ${TRANSFORM_TOPIC} or ${TRANSFORM_STATIC_TOPIC} present?`;
+    return msg + ". No transforms found";
   }
   return msg;
 };
@@ -504,11 +502,11 @@ export default class SceneBuilder implements MarkerProvider {
     badFrameError.namespaces.add(namespace);
     badFrameError.frameIds.add(frame_id);
 
-    const pose = (this.transforms as any).apply(
+    const pose = (this.transforms as Transforms).apply(
       emptyPose(),
       deepParse(marker.pose()),
       frame_id,
-      this.rootTransformID as any,
+      this.rootTransformID as string,
     );
     if (!pose) {
       const topicMissingError = this._addError(this.errors.topicsMissingTransforms, topic);

--- a/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -109,6 +109,7 @@ import {
   VISUALIZATION_MSGS_MARKER_DATATYPE,
   WEBVIZ_MARKER_ARRAY_DATATYPE,
   WEBVIZ_MARKER_DATATYPE,
+  TRANSFORM_STAMPED_DATATYPE,
 } from "@foxglove-studio/app/util/globalConstants";
 import { inVideoRecordingMode } from "@foxglove-studio/app/util/inAutomatedRunMode";
 import { getTopicsByTopicName } from "@foxglove-studio/app/util/selectors";
@@ -401,7 +402,24 @@ export default function Layout({
     visibleTopicsCountByKey,
   } = topicTreeData;
 
-  useEffect(() => setSubscriptions(selectedTopicNames), [selectedTopicNames, setSubscriptions]);
+  const subscribedTopics = useMemo(() => {
+    const allTopics = new Set<string>(selectedTopicNames);
+
+    // Subscribe to all TF topics
+    for (const topic of memoizedTopics) {
+      if (
+        topic.datatype === TF_DATATYPE ||
+        topic.datatype === TF2_DATATYPE ||
+        topic.datatype === TRANSFORM_STAMPED_DATATYPE
+      ) {
+        allTopics.add(topic.name);
+      }
+    }
+
+    return Array.from(allTopics.values());
+  }, [memoizedTopics, selectedTopicNames]);
+
+  useEffect(() => setSubscriptions(subscribedTopics), [subscribedTopics, setSubscriptions]);
   const { playerId } = useDataSourceInfo();
 
   // If a user selects a marker or hovers over a TopicPicker row, highlight relevant markers

--- a/app/panels/ThreeDimensionalViz/Transforms.ts
+++ b/app/panels/ThreeDimensionalViz/Transforms.ts
@@ -149,6 +149,10 @@ class TfStore {
     return result;
   }
 
+  getMaybe(key: string): Transform | undefined {
+    return this._storage.get(stripLeadingSlash(key));
+  }
+
   has(key: string): boolean {
     return this._storage.has(stripLeadingSlash(key));
   }
@@ -198,8 +202,8 @@ export default class Transforms {
     frameId: string,
     rootId: string,
   ): MutablePose | undefined {
-    const tf = this.storage.get(frameId);
-    return tf.apply(output, original, rootId);
+    const tf = this.storage.getMaybe(frameId);
+    return tf?.apply(output, original, rootId);
   }
 
   rootOfTransform(transformID: string): Transform {

--- a/app/panels/ThreeDimensionalViz/index.tsx
+++ b/app/panels/ThreeDimensionalViz/index.tsx
@@ -29,7 +29,6 @@ import { ThreeDimensionalVizConfig } from "@foxglove-studio/app/panels/ThreeDime
 import withTransforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/withTransforms";
 import { Frame, Topic } from "@foxglove-studio/app/players/types";
 import { SaveConfig } from "@foxglove-studio/app/types/panels";
-import { TRANSFORM_TOPIC, TRANSFORM_STATIC_TOPIC } from "@foxglove-studio/app/util/globalConstants";
 
 import { FrameCompatibilityDEPRECATED } from "./FrameCompatibility";
 
@@ -86,9 +85,7 @@ const BaseRenderer = (props: Props, ref: any) => {
   });
 
   const onSetSubscriptions = useCallback(
-    (subscriptions: string[]) => {
-      setSubscriptions([TRANSFORM_TOPIC, TRANSFORM_STATIC_TOPIC, ...subscriptions]);
-    },
+    (subscriptions: string[]) => setSubscriptions(subscriptions),
     [setSubscriptions],
   );
 

--- a/app/panels/ThreeDimensionalViz/withTransforms.tsx
+++ b/app/panels/ThreeDimensionalViz/withTransforms.tsx
@@ -75,7 +75,7 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
         transforms = new Transforms();
       }
 
-      // FIXME: Memoize this, it rarely changes so no need to build it every frame
+      // TODO: Memoize this, it rarely changes so no need to build it every frame
       const topicsToDatatypes = new Map<string, string>(topics.map((t) => [t.name, t.datatype]));
 
       // Find any references to previously unseen frames in the set of incoming messages

--- a/app/panels/ThreeDimensionalViz/withTransforms.tsx
+++ b/app/panels/ThreeDimensionalViz/withTransforms.tsx
@@ -15,14 +15,18 @@ import hoistNonReactStatics from "hoist-non-react-statics";
 import PropTypes from "prop-types";
 
 import Transforms from "@foxglove-studio/app/panels/ThreeDimensionalViz/Transforms";
-import { Frame, Message } from "@foxglove-studio/app/players/types";
+import { Frame, Message, Topic } from "@foxglove-studio/app/players/types";
 import { TF } from "@foxglove-studio/app/types/Messages";
 import { isBobject, deepParse } from "@foxglove-studio/app/util/binaryObjects";
-import { TRANSFORM_STATIC_TOPIC, TRANSFORM_TOPIC } from "@foxglove-studio/app/util/globalConstants";
+import {
+  TF2_DATATYPE,
+  TF_DATATYPE,
+  TRANSFORM_STAMPED_DATATYPE,
+} from "@foxglove-studio/app/util/globalConstants";
 
 type State = { transforms: Transforms };
 type TfMessage = { transforms: TF[] };
-type BaseProps = { frame: Frame; cleared: boolean };
+type BaseProps = { frame: Frame; cleared?: boolean; topics: Topic[] };
 
 function consumeTfs(tfs: Message[] | undefined, transforms: Transforms): void {
   if (tfs != undefined) {
@@ -35,9 +39,23 @@ function consumeTfs(tfs: Message[] | undefined, transforms: Transforms): void {
   }
 }
 
+function consumeSingleTfs(tfs: Message[] | undefined, transforms: Transforms): void {
+  if (tfs != undefined) {
+    for (const { message } of tfs) {
+      const parsedMessage = (isBobject(message) ? deepParse(message) : message) as TF;
+      transforms.consume(parsedMessage);
+    }
+  }
+}
+
 function withTransforms<Props extends any>(ChildComponent: React.ComponentType<Props>) {
   class Component extends React.PureComponent<
-    Partial<{ frame: Frame; cleared: boolean; forwardedRef: any }>,
+    Partial<{
+      frame: Frame;
+      topics: Topic[];
+      cleared?: boolean;
+      forwardedRef: any;
+    }>,
     State
   > {
     static displayName = `withTransforms(${
@@ -51,17 +69,23 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
       nextProps: Props,
       prevState: State,
     ): Partial<State> | undefined {
-      const { frame, cleared } = nextProps as BaseProps;
+      const { frame, cleared, topics } = nextProps as BaseProps;
       let { transforms } = prevState;
-      if (cleared) {
+      if (cleared != undefined && cleared) {
         transforms = new Transforms();
       }
+
+      // FIXME: Memoize this, it rarely changes so no need to build it every frame
+      const topicsToDatatypes = new Map<string, string>(topics.map((t) => [t.name, t.datatype]));
 
       // Find any references to previously unseen frames in the set of incoming messages
       // Note the naming confusion between `frame` (a map of topic names to messages received on
       // that topic) and transform frames (coordinate frames)
       for (const topic in frame) {
-        for (const msg of frame[topic] as Message[]) {
+        const datatype = topicsToDatatypes.get(topic) ?? "";
+        const msgs = frame[topic] as Message[];
+
+        for (const msg of msgs) {
           const frameId: string | undefined = isBobject(msg.message)
             ? msg.message.header?.().frame_id?.()
             : msg.message.header?.frame_id;
@@ -69,11 +93,18 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
             transforms.register(frameId);
           }
         }
-      }
 
-      // Process all new /tf and /tf_static messages
-      consumeTfs(frame[TRANSFORM_TOPIC], transforms);
-      consumeTfs(frame[TRANSFORM_STATIC_TOPIC], transforms);
+        // Process all TF topics (ex: /tf and /tf_static)
+        switch (datatype) {
+          case TF_DATATYPE:
+          case TF2_DATATYPE:
+            consumeTfs(msgs, transforms);
+            break;
+          case TRANSFORM_STAMPED_DATATYPE:
+            consumeSingleTfs(msgs, transforms);
+            break;
+        }
+      }
 
       return { transforms };
     }

--- a/app/panels/ThreeDimensionalViz/withTransforms.tsx
+++ b/app/panels/ThreeDimensionalViz/withTransforms.tsx
@@ -24,7 +24,7 @@ import {
   TRANSFORM_STAMPED_DATATYPE,
 } from "@foxglove-studio/app/util/globalConstants";
 
-type State = { transforms: Transforms };
+type State = { transforms: Transforms; topics: Topic[]; topicsToDatatypes: Map<string, string> };
 type TfMessage = { transforms: TF[] };
 type BaseProps = { frame: Frame; cleared?: boolean; topics: Topic[] };
 
@@ -63,20 +63,21 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
     })`;
     static contextTypes = { store: PropTypes.any };
 
-    state: State = { transforms: new Transforms() };
+    state: State = { transforms: new Transforms(), topics: [], topicsToDatatypes: new Map() };
 
     static getDerivedStateFromProps(
       nextProps: Props,
       prevState: State,
     ): Partial<State> | undefined {
       const { frame, cleared, topics } = nextProps as BaseProps;
-      let { transforms } = prevState;
+      let { transforms, topicsToDatatypes } = prevState;
       if (cleared != undefined && cleared) {
         transforms = new Transforms();
       }
 
-      // TODO: Memoize this, it rarely changes so no need to build it every frame
-      const topicsToDatatypes = new Map<string, string>(topics.map((t) => [t.name, t.datatype]));
+      if (topics !== prevState.topics) {
+        topicsToDatatypes = new Map<string, string>(topics.map((t) => [t.name, t.datatype]));
+      }
 
       // Find any references to previously unseen frames in the set of incoming messages
       // Note the naming confusion between `frame` (a map of topic names to messages received on
@@ -106,7 +107,7 @@ function withTransforms<Props extends any>(ChildComponent: React.ComponentType<P
         }
       }
 
-      return { transforms };
+      return { transforms, topics, topicsToDatatypes };
     }
 
     render() {

--- a/app/util/globalConstants.ts
+++ b/app/util/globalConstants.ts
@@ -34,7 +34,6 @@ export const FRAMELESS = "frameless";
 export const DEFAULT_WEBVIZ_NODE_PREFIX = "/webviz_node/";
 
 export const TRANSFORM_TOPIC = "/tf";
-export const TRANSFORM_STATIC_TOPIC = "/tf_static";
 export const DIAGNOSTIC_TOPIC = "/diagnostics";
 export const ROSOUT_TOPIC = "/rosout";
 export const SOCKET_KEY = "dataSource.websocket";
@@ -50,6 +49,7 @@ export const SENSOR_MSGS_LASER_SCAN_DATATYPE = "sensor_msgs/LaserScan";
 export const WEBVIZ_MARKER_DATATYPE = "visualization_msgs/WebvizMarker";
 export const WEBVIZ_MARKER_ARRAY_DATATYPE = "visualization_msgs/WebvizMarkerArray";
 export const FUTURE_VIZ_MSGS_DATATYPE = "future_visualization_msgs/WebvizMarkerArray";
+export const TRANSFORM_STAMPED_DATATYPE = "geometry_msgs/TransformStamped";
 export const TF_DATATYPE = "tf/tfMessage";
 export const TF2_DATATYPE = "tf2_msgs/TFMessage";
 export const VELODYNE_SCAN_DATATYPE = "velodyne_msgs/VelodyneScan";


### PR DESCRIPTION
Previously we looked for magic topic names of `/tf` and `/tf_static` to collect all incoming transforms for the 3D panel. This switches from topic names to datatypes, subscribing to any topic with a supported TF datatype and extracting transforms each frame.