### PR TITLE
Don't render chart data if there are no bounds for downsampling

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -76,7 +76,7 @@
     "react-table": "7.7.0",
     "react-toast-notifications": "2.4.4",
     "react-transition-group": "4.4.2",
-    "react-use": "17.2.4",
+    "react-use": "patch:react-use@17.2.4#../../patches/react-use.patch",
     "react-virtualized": "9.22.3",
     "regl-worldview": "github:foxglove/webviz#workspace=regl-worldview&commit=6eb0e8c45eff795f8718f33bf3e10478951e7249",
     "rehype-raw": "5.1.0",

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -20,9 +20,9 @@ type DownsampleBounds = {
 };
 
 export default function downsample(dataset: DataSet, bounds: DownsampleBounds): DataSet {
-  // each datum point is treated as occupying 4x the pixels
-  const pixelPerXValue = bounds.width / 4 / (bounds.x.max - bounds.x.min);
-  const pixelPerYValue = bounds.height / 4 / (bounds.y.max - bounds.y.min);
+  // each datum point is treated as occupying a pixel
+  const pixelPerXValue = bounds.width / (bounds.x.max - bounds.x.min);
+  const pixelPerYValue = bounds.height / (bounds.y.max - bounds.y.min);
 
   // degenerate case
   if (dataset.data.length <= 1) {

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -23,6 +23,7 @@ import React, {
   useMemo,
   MouseEvent,
 } from "react";
+import { useThrottle } from "react-use";
 import { Time } from "rosbag";
 import styled from "styled-components";
 import { useDebouncedCallback } from "use-debounce";
@@ -201,7 +202,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     resumeFrame.current = undefined;
 
     if (current) {
-      // allow the chart offscreen canvas to render to screen
+      // allow the chart offscreen canvas to render to screen before calling done
       requestAnimationFrame(current);
     }
   }, []);
@@ -213,7 +214,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   const linesToHide = useMemo(() => props.linesToHide ?? {}, [props.linesToHide]);
 
   useEffect(() => {
-    // cleanup pased frames on unmount or dataset changes
+    // cleanup paused frames on unmount or dataset changes
     return () => {
       onChartUpdate();
     };
@@ -251,11 +252,11 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   }, [datasets]);
 
   // avoid re-doing a downsample on every scale change, instead mark the downsample as dirty
-  // with a debounce and if downsampling hasn't happened after some time, trigger a downsample
-  const [invalidateDownsample, setDownsampleFlush] = useState(1);
+  // with a debounce and if downsampling hasn't happened after some time, trigger a downsample via state update
+  const [invalidateDownsample, setDownsampleFlush] = useState({});
   const queueDownsampleInvalidate = useDebouncedCallback(
     () => {
-      setDownsampleFlush((old) => old + 1);
+      setDownsampleFlush({});
     },
     100,
     { leading: false },
@@ -650,6 +651,8 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     } as ScaleOptions;
   }, [datasetBounds.y, yAxes, hasUserPannedOrZoomed]);
 
+  const datasetBoundsRef = useRef(datasetBounds);
+  datasetBoundsRef.current = datasetBounds;
   const downsampleDatasets = useCallback(
     (fullDatasets: typeof datasets) => {
       const currentScales = currentScalesRef.current;
@@ -676,8 +679,36 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
         };
       }
 
+      const dataBounds = datasetBoundsRef.current;
+
+      // if we don't have bounds (chart not initialized) but do have dataset bounds
+      // then setup bounds as x/y min/max around the dataset values rather than the scales
+      if (
+        !bounds &&
+        dataBounds.x.min != undefined &&
+        dataBounds.x.max != undefined &&
+        dataBounds.y.min != undefined &&
+        dataBounds.y.max != undefined
+      ) {
+        bounds = {
+          width,
+          height,
+          x: {
+            min: dataBounds.x.min,
+            max: dataBounds.x.max,
+          },
+          y: {
+            min: dataBounds.y.min,
+            max: dataBounds.y.max,
+          },
+        };
+      }
+
+      // If we don't have any bounds - we assume the component is still initializing and return no data
+      // The other alternative is to return the full data set. This leads to rendering full fidelity data
+      // which causes render pauses and blank charts for large data sets.
       if (!bounds) {
-        return fullDatasets;
+        return [];
       }
 
       return fullDatasets.map((dataset) => {
@@ -713,9 +744,18 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     });
   }, [datasets, linesToHide]);
 
-  const downsampledData = useMemo(() => {
+  // throttle the downsampleDatasets callback since this is an input to the downsampledData memo
+  // avoids down a downsample if the callback changes rapidly
+  const throttledDownsample = useThrottle(() => downsampleDatasets, 100);
+
+  // downsample datasets with the latest downsample function
+  const downsampledDatasets = useMemo(() => {
     invalidateDownsample;
 
+    return throttledDownsample(visibleDatasets);
+  }, [invalidateDownsample, throttledDownsample, visibleDatasets]);
+
+  const downsampledData = useMemo(() => {
     if (resumeFrame.current) {
       log.warn("force resumed paused frame");
       resumeFrame.current();
@@ -726,9 +766,9 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
 
     return {
       labels,
-      datasets: downsampleDatasets(visibleDatasets),
+      datasets: downsampledDatasets,
     };
-  }, [visibleDatasets, downsampleDatasets, labels, pauseFrame, invalidateDownsample]);
+  }, [pauseFrame, labels, downsampledDatasets]);
 
   const options = useMemo<ChartOptions>(() => {
     return {

--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -274,7 +274,7 @@ function getDatasetAndTooltipsFromMessagePlotPath(
     showLine,
     fill: false,
     borderWidth: 1,
-    pointRadius: 1.5,
+    pointRadius: 1,
     pointHoverRadius: 3,
     pointBackgroundColor: lightColor(borderColor),
     pointBorderColor: "transparent",

--- a/patches/react-use.patch
+++ b/patches/react-use.patch
@@ -1,0 +1,16 @@
+diff --git a/esm/useThrottle.d.ts b/esm/useThrottle.d.ts
+index bb20b9649ddaef1015e027ef14ce9a557eabc1b3..9f9173a7d7308d9c573947305976d88c28f0c984 100644
+--- a/esm/useThrottle.d.ts
++++ b/esm/useThrottle.d.ts
+@@ -1,2 +1,2 @@
+-declare const useThrottle: <T>(value: T, ms?: number) => T;
++declare const useThrottle: <T>(value: T | (() => T), ms?: number) => T;
+ export default useThrottle;
+diff --git a/lib/useThrottle.d.ts b/lib/useThrottle.d.ts
+index bb20b9649ddaef1015e027ef14ce9a557eabc1b3..9f9173a7d7308d9c573947305976d88c28f0c984 100644
+--- a/lib/useThrottle.d.ts
++++ b/lib/useThrottle.d.ts
+@@ -1,2 +1,2 @@
+-declare const useThrottle: <T>(value: T, ms?: number) => T;
++declare const useThrottle: <T>(value: T | (() => T), ms?: number) => T;
+ export default useThrottle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,7 +2772,7 @@ __metadata:
     react-table: 7.7.0
     react-toast-notifications: 2.4.4
     react-transition-group: 4.4.2
-    react-use: 17.2.4
+    react-use: "patch:react-use@17.2.4#../../patches/react-use.patch"
     react-virtualized: 9.22.3
     reg-notify-github-plugin: 0.10.15
     reg-publish-gcs-plugin: 0.10.15
@@ -21928,7 +21928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.2.4":
+react-use@17.2.4:
   version: 17.2.4
   resolution: "react-use@npm:17.2.4"
   dependencies:
@@ -21950,6 +21950,31 @@ __metadata:
     react: ^16.8.0  || ^17.0.0
     react-dom: ^16.8.0  || ^17.0.0
   checksum: 3c885c3798bb07581f78f8445c0a9545c1bb8876ea5bdbe0236ebf3f923dc3572a0f71324f02ecddb8515b0625d7f3e2560da751bdf51f5a2fdb47290a689292
+  languageName: node
+  linkType: hard
+
+"react-use@patch:react-use@17.2.4#../../patches/react-use.patch::locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base":
+  version: 17.2.4
+  resolution: "react-use@patch:react-use@npm%3A17.2.4#../../patches/react-use.patch::version=17.2.4&hash=d5e839&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
+  dependencies:
+    "@types/js-cookie": ^2.2.6
+    "@xobotyi/scrollbar-width": ^1.9.5
+    copy-to-clipboard: ^3.3.1
+    fast-deep-equal: ^3.1.3
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^2.2.1
+    nano-css: ^5.3.1
+    react-universal-interface: ^0.6.2
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.1.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^3.0.1
+    ts-easing: ^0.2.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0
+    react-dom: ^16.8.0  || ^17.0.0
+  checksum: 19b8ae4330e3c9d4da553b7b6d00ce2eac384741c0bb5814724012b49baaf554b96f37acc3d2cd2bfeaf3fddd842a85db6e3606fdae615dcfa115d0d8039a2fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When the plot is initially mounted the bounds are not known. This
resulted in trying to render the entire dataset rather than a downsampled
version. For large datasets, this caused a blank chart while the
dataset was transferred to the worker and rendered which can take seconds
for large datasets. This occurs when adding panels to alter the layout.

This change updates the downsample behavior to return no datapoints
if the chart bounds are not known (during initialization) so that regular
downsampling can happen and avoid render delays.