### PR TITLE
Add NativeAppMenuContext

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -56,6 +56,7 @@ export interface OsContext {
 
   // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.
   addIpcEventListener(eventName: OsContextForwardedEvent, handler: () => void): void;
+  removeIpcEventListener(eventName: OsContextForwardedEvent, handler: () => void): void;
 
   // Manage file menu input source menu items
   menuAddInputSource(name: string, handler: () => void): Promise<void>;

--- a/app/Workspace.tsx
+++ b/app/Workspace.tsx
@@ -46,6 +46,7 @@ import { useAssets } from "@foxglove-studio/app/context/AssetContext";
 import LinkHandlerContext from "@foxglove-studio/app/context/LinkHandlerContext";
 import { usePlayerSelection } from "@foxglove-studio/app/context/PlayerSelectionContext";
 import useElectronFilesToOpen from "@foxglove-studio/app/hooks/useElectronFilesToOpen";
+import useNativeAppMenuEvent from "@foxglove-studio/app/hooks/useNativeAppMenuEvent";
 import useSelectPanel from "@foxglove-studio/app/hooks/useSelectPanel";
 import welcomeLayout from "@foxglove-studio/app/layouts/welcomeLayout";
 import { PlayerPresence } from "@foxglove-studio/app/players/types";
@@ -140,34 +141,50 @@ export default function Workspace(): JSX.Element {
     // Add a hook for integration tests.
     (window as TestableWindow).setPanelLayout = (payload: ImportPanelLayoutPayload) =>
       dispatch(importPanelLayout(payload));
+  }, [dispatch, openWelcomeLayout]);
 
-    // For undo/redo events, first try the browser's native undo/redo, and if that is disabled, then
-    // undo/redo the layout history. Note that in GlobalKeyListener we also handle the keyboard
-    // events for undo/redo, so if an input or textarea element that would handle the event is not
-    // focused, the GlobalKeyListener will handle it. The listeners here are to handle the case when
-    // an editable element is focused, or when the user directly chooses the undo/redo menu item.
-    OsContextSingleton?.addIpcEventListener("undo", () => {
+  // For undo/redo events, first try the browser's native undo/redo, and if that is disabled, then
+  // undo/redo the layout history. Note that in GlobalKeyListener we also handle the keyboard
+  // events for undo/redo, so if an input or textarea element that would handle the event is not
+  // focused, the GlobalKeyListener will handle it. The listeners here are to handle the case when
+  // an editable element is focused, or when the user directly chooses the undo/redo menu item.
+
+  useNativeAppMenuEvent(
+    "undo",
+    useCallback(() => {
       if (!document.execCommand("undo")) {
         dispatch(undoLayoutChange());
       }
-    });
-    OsContextSingleton?.addIpcEventListener("redo", () => {
+    }, [dispatch]),
+  );
+
+  useNativeAppMenuEvent(
+    "redo",
+    useCallback(() => {
       if (!document.execCommand("redo")) {
         dispatch(redoLayoutChange());
       }
-    });
+    }, [dispatch]),
+  );
 
-    OsContextSingleton?.addIpcEventListener("open-preferences", () =>
-      setSelectedSidebarItem((item) => (item === "preferences" ? undefined : "preferences")),
-    );
-    OsContextSingleton?.addIpcEventListener("open-message-path-syntax-help", () =>
-      setMessagePathSyntaxModalOpen(true),
-    );
-    OsContextSingleton?.addIpcEventListener("open-keyboard-shortcuts", () =>
-      setShortcutsModalOpen(true),
-    );
-    OsContextSingleton?.addIpcEventListener("open-welcome-layout", () => openWelcomeLayout());
-  }, [dispatch, openWelcomeLayout]);
+  useNativeAppMenuEvent(
+    "open-preferences",
+    useCallback(() => {
+      setSelectedSidebarItem((item) => (item === "preferences" ? undefined : "preferences"));
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-message-path-syntax-help",
+    useCallback(() => setMessagePathSyntaxModalOpen(true), []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-keyboard-shortcuts",
+    useCallback(() => setShortcutsModalOpen(true), []),
+  );
+
+  useNativeAppMenuEvent("open-welcome-layout", openWelcomeLayout);
 
   const appConfiguration = useAppConfiguration();
   const { addToast } = useToasts();

--- a/app/components/NativeFileMenuPlayerSelection.tsx
+++ b/app/components/NativeFileMenuPlayerSelection.tsx
@@ -4,26 +4,32 @@
 
 import { ReactElement, useEffect } from "react";
 
-import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
+import { useNativeAppMenu } from "@foxglove-studio/app/context/NativeAppMenuContext";
 import { usePlayerSelection } from "@foxglove-studio/app/context/PlayerSelectionContext";
 
 // NativeFileMenuPlayerSelection adds available player selection items to the apps native OS menubar
 export function NativeFileMenuPlayerSelection(): ReactElement {
   const { selectSource, availableSources } = usePlayerSelection();
 
+  const nativeAppMenu = useNativeAppMenu();
+
   useEffect(() => {
+    if (!nativeAppMenu) {
+      return;
+    }
+
     for (const item of availableSources) {
-      OsContextSingleton?.menuAddInputSource(item.name, () => {
+      nativeAppMenu.addFileEntry(item.name, () => {
         selectSource(item);
       });
     }
 
     return () => {
       for (const item of availableSources) {
-        OsContextSingleton?.menuRemoveInputSource(item.name);
+        nativeAppMenu.removeFileEntry(item.name);
       }
     };
-  }, [availableSources, selectSource]);
+  }, [availableSources, nativeAppMenu, selectSource]);
 
   return <></>;
 }

--- a/app/context/NativeAppMenuContext.ts
+++ b/app/context/NativeAppMenuContext.ts
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+export type NativeAppMenuEvent =
+  | "open-preferences"
+  | "open-keyboard-shortcuts"
+  | "open-message-path-syntax-help"
+  | "open-welcome-layout"
+  | "undo"
+  | "redo";
+
+type Handler = () => void;
+
+export interface NativeAppMenu {
+  addFileEntry(name: string, handler: Handler): void;
+  removeFileEntry(name: string): void;
+
+  on(name: NativeAppMenuEvent, handler: Handler): void;
+  off(name: NativeAppMenuEvent, handler: Handler): void;
+}
+
+const NativeAppMenuContext = createContext<NativeAppMenu | undefined>(undefined);
+
+export function useNativeAppMenu(): NativeAppMenu | undefined {
+  return useContext(NativeAppMenuContext);
+}
+
+export default NativeAppMenuContext;

--- a/app/hooks/useNativeAppMenuEvent.ts
+++ b/app/hooks/useNativeAppMenuEvent.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useEffect } from "react";
+
+import {
+  NativeAppMenuEvent,
+  useNativeAppMenu,
+} from "@foxglove-studio/app/context/NativeAppMenuContext";
+
+type EventHandler = () => void;
+
+export default function useNativeAppMenuEvent(
+  eventName: NativeAppMenuEvent,
+  handler: EventHandler,
+): void {
+  const nativeAppMenu = useNativeAppMenu();
+
+  useEffect(() => {
+    if (!nativeAppMenu) {
+      return;
+    }
+
+    const fn = handler;
+    nativeAppMenu.on(eventName, fn);
+
+    return () => {
+      nativeAppMenu.off(eventName, fn);
+    };
+  }, [eventName, handler, nativeAppMenu]);
+}

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -77,6 +77,9 @@ const ctx: OsContext = {
   addIpcEventListener(eventName: OsContextForwardedEvent, handler: () => void) {
     ipcRenderer.on(eventName, () => handler());
   },
+  removeIpcEventListener(eventName: OsContextForwardedEvent, handler: () => void) {
+    ipcRenderer.off(eventName, () => handler());
+  },
   async menuAddInputSource(name: string, handler: () => void) {
     if (menuClickListeners.has(name)) {
       throw new Error(`Menu input source ${name} already exists`);

--- a/desktop/renderer/App.tsx
+++ b/desktop/renderer/App.tsx
@@ -35,6 +35,8 @@ import URDFAssetLoader from "@foxglove-studio/app/services/URDFAssetLoader";
 import getGlobalStore from "@foxglove-studio/app/store/getGlobalStore";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
 
+import NativeAppMenuProvider from "./components/NativeAppMenuProvider";
+
 const BuiltinPanelCatalogProvider = React.lazy(
   () => import("@foxglove-studio/app/context/BuiltinPanelCatalogProvider"),
 );
@@ -90,6 +92,7 @@ export default function App(): ReactElement {
     <ExperimentalFeaturesLocalStorageProvider features={experimentalFeatures} />,
     <PlayerManager playerSources={playerSources} />,
     <AssetsProvider loaders={assetLoaders} />,
+    <NativeAppMenuProvider />,
     /* eslint-enable react/jsx-key */
   ];
 

--- a/desktop/renderer/components/NativeAppMenuProvider.tsx
+++ b/desktop/renderer/components/NativeAppMenuProvider.tsx
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useMemo } from "react";
+
+import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
+import NativeAppMenuContext, {
+  NativeAppMenu,
+  NativeAppMenuEvent,
+} from "@foxglove-studio/app/context/NativeAppMenuContext";
+
+type Handler = () => void;
+
+export default function NativeAppMenuProvider(props: PropsWithChildren<unknown>): JSX.Element {
+  const value = useMemo<NativeAppMenu>(() => {
+    return {
+      addFileEntry: (name: string, handler: Handler) => {
+        OsContextSingleton?.menuAddInputSource(name, handler);
+      },
+      removeFileEntry: (name: string) => {
+        OsContextSingleton?.menuRemoveInputSource(name);
+      },
+      on: (name: NativeAppMenuEvent, listener: Handler) => {
+        OsContextSingleton?.addIpcEventListener(name, listener);
+      },
+      off: (name: NativeAppMenuEvent, listener: Handler) => {
+        OsContextSingleton?.removeIpcEventListener(name, listener);
+      },
+    };
+  }, []);
+
+  return (
+    <NativeAppMenuContext.Provider value={value}>{props.children}</NativeAppMenuContext.Provider>
+  );
+}


### PR DESCRIPTION
The NativeAppMenuContext exposes functionality for interfacing
with a native app menu within the app. The provider is environment
specific.

---
This continues my quest to remove OsContextSingleton uses within app for the purpose of making it more flexible to different environment and removing a global catch-all object.