### PR TITLE
Add comment to lint command making it more visible in GitHub Actions log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           # required checks don't need to change if we ever change the commands used.
           - name: lint
             command: |
+              # lint steps
               yarn dedupe --check
               yarn run tsc --noEmit # typecheck files that are not included by webpack or package builds
               yarn run lint:ci


### PR DESCRIPTION
Previously in the github actions log, the entry for the lint step would just look like `yarn dedupe --check` (because that was the first line of the multi-line command). Making a comment the first line should hopefully make it easier to find the lint step in the actions log.

<img width="207" alt="image" src="https://user-images.githubusercontent.com/14237/117084885-0cab3580-ace4-11eb-9bba-3e663e9c9fcc.png">