### PR TITLE
Enable projectReferences for ts-loader

### DIFF
--- a/app/webpack.ts
+++ b/app/webpack.ts
@@ -82,6 +82,7 @@ export function makeConfig(
                 // https://github.com/TypeStrong/ts-loader#onlycompilebundledfiles
                 // avoid looking at files which are not part of the bundle
                 onlyCompileBundledFiles: true,
+                projectReferences: true,
                 configFile: isDev ? "tsconfig.dev.json" : "tsconfig.json",
                 getCustomTransformers: () => ({
                   before: [

--- a/desktop/webpack.main.config.ts
+++ b/desktop/webpack.main.config.ts
@@ -54,6 +54,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
               // https://github.com/TypeStrong/ts-loader#onlycompilebundledfiles
               // avoid looking at files which are not part of the bundle
               onlyCompileBundledFiles: true,
+              projectReferences: true,
             },
           },
         },

--- a/desktop/webpack.preload.config.ts
+++ b/desktop/webpack.preload.config.ts
@@ -37,6 +37,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
               // https://github.com/TypeStrong/ts-loader#onlycompilebundledfiles
               // avoid looking at files which are not part of the bundle
               onlyCompileBundledFiles: true,
+              projectReferences: true,
             },
           },
         },


### PR DESCRIPTION
This isn't strictly necessary today, but it will be needed if someone adds references to our tsconfig and expects webpack to correctly compile dependencies.

This was part of my learnings from https://github.com/foxglove/studio/pull/609 (which was broken into pieces and merged incrementally), and this was intended to happen in a follow up PR.