### PR TITLE
Remove handleToolbarDoubleClick and getDeepLinks from OsContext

### DIFF
--- a/app/OsContext.ts
+++ b/app/OsContext.ts
@@ -2,9 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Events that are forwarded from the main process and can be listened to using ctxbridge.addIpcEventListener
-export type OsContextForwardedEvent = "enter-full-screen" | "leave-full-screen";
-
 export interface NetworkInterface {
   name: string;
   family: "IPv4" | "IPv6";
@@ -23,8 +20,6 @@ export interface OsContext {
   // The process id of this application
   pid: number;
 
-  handleToolbarDoubleClick: () => void;
-
   // Retrieve an environment variable
   getEnvVar: (envVar: string) => string | undefined;
   // Get the operating system hostname
@@ -35,7 +30,4 @@ export interface OsContext {
   getMachineId: () => Promise<string>;
   // Get the version string from package.json
   getAppVersion: () => string;
-
-  // Get an array of deep links provided on app launch
-  getDeepLinks: () => string[];
 }

--- a/app/components/PlayerManager.tsx
+++ b/app/components/PlayerManager.tsx
@@ -22,7 +22,6 @@ import {
 } from "react";
 import { connect, ConnectedProps } from "react-redux";
 import { useLocalStorage, useMountedState } from "react-use";
-import { URL } from "universal-url";
 
 import { AppSetting } from "@foxglove-studio/app/AppSetting";
 import OsContextSingleton from "@foxglove-studio/app/OsContextSingleton";
@@ -429,34 +428,6 @@ function PlayerManager({
         return;
     }
   }, []);
-
-  useEffect(() => {
-    const links = OsContextSingleton?.getDeepLinks() ?? [];
-    const firstLink = links[0];
-    if (firstLink == undefined) {
-      return;
-    }
-
-    try {
-      const url = new URL(firstLink);
-      // only support the open command
-
-      // Test if the pathname matches //open or //open/
-      if (!/\/\/open\/?/.test(url.pathname)) {
-        return;
-      }
-
-      // only support rosbag urls
-      const type = url.searchParams.get("type");
-      const bagUrl = url.searchParams.get("url");
-      if (type !== "rosbag" || bagUrl == undefined) {
-        return;
-      }
-      setPlayer(async (options: BuildPlayerOptions) => buildPlayerFromBagURLs([bagUrl], options));
-    } catch (err) {
-      log.error(err);
-    }
-  }, [setPlayer]);
 
   const prompt = usePrompt();
   const storage = useMemo(() => new Storage(), []);

--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -43,4 +43,11 @@ interface Storage {
   delete(datastore: string, key: string): Promise<void>;
 }
 
-export type { NativeMenuBridge, Storage, StorageContent };
+interface Desktop {
+  handleToolbarDoubleClick: () => void;
+
+  // Get an array of deep links provided on app launch
+  getDeepLinks: () => string[];
+}
+
+export type { NativeMenuBridge, Storage, StorageContent, Desktop };

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -13,7 +13,7 @@ import { APP_NAME, APP_VERSION } from "@foxglove-studio/app/version";
 import { PreloaderSockets } from "@foxglove/electron-socket/preloader";
 import Logger from "@foxglove/log";
 
-import { ForwardedMenuEvent, NativeMenuBridge, Storage } from "../common/types";
+import { Desktop, ForwardedMenuEvent, NativeMenuBridge, Storage } from "../common/types";
 import LocalFileStorage from "./LocalFileStorage";
 
 const log = Logger.getLogger(__filename);
@@ -73,9 +73,6 @@ const machineIdPromise = machineId();
 const ctx: OsContext = {
   platform: process.platform,
   pid: process.pid,
-  handleToolbarDoubleClick() {
-    ipcRenderer.send("window.toolbar-double-clicked");
-  },
 
   // Environment queries
   getEnvVar: (envVar: string) => process.env[envVar],
@@ -100,7 +97,12 @@ const ctx: OsContext = {
   getAppVersion: (): string => {
     return APP_VERSION;
   },
+};
 
+const desktopBridge: Desktop = {
+  handleToolbarDoubleClick() {
+    ipcRenderer.send("window.toolbar-double-clicked");
+  },
   getDeepLinks: (): string[] => {
     return window.process.argv.filter((arg) => arg.startsWith("foxglove://"));
   },
@@ -159,6 +161,7 @@ contextBridge.exposeInMainWorld("ctxbridge", ctx);
 contextBridge.exposeInMainWorld("menuBridge", menuBridge);
 contextBridge.exposeInMainWorld("storageBridge", storageBridge);
 contextBridge.exposeInMainWorld("allowCrashReporting", allowCrashReporting);
+contextBridge.exposeInMainWorld("desktopBridge", desktopBridge);
 
 // Load telemetry opt-out settings from window.process.argv
 function getTelemetrySettings(): [crashReportingEnabled: boolean] {

--- a/desktop/renderer/App.tsx
+++ b/desktop/renderer/App.tsx
@@ -10,7 +10,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ReactElement, useState, Suspense } from "react";
+import { ReactElement, useState, Suspense, useCallback, useMemo } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { Provider as ReduxProvider } from "react-redux";
@@ -29,6 +29,7 @@ import URDFAssetLoader from "@foxglove-studio/app/services/URDFAssetLoader";
 import getGlobalStore from "@foxglove-studio/app/store/getGlobalStore";
 import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
 
+import { Desktop } from "../common/types";
 import NativeAppMenuProvider from "./components/NativeAppMenuProvider";
 import NativeStorageAppConfigurationProvider from "./components/NativeStorageAppConfigurationProvider";
 import NativeStorageLayoutStorageProvider from "./components/NativeStorageLayoutStorageProvider";
@@ -40,6 +41,8 @@ const BuiltinPanelCatalogProvider = React.lazy(
 const Workspace = React.lazy(() => import("@foxglove-studio/app/Workspace"));
 
 const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
+
+const desktopBridge = (global as { desktopBridge?: Desktop }).desktopBridge;
 
 export default function App(): ReactElement {
   const globalStore = getGlobalStore();
@@ -80,6 +83,14 @@ export default function App(): ReactElement {
     /* eslint-enable react/jsx-key */
   ];
 
+  const deepLinks = useMemo(() => {
+    return desktopBridge?.getDeepLinks() ?? [];
+  }, []);
+
+  const handleToolbarDoubleClick = useCallback(() => {
+    desktopBridge?.handleToolbarDoubleClick();
+  }, []);
+
   return (
     <ErrorBoundary>
       <MultiProvider providers={providers}>
@@ -88,7 +99,11 @@ export default function App(): ReactElement {
         <DndProvider backend={HTML5Backend}>
           <Suspense fallback={<></>}>
             <BuiltinPanelCatalogProvider>
-              <Workspace demoBagUrl={DEMO_BAG_URL} />
+              <Workspace
+                demoBagUrl={DEMO_BAG_URL}
+                deepLinks={deepLinks}
+                onToolbarDoubleClick={handleToolbarDoubleClick}
+              />
             </BuiltinPanelCatalogProvider>
           </Suspense>
         </DndProvider>


### PR DESCRIPTION
These are desktop specific functions exposed by preloader. Provide
them to the workspace via properties on the Workspace component rather than via a global singleton.