### PR TITLE
Remove react-leaflet

### DIFF
--- a/ci/license-check.ts
+++ b/ci/license-check.ts
@@ -25,7 +25,7 @@ const ALLOWED_LICENSES = [
   "OFL-1.1",
 ];
 
-const EXCLUDED_PACKAGES = ["@react-leaflet/core@1.1.0", "gl-vec3@1.1.3", "react-leaflet@3.2.0"];
+const EXCLUDED_PACKAGES = ["gl-vec3@1.1.3"];
 
 async function main() {
   const output = await initChecker({

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -67,7 +67,6 @@
     "react-input-autosize": "3.0.0",
     "react-is": "17.0.2",
     "react-json-tree": "0.15.0",
-    "react-leaflet": "3.2.0",
     "react-markdown": "6.0.2",
     "react-monaco-editor": "0.43.0",
     "react-mosaic-component": "5.0.0",

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -84,15 +84,11 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     const newRenderState: RenderState = prevRenderState.current;
 
     if (watchedFieldsRef.current.has("currentFrame")) {
-      const currentFrame =
-        playerState.activeData?.messages.filter((messageEvent) => {
-          return subscribedTopicsRef.current.has(messageEvent.topic);
-        }) ?? [];
-      // if there are new frames we should update
-      if (currentFrame?.length !== 0 || prevRenderState.current.currentFrame?.length !== 0) {
-        shouldRender = true;
-        newRenderState.currentFrame = currentFrame;
-      }
+      const currentFrame = playerState.activeData?.messages.filter((messageEvent) => {
+        return subscribedTopicsRef.current.has(messageEvent.topic);
+      });
+      shouldRender = true;
+      newRenderState.currentFrame = currentFrame;
     }
 
     if (watchedFieldsRef.current.has("topics")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,7 +2763,6 @@ __metadata:
     react-input-autosize: 3.0.0
     react-is: 17.0.2
     react-json-tree: 0.15.0
-    react-leaflet: 3.2.0
     react-markdown: 6.0.2
     react-monaco-editor: 0.43.0
     react-mosaic-component: 5.0.0
@@ -3700,17 +3699,6 @@ __metadata:
   version: 2.0.0
   resolution: "@react-dnd/shallowequal@npm:2.0.0"
   checksum: b5bbdc795d65945bb7ba2322bed5cf8d4c6fe91dced98c3b10e3d16822c438f558751135ff296f8d1aa1eaa9d0037dacab2b522ca5eb812175123b9996966dcb
-  languageName: node
-  linkType: hard
-
-"@react-leaflet/core@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@react-leaflet/core@npm:1.1.0"
-  peerDependencies:
-    leaflet: ^1.7.1
-    react: ^17.0.1
-    react-dom: ^17.0.1
-  checksum: 314b689b047622e87a128cc5c0b345ac86d355fda92648b696a540d831f86eee63eb9639c6329e50d3b2602b9c937a412b5991661c470dc7b5f19e05e69adc94
   languageName: node
   linkType: hard
 
@@ -21622,19 +21610,6 @@ __metadata:
     "@types/react": ^16.3.0 || ^17.0.0
     react: ^16.3.0 || ^17.0.0
   checksum: c65b6017dd7bf4168304af3a8589d9d4551282e60d7ce49d3a59fb529d9e52e63757deee9bda00f0c9f2119dba60a217fe635c81f4bcfd6a1ba0a3e38a044b71
-  languageName: node
-  linkType: hard
-
-"react-leaflet@npm:3.2.0":
-  version: 3.2.0
-  resolution: "react-leaflet@npm:3.2.0"
-  dependencies:
-    "@react-leaflet/core": ^1.1.0
-  peerDependencies:
-    leaflet: ^1.7.1
-    react: ^17.0.1
-    react-dom: ^17.0.1
-  checksum: 49b540952d883893ad7e0ec70679bfc5e443ba7c25a6b74ec11bfd114f0fd3be33abb86f40acee490abfe6670951f3ce8c2ac86cc32d308c7fd2dc31a684ca57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
react-leaflet uses a non-standard OSS license. Since we use only a small set of leaflet
features we move over to using leaflet directly.

Fixes #1182
Fixes #1105