### PR TITLE
Fix follow feature of plots

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -258,7 +258,10 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       setDownsampleFlush((old) => old + 1);
     },
     100,
-    { leading: false },
+    // maxWait equal to debounce timeout makes the debounce act like a throttle
+    // Without a maxWait - invocations of the debounced invalidate reset the countdown
+    // resulting in no invalidation when scales are constantly changing (playback)
+    { leading: false, maxWait: 100 },
   );
 
   const updateScales = useCallback(
@@ -542,10 +545,8 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       min = defaultView.minXValue;
       max = defaultView.maxXValue;
     } else if (defaultView?.type === "following") {
-      max = datasetBounds.x.max;
-      if (max != undefined) {
-        min = max - defaultView.width;
-      }
+      max = currentTime ?? 0;
+      min = max - defaultView.width;
     } else {
       min = datasetBounds.x.min;
       max = datasetBounds.x.max;
@@ -573,6 +574,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
 
     return { min, max };
   }, [
+    currentTime,
     datasetBounds.x.max,
     datasetBounds.x.min,
     defaultView,

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -229,6 +229,9 @@ function Plot(props: Props) {
   const preloadingEndTime = timeToXValueForPreloading(endTime);
   let defaultView: ChartDefaultView | undefined;
   if (preloadingDisplayTime != undefined) {
+    // display time == end time when streamking data..., and start time was 0
+    // could use start time of 0 to indicate live stream?
+    //console.log(preloadingDisplayTime, preloadingStartTime, preloadingEndTime);
     if (followingViewWidth != undefined && +followingViewWidth > 0) {
       // Will be ignored in TimeBasedChart for non-preloading plots and non-timestamp plots.
       defaultView = { type: "following", width: +followingViewWidth };

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -18,7 +18,7 @@ export type PlotConfig = {
   showLegend: boolean;
   xAxisVal: PlotXAxisVal;
   xAxisPath?: BasePlotPath;
-  followingViewWidth?: string | number;
+  followingViewWidth?: number;
 };
 
 export const plotableRosTypes = [


### PR DESCRIPTION
During many refactors plot panels lost the ability to "follow". The follow
feature keeps a fixed window behind the current playback time displayed in
the plot.