### PR TITLE
Remove explicit @jest/types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@babel/preset-typescript": "7.13.0",
     "@foxglove/electron-socket": "workspace:packages/electron-socket",
     "@foxglove/tsconfig": "workspace:packages/@foxglove/tsconfig",
-    "@jest/types": "26.6.2",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-beta.1",
     "@sentry/electron": "2.4.0",
     "@sentry/webpack-plugin": "1.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:26.6.2, @jest/types@npm:^26.6.2":
+"@jest/types@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/types@npm:26.6.2"
   dependencies:
@@ -12713,7 +12713,6 @@ __metadata:
     "@babel/preset-typescript": 7.13.0
     "@foxglove/electron-socket": "workspace:packages/electron-socket"
     "@foxglove/tsconfig": "workspace:packages/@foxglove/tsconfig"
-    "@jest/types": 26.6.2
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.0-beta.1
     "@sentry/electron": 2.4.0
     "@sentry/webpack-plugin": 1.15.1


### PR DESCRIPTION
This appears to be an internal dependency, and is not mentioned anywhere in the documentation as something that should be explicitly added to a package.json file.

It was added by me in https://github.com/foxglove/studio/pull/44 (not sure why).