### PR TITLE
Fix panel settings being incorrectly overwritten

### DIFF
--- a/app/context/CurrentLayoutContext/useCurrentLayoutSelector.test.tsx
+++ b/app/context/CurrentLayoutContext/useCurrentLayoutSelector.test.tsx
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { act, renderHook } from "@testing-library/react-hooks";
+import { useLayoutEffect } from "react";
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import CurrentLayoutState, {
+  DEFAULT_LAYOUT_FOR_TESTS,
+} from "@foxglove/studio-base/providers/CurrentLayoutProvider/CurrentLayoutState";
+
+import CurrentLayoutContext, { useCurrentLayoutSelector } from "./index";
+
+describe("useCurrentLayoutSelector", () => {
+  it("updates when layout changes", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+      configById: { foo: { value: 42 } },
+    });
+    const { result } = renderHook((selector) => useCurrentLayoutSelector(selector), {
+      initialProps: (panelsState: PanelsState) => panelsState.configById["foo"],
+      wrapper({ children }) {
+        return (
+          <CurrentLayoutContext.Provider value={state}>{children}</CurrentLayoutContext.Provider>
+        );
+      },
+    });
+
+    expect(result.all).toEqual([{ value: 42 }]);
+
+    act(() => state.actions.savePanelConfigs({ configs: [{ id: "foo", config: { value: 1 } }] }));
+    expect(result.all).toEqual([{ value: 42 }, { value: 1 }]);
+  });
+
+  it("updates when selector changes", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+      configById: {
+        foo: { value: 42 },
+        bar: { otherValue: 0 },
+      },
+    });
+
+    const { result, rerender } = renderHook((selector) => useCurrentLayoutSelector(selector), {
+      initialProps: (panelsState: PanelsState) => panelsState.configById["foo"],
+      wrapper({ children }) {
+        return (
+          <CurrentLayoutContext.Provider value={state}>{children}</CurrentLayoutContext.Provider>
+        );
+      },
+    });
+
+    expect(result.all).toEqual([{ value: 42 }]);
+
+    rerender((panelsState) => panelsState.configById["bar"]);
+    expect(result.all).toEqual([{ value: 42 }, { otherValue: 0 }]);
+  });
+
+  it("updates when state changes before subscribe", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+      configById: {
+        foo: { value: 42 },
+        bar: { otherValue: 0 },
+      },
+    });
+
+    // If a sibling component updates the config in an effect, the config may change before the hook
+    // is able to add a listener. It must immediately update with the new value in order to produce
+    // consistent results.
+    function ChangeState() {
+      useLayoutEffect(() => {
+        state.actions.updatePanelConfigs("foo", ({ value }) => ({ value: (value as number) + 1 }));
+      }, []);
+      return ReactNull;
+    }
+
+    const { result } = renderHook((selector) => useCurrentLayoutSelector(selector), {
+      initialProps: (panelsState: PanelsState) => panelsState.configById["foo"],
+      wrapper({ children }) {
+        return (
+          <CurrentLayoutContext.Provider value={state}>
+            <ChangeState />
+            {children}
+          </CurrentLayoutContext.Provider>
+        );
+      },
+    });
+
+    expect(result.all).toEqual([{ value: 42 }, { value: 43 }]);
+  });
+});


### PR DESCRIPTION
useCurrentLayoutSelector had a bug where a change in the selector only (but no change in the panel config) would not trigger a re-render and update the result. This was triggered by panel settings sidebar, which changes the selector when a panel is selected or deselected. This led to a stale or incorrect config (such as from another panel) being merged with the default config, and the wrong settings being saved (thanks @esthersweon for catching this!).

Fixing the selector bug by adding another setState would be simple, but I wanted to avoid unnecessary renders and also fix a race condition between subscribing and state updates happening in an effect, so I went for a more involved change. (A similar race condition may occur in a couple other places in the app, `useContextSelector` and `useSelectedPanels`, but those can be tackled later in separate PRs.)