### PR TITLE
Change lazy message toJSON to fully deserialize the message

### DIFF
--- a/packages/rosmsg-deser/src/LazyMessageReader.test.ts
+++ b/packages/rosmsg-deser/src/LazyMessageReader.test.ts
@@ -270,7 +270,7 @@ describe("LazyReader", () => {
       expect(reader.source()).toMatchSnapshot(msgDef);
 
       // check that our message matches the object
-      expect(read.toJSON()).toMatchObject(expected);
+      expect(read.toJSON()).toEqual(expected);
     },
   );
 });

--- a/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/packages/rosmsg-deser/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -45,7 +45,8 @@ class custom_type_CustomType {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -97,10 +98,11 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
-      custom: this.custom,
+      custom: this.custom.toJSON(),
     };
   }
 
@@ -165,7 +167,8 @@ class custom_type_MoreCustom {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       field: this.field,
@@ -217,10 +220,11 @@ class custom_type_CustomType {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
-      another: this.another,
+      another: this.another.toJSON(),
     };
   }
 
@@ -269,10 +273,11 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
-      custom: this.custom,
+      custom: this.custom.map((item) => item.toJSON()),
     };
   }
 
@@ -337,7 +342,8 @@ class custom_type_CustomType {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -389,10 +395,11 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
-      custom: this.custom,
+      custom: this.custom.map((item) => item.toJSON()),
     };
   }
 
@@ -457,7 +464,8 @@ class custom_type_CustomType {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -509,10 +517,11 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
-      custom: this.custom,
+      custom: this.custom.map((item) => item.toJSON()),
     };
   }
 
@@ -572,7 +581,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       stamp: this.stamp,
@@ -632,7 +642,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -690,7 +701,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -747,7 +759,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -807,7 +820,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -894,7 +908,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -960,7 +975,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -1017,7 +1033,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1077,7 +1094,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       status: this.status,
@@ -1154,7 +1172,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -1215,7 +1234,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1271,7 +1291,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1331,7 +1352,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -1389,7 +1411,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -1446,7 +1469,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1502,7 +1526,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1558,7 +1583,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1614,7 +1640,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1674,7 +1701,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -1732,7 +1760,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1788,7 +1817,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1868,7 +1898,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -1932,7 +1963,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -1991,7 +2023,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -2050,7 +2083,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -2115,7 +2149,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -2178,7 +2213,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       stamp: this.stamp,
@@ -2238,7 +2274,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -2296,7 +2333,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       arr: this.arr,
@@ -2378,7 +2416,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       blank: this.blank,
@@ -2463,7 +2502,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       blank: this.blank,
@@ -2551,7 +2591,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       blank: this.blank,
@@ -2640,7 +2681,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       blank: this.blank,
@@ -2704,7 +2746,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -2760,7 +2803,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -2816,7 +2860,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       first: this.first,
@@ -2873,7 +2918,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -2929,7 +2975,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -2985,7 +3032,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -3041,7 +3089,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -3097,7 +3146,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,
@@ -3153,7 +3203,8 @@ class __RootMsg {
   }
 
   // return a json object of the fields
-  // this fully parses the message
+  // This fully deserializes all fields of the message into native types
+  // Typed arrays are considered native types and remain as typed arrays
   toJSON() {
     return {
       sample: this.sample,

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -97,7 +97,7 @@ const dataWithoutWrappingArray = (data: any) => {
 
 // lazy messages don't have own properties so we need to invoke "toJSON" to get the message
 // as a regular object
-function maybeShallowParse(val: unknown) {
+function maybeDeepParse(val: unknown) {
   if (val && typeof val === "object" && "toJSON" in val) {
     return (val as { toJSON: () => unknown }).toJSON();
   }
@@ -328,12 +328,7 @@ function RawMessages(props: Props) {
     // lazy messages have non-enumerable getters but do have a toJSON method to turn themselves into an object
     const diff =
       diffEnabled &&
-      getDiff(
-        JSON.parse(JSON.stringify(data)),
-        JSON.parse(JSON.stringify(diffData)),
-        undefined,
-        showFullMessageForDiff,
-      );
+      getDiff(maybeDeepParse(data), maybeDeepParse(diffData), undefined, showFullMessageForDiff);
     const diffLabelTexts = Object.values(diffLabels).map(({ labelText }) => labelText);
 
     const CheckboxComponent = showFullMessageForDiff
@@ -388,7 +383,7 @@ function RawMessages(props: Props) {
                 return valueRenderer(rootStructureItem, data, baseItem.queriedData, ...args);
               }}
               postprocessValue={(rawVal: unknown) => {
-                const val = maybeShallowParse(rawVal);
+                const val = maybeDeepParse(rawVal);
                 if (
                   typeof val === "object" &&
                   val != undefined &&


### PR DESCRIPTION
Rather than deserializing only the first set of fields, the toJSON
method on a lazy message now deserializes the entire message including
nested fields and arrays. This makes toJSON useful for places where
you may want to entirely expand the message at the expense of deserializing.

fixes #1183

--

Tested node playground as shown below

<img width="1012" alt="Screen Shot 2021-06-09 at 7 26 48 PM" src="https://user-images.githubusercontent.com/84792/121456105-5e398680-c95a-11eb-8aae-6bedff9ab979.png">
