### PR TITLE
Rework browser window initialization and app lazy loading

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -10,294 +10,35 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ActionButton, Modal } from "@fluentui/react";
-import AlertIcon from "@mdi/svg/svg/alert.svg";
-import { ReactElement, useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { ReactElement, useState, useEffect, useMemo, Suspense } from "react";
 import { DndProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
-import { Provider, useDispatch } from "react-redux";
-import { useMountedState } from "react-use";
-import styled from "styled-components";
+import { Provider } from "react-redux";
 
 import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
-import { redoLayoutChange, undoLayoutChange } from "@foxglove-studio/app/actions/layoutHistory";
-import { importPanelLayout, loadLayout } from "@foxglove-studio/app/actions/panels";
-import AddPanelMenu from "@foxglove-studio/app/components/AddPanelMenu";
-import DocumentDropListener from "@foxglove-studio/app/components/DocumentDropListener";
-import DropOverlay from "@foxglove-studio/app/components/DropOverlay";
 import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
-import GlobalKeyListener from "@foxglove-studio/app/components/GlobalKeyListener";
-import GlobalVariablesMenu from "@foxglove-studio/app/components/GlobalVariablesMenu";
-import HelpModal from "@foxglove-studio/app/components/HelpModal";
-import Icon from "@foxglove-studio/app/components/Icon";
-import LayoutMenu from "@foxglove-studio/app/components/LayoutMenu";
 import LayoutStorageReduxAdapter from "@foxglove-studio/app/components/LayoutStorageReduxAdapter";
-import messagePathHelp from "@foxglove-studio/app/components/MessagePathSyntax/index.help.md";
-import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
 import { NativeFileMenuPlayerSelection } from "@foxglove-studio/app/components/NativeFileMenuPlayerSelection";
-import NotificationDisplay from "@foxglove-studio/app/components/NotificationDisplay";
-import PanelLayout from "@foxglove-studio/app/components/PanelLayout";
 import ParamAssetAdapter from "@foxglove-studio/app/components/ParamAssetAdapter";
-import PlaybackControls from "@foxglove-studio/app/components/PlaybackControls";
 import PlayerManager from "@foxglove-studio/app/components/PlayerManager";
-import Preferences from "@foxglove-studio/app/components/Preferences";
-import { RenderToBodyComponent } from "@foxglove-studio/app/components/RenderToBodyComponent";
-import ShortcutsModal from "@foxglove-studio/app/components/ShortcutsModal";
-import SpinningLoadingIcon from "@foxglove-studio/app/components/SpinningLoadingIcon";
-import TinyConnectionPicker from "@foxglove-studio/app/components/TinyConnectionPicker";
-import Toolbar from "@foxglove-studio/app/components/Toolbar";
 import AnalyticsProvider from "@foxglove-studio/app/context/AnalyticsProvider";
-import { useAppConfiguration } from "@foxglove-studio/app/context/AppConfigurationContext";
-import { AssetsProvider, useAssets } from "@foxglove-studio/app/context/AssetContext";
-import BuiltinPanelCatalogProvider from "@foxglove-studio/app/context/BuiltinPanelCatalogProvider";
+import { AssetsProvider } from "@foxglove-studio/app/context/AssetContext";
 import ExperimentalFeaturesLocalStorageProvider from "@foxglove-studio/app/context/ExperimentalFeaturesLocalStorageProvider";
-import LinkHandlerContext from "@foxglove-studio/app/context/LinkHandlerContext";
 import ModalHost from "@foxglove-studio/app/context/ModalHost";
 import OsContextAppConfigurationProvider from "@foxglove-studio/app/context/OsContextAppConfigurationProvider";
 import OsContextLayoutStorageProvider from "@foxglove-studio/app/context/OsContextLayoutStorageProvider";
-import {
-  PlayerSourceDefinition,
-  usePlayerSelection,
-} from "@foxglove-studio/app/context/PlayerSelectionContext";
+import { PlayerSourceDefinition } from "@foxglove-studio/app/context/PlayerSelectionContext";
 import WindowGeometryContext from "@foxglove-studio/app/context/WindowGeometryContext";
 import experimentalFeatures from "@foxglove-studio/app/experimentalFeatures";
-import useElectronFilesToOpen from "@foxglove-studio/app/hooks/useElectronFilesToOpen";
-import welcomeLayout from "@foxglove-studio/app/layouts/welcomeLayout";
-import { PlayerPresence } from "@foxglove-studio/app/players/types";
 import URDFAssetLoader from "@foxglove-studio/app/services/URDFAssetLoader";
 import getGlobalStore from "@foxglove-studio/app/store/getGlobalStore";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
-import { ImportPanelLayoutPayload } from "@foxglove-studio/app/types/panels";
-import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
-import inAutomatedRunMode from "@foxglove-studio/app/util/inAutomatedRunMode";
 
-type TestableWindow = Window & { setPanelLayout?: (payload: ImportPanelLayoutPayload) => void };
+const BuiltinPanelCatalogProvider = React.lazy(
+  () => import("@foxglove-studio/app/context/BuiltinPanelCatalogProvider"),
+);
 
-const SToolbarItem = styled.div`
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  height: 100%;
-  min-width: 40px;
-
-  // Allow interacting with buttons in the title bar without dragging the window
-  -webkit-app-region: no-drag;
-`;
-
-const TruncatedText = styled.span`
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  line-height: normal;
-`;
-
-function Root() {
-  const containerRef = useRef<HTMLDivElement>(ReactNull);
-  const dispatch = useDispatch();
-  const { currentSourceName, setPlayerFromFiles, setPlayerFromDemoBag } = usePlayerSelection();
-  const playerPresence = useMessagePipeline(
-    useCallback(({ playerState }) => playerState.presence, []),
-  );
-  const playerCapabilities = useMessagePipeline(
-    useCallback(({ playerState }) => playerState.capabilities, []),
-  );
-  const [preferencesOpen, setPreferencesOpen] = useState(false);
-  const [shortcutsModalOpen, setShortcutsModalOpen] = useState(false);
-  const [messagePathSyntaxModalOpen, setMessagePathSyntaxModalOpen] = useState(false);
-
-  const isMounted = useMountedState();
-
-  const openWelcomeLayout = useCallback(async () => {
-    if (isMounted()) {
-      dispatch(loadLayout(welcomeLayout));
-      await setPlayerFromDemoBag();
-    }
-  }, [dispatch, setPlayerFromDemoBag, isMounted]);
-
-  const handleInternalLink = useCallback((event: React.MouseEvent, href: string) => {
-    if (href === "#help:message-path-syntax") {
-      event.preventDefault();
-      setMessagePathSyntaxModalOpen(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    // Focus on page load to enable keyboard interaction.
-    if (containerRef.current) {
-      containerRef.current.focus();
-    }
-    // Add a hook for integration tests.
-    (window as TestableWindow).setPanelLayout = (payload: ImportPanelLayoutPayload) =>
-      dispatch(importPanelLayout(payload));
-
-    // For undo/redo events, first try the browser's native undo/redo, and if that is disabled, then
-    // undo/redo the layout history. Note that in GlobalKeyListener we also handle the keyboard
-    // events for undo/redo, so if an input or textarea element that would handle the event is not
-    // focused, the GlobalKeyListener will handle it. The listeners here are to handle the case when
-    // an editable element is focused, or when the user directly chooses the undo/redo menu item.
-    OsContextSingleton?.addIpcEventListener("undo", () => {
-      if (!document.execCommand("undo")) {
-        dispatch(undoLayoutChange());
-      }
-    });
-    OsContextSingleton?.addIpcEventListener("redo", () => {
-      if (!document.execCommand("redo")) {
-        dispatch(redoLayoutChange());
-      }
-    });
-
-    OsContextSingleton?.addIpcEventListener("open-preferences", () => setPreferencesOpen(true));
-    OsContextSingleton?.addIpcEventListener("open-message-path-syntax-help", () =>
-      setMessagePathSyntaxModalOpen(true),
-    );
-    OsContextSingleton?.addIpcEventListener("open-keyboard-shortcuts", () =>
-      setShortcutsModalOpen(true),
-    );
-    OsContextSingleton?.addIpcEventListener("open-welcome-layout", () => openWelcomeLayout());
-  }, [dispatch, openWelcomeLayout]);
-
-  const appConfiguration = useAppConfiguration();
-
-  // Show welcome layout on first run
-  useEffect(() => {
-    (async () => {
-      const welcomeLayoutShown = await appConfiguration.get("onboarding.welcome-layout.shown");
-      if (!welcomeLayoutShown) {
-        // Set configuration *before* opening the layout to avoid infinite recursion when the player
-        // loading state causes us to re-render.
-        await appConfiguration.set("onboarding.welcome-layout.shown", true);
-        await openWelcomeLayout();
-      }
-    })();
-  }, [appConfiguration, openWelcomeLayout]);
-
-  const { loadFromFile } = useAssets();
-
-  const openFiles = useCallback(
-    async (files: FileList, { shiftPressed }: { shiftPressed: boolean }) => {
-      const otherFiles: File[] = [];
-      for (const file of files) {
-        if (!(await loadFromFile(file, file.path))) {
-          otherFiles.push(file);
-        }
-      }
-
-      if (otherFiles.length > 0) {
-        setPlayerFromFiles(otherFiles, { append: shiftPressed });
-      }
-    },
-    [loadFromFile, setPlayerFromFiles],
-  );
-
-  // files the main thread told us to open
-  const filesToOpen = useElectronFilesToOpen();
-  useEffect(() => {
-    if (filesToOpen) {
-      openFiles(filesToOpen, { shiftPressed: false });
-    }
-  }, [filesToOpen, openFiles]);
-
-  const dropHandler = useCallback(
-    ({ files, shiftPressed }: { files: FileList; shiftPressed: boolean }) => {
-      openFiles(files, { shiftPressed });
-    },
-    [openFiles],
-  );
-
-  const presenceIcon = (() => {
-    switch (playerPresence) {
-      case PlayerPresence.NOT_PRESENT:
-      case PlayerPresence.PRESENT:
-        return undefined;
-      case PlayerPresence.CONSTRUCTING:
-      case PlayerPresence.INITIALIZING:
-      case PlayerPresence.RECONNECTING:
-        return (
-          <Icon small style={{ paddingLeft: 10 }}>
-            <SpinningLoadingIcon />
-          </Icon>
-        );
-      case PlayerPresence.ERROR:
-        return (
-          <Icon small style={{ paddingLeft: 10 }}>
-            <AlertIcon />
-          </Icon>
-        );
-    }
-  })();
-
-  const showPlaybackControls =
-    playerPresence === PlayerPresence.NOT_PRESENT || playerCapabilities.includes("playbackControl");
-
-  return (
-    <LinkHandlerContext.Provider value={handleInternalLink}>
-      <DocumentDropListener filesSelected={dropHandler}>
-        <DropOverlay>
-          <div style={{ fontSize: "4em", marginBottom: "1em" }}>Drop a bag file to load it!</div>
-          <div style={{ fontSize: "2em" }}>
-            (hold SHIFT while dropping a second bag file to add it
-            <br />
-            with all topics prefixed with {SECOND_SOURCE_PREFIX})
-          </div>
-        </DropOverlay>
-      </DocumentDropListener>
-      <div ref={containerRef} className="app-container" tabIndex={0}>
-        <GlobalKeyListener />
-        {shortcutsModalOpen && (
-          <ShortcutsModal onRequestClose={() => setShortcutsModalOpen(false)} />
-        )}
-        {messagePathSyntaxModalOpen && (
-          <RenderToBodyComponent>
-            <HelpModal onRequestClose={() => setMessagePathSyntaxModalOpen(false)}>
-              {messagePathHelp}
-            </HelpModal>
-          </RenderToBodyComponent>
-        )}
-
-        <Toolbar onDoubleClick={OsContextSingleton?.handleToolbarDoubleClick}>
-          <SToolbarItem>
-            <TinyConnectionPicker />
-          </SToolbarItem>
-          <SToolbarItem style={{ flex: "0 1 auto" }}>
-            <TruncatedText>{currentSourceName ?? "Select a data source"}</TruncatedText>{" "}
-            {presenceIcon}
-          </SToolbarItem>
-          <div style={{ flexGrow: 1 }}></div>
-          <SToolbarItem style={{ marginRight: 5 }}>
-            {!inAutomatedRunMode() && <NotificationDisplay />}
-          </SToolbarItem>
-          <SToolbarItem>
-            <LayoutMenu />
-          </SToolbarItem>
-          <SToolbarItem>
-            <AddPanelMenu />
-          </SToolbarItem>
-          <SToolbarItem>
-            <GlobalVariablesMenu />
-          </SToolbarItem>
-          <SToolbarItem>
-            <ActionButton
-              iconProps={{
-                iconName: "Settings",
-                styles: { root: { "& span": { verticalAlign: "baseline" } } },
-              }}
-              onClick={() => setPreferencesOpen(true)}
-            />
-            <Modal
-              styles={{ main: { width: "80vw", maxWidth: 850, height: "80vh", maxHeight: 600 } }}
-              isOpen={preferencesOpen}
-              onDismiss={() => setPreferencesOpen(false)}
-            >
-              <Preferences />
-            </Modal>
-          </SToolbarItem>
-        </Toolbar>
-        <PanelLayout />
-        {showPlaybackControls && <PlaybackControls />}
-      </div>
-    </LinkHandlerContext.Provider>
-  );
-}
+const Workspace = React.lazy(() => import("./Workspace"));
 
 export default function App(): ReactElement {
   const globalStore = getGlobalStore();
@@ -363,9 +104,11 @@ export default function App(): ReactElement {
         <ParamAssetAdapter />
         <NativeFileMenuPlayerSelection />
         <DndProvider backend={HTML5Backend}>
-          <BuiltinPanelCatalogProvider>
-            <Root />
-          </BuiltinPanelCatalogProvider>
+          <Suspense fallback={<></>}>
+            <BuiltinPanelCatalogProvider>
+              <Workspace />
+            </BuiltinPanelCatalogProvider>
+          </Suspense>
         </DndProvider>
       </ErrorBoundary>
     </AllProviders>

--- a/app/Workspace.tsx
+++ b/app/Workspace.tsx
@@ -1,0 +1,279 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { ActionButton, Modal } from "@fluentui/react";
+import AlertIcon from "@mdi/svg/svg/alert.svg";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { useMountedState } from "react-use";
+import styled from "styled-components";
+
+import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
+import { redoLayoutChange, undoLayoutChange } from "@foxglove-studio/app/actions/layoutHistory";
+import { importPanelLayout, loadLayout } from "@foxglove-studio/app/actions/panels";
+import AddPanelMenu from "@foxglove-studio/app/components/AddPanelMenu";
+import DocumentDropListener from "@foxglove-studio/app/components/DocumentDropListener";
+import DropOverlay from "@foxglove-studio/app/components/DropOverlay";
+import GlobalKeyListener from "@foxglove-studio/app/components/GlobalKeyListener";
+import GlobalVariablesMenu from "@foxglove-studio/app/components/GlobalVariablesMenu";
+import HelpModal from "@foxglove-studio/app/components/HelpModal";
+import Icon from "@foxglove-studio/app/components/Icon";
+import LayoutMenu from "@foxglove-studio/app/components/LayoutMenu";
+import messagePathHelp from "@foxglove-studio/app/components/MessagePathSyntax/index.help.md";
+import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
+import NotificationDisplay from "@foxglove-studio/app/components/NotificationDisplay";
+import PanelLayout from "@foxglove-studio/app/components/PanelLayout";
+import PlaybackControls from "@foxglove-studio/app/components/PlaybackControls";
+import Preferences from "@foxglove-studio/app/components/Preferences";
+import { RenderToBodyComponent } from "@foxglove-studio/app/components/RenderToBodyComponent";
+import ShortcutsModal from "@foxglove-studio/app/components/ShortcutsModal";
+import SpinningLoadingIcon from "@foxglove-studio/app/components/SpinningLoadingIcon";
+import TinyConnectionPicker from "@foxglove-studio/app/components/TinyConnectionPicker";
+import Toolbar from "@foxglove-studio/app/components/Toolbar";
+import { useAppConfiguration } from "@foxglove-studio/app/context/AppConfigurationContext";
+import { useAssets } from "@foxglove-studio/app/context/AssetContext";
+import LinkHandlerContext from "@foxglove-studio/app/context/LinkHandlerContext";
+import { usePlayerSelection } from "@foxglove-studio/app/context/PlayerSelectionContext";
+import useElectronFilesToOpen from "@foxglove-studio/app/hooks/useElectronFilesToOpen";
+import welcomeLayout from "@foxglove-studio/app/layouts/welcomeLayout";
+import { PlayerPresence } from "@foxglove-studio/app/players/types";
+import { ImportPanelLayoutPayload } from "@foxglove-studio/app/types/panels";
+import { SECOND_SOURCE_PREFIX } from "@foxglove-studio/app/util/globalConstants";
+import inAutomatedRunMode from "@foxglove-studio/app/util/inAutomatedRunMode";
+
+type TestableWindow = Window & { setPanelLayout?: (payload: ImportPanelLayoutPayload) => void };
+
+const SToolbarItem = styled.div`
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  min-width: 40px;
+
+  // Allow interacting with buttons in the title bar without dragging the window
+  -webkit-app-region: no-drag;
+`;
+
+const TruncatedText = styled.span`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  line-height: normal;
+`;
+
+export default function Workspace(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(ReactNull);
+  const dispatch = useDispatch();
+  const { currentSourceName, setPlayerFromFiles, setPlayerFromDemoBag } = usePlayerSelection();
+  const playerPresence = useMessagePipeline(
+    useCallback(({ playerState }) => playerState.presence, []),
+  );
+  const playerCapabilities = useMessagePipeline(
+    useCallback(({ playerState }) => playerState.capabilities, []),
+  );
+  const [preferencesOpen, setPreferencesOpen] = useState(false);
+  const [shortcutsModalOpen, setShortcutsModalOpen] = useState(false);
+  const [messagePathSyntaxModalOpen, setMessagePathSyntaxModalOpen] = useState(false);
+
+  const isMounted = useMountedState();
+
+  const openWelcomeLayout = useCallback(async () => {
+    if (isMounted()) {
+      dispatch(loadLayout(welcomeLayout));
+      await setPlayerFromDemoBag();
+    }
+  }, [dispatch, setPlayerFromDemoBag, isMounted]);
+
+  const handleInternalLink = useCallback((event: React.MouseEvent, href: string) => {
+    if (href === "#help:message-path-syntax") {
+      event.preventDefault();
+      setMessagePathSyntaxModalOpen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Focus on page load to enable keyboard interaction.
+    if (containerRef.current) {
+      containerRef.current.focus();
+    }
+    // Add a hook for integration tests.
+    (window as TestableWindow).setPanelLayout = (payload: ImportPanelLayoutPayload) =>
+      dispatch(importPanelLayout(payload));
+
+    // For undo/redo events, first try the browser's native undo/redo, and if that is disabled, then
+    // undo/redo the layout history. Note that in GlobalKeyListener we also handle the keyboard
+    // events for undo/redo, so if an input or textarea element that would handle the event is not
+    // focused, the GlobalKeyListener will handle it. The listeners here are to handle the case when
+    // an editable element is focused, or when the user directly chooses the undo/redo menu item.
+    OsContextSingleton?.addIpcEventListener("undo", () => {
+      if (!document.execCommand("undo")) {
+        dispatch(undoLayoutChange());
+      }
+    });
+    OsContextSingleton?.addIpcEventListener("redo", () => {
+      if (!document.execCommand("redo")) {
+        dispatch(redoLayoutChange());
+      }
+    });
+
+    OsContextSingleton?.addIpcEventListener("open-preferences", () => setPreferencesOpen(true));
+    OsContextSingleton?.addIpcEventListener("open-message-path-syntax-help", () =>
+      setMessagePathSyntaxModalOpen(true),
+    );
+    OsContextSingleton?.addIpcEventListener("open-keyboard-shortcuts", () =>
+      setShortcutsModalOpen(true),
+    );
+    OsContextSingleton?.addIpcEventListener("open-welcome-layout", () => openWelcomeLayout());
+  }, [dispatch, openWelcomeLayout]);
+
+  const appConfiguration = useAppConfiguration();
+
+  // Show welcome layout on first run
+  useEffect(() => {
+    (async () => {
+      const welcomeLayoutShown = await appConfiguration.get("onboarding.welcome-layout.shown");
+      if (!welcomeLayoutShown) {
+        // Set configuration *before* opening the layout to avoid infinite recursion when the player
+        // loading state causes us to re-render.
+        await appConfiguration.set("onboarding.welcome-layout.shown", true);
+        await openWelcomeLayout();
+      }
+    })();
+  }, [appConfiguration, openWelcomeLayout]);
+
+  const { loadFromFile } = useAssets();
+
+  const openFiles = useCallback(
+    async (files: FileList, { shiftPressed }: { shiftPressed: boolean }) => {
+      const otherFiles: File[] = [];
+      for (const file of files) {
+        if (!(await loadFromFile(file, file.path))) {
+          otherFiles.push(file);
+        }
+      }
+
+      if (otherFiles.length > 0) {
+        setPlayerFromFiles(otherFiles, { append: shiftPressed });
+      }
+    },
+    [loadFromFile, setPlayerFromFiles],
+  );
+
+  // files the main thread told us to open
+  const filesToOpen = useElectronFilesToOpen();
+  useEffect(() => {
+    if (filesToOpen) {
+      openFiles(filesToOpen, { shiftPressed: false });
+    }
+  }, [filesToOpen, openFiles]);
+
+  const dropHandler = useCallback(
+    ({ files, shiftPressed }: { files: FileList; shiftPressed: boolean }) => {
+      openFiles(files, { shiftPressed });
+    },
+    [openFiles],
+  );
+
+  const presenceIcon = (() => {
+    switch (playerPresence) {
+      case PlayerPresence.NOT_PRESENT:
+      case PlayerPresence.PRESENT:
+        return undefined;
+      case PlayerPresence.CONSTRUCTING:
+      case PlayerPresence.INITIALIZING:
+      case PlayerPresence.RECONNECTING:
+        return (
+          <Icon small style={{ paddingLeft: 10 }}>
+            <SpinningLoadingIcon />
+          </Icon>
+        );
+      case PlayerPresence.ERROR:
+        return (
+          <Icon small style={{ paddingLeft: 10 }}>
+            <AlertIcon />
+          </Icon>
+        );
+    }
+  })();
+
+  const showPlaybackControls =
+    playerPresence === PlayerPresence.NOT_PRESENT || playerCapabilities.includes("playbackControl");
+
+  return (
+    <LinkHandlerContext.Provider value={handleInternalLink}>
+      <DocumentDropListener filesSelected={dropHandler}>
+        <DropOverlay>
+          <div style={{ fontSize: "4em", marginBottom: "1em" }}>Drop a bag file to load it!</div>
+          <div style={{ fontSize: "2em" }}>
+            (hold SHIFT while dropping a second bag file to add it
+            <br />
+            with all topics prefixed with {SECOND_SOURCE_PREFIX})
+          </div>
+        </DropOverlay>
+      </DocumentDropListener>
+      <div ref={containerRef} className="app-container" tabIndex={0}>
+        <GlobalKeyListener />
+        {shortcutsModalOpen && (
+          <ShortcutsModal onRequestClose={() => setShortcutsModalOpen(false)} />
+        )}
+        {messagePathSyntaxModalOpen && (
+          <RenderToBodyComponent>
+            <HelpModal onRequestClose={() => setMessagePathSyntaxModalOpen(false)}>
+              {messagePathHelp}
+            </HelpModal>
+          </RenderToBodyComponent>
+        )}
+
+        <Toolbar onDoubleClick={OsContextSingleton?.handleToolbarDoubleClick}>
+          <SToolbarItem>
+            <TinyConnectionPicker />
+          </SToolbarItem>
+          <SToolbarItem style={{ flex: "0 1 auto" }}>
+            <TruncatedText>{currentSourceName ?? "Select a data source"}</TruncatedText>{" "}
+            {presenceIcon}
+          </SToolbarItem>
+          <div style={{ flexGrow: 1 }}></div>
+          <SToolbarItem style={{ marginRight: 5 }}>
+            {!inAutomatedRunMode() && <NotificationDisplay />}
+          </SToolbarItem>
+          <SToolbarItem>
+            <LayoutMenu />
+          </SToolbarItem>
+          <SToolbarItem>
+            <AddPanelMenu />
+          </SToolbarItem>
+          <SToolbarItem>
+            <GlobalVariablesMenu />
+          </SToolbarItem>
+          <SToolbarItem>
+            <ActionButton
+              iconProps={{
+                iconName: "Settings",
+                styles: { root: { "& span": { verticalAlign: "baseline" } } },
+              }}
+              onClick={() => setPreferencesOpen(true)}
+            />
+            <Modal
+              styles={{ main: { width: "80vw", maxWidth: 850, height: "80vh", maxHeight: 600 } }}
+              isOpen={preferencesOpen}
+              onDismiss={() => setPreferencesOpen(false)}
+            >
+              <Preferences />
+            </Modal>
+          </SToolbarItem>
+        </Toolbar>
+        <PanelLayout />
+        {showPlaybackControls && <PlaybackControls />}
+      </div>
+    </LinkHandlerContext.Provider>
+  );
+}

--- a/desktop/StudioWindow.ts
+++ b/desktop/StudioWindow.ts
@@ -302,10 +302,14 @@ class StudioWindow {
     browserWindow.once("closed", () => {
       StudioWindow.windowsByContentId.delete(id);
     });
+  }
 
+  load(): void {
     // load after setting windowsById so any ipc handlers with id lookup work
     log.info(`window.loadURL(${rendererPath})`);
-    browserWindow.loadURL(rendererPath).then(() => log.info("window URL loaded"));
+    this._window.loadURL(rendererPath).then(() => {
+      log.info("window URL loaded");
+    });
   }
 
   addInputSource(name: string): void {

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -17,6 +17,7 @@ import LocalFileStorage from "./LocalFileStorage";
 
 const log = Logger.getLogger(__filename);
 
+log.debug(`Start Preload`);
 log.info(`${APP_NAME} ${APP_VERSION}`);
 log.info(`initializing preloader, argv="${window.process.argv.join(" ")}"`);
 
@@ -149,3 +150,5 @@ function getTelemetrySettings(): [crashReportingEnabled: boolean, telemetryEnabl
   );
   return [crashReportingEnabled, telemetryEnabled];
 }
+
+log.debug(`End Preload`);

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -50,10 +50,6 @@ export function makeConfig(_: unknown, argv: WebpackArgv, options?: Options): Co
     entry: "./index.tsx",
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
-    optimization: {
-      minimize: false,
-    },
-
     output: {
       publicPath: isServe ? "/renderer/" : "",
       path: path.resolve(__dirname, ".webpack", "renderer"),


### PR DESCRIPTION
These changes decrease the perceived and actual startup delay.

* Move StudioWindow creation to the start of app "ready" to get a window displayed asap
* Split Root out of App.tsx into Workspace.tsx
* Load BuiltinPanelCatalogProvider and Workspace via React.lazy to reduce bundle size.
    
The reduced bundle size allows for minimize optimization for the prod build to succeed without node.js heap out-of-memory errors. Minimize on production bundles further reduces the initial script parsing time for v8.

This PR shows how the prod build fails to minimize without splitting the bundle https://github.com/foxglove/studio/pull/638