### PR TITLE
Remove unnecessary .eslintrc.yaml files from packages

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -36,7 +36,9 @@ parserOptions:
 
   ecmaVersion: 12
   sourceType: module
-  project: tsconfig.json
+  project:
+    - "./tsconfig.json"
+    - "./packages/**/tsconfig.json"
 
 settings:
   react:

--- a/packages/electron-socket/.eslintrc.yaml
+++ b/packages/electron-socket/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/electron-socket/tsconfig.json

--- a/packages/just-fetch/.eslintrc.yaml
+++ b/packages/just-fetch/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/just-fetch/tsconfig.json

--- a/packages/just-fetch/browser/.eslintrc.yaml
+++ b/packages/just-fetch/browser/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/just-fetch/browser/tsconfig.json

--- a/packages/log/.eslintrc.yaml
+++ b/packages/log/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/log/tsconfig.json

--- a/packages/ros1-turtlesim-test/.eslintrc.yaml
+++ b/packages/ros1-turtlesim-test/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/ros1-turtlesim-test/tsconfig.json

--- a/packages/ros1/.eslintrc.yaml
+++ b/packages/ros1/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/ros1/tsconfig.json

--- a/packages/rosmsg-bobject/.eslintrc.yaml
+++ b/packages/rosmsg-bobject/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/rosmsg-bobject/tsconfig.json

--- a/packages/rosmsg-deser/.eslintrc.yaml
+++ b/packages/rosmsg-deser/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/rosmsg-deser/tsconfig.json

--- a/packages/velodyne-cloud/.eslintrc.yaml
+++ b/packages/velodyne-cloud/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/velodyne-cloud/tsconfig.json

--- a/packages/wasm-bz2/.eslintrc.yaml
+++ b/packages/wasm-bz2/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/wasm-bz2/tsconfig.json

--- a/packages/xmlrpc/.eslintrc.yaml
+++ b/packages/xmlrpc/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: packages/xmlrpc/tsconfig.json


### PR DESCRIPTION
Another extraction from https://github.com/foxglove/studio/pull/618.

It's not necessary to have an eslintrc in each directory. Instead, we reference all `tsconfig.json` files from the root eslintrc. This is documented at https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/MONOREPO.md