### PR TITLE
Image: allow adjusting min/max values for mono16 images

### DIFF
--- a/app/panels/ImageView/ImageCanvas.stories.tsx
+++ b/app/panels/ImageView/ImageCanvas.stories.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { storiesOf } from "@storybook/react";
 import { range, noop } from "lodash";
 
 import ImageView from "@foxglove-studio/app/panels/ImageView";
@@ -326,7 +325,15 @@ function BayerStory({ encoding }: { encoding: string }) {
   );
 }
 
-function Mono16Story({ bigEndian }: { bigEndian: boolean }) {
+function Mono16Story({
+  bigEndian,
+  minValue,
+  maxValue,
+}: {
+  minValue?: number;
+  maxValue?: number;
+  bigEndian: boolean;
+}) {
   const width = 2000;
   const height = 1000;
   const data = new Uint8Array(width * height * 2);
@@ -346,7 +353,7 @@ function Mono16Story({ bigEndian }: { bigEndian: boolean }) {
         message: { data, width, height, encoding: "16UC1", is_bigendian: bigEndian ? 1 : 0 },
       }}
       rawMarkerData={noMarkersMarkerData}
-      config={config}
+      config={{ ...config, minValue, maxValue }}
       saveConfig={noop}
       onStartRenderImage={() => () => undefined}
     />
@@ -385,183 +392,194 @@ function ShouldCallOnRenderImage({
   );
 }
 
-storiesOf("panels/ImageView/ImageCanvas", module)
-  .addParameters({
+export default {
+  title: "panels/ImageView/ImageCanvas",
+  component: ImageCanvas,
+  parameters: {
     chromatic: {
       delay: 2500,
     },
-  })
-  .add("markers", () => (
-    <LoadImageMessage>
-      {(imageMessage: any) => (
-        <div>
-          <h2>original markers</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: undefined,
-              scale: 1,
-              transformMarkers: false,
-            }}
-            config={config}
-            saveConfig={noop}
-            onStartRenderImage={() => () => undefined}
-          />
-          <br />
-          <h2>transformed markers</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: cameraInfo as any,
-              scale: 1,
-              transformMarkers: true,
-            }}
-            config={config}
-            saveConfig={noop}
-            onStartRenderImage={() => () => undefined}
-          />
-          <h2>markers with different original image size</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: { ...cameraInfo, width: 200, height: 150 } as any,
-              scale: 1,
-              transformMarkers: true,
-            }}
-            config={config}
-            saveConfig={noop}
-            onStartRenderImage={() => () => undefined}
-          />
-        </div>
+  },
+};
+export const Markers = (): JSX.Element => (
+  <LoadImageMessage>
+    {(imageMessage: any) => (
+      <div>
+        <h2>original markers</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: undefined,
+            scale: 1,
+            transformMarkers: false,
+          }}
+          config={config}
+          saveConfig={noop}
+          onStartRenderImage={() => () => undefined}
+        />
+        <br />
+        <h2>transformed markers</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: cameraInfo as any,
+            scale: 1,
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          onStartRenderImage={() => () => undefined}
+        />
+        <h2>markers with different original image size</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: { ...cameraInfo, width: 200, height: 150 } as any,
+            scale: 1,
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          onStartRenderImage={() => () => undefined}
+        />
+      </div>
+    )}
+  </LoadImageMessage>
+);
+export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => (
+  <LoadImageMessage>
+    {(imageMessage: any) => (
+      <div>
+        <h2>original markers</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: undefined,
+            scale: 1,
+            transformMarkers: false,
+          }}
+          config={config}
+          saveConfig={noop}
+          useMainThreadRenderingForTesting
+          onStartRenderImage={() => () => undefined}
+        />
+        <br />
+        <h2>transformed markers</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: cameraInfo as any,
+            scale: 1,
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          useMainThreadRenderingForTesting
+          onStartRenderImage={() => () => undefined}
+        />
+        <h2>markers with different original image size</h2>
+        <ImageCanvas
+          topic={topics[1]}
+          image={imageMessage}
+          rawMarkerData={{
+            markers,
+            cameraInfo: { ...cameraInfo, width: 200, height: 150 } as any,
+            scale: 1,
+            transformMarkers: true,
+          }}
+          config={config}
+          saveConfig={noop}
+          useMainThreadRenderingForTesting
+          onStartRenderImage={() => () => undefined}
+        />
+      </div>
+    )}
+  </LoadImageMessage>
+);
+export const ErrorState = (): JSX.Element => {
+  return (
+    <ImageCanvas
+      topic={topics[0]}
+      image={{
+        topic: "/foo",
+        receiveTime: { sec: 0, nsec: 0 },
+        message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
+      }}
+      rawMarkerData={noMarkersMarkerData}
+      config={config}
+      saveConfig={noop}
+      onStartRenderImage={() => () => undefined}
+    />
+  );
+};
+export const CallsOnRenderFrameWhenRenderingSucceeds = (): JSX.Element => {
+  return (
+    <ShouldCallOnRenderImage>
+      {(onStartRenderImage) => (
+        <LoadImageMessage>
+          {(imageMessage: any) => (
+            <ImageCanvas
+              topic={topics[0]}
+              image={imageMessage}
+              rawMarkerData={{
+                markers,
+                cameraInfo: undefined,
+                scale: 1,
+                transformMarkers: false,
+              }}
+              config={config}
+              saveConfig={noop}
+              onStartRenderImage={onStartRenderImage}
+            />
+          )}
+        </LoadImageMessage>
       )}
-    </LoadImageMessage>
-  ))
-  .add("Markers with fallback rendering using the main thread", () => (
-    <LoadImageMessage>
-      {(imageMessage: any) => (
-        <div>
-          <h2>original markers</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: undefined,
-              scale: 1,
-              transformMarkers: false,
-            }}
-            config={config}
-            saveConfig={noop}
-            useMainThreadRenderingForTesting
-            onStartRenderImage={() => () => undefined}
-          />
-          <br />
-          <h2>transformed markers</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: cameraInfo as any,
-              scale: 1,
-              transformMarkers: true,
-            }}
-            config={config}
-            saveConfig={noop}
-            useMainThreadRenderingForTesting
-            onStartRenderImage={() => () => undefined}
-          />
-          <h2>markers with different original image size</h2>
-          <ImageCanvas
-            topic={topics[1]}
-            image={imageMessage}
-            rawMarkerData={{
-              markers,
-              cameraInfo: { ...cameraInfo, width: 200, height: 150 } as any,
-              scale: 1,
-              transformMarkers: true,
-            }}
-            config={config}
-            saveConfig={noop}
-            useMainThreadRenderingForTesting
-            onStartRenderImage={() => () => undefined}
-          />
-        </div>
+    </ShouldCallOnRenderImage>
+  );
+};
+export const CallsOnRenderFrameWhenRenderingFails = (): JSX.Element => {
+  return (
+    <ShouldCallOnRenderImage>
+      {(onStartRenderImage) => (
+        <ImageCanvas
+          topic={topics[0]}
+          image={{
+            topic: "/foo",
+            receiveTime: { sec: 0, nsec: 0 },
+            message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
+          }}
+          rawMarkerData={noMarkersMarkerData}
+          config={config}
+          saveConfig={noop}
+          onStartRenderImage={onStartRenderImage}
+        />
       )}
-    </LoadImageMessage>
-  ))
-  .add("error state", () => {
-    return (
-      <ImageCanvas
-        topic={topics[0]}
-        image={{
-          topic: "/foo",
-          receiveTime: { sec: 0, nsec: 0 },
-          message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
-        }}
-        rawMarkerData={noMarkersMarkerData}
-        config={config}
-        saveConfig={noop}
-        onStartRenderImage={() => () => undefined}
-      />
-    );
-  })
-  .add("Calls onRenderFrame when rendering succeeds", () => {
-    return (
-      <ShouldCallOnRenderImage>
-        {(onStartRenderImage) => (
-          <LoadImageMessage>
-            {(imageMessage: any) => (
-              <ImageCanvas
-                topic={topics[0]}
-                image={imageMessage}
-                rawMarkerData={{
-                  markers,
-                  cameraInfo: undefined,
-                  scale: 1,
-                  transformMarkers: false,
-                }}
-                config={config}
-                saveConfig={noop}
-                onStartRenderImage={onStartRenderImage}
-              />
-            )}
-          </LoadImageMessage>
-        )}
-      </ShouldCallOnRenderImage>
-    );
-  })
-  .add("calls onRenderFrame when rendering fails", () => {
-    return (
-      <ShouldCallOnRenderImage>
-        {(onStartRenderImage) => (
-          <ImageCanvas
-            topic={topics[0]}
-            image={{
-              topic: "/foo",
-              receiveTime: { sec: 0, nsec: 0 },
-              message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
-            }}
-            rawMarkerData={noMarkersMarkerData}
-            config={config}
-            saveConfig={noop}
-            onStartRenderImage={onStartRenderImage}
-          />
-        )}
-      </ShouldCallOnRenderImage>
-    );
-  })
-  .add("rgb8", () => <RGBStory encoding="rgb8" />)
-  .add("bgr8", () => <RGBStory encoding="bgr8" />)
-  .add("mono16 big endian", () => <Mono16Story bigEndian={true} />)
-  .add("mono16 little endian", () => <Mono16Story bigEndian={false} />)
-  .add("bayer_rggb8", () => <BayerStory encoding="bayer_rggb8" />)
-  .add("bayer_bggr8", () => <BayerStory encoding="bayer_bggr8" />)
-  .add("bayer_gbrg8", () => <BayerStory encoding="bayer_gbrg8" />)
-  .add("bayer_grbg8", () => <BayerStory encoding="bayer_grbg8" />);
+    </ShouldCallOnRenderImage>
+  );
+};
+export const RGB8 = (): JSX.Element => <RGBStory encoding="rgb8" />;
+export const BGR8 = (): JSX.Element => <RGBStory encoding="bgr8" />;
+
+export const Mono16BigEndian = (): JSX.Element => <Mono16Story bigEndian={true} />;
+export const Mono16LittleEndian = (): JSX.Element => <Mono16Story bigEndian={false} />;
+
+const mono16Args = { minValue: 5000, maxValue: 20000 };
+export const Mono16CustomMinMax = (args: typeof mono16Args): JSX.Element => (
+  <Mono16Story bigEndian {...args} />
+);
+Mono16CustomMinMax.args = mono16Args;
+
+export const BayerRGGB8 = (): JSX.Element => <BayerStory encoding="bayer_rggb8" />;
+export const BayerBGGR8 = (): JSX.Element => <BayerStory encoding="bayer_bggr8" />;
+export const BayerGBRG8 = (): JSX.Element => <BayerStory encoding="bayer_gbrg8" />;
+export const BayerGRBG8 = (): JSX.Element => <BayerStory encoding="bayer_grbg8" />;

--- a/app/panels/ImageView/ImageCanvas.worker.ts
+++ b/app/panels/ImageView/ImageCanvas.worker.ts
@@ -16,7 +16,7 @@ import Rpc, { Channel } from "@foxglove-studio/app/util/Rpc";
 import { setupWorker } from "@foxglove-studio/app/util/RpcWorkerUtils";
 
 import { renderImage } from "./renderImage";
-import { Dimensions, RawMarkerData, OffscreenCanvas } from "./util";
+import { Dimensions, RawMarkerData, OffscreenCanvas, RenderOptions } from "./util";
 
 export default class ImageCanvasWorker {
   _idToCanvas: {
@@ -39,14 +39,16 @@ export default class ImageCanvasWorker {
         imageMessage,
         imageMessageDatatype,
         rawMarkerData,
+        options,
       }: {
         id: string;
         imageMessage?: MessageEvent<unknown>;
         imageMessageDatatype?: string;
         rawMarkerData: RawMarkerData;
+        options: RenderOptions;
       }): Promise<Dimensions | undefined> => {
         const canvas = this._idToCanvas[id];
-        return renderImage({ canvas, imageMessage, imageMessageDatatype, rawMarkerData });
+        return renderImage({ canvas, imageMessage, imageMessageDatatype, rawMarkerData, options });
       },
     );
   }

--- a/app/panels/ImageView/decodings.test.ts
+++ b/app/panels/ImageView/decodings.test.ts
@@ -18,7 +18,6 @@ describe("decodeBayer*()", () => {
     const output = new Uint8ClampedArray(2 * 2 * 4);
     decodeBayerRGGB8(new Uint8Array([10, 20, 30, 40]), 2, 2, output);
     expect(output).toStrictEqual(
-      // prettier-ignore
       new Uint8ClampedArray([10, 20, 40, 255, 10, 20, 40, 255, 10, 30, 40, 255, 10, 30, 40, 255]),
     );
   });

--- a/app/panels/ImageView/index.tsx
+++ b/app/panels/ImageView/index.tsx
@@ -70,17 +70,13 @@ type DefaultConfig = {
   synchronize: boolean;
 };
 
-export type ImageViewPanelHooks = {
-  defaultConfig: DefaultConfig;
-  imageMarkerDatatypes: string[];
-};
-
 export type Config = DefaultConfig & {
-  panelHooks?: ImageViewPanelHooks;
   transformMarkers: boolean;
   mode?: "fit" | "fill" | "other";
   zoomPercentage?: number;
   offset?: number[];
+  minValue?: number;
+  maxValue?: number;
   saveStoryConfig?: () => void;
 };
 
@@ -272,7 +268,6 @@ function ImageView(props: Props) {
     scale,
     cameraTopic,
     enabledMarkerTopics,
-    panelHooks,
     transformMarkers,
     customMarkerTopicOptions = NO_CUSTOM_OPTIONS,
   } = config;
@@ -626,7 +621,6 @@ function ImageView(props: Props) {
       {/* Always render the ImageCanvas because it's expensive to unmount and start up. */}
       {imageMessageToRender && (
         <ImageCanvas
-          panelHooks={panelHooks}
           topic={cameraTopicFullObject}
           image={imageMessageToRender}
           rawMarkerData={rawMarkerData}
@@ -654,6 +648,20 @@ const defaultConfig: Config = {
 
 const configSchema: PanelConfigSchema<Config> = [
   { key: "synchronize", type: "toggle", title: "Synchronize images and markers" },
+  {
+    key: "minValue",
+    type: "number",
+    title: "Minimum value (depth images)",
+    placeholder: "0",
+    allowEmpty: true,
+  },
+  {
+    key: "maxValue",
+    type: "number",
+    title: "Maximum value (depth images)",
+    placeholder: "10000",
+    allowEmpty: true,
+  },
   {
     key: "scale",
     type: "dropdown",

--- a/app/panels/ImageView/util.ts
+++ b/app/panels/ImageView/util.ts
@@ -26,6 +26,11 @@ import CameraModel from "./CameraModel";
 // TODO: change this to the Flow definition once it's been added.
 export type OffscreenCanvas = HTMLCanvasElement;
 
+export type RenderOptions = {
+  minValue?: number;
+  maxValue?: number;
+};
+
 export type Dimensions = { width: number; height: number };
 
 export type MarkerOption = {

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -977,7 +977,6 @@ export default class SceneBuilder implements MarkerProvider {
     // allow topic settings to override renderable marker command (see MarkerSettingsEditor.js)
     const { overrideCommand } = this._settingsByKey[`t:${topic.name}`] || {};
 
-    // prettier-ignore
     switch (marker.type) {
       case 0:
         return add.arrow(marker);
@@ -1026,13 +1025,11 @@ export default class SceneBuilder implements MarkerProvider {
         return add.overlayIcon(marker);
       case 110:
         return add.color(marker);
-      default:
-        {
-          if (!this._hooks.addMarkerToCollector(add, marker)) {
-            this._setTopicError(topic.name, `Unsupported marker type: ${marker.type}`);
-          }
+      default: {
+        if (!this._hooks.addMarkerToCollector(add, marker)) {
+          this._setTopicError(topic.name, `Unsupported marker type: ${marker.type}`);
         }
-
+      }
     }
   }
 }


### PR DESCRIPTION
cc @jackma
Closes #680.

Depth settings are currently only used for mono16/16UC1 images.

Potential further improvements would be an option to adjust the range dynamically based on the min/max values in each frame.

<img width="629" alt="Screen Shot 2021-05-12 at 3 16 47 PM" src="https://user-images.githubusercontent.com/14237/118063670-4360fb80-b335-11eb-95e0-13b1dde19516.png">
<img width="631" alt="Screen Shot 2021-05-12 at 3 17 01 PM" src="https://user-images.githubusercontent.com/14237/118063677-452abf00-b335-11eb-820c-cb48d5941602.png">