### PR TITLE
Register studio as a url handler for foxglove:// files

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -77,6 +77,9 @@ export interface OsContext {
   // Get the version string from package.json
   getAppVersion: () => string;
 
+  // Get an array of deep links provided on app launch
+  getDeepLinks: () => string[];
+
   // file backed key/value storage
   storage: Storage;
 }

--- a/app/components/PlayerManager.tsx
+++ b/app/components/PlayerManager.tsx
@@ -434,7 +434,9 @@ function PlayerManager({
     try {
       const url = new URL(firstLink);
       // only support the open command
-      if (url.pathname !== "//open") {
+
+      // Test if the pathname matches //open or //open/
+      if (!/\/\/open\/?/.test(url.pathname)) {
         return;
       }
 

--- a/app/components/PlayerManager.tsx
+++ b/app/components/PlayerManager.tsx
@@ -14,6 +14,7 @@
 import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useAsync, useLocalStorage, useMountedState } from "react-use";
+import { URL } from "universal-url";
 
 import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
 import {
@@ -422,6 +423,32 @@ function PlayerManager({
         return;
     }
   }, []);
+
+  useEffect(() => {
+    const links = OsContextSingleton?.getDeepLinks() ?? [];
+    const firstLink = links[0];
+    if (firstLink == undefined) {
+      return;
+    }
+
+    try {
+      const url = new URL(firstLink);
+      // only support the open command
+      if (url.pathname !== "//open") {
+        return;
+      }
+
+      // only support rosbag urls
+      const type = url.searchParams.get("type");
+      const bagUrl = url.searchParams.get("url");
+      if (type !== "rosbag" || bagUrl == undefined) {
+        return;
+      }
+      setPlayer(async (options: BuildPlayerOptions) => buildPlayerFromBagURLs([bagUrl], options));
+    } catch (err) {
+      log.error(err);
+    }
+  }, [setPlayer]);
 
   // The first time we load a source, we restore the previous source state (i.e. url)
   // and try to automatically load the source.

--- a/desktop/StudioWindow.ts
+++ b/desktop/StudioWindow.ts
@@ -1,0 +1,400 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  app,
+  BrowserWindow,
+  BrowserWindowConstructorOptions,
+  Menu,
+  MenuItemConstructorOptions,
+  shell,
+  systemPreferences,
+  MenuItem,
+} from "electron";
+import path from "path";
+
+import { APP_NAME } from "@foxglove-studio/app/constants";
+import colors from "@foxglove-studio/app/styles/colors.module.scss";
+import Logger from "@foxglove/log";
+
+import { simulateUserClick } from "./simulateUserClick";
+import { getTelemetrySettings } from "./telemetry";
+
+declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
+
+const isMac = process.platform === "darwin";
+const isProduction = process.env.NODE_ENV === "production";
+const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
+
+const closeMenuItem: MenuItemConstructorOptions = isMac ? { role: "close" } : { role: "quit" };
+
+const log = Logger.getLogger(__filename);
+
+function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
+  const [allowCrashReporting, allowTelemetry] = getTelemetrySettings();
+
+  const preloadPath = path.join(app.getAppPath(), "main", "preload.js");
+
+  const windowOptions: BrowserWindowConstructorOptions = {
+    height: 800,
+    width: 1200,
+    autoHideMenuBar: true,
+    title: APP_NAME,
+    webPreferences: {
+      contextIsolation: true,
+      preload: preloadPath,
+      nodeIntegration: false,
+      additionalArguments: [
+        `--allowCrashReporting=${allowCrashReporting ? "1" : "0"}`,
+        `--allowTelemetry=${allowTelemetry ? "1" : "0"}`,
+        ...deepLinks,
+      ],
+      // Disable webSecurity in development so we can make XML-RPC calls, load
+      // remote data, etc. In production, the app is served from file:// URLs so
+      // the Origin header is not sent, disabling the CORS
+      // Access-Control-Allow-Origin check
+      webSecurity: isProduction,
+    },
+    backgroundColor: colors.background,
+  };
+  if (isMac) {
+    windowOptions.titleBarStyle = "hiddenInset";
+  }
+
+  const browserWindow = new BrowserWindow(windowOptions);
+
+  // Forward full screen events to the renderer
+  browserWindow.addListener("enter-full-screen", () =>
+    browserWindow.webContents.send("enter-full-screen"),
+  );
+
+  browserWindow.addListener("leave-full-screen", () =>
+    browserWindow.webContents.send("leave-full-screen"),
+  );
+
+  browserWindow.webContents.once("dom-ready", () => {
+    if (!isProduction) {
+      browserWindow.webContents.openDevTools();
+    }
+  });
+
+  // Open all new windows in an external browser
+  // Note: this API is supposed to be superseded by webContents.setWindowOpenHandler,
+  // but using that causes the app to freeze when a new window is opened.
+  browserWindow.webContents.on("new-window", (event, url) => {
+    event.preventDefault();
+    shell.openExternal(url);
+  });
+
+  browserWindow.webContents.on("ipc-message", (_event: unknown, channel: string) => {
+    if (channel === "window.toolbar-double-clicked") {
+      const action: string =
+        systemPreferences.getUserDefault?.("AppleActionOnDoubleClick", "string") || "Maximize";
+      if (action === "Minimize") {
+        browserWindow.minimize();
+      } else if (action === "Maximize") {
+        browserWindow.isMaximized() ? browserWindow.unmaximize() : browserWindow.maximize();
+      } else {
+        // "None"
+      }
+    }
+  });
+
+  return browserWindow;
+}
+
+function buildMenu(browserWindow: BrowserWindow): Menu {
+  const menuTemplate: MenuItemConstructorOptions[] = [];
+
+  if (isMac) {
+    menuTemplate.push({
+      role: "appMenu",
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        {
+          label: "Preferences…",
+          accelerator: "CommandOrControl+,",
+          click: () => browserWindow.webContents.send("open-preferences"),
+        },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    });
+  }
+
+  menuTemplate.push({
+    role: "fileMenu",
+    label: "File",
+    id: "fileMenu",
+    submenu: [
+      {
+        label: "New Window",
+        click: () => {
+          new StudioWindow();
+        },
+      },
+      { type: "separator" },
+      closeMenuItem,
+    ],
+  });
+
+  menuTemplate.push({
+    role: "editMenu",
+    label: "Edit",
+    submenu: [
+      {
+        label: "Undo",
+        accelerator: "CommandOrControl+Z",
+        click: () => browserWindow.webContents.send("undo"),
+      },
+      {
+        label: "Redo",
+        accelerator: "CommandOrControl+Shift+Z",
+        click: () => browserWindow.webContents.send("redo"),
+      },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      ...(isMac
+        ? [
+            { role: "pasteAndMatchStyle" } as const,
+            { role: "delete" } as const,
+            { role: "selectAll" } as const,
+          ]
+        : [
+            { role: "delete" } as const,
+            { type: "separator" } as const,
+            { role: "selectAll" } as const,
+          ]),
+    ],
+  });
+
+  const showSharedWorkersMenu = () => {
+    // Electron doesn't let us update dynamic menus when they are being opened, so just open a popup
+    // context menu. This is ugly, but only for development anyway.
+    // https://github.com/electron/electron/issues/528
+    const workers = browserWindow.webContents.getAllSharedWorkers();
+    Menu.buildFromTemplate(
+      workers.length === 0
+        ? [{ label: "No Shared Workers", enabled: false }]
+        : workers.map(
+            (worker) =>
+              new MenuItem({
+                label: worker.url,
+                click() {
+                  browserWindow.webContents.closeDevTools();
+                  browserWindow.webContents.inspectSharedWorkerById(worker.id);
+                },
+              }),
+          ),
+    ).popup();
+  };
+
+  menuTemplate.push({
+    role: "viewMenu",
+    label: "View",
+    submenu: [
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+      { type: "separator" },
+      {
+        label: "Advanced",
+        submenu: [
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          {
+            label: "Inspect Shared Worker…",
+            click() {
+              showSharedWorkersMenu();
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  menuTemplate.push({
+    role: "help",
+    submenu: [
+      {
+        label: "Welcome",
+        click: () => browserWindow.webContents.send("open-welcome-layout"),
+      },
+      {
+        label: "Message Path Syntax",
+        click: () => browserWindow.webContents.send("open-message-path-syntax-help"),
+      },
+      {
+        label: "Keyboard Shortcuts",
+        accelerator: "CommandOrControl+/",
+        click: () => browserWindow.webContents.send("open-keyboard-shortcuts"),
+      },
+      {
+        label: "Learn More",
+        click: async () => shell.openExternal("https://foxglove.dev"),
+      },
+    ],
+  });
+
+  return Menu.buildFromTemplate(menuTemplate);
+}
+
+class StudioWindow {
+  // track windows by the web-contents id
+  // The web contents id is most broadly available across IPC events and app handlers
+  // BrowserWindow.id is not as available
+  private static windowsByContentId = new Map<number, StudioWindow>();
+
+  private _window: BrowserWindow;
+  private _menu: Menu;
+
+  private _inputSources = new Set<string>();
+
+  constructor(deepLinks: string[] = []) {
+    const browserWindow = newStudioWindow(deepLinks);
+    this._window = browserWindow;
+    this._menu = buildMenu(browserWindow);
+
+    const id = browserWindow.webContents.id;
+
+    log.info(`New studio window ${id}`);
+    StudioWindow.windowsByContentId.set(id, this);
+
+    // when a window closes and it is the current application menu, clear the input sources
+    browserWindow.once("close", () => {
+      if (Menu.getApplicationMenu() === this._menu) {
+        const existingMenu = Menu.getApplicationMenu();
+        const fileMenu = existingMenu?.getMenuItemById("fileMenu");
+        (fileMenu?.submenu as any)?.clear();
+        fileMenu?.submenu?.append(
+          new MenuItem({
+            label: "New Window",
+            click: () => {
+              new StudioWindow();
+            },
+          }),
+        );
+
+        fileMenu?.submenu?.append(
+          new MenuItem({
+            type: "separator",
+          }),
+        );
+
+        fileMenu?.submenu?.append(new MenuItem(closeMenuItem));
+        Menu.setApplicationMenu(existingMenu);
+      }
+    });
+    browserWindow.once("closed", () => {
+      StudioWindow.windowsByContentId.delete(id);
+    });
+
+    // load after setting windowsById so any ipc handlers with id lookup work
+    log.info(`window.loadURL(${rendererPath})`);
+    browserWindow.loadURL(rendererPath).then(() => log.info("window URL loaded"));
+  }
+
+  addInputSource(name: string): void {
+    this._inputSources.add(name);
+
+    const fileMenu = this._menu.getMenuItemById("fileMenu");
+    if (!fileMenu) {
+      return;
+    }
+
+    const existingItem = fileMenu.submenu?.getMenuItemById(name);
+    // If the item already exists, we can silently return
+    // The existing click handler will support the new item since they have the same name
+    if (existingItem) {
+      existingItem.visible = true;
+      return;
+    }
+
+    // build new file menu
+    this.rebuildFileMenu(fileMenu);
+
+    this._window.setMenu(this._menu);
+  }
+
+  removeInputSource(name: string): void {
+    this._inputSources.delete(name);
+
+    const fileMenu = this._menu?.getMenuItemById("fileMenu");
+    if (!fileMenu) {
+      return;
+    }
+
+    this.rebuildFileMenu(fileMenu);
+    this._window.setMenu(this._menu);
+  }
+
+  getBrowserWindow(): BrowserWindow {
+    return this._window;
+  }
+
+  getMenu(): Menu {
+    return this._menu;
+  }
+
+  static fromWebContentsId(id: number): StudioWindow | undefined {
+    return StudioWindow.windowsByContentId.get(id);
+  }
+
+  private rebuildFileMenu(fileMenu: MenuItem): void {
+    const browserWindow = this._window;
+
+    (fileMenu.submenu as any).clear();
+    fileMenu.submenu?.items.splice(0, fileMenu.submenu.items.length);
+
+    fileMenu.submenu?.append(
+      new MenuItem({
+        label: "New Window",
+        click: () => {
+          new StudioWindow();
+        },
+      }),
+    );
+
+    fileMenu.submenu?.append(
+      new MenuItem({
+        type: "separator",
+      }),
+    );
+
+    for (const sourceName of this._inputSources) {
+      fileMenu.submenu?.append(
+        new MenuItem({
+          label: `Open ${sourceName}`,
+          click: async () => {
+            await simulateUserClick(browserWindow);
+            browserWindow.webContents.send("menu.click-input-source", sourceName);
+          },
+        }),
+      );
+    }
+
+    fileMenu.submenu?.append(
+      new MenuItem({
+        type: "separator",
+      }),
+    );
+
+    fileMenu.submenu?.append(new MenuItem(closeMenuItem));
+  }
+}
+
+export default StudioWindow;

--- a/desktop/menu.ts
+++ b/desktop/menu.ts
@@ -2,76 +2,46 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { BrowserWindow, ipcMain, Menu, MenuItem } from "electron";
+import { ipcMain, Menu } from "electron";
 
-import { simulateUserClick } from "./simulateUserClick";
+import StudioWindow from "./StudioWindow";
 
 // Install handlers for ipc menu add and remove events
 // These handlers allow for the preload/renderer to manage the list of "File Open ..." items.
 export function installMenuInterface(): void {
   ipcMain.removeHandler("menu.add-input-source");
-  ipcMain.handle("menu.add-input-source", (_ev: unknown, ...args) => {
+  ipcMain.handle("menu.add-input-source", (ev, ...args) => {
     const name = args[0];
     if (typeof name !== "string") {
       throw new Error("menu.add-input-source argument 'name' must be a string");
     }
 
-    const appMenu = Menu.getApplicationMenu();
-    const fileMenu = appMenu?.getMenuItemById("fileMenu");
-    if (!fileMenu) {
-      return;
+    const studioWindow = StudioWindow.fromWebContentsId(ev.sender.id);
+    if (!studioWindow) {
+      throw new Error(`Could not find window for id ${ev.sender.id}`);
     }
 
-    const existingItem = fileMenu.submenu?.getMenuItemById(name);
-    // If the item already exists, we can silently return
-    // The existing click handler will support the new item since they have the same name
-    if (existingItem) {
-      existingItem.visible = true;
-      Menu.setApplicationMenu(appMenu);
-      return;
+    studioWindow.addInputSource(name);
+    if (studioWindow.getBrowserWindow().isFocused()) {
+      Menu.setApplicationMenu(studioWindow.getMenu());
     }
-
-    const idx = fileMenu.submenu?.items.findIndex((item) => {
-      return item.role === "close" || item.role === "quit";
-    });
-    if (idx === undefined || idx < 0) {
-      return;
-    }
-
-    fileMenu.submenu?.insert(
-      idx,
-      new MenuItem({
-        label: `Open ${name}`,
-        id: name,
-        click: async () => {
-          const focusedWindow = BrowserWindow.getFocusedWindow();
-          if (!focusedWindow) {
-            return;
-          }
-
-          await simulateUserClick(focusedWindow);
-          focusedWindow.webContents.send("menu.click-input-source", name);
-        },
-      }),
-    );
-    Menu.setApplicationMenu(appMenu);
   });
 
   ipcMain.removeHandler("menu.remove-input-source");
-  ipcMain.handle("menu.remove-input-source", (_ev: unknown, ...args) => {
+  ipcMain.handle("menu.remove-input-source", (ev, ...args) => {
     const name = args[0];
     if (typeof name !== "string") {
       throw new Error("menu.add-input-source argument 'name' must be a string");
     }
 
-    const appMenu = Menu.getApplicationMenu();
-    const fileMenu = appMenu?.getMenuItemById("fileMenu");
-
-    const menuItem = fileMenu?.submenu?.getMenuItemById(name);
-    if (menuItem) {
-      menuItem.visible = false;
+    const studioWindow = StudioWindow.fromWebContentsId(ev.sender.id);
+    if (!studioWindow) {
+      throw new Error(`Could not find window for id ${ev.sender.id}`);
     }
 
-    Menu.setApplicationMenu(appMenu);
+    studioWindow.removeInputSource(name);
+    if (studioWindow.getBrowserWindow().isFocused()) {
+      Menu.setApplicationMenu(studioWindow.getMenu());
+    }
   });
 }

--- a/desktop/telemetry.ts
+++ b/desktop/telemetry.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { app } from "electron";
+import fs from "fs";
+import path from "path";
+
+function getTelemetrySettings(): [crashReportingEnabled: boolean, telemetryEnabled: boolean] {
+  const datastoreDir = path.join(app.getPath("userData"), "studio-datastores", "settings");
+  const settingsPath = path.join(datastoreDir, "settings.json");
+  let crashReportingEnabled = true;
+  let telemetryEnabled = true;
+
+  try {
+    fs.mkdirSync(datastoreDir, { recursive: true });
+  } catch {
+    // Ignore directory creation errors, including dir already exists
+  }
+
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, { encoding: "utf8" }));
+    crashReportingEnabled = settings["telemetry.crashReportingEnabled"] ?? true;
+    telemetryEnabled = settings["telemetry.telemetryEnabled"] ?? true;
+  } catch {
+    // Ignore file load or parsing errors, including settings.json not existing
+  }
+
+  return [crashReportingEnabled, telemetryEnabled];
+}
+
+export { getTelemetrySettings };

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -10,6 +10,12 @@
   "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
   "afterSign": "resources/notarize.ts",
   "icon": "resources/icon/icon.icns",
+  "protocols": [
+    {
+      "name": "foxglove",
+      "schemes": ["foxglove"]
+    }
+  ],
   "linux": {
     "target": [
       {
@@ -56,6 +62,12 @@
           "LSHandlerRank": "Default",
           "CFBundleTypeIconSystemGenerated": 1,
           "LSItemContentTypes": ["org.ros.bag"]
+        }
+      ],
+      "CFBundleURLTypes": [
+        {
+          "CFBundleURLSchemes": ["foxglove"],
+          "CFBundleTypeRole": "Viewer"
         }
       ],
       "UTImportedTypeDeclarations": [

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -117,6 +117,10 @@ const ctx: OsContext = {
     return APP_VERSION;
   },
 
+  getDeepLinks: (): string[] => {
+    return window.process.argv.filter((arg) => arg.startsWith("foxglove://"));
+  },
+
   // Context bridge cannot expose "classes" only exposes functions
   // We use .bind to attach the localFileStorage instance as _this_ to the function
   storage: {


### PR DESCRIPTION
This change adds support for foxglove:// urls and `File -> New Window`.

`foxglove://` url support provides a way for hyperlinks links to invoke actions into the studio app. Such actions could include features like loading a bag file and jumping to a particular time, loading specific layouts, etc.

The first supported link is `foxglove://open?type=rosbag&url=http://...`. Clicking the link will inform studio to open the remote bag file.

Here is what a link to our demo bag would look like.
`foxglove://open?type=rosbag&url=https://storage.googleapis.com/foxglove-public-assets/demo.bag`