### PR TITLE
Add File->Preferences menu on Linux+Windows

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -145,6 +145,16 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
           new StudioWindow().load();
         },
       },
+      ...(isMac
+        ? []
+        : [
+            { type: "separator" } as const,
+            {
+              label: "Preferences…",
+              accelerator: "CommandOrControl+,",
+              click: () => browserWindow.webContents.send("open-preferences"),
+            } as const,
+          ]),
       { type: "separator" },
       closeMenuItem,
     ],
@@ -394,6 +404,22 @@ class StudioWindow {
             await simulateUserClick(browserWindow);
             browserWindow.webContents.send("menu.click-input-source", sourceName);
           },
+        }),
+      );
+    }
+
+    if (!isMac) {
+      fileMenu.submenu?.append(
+        new MenuItem({
+          type: "separator",
+        }),
+      );
+
+      fileMenu.submenu?.append(
+        new MenuItem({
+          label: "Preferences…",
+          accelerator: "CommandOrControl+,",
+          click: () => browserWindow.webContents.send("open-preferences"),
         }),
       );
     }


### PR DESCRIPTION
This exists on the Application menu on macOS. Whether it deserves a menu entry is a separate discussion, but for now I'm adding it to the File menu on non-mac platforms (as other applications do).