### PR TITLE
All packages inherit from tsconfig.base.json

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,17 +1,26 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "./**/*",
+    "./**/*.json",
+    "./.storybook/**/*",
+    "../package.json",
+    "../typings/*.d.ts",
+    // Webpack config is imported by Storybook
+    "../webpack.*.config.ts",
+    "../WebpackArgv.ts"
+  ],
   "compilerOptions": {
-    "baseUrl": ".",
-    "module": "es2020",
+    "noEmit": true,
+    "rootDir": "../",
     "jsx": "react-jsx",
-    "lib": ["DOM", "DOM.Iterable", "es2020"],
+    "lib": ["dom", "dom.iterable", "es2020"],
     "paths": {
+      // Storybook breaks without this
       "micro-memoize": ["../typings/micro-memoize"],
-      "@foxglove-studio/app/*": ["*"]
-    }
-  },
-  "typeAcquisition": {
-    "exclude": ["node"]
-  },
-  "include": ["**/*", "../typings/*.d.ts", ".storybook/*"]
+      // This is only needed for vscode import suggestions
+      "@foxglove-studio/app/*": ["./*"]
+    },
+    "noUnusedParameters": false
+  }
 }

--- a/ci/tsconfig.json
+++ b/ci/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "lib": ["es2020"]
-  },
-  "include": ["*.ts"]
-}

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,4 +1,7 @@
 {
-  "extends": "../tsconfig.json",
-  "include": ["**/*", "../typings/*.d.ts"]
+  "extends": "../tsconfig.base.json",
+  "include": ["./**/*", "../typings/*.d.ts"],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }

--- a/packages/electron-socket/tsconfig.json
+++ b/packages/electron-socket/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["./*.ts", "./src/**/*"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "lib": ["es2020", "dom"],
-    "composite": true,
-    "noUnusedParameters": true,
-    "noEmit": true
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["dom", "es2020"]
   }
 }

--- a/packages/just-fetch/tsconfig.json
+++ b/packages/just-fetch/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "commonjs",
-    "lib": ["dom", "es2020"],
-    "declaration": true,
-    "rootDir": "."
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["dom", "es2020"]
   }
 }

--- a/packages/log/tsconfig.json
+++ b/packages/log/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "test/**/*.ts", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "noEmit": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   }
 }

--- a/packages/ros1-turtlesim-test/tsconfig.json
+++ b/packages/ros1-turtlesim-test/tsconfig.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "commonjs",
-    "lib": ["es2020"],
-    "declaration": true,
     "rootDir": "./src",
-    "noUnusedParameters": true,
-    "noEmit": true
-  }
+    "outDir": "./dist"
+  },
+  "references": [{ "path": "../ros1" }, { "path": "../xmlrpc" }]
 }

--- a/packages/ros1/src/RosNode.ts
+++ b/packages/ros1/src/RosNode.ts
@@ -15,7 +15,7 @@ import { RosParamClient } from "./RosParamClient";
 import { Subscription } from "./Subscription";
 import { TcpConnection } from "./TcpConnection";
 import { TcpSocketCreate, TcpServer, TcpAddress, NetworkInterface } from "./TcpTypes";
-import { RosXmlRpcResponse, RosXmlRpcResponseOrFault } from "./XmlRpcTypes";
+import { RosXmlRpcResponse } from "./XmlRpcTypes";
 import { isEmptyPlainObject } from "./objectTests";
 
 export type RosGraph = {
@@ -247,7 +247,7 @@ export class RosNode extends EventEmitter {
     this.parameters.clear();
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i] as string;
-      const entry = res[i] as RosXmlRpcResponseOrFault;
+      const entry = res[i];
       if (entry instanceof XmlRpcFault) {
         this._log?.warn?.(`subscribeAllParams errored on "${key}" (${entry})`);
         continue;

--- a/packages/ros1/tsconfig.json
+++ b/packages/ros1/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "lib": ["es2020"],
-    "declaration": true,
-    "rootDir": ".",
-    "noUnusedParameters": true,
-    "noEmit": true
-  }
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "references": [{ "path": "../xmlrpc" }]
 }

--- a/packages/rosmsg-bobject/package.json
+++ b/packages/rosmsg-bobject/package.json
@@ -2,5 +2,9 @@
   "name": "@foxglove/rosmsg-bobject",
   "version": "0.0.0",
   "private": true,
-  "main": "./src/index.ts"
+  "main": "./src/index.ts",
+  "devDependencies": {
+    "jest": "26.6.3",
+    "typescript": "4.2.2"
+  }
 }

--- a/packages/rosmsg-bobject/tsconfig.json
+++ b/packages/rosmsg-bobject/tsconfig.json
@@ -1,8 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "test/**/*.ts", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "noEmit": true
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["dom", "es2020"]
   }
 }

--- a/packages/rosmsg-deser/package.json
+++ b/packages/rosmsg-deser/package.json
@@ -3,5 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "main": "src/index.ts",
-  "module": "src/index.ts"
+  "module": "src/index.ts",
+  "devDependencies": {
+    "jest": "26.6.3",
+    "typescript": "4.2.2"
+  }
 }

--- a/packages/rosmsg-deser/tsconfig.json
+++ b/packages/rosmsg-deser/tsconfig.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "lib": ["es2020"],
-    "noUnusedParameters": true,
-    "noEmit": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   }
 }

--- a/packages/velodyne-cloud/tsconfig.json
+++ b/packages/velodyne-cloud/tsconfig.json
@@ -1,12 +1,8 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.json", "fixtures/**/*", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*", "./src/**/*.json"],
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "commonjs",
-    "lib": ["es2020"],
-    "declaration": true,
-    "rootDir": ".",
-    "noUnusedParameters": true
+    "rootDir": "./src",
+    "outDir": "./dist"
   }
 }

--- a/packages/wasm-bz2/tsconfig.json
+++ b/packages/wasm-bz2/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["*.ts", "src/*.ts", "test/*.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "module": "es2020",
-    "lib": ["es2020", "DOM"],
-    "declaration": true,
-    "rootDir": ".",
-    "noUnusedParameters": true,
-    "noEmit": true
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["dom", "es2020"]
   }
 }

--- a/packages/xmlrpc/tsconfig.json
+++ b/packages/xmlrpc/tsconfig.json
@@ -1,12 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "jest.config.ts"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src/**/*"],
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "commonjs",
-    "lib": ["es2020"],
-    "declaration": true,
-    "rootDir": ".",
-    "noUnusedParameters": true
-  }
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "references": [{ "path": "../just-fetch" }]
 }

--- a/preload/tsconfig.json
+++ b/preload/tsconfig.json
@@ -1,4 +1,8 @@
 {
-  "extends": "../tsconfig.json",
-  "include": ["**/*", "../typings/*.d.ts"]
+  "extends": "../tsconfig.base.json",
+  "include": ["./**/*", "../typings/*.d.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["dom", "es2020"]
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,47 @@
+// Base TypeScript configuration
+// https://www.typescriptlang.org/tsconfig
+{
+  "compilerOptions": {
+    // build es2020 modules by default
+    "module": "es2020",
+    "target": "es2020",
+    "lib": ["es2020"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "importHelpers": false,
+
+    // webpack handles JS imports for us
+    "allowJs": false,
+
+    // support fast package rebuilds
+    "composite": true,
+
+    // produce consistent output across all platforms
+    "newLine": "lf",
+
+    // allow typed JSON imports
+    "resolveJsonModule": true,
+
+    // produce .js.map, .d.ts and .d.ts.map files when emit is enabled
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+
+    // recommended for faster compilation
+    "skipLibCheck": true,
+
+    // be as strict as possible, but no stricter
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // load our custom types
+    "typeRoots": ["./node_modules/@types", "./typings"]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,18 @@
+// Root tsconfig.json
+// Do not "extend" from this file, use tsconfig.base.json instead.
+// Do not "include" files here if they are already included by another tsconfig.json.
 {
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "./*.ts",
+    "./*.js",
+    "./**/jest.config.ts",
+    "./ci/**/*.ts",
+    "./test/**/*.ts",
+    "./resources/notarize.ts"
+  ],
   "compilerOptions": {
-    "target": "es2020",
     "module": "commonjs",
-    "newLine": "lf",
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true,
-    "importHelpers": true,
-    "sourceMap": true,
-    "moduleResolution": "node",
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "strict": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "typeRoots": ["node_modules/@types", "./typings"]
-  },
-  "include": ["*.ts", "*.js", "test/**/*.ts", "resources/notarize.ts"],
-  "exclude": ["node_modules"]
+    "noEmit": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2206,12 +2206,18 @@ __metadata:
 "@foxglove/rosmsg-bobject@workspace:packages/rosmsg-bobject":
   version: 0.0.0-use.local
   resolution: "@foxglove/rosmsg-bobject@workspace:packages/rosmsg-bobject"
+  dependencies:
+    jest: 26.6.3
+    typescript: 4.2.2
   languageName: unknown
   linkType: soft
 
 "@foxglove/rosmsg-deser@workspace:packages/rosmsg-deser":
   version: 0.0.0-use.local
   resolution: "@foxglove/rosmsg-deser@workspace:packages/rosmsg-deser"
+  dependencies:
+    jest: 26.6.3
+    typescript: 4.2.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- All tsconfig files inherit from new `tsconfig.base.json`
- Convert everything to ESM (except webpack.config.ts files in root which can't handle it)

Future work:
- Add missing `dependencies` and `devDepenedencies` and standardize `packages/*/package.json` files
- Add `clean`, `prepack`, and `test` scripts to `packages/*/package.json` files
- Point package.json `main` to compiled JS files and have webpack use typescript project references (if jest can support this)