### PR TITLE
Remove tabs from Preferences sidebar

### DIFF
--- a/app/components/ExperimentalFeatureSettings.tsx
+++ b/app/components/ExperimentalFeatureSettings.tsx
@@ -57,7 +57,7 @@ function ExperimentalFeatureItem(props: { feature: Feature }) {
 export function ExperimentalFeatureSettings(): React.ReactElement {
   const theme = useTheme();
   return (
-    <Stack style={{ padding: theme.spacing.m }} tokens={{ childrenGap: theme.spacing.m }}>
+    <Stack tokens={{ childrenGap: theme.spacing.m }}>
       {features.length === 0 && (
         <p>
           <em>Currently there are no experimental features.</em>

--- a/app/components/Preferences.tsx
+++ b/app/components/Preferences.tsx
@@ -5,8 +5,6 @@ import {
   Checkbox,
   DirectionalHint,
   IComboBoxOption,
-  Pivot,
-  PivotItem,
   SelectableOptionMenuItemType,
   Stack,
   Text,
@@ -150,6 +148,23 @@ function RosHostname(): React.ReactElement {
   );
 }
 
+function SectionHeader({ children }: React.PropsWithChildren<unknown>) {
+  const theme = useTheme();
+  return (
+    <Text
+      block
+      as="h2"
+      variant="large"
+      style={{
+        marginBottom: theme.spacing.s1,
+        color: theme.palette.themeSecondary,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
 export default function Preferences(): React.ReactElement {
   const theme = useTheme();
 
@@ -162,8 +177,9 @@ export default function Preferences(): React.ReactElement {
 
   return (
     <SidebarContent title="Preferences">
-      <Pivot>
-        <PivotItem headerText="General" style={{ paddingTop: theme.spacing.m }}>
+      <Stack tokens={{ childrenGap: 30 }}>
+        <Stack.Item>
+          <SectionHeader>General</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
             <Stack.Item>
               <TimezoneSettings />
@@ -172,8 +188,9 @@ export default function Preferences(): React.ReactElement {
               <RosHostname />
             </Stack.Item>
           </Stack>
-        </PivotItem>
-        <PivotItem headerText="Privacy" style={{ paddingTop: theme.spacing.m }}>
+        </Stack.Item>
+        <Stack.Item>
+          <SectionHeader>Privacy</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
             <Text style={{ color: theme.palette.neutralSecondary }}>
               Changes will take effect the next time {APP_NAME} is launched.
@@ -189,11 +206,12 @@ export default function Preferences(): React.ReactElement {
               label="Send anonymized crash reports"
             />
           </Stack>
-        </PivotItem>
-        <PivotItem headerText="Experimental Features">
+        </Stack.Item>
+        <Stack.Item>
+          <SectionHeader>Experimental Features</SectionHeader>
           <ExperimentalFeatureSettings />
-        </PivotItem>
-      </Pivot>
+        </Stack.Item>
+      </Stack>
     </SidebarContent>
   );
 }

--- a/app/components/SidebarContent.tsx
+++ b/app/components/SidebarContent.tsx
@@ -32,7 +32,7 @@ export function SidebarContent({
         horizontalAlign="space-between"
         style={{ padding: noPadding ? theme.spacing.m : undefined, paddingBottom: theme.spacing.m }}
       >
-        <Text as="h2" variant="large">
+        <Text as="h2" variant="xLarge">
           {title}
         </Text>
         {Boolean(helpContent) && (


### PR DESCRIPTION
Now that preferences are in a sidebar, the tabbed Pivot UI doesn't really fit. Just stack all the items instead, since we don't have many settings.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/14237/117725223-8cbc1a00-b180-11eb-803a-95f567fad1a4.png">
