### PR TITLE
Fix unstable useMessagePipeline selectors

### DIFF
--- a/app/PanelAPI/useDataSourceInfo.ts
+++ b/app/PanelAPI/useDataSourceInfo.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { Time } from "rosbag";
 
 import {
@@ -31,36 +31,32 @@ export type DataSourceInfo = {
   playerId: string;
 };
 
+function selectDatatypes(ctx: MessagePipelineContext) {
+  return ctx.datatypes;
+}
+
+function selectTopics(ctx: MessagePipelineContext) {
+  return ctx.sortedTopics;
+}
+
+function selectStartTime(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.startTime;
+}
+
+function selectCapabilities(ctx: MessagePipelineContext) {
+  return ctx.playerState.capabilities;
+}
+
+function selectPlayerId(ctx: MessagePipelineContext) {
+  return ctx.playerState.playerId;
+}
+
 export default function useDataSourceInfo(): DataSourceInfo {
-  const datatypes = useMessagePipeline(
-    useCallback(
-      ({ datatypes: pipelineDatatypes }: MessagePipelineContext) => pipelineDatatypes,
-      [],
-    ),
-  );
-  const topics = useMessagePipeline(
-    useCallback(({ sortedTopics }: MessagePipelineContext) => sortedTopics, []),
-  );
-  const startTime = useMessagePipeline(
-    useCallback(
-      ({ playerState: { activeData } }: MessagePipelineContext) => activeData?.startTime,
-      [],
-    ),
-  );
-  const capabilities = useMessagePipeline(
-    useCallback(
-      ({ playerState: { capabilities: playerStateCapabilities } }: MessagePipelineContext) =>
-        playerStateCapabilities,
-      [],
-    ),
-  );
-  const playerId = useMessagePipeline(
-    useCallback(
-      ({ playerState: { playerId: playerStatePlayerId } }: MessagePipelineContext) =>
-        playerStatePlayerId,
-      [],
-    ),
-  );
+  const datatypes = useMessagePipeline(selectDatatypes);
+  const topics = useMessagePipeline(selectTopics);
+  const startTime = useMessagePipeline(selectStartTime);
+  const capabilities = useMessagePipeline(selectCapabilities);
+  const playerId = useMessagePipeline(selectPlayerId);
 
   // we want the returned object to have a stable identity
   return useMemo<DataSourceInfo>(() => {

--- a/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -46,11 +46,12 @@ const BottomTick = styled.div`
   border-bottom: 5px solid #f7be00;
 `;
 
-function getStartAndEndTime({ playerState: { activeData } }: MessagePipelineContext) {
-  if (activeData == undefined) {
-    return { startTime: undefined, endTime: undefined };
-  }
-  return { startTime: activeData.startTime, endTime: activeData.endTime };
+function getStartTime(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.startTime;
+}
+
+function getEndTime(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.endTime;
 }
 
 type Props = {
@@ -58,7 +59,9 @@ type Props = {
 };
 
 export default React.memo<Props>(function PlaybackBarHoverTicks({ componentId }: Props) {
-  const { startTime, endTime } = useMessagePipeline(getStartAndEndTime);
+  const startTime = useMessagePipeline(getStartTime);
+  const endTime = useMessagePipeline(getEndTime);
+
   const { width, ref } = useResizeDetector({
     handleHeight: false,
   });

--- a/app/components/PlaybackControls/index.tsx
+++ b/app/components/PlaybackControls/index.tsx
@@ -307,18 +307,27 @@ export const UnconnectedPlaybackControls = memo<PlaybackControlProps>(
   },
 );
 
-const getProps = ({
-  pausePlayback,
-  seekPlayback,
-  startPlayback,
-  playerState,
-}: MessagePipelineContext) => ({
-  pause: pausePlayback,
-  seek: seekPlayback,
-  play: startPlayback,
-  player: playerState,
-});
+function getPause(ctx: MessagePipelineContext) {
+  return ctx.pausePlayback;
+}
+
+function getPlay(ctx: MessagePipelineContext) {
+  return ctx.startPlayback;
+}
+
+function getSeek(ctx: MessagePipelineContext) {
+  return ctx.seekPlayback;
+}
+
+function getPlayer(ctx: MessagePipelineContext) {
+  return ctx.playerState;
+}
 
 export default function PlaybackControls(): JSX.Element {
-  return <UnconnectedPlaybackControls {...useMessagePipeline(getProps)} />;
+  const pause = useMessagePipeline(getPause);
+  const play = useMessagePipeline(getPlay);
+  const seek = useMessagePipeline(getSeek);
+  const player = useMessagePipeline(getPlayer);
+
+  return <UnconnectedPlaybackControls pause={pause} seek={seek} play={play} player={player} />;
 }

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -27,7 +27,10 @@ import {
   MessageDataItemsByPath,
   useDecodeMessagePathsForMessagesByTopic,
 } from "@foxglove-studio/app/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import { useMessagePipeline } from "@foxglove-studio/app/components/MessagePipeline";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove-studio/app/components/MessagePipeline";
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import {
@@ -119,6 +122,18 @@ function getBlockItemsByPath(decodeMessagePathsForMessagesByTopic: any, blocks: 
     });
   });
   return ret;
+}
+
+function selectCurrentTime(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.currentTime;
+}
+
+function selectEndTime(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.endTime;
+}
+
+function selectSeek(ctx: MessagePipelineContext) {
+  return ctx.seekPlayback;
 }
 
 function Plot(props: Props) {
@@ -221,16 +236,10 @@ function Plot(props: Props) {
     [yAxisPaths, mergedItems, startTime, xAxisVal, xAxisPath],
   );
 
-  const { currentTime, endTime, seekPlayback: seek } = useMessagePipeline(
-    useCallback(
-      ({ seekPlayback, playerState: { activeData } }) => ({
-        currentTime: activeData?.currentTime,
-        endTime: activeData?.endTime,
-        seekPlayback,
-      }),
-      [],
-    ),
-  );
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const endTime = useMessagePipeline(selectEndTime);
+  const seek = useMessagePipeline(selectSeek);
+
   // Min/max x-values and playback position indicator are only used for preloaded plots. In non-
   // preloaded plots min x-value is always the last seek time, and the max x-value is the current
   // playback time.

--- a/app/panels/SourceInfo/index.tsx
+++ b/app/panels/SourceInfo/index.tsx
@@ -67,19 +67,12 @@ const SHeaderItem = styled.div`
 `;
 
 function SourceInfo() {
-  const { topics, startTime, endTime } = useMessagePipeline(
-    useCallback(
-      ({ playerState: { activeData } }) =>
-        activeData
-          ? {
-              topics: activeData.topics,
-              startTime: activeData.startTime,
-              endTime: activeData.endTime,
-            }
-          : { topics: [], startTime: undefined, endTime: undefined },
-      [],
-    ),
+  const topics = useMessagePipeline(useCallback((ctx) => ctx.playerState.activeData?.topics, []));
+  const startTime = useMessagePipeline(
+    useCallback((ctx) => ctx.playerState.activeData?.startTime, []),
   );
+  const endTime = useMessagePipeline(useCallback((ctx) => ctx.playerState.activeData?.endTime, []));
+
   if (!startTime || !endTime) {
     return (
       <>

--- a/app/panels/TopicGraph/index.tsx
+++ b/app/panels/TopicGraph/index.tsx
@@ -121,18 +121,16 @@ function unionInto<T>(dest: Set<T>, ...iterables: Set<T>[]): void {
 }
 
 function TopicGraph() {
-  const { publishedTopics, subscribedTopics, services } = useMessagePipeline(
-    useCallback(
-      ({ playerState: { activeData } }) =>
-        activeData
-          ? {
-              publishedTopics: activeData.publishedTopics,
-              subscribedTopics: activeData.subscribedTopics,
-              services: activeData.services,
-            }
-          : { publishedTopics: undefined, subscribedTopics: undefined, services: undefined },
-      [],
-    ),
+  const publishedTopics = useMessagePipeline(
+    useCallback((ctx) => ctx.playerState.activeData?.publishedTopics, []),
+  );
+
+  const subscribedTopics = useMessagePipeline(
+    useCallback((ctx) => ctx.playerState.activeData?.subscribedTopics, []),
+  );
+
+  const services = useMessagePipeline(
+    useCallback((ctx) => ctx.playerState.activeData?.services, []),
   );
 
   const elements = useMemo<cytoscape.ElementDefinition[]>(() => {


### PR DESCRIPTION
If the selector of useMessagePipeline returns a different object for
each invocation it will cause a state set and re-render. Which will
invoke the selector which would again return a different object and repeat
the cycle.

This change invokes the selector twice (in development) and compares the value.
If the value is different (reference equality fails), then a warning is shown
to fix this error during development.