### PR TITLE
Add wrapper to check for missing Git LFS before running yarn

### DIFF
--- a/.yarn/yarn-wrapper.js
+++ b/.yarn/yarn-wrapper.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// This script checks for missing Git LFS before attempting to run yarn
+
+const path = require("path");
+const fs = require("fs");
+
+const REAL_YARN = path.join(__dirname, "releases", "yarn-2.4.1.cjs");
+
+try {
+  if (fs.statSync(REAL_YARN).size < 10000) {
+    throw new Error(
+      "Error: Please configure Git LFS ( https://git-lfs.github.com/ ) then run `git lfs pull`.",
+    );
+  }
+} catch (e) {
+  // Catch missing file or LFS error
+  console.error(e.message);
+  process.exit(1);
+}
+
+// Handoff to real yarn
+require(REAL_YARN);

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,4 +10,4 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
     spec: "@yarnpkg/plugin-version"
 
-yarnPath: .yarn/releases/yarn-2.4.1.cjs
+yarnPath: .yarn/yarn-wrapper.js


### PR DESCRIPTION
Wrapper script to make sure Git LFS is installed before attempting to run yarn. Prevents obscure message posted in Slack if you forgot to install LFS:

```
$ yarn install
/home/user/src/foxglove-studio/.yarn/releases/yarn-2.4.1.cjs: 1: version: not found
/home/user/src/foxglove-studio/.yarn/releases/yarn-2.4.1.cjs: 2: oid: not found
size: '1640042': No such file
```

It does mean that whenever we run `yarn set version latest` to upgrade yarn, someone will have to manually update this script with the path to new yarn version (if they forget, at least they will get a pretty obvious error about missing yarn file).