### PR TITLE
Use app timezone setting in playback bar

### DIFF
--- a/app/components/PlaybackControls/index.stories.tsx
+++ b/app/components/PlaybackControls/index.stories.tsx
@@ -18,6 +18,9 @@ import TestUtils from "react-dom/test-utils";
 
 import { setPlaybackConfig } from "@foxglove-studio/app/actions/panels";
 import MockMessagePipelineProvider from "@foxglove-studio/app/components/MessagePipeline/MockMessagePipelineProvider";
+import AppConfigurationContext, {
+  AppConfiguration,
+} from "@foxglove-studio/app/context/AppConfigurationContext";
 import {
   PlayerCapabilities,
   PlayerPresence,
@@ -58,6 +61,13 @@ function getPlayerState(): PlayerState {
   return player;
 }
 
+const mockAppConfiguration: AppConfiguration = {
+  get: async () => undefined,
+  set: async () => {},
+  addChangeListener: () => {},
+  removeChangeListener: () => {},
+};
+
 function Wrapper({
   activeData,
   children,
@@ -68,13 +78,15 @@ function Wrapper({
   store?: any;
 }) {
   return (
-    <MockMessagePipelineProvider
-      capabilities={["setSpeed", "playbackControl"]}
-      store={store}
-      activeData={activeData}
-    >
-      <div style={{ padding: 20, margin: 100 }}>{children}</div>
-    </MockMessagePipelineProvider>
+    <AppConfigurationContext.Provider value={mockAppConfiguration}>
+      <MockMessagePipelineProvider
+        capabilities={["setSpeed", "playbackControl"]}
+        store={store}
+        activeData={activeData}
+      >
+        <div style={{ padding: 20, margin: 100 }}>{children}</div>
+      </MockMessagePipelineProvider>
+    </AppConfigurationContext.Provider>
   );
 }
 

--- a/app/components/PlaybackControls/index.tsx
+++ b/app/components/PlaybackControls/index.tsx
@@ -42,6 +42,7 @@ import {
 import PlaybackSpeedControls from "@foxglove-studio/app/components/PlaybackSpeedControls";
 import Slider from "@foxglove-studio/app/components/Slider";
 import { useTooltip } from "@foxglove-studio/app/components/Tooltip";
+import useTimezone from "@foxglove-studio/app/hooks/useTimezone";
 import { PlayerState, PlayerStateActiveData } from "@foxglove-studio/app/players/types";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { formatTime } from "@foxglove-studio/app/util/formatTime";
@@ -104,6 +105,7 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
       contents: tooltipState?.tip,
     });
     const { seek, pause, play, player } = props;
+    const timezone = useTimezone();
 
     // playerState is unstable, and will cause callbacks to change identity every frame. They can take
     // a ref instead.
@@ -287,6 +289,7 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
           onSeek={seek}
           onPause={pause}
           isPlaying={isPlaying ?? false}
+          timezone={timezone}
         />
         {seekControls}
       </Flex>

--- a/app/hooks/useTimezone.ts
+++ b/app/hooks/useTimezone.ts
@@ -6,5 +6,5 @@ import { useAsyncAppConfigurationValue } from "@foxglove-studio/app/hooks/useAsy
 
 export default function useTimezone(): string | undefined {
   const [timezone] = useAsyncAppConfigurationValue<string>("timezone");
-  return timezone.value;
+  return timezone.value === "" ? undefined : timezone.value;
 }


### PR DESCRIPTION
Also fix an issue where setting the timezone to "Detect from system" would result in using UTC instead, because an empty string was passed in.