### PR TITLE
Change rawUserUtils imports to relative

### DIFF
--- a/app/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils.ts
+++ b/app/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils.ts
@@ -2,12 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import markers from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/markers.ts?raw";
-import pointClouds from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/pointClouds.ts?raw";
-import readers from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/readers.ts?raw";
-import time from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time.ts?raw";
-import types from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/types.ts?raw";
-import vectors from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/vectors.ts?raw";
+import markers from "./userUtils/markers.ts?raw";
+import pointClouds from "./userUtils/pointClouds.ts?raw";
+import readers from "./userUtils/readers.ts?raw";
+import time from "./userUtils/time.ts?raw";
+import types from "./userUtils/types.ts?raw";
+import vectors from "./userUtils/vectors.ts?raw";
 
 export default [
   { fileName: "pointClouds.ts", sourceCode: pointClouds },


### PR DESCRIPTION
Avoids having to tweak the typescriptTransformerWithRawImports if we rename the package
or move the location of the files relative to the package root.