### PR TITLE
App setting to reduce the message pipeline framerate

### DIFF
--- a/app/AppSetting.ts
+++ b/app/AppSetting.ts
@@ -4,6 +4,7 @@
 
 export enum AppSetting {
   CRASH_REPORTING_ENABLED = "telemetry.crashReportingEnabled",
+  MESSAGE_HZ = "messageHz",
   ROS1_ROS_HOSTNAME = "ros1.ros_hostname",
   TELEMETRY_ENABLED = "telemetry.telemetryEnabled",
   TIMEZONE = "timezone",

--- a/app/AppSetting.ts
+++ b/app/AppSetting.ts
@@ -4,7 +4,7 @@
 
 export enum AppSetting {
   CRASH_REPORTING_ENABLED = "telemetry.crashReportingEnabled",
-  MESSAGE_HZ = "messageHz",
+  MESSAGE_RATE = "messageRate",
   ROS1_ROS_HOSTNAME = "ros1.ros_hostname",
   TELEMETRY_ENABLED = "telemetry.telemetryEnabled",
   TIMEZONE = "timezone",

--- a/app/components/ExperimentalFeatureSettings.stories.tsx
+++ b/app/components/ExperimentalFeatureSettings.stories.tsx
@@ -14,24 +14,8 @@
 import { ReactElement, useState } from "react";
 
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
-import AppConfigurationContext, {
-  AppConfiguration,
-  AppConfigurationValue,
-} from "@foxglove/studio-base/context/AppConfigurationContext";
-
-function makeConfiguration(entries?: [string, AppConfigurationValue][]): AppConfiguration {
-  const map = new Map<string, AppConfigurationValue>(entries);
-  const listeners = new Set<(newValue: AppConfigurationValue) => void>();
-  return {
-    get: (key: string) => map.get(key),
-    set: async (key: string, value: AppConfigurationValue) => {
-      map.set(key, value);
-      [...listeners].forEach((listener) => listener(value));
-    },
-    addChangeListener: (_key, cb) => listeners.add(cb),
-    removeChangeListener: (_key, cb) => listeners.delete(cb),
-  };
-}
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import { makeConfiguration } from "@foxglove/studio-base/util/makeConfiguration";
 
 export default {
   title: "components/ExperimentalFeatureSettings",

--- a/app/components/MessagePipeline/index.test.tsx
+++ b/app/components/MessagePipeline/index.test.tsx
@@ -14,9 +14,10 @@
 
 import { renderHook, RenderResult } from "@testing-library/react-hooks/dom";
 import { last } from "lodash";
-import { PropsWithChildren, useCallback } from "react";
+import { PropsWithChildren, useCallback, useState } from "react";
 import { act } from "react-dom/test-utils";
 
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerPresence, PlayerStateActiveData } from "@foxglove/studio-base/players/types";
 import delay from "@foxglove/studio-base/util/delay";
@@ -25,6 +26,7 @@ import {
   resetLogEventForTests,
   Tags,
 } from "@foxglove/studio-base/util/logEvent";
+import { makeConfiguration } from "@foxglove/studio-base/util/makeConfiguration";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 import tick from "@foxglove/studio-base/util/tick";
 
@@ -43,14 +45,19 @@ type WrapperProps = {
   maybePlayer: MaybePlayer;
   globalVariables?: GlobalVariables;
 };
+
 function Hook(_props: WrapperProps) {
   return useMessagePipeline(useCallback((value) => value, []));
 }
+
 function Wrapper({ children, maybePlayer, globalVariables }: PropsWithChildren<WrapperProps>) {
+  const [config] = useState(() => makeConfiguration());
   return (
-    <MessagePipelineProvider maybePlayer={maybePlayer} globalVariables={globalVariables}>
-      {children}
-    </MessagePipelineProvider>
+    <AppConfigurationContext.Provider value={config}>
+      <MessagePipelineProvider maybePlayer={maybePlayer} globalVariables={globalVariables}>
+        {children}
+      </MessagePipelineProvider>
+    </AppConfigurationContext.Provider>
   );
 }
 

--- a/app/components/MessagePipeline/index.tsx
+++ b/app/components/MessagePipeline/index.tsx
@@ -14,6 +14,8 @@
 import { debounce, flatten, groupBy } from "lodash";
 import { Time } from "rosbag";
 
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useContextSelector from "@foxglove/studio-base/hooks/useContextSelector";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import useShallowMemo from "@foxglove/studio-base/hooks/useShallowMemo";
@@ -38,8 +40,6 @@ import signal from "@foxglove/studio-base/util/signal";
 
 import { pauseFrameForPromises, FramePromise } from "./pauseFrameForPromise";
 import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 
 const { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } = React;
 
@@ -157,8 +157,8 @@ export function MessagePipelineProvider({
   }, [maybePlayer.error]);
 
   // Slow down the message pipeline framerate to the given FPS if it is set to less than 60
-  const [messageHz] = useAppConfigurationValue<number>(AppSetting.MESSAGE_HZ);
-  const skipFrames = 60 / (messageHz ?? 60) - 1;
+  const [messageRate] = useAppConfigurationValue<number>(AppSetting.MESSAGE_RATE);
+  const skipFrames = 60 / (messageRate ?? 60) - 1;
 
   // Delay the player listener promise until rendering has finished for the latest data.
   useLayoutEffect(() => {
@@ -191,7 +191,7 @@ export function MessagePipelineProvider({
         }
       }
     }, skipFrames);
-  }, [playerState]);
+  }, [playerState, skipFrames]);
 
   useEffect(() => {
     currentPlayer.current = player;

--- a/app/components/MessagePipeline/index.tsx
+++ b/app/components/MessagePipeline/index.tsx
@@ -32,11 +32,14 @@ import {
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import createSelectableContext from "@foxglove/studio-base/util/createSelectableContext";
+import { requestThrottledAnimationFrame } from "@foxglove/studio-base/util/requestThrottledAnimationFrame";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 import signal from "@foxglove/studio-base/util/signal";
 
 import { pauseFrameForPromises, FramePromise } from "./pauseFrameForPromise";
 import warnOnOutOfSyncMessages from "./warnOnOutOfSyncMessages";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 
 const { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } = React;
 
@@ -153,13 +156,17 @@ export function MessagePipelineProvider({
     }
   }, [maybePlayer.error]);
 
+  // Slow down the message pipeline framerate to the given FPS if it is set to less than 60
+  const [messageHz] = useAppConfigurationValue<number>(AppSetting.MESSAGE_HZ);
+  const skipFrames = 60 / (messageHz ?? 60) - 1;
+
   // Delay the player listener promise until rendering has finished for the latest data.
   useLayoutEffect(() => {
     // In certain cases like the player being replaced (reproduce by dragging a bag in while playing), we can
     // replace the new playerTickState. We want to use one playerTickState throughout the entire tick, since it's
     // implicitly tied to the player.
     const currentPlayerTickState = playerTickState.current;
-    requestAnimationFrame(async () => {
+    requestThrottledAnimationFrame(async () => {
       if (currentPlayerTickState.resolveFn && !currentPlayerTickState.waitingForPromises) {
         if (currentPlayerTickState.promisesToWaitFor.length > 0) {
           // If we have finished rendering but we still have to wait for some promises wait for them here.
@@ -183,7 +190,7 @@ export function MessagePipelineProvider({
           currentPlayerTickState.resolveFn = undefined;
         }
       }
-    });
+    }, skipFrames);
   }, [playerState]);
 
   useEffect(() => {

--- a/app/components/Preferences.stories.tsx
+++ b/app/components/Preferences.stories.tsx
@@ -15,24 +15,8 @@ import { storiesOf } from "@storybook/react";
 import { useState } from "react";
 
 import Preferences from "@foxglove/studio-base/components/Preferences";
-import AppConfigurationContext, {
-  AppConfiguration,
-  AppConfigurationValue,
-} from "@foxglove/studio-base/context/AppConfigurationContext";
-
-function makeConfiguration(entries?: [string, AppConfigurationValue][]): AppConfiguration {
-  const map = new Map<string, AppConfigurationValue>(entries);
-  const listeners = new Set<(newValue: AppConfigurationValue) => void>();
-  return {
-    get: (key: string) => map.get(key),
-    set: async (key: string, value: AppConfigurationValue) => {
-      map.set(key, value);
-      [...listeners].forEach((listener) => listener(value));
-    },
-    addChangeListener: (_key, cb) => listeners.add(cb),
-    removeChangeListener: (_key, cb) => listeners.delete(cb),
-  };
-}
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import { makeConfiguration } from "@foxglove/studio-base/util/makeConfiguration";
 
 export function Default(): React.ReactElement {
   const [config] = useState(() => makeConfiguration());

--- a/app/components/Preferences.tsx
+++ b/app/components/Preferences.tsx
@@ -25,6 +25,8 @@ import { nonEmptyOrUndefined } from "@foxglove/studio-base/util/emptyOrUndefined
 import filterMap from "@foxglove/studio-base/util/filterMap";
 import fuzzyFilter from "@foxglove/studio-base/util/fuzzyFilter";
 
+const MESSAGE_RATES = [1, 3, 5, 10, 15, 20, 30, 60];
+
 function formatTimezone(name: string) {
   const tz = moment.tz(name);
   const zoneAbbr = tz.zoneAbbr();
@@ -122,6 +124,35 @@ function TimezoneSettings(): React.ReactElement {
   );
 }
 
+function MessageFramerate(): React.ReactElement {
+  type Option = IComboBoxOption & { data: number };
+
+  const [messageHz, setMesageHz] = useAppConfigurationValue<number>(AppSetting.MESSAGE_HZ);
+  const entries = useMemo(
+    () => MESSAGE_RATES.map((rate) => ({ key: rate, text: `${rate}`, data: rate })),
+    [],
+  );
+
+  return (
+    <VirtualizedComboBox
+      label="Message framerate:"
+      options={entries}
+      autoComplete="on"
+      openOnKeyboardFocus
+      selectedKey={messageHz ?? 60}
+      onChange={(_event, option) => {
+        if (option) {
+          setMesageHz(option.data);
+        }
+      }}
+      calloutProps={{
+        directionalHint: DirectionalHint.bottomLeftEdge,
+        directionalHintFixed: true,
+      }}
+    />
+  );
+}
+
 function RosHostname(): React.ReactElement {
   const [rosHostname, setRosHostname] = useAppConfigurationValue<string>(
     AppSetting.ROS1_ROS_HOSTNAME,
@@ -181,6 +212,9 @@ export default function Preferences(): React.ReactElement {
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
             <Stack.Item>
               <TimezoneSettings />
+            </Stack.Item>
+            <Stack.Item>
+              <MessageFramerate />
             </Stack.Item>
             <Stack.Item>
               <RosHostname />

--- a/app/components/Preferences.tsx
+++ b/app/components/Preferences.tsx
@@ -125,9 +125,7 @@ function TimezoneSettings(): React.ReactElement {
 }
 
 function MessageFramerate(): React.ReactElement {
-  type Option = IComboBoxOption & { data: number };
-
-  const [messageHz, setMesageHz] = useAppConfigurationValue<number>(AppSetting.MESSAGE_HZ);
+  const [messageRate, setMesageRate] = useAppConfigurationValue<number>(AppSetting.MESSAGE_RATE);
   const entries = useMemo(
     () => MESSAGE_RATES.map((rate) => ({ key: rate, text: `${rate}`, data: rate })),
     [],
@@ -135,14 +133,14 @@ function MessageFramerate(): React.ReactElement {
 
   return (
     <VirtualizedComboBox
-      label="Message framerate:"
+      label="Message rate (Hz):"
       options={entries}
       autoComplete="on"
       openOnKeyboardFocus
-      selectedKey={messageHz ?? 60}
+      selectedKey={messageRate ?? 60}
       onChange={(_event, option) => {
         if (option) {
-          setMesageHz(option.data);
+          setMesageRate(option.data);
         }
       }}
       calloutProps={{

--- a/app/panels/WelcomePanel/index.stories.tsx
+++ b/app/panels/WelcomePanel/index.stories.tsx
@@ -5,33 +5,16 @@ import { action } from "@storybook/addon-actions";
 import { useEffect, useRef, useState } from "react";
 import ReactTestUtils from "react-dom/test-utils";
 
-import AppConfigurationContext, {
-  AppConfiguration,
-  AppConfigurationValue,
-  ChangeHandler,
-} from "@foxglove/studio-base/context/AppConfigurationContext";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import WelcomePanel from "@foxglove/studio-base/panels/WelcomePanel";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import { makeConfiguration } from "@foxglove/studio-base/util/makeConfiguration";
 import signal from "@foxglove/studio-base/util/signal";
 
 export default {
   title: "panels/WelcomePanel/index",
   component: WelcomePanel,
 };
-
-function makeConfiguration(entries?: [string, AppConfigurationValue][]): AppConfiguration {
-  const map = new Map<string, AppConfigurationValue>(entries);
-  const listeners = new Set<ChangeHandler>();
-  return {
-    get: (key: string) => map.get(key),
-    set: async (key: string, value: AppConfigurationValue) => {
-      map.set(key, value);
-      [...listeners].forEach((listener) => listener(value));
-    },
-    addChangeListener: (_key, cb) => listeners.add(cb),
-    removeChangeListener: (_key, cb) => listeners.delete(cb),
-  };
-}
 
 export function Default(): React.ReactElement {
   const [config] = useState(() => makeConfiguration());

--- a/app/util/makeConfiguration.ts
+++ b/app/util/makeConfiguration.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  AppConfiguration,
+  AppConfigurationValue,
+} from "@foxglove/studio-base/context/AppConfigurationContext";
+
+export function makeConfiguration(entries?: [string, AppConfigurationValue][]): AppConfiguration {
+  const map = new Map<string, AppConfigurationValue>(entries);
+  const listeners = new Set<(newValue: AppConfigurationValue) => void>();
+  return {
+    get: (key: string) => map.get(key),
+    set: async (key: string, value: AppConfigurationValue) => {
+      map.set(key, value);
+      [...listeners].forEach((listener) => listener(value));
+    },
+    addChangeListener: (_key, cb) => listeners.add(cb),
+    removeChangeListener: (_key, cb) => listeners.delete(cb),
+  };
+}

--- a/app/util/requestThrottledAnimationFrame.ts
+++ b/app/util/requestThrottledAnimationFrame.ts
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Wrapper for `requestAnimationFrame` that will skip a user-specified number of frames before
+ * executing the callback.
+ * @param callback Function to execute
+ * @param skipFrames Number of additional times to call `requestAnimationFrame`
+ */
+export function requestThrottledAnimationFrame(
+  callback: FrameRequestCallback,
+  skipFrames: number,
+): void {
+  let remaining = 1 + skipFrames;
+
+  const fn = (timestamp: number) => {
+    if (--remaining <= 0) {
+      return callback(timestamp);
+    }
+    requestAnimationFrame(fn);
+  };
+
+  requestAnimationFrame(fn);
+}


### PR DESCRIPTION
This adds an app-wide configuration setting titled "Message rate (Hz)" (`messageRate`) to lower the framerate of the message pipeline. The application will continue to render at 60fps providing a smooth UI, but the message pipeline can run at a fraction of the redraw framerate which reduces the frequency of redraws for panels such as Raw Messages and Data Source Info.

With those two panels open, Windows 10 energy consumption for FGS goes from Very High at 60 to High at 30 and Medium at 15.

This is one approach to resolving https://github.com/foxglove/studio/issues/959, although we should separately investigate why that panel takes so long to redraw.
