### PR TITLE
Remove Hippocratic license

### DIFF
--- a/licenses.test.ts
+++ b/licenses.test.ts
@@ -20,7 +20,6 @@ const ALLOWED_LICENSES = [
   "WTFPL",
   "Unlicense",
   "OFL-1.1",
-  "Hippocratic-2.1",
 ];
 const EXCLUDED_PACKAGES = ["gl-vec3@1.1.3", "pngparse@2.0.1"];
 


### PR DESCRIPTION
We wish to make use of Foxglove Studio easy for consumers. To the extent possible, we should rely on popular and well-understood licenses approved by the OSI.