### PR TITLE
Repro case for incorrect positioning

### DIFF
--- a/app/panels/Rosout/index.stories.tsx
+++ b/app/panels/Rosout/index.stories.tsx
@@ -85,7 +85,7 @@ export default {
 
 export const Simple = (): JSX.Element => {
   return (
-    <>
+    <div style={{ margin: 40, position: "relative", height: "100%" }}>
       <div style={{ fontSize: 20, padding: 10, width: "50%" }}>
         Look at the position of the .contract-trigger::before pseudo element in the inspector. It
         has top:0 and left:0, but is not aligned with the top/left of its parent.
@@ -95,7 +95,7 @@ export const Simple = (): JSX.Element => {
           <Rosout />
         </PanelSetup>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/app/panels/Rosout/index.stories.tsx
+++ b/app/panels/Rosout/index.stories.tsx
@@ -85,9 +85,17 @@ export default {
 
 export const Simple = (): JSX.Element => {
   return (
-    <PanelSetup fixture={fixture}>
-      <Rosout />
-    </PanelSetup>
+    <>
+      <div style={{ fontSize: 20, padding: 10, width: "50%" }}>
+        Look at the position of the .contract-trigger::before pseudo element in the inspector. It
+        has top:0 and left:0, but is not aligned with the top/left of its parent.
+      </div>
+      <div style={{ position: "absolute", left: "50%", right: 0, top: 0, bottom: 0 }}>
+        <PanelSetup>
+          <Rosout />
+        </PanelSetup>
+      </div>
+    </>
   );
 };
 

--- a/app/panels/Rosout/index.stories.tsx
+++ b/app/panels/Rosout/index.stories.tsx
@@ -90,7 +90,7 @@ export const Simple = (): JSX.Element => {
         Look at the position of the .contract-trigger::before pseudo element in the inspector. It
         has top:0 and left:0, but is not aligned with the top/left of its parent.
       </div>
-      <div style={{ position: "absolute", left: "50%", right: 0, top: 0, bottom: 0 }}>
+      <div style={{ position: "absolute", left: "70%", right: "20%", top: "40%", bottom: "40%" }}>
         <PanelSetup>
           <Rosout />
         </PanelSetup>


### PR DESCRIPTION
https://bugs.chromium.org/p/chromium/issues/detail?id=1208623

Researching #907. It appears a sizing pseudo-element added by react-virtualized is incorrectly positioned relative to its parent element.

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/14237/118054576-38e93680-b322-11eb-87e4-1b8788573d75.png">

<img width="1296" alt="image" src="https://user-images.githubusercontent.com/14237/118054616-4a324300-b322-11eb-8ccd-21e20e4118ba.png">
