### PR TITLE
Remove overflow hidden from ButtonBase

### DIFF
--- a/app/components/ButtonBase.tsx
+++ b/app/components/ButtonBase.tsx
@@ -111,7 +111,7 @@ class ButtonBaseImpl extends React.Component<Props> {
         onFocus={onFocus}
         onMouseLeave={this.onMouseLeave}
         onMouseUp={this.onMouseUp}
-        style={{ position: "relative", zIndex: 0, overflow: "hidden", ...style }}
+        style={{ position: "relative", ...style }}
         title={tooltip}
         disabled={disabled}
         ref={innerRef}


### PR DESCRIPTION
Hiding overflow results in buttons cutting off their internal content
if they downsize vertically.

This change also removes zIndex: 0 from the ButtonBase in favor of
using the zindex of the container.

Fixes #718