### PR TITLE
Remove magic app constants

### DIFF
--- a/app/components/Preferences.tsx
+++ b/app/components/Preferences.tsx
@@ -17,6 +17,7 @@ import moment from "moment-timezone";
 import { useCallback, useMemo, useState } from "react";
 
 import { ExperimentalFeatureSettings } from "@foxglove-studio/app/components/ExperimentalFeatureSettings";
+import { APP_NAME } from "@foxglove-studio/app/constants";
 import { useAsyncAppConfigurationValue } from "@foxglove-studio/app/hooks/useAsyncAppConfigurationValue";
 import filterMap from "@foxglove-studio/app/util/filterMap";
 import fuzzyFilter from "@foxglove-studio/app/util/fuzzyFilter";

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import packageJson from "../package.json";
+
+export const APP_NAME: string = packageJson.productName;
+export const APP_VERSION: string = packageJson.version;
+export const APP_HOMEPAGE: string = packageJson.homepage;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -9,6 +9,7 @@ import "@foxglove-studio/app/styles/global.scss";
 
 import App from "@foxglove-studio/app/App";
 import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
+import { APP_VERSION } from "@foxglove-studio/app/constants";
 import installDevtoolsFormatters from "@foxglove-studio/app/util/installDevtoolsFormatters";
 import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
 import overwriteFetch from "@foxglove-studio/app/util/overwriteFetch";

--- a/app/panels/WelcomePanel/index.tsx
+++ b/app/panels/WelcomePanel/index.tsx
@@ -18,6 +18,7 @@ import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import TextContent from "@foxglove-studio/app/components/TextContent";
 import TextField from "@foxglove-studio/app/components/TextField";
+import { APP_NAME } from "@foxglove-studio/app/constants";
 import { usePlayerSelection } from "@foxglove-studio/app/context/PlayerSelectionContext";
 import { useAsyncAppConfigurationValue } from "@foxglove-studio/app/hooks/useAsyncAppConfigurationValue";
 import subscribeToNewsletter from "@foxglove-studio/app/panels/WelcomePanel/subscribeToNewsletter";

--- a/desktop/index.ts
+++ b/desktop/index.ts
@@ -28,17 +28,17 @@ import { autoUpdater } from "electron-updater";
 import fs from "fs";
 import path from "path";
 
+import { APP_NAME, APP_VERSION, APP_HOMEPAGE } from "@foxglove-studio/app/constants";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import Logger from "@foxglove/log";
 
-import packageJson from "../package.json";
 import { installMenuInterface } from "./menu";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
 const log = Logger.getLogger(__filename);
 
-log.info(`${packageJson.productName} ${packageJson.version}`);
+log.info(`${APP_NAME} ${APP_VERSION}`);
 
 const isMac = process.platform === "darwin";
 const isProduction = process.env.NODE_ENV === "production";
@@ -115,11 +115,11 @@ async function createWindow(): Promise<void> {
   const mainWindow = new BrowserWindow(windowOptions);
 
   app.setAboutPanelOptions({
-    applicationName: packageJson.productName,
+    applicationName: APP_NAME,
     applicationVersion: APP_VERSION,
     version: process.platform,
     copyright: undefined,
-    website: packageJson.homepage,
+    website: APP_HOMEPAGE,
     iconPath: undefined,
   });
 
@@ -364,7 +364,7 @@ app.on("ready", async () => {
   // Only stable builds check for automatic updates
   if (process.env.NODE_ENV !== "production") {
     log.info("Automatic updates disabled (development environment)");
-  } else if (/-(dev|nightly)/.test(packageJson.version)) {
+  } else if (/-(dev|nightly)/.test(APP_VERSION)) {
     log.info("Automatic updates disabled (development build)");
   } else {
     autoUpdater.checkForUpdatesAndNotify().catch((err) => {

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -9,15 +9,15 @@ import os from "os";
 
 import type { OsContext, OsContextForwardedEvent } from "@foxglove-studio/app/OsContext";
 import { NetworkInterface } from "@foxglove-studio/app/OsContext";
+import { APP_NAME, APP_VERSION } from "@foxglove-studio/app/constants";
 import { PreloaderSockets } from "@foxglove/electron-socket/preloader";
 import Logger from "@foxglove/log";
 
-import packageJson from "../package.json";
 import LocalFileStorage from "./LocalFileStorage";
 
 const log = Logger.getLogger(__filename);
 
-log.info(`${packageJson.productName} ${packageJson.version}`);
+log.info(`${APP_NAME} ${APP_VERSION}`);
 log.info(`initializing preloader, argv="${window.process.argv.join(" ")}"`);
 
 // Load opt-out settings for crash reporting and telemetry
@@ -114,7 +114,7 @@ const ctx: OsContext = {
     return machineIdSync();
   },
   getAppVersion: (): string => {
-    return packageJson.version;
+    return APP_VERSION;
   },
 
   // Context bridge cannot expose "classes" only exposes functions

--- a/typings/webpack-defines.d.ts
+++ b/typings/webpack-defines.d.ts
@@ -3,6 +3,4 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 // Should match DefinePlugin in webpack configuration
-declare const APP_NAME: string;
-declare const APP_VERSION: string;
 declare const ReactNull: ReactNull;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,7 +8,7 @@ import path from "path";
 import type { Configuration } from "webpack";
 import type { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
 
-import packageInfo from "./package.json";
+import packageJson from "./package.json";
 import main from "./webpack.main.config";
 import preload from "./webpack.preload.config";
 import renderer from "./webpack.renderer.config";
@@ -52,13 +52,13 @@ const devServerConfig: WebpackConfiguration = {
       filename: "package.json",
       templateContent: JSON.stringify({
         main: "main/main.js",
-        name: packageInfo.name,
-        productName: packageInfo.productName,
-        version: packageInfo.version,
-        description: packageInfo.description,
-        productDescription: packageInfo.productDescription,
-        license: packageInfo.license,
-        author: packageInfo.author,
+        name: packageJson.name,
+        productName: packageJson.productName,
+        version: packageJson.version,
+        description: packageJson.description,
+        productDescription: packageJson.productDescription,
+        license: packageJson.license,
+        author: packageJson.author,
       }),
     }),
   ],

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -7,7 +7,6 @@ import path from "path";
 import { Configuration, ResolveOptions, DefinePlugin, EnvironmentPlugin } from "webpack";
 
 import { WebpackArgv } from "./WebpackArgv";
-import packageJson from "./package.json";
 
 export default (_: unknown, argv: WebpackArgv): Configuration => {
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
@@ -73,9 +72,6 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
     plugins: [
       new DefinePlugin({
         MAIN_WINDOW_WEBPACK_ENTRY: rendererEntry,
-        // Should match webpack-defines.d.ts
-        APP_NAME: JSON.stringify(packageJson.productName),
-        APP_VERSION: JSON.stringify(packageJson.version),
       }),
       new EnvironmentPlugin({
         SENTRY_DSN: process.env.SENTRY_DSN ?? null, // eslint-disable-line no-restricted-syntax

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -17,7 +17,6 @@ import webpack, {
 } from "webpack";
 
 import { WebpackArgv } from "./WebpackArgv";
-import packageJson from "./package.json";
 
 const styledComponentsTransformer = createStyledComponentsTransformer({
   getDisplayName: (filename, bindingName) => {
@@ -214,8 +213,6 @@ export function makeConfig(_: unknown, argv: WebpackArgv, options?: Options): Co
       }),
       new webpack.DefinePlugin({
         // Should match webpack-defines.d.ts
-        APP_NAME: JSON.stringify(packageJson.productName),
-        APP_VERSION: JSON.stringify(packageJson.version),
         ReactNull: null, // eslint-disable-line no-restricted-syntax
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales


### PR DESCRIPTION
Remove magic `APP_NAME` and `APP_VERSION` from Webpack DefinePlugin, since they were defined in 3 places (renderer/main/preload webpack configs) and sometimes causing production errors due to being defined in one file and not others.

Now they are normal typed constants imported directly.