### PR TITLE
Fix occupancy grid rendering in 3d panel

### DIFF
--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -684,8 +684,21 @@ export default class SceneBuilder implements MarkerProvider {
     // in the future these will be customizable via the UI
     const [alpha, map] = this._hooks.getOccupancyGridValues(topic);
 
+    const { header, info, data } = message;
     const mappedMessage = {
-      ...message,
+      header: {
+        frame_id: header.frame_id,
+        stamp: header.stamp,
+        seq: header.seq,
+      },
+      info: {
+        map_load_time: info.map_load_time,
+        resolution: info.resolution,
+        width: info.width,
+        height: info.height,
+        origin: info.origin,
+      },
+      data,
       alpha,
       map,
       type,


### PR DESCRIPTION
Lazy messages broke occupancy grid rendering because lazy messages do
not support the spread operator and occupancy grid rendering was
spreading message. Instead of spreading, explicitly pass along the
required fields.

Fixes #1028