### PR TITLE
Fix resize detector in PlaybackBarHoverTicks

### DIFF
--- a/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/app/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -80,17 +80,14 @@ export default React.memo<Props>(function PlaybackBarHoverTicks({ componentId }:
       },
     };
   }, [width, startTime, endTime]);
-
-  if (!scaleBounds) {
-    return ReactNull;
-  }
-
   return (
     <div ref={ref} style={{ width: "100%" }}>
-      <HoverBar componentId={componentId} scales={scaleBounds} isTimestampScale>
-        <TopTick />
-        <BottomTick />
-      </HoverBar>
+      {scaleBounds && (
+        <HoverBar componentId={componentId} scales={scaleBounds} isTimestampScale>
+          <TopTick />
+          <BottomTick />
+        </HoverBar>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
`react-resize-detector` depends on the `ref`'d component being immediately available after the first render. In this case the resize detector was not properly attached because the initial render returned null. Instead, we can unconditionally render the measured element, and just not render the HoverBar if the bounds are unknown.

cc @defunctzombie 