### PR TITLE
Rename useConfig to usePanelConfig and add default param.

### DIFF
--- a/app/PanelAPI/index.ts
+++ b/app/PanelAPI/index.ts
@@ -25,4 +25,4 @@ export { useBlocksByTopic } from "./useBlocksByTopic";
 
 export { default as useParameter } from "./useParameter";
 
-export * from "./useConfig";
+export * from "./usePanelConfig";

--- a/app/PanelAPI/usePanelConfig.ts
+++ b/app/PanelAPI/usePanelConfig.ts
@@ -14,9 +14,11 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 /**
- * Mix partial panel config from savedProps with the panel type's `defaultConfig` to form the complete panel configuration.
+ * Get/Set the panel's configuration. Return value is similar to useState (i.e [value, setter])
+ *
+ * The config value mixes any persisted config with the default config.
  */
-export function useConfig<Config>(): [Config, SaveConfig<Config>] {
+export function usePanelConfig<Config>(defaultConfig?: Config): [Config, SaveConfig<Config>] {
   const panelId = usePanelId();
   const panelCatalog = usePanelCatalog();
   const panelComponent = useMemo(
@@ -29,14 +31,14 @@ export function useConfig<Config>(): [Config, SaveConfig<Config>] {
   if (panelId != undefined && !panelComponent) {
     throw new Error(`Attempt to useConfig() with unknown panel id ${panelId}`);
   }
-  return useConfigById(panelId, panelComponent?.defaultConfig);
+  return usePanelConfigById(panelId, defaultConfig);
 }
 
 /**
- * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels
+ * Like `usePanelConfig`, but for a specific panel id. This generally shouldn't be used by panels
  * directly, but is for use in internal code that's running outside of regular context providers.
  */
-export function useConfigById<Config>(
+export function usePanelConfigById<Config>(
   panelId: string | undefined,
   defaultConfig: Config | undefined,
 ): [Config, SaveConfig<Config>] {

--- a/app/components/Panel.tsx
+++ b/app/components/Panel.tsx
@@ -41,7 +41,7 @@ import {
 } from "react-mosaic-component";
 import styled from "styled-components";
 
-import { useConfigById } from "@foxglove/studio-base/PanelAPI";
+import { usePanelConfigById } from "@foxglove/studio-base/PanelAPI";
 import Button from "@foxglove/studio-base/components/Button";
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
 import Flex from "@foxglove/studio-base/components/Flex";
@@ -158,7 +158,7 @@ export default function Panel<Config extends PanelConfig>(
       [panelCatalog, type],
     );
 
-    const [config, saveConfig] = useConfigById<Config>(childId, PanelComponent.defaultConfig);
+    const [config, saveConfig] = usePanelConfigById<Config>(childId, PanelComponent.defaultConfig);
     const panelComponentConfig = useMemo(
       () => ({ ...config, ...overrideConfig }),
       [config, overrideConfig],

--- a/app/components/PanelSettings/index.tsx
+++ b/app/components/PanelSettings/index.tsx
@@ -6,7 +6,7 @@ import { DefaultButton, Stack, Text, useTheme } from "@fluentui/react";
 import { StrictMode, useMemo, useState } from "react";
 import { useUnmount } from "react-use";
 
-import { useConfigById } from "@foxglove/studio-base/PanelAPI";
+import { usePanelConfigById } from "@foxglove/studio-base/PanelAPI";
 import ShareJsonModal from "@foxglove/studio-base/components/ShareJsonModal";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import {
@@ -63,7 +63,7 @@ export default function PanelSettings(): JSX.Element {
     );
   }, [selectedPanelId, showShareModal, getCurrentLayout, savePanelConfigs]);
 
-  const [config, saveConfig] = useConfigById<Record<string, unknown>>(
+  const [config, saveConfig] = usePanelConfigById<Record<string, unknown>>(
     selectedPanelId,
     panelInfo?.component.defaultConfig,
   );


### PR DESCRIPTION
Rather than specifying a default as a static property on the function component,
pass it as an argument to usePanelConfig similar to useState initialization.