### PR TITLE
Extensions sidebar

### DIFF
--- a/desktop/renderer/providers/ExtensionLoaderProvider.tsx
+++ b/desktop/renderer/providers/ExtensionLoaderProvider.tsx
@@ -15,6 +15,7 @@ const desktopBridge = (global as { desktopBridge?: Desktop }).desktopBridge;
 
 type PackageInfo = {
   name: string;
+  displayName: string;
 };
 
 export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown>): JSX.Element {
@@ -26,7 +27,8 @@ export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown
       const pkgInfo = item.packageJson as PackageInfo;
 
       return {
-        name: pkgInfo.name,
+        id: pkgInfo.name,
+        name: pkgInfo.displayName,
         source: item.source,
       };
     });

--- a/desktop/renderer/providers/ExtensionLoaderProvider.tsx
+++ b/desktop/renderer/providers/ExtensionLoaderProvider.tsx
@@ -16,6 +16,12 @@ const desktopBridge = (global as { desktopBridge?: Desktop }).desktopBridge;
 type PackageInfo = {
   name: string;
   displayName: string;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  keywords: string[];
 };
 
 export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown>): JSX.Element {
@@ -29,6 +35,12 @@ export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown
       return {
         id: pkgInfo.name,
         name: pkgInfo.displayName,
+        description: pkgInfo.description,
+        publisher: pkgInfo.publisher,
+        homepage: pkgInfo.homepage,
+        license: pkgInfo.license,
+        version: pkgInfo.version,
+        keywords: pkgInfo.keywords,
         source: item.source,
       };
     });

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -17,6 +17,7 @@ import ModalHost from "@foxglove/studio-base/context/ModalHost";
 import { PlayerSourceDefinition } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
 import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider";
+import ExtensionMarketplaceProvider from "@foxglove/studio-base/providers/ExtensionMarketplaceProvider";
 import ExtensionRegistryProvider from "@foxglove/studio-base/providers/ExtensionRegistryProvider";
 import PanelCatalogProvider from "@foxglove/studio-base/providers/PanelCatalogProvider";
 import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
@@ -39,6 +40,7 @@ export default function App(props: AppProps): JSX.Element {
     <HoverValueProvider />,
     <UserNodeStateProvider />,
     <CurrentLayoutProvider />,
+    <ExtensionMarketplaceProvider />,
     <ExtensionRegistryProvider />,
     <PlayerManager playerSources={props.availableSources} />,
     /* eslint-enable react/jsx-key */

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -10,4 +10,5 @@ export enum AppSetting {
   TIMEZONE = "timezone",
   UNLIMITED_MEMORY_CACHE = "experimental.unlimited-memory-cache",
   SHOW_DEBUG_PANELS = "showDebugPanels",
+  EXTENSION_MARKETPLACE = "extensionMarketplace",
 }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -17,6 +17,7 @@ import { useMountedState } from "react-use";
 import styled from "styled-components";
 
 import Log from "@foxglove/log";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AccountSettings from "@foxglove/studio-base/components/AccountSettings";
 import ConnectionList from "@foxglove/studio-base/components/ConnectionList";
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
@@ -49,6 +50,7 @@ import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext
 import { PanelSettingsContext } from "@foxglove/studio-base/context/PanelSettingsContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
@@ -364,6 +366,17 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     [selectedSidebarItem],
   );
 
+  const [showMarketplace = false] = useAppConfigurationValue<boolean>(
+    AppSetting.EXTENSION_MARKETPLACE,
+  );
+  const sidebarItems = useMemo(() => {
+    const filteredSidebarItems = new Map(SIDEBAR_ITEMS);
+    if (!showMarketplace) {
+      filteredSidebarItems.delete("extensions");
+    }
+    return filteredSidebarItems;
+  }, [showMarketplace]);
+
   return (
     <MultiProvider
       providers={[
@@ -408,7 +421,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           </SToolbarItem>
         </Toolbar>
         <Sidebar
-          items={SIDEBAR_ITEMS}
+          items={sidebarItems}
           bottomItems={SIDEBAR_BOTTOM_ITEMS}
           selectedKey={selectedSidebarItem}
           onSelectKey={setSelectedSidebarItem}

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -21,7 +21,7 @@ import AccountSettings from "@foxglove/studio-base/components/AccountSettings";
 import ConnectionList from "@foxglove/studio-base/components/ConnectionList";
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
 import DropOverlay from "@foxglove/studio-base/components/DropOverlay";
-import Extensions from "@foxglove/studio-base/components/Extensions";
+import ExtensionsSidebar from "@foxglove/studio-base/components/ExtensionsSidebar";
 import GlobalKeyListener from "@foxglove/studio-base/components/GlobalKeyListener";
 import GlobalVariablesTable from "@foxglove/studio-base/components/GlobalVariablesTable";
 import variablesHelp from "@foxglove/studio-base/components/GlobalVariablesTable/index.help.md";
@@ -97,7 +97,7 @@ const SIDEBAR_ITEMS = new Map<SidebarItemKey, SidebarItem>([
   ],
   ["variables", { iconName: "Variable2", title: "Variables", component: Variables }],
   ["preferences", { iconName: "Settings", title: "Preferences", component: Preferences }],
-  ["extensions", { iconName: "AddIn", title: "Extensions", component: Extensions }],
+  ["extensions", { iconName: "AddIn", title: "Extensions", component: ExtensionsSidebar }],
   ...(process.env.NODE_ENV === "production"
     ? []
     : [

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -21,6 +21,7 @@ import AccountSettings from "@foxglove/studio-base/components/AccountSettings";
 import ConnectionList from "@foxglove/studio-base/components/ConnectionList";
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
 import DropOverlay from "@foxglove/studio-base/components/DropOverlay";
+import Extensions from "@foxglove/studio-base/components/Extensions";
 import GlobalKeyListener from "@foxglove/studio-base/components/GlobalKeyListener";
 import GlobalVariablesTable from "@foxglove/studio-base/components/GlobalVariablesTable";
 import variablesHelp from "@foxglove/studio-base/components/GlobalVariablesTable/index.help.md";
@@ -80,6 +81,7 @@ type SidebarItemKey =
   | "add-panel"
   | "panel-settings"
   | "variables"
+  | "extensions"
   | "account"
   | "preferences";
 
@@ -95,6 +97,7 @@ const SIDEBAR_ITEMS = new Map<SidebarItemKey, SidebarItem>([
   ],
   ["variables", { iconName: "Variable2", title: "Variables", component: Variables }],
   ["preferences", { iconName: "Settings", title: "Preferences", component: Preferences }],
+  ["extensions", { iconName: "AddIn", title: "Extensions", component: Extensions }],
   ...(process.env.NODE_ENV === "production"
     ? []
     : [

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -33,6 +33,11 @@ const features: Feature[] = [
     name: "Studio Debug Panels",
     description: <>Show Studio debug panels in the add panel list.</>,
   },
+  {
+    key: AppSetting.EXTENSION_MARKETPLACE,
+    name: "Extension Marketplace",
+    description: <>Enable the extension marketplace for installing/uninstalling extensions</>,
+  },
 ];
 
 function ExperimentalFeatureItem(props: { feature: Feature }) {

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -1,0 +1,119 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ActionButton, Pivot, PivotItem } from "@fluentui/react";
+import { useAsync } from "react-use";
+import styled from "styled-components";
+
+import Button from "@foxglove/studio-base/components/Button";
+import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import TextContent from "@foxglove/studio-base/components/TextContent";
+
+export type ExtensionEntry = {
+  id: string;
+  installed?: boolean;
+  name: string;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  readme?: string;
+  changelog?: string;
+  shasum?: string;
+  foxe?: string;
+  keywords?: string[];
+  time?: Record<string, string>;
+};
+
+type Props = {
+  extension: ExtensionEntry;
+  onClose: () => void;
+};
+
+const ExtensionId = styled.a`
+  border-radius: 3px;
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 3px;
+  text-decoration: none;
+`;
+
+const Publisher = styled.div`
+  color: #e2dce9;
+  margin-top: 8px;
+  margin-bottom: 16px;
+`;
+
+const Version = styled.span`
+  color: #7a777d;
+  font-size: 80%;
+  margin-left: 8px;
+`;
+
+const License = styled.span`
+  color: #7a777d;
+  font-size: 80%;
+  margin-left: 8px;
+`;
+
+const Description = styled.div`
+  margin-top: 16px;
+  margin-bottom: 16px;
+`;
+
+export function ExtensionDetails({ extension, onClose }: Props): React.ReactElement {
+  const readmeUrl = extension.readme;
+  const changelogUrl = extension.changelog;
+
+  const { value: readmeContent } = useAsync(
+    async () => (readmeUrl != undefined ? await (await fetch(readmeUrl)).text() : ""),
+    [readmeUrl],
+  );
+  const { value: changelogContent } = useAsync(
+    async () => (changelogUrl != undefined ? await (await fetch(changelogUrl)).text() : ""),
+    [changelogUrl],
+  );
+
+  return (
+    <SidebarContent title={extension.name} padRight>
+      <ActionButton
+        iconProps={{ iconName: "Cancel" }}
+        style={{ position: "absolute", top: 0, right: 0 }}
+        onClick={onClose}
+      ></ActionButton>
+      <ExtensionId href={extension.homepage} target="_blank">
+        {extension.id}
+      </ExtensionId>
+      <Version>{`v${extension.version}`}</Version>
+      <License>{extension.license}</License>
+      <Publisher>{extension.publisher}</Publisher>
+      <Description>{extension.description}</Description>
+      {extension.installed === true ? <UninstallButton /> : <InstallButton />}
+      <Pivot style={{ marginTop: "16px" }}>
+        <PivotItem headerText="README">
+          <TextContent>{readmeContent}</TextContent>
+        </PivotItem>
+        <PivotItem headerText="CHANGELOG">
+          <TextContent>{changelogContent}</TextContent>
+        </PivotItem>
+      </Pivot>
+    </SidebarContent>
+  );
+}
+
+function UninstallButton(): React.ReactElement {
+  return (
+    <Button style={{ minWidth: "100px" }} onClick={() => {}}>
+      Uninstall
+    </Button>
+  );
+}
+
+function InstallButton(): React.ReactElement {
+  return (
+    <Button style={{ minWidth: "100px" }} onClick={() => {}}>
+      Install
+    </Button>
+  );
+}

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -76,10 +76,10 @@ export function ExtensionDetails({ extension, onClose }: Props): React.ReactElem
   );
 
   return (
-    <SidebarContent title={extension.name} padRight>
+    <SidebarContent title={extension.name} paddingLeft="32px">
       <ActionButton
-        iconProps={{ iconName: "Cancel" }}
-        style={{ position: "absolute", top: 0, right: 0 }}
+        iconProps={{ iconName: "ChevronLeft" }}
+        style={{ position: "absolute", top: "5px", left: "8px" }}
         onClick={onClose}
       ></ActionButton>
       <ExtensionId href={extension.homepage} target="_blank">

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -9,26 +9,13 @@ import styled from "styled-components";
 import Button from "@foxglove/studio-base/components/Button";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import TextContent from "@foxglove/studio-base/components/TextContent";
-
-export type ExtensionEntry = {
-  id: string;
-  installed?: boolean;
-  name: string;
-  description: string;
-  publisher: string;
-  homepage: string;
-  license: string;
-  version: string;
-  readme?: string;
-  changelog?: string;
-  shasum?: string;
-  foxe?: string;
-  keywords?: string[];
-  time?: Record<string, string>;
-};
+import {
+  ExtensionMarketplaceDetail,
+  useExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
 
 type Props = {
-  extension: ExtensionEntry;
+  extension: ExtensionMarketplaceDetail;
   onClose: () => void;
 };
 
@@ -63,16 +50,17 @@ const Description = styled.div`
 `;
 
 export function ExtensionDetails({ extension, onClose }: Props): React.ReactElement {
+  const marketplace = useExtensionMarketplace();
   const readmeUrl = extension.readme;
   const changelogUrl = extension.changelog;
 
   const { value: readmeContent } = useAsync(
-    async () => (readmeUrl != undefined ? await (await fetch(readmeUrl)).text() : ""),
-    [readmeUrl],
+    async () => (readmeUrl != undefined ? await marketplace.getMarkdown(readmeUrl) : ""),
+    [marketplace, readmeUrl],
   );
   const { value: changelogContent } = useAsync(
-    async () => (changelogUrl != undefined ? await (await fetch(changelogUrl)).text() : ""),
-    [changelogUrl],
+    async () => (changelogUrl != undefined ? await marketplace.getMarkdown(changelogUrl) : ""),
+    [marketplace, changelogUrl],
   );
 
   return (

--- a/packages/studio-base/src/components/Extensions.tsx
+++ b/packages/studio-base/src/components/Extensions.tsx
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { Stack, useTheme } from "@fluentui/react";
+import { useAsync } from "react-use";
+import styled from "styled-components";
+
+import { SectionHeader } from "@foxglove/studio-base/components/Menu";
+import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
+
+const MARKETPLACE_URL =
+  "https://raw.githubusercontent.com/foxglove/studio-extension-marketplace/main/extensions.json";
+
+type MarketplaceEntry = {
+  id: string;
+  name: string;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  shasum: string;
+  foxe: string;
+  keywords: string[];
+  time: Record<string, string>;
+};
+
+const Name = styled.span`
+  color: #8b888f;
+  font-weight: bold;
+`;
+
+const Version = styled.span`
+  color: #7a777d;
+  font-size: 80%;
+  margin-left: 8px;
+`;
+
+const Description = styled.span`
+  color: #8b888f;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  display: inline-block;
+  overflow: hidden;
+`;
+
+const DescriptionLine = styled.div`
+  margin-top: 6px;
+`;
+
+const Publisher = styled.span`
+  color: #e2dce9;
+`;
+
+const PublisherLine = styled.div`
+  margin-top: 4px;
+  margin-bottom: 12px;
+`;
+
+export default function Extensions(): React.ReactElement {
+  const theme = useTheme();
+
+  const extensionLoader = useExtensionLoader();
+
+  const { value: installed, error: installedError } = useAsync(async () => {
+    const extensionList = await extensionLoader.getExtensions();
+    return extensionList.map((extension) => (
+      <Stack.Item key={extension.id}>
+        <div>{extension.name}</div>
+      </Stack.Item>
+    ));
+  }, [extensionLoader]);
+
+  if (installedError) {
+    throw installedError;
+  }
+
+  const { value: available, error: availableError } = useAsync(async () => {
+    const data = await fetch(MARKETPLACE_URL);
+    const entries = (await data.json()) as MarketplaceEntry[];
+    return entries.map((entry) => (
+      <Stack.Item key={entry.id}>
+        <div>
+          <Name>{entry.name}</Name>
+          <Version>{entry.version}</Version>
+        </div>
+        <DescriptionLine>
+          <Description>{entry.description}</Description>
+        </DescriptionLine>
+        <PublisherLine>
+          <Publisher>{entry.publisher}</Publisher>
+        </PublisherLine>
+      </Stack.Item>
+    ));
+  }, []);
+
+  if (availableError) {
+    throw availableError;
+  }
+
+  return (
+    <SidebarContent title="Extensions">
+      <Stack tokens={{ childrenGap: 30 }}>
+        <Stack.Item>
+          <SectionHeader>Installed</SectionHeader>
+          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>{installed}</Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <SectionHeader>Available</SectionHeader>
+          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>{available}</Stack>
+        </Stack.Item>
+      </Stack>
+    </SidebarContent>
+  );
+}

--- a/packages/studio-base/src/components/Extensions.tsx
+++ b/packages/studio-base/src/components/Extensions.tsx
@@ -1,10 +1,12 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { Stack, useTheme } from "@fluentui/react";
+import { mergeStyles, MessageBar, MessageBarType, Stack, useTheme } from "@fluentui/react";
+import { useState } from "react";
 import { useAsync } from "react-use";
 import styled from "styled-components";
 
+import Button from "@foxglove/studio-base/components/Button";
 import { SectionHeader } from "@foxglove/studio-base/components/Menu";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
@@ -26,9 +28,28 @@ type MarketplaceEntry = {
   time: Record<string, string>;
 };
 
+const ListItem = styled.div``;
+
+const ListItemStyles = mergeStyles({
+  marginLeft: "-16px",
+  marginRight: "-16px",
+  paddingLeft: "16px",
+  paddingRight: "16px",
+  selectors: {
+    ":hover": {
+      backgroundColor: "rgba(255, 255, 255, 0.05)",
+      cursor: "pointer",
+    },
+  },
+});
+
 const Name = styled.span`
   color: #8b888f;
   font-weight: bold;
+`;
+
+const NameLine = styled.div`
+  margin-top: 6px;
 `;
 
 const Version = styled.span`
@@ -56,11 +77,14 @@ const Publisher = styled.span`
 
 const PublisherLine = styled.div`
   margin-top: 4px;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 `;
 
 export default function Extensions(): React.ReactElement {
   const theme = useTheme();
+
+  const [shouldFetch, setShouldFetch] = useState<boolean>(true);
+  const [marketplaceEntries, setMarketplaceEntries] = useState<MarketplaceEntry[]>([]);
 
   const extensionLoader = useExtensionLoader();
 
@@ -77,27 +101,42 @@ export default function Extensions(): React.ReactElement {
     throw installedError;
   }
 
-  const { value: available, error: availableError } = useAsync(async () => {
+  const { error: availableError } = useAsync(async () => {
+    if (!shouldFetch) {
+      return;
+    }
+    setShouldFetch(false);
+
     const data = await fetch(MARKETPLACE_URL);
     const entries = (await data.json()) as MarketplaceEntry[];
-    return entries.map((entry) => (
-      <Stack.Item key={entry.id}>
-        <div>
-          <Name>{entry.name}</Name>
-          <Version>{entry.version}</Version>
-        </div>
-        <DescriptionLine>
-          <Description>{entry.description}</Description>
-        </DescriptionLine>
-        <PublisherLine>
-          <Publisher>{entry.publisher}</Publisher>
-        </PublisherLine>
-      </Stack.Item>
-    ));
-  }, []);
+    setMarketplaceEntries(entries);
+  }, [shouldFetch]);
 
   if (availableError) {
-    throw availableError;
+    const errorMsg =
+      "Failed to fetch the list of available extensions. Check your Internet connection and try again.";
+    return (
+      <SidebarContent title="Extensions">
+        <MessageBar
+          messageBarType={MessageBarType.error}
+          isMultiline={true}
+          dismissButtonAriaLabel="Close"
+        >
+          {errorMsg}
+        </MessageBar>
+        <Button
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+          onClick={() => setShouldFetch(true)}
+        >
+          Retry Fetching Extensions
+        </Button>
+      </SidebarContent>
+    );
   }
 
   return (
@@ -105,11 +144,30 @@ export default function Extensions(): React.ReactElement {
       <Stack tokens={{ childrenGap: 30 }}>
         <Stack.Item>
           <SectionHeader>Installed</SectionHeader>
-          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>{installed}</Stack>
+          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
+            {installed && installed.length > 0 ? installed : "No installed extensions"}
+          </Stack>
         </Stack.Item>
         <Stack.Item>
           <SectionHeader>Available</SectionHeader>
-          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>{available}</Stack>
+          <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
+            {marketplaceEntries.map((entry) => (
+              <Stack.Item key={entry.id} className={ListItemStyles}>
+                <ListItem>
+                  <NameLine>
+                    <Name>{entry.name}</Name>
+                    <Version>{entry.version}</Version>
+                  </NameLine>
+                  <DescriptionLine>
+                    <Description>{entry.description}</Description>
+                  </DescriptionLine>
+                  <PublisherLine>
+                    <Publisher>{entry.publisher}</Publisher>
+                  </PublisherLine>
+                </ListItem>
+              </Stack.Item>
+            ))}
+          </Stack>
         </Stack.Item>
       </Stack>
     </SidebarContent>

--- a/packages/studio-base/src/components/Extensions.tsx
+++ b/packages/studio-base/src/components/Extensions.tsx
@@ -1,8 +1,9 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import { mergeStyles, MessageBar, MessageBarType, Stack, useTheme } from "@fluentui/react";
-import { useState } from "react";
+import { SetStateAction, useMemo, useState } from "react";
 import { useAsync } from "react-use";
 import styled from "styled-components";
 
@@ -11,24 +12,10 @@ import { SectionHeader } from "@foxglove/studio-base/components/Menu";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
 
+import { ExtensionDetails, ExtensionEntry } from "./ExtensionDetails";
+
 const MARKETPLACE_URL =
   "https://raw.githubusercontent.com/foxglove/studio-extension-marketplace/main/extensions.json";
-
-type MarketplaceEntry = {
-  id: string;
-  name: string;
-  description: string;
-  publisher: string;
-  homepage: string;
-  license: string;
-  version: string;
-  shasum: string;
-  foxe: string;
-  keywords: string[];
-  time: Record<string, string>;
-};
-
-const ListItem = styled.div``;
 
 const ListItemStyles = mergeStyles({
   marginLeft: "-16px",
@@ -84,18 +71,15 @@ export default function Extensions(): React.ReactElement {
   const theme = useTheme();
 
   const [shouldFetch, setShouldFetch] = useState<boolean>(true);
-  const [marketplaceEntries, setMarketplaceEntries] = useState<MarketplaceEntry[]>([]);
+  const [marketplaceEntries, setMarketplaceEntries] = useState<ExtensionEntry[]>([]);
+  const [focusedExtension, setFocusedExtension] = useState<ExtensionEntry | undefined>(undefined);
 
   const extensionLoader = useExtensionLoader();
 
-  const { value: installed, error: installedError } = useAsync(async () => {
-    const extensionList = await extensionLoader.getExtensions();
-    return extensionList.map((extension) => (
-      <Stack.Item key={extension.id}>
-        <div>{extension.name}</div>
-      </Stack.Item>
-    ));
-  }, [extensionLoader]);
+  const { value: installed, error: installedError } = useAsync(
+    async () => await extensionLoader.getExtensions(),
+    [extensionLoader],
+  );
 
   if (installedError) {
     throw installedError;
@@ -108,35 +92,50 @@ export default function Extensions(): React.ReactElement {
     setShouldFetch(false);
 
     const data = await fetch(MARKETPLACE_URL);
-    const entries = (await data.json()) as MarketplaceEntry[];
+    const entries = (await data.json()) as ExtensionEntry[];
     setMarketplaceEntries(entries);
   }, [shouldFetch]);
 
-  if (availableError) {
-    const errorMsg =
-      "Failed to fetch the list of available extensions. Check your Internet connection and try again.";
+  const marketplaceMap = useMemo(
+    () => new Map<string, ExtensionEntry>(marketplaceEntries.map((entry) => [entry.id, entry])),
+    [marketplaceEntries],
+  );
+
+  const installedEntries = useMemo<ExtensionEntry[]>(
+    () =>
+      (installed ?? []).map((entry) => {
+        const marketplaceEntry = marketplaceMap.get(entry.id);
+        if (marketplaceEntry != undefined) {
+          marketplaceEntry.installed = true;
+          return marketplaceEntry;
+        }
+
+        return {
+          id: entry.id,
+          installed: true,
+          name: entry.name,
+          description: entry.description,
+          publisher: entry.publisher,
+          homepage: entry.homepage,
+          license: entry.license,
+          version: entry.version,
+          keywords: entry.keywords,
+        };
+      }),
+    [installed, marketplaceMap],
+  );
+
+  if (focusedExtension != undefined) {
     return (
-      <SidebarContent title="Extensions">
-        <MessageBar
-          messageBarType={MessageBarType.error}
-          isMultiline={true}
-          dismissButtonAriaLabel="Close"
-        >
-          {errorMsg}
-        </MessageBar>
-        <Button
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-          }}
-          onClick={() => setShouldFetch(true)}
-        >
-          Retry Fetching Extensions
-        </Button>
-      </SidebarContent>
+      <ExtensionDetails
+        extension={focusedExtension}
+        onClose={() => setFocusedExtension(undefined)}
+      />
     );
+  }
+
+  if (availableError) {
+    return FetchError(() => setShouldFetch(true));
   }
 
   return (
@@ -145,31 +144,69 @@ export default function Extensions(): React.ReactElement {
         <Stack.Item>
           <SectionHeader>Installed</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
-            {installed && installed.length > 0 ? installed : "No installed extensions"}
+            {installedEntries.length > 0
+              ? installedEntries.map((entry) => ExtensionListEntry(entry, setFocusedExtension))
+              : "No installed extensions"}
           </Stack>
         </Stack.Item>
         <Stack.Item>
           <SectionHeader>Available</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
-            {marketplaceEntries.map((entry) => (
-              <Stack.Item key={entry.id} className={ListItemStyles}>
-                <ListItem>
-                  <NameLine>
-                    <Name>{entry.name}</Name>
-                    <Version>{entry.version}</Version>
-                  </NameLine>
-                  <DescriptionLine>
-                    <Description>{entry.description}</Description>
-                  </DescriptionLine>
-                  <PublisherLine>
-                    <Publisher>{entry.publisher}</Publisher>
-                  </PublisherLine>
-                </ListItem>
-              </Stack.Item>
-            ))}
+            {marketplaceEntries.map((entry) => ExtensionListEntry(entry, setFocusedExtension))}
           </Stack>
         </Stack.Item>
       </Stack>
+    </SidebarContent>
+  );
+}
+
+function ExtensionListEntry(
+  entry: ExtensionEntry,
+  setFocusedExtension: (value: SetStateAction<ExtensionEntry | undefined>) => void,
+): React.ReactElement {
+  return (
+    <Stack.Item
+      key={entry.id}
+      className={ListItemStyles}
+      onClick={() => setFocusedExtension(entry)}
+    >
+      <NameLine>
+        <Name>{entry.name}</Name>
+        <Version>{entry.version}</Version>
+      </NameLine>
+      <DescriptionLine>
+        <Description>{entry.description}</Description>
+      </DescriptionLine>
+      <PublisherLine>
+        <Publisher>{entry.publisher}</Publisher>
+      </PublisherLine>
+    </Stack.Item>
+  );
+}
+
+function FetchError(onRetry: () => void): React.ReactElement {
+  const errorMsg =
+    "Failed to fetch the list of available extensions. Check your Internet connection and try again.";
+  return (
+    <SidebarContent title="Extensions">
+      <MessageBar
+        messageBarType={MessageBarType.error}
+        isMultiline={true}
+        dismissButtonAriaLabel="Close"
+      >
+        {errorMsg}
+      </MessageBar>
+      <Button
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+        }}
+        onClick={onRetry}
+      >
+        Retry Fetching Extensions
+      </Button>
     </SidebarContent>
   );
 }

--- a/packages/studio-base/src/components/ExtensionsSidebar.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar.tsx
@@ -67,7 +67,7 @@ const PublisherLine = styled.div`
   margin-bottom: 10px;
 `;
 
-export default function Extensions(): React.ReactElement {
+export default function ExtensionsSidebar(): React.ReactElement {
   const theme = useTheme();
 
   const [shouldFetch, setShouldFetch] = useState<boolean>(true);

--- a/packages/studio-base/src/components/ExtensionsSidebar.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar.tsx
@@ -11,11 +11,12 @@ import Button from "@foxglove/studio-base/components/Button";
 import { SectionHeader } from "@foxglove/studio-base/components/Menu";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
+import {
+  ExtensionMarketplaceDetail,
+  useExtensionMarketplace,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
 
-import { ExtensionDetails, ExtensionEntry } from "./ExtensionDetails";
-
-const MARKETPLACE_URL =
-  "https://raw.githubusercontent.com/foxglove/studio-extension-marketplace/main/extensions.json";
+import { ExtensionDetails } from "./ExtensionDetails";
 
 const ListItemStyles = mergeStyles({
   marginLeft: "-16px",
@@ -71,10 +72,12 @@ export default function ExtensionsSidebar(): React.ReactElement {
   const theme = useTheme();
 
   const [shouldFetch, setShouldFetch] = useState<boolean>(true);
-  const [marketplaceEntries, setMarketplaceEntries] = useState<ExtensionEntry[]>([]);
-  const [focusedExtension, setFocusedExtension] = useState<ExtensionEntry | undefined>(undefined);
+  const [marketplaceEntries, setMarketplaceEntries] = useState<ExtensionMarketplaceDetail[]>([]);
+  const [focusedExtension, setFocusedExtension] =
+    useState<ExtensionMarketplaceDetail | undefined>(undefined);
 
   const extensionLoader = useExtensionLoader();
+  const marketplace = useExtensionMarketplace();
 
   const { value: installed, error: installedError } = useAsync(
     async () => await extensionLoader.getExtensions(),
@@ -91,17 +94,19 @@ export default function ExtensionsSidebar(): React.ReactElement {
     }
     setShouldFetch(false);
 
-    const data = await fetch(MARKETPLACE_URL);
-    const entries = (await data.json()) as ExtensionEntry[];
+    const entries = await marketplace.getAvailableExtensions();
     setMarketplaceEntries(entries);
-  }, [shouldFetch]);
+  }, [marketplace, shouldFetch]);
 
   const marketplaceMap = useMemo(
-    () => new Map<string, ExtensionEntry>(marketplaceEntries.map((entry) => [entry.id, entry])),
+    () =>
+      new Map<string, ExtensionMarketplaceDetail>(
+        marketplaceEntries.map((entry) => [entry.id, entry]),
+      ),
     [marketplaceEntries],
   );
 
-  const installedEntries = useMemo<ExtensionEntry[]>(
+  const installedEntries = useMemo<ExtensionMarketplaceDetail[]>(
     () =>
       (installed ?? []).map((entry) => {
         const marketplaceEntry = marketplaceMap.get(entry.id);
@@ -161,8 +166,8 @@ export default function ExtensionsSidebar(): React.ReactElement {
 }
 
 function ExtensionListEntry(
-  entry: ExtensionEntry,
-  setFocusedExtension: (value: SetStateAction<ExtensionEntry | undefined>) => void,
+  entry: ExtensionMarketplaceDetail,
+  setFocusedExtension: (value: SetStateAction<ExtensionMarketplaceDetail | undefined>) => void,
 ): React.ReactElement {
   return (
     <Stack.Item

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -8,7 +8,7 @@ import HelpButton from "@foxglove/studio-base/components/PanelToolbar/HelpButton
 
 export function SidebarContent({
   noPadding = false,
-  padRight = false,
+  paddingLeft,
   title,
   children,
   helpContent,
@@ -16,7 +16,7 @@ export function SidebarContent({
   title: string;
   helpContent?: React.ReactNode;
   noPadding?: boolean;
-  padRight?: boolean;
+  paddingLeft?: string;
 }>): JSX.Element {
   const theme = useTheme();
   return (
@@ -35,7 +35,7 @@ export function SidebarContent({
         style={{
           padding: noPadding ? theme.spacing.m : undefined,
           paddingBottom: theme.spacing.m,
-          paddingRight: padRight ? theme.spacing.m : undefined,
+          paddingLeft,
         }}
       >
         <Text as="h2" variant="xLarge">

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -8,6 +8,7 @@ import HelpButton from "@foxglove/studio-base/components/PanelToolbar/HelpButton
 
 export function SidebarContent({
   noPadding = false,
+  padRight = false,
   title,
   children,
   helpContent,
@@ -15,6 +16,7 @@ export function SidebarContent({
   title: string;
   helpContent?: React.ReactNode;
   noPadding?: boolean;
+  padRight?: boolean;
 }>): JSX.Element {
   const theme = useTheme();
   return (
@@ -30,7 +32,11 @@ export function SidebarContent({
       <Stack
         horizontal
         horizontalAlign="space-between"
-        style={{ padding: noPadding ? theme.spacing.m : undefined, paddingBottom: theme.spacing.m }}
+        style={{
+          padding: noPadding ? theme.spacing.m : undefined,
+          paddingBottom: theme.spacing.m,
+          paddingRight: padRight ? theme.spacing.m : undefined,
+        }}
       >
         <Text as="h2" variant="xLarge">
           {title}

--- a/packages/studio-base/src/context/ExtensionLoaderContext.ts
+++ b/packages/studio-base/src/context/ExtensionLoaderContext.ts
@@ -5,6 +5,7 @@
 import { createContext, useContext } from "react";
 
 export interface ExtensionDetail {
+  id: string;
   name: string;
   source: string;
 }

--- a/packages/studio-base/src/context/ExtensionLoaderContext.ts
+++ b/packages/studio-base/src/context/ExtensionLoaderContext.ts
@@ -7,6 +7,12 @@ import { createContext, useContext } from "react";
 export interface ExtensionDetail {
   id: string;
   name: string;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  keywords: string[];
   source: string;
 }
 

--- a/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
+++ b/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+export type ExtensionMarketplaceDetail = {
+  id: string;
+  installed?: boolean;
+  name: string;
+  description: string;
+  publisher: string;
+  homepage: string;
+  license: string;
+  version: string;
+  readme?: string;
+  changelog?: string;
+  shasum?: string;
+  foxe?: string;
+  keywords?: string[];
+  time?: Record<string, string>;
+};
+
+export interface ExtensionMarketplace {
+  getAvailableExtensions(): Promise<ExtensionMarketplaceDetail[]>;
+  getMarkdown(url: string): Promise<string>;
+}
+
+const ExtensionMarketplaceContext = createContext<ExtensionMarketplace | undefined>(undefined);
+
+export function useExtensionMarketplace(): ExtensionMarketplace {
+  const extensionMarketplace = useContext(ExtensionMarketplaceContext);
+  if (extensionMarketplace == undefined) {
+    throw new Error(
+      "An ExtensionMarketplaceContext provider is required to useExtensionMarketplace",
+    );
+  }
+  return extensionMarketplace;
+}
+
+export default ExtensionMarketplaceContext;

--- a/packages/studio-base/src/providers/ExtensionMarketplaceProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionMarketplaceProvider.tsx
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback } from "react";
+
+import { useShallowMemo } from "@foxglove/hooks";
+import ExtensionMarketplaceContext, {
+  ExtensionMarketplaceDetail,
+} from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
+
+const MARKETPLACE_URL =
+  "https://raw.githubusercontent.com/foxglove/studio-extension-marketplace/main/extensions.json";
+
+export default function ExtensionMarketplaceProvider({
+  children,
+}: React.PropsWithChildren<unknown>): JSX.Element {
+  const getAvailableExtensions = useCallback(async (): Promise<ExtensionMarketplaceDetail[]> => {
+    const res = await fetch(MARKETPLACE_URL);
+    return (await res.json()) as ExtensionMarketplaceDetail[];
+  }, []);
+  const getMarkdown = useCallback(async (url: string): Promise<string> => {
+    const res = await fetch(url);
+    return await res.text();
+  }, []);
+  const marketplace = useShallowMemo({
+    getAvailableExtensions,
+    getMarkdown,
+  });
+  return (
+    <ExtensionMarketplaceContext.Provider value={marketplace}>
+      {children}
+    </ExtensionMarketplaceContext.Provider>
+  );
+}

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -15,6 +15,7 @@ const icons: {
   [N in RegisteredIconNames]: React.ReactElement;
 } = {
   Add: <Icons.AddIcon />,
+  AddIn: <Icons.AddInIcon />,
   Cancel: <Icons.CancelIcon />,
   CheckMark: <Icons.CheckMarkIcon />,
   ChevronDown: <Icons.ChevronDownIcon />,

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -20,6 +20,7 @@ const icons: {
   CheckMark: <Icons.CheckMarkIcon />,
   ChevronDown: <Icons.ChevronDownIcon />,
   ChevronDownSmall: <Icons.ChevronDownSmallIcon />,
+  ChevronLeft: <Icons.ChevronLeftIcon />,
   ChevronRight: <Icons.ChevronRightIcon />,
   ChevronUpSmall: <Icons.ChevronUpSmallIcon />,
   CirclePlus: <Icons.CirclePlusIcon />,

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -15,6 +15,7 @@ declare global {
     | "CheckMark"
     | "ChevronDown"
     | "ChevronDownSmall"
+    | "ChevronLeft"
     | "ChevronRight"
     | "ChevronUpSmall"
     | "CirclePlus"

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -10,6 +10,7 @@ declare global {
   type RegisteredIconNames =
     | CustomIconNames
     | "Add"
+    | "AddIn"
     | "Cancel"
     | "CheckMark"
     | "ChevronDown"

--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -21,6 +21,7 @@ export default function ExtensionRegistryProvider(props: PropsWithChildren<unkno
 
       const extensions: ExtensionDetail[] = [
         {
+          id: "foxglove.builtin",
           name: "builtin",
           source: source,
         },

--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -22,7 +22,13 @@ export default function ExtensionRegistryProvider(props: PropsWithChildren<unkno
       const extensions: ExtensionDetail[] = [
         {
           id: "foxglove.builtin",
-          name: "builtin",
+          name: "Built-In Extensions",
+          description: "Foxglove Studio built-in extensions",
+          publisher: "Foxglove",
+          homepage: "https://github.com/foxglove/studio",
+          license: "MPL-2.0",
+          version: "0.0.0",
+          keywords: [],
           source: source,
         },
       ];


### PR DESCRIPTION
Adds browsable lists of installed extensions and extensions that are available to be installed. The UI includes buttons for installing and uninstalling extensions that will need to be hooked up in a future PR.

<img width="310" alt="extensions-list" src="https://user-images.githubusercontent.com/195374/121265815-44bb1080-c86e-11eb-83a2-25214fabfc79.png">

<img width="300" alt="extensions-details" src="https://user-images.githubusercontent.com/195374/121265820-4684d400-c86e-11eb-842c-72fafaf9fdd2.png">
