### PR TITLE
Better cross-platform support for ros1-turtlesim-docker

### DIFF
--- a/packages/ros1-turtlesim-test/sample-robot-docker/Dockerfile
+++ b/packages/ros1-turtlesim-test/sample-robot-docker/Dockerfile
@@ -7,10 +7,19 @@ RUN apt-get update && apt-get install -y \
 
 RUN useradd -ms /bin/bash rosuser
 
+# Enable sudo for rosuser
+RUN adduser rosuser sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 USER rosuser
 ENV HOME=/home/rosuser
 WORKDIR /home/rosuser
 
-COPY entrypoint.sh /home/rosuser/entrypoint.sh
+COPY container-scripts/build.sh /home/rosuser/build.sh
+COPY container-scripts/entrypoint.sh /home/rosuser/entrypoint.sh
+
+# ROS build and auto-configure on bash login
+RUN /home/rosuser/build.sh
+RUN echo "source ~/catkin_ws/devel/setup.bash" >> /home/rosuser/.bashrc
 
 ENTRYPOINT [ "/bin/bash", "/home/rosuser/entrypoint.sh" ]

--- a/packages/ros1-turtlesim-test/sample-robot-docker/container-scripts/build.sh
+++ b/packages/ros1-turtlesim-test/sample-robot-docker/container-scripts/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws/
+source /opt/ros/noetic/setup.bash
+catkin_make

--- a/packages/ros1-turtlesim-test/sample-robot-docker/container-scripts/entrypoint.sh
+++ b/packages/ros1-turtlesim-test/sample-robot-docker/container-scripts/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir -p ~/catkin_ws/src
-cd ~/catkin_ws/
-source /opt/ros/noetic/setup.bash
-catkin_make
 source ~/catkin_ws/devel/setup.bash
 
 roscore &

--- a/packages/ros1-turtlesim-test/sample-robot-docker/start-robot.bat
+++ b/packages/ros1-turtlesim-test/sample-robot-docker/start-robot.bat
@@ -1,0 +1,20 @@
+cd /d "%~dp0"
+
+set ROSCORE_PORT=11311
+set MIN_PORT=11312
+set MAX_PORT=11366
+set HOSTNAME=%COMPUTERNAME%
+set HOME=%HOMEDRIVE%%HOMEPATH%
+
+docker build --tag sample-robot .
+
+docker run ^
+  -it ^
+  --rm ^
+  --sysctl net.ipv4.ip_local_port_range="%MIN_PORT% %MAX_PORT%" ^
+  --hostname %HOSTNAME% ^
+  -e ROS_MASTER_URI="http://%HOSTNAME%:%ROSCORE_PORT%/" ^
+  -e ROS_HOSTNAME="%HOSTNAME%" ^
+  -p %ROSCORE_PORT%-%MAX_PORT%:%ROSCORE_PORT%-%MAX_PORT% ^
+  --name sample-robot ^
+  sample-robot


### PR DESCRIPTION
* All platforms: Move cmake compilation into docker build, not every run. Better support for `docker exec -it sample-robot /bin/bash` by enabling sudo and auto-sourcing setup.bash.
* Linux: Use host mode networking. This will allow roscore to communicate back to FGS when rosparams change or publishers go online/offline.
* Windows: Add a start-robot.bat batch script that builds and runs.
