### PR TITLE
Enable `@typescript-eslint/consistent-type-assertions` and use `as`-style assertions everywhere

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -71,6 +71,9 @@ rules:
   "@typescript-eslint/prefer-regexp-exec": off
   "@typescript-eslint/no-unnecessary-condition": off # similar to strict-boolean-expressions, but catches more (noisy) cases?
 
+  "@typescript-eslint/consistent-type-assertions":
+    - error
+    - { assertionStyle: as }
   "@typescript-eslint/no-explicit-any": error
   "@typescript-eslint/prefer-nullish-coalescing": error
   "@typescript-eslint/no-non-null-assertion": error

--- a/app/PanelAPI/useBlocksByTopic.ts
+++ b/app/PanelAPI/useBlocksByTopic.ts
@@ -80,7 +80,7 @@ const useSubscribeToTopicsForBlocks = (topics: readonly string[]) => {
   );
   const subscriptions: SubscribePayload[] = useMemo(() => {
     const requester = panelType != undefined ? { type: "panel", name: panelType } : undefined;
-    return topics.map((topic) => <SubscribePayload>{ topic, requester });
+    return topics.map((topic) => ({ topic, requester } as SubscribePayload));
   }, [panelType, topics]);
   useEffect(() => setSubscriptions(id, subscriptions), [id, setSubscriptions, subscriptions]);
   useCleanup(() => setSubscriptions(id, []));

--- a/app/dataProviders/BagDataProvider.ts
+++ b/app/dataProviders/BagDataProvider.ts
@@ -147,7 +147,7 @@ export default class BagDataProvider implements DataProvider {
         try {
           await remoteReader.open(); // Important that we call this first, because it might throw an error if the file can't be read.
         } catch (err) {
-          sendNotification("Fetching remote bag failed", (<Error>err).message, "user", "error");
+          sendNotification("Fetching remote bag failed", (err as Error).message, "user", "error");
           return new Promise(() => {}); // Just never finish initializing.
         }
         if (remoteReader.size() === 0) {
@@ -160,7 +160,7 @@ export default class BagDataProvider implements DataProvider {
         try {
           await this._bag.open();
         } catch (err) {
-          sendNotification("Opening remote bag failed", (<Error>err).message, "user", "error");
+          sendNotification("Opening remote bag failed", (err as Error).message, "user", "error");
           return new Promise(() => {}); // Just never finish initializing.
         }
       } else {

--- a/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/app/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -770,7 +770,7 @@ export default class SceneBuilder implements MarkerProvider {
     // to an infinite lifetime. But do allow for 0 values based on user preferences.
     const decayTimeInSec = this._settingsByKey[`t:${topic}`]?.decayTime;
     const lifetime = decayTimeInSec ? fromSec(decayTimeInSec) : undefined;
-    (<MessageCollector>this.collectors[topic]).addNonMarker(topic, mappedMessage, lifetime);
+    (this.collectors[topic] as MessageCollector).addNonMarker(topic, mappedMessage, lifetime);
   };
 
   setCurrentTime = (currentTime: { sec: number; nsec: number }): void => {
@@ -908,10 +908,10 @@ export default class SceneBuilder implements MarkerProvider {
     this.errors.topicsWithBadFrameIds.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();
-    (<MessageCollector>this.collectors[topic]).setClock(this._clock ?? { sec: 0, nsec: 0 });
-    (<MessageCollector>this.collectors[topic]).flush();
+    (this.collectors[topic] as MessageCollector).setClock(this._clock ?? { sec: 0, nsec: 0 });
+    (this.collectors[topic] as MessageCollector).flush();
 
-    const datatype = (<Topic>this.topicsByName[topic]).datatype;
+    const datatype = (this.topicsByName[topic] as Topic).datatype;
     // If topic has a decayTime set, markers with no lifetime will get one
     // later on, so we don't need to filter them. Note: A decayTime of zero is
     // defined as an infinite lifetime

--- a/app/players/OrderedStampPlayer.ts
+++ b/app/players/OrderedStampPlayer.ts
@@ -81,11 +81,10 @@ export default class OrderedStampPlayer implements Player {
       }
 
       // Only store messages with a header stamp.
-      const [newMessagesWithHeaders, newMessagesWithoutHeaders] = <
-        [MessageEvent<StampedMessage>[], MessageEvent<unknown>[]]
-      >partition(activeData.messages, (message) =>
-        isTime((message.message as Partial<StampedMessage>).header?.stamp),
-      );
+      const [newMessagesWithHeaders, newMessagesWithoutHeaders] = partition(
+        activeData.messages,
+        (message) => isTime((message.message as Partial<StampedMessage>).header?.stamp),
+      ) as [MessageEvent<StampedMessage>[], MessageEvent<unknown>[]];
 
       const topicsWithoutHeaders = new Set<string>();
       newMessagesWithoutHeaders.forEach(({ topic }) => {

--- a/app/util/time.ts
+++ b/app/util/time.ts
@@ -174,16 +174,16 @@ export function findClosestTimestampIndex(
     return -1;
   }
   let [l, r] = [0, maxIdx];
-  if (currT <= <number>timestamps[0]) {
+  if (currT <= (timestamps[0] as number)) {
     return 0;
-  } else if (currT >= <number>timestamps[maxIdx]) {
+  } else if (currT >= (timestamps[maxIdx] as number)) {
     return maxIdx;
   }
 
   while (l <= r) {
     const m = l + Math.floor((r - l) / 2);
-    const prevT = <number>timestamps[m];
-    const nextT = <number>timestamps[m + 1];
+    const prevT = timestamps[m] as number;
+    const nextT = timestamps[m + 1] as number;
 
     if (prevT <= currT && currT < nextT) {
       return m;


### PR DESCRIPTION
`<T>x` style assertions are not compatible with JSX code, so for consistency we prefer `x as T` everywhere.