### PR TITLE
Load tsconfig.json files from root eslintrc

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -31,14 +31,9 @@ extends:
 
 parser: "@typescript-eslint/parser"
 parserOptions:
-  ecmaFeatures:
-    jsx: true
-
-  ecmaVersion: 12
+  ecmaVersion: 2020
   sourceType: module
-  project:
-    - "./tsconfig.json"
-    - "./packages/**/tsconfig.json"
+  project: ./**/tsconfig.json
 
 settings:
   react:

--- a/app/.eslintrc.yaml
+++ b/app/.eslintrc.yaml
@@ -1,5 +1,3 @@
-parserOptions:
-  project: app/tsconfig.json
 settings:
   import/resolver:
     webpack:

--- a/ci/.eslintrc.yaml
+++ b/ci/.eslintrc.yaml
@@ -1,2 +1,0 @@
-parserOptions:
-  project: ci/tsconfig.json

--- a/desktop/.eslintrc.yaml
+++ b/desktop/.eslintrc.yaml
@@ -1,5 +1,3 @@
-parserOptions:
-  project: desktop/tsconfig.json
 settings:
   import/resolver:
     webpack:

--- a/preload/.eslintrc.yaml
+++ b/preload/.eslintrc.yaml
@@ -1,5 +1,3 @@
-parserOptions:
-  project: preload/tsconfig.json
 settings:
   import/resolver:
     webpack:


### PR DESCRIPTION
Remove unnecessary `parserOptions.project` in `.eslintrc.yaml` files. Instead, we specify all tsconfig files in the root `.eslintrc.yaml`.

I also deleted a bunch in https://github.com/foxglove/studio/pull/620, this is just remaining cleanup.

Fewer configuration files and overridden settings is easier to understand.