### PR TITLE
Add "Duplicate" entry to layout menu

### DIFF
--- a/app/components/LayoutMenu.tsx
+++ b/app/components/LayoutMenu.tsx
@@ -18,6 +18,7 @@ import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/
 import { Layout, useLayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
 import useLatestNonNull from "@foxglove/studio-base/hooks/useLatestNonNull";
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
+import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
@@ -151,6 +152,24 @@ export default function LayoutMenu({
     [layoutStorage, fetchLayouts],
   );
 
+  const newEmptyLayout = useCallback(() => {
+    const name = "empty layout";
+    const id = uuidv4();
+
+    const newState: PanelsState = {
+      id: id,
+      name: name,
+      globalVariables: {},
+      layout: undefined,
+      linkedGlobalVariables: [],
+      playbackConfig: defaultPlaybackConfig,
+      configById: {},
+      userNodes: {},
+    };
+
+    loadLayout(newState);
+  }, [loadLayout]);
+
   const duplicateLayout = useCallback(() => {
     const currentPanelsState = getCurrentLayout();
     const name = `${currentPanelsState.name ?? "unnamed"} copy`;
@@ -231,7 +250,13 @@ export default function LayoutMenu({
   const items: IContextualMenuItem[] = [
     ...layoutItems,
     { key: "divider_1", itemType: ContextualMenuItemType.Divider },
-    { key: "new", text: "New", onClick: duplicateLayout, iconProps: { iconName: "Add" } },
+    { key: "new", text: "New", onClick: newEmptyLayout, iconProps: { iconName: "Add" } },
+    {
+      key: "duplicate",
+      text: "Duplicate",
+      onClick: duplicateLayout,
+      iconProps: { iconName: "Copy" },
+    },
     { key: "export", text: "Export", onClick: exportAction, iconProps: { iconName: "Share" } },
     { key: "import", text: "Import", onClick: importAction, iconProps: { iconName: "OpenFile" } },
   ];

--- a/app/theme/ThemeProvider.tsx
+++ b/app/theme/ThemeProvider.tsx
@@ -26,6 +26,7 @@ const icons: {
   ClearSelection: <Icons.ClearSelectionIcon />,
   CodeEdit: <Icons.CodeEditIcon />,
   Contact: <Icons.ContactIcon />,
+  Copy: <Icons.CopyIcon />,
   DataManagementSettings: <Icons.DataManagementSettingsIcon />,
   Delete: <Icons.DeleteIcon />,
   Edit: <Icons.EditIcon />,

--- a/app/typings/fluentui.d.ts
+++ b/app/typings/fluentui.d.ts
@@ -21,6 +21,7 @@ declare global {
     | "ClearSelection"
     | "CodeEdit"
     | "Contact"
+    | "Copy"
     | "DataManagementSettings"
     | "Delete"
     | "Edit"


### PR DESCRIPTION
The Duplicate entry copies the current layout into a new layout. This
change updates the existing "New" menu entry to make an empty layout rather
than duplicate as it did prior to this change.