### PR TITLE
Remove "minimize: false" from webpack renderer

### DIFF
--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -50,10 +50,6 @@ export function makeConfig(_: unknown, argv: WebpackArgv, options?: Options): Co
     entry: "./index.tsx",
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
-    optimization: {
-      minimize: false,
-    },
-
     output: {
       publicPath: isServe ? "/renderer/" : "",
       path: path.resolve(__dirname, ".webpack", "renderer"),


### PR DESCRIPTION
Allow production builds to minify. The renderer thread must parse the
javascript bundle before it can render anything to screen. As the bundle
size grows - more work is done and rendering is delayed.