### PR TITLE
Fix macOS open window from dock

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -281,7 +281,7 @@ app.on("ready", async () => {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) {
-      new StudioWindow();
+      new StudioWindow().load();
     }
   });
 


### PR DESCRIPTION
The change to add support for multiple windows broke launching
a new window from the macOS dock when no windows were open. This
change fixes the bug by calling "load" on the new studio window instance.

Fixes #939