### PR TITLE
Remove "file:" from script-src in desktop.

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -241,8 +241,7 @@ app.on("ready", async () => {
   // See: https://www.electronjs.org/docs/tutorial/security
   const contentSecurityPolicy: Record<string, string> = {
     "default-src": "'self'",
-    // We should use x-foxglove-extension: instead of file: (see https://github.com/foxglove/studio/issues/895)
-    "script-src": `'self' 'unsafe-inline' 'unsafe-eval' file:`,
+    "script-src": `'self' 'unsafe-inline' 'unsafe-eval'`,
     "worker-src": `'self' blob:`,
     "style-src": "'self' 'unsafe-inline'",
     "connect-src": "'self' ws: wss: http: https: x-foxglove-ros-package:",


### PR DESCRIPTION
This is counter to our security model which tries to _prevent_
having renderer code arbitrarily access any file on the user's machine.