### PR TITLE
Make dev mode icon work on Windows

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -19,6 +19,7 @@ import Logger from "@foxglove/log";
 import colors from "@foxglove/studio-base/styles/colors.module.scss";
 
 import pkgInfo from "../../package.json";
+import { getDevModeIcon } from "./setDevModeDockIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
 
@@ -62,6 +63,13 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     },
     backgroundColor: colors.background,
   };
+  if (!isProduction) {
+    const devIcon = getDevModeIcon();
+    if (devIcon) {
+      windowOptions.icon = devIcon;
+      console.log("set icon");
+    }
+  }
   if (isMac) {
     windowOptions.titleBarStyle = "hiddenInset";
   }

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -19,7 +19,7 @@ import Logger from "@foxglove/log";
 import colors from "@foxglove/studio-base/styles/colors.module.scss";
 
 import pkgInfo from "../../package.json";
-import { getDevModeIcon } from "./setDevModeDockIcon";
+import getDevModeIcon from "./getDevModeIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
 
@@ -67,7 +67,6 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     const devIcon = getDevModeIcon();
     if (devIcon) {
       windowOptions.icon = devIcon;
-      console.log("set icon");
     }
   }
   if (isMac) {

--- a/desktop/main/getDevModeIcon.ts
+++ b/desktop/main/getDevModeIcon.ts
@@ -2,11 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { rgb2hsv, hsv2rgb } from "@fluentui/react";
-import { app, NativeImage, nativeImage } from "electron";
+import { NativeImage, nativeImage } from "electron";
 
 const ROTATION_DEGREES = 270;
 
-export function getDevModeIcon(): NativeImage | undefined {
+/** The regular app icon with a hue shift for development mode. */
+export default function getDevModeIcon(): NativeImage | undefined {
   try {
     // This can fail when opening the app from a packaged DMG.
     const originalIcon = nativeImage.createFromPath("resources/icon/icon.png");
@@ -23,16 +24,5 @@ export function getDevModeIcon(): NativeImage | undefined {
   } catch (error) {
     console.error("Unable to create dev mode icon", error);
     return undefined;
-  }
-}
-
-/** Set an icon with a hue shift for development mode. */
-export default function setDevModeDockIcon(): void {
-  if (app.dock == undefined) {
-    return;
-  }
-  const devIcon = getDevModeIcon();
-  if (devIcon) {
-    app.dock.setIcon(devIcon);
   }
 }

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -48,6 +48,13 @@ function main() {
 
   const isProduction = process.env.NODE_ENV === "production";
 
+  if (!isProduction && app.dock != undefined) {
+    const devIcon = getDevModeIcon();
+    if (devIcon) {
+      app.dock.setIcon(devIcon);
+    }
+  }
+
   // Suppress Electron Security Warning in development
   // See the comment for the webSecurity setting on browser window
   process.env["ELECTRON_DISABLE_SECURITY_WARNINGS"] = isProduction ? "false" : "true";
@@ -236,12 +243,6 @@ function main() {
 
     if (!isProduction) {
       await installChromeExtensions();
-      if (app.dock != undefined) {
-        const devIcon = getDevModeIcon();
-        if (devIcon) {
-          app.dock.setIcon(devIcon);
-        }
-      }
     }
 
     // Content Security Policy

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -15,6 +15,7 @@ import Logger from "@foxglove/log";
 
 import pkgInfo from "../../package.json";
 import StudioWindow from "./StudioWindow";
+import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
 import installChromeExtensions from "./installChromeExtensions";
 import { installMenuInterface } from "./menu";
@@ -22,7 +23,6 @@ import {
   registerRosPackageProtocolHandlers,
   registerRosPackageProtocolSchemes,
 } from "./rosPackageResources";
-import setDevModeDockIcon from "./setDevModeDockIcon";
 import { getTelemetrySettings } from "./telemetry";
 
 const log = Logger.getLogger(__filename);
@@ -236,7 +236,12 @@ function main() {
 
     if (!isProduction) {
       await installChromeExtensions();
-      setDevModeDockIcon();
+      if (app.dock != undefined) {
+        const devIcon = getDevModeIcon();
+        if (devIcon) {
+          app.dock.setIcon(devIcon);
+        }
+      }
     }
 
     // Content Security Policy

--- a/desktop/main/setDevModeDockIcon.ts
+++ b/desktop/main/setDevModeDockIcon.ts
@@ -2,15 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { rgb2hsv, hsv2rgb } from "@fluentui/react";
-import { app, nativeImage } from "electron";
+import { app, NativeImage, nativeImage } from "electron";
 
 const ROTATION_DEGREES = 270;
 
-/** Set an icon with a hue shift for development mode. */
-export default function setDevModeDockIcon(): void {
-  if (app.dock == undefined) {
-    return;
-  }
+export function getDevModeIcon(): NativeImage | undefined {
   try {
     // This can fail when opening the app from a packaged DMG.
     const originalIcon = nativeImage.createFromPath("resources/icon/icon.png");
@@ -23,9 +19,20 @@ export default function setDevModeDockIcon(): void {
       ({ r: buffer[i], g: buffer[i + 1], b: buffer[i + 2] } = hsv2rgb(hsv.h, hsv.s, hsv.v));
     }
 
-    const devIcon = nativeImage.createFromBuffer(buffer, originalIcon.getSize());
-    app.dock.setIcon(devIcon);
+    return nativeImage.createFromBuffer(buffer, originalIcon.getSize());
   } catch (error) {
-    console.error("Unable to set icon", error);
+    console.error("Unable to create dev mode icon", error);
+    return undefined;
+  }
+}
+
+/** Set an icon with a hue shift for development mode. */
+export default function setDevModeDockIcon(): void {
+  if (app.dock == undefined) {
+    return;
+  }
+  const devIcon = getDevModeIcon();
+  if (devIcon) {
+    app.dock.setIcon(devIcon);
   }
 }


### PR DESCRIPTION
Set the `icon` on BrowserWindow for Windows, since app.dock is only available on macOS.