### PR TITLE
Fix – Raise error in MessagePathInput for unsupported math modifiers

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -149,6 +149,9 @@ storiesOf("components/MessagePathInput", module)
   .add("autocomplete for path with globalVariables variables in slice (start and end idx)", () => {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
   })
+  .add("path with invalid math modifier", () => {
+    return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
+  })
   .add("autocomplete when prioritized datatype is available", () => {
     return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
   })

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -147,6 +147,7 @@ function getExamplePrimitive(primitiveType: RosPrimitive) {
 }
 
 type MessagePathInputBaseProps = {
+  supportsMathModifiers?: boolean;
   path: string; // A path of the form `/topic.some_field[:]{id==42}.x`
   index?: number; // Optional index field which gets passed to `onChange` (so you don't have to create anonymous functions)
   onChange: (value: string, index?: number) => void;
@@ -233,6 +234,7 @@ class MessagePathInputUnconnected extends React.PureComponent<
 
   override render() {
     const {
+      supportsMathModifiers,
       path,
       topics,
       datatypes,
@@ -373,6 +375,9 @@ class MessagePathInputUnconnected extends React.PureComponent<
           )
         : autocompleteItems;
 
+    const usesUnsupportedMathModifier =
+      (supportsMathModifiers == undefined || !supportsMathModifiers) && path.includes(".@");
+
     return (
       <div
         style={{ display: "flex", flex: "1 1 auto", minWidth: 0, justifyContent: "space-between" }}
@@ -385,7 +390,10 @@ class MessagePathInputUnconnected extends React.PureComponent<
           onSelect={(value: string, _item: unknown, autocomplete: Autocomplete<string>) =>
             this._onSelect(value, autocomplete, autocompleteType, autocompleteRange)
           }
-          hasError={autocompleteType != undefined && !disableAutocomplete && path.length > 0}
+          hasError={
+            usesUnsupportedMathModifier ||
+            (autocompleteType != undefined && !disableAutocomplete && path.length > 0)
+          }
           autocompleteKey={autocompleteType}
           placeholder={
             placeholder != undefined && placeholder !== ""

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -203,6 +203,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
                 })}
               >
                 <MessagePathInput
+                  supportsMathModifiers
                   path={path.value}
                   onChange={onInputChange}
                   onTimestampMethodChange={onInputTimestampMethodChange}


### PR DESCRIPTION
- Addresses https://github.com/foxglove/studio/issues/849 
- Should only be valid in Plot panel's y-axis values

Example:
<img width="622" alt="Screen Shot 2021-06-10 at 1 17 13 AM" src="https://user-images.githubusercontent.com/6993359/121490855-45e16000-c98a-11eb-844b-a69b8403c2ef.png">

Added story:
<img width="456" alt="Screen Shot 2021-06-10 at 10 24 41 AM" src="https://user-images.githubusercontent.com/6993359/121569885-24a66100-c9d6-11eb-983d-69b25b1bdae8.png">

Story for using math modifiers in Plot panel already exists.