### PR TITLE
Disable noUnusedParameters for development

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -98,6 +98,8 @@ rules:
   foxglove-license-header: error
 
   curly: error
+  # This rule is similar to TS's noUnusedLocals/noUnusedParameters, but we still want to enable the
+  # check for any .js files
   "@typescript-eslint/no-unused-vars":
     - error
     - { vars: all, args: after-used, varsIgnorePattern: "^_", argsIgnorePattern: "^_" }

--- a/app/.storybook/main.ts
+++ b/app/.storybook/main.ts
@@ -22,7 +22,7 @@ module.exports = {
     const rendererConfig = makeConfig(
       undefined,
       { mode: config.mode },
-      { allowUnusedLocals: true },
+      { allowUnusedVariables: true },
     );
 
     return {

--- a/app/webpack.ts
+++ b/app/webpack.ts
@@ -23,7 +23,7 @@ type Options = {
   // During hot reloading and development it is useful to comment out code while iterating.
   // We ignore errors from unused locals to avoid having to also comment
   // those out while iterating.
-  allowUnusedLocals?: boolean;
+  allowUnusedVariables?: boolean;
 };
 
 // Create a partial webpack configuration required to build app using webpack.
@@ -36,7 +36,7 @@ export function makeConfig(
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
-  const { allowUnusedLocals = isDev && isServe } = options ?? {};
+  const { allowUnusedVariables = isDev && isServe } = options ?? {};
 
   return {
     resolve: {
@@ -198,7 +198,8 @@ export function makeConfig(
         typescript: {
           configOverwrite: {
             compilerOptions: {
-              noUnusedLocals: !allowUnusedLocals,
+              noUnusedLocals: !allowUnusedVariables,
+              noUnusedParameters: !allowUnusedVariables,
             },
           },
         },

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -17,7 +17,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
-  const allowUnusedLocals = isDev && isServe;
+  const allowUnusedVariables = isDev && isServe;
 
   const plugins: WebpackPluginInstance[] = [];
 
@@ -48,7 +48,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
     );
   }
 
-  const appWebpackConfig = makeConfig(env, argv, { allowUnusedLocals });
+  const appWebpackConfig = makeConfig(env, argv, { allowUnusedVariables });
 
   const config: Configuration = {
     ...appWebpackConfig,

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -17,7 +17,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
-  const allowUnusedLocals = isDev && isServe;
+  const allowUnusedVariables = isDev && isServe;
 
   const plugins: WebpackPluginInstance[] = [];
 
@@ -42,7 +42,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
     );
   }
 
-  const appWebpackConfig = makeConfig(env, argv, { allowUnusedLocals });
+  const appWebpackConfig = makeConfig(env, argv, { allowUnusedVariables });
 
   const config: Configuration = {
     ...appWebpackConfig,


### PR DESCRIPTION
Similar to how we disable noUnusedLocals to make development smoother, we can also disable noUnusedParameters.

The `no-unused-vars` lint rule covers the same cases, but can still be useful when we are linting JS code.