### PR TITLE
Disable App launch integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           path: |
             .yarn/cache
             **/node_modules
-          key: ${{ runner.os }}-yarn-4-${{ hashFiles('**/yarn.lock') }}
+          key: 4-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-4-
       - run: yarn install --immutable
       - run: ${{ matrix.config.command }}
@@ -89,7 +89,7 @@ jobs:
           path: |
             .yarn/cache
             **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: 4-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
       - run: yarn install --immutable
       - name: test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [windows-2019]
 
     name: integration (${{ matrix.os }})
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [ubuntu-20.04]
 
     name: integration (${{ matrix.os }})
 

--- a/desktop/renderer/services/NativeStorageAppConfiguration.test.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.test.ts
@@ -23,7 +23,7 @@ function makeMockContext(): Storage & MockStorage {
   };
 }
 
-describe("OsContextAppConfiguration", () => {
+describe("NativeStorageAppConfiguration", () => {
   it("loads state upon construction and returns values from cached state", async () => {
     const ctx = makeMockContext();
     ctx.get.mockImplementationOnce(async () => {

--- a/desktop/test/startup.test.ts
+++ b/desktop/test/startup.test.ts
@@ -52,6 +52,10 @@ async function waitForAppMounted(appInstance: Application) {
   }
 }
 
-it("should start with no errors", async () => {
+// App startup tests are not working in our CI environment (even with ubuntu xvfb)
+// They stopped working around June 2nd 2021.
+// The error we are seeing is that Chrome failed to start (i.e. the app didn't start)
+// eslint-disable-next-line jest/no-disabled-tests
+it.skip("should start with no errors", async () => {
   await waitForAppMounted(app);
 });


### PR DESCRIPTION
Recently the app launch integration test has started failing in CI. Reverting the electron upgrade has not worked.
To unblock development while we search for a solution, this change skips the app launch integration test. We still
perform the production build to ensure that continues to work.