### PR TITLE
Remove duplicate ForkTsCheckerWebpackPlugin for web build

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -6,7 +6,6 @@ import ReactRefreshPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import SentryWebpackPlugin from "@sentry/webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
-import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import { Configuration, EnvironmentPlugin, WebpackPluginInstance } from "webpack";
@@ -115,11 +114,6 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
           messagingSenderId: "667544771216",
           appId: "1:667544771216:web:f8e6d9705a3c28e73a5615",
         }),
-      }),
-      new ForkTsCheckerWebpackPlugin({
-        typescript: {
-          configFile: "src/tsconfig.json",
-        },
       }),
       new CopyPlugin({
         patterns: [{ from: "public" }],


### PR DESCRIPTION
Introduced by https://github.com/foxglove/studio/pull/1109. This is not needed here because this plugin is already inherited from `const appWebpackConfig = makeConfig()`.

Blocking https://github.com/foxglove/studio/pull/1017 but I am landing this fix separately.