### PR TITLE
Load new StudioWindows when creating via File -> New Window

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -141,7 +141,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       {
         label: "New Window",
         click: () => {
-          new StudioWindow();
+          new StudioWindow().load();
         },
       },
       { type: "separator" },
@@ -286,7 +286,7 @@ class StudioWindow {
           new MenuItem({
             label: "New Window",
             click: () => {
-              new StudioWindow();
+              new StudioWindow().load();
             },
           }),
         );
@@ -370,7 +370,7 @@ class StudioWindow {
       new MenuItem({
         label: "New Window",
         click: () => {
-          new StudioWindow();
+          new StudioWindow().load();
         },
       }),
     );


### PR DESCRIPTION
new StudioWindow does not _load_ the content by default. This was done
so main startup could create the window and load the page once more
setup items were in place. Once the app is ready - future windows
should load on create.