### PR TITLE
Fix monospace font crash

### DIFF
--- a/app/components/Chart/worker/ChartJSManager.ts
+++ b/app/components/Chart/worker/ChartJSManager.ts
@@ -51,6 +51,7 @@ type InitOpts = {
   data: ChartData;
   options: ChartOptions;
   devicePixelRatio: number;
+  fontLoaded: Promise<FontFace>;
 };
 
 export default class ChartJSManager {
@@ -64,8 +65,17 @@ export default class ChartJSManager {
     this.init(initOpts);
   }
 
-  async init({ id, node, type, data, options, devicePixelRatio }: InitOpts): Promise<void> {
-    log.debug(`ChartJSManager(${id}) init`);
+  async init({
+    id,
+    node,
+    type,
+    data,
+    options,
+    devicePixelRatio,
+    fontLoaded,
+  }: InitOpts): Promise<void> {
+    const font = await fontLoaded;
+    log.debug(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
 
     const fakeNode = {
       addEventListener: addEventListener(this._fakeNodeEvents),

--- a/app/styles/assets/latin-roboto-mono-bold-italic.woff2
+++ b/app/styles/assets/latin-roboto-mono-bold-italic.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:208cd5c0f1d791a16c74b58f96d65121f50f284a1f6542de292e5daeb98840ab
+size 13568

--- a/app/styles/assets/latin-roboto-mono-bold.woff2
+++ b/app/styles/assets/latin-roboto-mono-bold.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a992792c34e226d5ecff616df4edcafaa833ba9b4e1fa9f0726a49778fa0f6
+size 12288

--- a/app/styles/assets/latin-roboto-mono-italic.woff2
+++ b/app/styles/assets/latin-roboto-mono-italic.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b1c71dd7f4a26ee9e3184b593d688aa47750912b5e2ecb7379da7485b8800d
+size 13496

--- a/app/styles/assets/latin-roboto-mono.scss
+++ b/app/styles/assets/latin-roboto-mono.scss
@@ -1,0 +1,39 @@
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: italic;
+  font-weight: 400;
+  src: url("./assets/latin-roboto-mono-italic.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: italic;
+  font-weight: 700;
+  src: url("./assets/latin-roboto-mono-bold-italic.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: normal;
+  font-weight: 400;
+  src: url("./assets/latin-roboto-mono.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: normal;
+  font-weight: 700;
+  src: url("./assets/latin-roboto-mono-bold.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/app/styles/assets/latin-roboto-mono.woff2
+++ b/app/styles/assets/latin-roboto-mono.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1fd013ac18aebac28e366bf82aace3b2fb6900fecc4793303ed93aeadd31910
+size 12312

--- a/app/styles/fonts.module.scss
+++ b/app/styles/fonts.module.scss
@@ -24,18 +24,9 @@
   // Use fixed width numbers (important for numbers that update during playback)
   font-feature-settings: "tnum";
 }
+
+// We currently avoid monospace system fonts due to DWriteFont::Create electron crash
+// when rendering offscreen canvas (see comments in ChartJsMux.ts and https://github.com/foxglove/studio/pull/933).
 @mixin ff-monospace {
-  font-family:
-    // Apple
-    ui-monospace,
-    // Windows
-    "Cascadia Mono",
-    "Segoe UI Mono",
-    // Ubuntu
-    "Ubuntu Mono",
-    // Chrome OS and Android
-    "Roboto Mono",
-    // Fallback
-    "Menlo",
-    "Monaco", "Consolas", monospace;
+  font-family: "Roboto Mono";
 }

--- a/app/styles/fonts.ts
+++ b/app/styles/fonts.ts
@@ -5,4 +5,4 @@
 // Keep in sync with fonts.module.scss
 // We tried importing scss vars directly in JS, but style-loader doesn't support web workers
 export const SANS_SERIF = `-apple-system, BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Roboto", sans-serif`;
-export const MONOSPACE = `ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Ubuntu Mono", "Roboto Mono", "Menlo", "Monaco", "Consolas", monospace`;
+export const MONOSPACE = `"Roboto Mono"`;

--- a/app/styles/global.scss
+++ b/app/styles/global.scss
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 @import "./reset.scss";
+@import "./assets/latin-roboto-mono.scss";
 @import "./mixins.module.scss";
 @import "~rc-color-picker/assets/index.css";
 


### PR DESCRIPTION
Fix resurgence of `DWriteFont::Create Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ` errors.

This issue is actually pretty easy to reproduce, you just have to be running Windows with a hidpi / retina screen, and show the Plot panel (which uses offscreen canvas / web workers). I can even reproduce it using RDP connected to Windows from a retina Macbook Pro. It seems to be an electron (or lower) bug that we need to work around. I can't understand what is causing it - removing some of the final fallback fonts from our monospace stack seems to fix it some times (but not 100% of the time), but my windows box has `Cascadia Mono` installed, so it shouldn't even be looking at the fallback fonts.

In any case, as a workaround I am restoring our use of `Roboto Mono` everywhere (including explicitly loading it into web workers) that was removed in https://github.com/foxglove/studio/pull/888.

A better approach in the future might be to explicitly bundle [Cascadia Mono](https://github.com/microsoft/cascadia-code) on Windows, and use system monospace fonts everywhere else. But I've spent enough time on this for now and would prefer to just ship a fix.

Typical stack trace:

```
Fatal Error: 0xc0000002 / 0x00000001

Thread 18724 Crashed:
0   KERNELBASE.dll                  0x7ff9ca2f4b89      RaiseException
1   DWrite.dll                      0x7ff9934dc464      DWriteFont::Create
2   DWrite.dll                      0x7ff9934ddd4c      DWriteFont::Create
3   DWrite.dll                      0x7ff9934c10a5      DWriteFontFamily::GetFirstMatchingFont
4   Foxglove Studio.exe             0x7ff698d75ee0      SkFontStyleSet_DirectWrite::matchStyle (SkFontMgr_win_dw.cpp:1237)
5   Foxglove Studio.exe             0x7ff698d75e6c      SkFontMgr_DirectWrite::onMatchFamilyStyle (SkFontMgr_win_dw.cpp:526)
6   Foxglove Studio.exe             0x7ff699990389      blink::FontCache::CreateTypeface (font_cache_skia.cc:238)
7   Foxglove Studio.exe             0x7ff6993b231c      blink::FontCache::CreateFontPlatformData (font_cache_skia_win.cc:602)
8   Foxglove Studio.exe             0x7ff69a9d8fb9      blink::FontCache::GetFontPlatformData (font_cache.cc:200)
9   Foxglove Studio.exe             0x7ff6997c1588      blink::FontFallbackList::CompositeKey (font_fallback_list.cc:215)
10  Foxglove Studio.exe             0x7ff6993a8264      [inlined] blink::FontFallbackList::GetShapeCache (font_fallback_list.h:80)
11  Foxglove Studio.exe             0x7ff6993a8264      blink::Font::GetShapeCache (font.cc:494)
12  Foxglove Studio.exe             0x7ff69d3bc16b      [inlined] blink::CachingWordShaper::GetShapeCache (caching_word_shaper.cc:40)
13  Foxglove Studio.exe             0x7ff69d3bc16b      blink::CachingWordShaper::IndividualCharacterAdvances (caching_word_shaper.cc:142)
14  Foxglove Studio.exe             0x7ff69cc9ee3e      blink::Font::IndividualCharacterAdvances (font.cc:584)
15  Foxglove Studio.exe             0x7ff69df15d51      blink::TextMetrics::Update (text_metrics.cc:75)
16  Foxglove Studio.exe             0x7ff69df15b7c      blink::TextMetrics::TextMetrics (text_metrics.cc:55)
17  Foxglove Studio.exe             0x7ff69dd532a1      [inlined] blink::MakeGarbageCollectedTrait<T>::Call (heap.h:568)
18  Foxglove Studio.exe             0x7ff69dd532a1      [inlined] blink::MakeGarbageCollected (heap.h:608)
19  Foxglove Studio.exe             0x7ff69dd532a1      blink::OffscreenCanvasRenderingContext2D::measureText (offscreen_canvas_rendering_context_2d.cc:734)
20  Foxglove Studio.exe             0x7ff699f86ab7      [inlined] blink::bindings::NativeValueTraitsStringAdapter::ToString (native_value_traits_impl.h:345)
21  Foxglove Studio.exe             0x7ff699f86ab7      [inlined] String (native_value_traits_impl.h:333)
22  Foxglove Studio.exe             0x7ff699f86ab7      blink::`anonymous namespace'::MeasureTextOperationCallback (v8_offscreen_canvas_rendering_context_2d.cc:3019)
23  Foxglove Studio.exe             0x7ff69a3b9035      v8::internal::FunctionCallbackArguments::Call (api-arguments-inl.h:158)
24  Foxglove Studio.exe             0x7ff69a3b8c34      v8::internal::`anonymous namespace'::HandleApiCallHelper<T> (builtins-api.cc:113)
25  Foxglove Studio.exe             0x7ff69a3b821f      v8::internal::Builtin_Impl_HandleApiCall (builtins-api.cc:143)
26  Foxglove Studio.exe             0x7ff69a3b80d6      v8::internal::Builtin_HandleApiCall (builtins-api.cc:131)
27  Foxglove Studio.exe             0x7ff69a6e823b      Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_BuiltinExit
```

Fixes https://github.com/foxglove/studio/issues/923