### PR TITLE
Disable sentry breadcrumbs

### DIFF
--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -29,6 +29,13 @@ if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
     release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
+    // creates more noise than benefit.
+    integrations: (integrations) => {
+      return integrations.filter((integration) => {
+        return integration.name !== "Breadcrumbs";
+      });
+    },
   });
 }
 

--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -34,6 +34,13 @@ if (
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
     release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
+    // creates more noise than benefit.
+    integrations: (integrations) => {
+      return integrations.filter((integration) => {
+        return integration.name !== "Breadcrumbs";
+      });
+    },
   });
 }
 


### PR DESCRIPTION
The breadcrumbs produce more noise than value. They also wrap calls
which we do not necessarily want wrapped (console, fetch, etc). We
have stacktraces from errors which is adequate for now.