### PR TITLE
Improve useContextSelector efficiency, remove bailout feature

### DIFF
--- a/app/PanelAPI/useMessageReducer.test.tsx
+++ b/app/PanelAPI/useMessageReducer.test.tsx
@@ -30,15 +30,13 @@ describe("useMessageReducer", () => {
       addMessagesOverride?: any;
     }) {
       try {
-        Test.result(
-          // eslint-disable-next-line react-hooks/rules-of-hooks
-          PanelAPI.useMessageReducer({
-            topics,
-            addMessage: useAddMessage ? Test.addMessage : undefined,
-            addMessages: useAddMessages ? addMessagesOverride || Test.addMessages : undefined,
-            restore: Test.restore,
-          }),
-        );
+        const result = PanelAPI.useMessageReducer({
+          topics,
+          addMessage: useAddMessage ? Test.addMessage : undefined,
+          addMessages: useAddMessages ? addMessagesOverride || Test.addMessages : undefined,
+          restore: Test.restore,
+        });
+        Test.result(result);
       } catch (e) {
         Test.error(e);
       }

--- a/app/PanelAPI/useMessageReducer.ts
+++ b/app/PanelAPI/useMessageReducer.ts
@@ -149,19 +149,23 @@ export function useMessageReducer<T>(props: Params<T>): T {
   const { restore, addMessage, addMessages } = props;
 
   const state = useRef<
-    | {
+    | Readonly<{
         messageEvents: PlayerStateActiveData["messages"] | undefined;
         lastSeekTime: number | undefined;
         reducedValue: T;
         restore: typeof restore;
         addMessage: typeof addMessage;
         addMessages: typeof addMessages;
-      }
+      }>
     | undefined
   >();
 
   return useMessagePipeline(
     useCallback(
+      // To compute the reduced value from new messages:
+      // - Call restore() to initialize state, if lastSeekTime has changed, or if reducers have changed
+      // - Call addMessage() or addMessages() if any new messages of interest have arrived
+      // - Otherwise, return the previous reducedValue so that we don't trigger an unnecessary render.
       function selectReducedMessages(ctx: MessagePipelineContext): T {
         const messageEvents = ctx.playerState.activeData?.messages;
         const lastSeekTime = ctx.playerState.activeData?.lastSeekTime;

--- a/app/PanelAPI/useMessageReducer.ts
+++ b/app/PanelAPI/useMessageReducer.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useRef, useCallback, useMemo, useState, useEffect, useContext } from "react";
+import { useRef, useMemo, useState, useEffect, useContext, useCallback } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import {
@@ -19,57 +19,18 @@ import {
   MessagePipelineContext,
 } from "@foxglove-studio/app/components/MessagePipeline";
 import PanelContext from "@foxglove-studio/app/components/PanelContext";
-import useChangeDetector from "@foxglove-studio/app/hooks/useChangeDetector";
 import useCleanup from "@foxglove-studio/app/hooks/useCleanup";
-import useContextSelector from "@foxglove-studio/app/hooks/useContextSelector";
 import useDeepMemo from "@foxglove-studio/app/hooks/useDeepMemo";
 import useShouldNotChangeOften from "@foxglove-studio/app/hooks/useShouldNotChangeOften";
-import { Message, SubscribePayload } from "@foxglove-studio/app/players/types";
+import {
+  Message,
+  PlayerStateActiveData,
+  SubscribePayload,
+} from "@foxglove-studio/app/players/types";
 
 type MessageReducer<T> = (arg0: T, message: Message) => T;
 type MessagesReducer<T> = (arg0: T, messages: readonly Message[]) => T;
 export type RequestedTopic = string | { topic: string; imageScale: number };
-
-// Apply changes in topics or messages to the reduced value.
-function useReducedValue<T>(
-  restore: (arg0?: T) => T,
-  addMessage?: MessageReducer<T>,
-  addMessages?: MessagesReducer<T>,
-  lastSeekTime?: number,
-  messages?: readonly Message[],
-): T {
-  const reducedValueRef = useRef<T | undefined>();
-
-  const shouldClear = useChangeDetector([lastSeekTime], false);
-  const reducersChanged = useChangeDetector([restore, addMessage, addMessages], false);
-  const messagesChanged = useChangeDetector([messages], true);
-
-  if (!reducedValueRef.current || shouldClear) {
-    // Call restore to create an initial state and whenever seek time changes.
-    reducedValueRef.current = restore(undefined);
-  } else if (reducersChanged) {
-    // Allow new reducers to restore the previous state when the reducers change.
-    reducedValueRef.current = restore(reducedValueRef.current);
-  }
-
-  // Use the addMessage reducer to process new messages.
-  if (messagesChanged && messages) {
-    if (addMessages) {
-      if (messages.length > 0) {
-        reducedValueRef.current = addMessages(reducedValueRef.current, messages);
-      }
-    } else if (addMessage) {
-      reducedValueRef.current = messages.reduce(
-        // .reduce() passes 4 args to callback function,
-        // but we want to call addMessage with only first 2 args
-        (value: T, message: Message) => addMessage(value, message),
-        reducedValueRef.current,
-      );
-    }
-  }
-
-  return reducedValueRef.current;
-}
 
 // Compute the subscriptions to be requested from the player.
 function useSubscriptions({
@@ -105,8 +66,6 @@ function useSubscriptions({
   }, [preloadingFallback, panelType, requestedTopics]);
 }
 
-const NO_MESSAGES = Object.freeze([]);
-
 type Params<T> = {
   topics: readonly RequestedTopic[];
 
@@ -125,6 +84,14 @@ type Params<T> = {
   // `useBlocksByTopic` for backwards compatibility.
   preloadingFallback?: boolean;
 };
+
+function selectRequestBackfill(ctx: MessagePipelineContext) {
+  return ctx.requestBackfill;
+}
+
+function selectSetSubscriptions(ctx: MessagePipelineContext) {
+  return ctx.setSubscriptions;
+}
 
 export function useMessageReducer<T>(props: Params<T>): T {
   const [id] = useState(() => uuidv4());
@@ -169,66 +136,78 @@ export function useMessageReducer<T>(props: Params<T>): T {
     panelType,
     preloadingFallback: props.preloadingFallback ?? false,
   });
-  const setSubscriptions = useMessagePipeline(
-    useCallback(
-      ({ setSubscriptions: pipelineSetSubscriptions }: MessagePipelineContext) =>
-        pipelineSetSubscriptions,
-      [],
-    ),
-  );
+
+  const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
   useEffect(() => setSubscriptions(id, subscriptions), [id, setSubscriptions, subscriptions]);
   useCleanup(() => setSubscriptions(id, []));
 
-  const requestBackfill = useMessagePipeline(
-    useCallback(
-      ({ requestBackfill: pipelineRequestBackfill }: MessagePipelineContext) =>
-        pipelineRequestBackfill,
-      [],
-    ),
-  );
+  const requestBackfill = useMessagePipeline(selectRequestBackfill);
+
   // Whenever `subscriptions` change, request a backfill, since we'd like to show fresh data.
   useEffect(() => requestBackfill(), [requestBackfill, subscriptions]);
 
-  // Keep a reference to the last messages we processed to ensure we never process them more than once.
-  // If the topics we care about change, the player should send us new messages soon anyway (via backfill if paused).
-  const lastProcessedMessagesRef = useRef<readonly Message[] | undefined>();
-  // Keep a ref to the latest requested topics we were rendered with, because the useMessagePipeline
-  // selector's dependencies aren't allowed to change.
-  const latestRequestedTopicsRef = useRef(requestedTopicsSet);
-  latestRequestedTopicsRef.current = requestedTopicsSet;
-  const messages = useMessagePipeline<readonly Message[]>(
-    useCallback(({ playerState: { activeData } }: MessagePipelineContext) => {
-      if (!activeData) {
-        return NO_MESSAGES; // identity must not change to avoid unnecessary re-renders
-      }
-      const messageData = activeData.messages;
-      if (lastProcessedMessagesRef.current === messageData) {
-        return useContextSelector.BAILOUT;
-      }
-      const filteredMessages = messageData.filter(({ topic }) =>
-        latestRequestedTopicsRef.current.has(topic),
-      );
-      // Bail out if we didn't want any of these messages, but not if this is our first render
-      const shouldBail =
-        lastProcessedMessagesRef.current != undefined && filteredMessages.length === 0;
-      lastProcessedMessagesRef.current = messageData;
-      return shouldBail ? useContextSelector.BAILOUT : filteredMessages;
-    }, []),
-  );
+  const { restore, addMessage, addMessages } = props;
 
-  const lastSeekTime = useMessagePipeline(
+  const state = useRef<
+    | {
+        messageEvents: PlayerStateActiveData["messages"] | undefined;
+        lastSeekTime: number | undefined;
+        reducedValue: T;
+        restore: typeof restore;
+        addMessage: typeof addMessage;
+        addMessages: typeof addMessages;
+      }
+    | undefined
+  >();
+
+  return useMessagePipeline(
     useCallback(
-      ({ playerState: { activeData } }: MessagePipelineContext) =>
-        activeData ? activeData.lastSeekTime : 0,
-      [],
-    ),
-  );
+      function selectReducedMessages(ctx: MessagePipelineContext): T {
+        const messageEvents = ctx.playerState.activeData?.messages;
+        const lastSeekTime = ctx.playerState.activeData?.lastSeekTime;
 
-  return useReducedValue<T>(
-    props.restore,
-    props.addMessage,
-    props.addMessages,
-    lastSeekTime,
-    messages,
+        let newReducedValue: T;
+        if (!state.current || lastSeekTime !== state.current.lastSeekTime) {
+          newReducedValue = restore(undefined);
+        } else if (
+          restore !== state.current.restore ||
+          addMessage !== state.current.addMessage ||
+          addMessages !== state.current.addMessages
+        ) {
+          newReducedValue = restore(state.current.reducedValue);
+        } else {
+          newReducedValue = state.current.reducedValue;
+        }
+
+        if (
+          messageEvents &&
+          messageEvents.length > 0 &&
+          messageEvents !== state.current?.messageEvents
+        ) {
+          const filtered = messageEvents.filter(({ topic }) => requestedTopicsSet.has(topic));
+          if (addMessages) {
+            if (filtered.length > 0) {
+              newReducedValue = addMessages(newReducedValue, filtered);
+            }
+          } else if (addMessage) {
+            for (const messageEvent of filtered) {
+              newReducedValue = addMessage(newReducedValue, messageEvent);
+            }
+          }
+        }
+
+        state.current = {
+          messageEvents,
+          lastSeekTime,
+          reducedValue: newReducedValue,
+          restore,
+          addMessage,
+          addMessages,
+        };
+
+        return state.current.reducedValue;
+      },
+      [addMessage, addMessages, restore, requestedTopicsSet],
+    ),
   );
 }

--- a/app/PanelAPI/useMessagesByTopic.test.tsx
+++ b/app/PanelAPI/useMessagesByTopic.test.tsx
@@ -97,6 +97,9 @@ describe("useMessagesByTopic", () => {
         <Test topics={["/foo"]} historySize={Infinity} />
       </MockMessagePipelineProvider>,
     );
+
+    expect(Test.result.mock.calls).toEqual([[{ "/foo": [message1, message2] }]]);
+
     root.setProps({ messages: [], children: <Test topics={["/foo", "/bar"]} historySize={1} /> });
 
     expect(Test.result.mock.calls).toEqual([

--- a/app/components/MessagePathSyntax/useMessagesByPath.test.tsx
+++ b/app/components/MessagePathSyntax/useMessagesByPath.test.tsx
@@ -144,10 +144,7 @@ describe("useMessagesByPath", () => {
     rerender({ ...initialProps, historySize: 2, messages: [...fixture.messages] });
     unmount();
 
-    // These extra renders are not ideal, but are necessary because the old MessageHistory wrapped itself in a React.memo.
     expect(result.all).toEqual([
-      { "/some/topic": [] },
-      { "/some/topic": [] },
       { "/some/topic": [] },
       { "/some/topic": [] },
       {
@@ -179,9 +176,7 @@ describe("useMessagesByPath", () => {
     // (since bufferSize=2).
     rerender({ ...initialProps, messages: [fixture.messages[2]] });
 
-    // These extra renders are not ideal, but are necessary because the old MessageHistory wrapped itself in a React.memo.
     expect(result.all).toEqual([
-      { "/some/topic": [queriedMessage(0), queriedMessage(1)] },
       { "/some/topic": [queriedMessage(0), queriedMessage(1)] },
       { "/some/topic": [queriedMessage(1), queriedMessage(2)] },
     ]);
@@ -203,14 +198,8 @@ describe("useMessagesByPath", () => {
 
     // Do the seek, and make sure we clear things out.
     rerender({ ...initialProps, messages: [], activeData: { lastSeekTime: 1 } });
-    expect(result.all.length).toEqual(3);
 
-    // These extra renders are not ideal, but are necessary because the old MessageHistory wrapped itself in a React.memo.
-    expect(result.all).toEqual([
-      { "/some/topic": [queriedMessage(0)] },
-      { "/some/topic": [queriedMessage(0)] },
-      { "/some/topic": [] },
-    ]);
+    expect(result.all).toEqual([{ "/some/topic": [queriedMessage(0)] }, { "/some/topic": [] }]);
   });
 
   it("returns the same when passing in a topic twice", () => {
@@ -403,12 +392,6 @@ describe("useMessagesByPath", () => {
 
     expect(result.all).toEqual([
       { "/some/topic": [queriedMessage(0)] },
-      {
-        // These extra renders are not ideal, but are necessary because the old MessageHistory wrapped itself in a React.memo.
-        "/some/topic.index": [
-          { message: fixture.messages[0], queriedData: [{ path: "/some/topic.index", value: 0 }] },
-        ],
-      },
       { "/some/topic.index": [] },
     ]);
   });

--- a/app/components/MessagePipeline/index.test.tsx
+++ b/app/components/MessagePipeline/index.test.tsx
@@ -134,13 +134,8 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         return ctx.playerState.presence;
       }),
     ).toEqual([
-      // Some unsightly duplication here - either an artifact of renderHook or a potential
-      // improvement by modifying useContextSelector.
-      PlayerPresence.NOT_PRESENT,
       PlayerPresence.NOT_PRESENT,
       PlayerPresence.CONSTRUCTING,
-      PlayerPresence.CONSTRUCTING,
-      PlayerPresence.ERROR,
       PlayerPresence.ERROR,
       PlayerPresence.INITIALIZING,
       PlayerPresence.PRESENT,
@@ -332,14 +327,14 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
       player2.playerId = "fake player 2";
       rerender({ maybePlayer: { player: player2 } });
       expect(player.close).toHaveBeenCalledTimes(1);
-      expect(result.all.length).toBe(5);
+      expect(result.all.length).toBe(4);
     });
 
     it("closes old player when new player is supplied and stops old player message flow", async () => {
       await act(() => player2.emit());
-      expect(result.all.length).toBe(6);
+      expect(result.all.length).toBe(5);
       await act(() => player.emit());
-      expect(result.all.length).toBe(6);
+      expect(result.all.length).toBe(5);
       expect(
         result.all.map((ctx) => {
           if (ctx instanceof Error) {
@@ -347,14 +342,14 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
           }
           return ctx.playerState.playerId;
         }),
-      ).toEqual(["", "fake player 1", "fake player 1", "fake player 1", "", "fake player 2"]);
+      ).toEqual(["", "fake player 1", "fake player 1", "", "fake player 2"]);
     });
 
     it("does not think the old player is the new player if it emits first", async () => {
       await act(() => player.emit());
-      expect(result.all.length).toBe(5);
+      expect(result.all.length).toBe(4);
       await act(() => player2.emit());
-      expect(result.all.length).toBe(6);
+      expect(result.all.length).toBe(5);
       expect(
         result.all.map((ctx) => {
           if (ctx instanceof Error) {
@@ -362,7 +357,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
           }
           return ctx.playerState.playerId;
         }),
-      ).toEqual(["", "fake player 1", "fake player 1", "fake player 1", "", "fake player 2"]);
+      ).toEqual(["", "fake player 1", "fake player 1", "", "fake player 2"]);
     });
   });
 
@@ -416,7 +411,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
     expect(result.all.length).toBe(2);
 
     rerender({ maybePlayer: { player: undefined } });
-    expect(result.all.length).toBe(5);
+    expect(result.all.length).toBe(4);
     expect((last(result.all) as MessagePipelineContext).playerState).toEqual({
       activeData,
       capabilities: [],

--- a/app/components/MessagePipeline/index.tsx
+++ b/app/components/MessagePipeline/index.tsx
@@ -68,9 +68,7 @@ export type MessagePipelineContext = {
 // exported only for MockMessagePipelineProvider
 export const ContextInternal = createSelectableContext<MessagePipelineContext>();
 
-export function useMessagePipeline<T>(
-  selector: (arg0: MessagePipelineContext) => T | typeof useContextSelector.BAILOUT,
-): T {
+export function useMessagePipeline<T>(selector: (arg0: MessagePipelineContext) => T): T {
   return useContextSelector(ContextInternal, selector);
 }
 

--- a/app/hooks/useChangeDetector.ts
+++ b/app/hooks/useChangeDetector.ts
@@ -14,7 +14,12 @@
 import { useRef } from "react";
 import shallowequal from "shallowequal";
 
-// Return initiallyTrue the first time, and again if any of the given deps have changed.
+/**
+ * Return initiallyTrue the first time, and again if any of the given deps have changed.
+ * @deprecated Render functions may be called more than once before effects are run, so relying on
+ * the result of useChangeDetector is dangerous. Instead, track the previously used values at the
+ * point they are being used.
+ */
 export default function useChangeDetector(deps: unknown[], initiallyTrue: boolean): boolean {
   const ref = useRef(initiallyTrue ? undefined : deps);
   const changed = !shallowequal(ref.current, deps);

--- a/app/hooks/useContextSelector.test.tsx
+++ b/app/hooks/useContextSelector.test.tsx
@@ -132,17 +132,21 @@ describe("createSelectableContext/useContextSelector", () => {
     root.unmount();
   });
 
-  it("propagates value to multiple consumers", () => {
+  it("propagates value to multiple consumers, including memoized subtrees", () => {
     const C = createSelectableContext<{ one: number; two: number }>();
     const Consumer1 = createTestConsumer(C, ({ one }) => one);
     const Consumer2 = createTestConsumer(C, ({ two }) => two);
 
+    const Memoized = React.memo(function Memoized({ children }: PropsWithChildren<unknown>) {
+      return <div>{children}</div>;
+    });
+
     const root = mount(
       <C.Provider value={{ one: 1, two: 2 }}>
         <Consumer1 />
-        <div>
+        <Memoized>
           <Consumer2 />
-        </div>
+        </Memoized>
       </C.Provider>,
     );
 

--- a/app/hooks/useContextSelector.test.tsx
+++ b/app/hooks/useContextSelector.test.tsx
@@ -12,7 +12,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { renderHook } from "@testing-library/react-hooks";
 import { mount } from "enzyme";
+import { PropsWithChildren } from "react";
 
 import useContextSelector from "@foxglove-studio/app/hooks/useContextSelector";
 import createSelectableContext, {
@@ -43,22 +45,6 @@ describe("createSelectableContext/useContextSelector", () => {
     (console.error as any).mockClear();
   });
 
-  it("throws when first selector call returns BAILOUT", () => {
-    jest.spyOn(console, "error").mockReturnValue(); // Library logs an error.
-    const C = createSelectableContext();
-    const Consumer = createTestConsumer(C, () => useContextSelector.BAILOUT);
-
-    expect(() =>
-      mount(
-        <C.Provider value={{}}>
-          <Consumer />
-        </C.Provider>,
-      ),
-    ).toThrow("Initial selector call must not return BAILOUT");
-
-    (console.error as any).mockClear();
-  });
-
   it("calls selector and render once with initial value", () => {
     const C = createSelectableContext();
     const Consumer = createTestConsumer(C, (x) => x);
@@ -78,11 +64,33 @@ describe("createSelectableContext/useContextSelector", () => {
     root.unmount();
   });
 
-  it("re-renders when selector returns new value that isn't BAILOUT", () => {
-    const C = createSelectableContext<{ num: number }>();
-    const Consumer = createTestConsumer(C, ({ num }) =>
-      num === 3 ? useContextSelector.BAILOUT : num,
+  it("doesn't render again when provided value and selector result change at the same time", () => {
+    const C = createSelectableContext<number>();
+
+    type Props = { value: number; selector: (x: number) => number };
+    const wrapper = ({ children, value }: PropsWithChildren<Props>) => (
+      <C.Provider value={value}>{children}</C.Provider>
     );
+    const { result, rerender } = renderHook(({ selector }) => useContextSelector(C, selector), {
+      wrapper,
+      initialProps: { value: 1, selector: (x) => x * 2 },
+    });
+
+    expect(result.all).toEqual([2]);
+    rerender({ value: 2, selector: (x) => x * 3 });
+    expect(result.all).toEqual([2, 6]);
+  });
+
+  it("re-renders when selector returns new value", () => {
+    const C = createSelectableContext<{ num: number }>();
+    let prevValue = -1;
+    const Consumer = createTestConsumer(C, ({ num }) => {
+      if (num === 3) {
+        return prevValue;
+      }
+      prevValue = num;
+      return num;
+    });
 
     const root = mount(
       <C.Provider value={{ num: 1 }}>
@@ -101,7 +109,7 @@ describe("createSelectableContext/useContextSelector", () => {
     expect(Consumer.selectorFn.mock.calls).toEqual([[{ num: 1 }], [{ num: 1 }], [{ num: 2 }]]);
     expect(Consumer.renderFn.mock.calls).toEqual([[1], [2]]);
 
-    // Selector returns BAILOUT, so no update should occur
+    // Selector returns the same value, so no update should occur
     root.setProps({ value: { num: 3 } });
     expect(Consumer.selectorFn.mock.calls).toEqual([
       [{ num: 1 }],

--- a/app/hooks/useContextSelector.ts
+++ b/app/hooks/useContextSelector.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useRef, useLayoutEffect, useState, useContext } from "react";
+import { useRef, useLayoutEffect, useState, useContext, useReducer } from "react";
 
 import { SelectableContext } from "@foxglove-studio/app/util/createSelectableContext";
 import Log from "@foxglove/log";
@@ -45,9 +45,9 @@ export default function useContextSelector<T, U>(
     throw new Error(`useContextSelector was used outside a corresponding <Provider />.`);
   }
 
-  const [, forceUpdate] = useState(0);
+  const [_, forceUpdate] = useReducer((x: number) => x + 1, 0);
   const state = useRef<
-    { contextValue: T; selectedValue: U; selector: (value: T) => U } | undefined
+    Readonly<{ contextValue: T; selectedValue: U; selector: (value: T) => U }> | undefined
   >();
   const contextValue = handle.currentValue();
   if (
@@ -67,7 +67,7 @@ export default function useContextSelector<T, U>(
     const sub = (newContextValue: T) => {
       const newSelectedValue = selectWithUnstableIdentityWarning(newContextValue, selector);
       if (newSelectedValue !== state.current?.selectedValue) {
-        forceUpdate((x) => x + 1);
+        forceUpdate();
       }
       state.current = {
         contextValue: newContextValue,

--- a/app/hooks/useContextSelector.ts
+++ b/app/hooks/useContextSelector.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useRef, useLayoutEffect, useState, useContext, useReducer } from "react";
+import { useRef, useLayoutEffect, useContext, useReducer } from "react";
 
 import { SelectableContext } from "@foxglove-studio/app/util/createSelectableContext";
 import Log from "@foxglove/log";

--- a/app/hooks/useContextSelector.ts
+++ b/app/hooks/useContextSelector.ts
@@ -24,7 +24,7 @@ function selectWithUnstableIdentityWarning<T, U>(value: T, selector: (value: T) 
     const secondResult = selector(value);
     if (result !== secondResult) {
       log.warn(`Selector ${selector.toString()} produced different values for the same input.
-This will cause unecesessery re-renders of your component.`);
+  This will cause unecesessery re-renders of your component.`);
     }
     return secondResult;
   }

--- a/app/hooks/useContextSelector.ts
+++ b/app/hooks/useContextSelector.ts
@@ -14,22 +14,30 @@
 import { useRef, useLayoutEffect, useState, useContext } from "react";
 
 import { SelectableContext } from "@foxglove-studio/app/util/createSelectableContext";
+import Log from "@foxglove/log";
 
-import useShouldNotChangeOften from "./useShouldNotChangeOften";
+const log = Log.getLogger(__filename);
 
-const BAILOUT: unique symbol = Symbol("BAILOUT");
+function selectWithUnstableIdentityWarning<T, U>(value: T, selector: (value: T) => U) {
+  const result = selector(value);
+  if (process.env.NODE_ENV === "development") {
+    const secondResult = selector(value);
+    if (result !== secondResult) {
+      log.warn(`Selector ${selector.toString()} produced different values for the same input.
+This will cause unecesessery re-renders of your component.`);
+    }
+    return secondResult;
+  }
+  return result;
+}
 
-// `useContextSelector(context, selector)` behaves like `selector(useContext(context))`, but
-// only triggers a re-render when the selected value actually changes.
-//
-// Changing the selector will not cause the context to be re-processed, so the selector must
-// not have external dependencies that change over time.
-//
-// `useContextSelector.BAILOUT` can be returned from the selector as a special sentinel that indicates
-// no update should occur. (Returning BAILOUT from the first call to selector is not allowed.)
+/**
+ * `useContextSelector(context, selector)` behaves like `selector(useContext(context))`, but
+ * only triggers a re-render when the selected value actually changes.
+ */
 export default function useContextSelector<T, U>(
   context: SelectableContext<T>,
-  selector: (arg0: T) => U | typeof BAILOUT,
+  selector: (value: T) => U,
 ): U {
   // eslint-disable-next-line no-underscore-dangle
   const handle = useContext(context._ctx);
@@ -37,39 +45,35 @@ export default function useContextSelector<T, U>(
     throw new Error(`useContextSelector was used outside a corresponding <Provider />.`);
   }
 
-  useShouldNotChangeOften(selector, () =>
-    console.warn(
-      `useContextSelector() selector (${selector.toString()}) is changing frequently. 
-Changing the selector will not cause the current context to be re-processed, 
-so you may have a bug if the selector depends on external state. 
-Wrap your selector in a useCallback() to silence this warning.`,
-    ),
-  );
+  const [, forceUpdate] = useState(0);
+  const state = useRef<
+    { contextValue: T; selectedValue: U; selector: (value: T) => U } | undefined
+  >();
+  const contextValue = handle.currentValue();
+  if (
+    state.current === undefined ||
+    contextValue !== state.current.contextValue ||
+    selector !== state.current.selector
+  ) {
+    state.current = {
+      contextValue,
+      selectedValue: selectWithUnstableIdentityWarning(contextValue, selector),
+      selector,
+    };
+  }
 
-  const [selectedValue, setSelectedValue] = useState(() => {
-    const value = selector(handle.currentValue());
-    if (value === BAILOUT) {
-      throw new Error("Initial selector call must not return BAILOUT");
-    }
-    return value;
-  });
-
-  const latestSelectedValue = useRef<symbol | U>();
+  // Subscribe to context updates, and trigger a re-render when the selected value changes.
   useLayoutEffect(() => {
-    latestSelectedValue.current = selectedValue;
-  });
-
-  // Subscribe to context updates, and setSelectedValue() only when the selected value changes.
-  useLayoutEffect(() => {
-    const sub = (newValue: T) => {
-      const newSelectedValue = selector(newValue);
-      if (newSelectedValue === BAILOUT) {
-        return;
+    const sub = (newContextValue: T) => {
+      const newSelectedValue = selectWithUnstableIdentityWarning(newContextValue, selector);
+      if (newSelectedValue !== state.current?.selectedValue) {
+        forceUpdate((x) => x + 1);
       }
-      if (newSelectedValue !== latestSelectedValue.current) {
-        // Because newSelectedValue might be a function, we have to always use the reducer form of setState.
-        setSelectedValue(() => newSelectedValue);
-      }
+      state.current = {
+        contextValue: newContextValue,
+        selectedValue: newSelectedValue,
+        selector,
+      };
     };
     handle.addSubscriber(sub);
     return () => {
@@ -77,7 +81,5 @@ Wrap your selector in a useCallback() to silence this warning.`,
     };
   }, [handle, selector]);
 
-  return selectedValue;
+  return state.current.selectedValue;
 }
-
-useContextSelector.BAILOUT = BAILOUT;

--- a/app/hooks/usePreviousValue.ts
+++ b/app/hooks/usePreviousValue.ts
@@ -16,7 +16,7 @@ import { useContext, useRef } from "react";
 import PanelContext from "@foxglove-studio/app/components/PanelContext";
 
 /**
- * @deprecated With React Strict Mode enabled, components render functions will be called twice in
+ * @deprecated With React Strict Mode enabled, components' render functions will be called twice in
  * dev mode. This means the value returned by usePreviousValue may not actually be the value from
  * the previous committed render.
  */

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
@@ -83,4 +83,57 @@ describe("FrameCompatibilityDEPRECATED", () => {
     const someTopicMessages = frame3["/some/topic"];
     expect(someTopicMessages).toEqual([messages[2]]);
   });
+
+  it("works in a memoized subtree", () => {
+    const childFn = jest.fn().mockReturnValue(undefined);
+    const MyComponentWithFrame = React.memo(
+      FrameCompatibilityDEPRECATED(
+        function MyComponent(props) {
+          childFn(props);
+          return ReactNull;
+        },
+        ["/some/topic"],
+      ),
+    );
+
+    const provider = mount(
+      <MockMessagePipelineProvider
+        messages={[messages[0]]}
+        datatypes={datatypes}
+        topics={[{ name: "/some/topic", datatype: "some/topic" }]}
+      >
+        <MyComponentWithFrame />
+      </MockMessagePipelineProvider>,
+    );
+
+    expect(childFn.mock.calls).toEqual([
+      [
+        {
+          frame: { "/some/topic": [messages[0]] },
+          cleared: true,
+          setSubscriptions: expect.any(Function),
+        },
+      ],
+    ]);
+
+    provider.setProps({ messages: [messages[1]] });
+    expect(childFn.mock.calls).toEqual([
+      [
+        {
+          frame: { "/some/topic": [messages[0]] },
+          cleared: true,
+          setSubscriptions: expect.any(Function),
+        },
+      ],
+      [
+        {
+          frame: { "/some/topic": [messages[1]] },
+          cleared: false,
+          setSubscriptions: expect.any(Function),
+        },
+      ],
+    ]);
+
+    provider.unmount();
+  });
 });

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.test.tsx
@@ -64,6 +64,7 @@ describe("FrameCompatibilityDEPRECATED", () => {
 
     // Make sure that we don't send `messages[0]` when receiving a new frame.
     provider.setProps({ messages: [messages[1], fooMsg1] });
+    expect(childFn.mock.calls.length).toBe(2);
     const frame2 = last(childFn.mock.calls)[0].frame;
     expect(Object.keys(frame2)).toEqual(["/some/topic"]);
     frameMessages = frame2["/some/topic"];

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
@@ -28,11 +28,15 @@ const useFrame = (
   // in this way yourself!! `restore` and `addMessage` should be pure functions and not have
   // side effects!
   const frame = React.useRef<Frame>({});
+  const cleared = React.useRef(false);
   const counter = React.useRef(0);
-  const lastClearTime = PanelAPI.useMessageReducer<number>({
+  PanelAPI.useMessageReducer<number>({
     topics,
-    restore: React.useCallback(() => {
+    restore: React.useCallback((prevValue) => {
       frame.current = {};
+      if (prevValue == undefined) {
+        cleared.current = true;
+      }
       return ++counter.current;
     }, []),
     addMessages: React.useCallback((_, messages: readonly Message[]) => {
@@ -43,10 +47,12 @@ const useFrame = (
     }, []),
   });
 
-  const cleared = useChangeDetector([lastClearTime], false);
-  const latestFrame = frame.current;
-  frame.current = {};
-  return { cleared, frame: latestFrame };
+  try {
+    return { cleared: cleared.current, frame: frame.current };
+  } finally {
+    frame.current = {};
+    cleared.current = false;
+  }
 };
 
 // This higher-order component provides compatibility between the old way of Panels receiving

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
@@ -28,21 +28,19 @@ const useFrame = (
   // in this way yourself!! `restore` and `addMessage` should be pure functions and not have
   // side effects!
   const frame = React.useRef<Frame>({});
-  const lastClearTime = PanelAPI.useMessageReducer({
+  const counter = React.useRef(0);
+  const lastClearTime = PanelAPI.useMessageReducer<number>({
     topics,
     restore: React.useCallback(() => {
       frame.current = {};
-      return Date.now();
-    }, [frame]),
-    addMessages: React.useCallback(
-      (time, messages: readonly Message[]) => {
-        for (const message of messages) {
-          (frame.current[message.topic] = frame.current[message.topic] ?? []).push(message);
-        }
-        return time;
-      },
-      [frame],
-    ),
+      return ++counter.current;
+    }, []),
+    addMessages: React.useCallback((_, messages: readonly Message[]) => {
+      for (const message of messages) {
+        (frame.current[message.topic] = frame.current[message.topic] ?? []).push(message);
+      }
+      return ++counter.current;
+    }, []),
   });
 
   const cleared = useChangeDetector([lastClearTime], false);

--- a/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
+++ b/app/panels/ThreeDimensionalViz/FrameCompatibility.tsx
@@ -15,7 +15,6 @@ import hoistNonReactStatics from "hoist-non-react-statics";
 import { uniq } from "lodash";
 
 import * as PanelAPI from "@foxglove-studio/app/PanelAPI";
-import useChangeDetector from "@foxglove-studio/app/hooks/useChangeDetector";
 import { Frame, Message, Topic } from "@foxglove-studio/app/players/types";
 
 const useFrame = (

--- a/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
@@ -135,11 +135,6 @@ describe("useSceneBuilderAndTransformsData", () => {
           [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"],
           ...staticallyAvailableNamespacesByTopic,
         },
-        {
-          "/foo": ["ns1", "ns2"],
-          [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"],
-          ...staticallyAvailableNamespacesByTopic,
-        },
       ]);
     });
 
@@ -149,10 +144,10 @@ describe("useSceneBuilderAndTransformsData", () => {
       expect(Test.result).toHaveBeenCalledTimes(1);
       // TFs were removed, but we still report them in the available namespaces.
       root.setProps(getMockProps({}));
-      expect(Test.result).toHaveBeenCalledTimes(3);
+      expect(Test.result).toHaveBeenCalledTimes(2);
 
       root.setProps(getMockProps({ mockTfIds: ["some_tf3"] }));
-      expect(Test.result).toHaveBeenCalledTimes(5);
+      expect(Test.result).toHaveBeenCalledTimes(3);
 
       // Technically we would only want the Test component to re-render once per props change.
       // However, this test is set up such that the MockTransforms object is replaced on each change.
@@ -160,8 +155,6 @@ describe("useSceneBuilderAndTransformsData", () => {
       expect(Test.result.mock.calls.map((args) => args[0].availableNamespacesByTopic)).toEqual([
         { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"] },
         { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"] },
-        { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"] },
-        { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2", "some_tf3"] },
         { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2", "some_tf3"] },
       ]);
     });
@@ -171,7 +164,6 @@ describe("useSceneBuilderAndTransformsData", () => {
       const root = mount(<Test {...getMockProps({ showTransforms: true })} />);
       root.setProps({ ...getMockProps({}), messagePipelineProps: { playerId: "somePlayerId" } });
       expect(Test.result.mock.calls.map((args) => args[0].availableNamespacesByTopic)).toEqual([
-        { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"] },
         { [TRANSFORM_TOPIC]: ["some_tf1", "some_tf2"] },
         {},
       ]);


### PR DESCRIPTION
Split from #646.

Update `createSelectableContext`/`useContextSelector` so it can run the selector (if it has changed) on each render, rather than needing to schedule a separate setState (the setState is still necessary when the subscriber is far away in a memoized part of the subtree).

Update `useMessageReducer` to do all the reducing inside its context selector, so we can remove the `BAILOUT` feature.

Remove some extra renders expected in tests, mostly added around the time of #363.