### PR TITLE
Change desktop and web imports to top level @foxglove-studio/app

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -8,12 +8,30 @@
 // See typings/index.d.ts for additional included references
 /// <reference types="./typings" />
 
-import App from "@foxglove-studio/app/App";
-import ErrorBoundary from "@foxglove-studio/app/components/ErrorBoundary";
-import MultiProvider from "@foxglove-studio/app/components/MultiProvider";
-import { PlayerSourceDefinition } from "@foxglove-studio/app/context/PlayerSelectionContext";
-import ThemeProvider from "@foxglove-studio/app/theme/ThemeProvider";
+import App from "./App";
+import { NetworkInterface, OsContext } from "./OsContext";
+import ErrorBoundary from "./components/ErrorBoundary";
+import MultiProvider from "./components/MultiProvider";
+import { PlayerSourceDefinition } from "./context/PlayerSelectionContext";
+import ThemeProvider from "./theme/ThemeProvider";
+import installDevtoolsFormatters from "./util/installDevtoolsFormatters";
+import { initializeLogEvent } from "./util/logEvent";
+import overwriteFetch from "./util/overwriteFetch";
+import waitForFonts from "./util/waitForFonts";
+import version from "./version";
 
-export { App, ErrorBoundary, MultiProvider, ThemeProvider };
+const pkgInfo = version;
 
-export type { PlayerSourceDefinition };
+export {
+  pkgInfo,
+  App,
+  ErrorBoundary,
+  MultiProvider,
+  ThemeProvider,
+  installDevtoolsFormatters,
+  initializeLogEvent,
+  overwriteFetch,
+  waitForFonts,
+};
+
+export type { PlayerSourceDefinition, OsContext, NetworkInterface };

--- a/app/version.ts
+++ b/app/version.ts
@@ -7,3 +7,9 @@ import packageJson from "../package.json";
 export const APP_NAME: string = packageJson.productName;
 export const APP_VERSION: string = packageJson.version;
 export const APP_HOMEPAGE: string = packageJson.homepage;
+
+export default {
+  name: APP_NAME,
+  homepage: APP_HOMEPAGE,
+  version: APP_VERSION,
+};

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -16,7 +16,7 @@ import { autoUpdater } from "electron-updater";
 import fs from "fs";
 import { URL } from "universal-url";
 
-import { APP_NAME, APP_VERSION, APP_HOMEPAGE } from "@foxglove-studio/app/version";
+import pkgInfo from "@foxglove-studio/app/version";
 import Logger from "@foxglove/log";
 
 import StudioWindow from "./StudioWindow";
@@ -31,7 +31,7 @@ import { getTelemetrySettings } from "./telemetry";
 const start = Date.now();
 const log = Logger.getLogger(__filename);
 
-log.info(`${APP_NAME} ${APP_VERSION}`);
+log.info(`${pkgInfo.name} ${pkgInfo.version}`);
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -51,7 +51,7 @@ if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
   initSentry({
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
-    release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    release: `${process.env.SENTRY_PROJECT}@${pkgInfo.version}`,
     // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
     // creates more noise than benefit.
     integrations: (integrations) => {
@@ -191,7 +191,7 @@ app.on("ready", async () => {
   // Only stable builds check for automatic updates
   if (process.env.NODE_ENV !== "production") {
     log.info("Automatic updates disabled (development environment)");
-  } else if (/-(dev|nightly)/.test(APP_VERSION)) {
+  } else if (/-(dev|nightly)/.test(pkgInfo.version)) {
     log.info("Automatic updates disabled (development version)");
   } else {
     autoUpdater.checkForUpdatesAndNotify().catch((err) => {
@@ -200,11 +200,11 @@ app.on("ready", async () => {
   }
 
   app.setAboutPanelOptions({
-    applicationName: APP_NAME,
-    applicationVersion: APP_VERSION,
+    applicationName: pkgInfo.name,
+    applicationVersion: pkgInfo.version,
     version: process.platform,
     copyright: undefined,
-    website: APP_HOMEPAGE,
+    website: pkgInfo.homepage,
     iconPath: undefined,
   });
 

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -7,9 +7,8 @@ import { contextBridge, ipcRenderer } from "electron";
 import { machineId } from "node-machine-id";
 import os from "os";
 
-import type { OsContext } from "@foxglove-studio/app/OsContext";
-import { NetworkInterface } from "@foxglove-studio/app/OsContext";
-import { APP_NAME, APP_VERSION } from "@foxglove-studio/app/version";
+import { NetworkInterface, OsContext } from "@foxglove-studio/app/OsContext";
+import pkgInfo from "@foxglove-studio/app/version";
 import { PreloaderSockets } from "@foxglove/electron-socket/preloader";
 import Logger from "@foxglove/log";
 
@@ -19,7 +18,7 @@ import LocalFileStorage from "./LocalFileStorage";
 const log = Logger.getLogger(__filename);
 
 log.debug(`Start Preload`);
-log.info(`${APP_NAME} ${APP_VERSION}`);
+log.info(`${pkgInfo.name} ${pkgInfo.version}`);
 log.info(`initializing preloader, argv="${window.process.argv.join(" ")}"`);
 
 // Load opt-out settings for crash reporting and telemetry
@@ -29,7 +28,7 @@ if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
   initSentry({
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
-    release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    release: `${process.env.SENTRY_PROJECT}@${pkgInfo.version}`,
     // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
     // creates more noise than benefit.
     integrations: (integrations) => {
@@ -95,7 +94,7 @@ const ctx: OsContext = {
     return machineIdPromise;
   },
   getAppVersion: (): string => {
-    return APP_VERSION;
+    return pkgInfo.version;
   },
 };
 

--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -10,11 +10,13 @@ import ReactDOM from "react-dom";
 
 import "@foxglove-studio/app/styles/global.scss";
 
-import installDevtoolsFormatters from "@foxglove-studio/app/util/installDevtoolsFormatters";
-import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
-import overwriteFetch from "@foxglove-studio/app/util/overwriteFetch";
-import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
-import { APP_VERSION } from "@foxglove-studio/app/version";
+import {
+  pkgInfo,
+  installDevtoolsFormatters,
+  initializeLogEvent,
+  overwriteFetch,
+  waitForFonts,
+} from "@foxglove-studio/app";
 import { Sockets } from "@foxglove/electron-socket/renderer";
 import Logger from "@foxglove/log";
 
@@ -33,7 +35,7 @@ if (isCrashReportingEnabled && typeof process.env.SENTRY_DSN === "string") {
   initSentry({
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
-    release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
+    release: `${process.env.SENTRY_PROJECT}@${pkgInfo.version}`,
     // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
     // creates more noise than benefit.
     integrations: (integrations) => {

--- a/desktop/test/globalSetup.ts
+++ b/desktop/test/globalSetup.ts
@@ -31,6 +31,7 @@ export default async (): Promise<void> => {
         return;
       }
       if (!result || result.hasErrors()) {
+        console.error(result?.toString());
         reject(new Error("webpack build failed"));
         return;
       }

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -7,11 +7,12 @@ import ReactDOM from "react-dom";
 
 import "@foxglove-studio/app/styles/global.scss";
 
-import installDevtoolsFormatters from "@foxglove-studio/app/util/installDevtoolsFormatters";
-import { initializeLogEvent } from "@foxglove-studio/app/util/logEvent";
-import overwriteFetch from "@foxglove-studio/app/util/overwriteFetch";
-import waitForFonts from "@foxglove-studio/app/util/waitForFonts";
-import { APP_VERSION } from "@foxglove-studio/app/version";
+import {
+  installDevtoolsFormatters,
+  initializeLogEvent,
+  overwriteFetch,
+  waitForFonts,
+} from "@foxglove-studio/app";
 import Logger from "@foxglove/log";
 
 import Root from "./Root";
@@ -25,7 +26,6 @@ if (typeof process.env.SENTRY_DSN === "string") {
   initSentry({
     dsn: process.env.SENTRY_DSN,
     autoSessionTracking: true,
-    release: `${process.env.SENTRY_PROJECT}@${APP_VERSION}`,
     // Remove the default breadbrumbs integration - it does not accurately track breadcrumbs and
     // creates more noise than benefit.
     integrations: (integrations) => {


### PR DESCRIPTION
Rather than import from a specific path within @foxglove-studio/app,
web and desktop should import from the publicly exposed interfaces.

Fixes #975 