### PR TITLE
Set sample-robot-docker hostname

### DIFF
--- a/packages/ros1-turtlesim-test/sample-robot-docker/start-robot.sh
+++ b/packages/ros1-turtlesim-test/sample-robot-docker/start-robot.sh
@@ -20,6 +20,7 @@ docker run \
   -it \
   --rm \
   --sysctl net.ipv4.ip_local_port_range="${MIN_PORT} ${MAX_PORT}" \
+  --hostname ${HOSTNAME} \
   -e ROS_MASTER_URI="http://${HOSTNAME}:${ROSCORE_PORT}/" \
   -e ROS_HOSTNAME="${HOSTNAME}" \
   -p ${ROSCORE_PORT}-${MAX_PORT}:${ROSCORE_PORT}-${MAX_PORT} \


### PR DESCRIPTION
This fixes the ROS node running in the Docker container not being able to connect to rosmaster now that ROS_MASTER_URI is set to $HOSTNAME. This means rosmaster won't be able to contact the Foxglove Studio XML-RPC server running on the host, but there doesn't seem to be an easy workaround for that (without --net=host) other than using a VM instead of a container.
