### PR TITLE
Add @foxglove/hooks package with useRethrow hook.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@fluentui/react": "8.14.0",
     "@fluentui/react-icons-mdl2": "1.1.0",
+    "@foxglove/hooks": "workspace:packages/@foxglove/hooks",
     "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud",
     "@mdi/svg": "5.9.55",
     "async-mutex": "0.3.1",

--- a/app/panels/Publish/index.tsx
+++ b/app/panels/Publish/index.tsx
@@ -29,6 +29,7 @@ import usePublisher from "@foxglove-studio/app/hooks/usePublisher";
 import { PlayerCapabilities, Topic } from "@foxglove-studio/app/players/types";
 import colors from "@foxglove-studio/app/styles/colors.module.scss";
 import { isNonEmptyOrUndefined } from "@foxglove-studio/app/util/emptyOrUndefined";
+import { useRethrow } from "@foxglove/hooks";
 
 import buildSampleMessage from "./buildSampleMessage";
 
@@ -155,13 +156,15 @@ function Publish(props: Props) {
     [saveConfig],
   );
 
-  const onPublishClicked = useCallback(() => {
-    if (topicName.length !== 0 && parsedObject) {
-      publish(parsedObject);
-    } else {
-      throw new Error(`called _publish() when input was invalid`);
-    }
-  }, [publish, parsedObject, topicName]);
+  const onPublishClicked = useRethrow(
+    useCallback(() => {
+      if (topicName.length !== 0 && parsedObject) {
+        publish(parsedObject);
+      } else {
+        throw new Error(`called _publish() when input was invalid`);
+      }
+    }, [publish, parsedObject, topicName]),
+  );
 
   const onChange = useCallback(
     (event: React.SyntheticEvent<HTMLTextAreaElement>) => {

--- a/packages/@foxglove/hooks/jest.config.json
+++ b/packages/@foxglove/hooks/jest.config.json
@@ -1,0 +1,9 @@
+{
+  "testRunner": "jest-circus/runner",
+  "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
+  "transform": {
+    "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
+  },
+  "//": "Native find is slow because it does not exclude files: https://github.com/facebook/jest/pull/11264#issuecomment-825377579",
+  "haste": { "forceNodeFilesystemAPI": true }
+}

--- a/packages/@foxglove/hooks/package.json
+++ b/packages/@foxglove/hooks/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@foxglove/hooks",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/foxglove/studio.git"
+  },
+  "author": {
+    "name": "Foxglove Technologies",
+    "email": "support@foxglove.dev"
+  },
+  "homepage": "https://foxglove.dev/",
+  "main": "./src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "prepack": "tsc -b"
+  },
+  "devDependencies": {
+    "typescript": "4.2.2"
+  }
+}

--- a/packages/@foxglove/hooks/src/index.ts
+++ b/packages/@foxglove/hooks/src/index.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import useRethrow from "./useRethrow";
+
+export { useRethrow };

--- a/packages/@foxglove/hooks/src/useRethrow.test.tsx
+++ b/packages/@foxglove/hooks/src/useRethrow.test.tsx
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import useRethrow from "./useRethrow";
+
+describe("useRethrow", () => {
+  it("should catch errors throw", async () => {
+    const { result } = renderHook(() => {
+      return useRethrow(() => {
+        throw new Error("foobar");
+      });
+    });
+
+    act(() => {
+      result.current();
+    });
+    expect(result.error?.message).toEqual("foobar");
+  });
+});

--- a/packages/@foxglove/hooks/src/useRethrow.ts
+++ b/packages/@foxglove/hooks/src/useRethrow.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback, useState } from "react";
+
+type Fn<A extends unknown[], R> = (...args: A) => R;
+
+/**
+ * React error boundaries do not catch errors from user event handlers (clicks, etc).
+ * This hook wraps a function which may throw, and re-throws the error within a render context.
+ * This allows react error boundaries to capture the error.
+ *
+ * see: https://github.com/facebook/react/issues/11409
+ * @param fn function to wrap in a try/catch
+ * @returns wrapped fn with the same signature as fn
+ */
+export default function useRethrow<Args extends unknown[], Ret>(
+  fn: Fn<Args, Ret>,
+): Fn<Args, Ret | void> {
+  const [_, setError] = useState(undefined);
+  return useCallback(
+    (...args: Args): Ret | void => {
+      try {
+        return fn(...args);
+      } catch (err) {
+        // throwing within a setError happens within a react render context
+        setError(() => {
+          throw err;
+        });
+      }
+    },
+    [fn],
+  );
+}

--- a/packages/@foxglove/hooks/tsconfig.json
+++ b/packages/@foxglove/hooks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@foxglove/tsconfig/tsconfig.base.json",
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2041,6 +2041,7 @@ __metadata:
   dependencies:
     "@fluentui/react": 8.14.0
     "@fluentui/react-icons-mdl2": 1.1.0
+    "@foxglove/hooks": "workspace:packages/@foxglove/hooks"
     "@foxglove/velodyne-cloud": "workspace:packages/velodyne-cloud"
     "@mdi/svg": 5.9.55
     "@storybook/addon-actions": 6.2.5
@@ -2193,6 +2194,14 @@ __metadata:
     typescript: 4.2.2
   peerDependencies:
     electron: ">=12"
+  languageName: unknown
+  linkType: soft
+
+"@foxglove/hooks@workspace:packages/@foxglove/hooks":
+  version: 0.0.0-use.local
+  resolution: "@foxglove/hooks@workspace:packages/@foxglove/hooks"
+  dependencies:
+    typescript: 4.2.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The useCatch hook surfaces errors thrown in a function handler
into the react render context. This allows these errors to bubble up
to an error boundary.

Update onPublishClick within the publish panel to useCatch when
publishing so publish errors are localized to the panel.