### PR TITLE
Remove extra ForkTsChecker by changing webpack `context` for web build

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -6,7 +6,6 @@ import ReactRefreshPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import SentryWebpackPlugin from "@sentry/webpack-plugin";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
-import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import { Configuration, EnvironmentPlugin, WebpackPluginInstance } from "webpack";
@@ -89,8 +88,8 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     ...appWebpackConfig,
 
     target: "web",
-    context: path.resolve(__dirname),
-    entry: "./src/index.tsx",
+    context: path.resolve(__dirname, "src"),
+    entry: "./index.tsx",
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
@@ -116,17 +115,8 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
           appId: "1:667544771216:web:f8e6d9705a3c28e73a5615",
         }),
       }),
-      new ForkTsCheckerWebpackPlugin({
-        typescript: {
-          // By default the ForkTsChecker provided by appWebpackConfig will look at
-          // web/tsconfig.json, which is only used for top-level .ts files in the web folder (i.e.
-          // this webpack config file) but will not typecheck files under src. We need another
-          // ForkTsChecker to check these files.
-          configFile: "src/tsconfig.json",
-        },
-      }),
       new CopyPlugin({
-        patterns: [{ from: "public" }],
+        patterns: [{ from: "../public" }],
       }),
       new HtmlWebpackPlugin({
         templateContent: `


### PR DESCRIPTION
Follow up to #1152. By changing the `context` we change which tsconfig.json is automatically picked up by the existing ForkTsChecker.