### PR TITLE
Migrate remaining users of non-public exports

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -12,6 +12,16 @@ import App from "./App";
 import { NetworkInterface, OsContext } from "./OsContext";
 import ErrorBoundary from "./components/ErrorBoundary";
 import MultiProvider from "./components/MultiProvider";
+import AppConfigurationContext, {
+  AppConfiguration,
+  AppConfigurationValue,
+  ChangeHandler,
+} from "./context/AppConfigurationContext";
+import LayoutStorageContext, { Layout, LayoutStorage } from "./context/LayoutStorageContext";
+import NativeAppMenuContext, {
+  NativeAppMenu,
+  NativeAppMenuEvent,
+} from "./context/NativeAppMenuContext";
 import { PlayerSourceDefinition } from "./context/PlayerSelectionContext";
 import ThemeProvider from "./theme/ThemeProvider";
 import installDevtoolsFormatters from "./util/installDevtoolsFormatters";
@@ -21,13 +31,27 @@ import waitForFonts from "./util/waitForFonts";
 
 export {
   App,
+  AppConfigurationContext,
   ErrorBoundary,
-  MultiProvider,
-  ThemeProvider,
-  installDevtoolsFormatters,
   initializeLogEvent,
+  installDevtoolsFormatters,
+  LayoutStorageContext,
+  MultiProvider,
+  NativeAppMenuContext,
   overwriteFetch,
+  ThemeProvider,
   waitForFonts,
 };
 
-export type { PlayerSourceDefinition, OsContext, NetworkInterface };
+export type {
+  AppConfiguration,
+  AppConfigurationValue,
+  ChangeHandler,
+  Layout,
+  LayoutStorage,
+  NativeAppMenu,
+  NativeAppMenuEvent,
+  NetworkInterface,
+  OsContext,
+  PlayerSourceDefinition,
+};

--- a/desktop/renderer/components/NativeAppMenuProvider.tsx
+++ b/desktop/renderer/components/NativeAppMenuProvider.tsx
@@ -4,10 +4,7 @@
 
 import { PropsWithChildren, useMemo } from "react";
 
-import NativeAppMenuContext, {
-  NativeAppMenu,
-  NativeAppMenuEvent,
-} from "@foxglove/studio-base/context/NativeAppMenuContext";
+import { NativeAppMenuContext, NativeAppMenu, NativeAppMenuEvent } from "@foxglove/studio-base";
 
 import { NativeMenuBridge } from "../../common/types";
 

--- a/desktop/renderer/components/NativeStorageAppConfigurationProvider.tsx
+++ b/desktop/renderer/components/NativeStorageAppConfigurationProvider.tsx
@@ -6,7 +6,7 @@ import { PropsWithChildren } from "react";
 import { useAsync } from "react-use";
 
 import Log from "@foxglove/log";
-import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import { AppConfigurationContext } from "@foxglove/studio-base";
 
 import { useNativeStorage } from "../context/NativeStorageContext";
 import NativeStorageAppConfiguration from "../services/NativeStorageAppConfiguration";

--- a/desktop/renderer/components/NativeStorageLayoutStorageProvider.tsx
+++ b/desktop/renderer/components/NativeStorageLayoutStorageProvider.tsx
@@ -4,7 +4,7 @@
 
 import { PropsWithChildren, useMemo } from "react";
 
-import LayoutStorageContext from "@foxglove/studio-base/context/LayoutStorageContext";
+import { LayoutStorageContext } from "@foxglove/studio-base";
 
 import { useNativeStorage } from "../context/NativeStorageContext";
 import NativeStorageLayoutStorage from "../services/NativeStorageLayoutStorage";

--- a/desktop/renderer/services/NativeStorageAppConfiguration.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.ts
@@ -3,11 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { Mutex } from "async-mutex";
 
-import {
-  AppConfiguration,
-  AppConfigurationValue,
-  ChangeHandler,
-} from "@foxglove/studio-base/context/AppConfigurationContext";
+import { AppConfiguration, AppConfigurationValue, ChangeHandler } from "@foxglove/studio-base";
 
 import { Storage } from "../../common/types";
 

--- a/desktop/renderer/services/NativeStorageLayoutStorage.ts
+++ b/desktop/renderer/services/NativeStorageLayoutStorage.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Layout, LayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
+import { Layout, LayoutStorage } from "@foxglove/studio-base";
 
 import { Storage } from "../../common/types";
 

--- a/web/src/components/AppConfigurationProvider.tsx
+++ b/web/src/components/AppConfigurationProvider.tsx
@@ -4,9 +4,7 @@
 
 import { PropsWithChildren, useState } from "react";
 
-import AppConfigurationContext, {
-  AppConfiguration,
-} from "@foxglove/studio-base/context/AppConfigurationContext";
+import { AppConfigurationContext, AppConfiguration } from "@foxglove/studio-base";
 
 export default function AppConfigurationProvider(props: PropsWithChildren<unknown>): JSX.Element {
   const [ctx] = useState(() => {

--- a/web/src/components/NoOpLayoutStorageProvider.tsx
+++ b/web/src/components/NoOpLayoutStorageProvider.tsx
@@ -4,9 +4,7 @@
 
 import { PropsWithChildren, useState } from "react";
 
-import LayourStorageContext, {
-  LayoutStorage,
-} from "@foxglove/studio-base/context/LayoutStorageContext";
+import { LayoutStorageContext, LayoutStorage } from "@foxglove/studio-base";
 
 export default function NoOpLayoutStorageProvider(props: PropsWithChildren<unknown>): JSX.Element {
   const [ctx] = useState<LayoutStorage>(() => {
@@ -27,6 +25,6 @@ export default function NoOpLayoutStorageProvider(props: PropsWithChildren<unkno
   });
 
   return (
-    <LayourStorageContext.Provider value={ctx}>{props.children}</LayourStorageContext.Provider>
+    <LayoutStorageContext.Provider value={ctx}>{props.children}</LayoutStorageContext.Provider>
   );
 }


### PR DESCRIPTION
Follow up work from https://github.com/foxglove/studio/pull/984:

Migrate everything outside `app` package to use explicit package exports (defined in `app/index.ts`). This means we are clear about the `studio-base` package's public API, and will enable renaming this folder without causing chaos.

There are a couple remaining nested imports inside `desktop/main` and `desktop/preload` that we don't want to migrate to this package yet, because it will require main and preload learning about tsx and we're not yet sure of the best solution.