### PR TITLE
Add .webpack to vscode search.exclude

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
     "**/*.code-search": true,
     "**/bower_components": true,
     "**/node_modules": true,
+    ".webpack": true,
     ".yarn/**": true,
     "yarn.lock": true
   },


### PR DESCRIPTION
.webpack is a build artifacts folder and should be excluded from vscode search by default