### PR TITLE
Add YARN_ENABLE_IMMUTABLE_INSTALLS=false for dependabot fix

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -53,6 +53,10 @@ jobs:
           restore-keys: ${{ runner.os }}-yarn-
 
       - run: yarn install --skip-builds
+        env:
+          # yarn runs in immutable mode "by default" in CI -- turning this off requires an
+          # undocumented env var
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - run: yarn dedupe
 


### PR DESCRIPTION
This action is currently failing with `The lockfile would have been modified by this install, which is explicitly forbidden.` However, the purpose of the action is to modify the lockfile.

This likely broke in the yarn upgrade (part of #1084).