### PR TITLE
Bump electron to 13.0.0-beta.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "colors": "1.4.0",
     "crypto-browserify": "3.12.0",
     "css-loader": "5.2.1",
-    "electron": "13.0.0-beta.13",
+    "electron": "13.0.0-beta.17",
     "electron-builder": "22.10.5",
     "electron-devtools-installer": "3.1.1",
     "electron-notarize": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10464,16 +10464,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:13.0.0-beta.13":
-  version: 13.0.0-beta.13
-  resolution: "electron@npm:13.0.0-beta.13"
+"electron@npm:13.0.0-beta.17":
+  version: 13.0.0-beta.17
+  resolution: "electron@npm:13.0.0-beta.17"
   dependencies:
     "@electron/get": ^1.0.1
     "@types/node": ^14.6.2
     extract-zip: ^1.0.3
   bin:
     electron: cli.js
-  checksum: 99ce33b5c6e6ba1e2b4b10026df84851280df57c49b7e8077090d18ce4a4ffcc1a18c363ed9c2160f29e34f3ed8e8c1b1168d9757d1262c6bba85eefc48dcdf1
+  checksum: ac108cff59707f74b84a4c9246e4404da1f8774651f502aa69cada795653ad3fd4c0570e24a9bf8021b624665173f6b467a863f55e801a05531aeffc8a8a21f2
   languageName: node
   linkType: hard
 
@@ -12122,7 +12122,7 @@ __metadata:
     colors: 1.4.0
     crypto-browserify: 3.12.0
     css-loader: 5.2.1
-    electron: 13.0.0-beta.13
+    electron: 13.0.0-beta.17
     electron-builder: 22.10.5
     electron-devtools-installer: 3.1.1
     electron-notarize: 1.0.0


### PR DESCRIPTION
The last few beta releases of Electron v13 have been failing integration tests.