### PR TITLE
Fix Plot chart x-axis range panel setting.

### DIFF
--- a/app/components/TimeBasedChart/index.tsx
+++ b/app/components/TimeBasedChart/index.tsx
@@ -540,6 +540,11 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     if (defaultView?.type === "fixed") {
       min = defaultView.minXValue;
       max = defaultView.maxXValue;
+    } else if (defaultView?.type === "following") {
+      max = datasetBounds.x.max;
+      if (max != undefined) {
+        min = max - defaultView.width;
+      }
     } else {
       min = datasetBounds.x.min;
       max = datasetBounds.x.max;
@@ -552,7 +557,8 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       if (globalBounds.userInteraction) {
         min = globalBounds.min;
         max = globalBounds.max;
-      } else {
+      } else if (defaultView?.type !== "following") {
+        // if following and no user interaction - we leave our bounds as they are
         min = Math.min(min ?? globalBounds.min, globalBounds.min);
         max = Math.max(max ?? globalBounds.max, globalBounds.max);
       }

--- a/app/panels/Plot/PlotChart.tsx
+++ b/app/panels/Plot/PlotChart.tsx
@@ -363,7 +363,7 @@ type PlotChartProps = {
   tooltips: TimeBasedChartTooltipData[];
   xAxisVal: PlotXAxisVal;
   currentTime?: number;
-  defaultView: ChartDefaultView;
+  defaultView?: ChartDefaultView;
   onClick?: TimeBasedChartProps["onClick"];
 };
 export default memo<PlotChartProps>(function PlotChart(props: PlotChartProps) {

--- a/app/panels/Plot/index.tsx
+++ b/app/panels/Plot/index.tsx
@@ -34,6 +34,7 @@ import {
 import Panel from "@foxglove-studio/app/components/Panel";
 import PanelToolbar from "@foxglove-studio/app/components/PanelToolbar";
 import {
+  ChartDefaultView,
   getTooltipItemForMessageHistoryItem,
   TooltipItem,
 } from "@foxglove-studio/app/components/TimeBasedChart";
@@ -233,7 +234,7 @@ function Plot(props: Props) {
   const preloadingDisplayTime = timeToXValueForPreloading(currentTime);
   const preloadingStartTime = timeToXValueForPreloading(startTime); // zero or undefined
   const preloadingEndTime = timeToXValueForPreloading(endTime);
-  let defaultView;
+  let defaultView: ChartDefaultView | undefined;
   if (preloadingDisplayTime != undefined) {
     if (followingViewWidth != undefined && +followingViewWidth > 0) {
       // Will be ignored in TimeBasedChart for non-preloading plots and non-timestamp plots.
@@ -269,7 +270,7 @@ function Plot(props: Props) {
         xAxisVal={xAxisVal}
         currentTime={preloadingDisplayTime}
         onClick={onClick}
-        defaultView={defaultView as any}
+        defaultView={defaultView}
       />
       <PlotLegend
         paths={yAxisPaths}


### PR DESCRIPTION
The "following" view setting was broken during the chartjs v3 upgrade.
This change adds support for "following" back to the plot.

Fixes #916