### PR TITLE
Fix drag-drop additional bag files when shift pressed.

### DIFF
--- a/app/Workspace.tsx
+++ b/app/Workspace.tsx
@@ -247,6 +247,10 @@ export default function Workspace(props: { demoBagUrl?: string }): JSX.Element {
     })();
   }, [appConfiguration, openWelcomeLayout]);
 
+  // previously loaded files are tracked so support the "add bag" feature which loads a second bag
+  // file when the user presses shift during a drag/drop
+  const previousFiles = useRef<File[]>([]);
+
   const { loadFromFile } = useAssets();
 
   const openFiles = useCallback(
@@ -267,11 +271,15 @@ export default function Workspace(props: { demoBagUrl?: string }): JSX.Element {
       }
 
       if (otherFiles.length > 0) {
+        if (shiftPressed) {
+          previousFiles.current = previousFiles.current.concat(otherFiles);
+        } else {
+          previousFiles.current = otherFiles;
+        }
         selectSource(
           { name: "Local Files", type: "file" },
           {
-            files: otherFiles,
-            append: shiftPressed,
+            files: previousFiles.current,
           },
         );
       }

--- a/app/components/PlayerManager.tsx
+++ b/app/components/PlayerManager.tsx
@@ -348,7 +348,6 @@ function PlayerManager({
 }: Props) {
   useWarnImmediateReRender();
 
-  const usedFiles = useRef<File[]>([]);
   const globalVariablesRef = useRef<GlobalVariables>(globalVariables);
   const [maybePlayer, setMaybePlayer] = useState<MaybePlayer<OrderedStampPlayer>>({});
   const [currentSourceName, setCurrentSourceName] = useState<string | undefined>(undefined);
@@ -479,14 +478,6 @@ function PlayerManager({
         const createPlayerBuilder = lookupPlayerBuilderFactory(selectedSource);
         if (!createPlayerBuilder) {
           throw new Error(`Could not create a player for ${selectedSource.name}`);
-        }
-
-        if (selectedSource.type === "file") {
-          if (!params?.append) {
-            usedFiles.current = [];
-          } else if (params?.files instanceof Array) {
-            usedFiles.current = params.files;
-          }
         }
 
         if (!params) {

--- a/app/context/PlayerSelectionContext.ts
+++ b/app/context/PlayerSelectionContext.ts
@@ -13,7 +13,6 @@ export type PlayerSourceDefinition = {
 
 type FileSourceParams = {
   files?: File[];
-  append?: boolean;
 };
 
 type HttpSourceParams = {


### PR DESCRIPTION
Changes in https://github.com/foxglove/studio/pull/868 broke "adding"
a bag file to an already loaded bag file by pressing _shift_ during
the drag-drop operation. This change fixes the behavior by moving
previously loaded file tracking up to the Workspace component where
the drag-drop is handled.

Fixes #915