### PR TITLE
Add react as a dependency to @foxglove/studio

### DIFF
--- a/packages/@foxglove/studio/package.json
+++ b/packages/@foxglove/studio/package.json
@@ -3,5 +3,11 @@
   "version": "0.1.0",
   "license": "MPL-2.0",
   "main": "",
-  "types": "index.d.ts"
+  "types": "index.d.ts",
+  "dependencies": {
+    "react": "17.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "17.0.6"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,6 +2815,9 @@ __metadata:
 "@foxglove/studio@workspace:packages/@foxglove/studio":
   version: 0.0.0-use.local
   resolution: "@foxglove/studio@workspace:packages/@foxglove/studio"
+  dependencies:
+    "@types/react": 17.0.6
+    react: 17.0.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This is required to pull in the jsx runtime when building extensions
