### PR TITLE
Align connection list items left

### DIFF
--- a/app/components/ConnectionList.tsx
+++ b/app/components/ConnectionList.tsx
@@ -40,7 +40,14 @@ export default function ConnectionList(): JSX.Element {
         return (
           <div key={source.name}>
             <ActionButton
-              styles={{ root: { margin: 0, padding: 0, width: "100%" } }}
+              styles={{
+                root: {
+                  margin: 0,
+                  padding: 0,
+                  width: "100%",
+                  textAlign: "left",
+                },
+              }}
               iconProps={{
                 iconName,
                 styles: { root: { "& span": { verticalAlign: "baseline" } } },


### PR DESCRIPTION
The connection list items should align left to maintain visual alignment
when the sidebar is narrow and they overflow to a second line. Prior
to this change a narrow sidebar would result in some items being center
aligned while a wideer sidebar would have all items left aligned. This
keeps the same left alignment regardless of sidebar width.