### PR TITLE
Add default config to useConfig panel api

### DIFF
--- a/app/PanelAPI/useConfig.test.tsx
+++ b/app/PanelAPI/useConfig.test.tsx
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { renderHook, act } from "@testing-library/react-hooks";
+import { PropsWithChildren } from "react";
+
+import CurrentLayoutContext from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { PanelIdContext } from "@foxglove/studio-base/context/PanelIdContext";
+import CurrentLayoutState, {
+  DEFAULT_LAYOUT_FOR_TESTS,
+} from "@foxglove/studio-base/providers/CurrentLayoutProvider/CurrentLayoutState";
+
+import { useConfig } from "./useConfig";
+
+describe("useConfig", () => {
+  it("initializes with a default value", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+    });
+
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <CurrentLayoutContext.Provider value={state}>
+          <PanelIdContext.Provider value="some-id">{children}</PanelIdContext.Provider>
+        </CurrentLayoutContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(() => useConfig<{ foo: string }>({ foo: "bar" }), { wrapper });
+    expect(result.current[0]).toEqual({ foo: "bar" });
+  });
+
+  it("initializes with existing value", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+      configById: { "some-id": { foo: 42 } },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <CurrentLayoutContext.Provider value={state}>
+          <PanelIdContext.Provider value="some-id">{children}</PanelIdContext.Provider>
+        </CurrentLayoutContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(() => useConfig<{ foo: string }>({ foo: "bar" }), { wrapper });
+    expect(result.current[0]).toEqual({ foo: 42 });
+  });
+
+  it("merges existing value with default value", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+      configById: { "some-id": { foo: 42 } },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <CurrentLayoutContext.Provider value={state}>
+          <PanelIdContext.Provider value="some-id">{children}</PanelIdContext.Provider>
+        </CurrentLayoutContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(
+      () => useConfig<{ foo?: string; another: string }>({ another: "bar" }),
+      {
+        wrapper,
+      },
+    );
+    expect(result.current[0]).toEqual({ foo: 42, another: "bar" });
+  });
+
+  it("should set the config", () => {
+    const state = new CurrentLayoutState({
+      ...DEFAULT_LAYOUT_FOR_TESTS,
+    });
+
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <CurrentLayoutContext.Provider value={state}>
+          <PanelIdContext.Provider value="some-id">{children}</PanelIdContext.Provider>
+        </CurrentLayoutContext.Provider>
+      );
+    };
+
+    const { result } = renderHook(() => useConfig<{ foo: string }>({ foo: "bar" }), { wrapper });
+    expect(result.current[0]).toEqual({ foo: "bar" });
+
+    state.addPanelsStateListener((newState) => {
+      expect(newState.configById["some-id"]?.foo).toEqual("reset");
+    });
+
+    // invoke setConfig
+    act(() => {
+      result.current[1]({
+        foo: "reset",
+      });
+    });
+
+    expect(result.current[0]).toEqual({ foo: "reset" });
+    expect.assertions(3);
+  });
+});

--- a/app/PanelAPI/useConfig.ts
+++ b/app/PanelAPI/useConfig.ts
@@ -9,33 +9,20 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { usePanelId } from "@foxglove/studio-base/context/PanelIdContext";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
-import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 /**
  * Mix partial panel config from savedProps with the panel type's `defaultConfig` to form the complete panel configuration.
  */
-export const useConfig: typeof panel.useConfig = () => {
+export const useConfig: typeof panel.useConfig = <Config>(defaultValue: Config) => {
   const panelId = usePanelId();
-  const panelCatalog = usePanelCatalog();
-  const panelComponent = useMemo(
-    () =>
-      panelId != undefined
-        ? panelCatalog.getPanelByType(getPanelTypeFromId(panelId))?.component
-        : undefined,
-    [panelCatalog, panelId],
-  );
-  if (panelId != undefined && !panelComponent) {
-    throw new Error(`Attempt to useConfig() with unknown panel id ${panelId}`);
-  }
-  return useConfigById(panelId, panelComponent?.defaultConfig);
+  return useConfigById(panelId, defaultValue);
 };
 
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels
- * directly, but is for use in internal code that's running outside of regular context providers.
+ * directly, but is for use in internal code that's running outside of a PanelIdContext.
  */
 export function useConfigById<Config>(
   panelId: string | undefined,

--- a/extensions/panels/HelloWorldPanel.tsx
+++ b/extensions/panels/HelloWorldPanel.tsx
@@ -4,8 +4,14 @@
 
 import { panel } from "@foxglove/studio";
 
+type Config = {
+  hello: string;
+};
+
 export default function HelloWorldPanel(): JSX.Element {
-  const [config] = panel.useConfig();
+  const [config] = panel.useConfig<Config>({
+    hello: "world",
+  });
 
   return (
     <>

--- a/packages/@foxglove/studio/index.d.ts
+++ b/packages/@foxglove/studio/index.d.ts
@@ -97,7 +97,9 @@ declare module "@foxglove/studio" {
        * Load/Save panel configuration. This behaves in a manner similar to React.useState except the state
        * is persisted with the current layout.
        */
-      useConfig<Config>(): [Config, (config: Partial<Config>) => void];
+      useConfig<Config extends Record<string, unknown>>(
+        defaultValue: Config,
+      ): [Config, (config: Partial<Config>) => void];
 
       /**
        * Data source info" encapsulates **rarely-changing** metadata about the source from which


### PR DESCRIPTION
The default config is passed to useConfig and merges with any persisted
configuration.