### PR TITLE
Reset all panels when player changes.

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -30,6 +30,7 @@ import {
   MaybePlayer,
   MessagePipelineProvider,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PlayerSelectionContext, {
@@ -477,7 +478,8 @@ export default function PlayerManager({
     <>
       <PlayerSelectionContext.Provider value={value}>
         <MessagePipelineProvider maybePlayer={maybePlayer} globalVariables={globalVariables}>
-          {children}
+          {/* To ensure no stale player state remains, we unmount all children when players change */}
+          <RemountOnValueChange value={maybePlayer}>{children}</RemountOnValueChange>
         </MessagePipelineProvider>
       </PlayerSelectionContext.Provider>
     </>

--- a/packages/studio-base/src/components/RemountOnValueChange.tsx
+++ b/packages/studio-base/src/components/RemountOnValueChange.tsx
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useLayoutEffect, useState } from "react";
+
+/**
+ * RemountOnValueChange will unmount and remount the children when _value_ changes.
+ * This is used when you want to "reset" the component tree for a specific value change.
+ *
+ * Note: Use sparingly and prefer hook dependencies to manage state updates. This should be a
+ * last resort nuclear option when you think that an entire subtree should be purged.
+ */
+export default function RemountOnValueChange(
+  props: PropsWithChildren<{ value: unknown }>,
+): JSX.Element {
+  const [value, setValue] = useState(props.value);
+
+  useLayoutEffect(() => {
+    setValue((old: unknown) => {
+      return old === props.value ? old : props.value;
+    });
+  }, [props.value]);
+
+  if (props.value !== value) {
+    return <></>;
+  }
+
+  return <>{props.children}</>;
+}


### PR DESCRIPTION
Use RemountOnValueChange to unmount/remount all components under
message pipeline. This clears any local cache or state management the
components may have related to stale messages, state, etc. In an ideal
world all components would detect player changes but for simplicity
most only consume messages and do not worry that a player changed.