### PR TITLE
Panel Extension API

### DIFF
--- a/packages/studio-base/src/PanelAPI/useConfig.ts
+++ b/packages/studio-base/src/PanelAPI/useConfig.ts
@@ -4,7 +4,6 @@
 
 import { useCallback, useMemo } from "react";
 
-import { panel } from "@foxglove/studio";
 import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
@@ -15,9 +14,10 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 /**
- * Mix partial panel config from savedProps with the panel type's `defaultConfig` to form the complete panel configuration.
+ * Load/Save panel configuration. This behaves in a manner similar to React.useState except the state
+ * is persisted with the current layout.
  */
-export const useConfig: typeof panel.useConfig = () => {
+export function useConfig<Config>(): [Config, (config: Partial<Config>) => void] {
   const panelId = usePanelId();
   const panelCatalog = usePanelCatalog();
   const panelComponent = useMemo(
@@ -31,7 +31,7 @@ export const useConfig: typeof panel.useConfig = () => {
     throw new Error(`Attempt to useConfig() with unknown panel id ${panelId}`);
   }
   return useConfigById(panelId, panelComponent?.defaultConfig);
-};
+}
 
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels

--- a/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
+++ b/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
@@ -13,7 +13,7 @@
 
 import { useMemo } from "react";
 
-import { DataSourceInfo, panel } from "@foxglove/studio";
+import { DataSourceInfo } from "@foxglove/studio";
 import {
   useMessagePipeline,
   MessagePipelineContext,
@@ -39,7 +39,13 @@ function selectPlayerId(ctx: MessagePipelineContext) {
   return ctx.playerState.playerId;
 }
 
-export const useDataSourceInfo: typeof panel.useDataSourceInfo = () => {
+/**
+ * Data source info" encapsulates **rarely-changing** metadata about the source from which
+ * Studio is loading data.
+ *
+ * A data source might be a local file, a remote file, or a streaming source.
+ */
+export function useDataSourceInfo(): DataSourceInfo {
   const datatypes = useMessagePipeline(selectDatatypes);
   const topics = useMessagePipeline(selectTopics);
   const startTime = useMessagePipeline(selectStartTime);
@@ -56,4 +62,4 @@ export const useDataSourceInfo: typeof panel.useDataSourceInfo = () => {
       playerId,
     };
   }, [capabilities, datatypes, playerId, startTime, topics]);
-};
+}

--- a/packages/studio-base/src/PanelAPI/useMessagesByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useMessagesByTopic.ts
@@ -14,7 +14,6 @@
 import { groupBy } from "lodash";
 import { useCallback } from "react";
 
-import { panel } from "@foxglove/studio";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import concatAndTruncate from "@foxglove/studio-base/util/concatAndTruncate";
@@ -24,13 +23,19 @@ import { useMessageReducer } from "./useMessageReducer";
 // Topic types that are not known at compile time
 type UnknownMessageEventsByTopic = Record<string, readonly MessageEvent<unknown>[]>;
 
-// Convenience wrapper around `useMessageReducer`, for if you just want some
-// recent messages for a few topics.
-export const useMessagesByTopic: typeof panel.useMessagesByTopic = ({
-  topics,
-  historySize,
-  preloadingFallback,
-}) => {
+/**
+ * useMessagesByTopic makes it easy to request some messages on some topics.
+ *
+ * Using this hook will cause the panel to re-render when new messages arrive on the requested topics.
+ * - During file playback the panel will re-render when the file is playing or when the user is scrubbing.
+ * - During live playback the panel will re-render when new messages arrive.
+ */
+export function useMessagesByTopic(params: {
+  topics: readonly string[];
+  historySize: number;
+  preloadingFallback?: boolean;
+}): Record<string, readonly MessageEvent<unknown>[]> {
+  const { historySize, topics, preloadingFallback } = params;
   const requestedTopics = useDeepMemo(topics);
 
   const addMessages = useCallback(
@@ -71,4 +76,4 @@ export const useMessagesByTopic: typeof panel.useMessagesByTopic = ({
     preloadingFallback,
     addMessages,
   });
-};
+}

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -15,6 +15,7 @@ import { debounce, flatten, groupBy } from "lodash";
 import { Time } from "rosbag";
 
 import { useShallowMemo } from "@foxglove/hooks";
+import { MessageEvent } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useContextSelector from "@foxglove/studio-base/hooks/useContextSelector";
@@ -22,7 +23,6 @@ import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables"
 import {
   AdvertisePayload,
   Frame,
-  MessageEvent,
   ParameterValue,
   Player,
   PlayerPresence,
@@ -234,6 +234,7 @@ export function MessagePipelineProvider({
         lastActiveData.current = newPlayerState.activeData;
         return newPlayerState;
       });
+
       return promise;
     });
     return () => {

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -78,8 +78,9 @@ const PerfInfo = styled.div`
   bottom: 2px;
   left: 2px;
   font-size: 9px;
-  opacity: 0.5;
+  opacity: 0.7;
   user-select: none;
+  mix-blend-mode: difference;
 `;
 
 type Props<Config> = {

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { CSSProperties, useLayoutEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+
+import { MessageEvent, PanelExtensionContext, RenderState, Topic } from "@foxglove/studio";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { PlayerState } from "@foxglove/studio-base/players/types";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
+
+type PanelExtensionAdapterProps = {
+  /** function that initializes the panel extension */
+  initPanel: (context: PanelExtensionContext) => void;
+
+  config: unknown;
+  saveConfig: SaveConfig<unknown>;
+
+  /** Help document for the panel */
+  help?: string;
+};
+
+const EmptyTopics: readonly Topic[] = [];
+
+/**
+ * PanelExtensionAdapter renders a panel extension via initPanel
+ *
+ * The adapter creates a PanelExtensionContext and invokes initPanel using the context.
+ */
+function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
+  const { initPanel, config, saveConfig } = props;
+
+  // We don't want changes to the config value to re-invoke initPanel in useLayoutEffect
+  const configRef = useRef(config);
+
+  const setSubscriptions = useMessagePipeline((ctx) => ctx.setSubscriptions);
+
+  const watchedFieldsRef = useRef(new Set<keyof RenderState>());
+  const subscribedTopicsRef = useRef(new Set<string>());
+  const panelElementRef = useRef<HTMLDivElement>(ReactNull);
+  const previousPlayerStateRef = useRef<PlayerState | undefined>(undefined);
+  const panelContextRef = useRef<PanelExtensionContext | undefined>(undefined);
+
+  // To avoid updating extended message stores once message pipeline blocks are no longer updating
+  // we store a ref to the blocks and only update stores when the ref is different
+  const prevBlocksRef = useRef<unknown>(undefined);
+
+  const renderingRef = useRef<boolean>(false);
+  const prevRenderState = useRef<RenderState>({});
+
+  const latestPipelineContextRef = useRef<MessagePipelineContext | undefined>(undefined);
+
+  const [slowRender, setSlowRender] = useState(false);
+
+  // we use message pipeline selector to capture updates and don't need to request animation frames
+  // multiple times so we gate requesting new message frames
+  const rafRequestedRef = useRef(false);
+
+  function renderPanel() {
+    rafRequestedRef.current = false;
+
+    const ctx = latestPipelineContextRef.current;
+    const { current: panelContext } = panelContextRef;
+    if (!panelContext || !panelContext.onRender || !ctx) {
+      return;
+    }
+
+    const playerState = ctx.playerState;
+    previousPlayerStateRef.current = playerState;
+
+    if (renderingRef.current) {
+      setSlowRender(true);
+      return;
+    }
+    setSlowRender(false);
+
+    // Should render indicates whether any fields of render state are updated
+    let shouldRender = false;
+    const newRenderState: RenderState = prevRenderState.current;
+
+    if (watchedFieldsRef.current.has("currentFrame")) {
+      const currentFrame =
+        playerState.activeData?.messages.filter((messageEvent) => {
+          return subscribedTopicsRef.current.has(messageEvent.topic);
+        }) ?? [];
+      // if there are new frames we should update
+      if (currentFrame?.length !== 0 || prevRenderState.current.currentFrame?.length !== 0) {
+        shouldRender = true;
+        newRenderState.currentFrame = currentFrame;
+      }
+    }
+
+    if (watchedFieldsRef.current.has("topics")) {
+      const newTopics = playerState.activeData?.topics ?? EmptyTopics;
+      if (newTopics !== prevRenderState.current.topics) {
+        shouldRender = true;
+        newRenderState.topics = newTopics;
+      }
+    }
+
+    if (watchedFieldsRef.current.has("allFrames")) {
+      // see comment for prevBlocksRef on why extended message store updates are gated this way
+      const newBlocks = playerState.progress.messageCache?.blocks;
+      if (newBlocks && prevBlocksRef.current !== newBlocks) {
+        shouldRender = true;
+        const frames: MessageEvent<unknown>[] = (newRenderState.allFrames = []);
+        for (const block of newBlocks) {
+          if (!block) {
+            continue;
+          }
+
+          for (const messageEvents of Object.values(block.messagesByTopic)) {
+            for (const messageEvent of messageEvents) {
+              if (!subscribedTopicsRef.current.has(messageEvent.topic)) {
+                continue;
+              }
+              frames.push(messageEvent);
+            }
+          }
+        }
+      }
+      prevBlocksRef.current = newBlocks;
+    }
+
+    if (!shouldRender) {
+      return;
+    }
+
+    // tell the panel to render and lockout future renders until rendering is complete
+    renderingRef.current = true;
+    panelContext.onRender(newRenderState, () => {
+      renderingRef.current = false;
+    });
+  }
+
+  useMessagePipeline((ctx) => {
+    latestPipelineContextRef.current = ctx;
+
+    const { current: panelContext } = panelContextRef;
+    if (!panelContext || !panelContext.onRender) {
+      return;
+    }
+
+    if (rafRequestedRef.current) {
+      return;
+    }
+    rafRequestedRef.current = true;
+    requestAnimationFrame(renderPanel);
+  });
+
+  useLayoutEffect(() => {
+    if (!panelElementRef.current) {
+      return;
+    }
+
+    const subscriberId = uuid();
+
+    const panelExtensionContext: PanelExtensionContext = {
+      panelElement: panelElementRef.current,
+
+      initialState: configRef.current,
+
+      saveState: saveConfig,
+
+      watch: (field: keyof RenderState) => {
+        watchedFieldsRef.current.add(field);
+      },
+
+      subscribe: (topics: string[]) => {
+        const subscribePayloads = topics.map((topic) => ({ topic }));
+        setSubscriptions(subscriberId, subscribePayloads);
+        for (const topic of topics) {
+          subscribedTopicsRef.current.add(topic);
+        }
+      },
+
+      unsubscribeAll: () => {
+        subscribedTopicsRef.current.clear();
+        setSubscriptions(subscriberId, []);
+      },
+    };
+
+    panelContextRef.current = panelExtensionContext;
+    initPanel(panelExtensionContext);
+
+    return () => {
+      panelContextRef.current = undefined;
+      setSubscriptions(subscriberId, []);
+    };
+  }, [initPanel, saveConfig, setSubscriptions]);
+
+  const style: CSSProperties = {};
+  if (slowRender) {
+    style.borderColor = "orange";
+    style.borderWidth = "1px";
+    style.borderStyle = "solid";
+  }
+
+  return (
+    <div style={{ width: "100%", height: "100%", overflow: "hidden", zIndex: 0, ...style }}>
+      <PanelToolbar floating helpContent={props.help} />
+      <div style={{ width: "100%", height: "100%", overflow: "hidden" }} ref={panelElementRef} />
+    </div>
+  );
+}
+
+export default PanelExtensionAdapter;

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Map as LeafMap } from "leaflet";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { MapContainer, TileLayer } from "react-leaflet";
+
+import { PanelExtensionContext, MessageEvent } from "@foxglove/studio";
+import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import { Topic } from "@foxglove/studio-base/players/types";
+
+import FilteredPointMarkers from "./FilteredPointMarkers";
+import { NavSatFixMsg, Point } from "./types";
+
+// Persisted panel state
+type Config = {
+  zoomLevel?: number;
+};
+
+type MapPanelProps = {
+  context: PanelExtensionContext;
+};
+
+function MapPanel(props: MapPanelProps): JSX.Element {
+  const { context } = props;
+
+  const [config] = useState<Config>(props.context.initialState as Config);
+
+  // Panel state management to update our set of messages
+  // We use state to trigger a render on the panel
+  const [navMessages, setNavMessages] = useState<readonly MessageEvent<unknown>[]>([]);
+  const [allNavMessages, setAllNavMessages] = useState<readonly MessageEvent<unknown>[]>([]);
+
+  // Panel state management to track the list of available topics
+  const [topics, setTopics] = useState<readonly Topic[]>([]);
+
+  // Subscribe to relevant topics
+  useEffect(() => {
+    // The map only supports sensor_msgs/NavSatFix
+    const eligibleTopics = topics
+      .filter((topic) => topic.datatype === "sensor_msgs/NavSatFix")
+      .map((topic) => topic.name);
+
+    context.subscribe(eligibleTopics);
+
+    return () => {
+      context.unsubscribeAll();
+    };
+  }, [context, topics]);
+
+  // The panel must indicate when it has finished rendering from a "render" call
+  // Here we track this callback in a ref and invoke it within the render function as an example
+  // For components that render off-screen or have delayed rendering, they would invoke this once
+  // they have rendered the latest set of messages or updates.
+  const doneRenderRef = useRef<(() => void) | undefined>(undefined);
+
+  // During the initial mount we setup our context render handler
+  useLayoutEffect(() => {
+    // tell the context we care about updates on these fields
+    context.watch("topics");
+    context.watch("currentFrame");
+    context.watch("allFrames");
+
+    // The render event handler updates the state for our messages an triggers a component render
+    //
+    // The panel must call the _done_ function passed to render indicating the render completed.
+    // The panel will not receive render calls until it calls done.
+    context.onRender = (renderState, done) => {
+      doneRenderRef.current = done;
+
+      if (renderState.topics) {
+        setTopics(renderState.topics);
+      }
+
+      if (renderState.currentFrame) {
+        setNavMessages(renderState.currentFrame);
+      }
+
+      if (renderState.allFrames) {
+        setAllNavMessages(renderState.allFrames);
+      }
+    };
+
+    // Remove any subscriptions if the effect happens to change
+    return () => {
+      context.onRender = undefined;
+    };
+  }, [context]);
+
+  // Trigger the done callback from the render event handler if we are rendering as a result of a
+  // panel context render event.
+  // This is done in an effect to indicate render is done after painting
+  useEffect(() => {
+    doneRenderRef.current?.();
+    doneRenderRef.current = undefined;
+  });
+
+  /// --- the remaining code is unrelated to the extension api ----- ///
+
+  const [center, setCenter] = useState<Point | undefined>();
+
+  // calculate center point from blocks if we don't have a center point
+  useEffect(() => {
+    setCenter((old) => {
+      // set center only once
+      if (old) {
+        return old;
+      }
+
+      for (const messageEvent of allNavMessages) {
+        const lat = (messageEvent.message as NavSatFixMsg).latitude;
+        const lon = (messageEvent.message as NavSatFixMsg).longitude;
+        const point: Point = {
+          lat,
+          lon,
+        };
+
+        return point;
+      }
+
+      return;
+    });
+  }, [allNavMessages]);
+
+  // calculate center point from streaming messages if we don't have a center point
+  useEffect(() => {
+    setCenter((old) => {
+      // set center only once
+      if (old) {
+        return old;
+      }
+
+      for (const messageEvent of navMessages) {
+        const point: Point = {
+          lat: (messageEvent.message as NavSatFixMsg).latitude,
+          lon: (messageEvent.message as NavSatFixMsg).longitude,
+        };
+
+        return point;
+      }
+
+      return;
+    });
+  }, [navMessages]);
+
+  const [currentMap, setCurrentMap] = useState<LeafMap | undefined>(undefined);
+
+  // persist panel config on zoom changes
+  useEffect(() => {
+    if (!currentMap) {
+      return;
+    }
+
+    const zoomChange = () => {
+      context.saveState({
+        zoomLevel: currentMap.getZoom(),
+      });
+    };
+
+    currentMap.on("zoom", zoomChange);
+    return () => {
+      currentMap.off("zoom", zoomChange);
+    };
+  }, [context, currentMap]);
+
+  if (!center) {
+    return <EmptyState>Waiting for first gps point...</EmptyState>;
+  }
+
+  return (
+    <MapContainer
+      whenCreated={setCurrentMap}
+      preferCanvas
+      style={{ width: "100%", height: "100%" }}
+      center={[center.lat, center.lon]}
+      zoom={config.zoomLevel ?? 10}
+      scrollWheelZoom={false}
+    >
+      <TileLayer
+        attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        maxNativeZoom={18}
+        maxZoom={24}
+      />
+      <FilteredPointMarkers allPoints={allNavMessages} currentPoints={navMessages} />
+    </MapContainer>
+  );
+}
+
+export default MapPanel;

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -14,6 +14,7 @@
 import { Time } from "rosbag";
 
 import { RosMsgDefinition } from "@foxglove/rosmsg";
+import type { MessageEvent } from "@foxglove/studio";
 import { BlockCache } from "@foxglove/studio-base/dataProviders/MemoryCacheDataProvider";
 import {
   AverageThroughput,
@@ -24,6 +25,9 @@ import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables"
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { Range } from "@foxglove/studio-base/util/ranges";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
+
+// re-exported until other import sites are updated from players/types to @foxglove/studio
+export type { MessageEvent };
 
 export type MessageDefinitionsByTopic = {
   [topic: string]: string;
@@ -217,13 +221,6 @@ export type Topic = {
   // messages, such as bags.
   numMessages?: number;
 };
-
-// A message event frames message data with the topic and receive time
-export type MessageEvent<T> = Readonly<{
-  topic: string;
-  receiveTime: Time;
-  message: T;
-}>;
 
 type RosSingularField = number | string | boolean | RosObject; // No time -- consider it a message.
 export type RosValue =

--- a/packages/studio-base/src/providers/ExtensionRegistryProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionRegistryProvider.tsx
@@ -7,8 +7,7 @@ import ReactDOM from "react-dom";
 import { useAsync } from "react-use";
 
 import Logger from "@foxglove/log";
-import StudioApi, { ExtensionContext, ExtensionModule } from "@foxglove/studio";
-import { useConfig, useMessagesByTopic, useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
+import { ExtensionContext, ExtensionModule } from "@foxglove/studio";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
 import ExtensionRegistryContext, {
   ExtensionRegistry,
@@ -16,14 +15,6 @@ import ExtensionRegistryContext, {
 } from "@foxglove/studio-base/context/ExtensionRegistryContext";
 
 const log = Logger.getLogger(__filename);
-
-const FoxgloveStudio: StudioApi = {
-  panel: {
-    useMessagesByTopic,
-    useDataSourceInfo,
-    useConfig,
-  },
-};
 
 export default function ExtensionRegistryProvider(props: PropsWithChildren<unknown>): JSX.Element {
   const extensionLoader = useExtensionLoader();
@@ -41,7 +32,7 @@ export default function ExtensionRegistryProvider(props: PropsWithChildren<unkno
 
       const module = { exports: {} };
       const require = (name: string) => {
-        return { react: React, "react-dom": ReactDOM, "@foxglove/studio": FoxgloveStudio }[name];
+        return { react: React, "react-dom": ReactDOM }[name];
       };
 
       const extensionMode =

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -6,6 +6,7 @@ import { PropsWithChildren, useMemo } from "react";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Panel from "@foxglove/studio-base/components/Panel";
+import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
 import PanelCatalogContext, {
@@ -14,6 +15,12 @@ import PanelCatalogContext, {
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import panels from "@foxglove/studio-base/panels";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
+
+type PanelProps = {
+  config: unknown;
+  saveConfig: SaveConfig<unknown>;
+};
 
 export default function PanelCatalogProvider(
   props: PropsWithChildren<unknown>,
@@ -26,12 +33,15 @@ export default function PanelCatalogProvider(
 
     return extensionPanels.map((panel) => {
       const panelType = `${panel.extensionName}.${panel.registration.name}`;
-      const PanelComponent = panel.registration.component;
-      const PanelWrapper = () => {
+      const PanelWrapper = (panelProps: PanelProps) => {
         return (
           <>
             <PanelToolbar floating />
-            <PanelComponent />
+            <PanelExtensionAdapter
+              config={panelProps.config}
+              saveConfig={panelProps.saveConfig}
+              initPanel={panel.registration.initPanel}
+            />
           </>
         );
       };

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -3,11 +3,5 @@
   "version": "0.1.0",
   "license": "MPL-2.0",
   "main": "",
-  "types": "index.d.ts",
-  "dependencies": {
-    "react": "17.0.2"
-  },
-  "devDependencies": {
-    "@types/react": "17.0.6"
-  }
+  "types": "index.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,9 +2817,6 @@ __metadata:
 "@foxglove/studio@workspace:packages/studio":
   version: 0.0.0-use.local
   resolution: "@foxglove/studio@workspace:packages/studio"
-  dependencies:
-    "@types/react": 17.0.6
-    react: 17.0.2
   languageName: unknown
   linkType: soft
 
@@ -5940,17 +5937,6 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: c626e3ca42b6173b0617102af6c1c8c6068f69fafeba51f5d614962cabaf98a5706295081941ece93da04117268cb0aad471be87e76dde7e0d5f79a46280c586
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:17.0.6":
-  version: 17.0.6
-  resolution: "@types/react@npm:17.0.6"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: dd687a9620d90cc7b9e50ed06ec73beb589fcb7ddfec7b166307af79cee7c521c1f2f1084ffd4ad6eaf7c937cfa446cc0b03cc3cd18e85e952501da2f2e0e0c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Extension API

All extensions have an entry point source file. This file must export an activate function which accepts an extension context. Here you register the components of your extension (i.e. panels).

An example entry point file that registers one sample panel called "my-panel" and one called "my-react-panel". Both panels produce the same output.

index.ts
```typescript
import { ExtensionContext, PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
import { initPanel } from "./MyPanel.ts";
import { initReactPanel } from "./MyReactPanel.tsx";

export function activate(extensionContext: ExtensionContext) {
  extensionContext.registerPanel({ name: "my-panel", initPanel: initPanel });
  extensionContext.registerPanel({ name: "my-react-panel", initPanel: initReactPanel });
}
```

Your panel entry point receives a `PanelExtensionContext` argument. This argument contains the root element for the panel and various methods to access data and interface with studio. Panels are framework agnostic. Here is an example using DOM primitives

MyPanel.ts
```typescript

export function initPanel(context: PanelExtensionContext) {
  const topicsListDiv = document.createElement("div");
  const messageCountDiv = document.createElement("div");

  context.panelElement.appendChild(topicsListDiv);
  context.panelElement.appendChild(messageCountDiv);

  // The render handler is run by the broader studio system during playback when your panel
  // needs to render because the fields it is watching have changed. How you handle rendering depends on your framework.
  // You can only setup one render handler - usually early on in setting up your panel.
  //
  // Without a render handler your panel will never receive updates.
  //
  // The render handler could be invoked as often as 60hz during playback if fields are changing often.
  context.onRender = (renderState: RenderState, done) => {
    topicsListDiv.innerText =  renderState?.topics.join(",");
    messageCountDiv.innerText = renderState?.currentFrame.length;

    // render functions receive a _done_ callback. You MUST call this callback to indicate your panel has finished rendering.
    // Your panel will not receive another render callback until _done_ is called from a prior render. If your panel is not done
    // rendering before the next render call, studio shows a notification to the user that your panel is delayed.
    done();
  };

  // After adding a render handler, you must indicate which fields from RenderState will trigger updates.
  // If you do not watch any fields then your panel will never render since the panel context will assume you do not want any updates.

  // tell the panel context that we care about any update to the _topic_ field of RenderState
  context.watch("topics");

  // tell the panel context we want messages for the current frame for topics we've subscribed to
  // This corresponds to the _currentFrame_ field of render state.
  context.watch("currentFrame");

  // subscribe to some topics, you could do this within other effects, based on input fields, etc
  // Once you subscribe to topics, currentFrame will contain message events from those topics (assuming there are messages).
  context.subscribe(["/some/topic"]);
}
```

Here we show an example using react. This example panel shows how to get updates for topics and messages on specific topics.

MyReactPanel.tsx
```typescript

function SamplePanel({ context }: { context: PanelExtensionContext}) {

  const [topics, setTopics] = useState<Topic[] | undefined>();
  const [messages, setMessages] = useState<MessageEvent<unknown>[] | undefined>();

  const doneRenderRef = useRef<(() => void) | undefined>();

  // We use a layout effect to setup render handling for our panel. We also setup some topic subscriptions.
  useLayoutEffect(() => {
    // The render handler is run by the broader studio system during playback when your panel
    // needs to render because the fields it is watching have changed. How you handle rendering depends on your framework.
    // You can only setup one render handler - usually early on in setting up your panel.
    //
    // Without a render handler your panel will never receive updates.
    //
    // The render handler could be invoked as often as 60hz during playback if fields are changing often.
    context.onRender = (renderState: RenderState, done) => {
       // render functions receive a _done_ callback. You MUST call this callback to indicate your panel has finished rendering.
       // Your panel will not receive another render callback until _done_ is called from a prior render. If your panel is not done
       // rendering before the next render call, studio shows a notification to the user that your panel is delayed.
       doneRenderRef.current = done;     
 
      // We may have new topics - since we are also watching for messages in the current frame, topics may not have changed
      // It is up to you to determine the correct action when state has not changed.
      setTopics(renderState.topics);
      
      // currentFrame has messages on subscribed topics since the last render call
      setMessages(renderState.currentFrame);
    };

    // After adding a render handler, you must indicate which fields from RenderState will trigger updates.
    // If you do not watch any fields then your panel will never render since the panel context will assume you do not want any updates.

    // tell the panel context that we care about any update to the _topic_ field of RenderState
    context.watch("topics");

    // tell the panel context we want messages for the current frame for topics we've subscribed to
    // This corresponds to the _currentFrame_ field of render state.
    context.watch("currentFrame");

    // subscribe to some topics, you could do this within other effects, based on input fields, etc
    // Once you subscribe to topics, currentFrame will contain message events from those topics (assuming there are messages).
    context.subscribe(["/some/topic"]);
  }, []);

  doneRenderRef.current?.();

  return (
    <>
      <div>{topics?.join(",")}</div>
      <div>{messages?.length}</div>
    </>
  );
}

export function initReactPanel(context: PanelExtensionContext) {
  ReactDOM.render(<SamplePanel context={context} />, context.panelElement);
}
```

