### PR TITLE
Use a single tsconfig for eslint to reduce memory usage and speed up linting

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -34,7 +34,7 @@ parser: "@typescript-eslint/parser"
 parserOptions:
   ecmaVersion: 2020
   sourceType: module
-  project: ./**/tsconfig.json
+  project: ./tsconfig.eslint.json
 
 settings:
   react:

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -182,7 +182,7 @@ rules:
 
 overrides:
   - rules:
-      "@typescript-eslint/no-explicit-any": warn
+      "@typescript-eslint/no-explicit-any": off
     files:
       - "app/components/Autocomplete.stories.tsx"
       - "app/components/Autocomplete.tsx"
@@ -442,7 +442,7 @@ overrides:
       - "packages/@types/regl-worldview/index.d.ts"
 
   - rules:
-      "@typescript-eslint/no-non-null-assertion": warn
+      "@typescript-eslint/no-non-null-assertion": off
     files:
       - "app/components/Autocomplete.tsx"
       - "app/components/Chart/index.stories.tsx"

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -182,7 +182,7 @@ rules:
 
 overrides:
   - rules:
-      "@typescript-eslint/no-explicit-any": off
+      "@typescript-eslint/no-explicit-any": warn
     files:
       - "app/components/Autocomplete.stories.tsx"
       - "app/components/Autocomplete.tsx"
@@ -442,7 +442,7 @@ overrides:
       - "packages/@types/regl-worldview/index.d.ts"
 
   - rules:
-      "@typescript-eslint/no-non-null-assertion": off
+      "@typescript-eslint/no-non-null-assertion": warn
     files:
       - "app/components/Autocomplete.tsx"
       - "app/components/Chart/index.stories.tsx"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:dev": "webpack --mode development --progress --config desktop/webpack.config.ts",
     "serve": "webpack serve --mode development --progress --config desktop/webpack.config.ts",
     "lint": "TIMING=1 eslint --rulesdir eslint-rules --report-unused-disable-directives --fix .",
-    "lint:ci": "TIMING=1 NODE_OPTIONS='--max-old-space-size=6144' eslint --rulesdir eslint-rules --report-unused-disable-directives --config .eslintrc.ci.yaml .",
+    "lint:ci": "TIMING=1 eslint --rulesdir eslint-rules --report-unused-disable-directives --config .eslintrc.ci.yaml .",
     "test": "jest",
     "test:debug": "NODE_OPTIONS='--inspect-brk' jest",
     "test:watch": "jest --watch",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,22 @@
+// tsconfig.json for eslint
+//
+// Because the typescript-eslint plugin does not receive information from eslint about the overall
+// set of files to be linted, it's forced to hold all TypeScript projects in memory at once. Since
+// our monorepo contains several separate projects, we run into memory limits when running eslint on
+// all the projects in a single run.
+//
+// Making eslint use just a single tsconfig means it doesn't need to hold as much in memory. This
+// works as long as our packages' tsconfigs don't vary much beyond the base config.
+//
+// Another alternative would be to run eslint separately on each project's files. This would be a
+// bit trickier to maintain since it requires a script to make multiple eslint runs, and possibly a
+// separate eslintrc file for each project to point it at the appropriate tsconfig (although it's
+// not clear this part is necessary).
+//
+// More detailed discussion at:
+// https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-846491212
+{
+  "extends": "@foxglove/tsconfig/tsconfig.base.json",
+  "include": ["**/*", "app/.storybook/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -18,5 +18,8 @@
 {
   "extends": "@foxglove/tsconfig/tsconfig.base.json",
   "include": ["**/*", "app/.storybook/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -20,6 +20,7 @@
   "include": ["**/*", "app/.storybook/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "es2020"],
     "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
Because the typescript-eslint plugin does not receive information from eslint about the overall set of files to be linted, it's forced to hold all TypeScript projects in memory at once. Since our monorepo contains several separate projects, we run into memory limits when running eslint on all the projects in a single run.

Making eslint use just a single tsconfig means it doesn't need to hold as much in memory (recommendation from https://github.com/typescript-eslint/typescript-eslint/issues/1192 and [typescript-eslint monorepo docs](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/MONOREPO.md#important-note-regarding-large--10-multi-package-monorepos)). It also makes linting much faster (CI job completes in 2min vs 8min).

This approach works as long as our packages' tsconfigs don't vary much beyond the base config. Another alternative would be to run eslint separately on each project's files. This would be a bit trickier to maintain since it requires a script to make multiple eslint runs, and possibly a separate eslintrc file for each project to point it at the appropriate tsconfig (although it's not clear this part is necessary).