### PR TITLE
Bump @foxglove/eslint-plugin

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -119,10 +119,6 @@ overrides:
           # Keeps the error count manageable while we enhance type information from the flow conversion
           allowAny: true
 
-      # The ! assertion is used (sparingly) in cases where tsc cannot automatically do bounds
-      # checking such as indexed array iteration
-      "@typescript-eslint/no-non-null-assertion": off
-
       # It's sometimes useful to explicitly name to guard against future changes
       "@typescript-eslint/no-inferrable-types": off
       "@typescript-eslint/no-empty-function": off

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "7.14.4",
     "@babel/preset-typescript": "7.13.0",
     "@foxglove/electron-socket": "workspace:packages/electron-socket",
-    "@foxglove/eslint-plugin": "0.6.0",
+    "@foxglove/eslint-plugin": "0.7.0",
     "@foxglove/tsconfig": "workspace:packages/tsconfig",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-beta.8",
     "@sentry/electron": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2552,16 +2552,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/eslint-plugin@npm:0.6.0":
-  version: 0.6.0
-  resolution: "@foxglove/eslint-plugin@npm:0.6.0"
+"@foxglove/eslint-plugin@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@foxglove/eslint-plugin@npm:0.7.0"
   peerDependencies:
     eslint: ^7
     eslint-config-prettier: ^8
     eslint-plugin-import: ^2
     eslint-plugin-prettier: ^3
     prettier: ^2
-  checksum: ad2ff39db43b201148597ec695f26e0e829df44a489e39b0826de59b8e8f2737a751db6b19964af2289dc304afbc346e78cd9e9a66e3c2f4139f0bb89d1549af
+  checksum: 11a33a0908179d0dc80819c62551ae11663df4fa1c413dd67b80af6d9649c33334148f0d3bd49d28688c2805ffbc4e9b74c045e69f3a0dad773be7dc07707e29
   languageName: node
   linkType: hard
 
@@ -13393,7 +13393,7 @@ __metadata:
     "@babel/preset-env": 7.14.4
     "@babel/preset-typescript": 7.13.0
     "@foxglove/electron-socket": "workspace:packages/electron-socket"
-    "@foxglove/eslint-plugin": 0.6.0
+    "@foxglove/eslint-plugin": 0.7.0
     "@foxglove/tsconfig": "workspace:packages/tsconfig"
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.0-beta.8
     "@sentry/electron": 2.4.1


### PR DESCRIPTION
Moves `@typescript-eslint/no-non-null-assertion` upstream.

Refs https://github.com/foxglove/studio/pull/1171 https://github.com/foxglove/eslint-plugin/pull/10