### PR TITLE
Enable React.StrictMode for new panels

### DIFF
--- a/app/components/MockPanelContextProvider.tsx
+++ b/app/components/MockPanelContextProvider.tsx
@@ -34,13 +34,14 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<any> = {
   },
   isHovered: false,
   isFocused: false,
+  supportsStrictMode: true,
 };
 function MockPanelContextProvider({
   children,
   ...rest
 }: MockProps & {
   children: ReactNode;
-}) {
+}): JSX.Element {
   return (
     <PanelContext.Provider
       value={{

--- a/app/components/Panel.test.tsx
+++ b/app/components/Panel.test.tsx
@@ -13,6 +13,7 @@
 
 import { mount } from "enzyme";
 import { createMemoryHistory } from "history";
+import { useEffect } from "react";
 
 import { savePanelConfigs } from "@foxglove-studio/app/actions/panels";
 import Panel from "@foxglove-studio/app/components/Panel";
@@ -23,16 +24,15 @@ import PanelSetup from "@foxglove-studio/app/stories/PanelSetup";
 type DummyConfig = { someString: string };
 type DummyProps = { config: DummyConfig; saveConfig: (arg0: Partial<DummyConfig>) => void };
 
-function getDummyPanel(renderFn: any) {
-  class DummyComponent extends React.Component<DummyProps> {
-    static panelType = "Dummy";
-    static defaultConfig = { someString: "hello world" };
-
-    render() {
-      renderFn(this.props);
-      return ReactNull;
-    }
+function getDummyPanel(renderFn: jest.Mock) {
+  function DummyComponent(props: DummyProps): ReactNull {
+    // Call the mock function in an effect rather than during render, since render may happen more
+    // than once due to React.StrictMode.
+    useEffect(() => renderFn(props));
+    return ReactNull;
   }
+  DummyComponent.panelType = "Dummy";
+  DummyComponent.defaultConfig = { someString: "hello world" };
   return Panel(DummyComponent);
 }
 

--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -122,6 +122,7 @@ type ActionProps = {
 export interface PanelStatics<Config> {
   panelType: string;
   defaultConfig: Config;
+  supportsStrictMode?: boolean;
 }
 
 const EMPTY_CONFIG = Object.freeze({});
@@ -560,6 +561,7 @@ export default function Panel<Config extends PanelConfig>(
             isHovered,
             isFocused,
             tabId,
+            supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
           }}
         >
           {/* Ensure user exits full-screen mode when leaving window, even if key is still pressed down */}
@@ -628,7 +630,13 @@ export default function Panel<Config extends PanelConfig>(
                 <CloseIcon /> <span>Exit fullscreen</span>
               </button>
             )}
-            <ErrorBoundary>{child}</ErrorBoundary>
+            <ErrorBoundary>
+              {PanelComponent.supportsStrictMode ?? true ? (
+                <React.StrictMode>{child}</React.StrictMode>
+              ) : (
+                child
+              )}
+            </ErrorBoundary>
             {process.env.NODE_ENV !== "production" && <PerfInfo ref={perfInfo} />}
           </Flex>
         </PanelContext.Provider>

--- a/app/components/PanelContext.ts
+++ b/app/components/PanelContext.ts
@@ -36,6 +36,7 @@ export type PanelContextType<T> = {
 
   isHovered: boolean;
   isFocused: boolean;
+  supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)
 };
 // Context used for components to know which panel they are inside
 const PanelContext = React.createContext<PanelContextType<PanelConfig> | undefined>(undefined);

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import AlertIcon from "@mdi/svg/svg/alert.svg";
 import ArrowSplitHorizontalIcon from "@mdi/svg/svg/arrow-split-horizontal.svg";
 import ArrowSplitVerticalIcon from "@mdi/svg/svg/arrow-split-vertical.svg";
 import CheckboxMultipleBlankOutlineIcon from "@mdi/svg/svg/checkbox-multiple-blank-outline.svg";
@@ -47,6 +48,7 @@ import { State } from "@foxglove-studio/app/reducers";
 import frameless from "@foxglove-studio/app/util/frameless";
 import { TAB_PANEL_TYPE } from "@foxglove-studio/app/util/globalConstants";
 import logEvent, { getEventNames, getEventTags } from "@foxglove-studio/app/util/logEvent";
+import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
 import MosaicDragHandle from "./MosaicDragHandle";
 import styles from "./index.module.scss";
@@ -306,7 +308,7 @@ export default React.memo<Props>(function PanelToolbar({
   menuContent,
   showHiddenControlsOnHover,
 }: Props) {
-  const { isHovered = false, id } = useContext(PanelContext) ?? {};
+  const { isHovered = false, id, supportsStrictMode = true } = useContext(PanelContext) ?? {};
   const [isDragging, setIsDragging] = useState(false);
   const onDragStart = useCallback(() => setIsDragging(true), []);
   const onDragEnd = useCallback(() => setIsDragging(false), []);
@@ -336,17 +338,26 @@ export default React.memo<Props>(function PanelToolbar({
   // Help-shown state must be hoisted outside the controls container so the modal can remain visible
   // when the panel is no longer hovered.
   const additionalIconsWithHelp = useMemo(() => {
-    return helpContent ? (
+    return (
       <>
         {additionalIcons}
-        <Icon tooltip="Help" fade onClick={() => setShowHelp(true)}>
-          <HelpCircleOutlineIcon className={styles.icon} />
-        </Icon>
+        {!supportsStrictMode && process.env.NODE_ENV !== "production" && (
+          <Icon
+            clickable={false}
+            style={{ color: colors.YELLOW }}
+            tooltip="[DEV MODE ONLY] React Strict Mode is not enabled for this panel. Please remove supportsStrictMode=false from the panel component and manually test this panel for regressions!"
+          >
+            <AlertIcon />
+          </Icon>
+        )}
+        {helpContent && (
+          <Icon tooltip="Help" fade onClick={() => setShowHelp(true)}>
+            <HelpCircleOutlineIcon className={styles.icon} />
+          </Icon>
+        )}
       </>
-    ) : (
-      additionalIcons
     );
-  }, [additionalIcons, helpContent]);
+  }, [additionalIcons, helpContent, supportsStrictMode]);
 
   const { width, ref: sizeRef } = useResizeDetector({
     handleHeight: false,

--- a/app/hooks/usePreviousValue.ts
+++ b/app/hooks/usePreviousValue.ts
@@ -11,9 +11,24 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useRef } from "react";
+import { useContext, useRef } from "react";
 
+import PanelContext from "@foxglove-studio/app/components/PanelContext";
+
+/**
+ * @deprecated With React Strict Mode enabled, components render functions will be called twice in
+ * dev mode. This means the value returned by usePreviousValue may not actually be the value from
+ * the previous committed render.
+ */
 export function usePreviousValue<T>(nextValue: T): T | undefined {
+  const { supportsStrictMode = false, type } = useContext(PanelContext) ?? {};
+  const warned = useRef(false);
+  if (supportsStrictMode && !warned.current) {
+    warned.current = true;
+    console.error(
+      `usePreviousValue used in a panel (${type}) with React Strict Mode enabled. This is probably a bug!`,
+    );
+  }
   const ref = useRef<T | undefined>(undefined);
   const previous = ref.current;
   ref.current = nextValue;

--- a/app/panels/GlobalVariableSlider/index.tsx
+++ b/app/panels/GlobalVariableSlider/index.tsx
@@ -159,5 +159,6 @@ GlobalVariableSliderPanel.defaultConfig = {
   sliderProps: { min: 0, max: 10, step: 1 },
   globalVariableName: "globalVariable",
 };
+GlobalVariableSliderPanel.supportsStrictMode = false;
 
 export default Panel(GlobalVariableSliderPanel);

--- a/app/panels/GlobalVariables/index.tsx
+++ b/app/panels/GlobalVariables/index.tsx
@@ -36,5 +36,6 @@ function GlobalVariables(): ReactElement {
 
 GlobalVariables.panelType = "Global";
 GlobalVariables.defaultConfig = {};
+GlobalVariables.supportsStrictMode = false;
 
 export default Panel(GlobalVariables);

--- a/app/panels/ImageView/index.tsx
+++ b/app/panels/ImageView/index.tsx
@@ -694,5 +694,6 @@ ImageView.defaultConfig = {
   zoomPercentage: 100,
   offset: [0, 0],
 } as Config;
+ImageView.supportsStrictMode = false;
 
 export default Panel(ImageView);

--- a/app/panels/InternalLogs/index.tsx
+++ b/app/panels/InternalLogs/index.tsx
@@ -76,5 +76,6 @@ InternalLogs.panelType = "InternalLogs";
 InternalLogs.defaultConfig = {
   disabledChannels: [],
 } as Config;
+InternalLogs.supportsStrictMode = false;
 
 export default Panel(InternalLogs);

--- a/app/panels/Internals.tsx
+++ b/app/panels/Internals.tsx
@@ -246,5 +246,6 @@ function Internals() {
 }
 Internals.panelType = "Internals";
 Internals.defaultConfig = {};
+Internals.supportsStrictMode = false;
 
 export default Panel(Internals);

--- a/app/panels/Map/index.tsx
+++ b/app/panels/Map/index.tsx
@@ -169,5 +169,6 @@ MapPanel.panelType = "map";
 MapPanel.defaultConfig = {
   zoomLevel: 10,
 } as Config;
+MapPanel.supportsStrictMode = false;
 
 export default Panel(MapPanel);

--- a/app/panels/NodePlayground/index.tsx
+++ b/app/panels/NodePlayground/index.tsx
@@ -387,5 +387,6 @@ NodePlayground.defaultConfig = {
   selectedNodeId: undefined,
   autoFormatOnSave: true,
 };
+NodePlayground.supportsStrictMode = false;
 
 export default Panel(NodePlayground);

--- a/app/panels/NumberOfRenders.tsx
+++ b/app/panels/NumberOfRenders.tsx
@@ -81,5 +81,6 @@ function NumberOfRenders() {
 
 NumberOfRenders.panelType = "NumberOfRenders";
 NumberOfRenders.defaultConfig = {};
+NumberOfRenders.supportsStrictMode = false;
 
 export default Panel(NumberOfRenders);

--- a/app/panels/Parameters/index.tsx
+++ b/app/panels/Parameters/index.tsx
@@ -136,5 +136,6 @@ function Parameters(): ReactElement {
 
 Parameters.panelType = "Parameters";
 Parameters.defaultConfig = {};
+Parameters.supportsStrictMode = false;
 
 export default Panel(Parameters);

--- a/app/panels/PlaybackPerformance/index.tsx
+++ b/app/panels/PlaybackPerformance/index.tsx
@@ -160,5 +160,6 @@ function PlaybackPerformance() {
 
 PlaybackPerformance.panelType = "PlaybackPerformance";
 PlaybackPerformance.defaultConfig = {};
+PlaybackPerformance.supportsStrictMode = false;
 
 export default Panel(PlaybackPerformance);

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -318,5 +318,6 @@ Plot.defaultConfig = {
   showLegend: true,
   xAxisVal: "timestamp" as const,
 };
+Plot.supportsStrictMode = false;
 
 export default Panel(Plot);

--- a/app/panels/Publish/index.tsx
+++ b/app/panels/Publish/index.tsx
@@ -293,5 +293,6 @@ export default Panel(
       advancedView: true,
       value: "",
     },
+    supportsStrictMode: false,
   }),
 );

--- a/app/panels/RawMessages/index.tsx
+++ b/app/panels/RawMessages/index.tsx
@@ -586,5 +586,6 @@ RawMessages.defaultConfig = {
   showFullMessageForDiff: false,
 };
 RawMessages.panelType = "RawMessages";
+RawMessages.supportsStrictMode = false;
 
 export default Panel(RawMessages);

--- a/app/panels/Rosout/index.tsx
+++ b/app/panels/Rosout/index.tsx
@@ -230,5 +230,6 @@ export default Panel(
   Object.assign(RosoutPanel, {
     defaultConfig: { searchTerms: [] as string[], minLogLevel: 1, topicToRender: ROSOUT_TOPIC },
     panelType: "RosOut",
+    supportsStrictMode: false,
   }),
 );

--- a/app/panels/SourceInfo/index.tsx
+++ b/app/panels/SourceInfo/index.tsx
@@ -163,5 +163,6 @@ function SourceInfo() {
 
 SourceInfo.panelType = "SourceInfo";
 SourceInfo.defaultConfig = {};
+SourceInfo.supportsStrictMode = false;
 
 export default Panel(SourceInfo);

--- a/app/panels/StateTransitions/index.tsx
+++ b/app/panels/StateTransitions/index.tsx
@@ -446,5 +446,6 @@ export default Panel(
   Object.assign(StateTransitions, {
     panelType: "StateTransitions",
     defaultConfig: { paths: [] },
+    supportsStrictMode: false,
   }),
 );

--- a/app/panels/SubscribeToList.tsx
+++ b/app/panels/SubscribeToList.tsx
@@ -50,5 +50,6 @@ function SubscribeToList({ config, saveConfig }: Props): React.ReactElement {
 
 SubscribeToList.panelType = "SubscribeToList";
 SubscribeToList.defaultConfig = { topics: "" };
+SubscribeToList.supportsStrictMode = false;
 
 export default Panel(SubscribeToList);

--- a/app/panels/Tab/index.tsx
+++ b/app/panels/Tab/index.tsx
@@ -148,5 +148,6 @@ function Tab({ config, saveConfig }: Props) {
 
 Tab.panelType = TAB_PANEL_TYPE;
 Tab.defaultConfig = DEFAULT_TAB_PANEL_CONFIG;
+Tab.supportsStrictMode = false;
 
 export default Panel(Tab);

--- a/app/panels/Table/index.tsx
+++ b/app/panels/Table/index.tsx
@@ -362,5 +362,6 @@ TablePanel.panelType = "Table";
 TablePanel.defaultConfig = {
   topicPath: "",
 };
+TablePanel.supportsStrictMode = false;
 
 export default Panel(TablePanel);

--- a/app/panels/ThreeDimensionalViz/index.tsx
+++ b/app/panels/ThreeDimensionalViz/index.tsx
@@ -210,6 +210,7 @@ BaseRenderer.defaultConfig = {
   autoSyncCameraState: false,
   autoTextBackgroundColor: true,
 };
+BaseRenderer.supportsStrictMode = false;
 
 export const Renderer = hoistNonReactStatics(
   React.forwardRef<Props, typeof BaseRenderer>(BaseRenderer as any),

--- a/app/panels/TopicGraph/index.tsx
+++ b/app/panels/TopicGraph/index.tsx
@@ -221,5 +221,6 @@ function TopicGraph() {
 
 TopicGraph.panelType = "TopicGraph";
 TopicGraph.defaultConfig = {};
+TopicGraph.supportsStrictMode = false;
 
 export default Panel(TopicGraph);

--- a/app/panels/URDFViewer/index.tsx
+++ b/app/panels/URDFViewer/index.tsx
@@ -11,7 +11,7 @@ import {
   Toggle,
   useTheme,
 } from "@fluentui/react";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { CameraStore, CameraListener, CameraState, DEFAULT_CAMERA_STATE } from "regl-worldview";
 
@@ -22,7 +22,6 @@ import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import { useAssets } from "@foxglove-studio/app/context/AssetContext";
 import useCleanup from "@foxglove-studio/app/hooks/useCleanup";
-import { usePreviousValue } from "@foxglove-studio/app/hooks/usePreviousValue";
 import { JointState } from "@foxglove-studio/app/types/Messages";
 import { SaveConfig } from "@foxglove-studio/app/types/panels";
 import filterMap from "@foxglove-studio/app/util/filterMap";
@@ -59,16 +58,17 @@ function URDFViewer({ config, saveConfig }: Props) {
   }, [assets, selectedAssetId]);
 
   // Automatically select newly added URDF assets
-  const prevAssets = usePreviousValue(assets);
+  const prevAssets = useRef<typeof assets | undefined>();
   useEffect(() => {
-    const prevAssetIds = new Set(prevAssets?.map(({ uuid }) => uuid));
+    const prevAssetIds = new Set(prevAssets.current?.map(({ uuid }) => uuid));
+    prevAssets.current = assets;
     for (const asset of assets) {
       if (!prevAssetIds.has(asset.uuid) && asset.type === "urdf") {
         setSelectedAssetId(asset.uuid);
         return;
       }
     }
-  }, [assets, prevAssets, selectedAssetId]);
+  }, [assets]);
 
   const [renderer] = useState(() => new Renderer());
 

--- a/app/panels/WelcomePanel/index.tsx
+++ b/app/panels/WelcomePanel/index.tsx
@@ -158,5 +158,6 @@ export default Panel(
   Object.assign(WelcomePanel, {
     panelType: "onboarding.welcome",
     defaultConfig: {},
+    supportsStrictMode: false,
   }),
 );

--- a/app/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/app/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -46,6 +46,7 @@ type Props = {
 class DiagnosticStatusPanel extends React.Component<Props> {
   static panelType = "DiagnosticStatusPanel";
   static defaultConfig: Config = { topicToRender: DIAGNOSTIC_TOPIC, collapsedSections: [] };
+  static supportsStrictMode = false;
 
   _onSelect = (value: string, entry: DiagnosticAutocompleteEntry, autocomplete: Autocomplete) => {
     const { saveConfig, config } = this.props;

--- a/app/panels/diagnostics/DiagnosticSummary.tsx
+++ b/app/panels/diagnostics/DiagnosticSummary.tsx
@@ -103,6 +103,7 @@ class DiagnosticSummary extends React.Component<Props> {
     hardwareIdFilter: "",
     topicToRender: DIAGNOSTIC_TOPIC,
   };
+  static supportsStrictMode = false;
 
   togglePinned = (info: DiagnosticInfo) => {
     this.props.saveConfig({ pinnedIds: toggle(this.props.config.pinnedIds, info.id) });


### PR DESCRIPTION
Read more about strict mode at https://reactjs.org/docs/strict-mode.html

> StrictMode is a tool for highlighting potential problems in an application. …  It activates additional checks and warnings for its descendants.

> Strict mode checks are run in development mode only; they do not impact the production build.

The most notable behavior of strict mode is that it causes component render functions, useMemo callbacks, and other kinds of functions that should be stateless to be called **twice per render** in dev mode. This may cause problems in components that use these in side-effectful ways, so I didn't want to immediately enable it by default in all panels. I added a warning icon in the panel toolbar to prompt us to enable it in existing panels incrementally:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/14237/115669426-f49ae580-a2e3-11eb-9655-84f1889c4e79.png">

Also enable strict mode for URDFViewer, by removing usePreviousValue (and mark usePreviousValue as deprecated).