### PR TITLE
Remove isCrashReportingEnabled and isTelemetryEnabled from OsContext

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -25,11 +25,6 @@ export interface OsContext {
 
   handleToolbarDoubleClick: () => void;
 
-  // Return true unless the user has opted out of crash reporting
-  isCrashReportingEnabled(): boolean;
-  // Return true unless the user has opted out of telemetry
-  isTelemetryEnabled(): boolean;
-
   // Retrieve an environment variable
   getEnvVar: (envVar: string) => string | undefined;
   // Get the operating system hostname

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -52,6 +52,13 @@ if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
     release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
+    // creates more noise than benefit.
+    integrations: (integrations) => {
+      return integrations.filter((integration) => {
+        return integration.name !== "Breadcrumbs";
+      });
+    },
     maxBreadcrumbs: 10,
   });
 }

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -23,7 +23,7 @@ log.info(`${APP_NAME} ${APP_VERSION}`);
 log.info(`initializing preloader, argv="${window.process.argv.join(" ")}"`);
 
 // Load opt-out settings for crash reporting and telemetry
-const [allowCrashReporting, allowTelemetry] = getTelemetrySettings();
+const [allowCrashReporting] = getTelemetrySettings();
 if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
   log.debug("initializing Sentry in preload");
   initSentry({
@@ -76,9 +76,6 @@ const ctx: OsContext = {
   handleToolbarDoubleClick() {
     ipcRenderer.send("window.toolbar-double-clicked");
   },
-
-  isCrashReportingEnabled: (): boolean => allowCrashReporting,
-  isTelemetryEnabled: (): boolean => allowTelemetry,
 
   // Environment queries
   getEnvVar: (envVar: string) => process.env[envVar],
@@ -161,17 +158,15 @@ const menuBridge: NativeMenuBridge = {
 contextBridge.exposeInMainWorld("ctxbridge", ctx);
 contextBridge.exposeInMainWorld("menuBridge", menuBridge);
 contextBridge.exposeInMainWorld("storageBridge", storageBridge);
+contextBridge.exposeInMainWorld("allowCrashReporting", allowCrashReporting);
 
 // Load telemetry opt-out settings from window.process.argv
-function getTelemetrySettings(): [crashReportingEnabled: boolean, telemetryEnabled: boolean] {
+function getTelemetrySettings(): [crashReportingEnabled: boolean] {
   const argv = window.process.argv;
   const crashReportingEnabled = Boolean(
     parseInt(argv.find((arg) => arg.indexOf("--allowCrashReporting=") === 0)?.split("=")[1] ?? "0"),
   );
-  const telemetryEnabled = Boolean(
-    parseInt(argv.find((arg) => arg.indexOf("--allowTelemetry=") === 0)?.split("=")[1] ?? "0"),
-  );
-  return [crashReportingEnabled, telemetryEnabled];
+  return [crashReportingEnabled];
 }
 
 log.debug(`End Preload`);

--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -10,7 +10,6 @@ import ReactDOM from "react-dom";
 
 import "@foxglove-studio/app/styles/global.scss";
 
-import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
 import installDevtoolsFormatters from "@foxglove-studio/app/util/installDevtoolsFormatters";
 import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
 import overwriteFetch from "@foxglove-studio/app/util/overwriteFetch";
@@ -25,10 +24,11 @@ const log = Logger.getLogger(__filename);
 
 log.debug("initializing renderer");
 
-if (
-  (OsContextSingleton?.isCrashReportingEnabled() ?? false) &&
-  typeof process.env.SENTRY_DSN === "string"
-) {
+// preload injects the crash reporting global based on app settings received from the main process
+const isCrashReportingEnabled =
+  (global as { allowCrashReporting?: boolean }).allowCrashReporting ?? false;
+
+if (isCrashReportingEnabled && typeof process.env.SENTRY_DSN === "string") {
   log.info("initializing Sentry in renderer");
   initSentry({
     dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
isTelemetryEnabled was unused. isCrashReporting is specific to preloader/render interaction so it is moved as a single value exposed by the preloader and read by renderer. No longer relevant to app.