### PR TITLE
Revert "Remove duplicate ForkTsCheckerWebpackPlugin for web build"

### DIFF
--- a/web/src/tsconfig.json
+++ b/web/src/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "es2020"],
     "paths": {
-      "@foxglove/studio-base/*": ["../packages/studio-base/src/*"]
+      "@foxglove/studio-base/*": ["../../packages/studio-base/src/*"]
     }
   }
 }

--- a/web/src/tsconfig.json
+++ b/web/src/tsconfig.json
@@ -4,6 +4,9 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"]
+    "lib": ["dom", "dom.iterable", "es2020"],
+    "paths": {
+      "@foxglove/studio-base/*": ["../packages/studio-base/src/*"]
+    }
   }
 }

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -118,6 +118,10 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
       }),
       new ForkTsCheckerWebpackPlugin({
         typescript: {
+          // By default the ForkTsChecker provided by appWebpackConfig will look at
+          // web/tsconfig.json, which is only used for top-level .ts files in the web folder (i.e.
+          // this webpack config file) but will not typecheck files under src. We need another
+          // ForkTsChecker to check these files.
           configFile: "src/tsconfig.json",
         },
       }),

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -6,6 +6,7 @@ import ReactRefreshPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import SentryWebpackPlugin from "@sentry/webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import { Configuration, EnvironmentPlugin, WebpackPluginInstance } from "webpack";
@@ -114,6 +115,11 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
           messagingSenderId: "667544771216",
           appId: "1:667544771216:web:f8e6d9705a3c28e73a5615",
         }),
+      }),
+      new ForkTsCheckerWebpackPlugin({
+        typescript: {
+          configFile: "src/tsconfig.json",
+        },
       }),
       new CopyPlugin({
         patterns: [{ from: "public" }],


### PR DESCRIPTION
🏓 Reverts foxglove/studio#1144

This is needed to catch TS errors in files in `web/src/`. By default the ForkTsChecker will look at `web/tsconfig.json`, which is only used for top-level .ts files in the web folder (i.e. `web/webpack.config.ts`) but will not typecheck files under `src`. An example error (with CI green) can be seen in https://github.com/foxglove/studio/pull/1151 ... this is the same error that was fixed in #1109 when I added the ForkTsChecker.