### PR TITLE
Use whole panel as drag preview image

### DIFF
--- a/app/components/Flex.tsx
+++ b/app/components/Flex.tsx
@@ -44,7 +44,7 @@ type Props = {
   // for storybook screenshots tests
   dataTest?: string;
 
-  ref?: LegacyRef<HTMLDivElement>;
+  innerRef?: LegacyRef<HTMLDivElement>;
 };
 
 const Flex = (props: Props) => {
@@ -67,7 +67,7 @@ const Flex = (props: Props) => {
     onMouseLeave,
     onMouseMove,
     dataTest,
-    ref,
+    innerRef,
   } = props;
   if (col != undefined && col === row) {
     throw new Error("Flex col and row are mutually exclusive");
@@ -89,7 +89,7 @@ const Flex = (props: Props) => {
 
   return (
     <div
-      ref={ref}
+      ref={innerRef}
       data-test={dataTest}
       className={combinedClasses}
       style={style}

--- a/app/components/MockPanelContextProvider.tsx
+++ b/app/components/MockPanelContextProvider.tsx
@@ -34,7 +34,6 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<any> = {
   },
   isHovered: false,
   isFocused: false,
-  isDragging: false,
   supportsStrictMode: true,
   connectToolbarDragHandle: () => {},
 };

--- a/app/components/MockPanelContextProvider.tsx
+++ b/app/components/MockPanelContextProvider.tsx
@@ -34,7 +34,9 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<any> = {
   },
   isHovered: false,
   isFocused: false,
+  isDragging: false,
   supportsStrictMode: true,
+  connectToolbarDragHandle: () => {},
 };
 function MockPanelContextProvider({
   children,

--- a/app/components/Panel.module.scss
+++ b/app/components/Panel.module.scss
@@ -48,8 +48,7 @@
 }
 
 .tabActionsOverlay,
-.quickActionsOverlay,
-.prohibitedSelection {
+.quickActionsOverlay {
   cursor: pointer;
   position: absolute;
   top: 0;
@@ -114,16 +113,6 @@
   p {
     font-size: 12px;
     color: $text-muted;
-  }
-}
-
-.prohibitedSelection {
-  padding: 10px;
-
-  .root:hover &,
-  // for screenshot tests
-  &:global(.hoverForScreenshot) {
-    background-color: rgba(45, 45, 51, 1);
   }
 }
 

--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -507,10 +507,7 @@ export default function Panel<Config extends PanelConfig>(
 
     const perfInfo = useRef<HTMLDivElement>(ReactNull);
     const quickActionsOverlayRef = useRef<HTMLDivElement>(ReactNull);
-    const [isDragging, setIsDragging] = useState(false);
     const onDragStart = useCallback(() => {
-      setIsDragging(true);
-
       // Temporarily hide the overlay so that the panel can be shown as the drag preview image --
       // even though the overlay is a sibling rather than a child, Chrome still includes it in the
       // preview if it is visible. Changing the appearance in the next React render cycle is not
@@ -522,8 +519,7 @@ export default function Panel<Config extends PanelConfig>(
         setTimeout(() => (overlay.style.opacity = "1"));
       }
     }, []);
-    const onDragEnd = useCallback(() => setIsDragging(false), []);
-    const dragSpec = { tabId, panelId: childId, onDragStart, onDragEnd };
+    const dragSpec = { tabId, panelId: childId, onDragStart };
     const [connectOverlayDragSource, connectOverlayDragPreview] = usePanelDrag(dragSpec);
     const [connectToolbarDragHandle, connectToolbarDragPreview] = usePanelDrag(dragSpec);
 
@@ -556,7 +552,6 @@ export default function Panel<Config extends PanelConfig>(
             enterFullscreen,
             isHovered,
             isFocused,
-            isDragging,
             tabId,
             supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
             connectToolbarDragHandle,

--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -61,9 +61,9 @@ import Flex from "@foxglove-studio/app/components/Flex";
 import Icon from "@foxglove-studio/app/components/Icon";
 import KeyListener from "@foxglove-studio/app/components/KeyListener";
 import PanelContext from "@foxglove-studio/app/components/PanelContext";
-import MosaicDragHandle from "@foxglove-studio/app/components/PanelToolbar/MosaicDragHandle";
 import { useExperimentalFeature } from "@foxglove-studio/app/context/ExperimentalFeaturesContext";
 import { usePanelCatalog } from "@foxglove-studio/app/context/PanelCatalogContext";
+import usePanelDrag from "@foxglove-studio/app/hooks/usePanelDrag";
 import { State } from "@foxglove-studio/app/reducers";
 import { TabPanelConfig } from "@foxglove-studio/app/types/layouts";
 import {
@@ -504,7 +504,29 @@ export default function Panel<Config extends PanelConfig>(
 
     const isDemoMode = useExperimentalFeature("demoMode");
     const renderCount = useRef(0);
+
     const perfInfo = useRef<HTMLDivElement>(ReactNull);
+    const quickActionsOverlayRef = useRef<HTMLDivElement>(ReactNull);
+    const [isDragging, setIsDragging] = useState(false);
+    const onDragStart = useCallback(() => {
+      setIsDragging(true);
+
+      // Temporarily hide the overlay so that the panel can be shown as the drag preview image --
+      // even though the overlay is a sibling rather than a child, Chrome still includes it in the
+      // preview if it is visible. Changing the appearance in the next React render cycle is not
+      // enough; it actually needs to happen during the dragstart event.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1203107
+      const overlay = quickActionsOverlayRef.current;
+      if (overlay) {
+        overlay.style.opacity = "0";
+        setTimeout(() => (overlay.style.opacity = "1"));
+      }
+    }, []);
+    const onDragEnd = useCallback(() => setIsDragging(false), []);
+    const dragSpec = { tabId, panelId: childId, onDragStart, onDragEnd };
+    const [connectOverlayDragSource, connectOverlayDragPreview] = usePanelDrag(dragSpec);
+    const [connectToolbarDragHandle, connectToolbarDragPreview] = usePanelDrag(dragSpec);
+
     return (
       <Profiler
         id={childId ?? "$unknown_id"}
@@ -534,8 +556,10 @@ export default function Panel<Config extends PanelConfig>(
             enterFullscreen,
             isHovered,
             isFocused,
+            isDragging,
             tabId,
             supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
+            connectToolbarDragHandle,
           }}
         >
           {/* Ensure user exits full-screen mode when leaving window, even if key is still pressed down */}
@@ -554,6 +578,10 @@ export default function Panel<Config extends PanelConfig>(
             col
             dataTest={`panel-mouseenter-container ${childId ?? ""}`}
             clip
+            innerRef={(el) => {
+              connectOverlayDragPreview(el);
+              connectToolbarDragPreview(el);
+            }}
           >
             {fullScreen && <div className={styles.notClickable} />}
             {isSelected && !fullScreen && numSelectedPanelsIfSelected > 1 && (
@@ -573,26 +601,31 @@ export default function Panel<Config extends PanelConfig>(
               </div>
             )}
             {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullScreen && (
-              <div className={styles.quickActionsOverlay} data-panel-overlay>
-                <MosaicDragHandle tabId={tabId}>
-                  <>
-                    <div>
-                      <FullscreenIcon />
-                      {shiftKeyPressed ? "Lock fullscreen" : "Fullscreen (Shift+click to lock)"}
-                    </div>
-                    <div>
-                      <Button onClick={closePanel} disabled={isOnlyPanel}>
-                        <TrashCanOutlineIcon />
-                        Remove
-                      </Button>
-                      <Button onClick={splitPanel}>
-                        <GridLargeIcon />
-                        Split
-                      </Button>
-                    </div>
-                    {!isOnlyPanel && <p>Drag to move</p>}
-                  </>
-                </MosaicDragHandle>
+              <div
+                className={styles.quickActionsOverlay}
+                ref={(el) => {
+                  quickActionsOverlayRef.current = el;
+                  connectOverlayDragSource(el);
+                }}
+                data-panel-overlay
+              >
+                <div>
+                  <div>
+                    <FullscreenIcon />
+                    {shiftKeyPressed ? "Lock fullscreen" : "Fullscreen (Shift+click to lock)"}
+                  </div>
+                  <div>
+                    <Button onClick={closePanel} disabled={isOnlyPanel}>
+                      <TrashCanOutlineIcon />
+                      Remove
+                    </Button>
+                    <Button onClick={splitPanel}>
+                      <GridLargeIcon />
+                      Split
+                    </Button>
+                  </div>
+                  {!isOnlyPanel && <p>Drag to move</p>}
+                </div>
               </div>
             )}
             {fullScreen && (
@@ -617,10 +650,10 @@ export default function Panel<Config extends PanelConfig>(
       </Profiler>
     );
   }
-  ConnectedPanel.displayName = `Panel(${PanelComponent.displayName ?? PanelComponent.name})`;
 
   return Object.assign(React.memo(ConnectedPanel), {
     defaultConfig: PanelComponent.defaultConfig,
     panelType: PanelComponent.panelType,
+    displayName: `Panel(${PanelComponent.displayName ?? PanelComponent.name})`,
   });
 }

--- a/app/components/PanelContext.ts
+++ b/app/components/PanelContext.ts
@@ -36,6 +36,8 @@ export type PanelContextType<T> = {
 
   isHovered: boolean;
   isFocused: boolean;
+  isDragging: boolean;
+  connectToolbarDragHandle: (el: Element | ReactNull) => void;
   supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)
 };
 // Context used for components to know which panel they are inside

--- a/app/components/PanelContext.ts
+++ b/app/components/PanelContext.ts
@@ -36,7 +36,6 @@ export type PanelContextType<T> = {
 
   isHovered: boolean;
   isFocused: boolean;
-  isDragging: boolean;
   connectToolbarDragHandle: (el: Element | ReactNull) => void;
   supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)
 };

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -302,8 +302,7 @@ export default React.memo<Props>(function PanelToolbar({
   menuContent,
   showHiddenControlsOnHover,
 }: Props) {
-  const { isHovered = false, id, supportsStrictMode = true, isDragging = false } =
-    useContext(PanelContext) ?? {};
+  const { isHovered = false, id, supportsStrictMode = true } = useContext(PanelContext) ?? {};
   const [containsOpen, setContainsOpen] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -359,7 +358,7 @@ export default React.memo<Props>(function PanelToolbar({
     return ReactNull;
   }
 
-  const isRendered = isHovered || containsOpen || isDragging || !!isUnknownPanel;
+  const isRendered = isHovered || containsOpen || !!isUnknownPanel;
 
   return (
     <div ref={sizeRef}>

--- a/app/components/PanelToolbar/index.tsx
+++ b/app/components/PanelToolbar/index.tsx
@@ -50,7 +50,6 @@ import { TAB_PANEL_TYPE } from "@foxglove-studio/app/util/globalConstants";
 import logEvent, { getEventNames, getEventTags } from "@foxglove-studio/app/util/logEvent";
 import { colors } from "@foxglove-studio/app/util/sharedStyleConstants";
 
-import MosaicDragHandle from "./MosaicDragHandle";
 import styles from "./index.module.scss";
 
 type Props = {
@@ -235,8 +234,6 @@ type PanelToolbarControlsProps = Pick<
   "additionalIcons" | "floating" | "menuContent" | "showHiddenControlsOnHover"
 > & {
   isRendered: boolean;
-  onDragStart: () => void;
-  onDragEnd: () => void;
   showPanelName?: boolean;
   isUnknownPanel: boolean;
   onEditPanelConfig: () => void;
@@ -250,20 +247,20 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
   isRendered,
   isUnknownPanel,
   menuContent,
-  onDragEnd,
-  onDragStart,
   showHiddenControlsOnHover = false,
   showPanelName = false,
   onEditPanelConfig,
 }: PanelToolbarControlsProps) {
-  const panelData = useContext(PanelContext);
+  const panelContext = useContext(PanelContext);
 
   return (
     <div
       className={styles.iconContainer}
       style={showHiddenControlsOnHover && !isRendered ? { visibility: "hidden" } : {}}
     >
-      {showPanelName && panelData && <div className={styles.panelName}>{panelData.title}</div>}
+      {showPanelName && panelContext && (
+        <div className={styles.panelName}>{panelContext.title}</div>
+      )}
       {additionalIcons}
       <Dropdown
         flatEdges={!floating}
@@ -274,7 +271,7 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
         }
       >
         <StandardMenuItems
-          tabId={panelData?.tabId}
+          tabId={panelContext?.tabId}
           isUnknownPanel={isUnknownPanel}
           onEditPanelConfig={onEditPanelConfig}
         />
@@ -282,14 +279,11 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
         {menuContent}
       </Dropdown>
       {!isUnknownPanel && (
-        <MosaicDragHandle onDragStart={onDragStart} onDragEnd={onDragEnd} tabId={panelData?.tabId}>
-          {/* Can only nest native nodes into <MosaicDragHandle>, so wrapping in a <span> */}
-          <span>
-            <Icon fade tooltip="Move panel (shortcut: ` or ~)">
-              <DragIcon className={styles.dragIcon} />
-            </Icon>
-          </span>
-        </MosaicDragHandle>
+        <span ref={panelContext?.connectToolbarDragHandle} data-test="mosaic-drag-handle">
+          <Icon fade tooltip="Move panel (shortcut: ` or ~)">
+            <DragIcon className={styles.dragIcon} />
+          </Icon>
+        </span>
       )}
     </div>
   );
@@ -308,10 +302,8 @@ export default React.memo<Props>(function PanelToolbar({
   menuContent,
   showHiddenControlsOnHover,
 }: Props) {
-  const { isHovered = false, id, supportsStrictMode = true } = useContext(PanelContext) ?? {};
-  const [isDragging, setIsDragging] = useState(false);
-  const onDragStart = useCallback(() => setIsDragging(true), []);
-  const onDragEnd = useCallback(() => setIsDragging(false), []);
+  const { isHovered = false, id, supportsStrictMode = true, isDragging = false } =
+    useContext(PanelContext) ?? {};
   const [containsOpen, setContainsOpen] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -390,8 +382,6 @@ export default React.memo<Props>(function PanelToolbar({
               menuContent={menuContent}
               showPanelName={(width ?? 0) > 360}
               additionalIcons={additionalIconsWithHelp}
-              onDragStart={onDragStart}
-              onDragEnd={onDragEnd}
               isUnknownPanel={!!isUnknownPanel}
               onEditPanelConfig={() => setShowShareModal(true)}
             />

--- a/app/hooks/usePanelDrag.tsx
+++ b/app/hooks/usePanelDrag.tsx
@@ -78,7 +78,6 @@ export default function usePanelDrag(props: {
         ownPath,
       });
     },
-    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
   });
 
   return [connectDragSource, connectDragPreview];

--- a/app/hooks/usePanelDrag.tsx
+++ b/app/hooks/usePanelDrag.tsx
@@ -12,26 +12,24 @@
 //   You may not use this file except in compliance with the License.
 
 import _ from "lodash";
-import React, { useContext, ReactNode } from "react";
-import { useDrag } from "react-dnd";
+import React, { useContext } from "react";
+import { useDrag, ConnectDragSource, ConnectDragPreview } from "react-dnd";
 import { MosaicDragType, MosaicWindowContext } from "react-mosaic-component";
 import { useSelector, useDispatch } from "react-redux";
 import { bindActionCreators } from "redux";
 
 import { startDrag, endDrag } from "@foxglove-studio/app/actions/panels";
-import { usePanelContext } from "@foxglove-studio/app/components/PanelContext";
 import { State } from "@foxglove-studio/app/reducers";
 
-// HOC to integrate mosaic drag functionality into any other component
-function MosaicDragHandle(props: {
-  children: ReactNode;
+// Hook to integrate mosaic drag functionality into any other component
+export default function usePanelDrag(props: {
   tabId?: string;
+  panelId?: string;
   onDragStart?: () => void;
   onDragEnd?: () => void;
-}) {
-  const { children, tabId: sourceTabId, onDragStart, onDragEnd } = props;
+}): [ConnectDragSource, ConnectDragPreview] {
+  const { tabId: sourceTabId, panelId, onDragStart, onDragEnd } = props;
   const { mosaicWindowActions } = useContext(MosaicWindowContext);
-  const { id } = usePanelContext();
 
   const dispatch = useDispatch();
   const mosaicId = useSelector(({ mosaic }: State) => mosaic.mosaicId);
@@ -41,7 +39,7 @@ function MosaicDragHandle(props: {
     dispatch,
   ]);
 
-  const [__, drag] = useDrag<any, any, any>({
+  const [, connectDragSource, connectDragPreview] = useDrag<any, any, any>({
     item: { type: MosaicDragType.WINDOW },
     begin: (_monitor) => {
       if (onDragStart) {
@@ -65,11 +63,14 @@ function MosaicDragHandle(props: {
       const ownPath = mosaicWindowActions.getPath();
       const dropResult = monitor.getDropResult() || {};
       const { position, path: destinationPath, tabId: targetTabId } = dropResult;
+      if (panelId == undefined) {
+        return;
+      }
 
       actions.endDrag({
         originalLayout: originalLayout as any,
         originalSavedProps,
-        panelId: id,
+        panelId,
         sourceTabId,
         targetTabId,
         position,
@@ -77,12 +78,8 @@ function MosaicDragHandle(props: {
         ownPath,
       });
     },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
   });
-  return (
-    <div ref={drag} data-test="mosaic-drag-handle">
-      {children}
-    </div>
-  );
-}
 
-export default MosaicDragHandle;
+  return [connectDragSource, connectDragPreview];
+}


### PR DESCRIPTION
Fixes drag previews so that the whole panel image is used as the drag preview, rather than the quick actions overlay or the drag handle in the toolbar. (Also filed https://bugs.chromium.org/p/chromium/issues/detail?id=1203107 since I needed a style.opacity hack to make this work for the overlay.)

Also fixed a layout issue where the draggable area of the overlay was not actually extending all the way to the edges of the panel, which makes it easier to drag panel backgrounds (should fix FG-246).

Supporting this for the PanelToolbar was a little weird since the toolbar is a separate component — I did it by passing the connectDragSource function down through PanelContext.

Before:

https://user-images.githubusercontent.com/14237/116175846-cd119780-a6ac-11eb-808b-1c9e8fa4fe88.mov

After:

https://user-images.githubusercontent.com/14237/116175859-d1d64b80-a6ac-11eb-8a67-31e81eaf3f23.mov
