### PR TITLE
LazyMessageReader: add missing deserializer for duration and improve TS coverage

### DIFF
--- a/packages/rosmsg-deser/src/BuiltinDeserialize.ts
+++ b/packages/rosmsg-deser/src/BuiltinDeserialize.ts
@@ -55,30 +55,108 @@ function MakeTypedArrayDeserialze<T extends Indexable>(
   };
 }
 
-const deserializers = {
-  bool: (view: DataView, offset: number): boolean => view.getUint8(offset) !== 0,
-  int8: (view: DataView, offset: number): number => view.getInt8(offset),
-  uint8: (view: DataView, offset: number): number => view.getUint8(offset),
-  int16: (view: DataView, offset: number): number => view.getInt16(offset, true),
-  uint16: (view: DataView, offset: number): number => view.getUint16(offset, true),
-  int32: (view: DataView, offset: number): number => view.getInt32(offset, true),
-  uint32: (view: DataView, offset: number): number => view.getUint32(offset, true),
-  int64: (view: DataView, offset: number): bigint => view.getBigInt64(offset, true),
-  uint64: (view: DataView, offset: number): bigint => view.getBigUint64(offset, true),
-  float32: (view: DataView, offset: number): number => view.getFloat32(offset, true),
-  float64: (view: DataView, offset: number): number => view.getFloat64(offset, true),
-  time: (view: DataView, offset: number): { sec: number; nsec: number } => {
+// Sizes for builtin types - if a type has a fixed size, the deserializer is able to optimize
+export const fixedSizeTypes = new Map([
+  ["bool", 1],
+  ["int8", 1],
+  ["uint8", 1],
+  ["int16", 2],
+  ["uint16", 2],
+  ["int32", 4],
+  ["uint32", 4],
+  ["int64", 8],
+  ["uint64", 8],
+  ["float32", 4],
+  ["float64", 8],
+  ["time", 8],
+  ["duration", 8],
+] as const);
+export type FixedSizeTypes = Parameters<typeof fixedSizeTypes.get>[0];
+
+type BuiltinTypeMap = {
+  bool: boolean;
+  int8: number;
+  uint8: number;
+  int16: number;
+  uint16: number;
+  int32: number;
+  uint32: number;
+  int64: bigint;
+  uint64: bigint;
+  float32: number;
+  float64: number;
+  time: { sec: number; nsec: number };
+  duration: { sec: number; nsec: number };
+};
+
+type BuiltinArrayTypeMap = {
+  int8: Int8Array;
+  uint8: Uint8Array;
+  int16: Int16Array;
+  uint16: Uint16Array;
+  int32: Int32Array;
+  uint32: Uint32Array;
+  int64: BigInt64Array;
+  uint64: BigUint64Array;
+  float32: Float32Array;
+  float64: Float64Array;
+};
+
+// This intersection enforces a TypeScript error if deserializers and fixedSizeTypes get out of sync
+// in either direction
+type BuiltinTypes = keyof BuiltinTypeMap & FixedSizeTypes;
+
+type BuiltinReaders = {
+  [K in BuiltinTypes]: (view: DataView, offset: number) => BuiltinTypeMap[K];
+} &
+  {
+    [K in BuiltinTypes as `${K}Array`]: (
+      view: DataView,
+      offset: number,
+      len: number,
+    ) => K extends keyof BuiltinArrayTypeMap ? BuiltinArrayTypeMap[K] : BuiltinTypeMap[K][];
+  };
+
+export const deserializers: BuiltinReaders & {
+  string: (view: DataView, offset: number) => string;
+  fixedArray: (
+    view: DataView,
+    offset: number,
+    len: number,
+    elementDeser: (view: DataView, offset: number) => unknown,
+    elementSize: (view: DataView, offset: number) => number,
+  ) => unknown[];
+  dynamicArray: (
+    view: DataView,
+    offset: number,
+    elementDeser: (view: DataView, offset: number) => unknown,
+    elementSize: (view: DataView, offset: number) => number,
+  ) => unknown[];
+} = {
+  bool: (view, offset) => view.getUint8(offset) !== 0,
+  int8: (view, offset) => view.getInt8(offset),
+  uint8: (view, offset) => view.getUint8(offset),
+  int16: (view, offset) => view.getInt16(offset, true),
+  uint16: (view, offset) => view.getUint16(offset, true),
+  int32: (view, offset) => view.getInt32(offset, true),
+  uint32: (view, offset) => view.getUint32(offset, true),
+  int64: (view, offset) => view.getBigInt64(offset, true),
+  uint64: (view, offset) => view.getBigUint64(offset, true),
+  float32: (view, offset) => view.getFloat32(offset, true),
+  float64: (view, offset) => view.getFloat64(offset, true),
+  time: (view, offset) => {
     const sec = view.getUint32(offset, true);
     const nsec = view.getUint32(offset + 4, true);
     return { sec, nsec };
   },
-  string: (view: DataView, offset: number): string => {
+  duration: (view, offset) => deserializers.time(view, offset),
+  string: (view, offset) => {
     const len = view.getInt32(offset, true);
     const codePoints = new Uint8Array(view.buffer, view.byteOffset + offset + 4, len);
     const decoder = new (global as any).TextDecoder("utf8");
     return decoder.decode(codePoints);
   },
-  boolArray: (view: DataView, offset: number, len: number): boolean[] => {
+  boolArray: (view, offset, len) => {
     const arr = new Array(len);
     for (let idx = 0; idx < len; ++idx) {
       arr[idx] = deserializers.bool(view, offset);
@@ -96,7 +174,7 @@ const deserializers = {
   uint64Array: MakeTypedArrayDeserialze(BigUint64Array, "getBigUint64"),
   float32Array: MakeTypedArrayDeserialze(Float32Array, "getFloat32"),
   float64Array: MakeTypedArrayDeserialze(Float64Array, "getFloat64"),
-  timeArray: (view: DataView, offset: number, len: number): { sec: number; nsec: number }[] => {
+  timeArray: (view, offset, len) => {
     // Time and Duration are actually arrays of int32
     // If the location of the TimeArray meets Int32Array aligned access requirements, we can use Int32Array
     // to speed up access to the int32 values.
@@ -126,15 +204,8 @@ const deserializers = {
 
     return timeArr;
   },
-  durationArray: (view: DataView, offset: number, len: number): { sec: number; nsec: number }[] =>
-    deserializers.timeArray(view, offset, len),
-  fixedArray: (
-    view: DataView,
-    offset: number,
-    len: number,
-    elementDeser: (view: DataView, offset: number) => unknown,
-    elementSize: (view: DataView, offset: number) => number,
-  ): unknown[] => {
+  durationArray: (view, offset, len) => deserializers.timeArray(view, offset, len),
+  fixedArray: (view, offset, len, elementDeser, elementSize) => {
     const arr = new Array<unknown>(len);
     for (let idx = 0; idx < len; ++idx) {
       arr[idx] = elementDeser(view, offset);
@@ -142,15 +213,8 @@ const deserializers = {
     }
     return arr;
   },
-  dynamicArray: (
-    view: DataView,
-    offset: number,
-    elementDeser: (buff: DataView, offset: number) => unknown,
-    elementSize: (buff: DataView, offset: number) => number,
-  ): unknown[] => {
+  dynamicArray: (view, offset, elementDeser, elementSize) => {
     const len = view.getUint32(offset, true);
     return deserializers.fixedArray(view, offset + 4, len, elementDeser, elementSize);
   },
 };
-
-export default deserializers;

--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -68,6 +68,16 @@ describe("LazyReader", () => {
       },
     ],
     [
+      `duration stamp`,
+      [0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00],
+      {
+        stamp: {
+          sec: 0,
+          nsec: 1,
+        },
+      },
+    ],
+    [
       `int32[] arr`,
       [
         ...[0x02, 0x00, 0x00, 0x00], // length
@@ -81,7 +91,17 @@ describe("LazyReader", () => {
       { arr: [{ sec: 1, nsec: 2 }] },
     ],
     [
+      `duration[1] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 1, nsec: 2 }] },
+    ],
+    [
       `time[] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 2, nsec: 3 }] },
+    ],
+    [
+      `duration[] arr`,
       [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
       { arr: [{ sec: 2, nsec: 3 }] },
     ],

--- a/packages/rosmsg-deser/src/LazyMessageReaderFactory.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReaderFactory.ts
@@ -3,24 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { RosMsgDefinition, RosMsgField } from "rosbag";
 
-import deserializers from "./BuiltinDeserialize";
-
-// Sizes for builtin types - if a type has a fixed size, the deserializer is able to optimize
-const fixedSizeTypes = new Map<string, number>([
-  ["bool", 1],
-  ["int8", 1],
-  ["uint8", 1],
-  ["int16", 2],
-  ["uint16", 2],
-  ["int32", 4],
-  ["uint32", 4],
-  ["int64", 8],
-  ["uint64", 8],
-  ["float32", 4],
-  ["float64", 8],
-  ["time", 8],
-  ["duration", 8],
-]);
+import { deserializers, fixedSizeTypes, FixedSizeTypes } from "./BuiltinDeserialize";
 
 const builtinSizes = {
   // strings are the only builtin type that are variable size
@@ -75,7 +58,7 @@ function sizeFunction(field: RosMsgField): string {
     return "";
   }
 
-  const fieldSize = fixedSizeTypes.get(field.type);
+  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
 
   // if the field size is not known, size will be calculated on-demand
   if (fieldSize == undefined) {
@@ -130,7 +113,7 @@ function sizePartForDefinition(className: string, field: RosMsgField): string {
     return "";
   }
 
-  const fieldSize = fixedSizeTypes.get(field.type);
+  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
   const isFixedArray = field.isArray === true && field.arrayLength != undefined;
 
   if (fieldSize != undefined && (isFixedArray || field.isArray === false)) {
@@ -175,7 +158,7 @@ function getterFunction(field: RosMsgField): string {
   // function to return size of individual array item
   const sizeFn = isBuiltinSize ? `sizes.${field.type}` : `${sanitizeName(field.type)}.size`;
 
-  const fieldSize = fixedSizeTypes.get(field.type);
+  const fieldSize = fixedSizeTypes.get(field.type as FixedSizeTypes);
 
   if (field.isArray === true) {
     const arrLen = field.arrayLength;

--- a/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -552,6 +552,192 @@ return __RootMsg;
 }"
 `;
 
+exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+      static stamp_size(view /* dataview */, offset) {
+          return 8;
+      }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // duration stamp
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          stamp_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            stamp: this.stamp
+          };
+        }
+
+        get stamp() {
+        const offset = this.stamp_offset(this.#view, this.#offset);
+        return readers.duration(this.#view, offset);
+      }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            const len = view.getUint32(offset, true);
+            return 4 + len * 8;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+    // duration arr
+    {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+    }
+    
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // duration[] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            const len = this.#view.getUint32(offset, true);
+            return readers.durationArray(this.#view, offset + 4, len);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
+exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
+"function anonymous(readers,sizes
+) {
+class __RootMsg {
+        
+          static arr_size(view /* dataview */, offset) {
+            return 8 * 1;
+          }
+
+        // return the total serialized size of the message in the view
+        static size(view /* DataView */, initOffset = 0) {
+            let totalSize = 0;
+            let offset = initOffset;
+
+            
+        // duration[1] arr
+        totalSize += 8;
+        offset += 8;
+      
+            
+            return totalSize;
+        }
+
+        
+          arr_offset(view, initOffset) {
+            return initOffset;
+          }
+
+        // return an instance of __RootMsg from the view at initOffset bytes into the view
+        // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+        static build(view /* DataView */, offset = 0) {
+            return new __RootMsg(view, offset);
+        }
+
+        #view = undefined;
+        #offset;
+  
+        constructor(view, offset = 0) {
+          this.#view = view;
+          this.#offset = offset;
+        }
+
+        // return a json object of the fields
+        // this fully parses the message
+        toJSON() {
+          return {
+            arr: this.arr
+          };
+        }
+
+        
+          // duration[1] arr
+          get arr() {
+            const offset = this.arr_offset(this.#view, this.#offset);
+            return readers.durationArray(this.#view, offset, 1);
+          }
+    }
+return __RootMsg;
+}"
+`;
+
 exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
 "function anonymous(readers,sizes
 ) {


### PR DESCRIPTION
Now removing the duration deserializer causes a type error.

Confirmed by manual testing that MarkerArray works again.