### PR TITLE
Show/hide panel toolbar using css instead of react state

### DIFF
--- a/packages/studio-base/src/components/MockPanelContextProvider.tsx
+++ b/packages/studio-base/src/components/MockPanelContextProvider.tsx
@@ -33,7 +33,6 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<PanelConfig> = {
   enterFullscreen: () => {
     // no-op
   },
-  isHovered: false,
   hasSettings: false,
   supportsStrictMode: true,
   connectToolbarDragHandle: () => {},

--- a/packages/studio-base/src/components/Panel.module.scss
+++ b/packages/studio-base/src/components/Panel.module.scss
@@ -6,6 +6,17 @@
   background-color: $dark;
   position: relative;
 
+  // To use css to hide/show toolbars on hover we use a global panelToolbar class
+  // because the PanelToolbar component is currently added within each panels render
+  // function rather than handling by the panel HOC
+  :global(.panelToolbarHovered) {
+    display: none;
+  }
+
+  &:hover :global(.panelToolbarHovered) {
+    display: flex;
+  }
+
   &:after {
     content: "";
     top: 0px;

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -148,7 +148,6 @@ export default function Panel<Config extends PanelConfig>(
     const [shiftKeyPressed, setShiftKeyPressed] = useState(false);
     const [cmdKeyPressed, setCmdKeyPressed] = useState(false);
     const [fullScreen, setFullScreen] = useState(false);
-    const [isHovered, setIsHovered] = useState(false);
     const [fullScreenLocked, setFullScreenLocked] = useState(false);
     const panelCatalog = usePanelCatalog();
 
@@ -315,10 +314,8 @@ export default function Panel<Config extends PanelConfig>(
       }
     }, [childId, config, getCurrentLayout, mosaicWindowActions, savePanelConfigs, tabId]);
 
-    const { onMouseEnter, onMouseLeave, onMouseMove, enterFullscreen, exitFullScreen } = useMemo(
+    const { onMouseMove, enterFullscreen, exitFullScreen } = useMemo(
       () => ({
-        onMouseEnter: () => setIsHovered(true),
-        onMouseLeave: () => setIsHovered(false),
         onMouseMove: ((e) => {
           if (e.metaKey !== cmdKeyPressed) {
             setCmdKeyPressed(e.metaKey);
@@ -430,7 +427,6 @@ export default function Panel<Config extends PanelConfig>(
                 updatePanelConfigs,
                 openSiblingPanel,
                 enterFullscreen,
-                isHovered,
                 hasSettings: PanelComponent.configSchema != undefined,
                 tabId,
                 supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
@@ -446,8 +442,6 @@ export default function Panel<Config extends PanelConfig>(
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
           <Flex
             onClick={onOverlayClick}
-            onMouseEnter={onMouseEnter}
-            onMouseLeave={onMouseLeave}
             onMouseMove={onMouseMove}
             className={cx({
               [styles.root!]: true,

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -29,7 +29,6 @@ export type PanelContextType<T> = {
   openSiblingPanel: OpenSiblingPanel;
   enterFullscreen: () => void;
 
-  isHovered: boolean;
   hasSettings: boolean;
   connectToolbarDragHandle: (el: Element | ReactNull) => void;
   supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)

--- a/packages/studio-base/src/components/PanelToolbar/index.module.scss
+++ b/packages/studio-base/src/components/PanelToolbar/index.module.scss
@@ -54,9 +54,7 @@ $panelToolbarSpacing: 4px;
     width: 100%;
     z-index: 5000;
     background-color: transparent;
-    transform: translateY(-10px);
     pointer-events: none;
-    opacity: 0;
 
     * {
       pointer-events: auto;
@@ -76,11 +74,6 @@ $panelToolbarSpacing: 4px;
 
   &:not(.floating) {
     min-height: $panelToolbarHeight + $panelToolbarSpacing;
-  }
-
-  &.floatingShow {
-    transform: translateY(0);
-    opacity: 1;
   }
 }
 

--- a/packages/studio-base/src/panels/Rosout/index.stories.tsx
+++ b/packages/studio-base/src/panels/Rosout/index.stories.tsx
@@ -126,24 +126,6 @@ export const TopicToRender = (): JSX.Element => {
   );
 };
 
-export const WithToolbarActive = (): JSX.Element => {
-  return (
-    <PanelSetup
-      fixture={fixture}
-      onMount={() => {
-        TestUtils.Simulate.mouseEnter(
-          document.querySelectorAll("[data-test~=panel-mouseenter-container]")[0]!,
-        );
-        setTimeout(() => {
-          TestUtils.Simulate.click(document.querySelectorAll("[data-test=panel-settings]")[0]!);
-        });
-      }}
-    >
-      <Rosout />
-    </PanelSetup>
-  );
-};
-
 export const FilteredTerms = (): JSX.Element => {
   return (
     <PanelSetup fixture={fixture}>

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -24,7 +24,6 @@ import Button from "@foxglove/studio-base/components/Button";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import useMessagesByPath from "@foxglove/studio-base/components/MessagePathSyntax/useMessagesByPath";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart, {
   getTooltipItemForMessageHistoryItem,
@@ -187,7 +186,6 @@ type Props = {
 
 const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const { config, saveConfig } = props;
-  const { isHovered } = usePanelContext();
   const { paths } = config;
 
   const onInputChange = (value: string, index?: number) => {
@@ -385,7 +383,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   return (
     <SRoot>
       <PanelToolbar floating helpContent={helpContent} />
-      <SAddButton show={isHovered}>
+      <SAddButton show={true}>
         <Button
           onClick={() =>
             saveConfig({
@@ -416,7 +414,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
             <SInputContainer
               key={index}
               style={{ top: index * heightPerTopic }}
-              shrink={index === 0 && isHovered}
+              shrink={index === 0}
             >
               <SInputDelete
                 onClick={() => {

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -93,7 +93,7 @@ export function TabbedToolbar(props: Props): JSX.Element {
 
   return (
     <STabbedToolbar highlight={isOver}>
-      <PanelToolbar helpContent={helpContent} showHiddenControlsOnHover>
+      <PanelToolbar helpContent={helpContent}>
         <STabs ref={dropRef} data-test="toolbar-droppable">
           {tabs.map((tab, i) => (
             <DraggableToolbarTab

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -243,20 +243,6 @@ storiesOf("panels/Tab/index", module)
       />
     </PanelSetup>
   ))
-  .add("many tabs do not cover panel toolbar", () => (
-    <PanelSetup
-      panelCatalog={new MockPanelCatalog()}
-      fixture={fixture}
-      onMount={() => {
-        const mouseEnterContainer = document.querySelectorAll(
-          "[data-test~=panel-mouseenter-container",
-        )[0]!;
-        TestUtils.Simulate.mouseEnter(mouseEnterContainer);
-      }}
-    >
-      <Tab overrideConfig={{ activeTabIdx: 1, tabs: manyTabs }} />
-    </PanelSetup>
-  ))
   .add("add tab", () => {
     return (
       <PanelSetup


### PR DESCRIPTION
CSS lets us show and hide child elements on hover. This is more reliable
than onMouseEnter/leave events which may not updated when the panel splits
or when child components capture the mouse events.