### PR TITLE
Fix markerKeyPath lookup in 3d panel

### DIFF
--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -602,9 +602,10 @@ export default class SceneBuilder implements MarkerProvider {
     const matchingMatcher = colorOverrideMarkerMatchers.find(({ checks = [] }) =>
       checks.every(({ markerKeyPath = [], value }) => {
         // Get the item at the key path
+        // i.e. key path: ["foo", "bar"] would return "value" in an object like {foo: {bar: "value" }}
         const markerValue = markerKeyPath.reduce(
-          (item: any, key) => item?.[key] && item[key](),
-          message as any,
+          (item: any, key) => item?.[key],
+          message as Record<string, unknown> | undefined,
         );
         return value === markerValue;
       }),


### PR DESCRIPTION
Looking up markers by key path was trying to invoke a key path as a function.
This was old behavior from when bobjects was around. Lazy messages and
regular js objects provide getters and properties for message fields rather
than functions.

Fixes #1007