### PR TITLE
ci: only run yarn install on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - windows-2019
         config:
           # Specify names so that the GitHub branch protection settings for
           # required checks don't need to change if we ever change the commands used.
@@ -34,15 +33,11 @@ jobs:
             command: yarn run test --maxWorkers=100%
           - name: storybook
             command: yarn workspace @foxglove/studio-base run chromatic
-        exclude:
+        include:
           - os: windows-2019
-            config: { name: lint }
-          - os: windows-2019
-            config: { name: test }
-          - os: windows-2019
-            config: { name: web }
-          - os: windows-2019
-            config: { name: storybook }
+            config:
+              name: packages
+              command: echo complete
 
     name: ${{ matrix.config.name }} (${{ matrix.os }})
 


### PR DESCRIPTION
Everyone is having problems with windows CI not playing nicely with yarn workspaces and our caching.

For now let's revert to only running `yarn install` on windows and not actually trying to build things.