### PR TITLE
Fix app crash when setPublishers called before Rosbridge connects

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -104,8 +104,8 @@ export default function App(): ReactElement {
   ];
 
   return (
-    <AllProviders providers={providers}>
-      <ErrorBoundary>
+    <ErrorBoundary>
+      <AllProviders providers={providers}>
         <LayoutStorageReduxAdapter />
         <NativeFileMenuPlayerSelection />
         <DndProvider backend={HTML5Backend}>
@@ -115,7 +115,7 @@ export default function App(): ReactElement {
             </BuiltinPanelCatalogProvider>
           </Suspense>
         </DndProvider>
-      </ErrorBoundary>
-    </AllProviders>
+      </AllProviders>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Rosbridge.setPublishers would check if it had a valid connection and
throw an Error if it did not. This resulted in a race between the publish
panel which invokes setPublishers (indirectly via usePublisher) on players
when a player is available and Rosbridge player not being connected when
setPublishers is invoked. This exposed an additional bug in Rosbridge
with publishers - publishers would not be re-created on reconnect.

This change fixes both issues. Instead of throwing in Rosbridge player if
there is no connection, store the advertise list. When a connection is established
the player creates the publishers from the advertise list. If a connection already
exists, we are able to make the publishers immediately. When a connection drops
and reconnects, the publishers are re-created.

An additional fix moves the ErrorBoundary in App.tsx to capture _all_ child elements
and display an error to the user if an exception is throw and unhandled anywhere in
the component tree. Prior to this move, the throw in setPublishers would result in
a blank app for the user since nothing visually surfaced the error.

Fixes #679,#848