### PR TITLE
Fix restoring saved sources in Player Manager

### DIFF
--- a/app/hooks/useWarnImmediateReRender.ts
+++ b/app/hooks/useWarnImmediateReRender.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { useRef } from "react";
+
+import Log from "@foxglove/log";
+
+const log = Log.getLogger(__filename);
+
+// useWarnImmediateReRender will warn if the component re-renders before the next animation frame
+// This typically indicates that the component state is changing in rapid succession and more
+// work is being done than necessary.
+//
+// Note: This detects state change triggers in useLayoutEffect. It does not detect state changes from
+// useEffect which run on the next animation frame.
+const useWarnImmediateReRender =
+  process.env.NODE_ENV !== "development"
+    ? () => {}
+    : () => {
+        const renderedRef = useRef(false);
+
+        if (renderedRef.current) {
+          log.warn("Component re-rendered immediately");
+        }
+
+        renderedRef.current = true;
+        requestAnimationFrame(() => {
+          renderedRef.current = false;
+        });
+      };
+
+export default useWarnImmediateReRender;

--- a/app/players/AnalyticsMetricsCollector.ts
+++ b/app/players/AnalyticsMetricsCollector.ts
@@ -10,6 +10,9 @@ import {
   SubscribePayload,
 } from "@foxglove-studio/app/players/types";
 import { Analytics, AppEvent } from "@foxglove-studio/app/services/Analytics";
+import Log from "@foxglove/log";
+
+const log = Log.getLogger(__filename);
 
 type EventData = { [key: string]: string | number | boolean };
 
@@ -19,6 +22,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
   private _analytics: Analytics;
 
   constructor(analytics: Analytics) {
+    log.debug("New AnalyticsMetricsCollector");
     this._analytics = analytics;
   }
 


### PR DESCRIPTION
useLocalStorage behavior changed in a recent release of react-use
(https://github.com/streamich/react-use/issues/1970) which led to
the saved source appearing to change during initial mount. This
triggered the source change logic multiple times and broke the fragile
first mount restore behavior.

This change re-works this behavior to restore the saved source once
on mount without any fragile refs traking whether to restore by
making an explicit selectSource function that accepts a restore argument.

Manually selecting a source via the PlayerSelection context avoids
restoring and shows prompts and dialogs.

Closes #810