### PR TITLE
Change PanelToolbar to display when in edit layout mode.

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -44,6 +44,7 @@ import Toolbar from "@foxglove/studio-base/components/Toolbar";
 import { useAppConfiguration } from "@foxglove/studio-base/context/AppConfigurationContext";
 import { useAssets } from "@foxglove/studio-base/context/AssetContext";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutEditContext } from "@foxglove/studio-base/context/LayoutEditContext";
 import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext";
 import { PanelSettingsContext } from "@foxglove/studio-base/context/PanelSettingsContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
@@ -163,6 +164,13 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     ) {
       setSelectedSidebarItem(undefined);
     }
+
+    if (selectedSidebarItem === "add-panel") {
+      //editLayout(true);
+    } else {
+      //editLayout(false);
+    }
+
     prevSourceName.current = currentSourceName;
   }, [selectedSidebarItem, currentSourceName]);
 
@@ -361,12 +369,20 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     [selectedSidebarItem],
   );
 
+  const layoutEdit = useMemo(
+    () => ({
+      editing: selectedSidebarItem === "add-panel",
+    }),
+    [selectedSidebarItem],
+  );
+
   return (
     <MultiProvider
       providers={[
         /* eslint-disable react/jsx-key */
         <LinkHandlerContext.Provider value={handleInternalLink} />,
         <PanelSettingsContext.Provider value={panelSettings} />,
+        <LayoutEditContext.Provider value={layoutEdit} />,
         /* eslint-enable react/jsx-key */
       ]}
     >

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -17,7 +17,6 @@ import styled from "styled-components";
 
 import Button from "@foxglove/studio-base/components/Button";
 import Flex from "@foxglove/studio-base/components/Flex";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { AppError } from "@foxglove/studio-base/util/errors";
 
 const Heading = styled.div`
@@ -67,17 +66,15 @@ export default class ErrorBoundary extends React.Component<
       }
       return (
         <Flex col style={{ maxHeight: "100%", maxWidth: "100%" }}>
-          <PanelToolbar>
-            <ErrorBanner>
-              <div style={{ flexGrow: 1 }}>An error occurred in {name}.</div>
-              <Button
-                style={{ background: "rgba(255, 255, 255, 0.5)" }}
-                onClick={() => this.setState({ error: undefined, errorInfo: undefined })}
-              >
-                Reload Panel
-              </Button>
-            </ErrorBanner>
-          </PanelToolbar>
+          <ErrorBanner>
+            <div style={{ flexGrow: 1 }}>An error occurred in {name}.</div>
+            <Button
+              style={{ background: "rgba(255, 255, 255, 0.5)" }}
+              onClick={() => this.setState({ error: undefined, errorInfo: undefined })}
+            >
+              Reload Panel
+            </Button>
+          </ErrorBanner>
           <Flex col scroll scrollX style={{ padding: "2px 6px" }}>
             <Heading>Error stack:</Heading>
             <pre>{error.stack}</pre>

--- a/packages/studio-base/src/components/Panel.module.scss
+++ b/packages/studio-base/src/components/Panel.module.scss
@@ -55,10 +55,13 @@
   left: 0;
   right: 0;
   bottom: 0;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-end;
+  font-size: 14px;
+  padding-top: 24px;
   z-index: 100000; // highest level within panel
-  display: none;
 
-  .root:hover > &,
   // for screenshot tests
   &:global(.hoverForScreenshot) {
     background-color: rgba(45, 45, 51, 1);
@@ -67,12 +70,6 @@
     justify-content: center;
     flex-wrap: wrap;
   }
-
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-end;
-  font-size: 14px;
-  padding-top: 24px;
 
   div {
     width: 100%;

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -29,7 +29,6 @@ export type PanelContextType<T> = {
   openSiblingPanel: OpenSiblingPanel;
   enterFullscreen: () => void;
 
-  isHovered: boolean;
   hasSettings: boolean;
   connectToolbarDragHandle: (el: Element | ReactNull) => void;
   supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -112,7 +112,7 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
       ) : (
         // If we haven't found a panel of the given type, render the panel selector
         <Flex col center dataTest={id}>
-          <PanelToolbar floating isUnknownPanel />
+          <PanelToolbar isUnknownPanel />
           Unknown panel type: {type}.
         </Flex>
       );

--- a/packages/studio-base/src/components/PanelToolbar/index.module.scss
+++ b/packages/studio-base/src/components/PanelToolbar/index.module.scss
@@ -16,6 +16,10 @@
 $panelToolbarHeight: 26px;
 $panelToolbarSpacing: 4px;
 
+.root {
+  background-color: $dark3;
+}
+
 .iconContainer {
   padding-top: $panelToolbarSpacing;
   display: flex;
@@ -34,6 +38,7 @@ $panelToolbarSpacing: 4px;
   font-size: 10px;
   opacity: 0.5;
   margin-right: 4px;
+  flex-grow: 1;
 }
 
 .panelToolbarContainer {
@@ -44,44 +49,6 @@ $panelToolbarSpacing: 4px;
   justify-content: flex-end;
   background-color: $toolbar-fixed;
   padding: $panelToolbarSpacing;
-
-  &.floating {
-    position: absolute;
-    right: 0;
-    // leave some room for possible scrollbar
-    padding-right: 8px;
-    top: 0;
-    width: 100%;
-    z-index: 5000;
-    background-color: transparent;
-    transform: translateY(-10px);
-    pointer-events: none;
-    opacity: 0;
-
-    * {
-      pointer-events: auto;
-    }
-
-    &.hasChildren {
-      left: 0;
-      background-color: $toolbar-fixed;
-    }
-
-    &:not(.hasChildren) .iconContainer {
-      background-color: $dark3;
-      border-radius: 4px;
-      box-shadow: 0 6px 40px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2);
-    }
-  }
-
-  &:not(.floating) {
-    min-height: $panelToolbarHeight + $panelToolbarSpacing;
-  }
-
-  &.floatingShow {
-    transform: translateY(0);
-    opacity: 1;
-  }
 }
 
 .icon,

--- a/packages/studio-base/src/context/LayoutEditContext.ts
+++ b/packages/studio-base/src/context/LayoutEditContext.ts
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+type LayoutEdit = {
+  editing: boolean;
+};
+
+export const LayoutEditContext = createContext<LayoutEdit>({
+  editing: false,
+});
+
+export function useLayoutEdit(): LayoutEdit {
+  return useContext(LayoutEditContext);
+}

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -13,7 +13,6 @@
 
 import GlobalVariableSlider from "@foxglove/studio-base/components/GlobalVariableSlider";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { SliderProps } from "@foxglove/studio-base/components/SliderWithTicks";
 import { PanelConfigSchema } from "@foxglove/studio-base/types/panels";
 
@@ -32,7 +31,6 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
 
   return (
     <div style={{ padding: "25px 4px 4px" }}>
-      <PanelToolbar floating />
       <GlobalVariableSlider sliderProps={sliderProps} globalVariableName={globalVariableName} />
     </div>
   );

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -32,7 +32,6 @@ import Icon from "@foxglove/studio-base/components/Icon";
 import { Item, SubMenu } from "@foxglove/studio-base/components/Menu";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -583,14 +582,12 @@ function ImageView(props: Props) {
 
   const toolbar = useMemo(() => {
     return (
-      <PanelToolbar floating={cameraTopic !== ""} helpContent={helpContent}>
-        <div className={style.controls}>
-          {imageTopicDropdown}
-          {markerDropdown}
-        </div>
-      </PanelToolbar>
+      <div className={style.controls}>
+        {imageTopicDropdown}
+        {markerDropdown}
+      </div>
     );
-  }, [imageTopicDropdown, markerDropdown, cameraTopic]);
+  }, [imageTopicDropdown, markerDropdown]);
 
   const renderBottomBar = () => {
     const canTransformMarkers = canTransformMarkersByTopic(cameraTopic);

--- a/packages/studio-base/src/panels/InternalLogs/index.tsx
+++ b/packages/studio-base/src/panels/InternalLogs/index.tsx
@@ -8,7 +8,6 @@ import log from "@foxglove/log";
 import Checkbox from "@foxglove/studio-base/components/Checkbox";
 import Flex from "@foxglove/studio-base/components/Flex";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 
 type Config = {
   // we store disabled channels so any new channels are default enabled
@@ -42,32 +41,29 @@ function InternalLogs(props: Props) {
 
   return (
     <Flex col>
-      <PanelToolbar />
-      <Flex col>
-        {channels.map((logger) => {
-          const label = logger.name().length === 0 ? "default" : logger.name();
-          return (
-            <div key={label}>
-              <Checkbox
-                checked={logger.isEnabled()}
-                label={label}
-                onChange={(newChecked) => {
-                  // track disabled channels so loggers are on by default
-                  if (newChecked) {
-                    disabledChannels.delete(label);
-                  } else {
-                    disabledChannels.add(label);
-                  }
+      {channels.map((logger) => {
+        const label = logger.name().length === 0 ? "default" : logger.name();
+        return (
+          <div key={label}>
+            <Checkbox
+              checked={logger.isEnabled()}
+              label={label}
+              onChange={(newChecked) => {
+                // track disabled channels so loggers are on by default
+                if (newChecked) {
+                  disabledChannels.delete(label);
+                } else {
+                  disabledChannels.add(label);
+                }
 
-                  props.saveConfig({
-                    disabledChannels: Array.from(disabledChannels.values()),
-                  });
-                }}
-              />
-            </div>
-          );
-        })}
-      </Flex>
+                props.saveConfig({
+                  disabledChannels: Array.from(disabledChannels.values()),
+                });
+              }}
+            />
+          </div>
+        );
+      })}
     </Flex>
   );
 }

--- a/packages/studio-base/src/panels/Internals.tsx
+++ b/packages/studio-base/src/panels/Internals.tsx
@@ -197,7 +197,6 @@ function Internals() {
 
   return (
     <Container>
-      <PanelToolbar floating />
       <h1>Recording</h1>
       <TextContent>
         Press to start recording topic data for debug purposes. The latest messages on each topic

--- a/packages/studio-base/src/panels/Map/index.tsx
+++ b/packages/studio-base/src/panels/Map/index.tsx
@@ -140,7 +140,6 @@ function MapPanel(props: Props) {
   if (!center) {
     return (
       <>
-        <PanelToolbar floating helpContent={helpContent} />
         <EmptyState>Waiting for first gps point...</EmptyState>
       </>
     );
@@ -148,7 +147,6 @@ function MapPanel(props: Props) {
 
   return (
     <>
-      <PanelToolbar floating helpContent={helpContent} />
       <MapContainer
         whenCreated={setCurrentMap}
         preferCanvas

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -231,7 +231,6 @@ function NodePlayground(props: Props) {
 
   return (
     <Stack verticalFill>
-      <PanelToolbar floating />
       <Stack horizontal verticalFill>
         <Sidebar
           explorer={explorer}

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -90,7 +90,6 @@ function Parameters(): ReactElement {
   if (!canGetParams) {
     return (
       <>
-        <PanelToolbar floating helpContent={helpContent} />
         <EmptyState>Connect to a ROS source to view parameters</EmptyState>
       </>
     );
@@ -98,7 +97,6 @@ function Parameters(): ReactElement {
 
   return (
     <ParametersPanel>
-      <PanelToolbar helpContent={helpContent} floating />
       <Scrollable>
         <ParametersTable>
           <table>

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
@@ -118,7 +118,6 @@ export function UnconnectedPlaybackPerformance({
 
   return (
     <Flex col>
-      <PanelToolbar floating helpContent={helpContent} />
       <Flex col wrap center start style={{ lineHeight: 1, whiteSpace: "nowrap" }}>
         <PlaybackPerformanceItem points={perfPoints.current.speed} maximum={1.6} decimalPlaces={2}>
           &times; realtime

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -258,7 +258,6 @@ function Plot(props: Props) {
 
   return (
     <Flex col clip center style={{ position: "relative" }}>
-      <PanelToolbar helpContent={helpContent} floating />
       <PlotChart
         paths={yAxisPaths}
         minYValue={parseFloat((minYValue ?? "")?.toString())}

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -20,7 +20,6 @@ import Autocomplete from "@foxglove/studio-base/components/Autocomplete";
 import Button from "@foxglove/studio-base/components/Button";
 import Flex from "@foxglove/studio-base/components/Flex";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import PanelToolbarLabel from "@foxglove/studio-base/components/PanelToolbarLabel";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
 import { PlayerCapabilities, Topic } from "@foxglove/studio-base/players/types";
@@ -177,7 +176,6 @@ function Publish(props: Props) {
 
   return (
     <Flex col style={{ height: "100%", padding: "12px" }}>
-      <PanelToolbar floating />
       {advancedView && (
         <SRow>
           <SSpan>Topic:</SSpan>

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -496,60 +496,58 @@ function RawMessages(props: Props) {
 
   return (
     <Flex col clip style={{ position: "relative" }}>
-      <PanelToolbar helpContent={helpContent}>
-        <Icon tooltip="Toggle diff" medium fade onClick={onToggleDiff} active={diffEnabled}>
-          <PlusMinusIcon />
-        </Icon>
-        <Icon
-          tooltip={expandAll ?? false ? "Collapse all" : "Expand all"}
-          medium
-          fade
-          onClick={onToggleExpandAll}
-          style={{ position: "relative", top: 1 }}
-        >
-          {expandAll ?? false ? <LessIcon /> : <MoreIcon />}
-        </Icon>
-        <div className={styles.topicInputs}>
-          <MessagePathInput
-            index={0}
-            path={topicPath}
-            onChange={onTopicPathChange}
-            inputStyle={{ height: "100%" }}
-          />
-          {diffEnabled && (
-            <Flex>
-              <Tooltip contents="Diff method" placement="top">
-                <>
-                  <Dropdown
-                    value={diffMethod}
-                    onChange={(newDiffMethod) => saveConfig({ diffMethod: newDiffMethod })}
-                    noPortal
-                  >
-                    <DropdownItem value={PREV_MSG_METHOD}>
-                      <span>{PREV_MSG_METHOD}</span>
-                    </DropdownItem>
-                    <DropdownItem value={OTHER_SOURCE_METHOD}>
-                      <span>{OTHER_SOURCE_METHOD}</span>
-                    </DropdownItem>
-                    <DropdownItem value={CUSTOM_METHOD}>
-                      <span>custom</span>
-                    </DropdownItem>
-                  </Dropdown>
-                </>
-              </Tooltip>
-              {diffMethod === CUSTOM_METHOD ? (
-                <MessagePathInput
-                  index={1}
-                  path={diffTopicPath}
-                  onChange={onDiffTopicPathChange}
-                  inputStyle={{ height: "100%" }}
-                  prioritizedDatatype={topic?.datatype}
-                />
-              ) : undefined}
-            </Flex>
-          )}
-        </div>
-      </PanelToolbar>
+      <Icon tooltip="Toggle diff" medium fade onClick={onToggleDiff} active={diffEnabled}>
+        <PlusMinusIcon />
+      </Icon>
+      <Icon
+        tooltip={expandAll ?? false ? "Collapse all" : "Expand all"}
+        medium
+        fade
+        onClick={onToggleExpandAll}
+        style={{ position: "relative", top: 1 }}
+      >
+        {expandAll ?? false ? <LessIcon /> : <MoreIcon />}
+      </Icon>
+      <div className={styles.topicInputs}>
+        <MessagePathInput
+          index={0}
+          path={topicPath}
+          onChange={onTopicPathChange}
+          inputStyle={{ height: "100%" }}
+        />
+        {diffEnabled && (
+          <Flex>
+            <Tooltip contents="Diff method" placement="top">
+              <>
+                <Dropdown
+                  value={diffMethod}
+                  onChange={(newDiffMethod) => saveConfig({ diffMethod: newDiffMethod })}
+                  noPortal
+                >
+                  <DropdownItem value={PREV_MSG_METHOD}>
+                    <span>{PREV_MSG_METHOD}</span>
+                  </DropdownItem>
+                  <DropdownItem value={OTHER_SOURCE_METHOD}>
+                    <span>{OTHER_SOURCE_METHOD}</span>
+                  </DropdownItem>
+                  <DropdownItem value={CUSTOM_METHOD}>
+                    <span>custom</span>
+                  </DropdownItem>
+                </Dropdown>
+              </>
+            </Tooltip>
+            {diffMethod === CUSTOM_METHOD ? (
+              <MessagePathInput
+                index={1}
+                path={diffTopicPath}
+                onChange={onDiffTopicPathChange}
+                inputStyle={{ height: "100%" }}
+                prioritizedDatatype={topic?.datatype}
+              />
+            ) : undefined}
+          </Flex>
+        )}
+      </div>
       {renderSingleTopicOrDiffOutput()}
     </Flex>
   );

--- a/packages/studio-base/src/panels/Rosout/index.tsx
+++ b/packages/studio-base/src/panels/Rosout/index.tsx
@@ -78,15 +78,13 @@ const RosoutPanel = React.memo(({ config, saveConfig }: Props) => {
 
   return (
     <Stack verticalFill>
-      <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
-        <FilterBar
-          searchTerms={searchTermsSet}
-          minLogLevel={minLogLevel}
-          nodeNames={seenNodeNames.current}
-          messages={filteredMessages}
-          onFilterChange={onFilterChange}
-        />
-      </PanelToolbar>
+      <FilterBar
+        searchTerms={searchTermsSet}
+        minLogLevel={minLogLevel}
+        nodeNames={seenNodeNames.current}
+        messages={filteredMessages}
+        onFilterChange={onFilterChange}
+      />
       <Stack grow>
         <LogList
           items={filteredMessages}

--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -17,7 +17,6 @@ import styled from "styled-components";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import SelectableTimestamp from "@foxglove/studio-base/components/SelectableTimestamp";
 import clipboard from "@foxglove/studio-base/util/clipboard";
 import { formatDuration } from "@foxglove/studio-base/util/formatTime";
@@ -76,7 +75,6 @@ function SourceInfo() {
   if (!startTime || !endTime) {
     return (
       <>
-        <PanelToolbar floating />
         <EmptyState>Waiting for data...</EmptyState>
       </>
     );
@@ -85,7 +83,6 @@ function SourceInfo() {
   const duration = subtractTimes(endTime, startTime);
   return (
     <>
-      <PanelToolbar floating />
       <STableContainer>
         <SHeader>
           <SHeaderItem>

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -24,8 +24,6 @@ import Button from "@foxglove/studio-base/components/Button";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import useMessagesByPath from "@foxglove/studio-base/components/MessagePathSyntax/useMessagesByPath";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart, {
   getTooltipItemForMessageHistoryItem,
   TimeBasedChartTooltipData,
@@ -187,7 +185,6 @@ type Props = {
 
 const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const { config, saveConfig } = props;
-  const { isHovered } = usePanelContext();
   const { paths } = config;
 
   const onInputChange = (value: string, index?: number) => {
@@ -384,8 +381,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   return (
     <SRoot>
-      <PanelToolbar floating helpContent={helpContent} />
-      <SAddButton show={isHovered}>
+      <SAddButton show={true}>
         <Button
           onClick={() =>
             saveConfig({
@@ -416,7 +412,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
             <SInputContainer
               key={index}
               style={{ top: index * heightPerTopic }}
-              shrink={index === 0 && isHovered}
+              shrink={index === 0}
             >
               <SInputDelete
                 onClick={() => {

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -93,36 +93,34 @@ export function TabbedToolbar(props: Props): JSX.Element {
 
   return (
     <STabbedToolbar highlight={isOver}>
-      <PanelToolbar helpContent={helpContent} showHiddenControlsOnHover>
-        <STabs ref={dropRef} data-test="toolbar-droppable">
-          {tabs.map((tab, i) => (
-            <DraggableToolbarTab
-              isActive={activeTabIdx === i}
-              key={i}
-              panelId={panelId}
-              setDraggingTabState={setDraggingTabState}
-              actions={actions}
-              tabCount={tabs.length}
-              tabIndex={i}
-              tabTitle={tab.title}
-            />
-          ))}
-          <Icon
-            small
-            fade
-            dataTest="add-tab"
-            tooltip="Add tab"
-            style={{
-              flexShrink: 0,
-              margin: "0 8px",
-              transition: "opacity 0.2s",
-            }}
-            onClick={actions.addTab}
-          >
-            <PlusIcon onMouseDown={(e) => e.preventDefault()} />
-          </Icon>
-        </STabs>
-      </PanelToolbar>
+      <STabs ref={dropRef} data-test="toolbar-droppable">
+        {tabs.map((tab, i) => (
+          <DraggableToolbarTab
+            isActive={activeTabIdx === i}
+            key={i}
+            panelId={panelId}
+            setDraggingTabState={setDraggingTabState}
+            actions={actions}
+            tabCount={tabs.length}
+            tabIndex={i}
+            tabTitle={tab.title}
+          />
+        ))}
+        <Icon
+          small
+          fade
+          dataTest="add-tab"
+          tooltip="Add tab"
+          style={{
+            flexShrink: 0,
+            margin: "0 8px",
+            transition: "opacity 0.2s",
+          }}
+          onClick={actions.addTab}
+        >
+          <PlusIcon onMouseDown={(e) => e.preventDefault()} />
+        </Icon>
+      </STabs>
     </STabbedToolbar>
   );
 }

--- a/packages/studio-base/src/panels/Table/index.tsx
+++ b/packages/studio-base/src/panels/Table/index.tsx
@@ -61,16 +61,14 @@ function TablePanel({ config, saveConfig }: Props) {
 
   return (
     <Flex col clip style={{ position: "relative" }}>
-      <PanelToolbar helpContent={helpContent}>
-        <div style={{ width: "100%", lineHeight: "20px" }}>
-          <MessagePathInput
-            index={0}
-            path={topicPath}
-            onChange={onTopicPathChange}
-            inputStyle={{ height: "100%" }}
-          />
-        </div>
-      </PanelToolbar>
+      <div style={{ width: "100%", lineHeight: "20px" }}>
+        <MessagePathInput
+          index={0}
+          path={topicPath}
+          onChange={onTopicPathChange}
+          inputStyle={{ height: "100%" }}
+        />
+      </div>
       {topicPath.length === 0 && <EmptyState>No topic selected</EmptyState>}
       {topicPath.length !== 0 && !isNonEmptyOrUndefined(cachedMessages) && (
         <EmptyState>Waiting for next message</EmptyState>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -795,7 +795,6 @@ export default function Layout({
           data-test="3dviz-layout"
         >
           <KeyListener keyDownHandlers={keyDownHandlers} />
-          <PanelToolbar floating helpContent={helpContent} />
           <div style={{ position: "absolute", width: "100%", height: "100%" }}>
             <div
               style={

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -261,7 +261,6 @@ function TopicGraph() {
   if (publishedTopics == undefined) {
     return (
       <>
-        <PanelToolbar floating helpContent={helpContent} />
         <EmptyState>Waiting for data...</EmptyState>
       </>
     );
@@ -269,7 +268,6 @@ function TopicGraph() {
 
   return (
     <>
-      <PanelToolbar floating helpContent={helpContent} />
       <Toolbar>
         <div className={styles.buttons}>
           <Button tooltip="Zoom Fit" onClick={onZoomFit}>

--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -176,36 +176,34 @@ function URDFViewer({ config, saveConfig }: Props) {
 
   return (
     <Flex col clip>
-      <PanelToolbar helpContent={helpContent}>
-        <Stack grow horizontal verticalAlign="baseline">
-          <Toggle
-            inlineLabel
-            offText="Manual joint control"
-            onText="Topic"
-            checked={!useCustomJointValues}
-            onChange={(_event, checked) =>
-              saveConfig({
-                jointStatesTopic:
-                  checked ?? false ? URDFViewer.defaultConfig.jointStatesTopic : undefined,
-              })
-            }
+      <Stack grow horizontal verticalAlign="baseline">
+        <Toggle
+          inlineLabel
+          offText="Manual joint control"
+          onText="Topic"
+          checked={!useCustomJointValues}
+          onChange={(_event, checked) =>
+            saveConfig({
+              jointStatesTopic:
+                checked ?? false ? URDFViewer.defaultConfig.jointStatesTopic : undefined,
+            })
+          }
+        />
+        {!useCustomJointValues && (
+          <ComboBox
+            allowFreeform
+            options={topicOptions}
+            selectedKey={jointStatesTopic}
+            onChange={(_event, option, _index, value) => {
+              if (option) {
+                saveConfig({ jointStatesTopic: option.key as string });
+              } else if (value != undefined) {
+                saveConfig({ jointStatesTopic: value });
+              }
+            }}
           />
-          {!useCustomJointValues && (
-            <ComboBox
-              allowFreeform
-              options={topicOptions}
-              selectedKey={jointStatesTopic}
-              onChange={(_event, option, _index, value) => {
-                if (option) {
-                  saveConfig({ jointStatesTopic: option.key as string });
-                } else if (value != undefined) {
-                  saveConfig({ jointStatesTopic: value });
-                }
-              }}
-            />
-          )}
-        </Stack>
-      </PanelToolbar>
+        )}
+      </Stack>
       <Stack verticalFill>
         {messageBar}
         {model == undefined ? (

--- a/packages/studio-base/src/panels/WelcomePanel/index.tsx
+++ b/packages/studio-base/src/panels/WelcomePanel/index.tsx
@@ -66,7 +66,6 @@ function WelcomePanel() {
 
   return (
     <Flex col scroll dataTest="welcome-content">
-      <PanelToolbar floating />
       <TextContent style={{ padding: 12 }}>
         <h2 style={{ fontSize: "1.5em", marginBottom: "0.8em" }}>Welcome</h2>
         <p>

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -113,17 +113,15 @@ function DiagnosticStatusPanel(props: Props) {
 
           return (
             <>
-              <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
-                <Autocomplete
-                  placeholder={selectedDisplayName ?? "Select a diagnostic"}
-                  items={buffer.sortedAutocompleteEntries}
-                  getItemText={(entry) => entry.displayName}
-                  getItemValue={(entry) => entry.id}
-                  onSelect={onSelect}
-                  selectedItem={selectedItem as any}
-                  inputStyle={{ height: "100%" }}
-                />
-              </PanelToolbar>
+              <Autocomplete
+                placeholder={selectedDisplayName ?? "Select a diagnostic"}
+                items={buffer.sortedAutocompleteEntries}
+                getItemText={(entry) => entry.displayName}
+                getItemValue={(entry) => entry.id}
+                onSelect={onSelect}
+                selectedItem={selectedItem as any}
+                inputStyle={{ height: "100%" }}
+              />
               {selectedItems != undefined && selectedItems.length > 0 ? (
                 <Flex col scroll>
                   {sortBy(selectedItems, ({ status }) => status.name.toLowerCase()).map((item) => (

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -160,9 +160,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   return (
     <Flex col className={styles.panel}>
-      <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
-        {hardwareFilter}
-      </PanelToolbar>
+      {hardwareFilter}
       <Flex col>
         <DiagnosticsHistory topic={topicToRender}>
           {(buffer) => {

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -30,7 +30,7 @@ export default function PanelCatalogProvider(
       const PanelWrapper = () => {
         return (
           <>
-            <PanelToolbar floating />
+            <PanelToolbar />
             <PanelComponent />
           </>
         );


### PR DESCRIPTION
Rather than have each panel add a panel toolbar, display the panel toolbar controls when editing a layout (adding/removing panels). This leaves the entire panel area for panel specific ui rather than earmarking a portion for our controls.