### PR TITLE
Gracefully handle ROS node connection failures, enter a retry loop for TCP socket failures

### DIFF
--- a/packages/ros1-turtlesim-test/tsconfig.json
+++ b/packages/ros1-turtlesim-test/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "module": "commonjs",
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/ros1/src/Connection.ts
+++ b/packages/ros1/src/Connection.ts
@@ -25,6 +25,8 @@ export interface Connection {
 
   transportType(): string;
 
+  connect(): Promise<void>;
+
   connected(): boolean;
 
   header(): Map<string, string>;

--- a/packages/ros1/src/TcpConnection.test.ts
+++ b/packages/ros1/src/TcpConnection.test.ts
@@ -84,7 +84,7 @@ describe("TcpConnection", () => {
       return Promise.resolve(new TcpSocketNode(options.host, options.port, new net.Socket()));
     };
     const socket = await tcpSocketCreate({ host: "localhost", port });
-    const connection = new TcpConnection(socket, CLIENT_HEADER);
+    const connection = new TcpConnection(socket, "localhost", port, CLIENT_HEADER);
     const p = new Promise((resolve, reject) => {
       connection.on("message", (msg, data: Uint8Array) => {
         expect(data.byteLength).toEqual(3);


### PR DESCRIPTION
This should handle all per-node communication failures. tcpros failures put the connection into a retry loop, and failed initial XML-RPC requests to ROS nodes log a warning and drop the connection. This could be improved to a separate retry loop in the future.
