### PR TITLE
Add useConfig, useDataSourceInfo, and useMessagesByTopic to public api

### DIFF
--- a/app/PanelAPI/index.ts
+++ b/app/PanelAPI/index.ts
@@ -14,8 +14,7 @@
 // This file contains hooks and components comprising the public API for Studio panel development.
 // Recommended use: import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 
-export { default as useDataSourceInfo } from "./useDataSourceInfo";
-export type { DataSourceInfo } from "./useDataSourceInfo";
+export { useDataSourceInfo } from "./useDataSourceInfo";
 
 export { useMessageReducer } from "./useMessageReducer";
 export type { RequestedTopic } from "./useMessageReducer";

--- a/app/PanelAPI/useConfig.ts
+++ b/app/PanelAPI/useConfig.ts
@@ -4,6 +4,7 @@
 
 import { useCallback, useMemo } from "react";
 
+import { panel } from "@foxglove/studio";
 import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
@@ -16,7 +17,7 @@ import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 /**
  * Mix partial panel config from savedProps with the panel type's `defaultConfig` to form the complete panel configuration.
  */
-export function useConfig<Config>(): [Config, SaveConfig<Config>] {
+export const useConfig: typeof panel.useConfig = () => {
   const panelId = usePanelId();
   const panelCatalog = usePanelCatalog();
   const panelComponent = useMemo(
@@ -30,7 +31,7 @@ export function useConfig<Config>(): [Config, SaveConfig<Config>] {
     throw new Error(`Attempt to useConfig() with unknown panel id ${panelId}`);
   }
   return useConfigById(panelId, panelComponent?.defaultConfig);
-}
+};
 
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels

--- a/app/PanelAPI/useDataSourceInfo.ts
+++ b/app/PanelAPI/useDataSourceInfo.ts
@@ -12,24 +12,12 @@
 //   You may not use this file except in compliance with the License.
 
 import { useMemo } from "react";
-import { Time } from "rosbag";
 
+import { DataSourceInfo, panel } from "@foxglove/studio";
 import {
   useMessagePipeline,
   MessagePipelineContext,
 } from "@foxglove/studio-base/components/MessagePipeline";
-import { Topic } from "@foxglove/studio-base/players/types";
-import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
-
-// Metadata about the source of data currently being displayed.
-// This is not expected to change often, usually when changing data sources.
-export type DataSourceInfo = {
-  topics: readonly Topic[];
-  datatypes: RosDatatypes;
-  capabilities: string[];
-  startTime?: Time; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
-  playerId: string;
-};
 
 function selectDatatypes(ctx: MessagePipelineContext) {
   return ctx.datatypes;
@@ -51,7 +39,7 @@ function selectPlayerId(ctx: MessagePipelineContext) {
   return ctx.playerState.playerId;
 }
 
-export default function useDataSourceInfo(): DataSourceInfo {
+export const useDataSourceInfo: typeof panel.useDataSourceInfo = () => {
   const datatypes = useMessagePipeline(selectDatatypes);
   const topics = useMessagePipeline(selectTopics);
   const startTime = useMessagePipeline(selectStartTime);
@@ -68,4 +56,4 @@ export default function useDataSourceInfo(): DataSourceInfo {
       playerId,
     };
   }, [capabilities, datatypes, playerId, startTime, topics]);
-}
+};

--- a/app/PanelAPI/useMessagesByTopic.ts
+++ b/app/PanelAPI/useMessagesByTopic.ts
@@ -14,6 +14,7 @@
 import { groupBy } from "lodash";
 import { useCallback } from "react";
 
+import { panel } from "@foxglove/studio";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import concatAndTruncate from "@foxglove/studio-base/util/concatAndTruncate";
@@ -25,15 +26,11 @@ type UnknownMessageEventsByTopic = Record<string, readonly MessageEvent<unknown>
 
 // Convenience wrapper around `useMessageReducer`, for if you just want some
 // recent messages for a few topics.
-export function useMessagesByTopic({
+export const useMessagesByTopic: typeof panel.useMessagesByTopic = ({
   topics,
   historySize,
   preloadingFallback,
-}: {
-  topics: readonly string[];
-  historySize: number;
-  preloadingFallback?: boolean;
-}): UnknownMessageEventsByTopic {
+}) => {
   const requestedTopics = useDeepMemo(topics);
 
   const addMessages = useCallback(
@@ -74,4 +71,4 @@ export function useMessagesByTopic({
     preloadingFallback,
     addMessages,
   });
-}
+};

--- a/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/app/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -26,7 +26,7 @@ import {
 import { Time } from "rosbag";
 import { useDebouncedCallback } from "use-debounce";
 
-import useDataSourceInfo from "@foxglove/studio-base/PanelAPI/useDataSourceInfo";
+import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";

--- a/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
+++ b/app/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
@@ -14,7 +14,7 @@
 import { mapKeys, difference } from "lodash";
 import { useMemo, useRef } from "react";
 
-import useDataSourceInfo from "@foxglove/studio-base/PanelAPI/useDataSourceInfo";
+import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import useChangeDetector from "@foxglove/studio-base/hooks/useChangeDetector";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { TRANSFORM_TOPIC } from "@foxglove/studio-base/util/globalConstants";

--- a/extensions/panels/HelloWorldPanel.tsx
+++ b/extensions/panels/HelloWorldPanel.tsx
@@ -2,6 +2,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { panel } from "@foxglove/studio";
+
 export default function HelloWorldPanel(): JSX.Element {
-  return <div>Hello World!</div>;
+  const [config] = panel.useConfig();
+
+  return (
+    <>
+      <div>Hello World!</div>
+      <div>{JSON.stringify(config)}</div>
+    </>
+  );
 }

--- a/packages/@foxglove/studio/index.d.ts
+++ b/packages/@foxglove/studio/index.d.ts
@@ -3,7 +3,52 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 declare module "@foxglove/studio" {
-  type ExtensionPanelRegistration = {
+  import { Time } from "rosbag";
+
+  import { RosMsgField } from "@foxglove/rosmsg";
+
+  export type RosDatatype = {
+    fields: RosMsgField[];
+  };
+
+  export type RosDatatypes = {
+    [key: string]: RosDatatype;
+  };
+
+  // Represents a ROS topic, though the actual data does not need to come from a ROS system.
+  export type Topic = {
+    // Of ROS topic format, i.e. "/some/topic". We currently depend on this slashes format a bit in
+    // `<MessageHistroy>`, though we could relax this and support arbitrary strings. It's nice to have
+    // a consistent representation for topics that people recognize though.
+    name: string;
+    // Name of the datatype (see `type PlayerStateActiveData` for details).
+    datatype: string;
+    // The original topic name, if the topic name was at some point renamed, e.g. in
+    // RenameDataProvider.
+    originalTopic?: string;
+    // The number of messages present on the topic. Valid only for sources with a fixed number of
+    // messages, such as bags.
+    numMessages?: number;
+  };
+
+  // Metadata about the source of data currently being displayed.
+  // This is not expected to change often, usually when changing data sources.
+  export type DataSourceInfo = {
+    topics: readonly Topic[];
+    datatypes: RosDatatypes;
+    capabilities: string[];
+    startTime?: Time; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
+    playerId: string;
+  };
+
+  // A message event frames message data with the topic and receive time
+  export type MessageEvent<T> = Readonly<{
+    topic: string;
+    receiveTime: Time;
+    message: T;
+  }>;
+
+  export type ExtensionPanelRegistration = {
     // Unique name of the panel within your extension
     //
     // NOTE: Panel names within your extension must be unique. The panel name identifies this panel
@@ -15,19 +60,62 @@ declare module "@foxglove/studio" {
     component: () => JSX.Element;
   };
 
-  interface ExtensionContext {
-    readonly extensionMode: "production" | "development" | "test";
+  export interface ExtensionContext {
+    /** The current _mode_ of the application. */
+    readonly mode: "production" | "development" | "test";
 
     registerPanel(params: ExtensionPanelRegistration): void;
   }
 
-  interface ExtensionActivate {
+  export interface ExtensionActivate {
     (extensionContext: ExtensionContext): void;
   }
 
   // ExtensionModule describes the interface your extension entry level module must export
   // as its default export
-  interface ExtensionModule {
+  export interface ExtensionModule {
     activate: ExtensionActivate;
   }
+
+  // The entire public API interface
+  interface StudioApi {
+    panel: {
+      /**
+       * useMessagesByTopic makes it easy to request some messages on some topics.
+       *
+       * Using this hook will cause the panel to re-render when new messages arrive on the requested topics.
+       * - During file playback the panel will re-render when the file is playing or when the user is scrubbing.
+       * - During live playback the panel will re-render when new messages arrive.
+       */
+      useMessagesByTopic(params: {
+        topics: readonly string[];
+        historySize: number;
+        preloadingFallback?: boolean;
+      }): Record<string, readonly MessageEvent<unknown>[]>;
+
+      /**
+       * Load/Save panel configuration. This behaves in a manner similar to React.useState except the state
+       * is persisted with the current layout.
+       */
+      useConfig<Config>(): [Config, (config: Partial<Config>) => void];
+
+      /**
+       * Data source info" encapsulates **rarely-changing** metadata about the source from which
+       * Studio is loading data.
+       *
+       * A data source might be a local file, a remote file, or a streaming source.
+       */
+      useDataSourceInfo(): DataSourceInfo;
+    };
+  }
+
+  // Individual apis are exposed as constants
+  // This is to support a pattern of `import { panel } from "@foxglove/studio"`
+
+  /**
+   * APIs for use within panels
+   */
+  export const panel: StudioApi["panel"];
+
+  export = StudioApi;
 }


### PR DESCRIPTION
These apis are exposed via `import { panel } from @foxglove/studio`. They cannot be imported directly and must be accessed from the panel import. The @foxglove/studio api surface is dependency injected when an extension loads.

See HelloWorldPanel.tsx in `extensions/panels` as an example.