### PR TITLE
Fix updatePanelConfig call in CameraInfo

### DIFF
--- a/app/panels/ThreeDimensionalViz/CameraInfo/index.stories.tsx
+++ b/app/panels/ThreeDimensionalViz/CameraInfo/index.stories.tsx
@@ -14,6 +14,7 @@
 import { storiesOf } from "@storybook/react";
 import { DEFAULT_CAMERA_STATE } from "regl-worldview";
 
+import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import CameraInfo, {
   CAMERA_TAB_TYPE,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/CameraInfo";
@@ -51,7 +52,9 @@ const DEFAULT_PROPS = {
 
 const CameraInfoWrapper = (props: any) => (
   <div style={containerStyle}>
-    <CameraInfo {...DEFAULT_PROPS} defaultSelectedTab={CAMERA_TAB_TYPE} {...props} />
+    <MockPanelContextProvider>
+      <CameraInfo {...DEFAULT_PROPS} defaultSelectedTab={CAMERA_TAB_TYPE} {...props} />
+    </MockPanelContextProvider>
   </div>
 );
 

--- a/app/panels/ThreeDimensionalViz/CameraInfo/index.tsx
+++ b/app/panels/ThreeDimensionalViz/CameraInfo/index.tsx
@@ -21,7 +21,7 @@ import Button from "@foxglove/studio-base/components/Button";
 import ExpandingToolbar, { ToolGroup } from "@foxglove/studio-base/components/ExpandingToolbar";
 import Flex from "@foxglove/studio-base/components/Flex";
 import Icon from "@foxglove/studio-base/components/Icon";
-import PanelContext from "@foxglove/studio-base/components/PanelContext";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import {
   UncontrolledValidatedInput,
@@ -36,7 +36,6 @@ import {
   getNewCameraStateOnFollowChange,
   TargetPose,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
-import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import colors from "@foxglove/studio-base/styles/colors.module.scss";
 import clipboard from "@foxglove/studio-base/util/clipboard";
 import { point2DValidator, cameraStateValidator } from "@foxglove/studio-base/util/validators";
@@ -120,7 +119,7 @@ export default function CameraInfo({
   defaultSelectedTab,
 }: CameraInfoProps): JSX.Element {
   const [selectedTab, setSelectedTab] = React.useState(defaultSelectedTab);
-  const { updatePanelConfig, saveConfig } = React.useContext(PanelContext) ?? ({} as any);
+  const { updatePanelConfigs, saveConfig } = usePanelContext();
   const [edit, setEdit] = React.useState<boolean>(false);
   const onEditToggle = React.useCallback(() => setEdit((currVal) => !currVal), []);
 
@@ -134,7 +133,7 @@ export default function CameraInfo({
   const camPos2DTrimmed = camPos2D.map((num: any) => +num.toFixed(2));
 
   const syncCameraState = () => {
-    updatePanelConfig("3D Panel", (config: ThreeDimensionalVizConfig) => {
+    updatePanelConfigs("3D Panel", (config) => {
       // Transform the camera state by whichever TF or orientation the other panels are following.
       const newCameraState = getNewCameraStateOnFollowChange({
         prevCameraState: cameraState,
@@ -210,7 +209,7 @@ export default function CameraInfo({
                       type="checkbox"
                       checked={autoSyncCameraState}
                       onChange={() =>
-                        updatePanelConfig("3D Panel", (config: any) => ({
+                        updatePanelConfigs("3D Panel", (config) => ({
                           ...config,
                           cameraState,
                           autoSyncCameraState: !autoSyncCameraState,


### PR DESCRIPTION
Commit 7183c3f0 removed updatePanelConfig, however CameraInfo had an
_any_ that hid the type error resulting in updatePanelConfig not being
a function. This became a runtime error.

Surfaced via https://sentry.io/organizations/foxglove/issues/2430989186/?project=5649767&referrer=slack