### PR TITLE
Move @foxglove/velodyne-cloud dependency to app/package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@fluentui/react": "8.14.0",
     "@fluentui/react-icons-mdl2": "1.1.0",
+    "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud",
     "@mdi/svg": "5.9.55",
     "async-mutex": "0.3.1",
     "chart.js": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@babel/preset-env": "7.13.15",
     "@babel/preset-typescript": "7.13.0",
     "@foxglove/electron-socket": "workspace:packages/electron-socket",
-    "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud",
     "@jest/types": "26.6.2",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-beta.1",
     "@sentry/electron": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,7 @@ __metadata:
   dependencies:
     "@fluentui/react": 8.14.0
     "@fluentui/react-icons-mdl2": 1.1.0
+    "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud"
     "@mdi/svg": 5.9.55
     "@storybook/addon-actions": 6.2.5
     "@storybook/addon-essentials": 6.2.5
@@ -12617,7 +12618,6 @@ __metadata:
     "@babel/preset-env": 7.13.15
     "@babel/preset-typescript": 7.13.0
     "@foxglove/electron-socket": "workspace:packages/electron-socket"
-    "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud"
     "@jest/types": 26.6.2
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.0-beta.1
     "@sentry/electron": 2.4.0


### PR DESCRIPTION
app/package.json should indicate all of its runtime dependencies - this one was misplaced at the top level

See https://github.com/foxglove/studio/pull/829