### PR TITLE
Allow higher zoom level for map panel

### DIFF
--- a/app/panels/Map/index.tsx
+++ b/app/panels/Map/index.tsx
@@ -156,6 +156,8 @@ function MapPanel(props: Props) {
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          maxNativeZoom={18}
+          maxZoom={24}
         />
         <FilteredPointMarkers messages={navMessages} blocks={blocks} />
       </MapContainer>


### PR DESCRIPTION
Once the user zooms beyond the time resolution tiles images are interpolated.
The resulting tile images are blurry but the user can continue to zoom in.

![image](https://user-images.githubusercontent.com/84792/115172449-2741a580-a07a-11eb-9491-80764f8d6131.png)
