### PR TITLE
Fix undo/redo

### DIFF
--- a/app/providers/CurrentLayoutProvider/CurrentLayoutState.ts
+++ b/app/providers/CurrentLayoutProvider/CurrentLayoutState.ts
@@ -65,6 +65,10 @@ export default class CurrentLayoutState implements CurrentLayout {
       historySize: LAYOUT_HISTORY_SIZE,
       throttleMs: LAYOUT_HISTORY_THROTTLE_MS,
     });
+
+    this.addPanelsStateListener((state) => {
+      this.undoRedo.updateState(state);
+    });
   }
 
   addPanelsStateListener = (listener: (_: PanelsState) => void): void => {


### PR DESCRIPTION
I broke this during some intermediate refactors in #1026. The undo/redo actions work but new states were not being pushed into the history.