### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 *.tsbuildinfo
+.docker/
 .DS_Store
 .webpack/
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14
+
+RUN curl -fsSL https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -qq git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+CMD bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.0"
+services:
+  app:
+    build: .
+    command: bash -c "yarn && yarn serve"
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/src
+      - ./.docker/yarn:/root/.yarn

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -37,6 +37,8 @@ const devServerConfig: WebpackConfiguration = {
       return /\.webpack[\\/](main[\\/](?!.*hot-update)|package\.json)/.test(filePath);
     },
     hot: true,
+    // Listen on all addresses (in case webpack-dev-server and electron are on different hosts)
+    host: "0.0.0.0",
     // The problem and solution are described at <https://github.com/webpack/webpack-dev-server/issues/1604>.
     // When running in dev mode two errors are logged to the dev console:
     //  "Invalid Host/Origin header"


### PR DESCRIPTION
Allows docker-based development per https://github.com/foxglove/studio/issues/343#issuecomment-828649467.

Currently this successfully runs `yarn serve` inside the container. I haven't tested running `yarn start` (electron) inside the container yet. I highly doubt it will work on macOS, but maybe it's not too hard to get it working on linux.