### PR TITLE
Add allowedExtensions to DocumentDropListener

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -20,6 +20,7 @@ import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
 import LayoutStorageReduxAdapter from "@foxglove-studio/app/components/LayoutStorageReduxAdapter";
 import { NativeFileMenuPlayerSelection } from "@foxglove-studio/app/components/NativeFileMenuPlayerSelection";
 import PlayerManager from "@foxglove-studio/app/components/PlayerManager";
+import StudioToastProvider from "@foxglove-studio/app/components/StudioToastProvider";
 import AnalyticsProvider from "@foxglove-studio/app/context/AnalyticsProvider";
 import { AssetsProvider } from "@foxglove-studio/app/context/AssetContext";
 import ExperimentalFeaturesLocalStorageProvider from "@foxglove-studio/app/context/ExperimentalFeaturesLocalStorageProvider";
@@ -93,6 +94,7 @@ export default function App(): ReactElement {
     <ThemeProvider />,
     <ModalHost />, // render modal elements inside the ThemeProvider
     <WindowGeometryContext.Provider value={windowGeometry} />,
+    <StudioToastProvider />,
     <ReduxProvider store={globalStore} />,
     <AnalyticsProvider />,
     <ExperimentalFeaturesLocalStorageProvider features={experimentalFeatures} />,

--- a/app/components/DocumentDropListener.test.tsx
+++ b/app/components/DocumentDropListener.test.tsx
@@ -12,14 +12,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { noop } from "lodash";
 import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { ToastProvider } from "react-toast-notifications";
 
 import DocumentDropListener from "@foxglove-studio/app/components/DocumentDropListener";
 
 describe("<DocumentDropListener>", () => {
-  let wrapper: any;
-  let windowDragoverHandler: any;
+  let wrapper: HTMLDivElement;
+  let windowDragoverHandler: typeof jest.fn;
 
   beforeEach(() => {
     windowDragoverHandler = jest.fn();
@@ -30,9 +31,11 @@ describe("<DocumentDropListener>", () => {
 
     ReactDOM.render(
       <div>
-        <DocumentDropListener filesSelected={noop}>
-          <div />
-        </DocumentDropListener>
+        <ToastProvider>
+          <DocumentDropListener allowedExtensions={[]}>
+            <div />
+          </DocumentDropListener>
+        </ToastProvider>
       </div>,
       wrapper,
     );
@@ -40,7 +43,9 @@ describe("<DocumentDropListener>", () => {
 
   it("allows the event to bubble if the dataTransfer has no files", async () => {
     // The event should bubble up from the document to the window
-    document.dispatchEvent(new CustomEvent("dragover", { bubbles: true, cancelable: true }));
+    act(() => {
+      document.dispatchEvent(new CustomEvent("dragover", { bubbles: true, cancelable: true }));
+    });
     expect(windowDragoverHandler).toHaveBeenCalled();
   });
 
@@ -53,7 +58,9 @@ describe("<DocumentDropListener>", () => {
     event.dataTransfer = {
       types: ["Files"],
     };
-    document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
+    act(() => {
+      document.dispatchEvent(event); // The event should NOT bubble up from the document to the window
+    });
     expect(windowDragoverHandler).not.toHaveBeenCalled();
   });
 

--- a/app/components/DocumentDropListener.tsx
+++ b/app/components/DocumentDropListener.tsx
@@ -11,75 +11,100 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { extname } from "path";
+import { useCallback, useLayoutEffect, useState } from "react";
+import { useToasts } from "react-toast-notifications";
+
 type Props = {
   children: React.ReactNode; // Shown when dragging in a file.
-  filesSelected: (arg0: { files: FileList; shiftPressed: boolean }) => void;
+  allowedExtensions?: string[];
+  filesSelected?: (arg: { files: FileList; shiftPressed: boolean }) => void;
 };
 
-type State = {
-  hovering: boolean;
-};
+export default function DocumentDropListener(props: Props): JSX.Element {
+  const [hovering, setHovering] = useState(false);
 
-export default class DocumentDropListener extends React.PureComponent<Props, State> {
-  state = { hovering: false };
+  const { filesSelected, allowedExtensions } = props;
 
-  componentDidMount(): void {
-    document.addEventListener("dragover", this._onDragOver);
-    document.addEventListener("drop", this._onDrop);
-    document.addEventListener("dragleave", this._onDragLeave);
-  }
+  const { addToast } = useToasts();
 
-  componentWillUnmount(): void {
-    document.removeEventListener("dragover", this._onDragOver);
-    document.removeEventListener("drop", this._onDrop);
-    document.removeEventListener("dragleave", this._onDragLeave);
-  }
+  const onDrop = useCallback(
+    (ev: DragEvent) => {
+      setHovering(false);
 
-  _onDrop = (ev: DragEvent): void => {
-    const { filesSelected } = this.props;
-    if (!ev.dataTransfer) {
-      return;
-    }
-    const { files } = ev.dataTransfer;
-    // allow event to bubble for non-file based drag and drop
-    if (files.length === 0) {
-      return;
-    }
-    ev.preventDefault();
-    ev.stopPropagation();
-    filesSelected({ files, shiftPressed: ev.shiftKey });
-    this.setState({ hovering: false });
-  };
+      if (!ev.dataTransfer) {
+        return;
+      }
+      const { files } = ev.dataTransfer;
+      // allow event to bubble for non-file based drag and drop
+      if (files.length === 0 || !allowedExtensions) {
+        return;
+      }
 
-  _onDragOver = (ev: DragEvent): void => {
-    const { dataTransfer } = ev;
-    // dataTransfer isn't guaranteed to exist by spec, so it must be checked
-    if (dataTransfer && dataTransfer.types.length === 1 && dataTransfer.types[0] === "Files") {
-      ev.stopPropagation();
+      const containsUnsupportedFiles = Array.from(files).some((file) => {
+        const fileExtension = extname(file.name);
+        return !allowedExtensions.includes(fileExtension);
+      });
+      if (containsUnsupportedFiles) {
+        addToast("The file format is unsupported.", {
+          appearance: "error",
+        });
+        return;
+      }
+
       ev.preventDefault();
-      dataTransfer.dropEffect = "copy";
-      this.setState({ hovering: true });
-    }
-  };
+      ev.stopPropagation();
+      filesSelected?.({ files, shiftPressed: ev.shiftKey });
+    },
+    [addToast, filesSelected, allowedExtensions],
+  );
 
-  _onDragLeave = (): void => {
-    this.setState({ hovering: false });
-  };
+  const onDragOver = useCallback(
+    (ev: DragEvent) => {
+      if (!allowedExtensions) {
+        return;
+      }
 
-  render(): JSX.Element {
-    return (
-      <>
-        <input // Expose a hidden input for Puppeteer to use to drop a file in.
-          type="file"
-          style={{ display: "none" }}
-          onChange={(event) =>
-            this.props.filesSelected({ files: event.target.files as any, shiftPressed: false })
+      const { dataTransfer } = ev;
+      if (dataTransfer?.types[0] === "Files") {
+        ev.stopPropagation();
+        ev.preventDefault();
+        dataTransfer.dropEffect = "copy";
+        setHovering(true);
+      }
+    },
+    [allowedExtensions],
+  );
+
+  const onDragLeave = useCallback(() => {
+    setHovering(false);
+  }, []);
+
+  useLayoutEffect(() => {
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("drop", onDrop);
+    document.addEventListener("dragleave", onDragLeave);
+    return () => {
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("drop", onDrop);
+      document.removeEventListener("dragleave", onDragLeave);
+    };
+  }, [onDragLeave, onDragOver, onDrop]);
+
+  return (
+    <>
+      <input // Expose a hidden input for Puppeteer to use to drop a file in.
+        type="file"
+        style={{ display: "none" }}
+        onChange={(event) => {
+          if (event.target.files) {
+            props.filesSelected?.({ files: event.target.files, shiftPressed: false });
           }
-          data-puppeteer-file-upload
-          multiple
-        />
-        {this.state.hovering && this.props.children}
-      </>
-    );
-  }
+        }}
+        data-puppeteer-file-upload
+        multiple
+      />
+      {hovering && props.children}
+    </>
+  );
 }

--- a/app/components/StudioToastProvider.tsx
+++ b/app/components/StudioToastProvider.tsx
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageBar, MessageBarType } from "@fluentui/react";
+import { PropsWithChildren } from "react";
+import { ToastProps, ToastProvider } from "react-toast-notifications";
+
+const StudioToast = (props: ToastProps) => {
+  const barType = (() => {
+    switch (props.appearance) {
+      case "info":
+        return MessageBarType.info;
+      case "success":
+        return MessageBarType.success;
+      case "warning":
+        return MessageBarType.warning;
+      case "error":
+        return MessageBarType.error;
+      default:
+        return MessageBarType.info;
+    }
+  })();
+
+  return (
+    <MessageBar
+      messageBarType={barType}
+      isMultiline={false}
+      onDismiss={() => props.onDismiss()}
+      dismissButtonAriaLabel="Close"
+    >
+      {props.children}
+    </MessageBar>
+  );
+};
+
+export default function StudioToastProvider(props: PropsWithChildren<unknown>): JSX.Element {
+  return (
+    <ToastProvider placement="top-center" components={{ Toast: StudioToast }}>
+      {props.children}
+    </ToastProvider>
+  );
+}

--- a/app/package.json
+++ b/app/package.json
@@ -61,6 +61,7 @@
     "react-redux": "7.2.4",
     "react-resize-detector": "6.7.0",
     "react-table": "7.7.0",
+    "react-toast-notifications": "2.4.4",
     "react-transition-group": "4.4.1",
     "react-use": "17.2.4",
     "react-virtualized": "9.22.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,7 +1671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/core@npm:^10.1.1":
+"@emotion/core@npm:^10.0.14, @emotion/core@npm:^10.1.1":
   version: 10.1.1
   resolution: "@emotion/core@npm:10.1.1"
   dependencies:
@@ -2142,6 +2142,7 @@ __metadata:
     react-redux: 7.2.4
     react-resize-detector: 6.7.0
     react-table: 7.7.0
+    react-toast-notifications: 2.4.4
     react-transition-group: 4.4.1
     react-use: 17.2.4
     react-virtualized: 9.22.3
@@ -21283,7 +21284,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-transition-group@npm:4.4.1":
+"react-toast-notifications@npm:2.4.4":
+  version: 2.4.4
+  resolution: "react-toast-notifications@npm:2.4.4"
+  dependencies:
+    "@emotion/core": ^10.0.14
+    react-transition-group: ^4.4.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0
+    react-dom: ^16.8.0 || ^17.0.0
+  checksum: c80f724344c2d0f48783b2151fecfa1147c8a776bacec6beeabe116c879ae7ff1fb3baab98ac8181c3c1f7df59dc458c9c9be5392945f6d3a11687c896df10de
+  languageName: node
+  linkType: hard
+
+"react-transition-group@npm:4.4.1, react-transition-group@npm:^4.4.1":
   version: 4.4.1
   resolution: "react-transition-group@npm:4.4.1"
   dependencies:


### PR DESCRIPTION
The allowed extensions indicate which files the drop listener will support.
If a file with an unsupported extension is dropped, a toast is shown to
the user indicating the file is unsupported.

<img width="437" alt="Screen Shot 2021-04-30 at 10 23 12 AM" src="https://user-images.githubusercontent.com/84792/116731162-37248800-a99e-11eb-89ef-cf1dc902a763.png">
<img width="325" alt="Screen Shot 2021-04-30 at 10 23 25 AM" src="https://user-images.githubusercontent.com/84792/116731169-37bd1e80-a99e-11eb-89f9-7214b293d5a1.png">

Closes #684