### PR TITLE
Fetch machineId asynchronously

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -73,7 +73,7 @@ export interface OsContext {
   // Get a listing for every network interface discovered on the system
   getNetworkInterfaces: () => NetworkInterface[];
   // Get a unique identifier for the system from the operating system
-  getMachineId: () => string;
+  getMachineId: () => Promise<string>;
   // Get the version string from package.json
   getAppVersion: () => string;
 

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -46,7 +46,7 @@ if (require("electron-squirrel-startup")) {
 // Load opt-out settings for crash reporting and telemetry
 const [allowCrashReporting] = getTelemetrySettings();
 if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
-  log.info("initializing Sentry in renderer");
+  log.info("initializing Sentry in main");
   initSentry({
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -4,7 +4,7 @@
 
 import { init as initSentry } from "@sentry/electron";
 import { contextBridge, ipcRenderer } from "electron";
-import { machineIdSync } from "node-machine-id";
+import { machineId } from "node-machine-id";
 import os from "os";
 
 import type { OsContext, OsContextForwardedEvent } from "@foxglove-studio/app/OsContext";
@@ -56,6 +56,10 @@ window.addEventListener(
 );
 
 const localFileStorage = new LocalFileStorage();
+
+// machineId() can sometimes take 500-2000ms on macOS
+// we fetch it early so that it is ready for Analytics.ts
+const machineIdPromise = machineId();
 
 const ctx: OsContext = {
   platform: process.platform,
@@ -111,8 +115,8 @@ const ctx: OsContext = {
     }
     return output;
   },
-  getMachineId: (): string => {
-    return machineIdSync();
+  getMachineId: (): Promise<string> => {
+    return machineIdPromise;
   },
   getAppVersion: (): string => {
     return APP_VERSION;


### PR DESCRIPTION
`OsContextSingleton.getMachineId()` was taking around 2s on my machine, and since we call it twice (when initializing analytics) was leading to about a 4s startup delay for production builds.

Changed to call this method asynchronously, and kick it off at the start of preload, so that it is ready by the time analytics needs it.

Also, initializing analytics now happens async, and `logEvent()` will await until it is ready.

Paired with @defunctzombie 