### PR TITLE
internal: Add RemoteLayoutStorage and LayoutStorage interfaces

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -25,5 +25,11 @@
     "prefix": "const",
     "body": "const {$2} = $1;",
     "description": "Destructure object"
+  },
+
+  "React component": {
+    "scope": "typescriptreact",
+    "prefix": "component",
+    "body": "export default function ${1:$TM_FILENAME_BASE}({ children }: React.PropsWithChildren<${2:unknown}>): JSX.Element {\n\t$0\n}"
   }
 }

--- a/desktop/renderer/components/NativeStorageLayoutStorageProvider.tsx
+++ b/desktop/renderer/components/NativeStorageLayoutStorageProvider.tsx
@@ -4,7 +4,7 @@
 
 import { PropsWithChildren, useMemo } from "react";
 
-import { LayoutStorageContext } from "@foxglove/studio-base";
+import { LocalLayoutStorageContext } from "@foxglove/studio-base";
 
 import { useNativeStorage } from "../context/NativeStorageContext";
 import NativeStorageLayoutStorage from "../services/NativeStorageLayoutStorage";
@@ -19,6 +19,8 @@ export default function NativeStorageLayoutStorageProvider(
   }, [storage]);
 
   return (
-    <LayoutStorageContext.Provider value={provider}>{props.children}</LayoutStorageContext.Provider>
+    <LocalLayoutStorageContext.Provider value={provider}>
+      {props.children}
+    </LocalLayoutStorageContext.Provider>
   );
 }

--- a/desktop/renderer/services/NativeStorageLayoutStorage.ts
+++ b/desktop/renderer/services/NativeStorageLayoutStorage.ts
@@ -2,11 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Layout, LayoutStorage } from "@foxglove/studio-base";
+import { LocalLayout, LocalLayoutStorage } from "@foxglove/studio-base";
 
 import { Storage } from "../../common/types";
 
-function assertLayout(value: unknown): asserts value is Layout {
+function assertLayout(value: unknown): asserts value is LocalLayout {
   if (typeof value !== "object" || value == undefined) {
     throw new Error("Invariant violation - layout item is not an object");
   }
@@ -17,7 +17,7 @@ function assertLayout(value: unknown): asserts value is Layout {
 }
 
 // Implement a LayoutStorage interface over OsContext
-export default class NativeStorageLayoutStorage implements LayoutStorage {
+export default class NativeStorageLayoutStorage implements LocalLayoutStorage {
   private static STORE_NAME = "layouts";
 
   private _ctx: Storage;
@@ -26,10 +26,10 @@ export default class NativeStorageLayoutStorage implements LayoutStorage {
     this._ctx = storage;
   }
 
-  async list(): Promise<Layout[]> {
+  async list(): Promise<LocalLayout[]> {
     const items = await this._ctx.all(NativeStorageLayoutStorage.STORE_NAME);
 
-    const layouts: Layout[] = [];
+    const layouts: LocalLayout[] = [];
     for (const item of items) {
       if (!(item instanceof Uint8Array)) {
         throw new Error("Invariant violation - layout item is not a buffer");
@@ -44,7 +44,7 @@ export default class NativeStorageLayoutStorage implements LayoutStorage {
     return layouts;
   }
 
-  async get(id: string): Promise<Layout | undefined> {
+  async get(id: string): Promise<LocalLayout | undefined> {
     const item = await this._ctx.get(NativeStorageLayoutStorage.STORE_NAME, id);
     if (item == undefined) {
       return undefined;
@@ -60,7 +60,7 @@ export default class NativeStorageLayoutStorage implements LayoutStorage {
     return parsed;
   }
 
-  async put(layout: Layout): Promise<void> {
+  async put(layout: LocalLayout): Promise<void> {
     const content = JSON.stringify(layout);
     return this._ctx.put(NativeStorageLayoutStorage.STORE_NAME, layout.id, content);
   }

--- a/packages/studio-base/src/components/LayoutMenu.stories.tsx
+++ b/packages/studio-base/src/components/LayoutMenu.stories.tsx
@@ -6,25 +6,23 @@ import { useMemo } from "react";
 
 import LayoutMenu from "@foxglove/studio-base/components/LayoutMenu";
 import CurrentLayoutContext from "@foxglove/studio-base/context/CurrentLayoutContext";
-import LayoutStorageContext, {
-  Layout,
-  LayoutStorage,
-} from "@foxglove/studio-base/context/LayoutStorageContext";
+import LocalLayoutStorageContext from "@foxglove/studio-base/context/LocalLayoutStorageContext";
 import CurrentLayoutState, {
   DEFAULT_LAYOUT_FOR_TESTS,
 } from "@foxglove/studio-base/providers/CurrentLayoutProvider/CurrentLayoutState";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
+import { LocalLayout, LocalLayoutStorage } from "@foxglove/studio-base/services/LocalLayoutStorage";
 
-class FakeLayoutStorage implements LayoutStorage {
-  private _layouts: Layout[];
+class FakeLayoutStorage implements LocalLayoutStorage {
+  private _layouts: LocalLayout[];
 
-  constructor(layouts: Layout[] = []) {
+  constructor(layouts: LocalLayout[] = []) {
     this._layouts = layouts;
   }
-  list(): Promise<Layout[]> {
+  list(): Promise<LocalLayout[]> {
     return Promise.resolve(this._layouts);
   }
-  get(_id: string): Promise<Layout | undefined> {
+  get(_id: string): Promise<LocalLayout | undefined> {
     throw new Error("Method not implemented.");
   }
   put(_layout: unknown): Promise<void> {
@@ -47,9 +45,9 @@ export function Empty(): JSX.Element {
   return (
     <div style={{ display: "flex", height: 400 }}>
       <CurrentLayoutContext.Provider value={currentLayout}>
-        <LayoutStorageContext.Provider value={storage}>
+        <LocalLayoutStorageContext.Provider value={storage}>
           <LayoutMenu defaultIsOpen />
-        </LayoutStorageContext.Provider>
+        </LocalLayoutStorageContext.Provider>
       </CurrentLayoutContext.Provider>
     </div>
   );
@@ -95,9 +93,9 @@ export function LayoutList(): JSX.Element {
   return (
     <div style={{ display: "flex", height: 400 }}>
       <CurrentLayoutContext.Provider value={mockLayoutContext}>
-        <LayoutStorageContext.Provider value={storage}>
+        <LocalLayoutStorageContext.Provider value={storage}>
           <LayoutMenu defaultIsOpen />
-        </LayoutStorageContext.Provider>
+        </LocalLayoutStorageContext.Provider>
       </CurrentLayoutContext.Provider>
     </div>
   );

--- a/packages/studio-base/src/components/LayoutMenu.tsx
+++ b/packages/studio-base/src/components/LayoutMenu.tsx
@@ -15,10 +15,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import { Layout, useLayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
+import { useLocalLayoutStorage } from "@foxglove/studio-base/context/LocalLayoutStorageContext";
 import useLatestNonNull from "@foxglove/studio-base/hooks/useLatestNonNull";
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
+import { LocalLayout } from "@foxglove/studio-base/services/LocalLayoutStorage";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
@@ -63,7 +64,7 @@ export default function LayoutMenu({
   }, [defaultIsOpen]);
 
   const { getCurrentLayout, loadLayout } = useCurrentLayoutActions();
-  const layoutStorage = useLayoutStorage();
+  const layoutStorage = useLocalLayoutStorage();
 
   // a basic stale-while-revalidate pattern to avoid flicker of layout menu when we reload the layout list
   // When we re-visit local/remote layouts we will want to look at something like swr (https://swr.vercel.app/)
@@ -83,7 +84,7 @@ export default function LayoutMenu({
   }, [error]);
 
   const renameAction = useCallback(
-    async (layout: Layout) => {
+    async (layout: LocalLayout) => {
       const value = await prompt({
         title: "Rename layout",
         value: layout.name,
@@ -136,7 +137,7 @@ export default function LayoutMenu({
   }, [isMounted, layoutStorage, loadLayout]);
 
   const selectAction = useCallback(
-    (layout: Layout) => {
+    (layout: LocalLayout) => {
       if (layout.state) {
         loadLayout(layout.state);
       }
@@ -145,7 +146,7 @@ export default function LayoutMenu({
   );
 
   const deleteLayout = useCallback(
-    async (layout: Layout) => {
+    async (layout: LocalLayout) => {
       await layoutStorage.delete(layout.id);
       fetchLayouts();
     },

--- a/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
@@ -37,7 +37,6 @@ export type PanelsState = {
   userNodes: UserNodes;
   linkedGlobalVariables: LinkedGlobalVariables;
   playbackConfig: PlaybackConfig;
-  version?: number;
 };
 
 export type ConfigsPayload = {

--- a/packages/studio-base/src/context/LayoutStorageContext.ts
+++ b/packages/studio-base/src/context/LayoutStorageContext.ts
@@ -4,20 +4,7 @@
 
 import { createContext, useContext } from "react";
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-
-export type Layout = {
-  id: string;
-  name: string;
-  state?: PanelsState;
-};
-
-export interface LayoutStorage {
-  list(): Promise<Layout[]>;
-  get(id: string): Promise<Layout | undefined>;
-  put(layout: Layout): Promise<void>;
-  delete(id: string): Promise<void>;
-}
+import { LayoutStorage } from "@foxglove/studio-base/services/LayoutStorage";
 
 const LayoutStorageContext = createContext<LayoutStorage | undefined>(undefined);
 

--- a/packages/studio-base/src/context/LocalLayoutStorageContext.ts
+++ b/packages/studio-base/src/context/LocalLayoutStorageContext.ts
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+import { LocalLayoutStorage } from "@foxglove/studio-base/services/LocalLayoutStorage";
+
+const LocalLayoutStorageContext = createContext<LocalLayoutStorage | undefined>(undefined);
+
+export function useLocalLayoutStorage(): LocalLayoutStorage {
+  const ctx = useContext(LocalLayoutStorageContext);
+  if (ctx === undefined) {
+    throw new Error("A LocalLayoutStorage provider is required to useLocalLayoutStorage");
+  }
+  return ctx;
+}
+
+export default LocalLayoutStorageContext;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -18,8 +18,11 @@ export type {
   AppConfigurationValue,
   ChangeHandler,
 } from "./context/AppConfigurationContext";
-export { default as LayoutStorageContext } from "./context/LayoutStorageContext";
-export type { Layout, LayoutStorage } from "./context/LayoutStorageContext";
+export { default as LocalLayoutStorageContext } from "./context/LocalLayoutStorageContext";
+export type {
+  LocalLayout,
+  LocalLayoutStorage,
+} from "@foxglove/studio-base/services/LocalLayoutStorage";
 export { default as NativeAppMenuContext } from "./context/NativeAppMenuContext";
 export type { NativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";
 export type { PlayerSourceDefinition } from "./context/PlayerSelectionContext";
@@ -33,3 +36,5 @@ export { default as ExtensionLoaderContext } from "./context/ExtensionLoaderCont
 export type { ExtensionLoader, ExtensionDetail } from "./context/ExtensionLoaderContext";
 export { default as AuthContext, useAuth } from "./context/AuthContext";
 export type { Auth, CurrentUser } from "./context/AuthContext";
+export { default as LayoutStorageContext } from "./context/LayoutStorageContext";
+export type { RemoteLayoutStorage } from "@foxglove/studio-base/services/RemoteLayoutStorage";

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -14,10 +14,11 @@ import {
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import LayoutStorageContext, { Layout } from "@foxglove/studio-base/context/LayoutStorageContext";
+import LocalLayoutStorageContext from "@foxglove/studio-base/context/LocalLayoutStorageContext";
 import { UserProfileStorageContext } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider";
+import { LocalLayout } from "@foxglove/studio-base/services/LocalLayoutStorage";
 import Storage from "@foxglove/studio-base/util/Storage";
 import signal from "@foxglove/studio-base/util/signal";
 
@@ -75,13 +76,13 @@ function renderTest({
   }
   mount(
     <ToastProvider>
-      <LayoutStorageContext.Provider value={mockLayoutStorage}>
+      <LocalLayoutStorageContext.Provider value={mockLayoutStorage}>
         <UserProfileStorageContext.Provider value={mockUserProfile}>
           <CurrentLayoutProvider>
             <Child />
           </CurrentLayoutProvider>
         </UserProfileStorageContext.Provider>
-      </LayoutStorageContext.Provider>
+      </LocalLayoutStorageContext.Provider>
     </ToastProvider>,
   );
   return { currentLayoutStates, actions, childMounted };
@@ -132,7 +133,7 @@ describe("CurrentLayoutProvider", () => {
             id: expect.any(String),
             name: "unnamed",
             state: expectedPanelsState,
-          } as Layout,
+          } as LocalLayout,
         ],
       ]);
 
@@ -189,7 +190,7 @@ describe("CurrentLayoutProvider", () => {
     };
     const layoutStorageGetCalled = signal();
     const mockLayoutStorage = makeMockLayoutStorage();
-    mockLayoutStorage.get.mockImplementation(async (): Promise<Layout> => {
+    mockLayoutStorage.get.mockImplementation(async (): Promise<LocalLayout> => {
       layoutStorageGetCalled.resolve();
       return { id: "example", name: "Example layout", state: expectedState };
     });
@@ -206,7 +207,7 @@ describe("CurrentLayoutProvider", () => {
 
   it("saves new layout selection into UserProfile", async () => {
     const mockLayoutStorage = makeMockLayoutStorage();
-    mockLayoutStorage.get.mockImplementation(async (): Promise<Layout> => {
+    mockLayoutStorage.get.mockImplementation(async (): Promise<LocalLayout> => {
       return { id: "example", name: "Example layout", state: TEST_LAYOUT };
     });
 
@@ -238,7 +239,7 @@ describe("CurrentLayoutProvider", () => {
   it("saves layout updates into LayoutStorage", async () => {
     const layoutStoragePutCalled = signal();
     const mockLayoutStorage = makeMockLayoutStorage();
-    mockLayoutStorage.get.mockImplementation(async (): Promise<Layout> => {
+    mockLayoutStorage.get.mockImplementation(async (): Promise<LocalLayout> => {
       return { id: TEST_LAYOUT.id, name: TEST_LAYOUT.name, state: TEST_LAYOUT };
     });
     mockLayoutStorage.put.mockImplementation(async () => layoutStoragePutCalled.resolve());

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -131,7 +131,6 @@ export default function CurrentLayoutProvider({
 
   const { getUserProfile } = useUserProfileStorage();
   const layoutStorage = useLocalLayoutStorage();
-  //FIXME: support for remote layout storage
 
   const loadInitialState = useAsync(async (): Promise<PanelsState | undefined> => {
     try {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import CurrentLayoutContext from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import { useLayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
+import { useLocalLayoutStorage } from "@foxglove/studio-base/context/LocalLayoutStorageContext";
 import { useUserProfileStorage } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import CurrentLayoutState from "@foxglove/studio-base/providers/CurrentLayoutProvider/CurrentLayoutState";
@@ -42,7 +42,7 @@ function CurrentLayoutProviderWithInitialState({
   const { addToast } = useToasts();
 
   const { setUserProfile } = useUserProfileStorage();
-  const layoutStorage = useLayoutStorage();
+  const layoutStorage = useLocalLayoutStorage();
 
   const [stateInstance] = useState(() => new CurrentLayoutState(initialState));
   const [panelsState, setPanelsState] = useState(() => stateInstance.actions.getCurrentLayout());
@@ -130,7 +130,8 @@ export default function CurrentLayoutProvider({
   const { addToast } = useToasts();
 
   const { getUserProfile } = useUserProfileStorage();
-  const layoutStorage = useLayoutStorage();
+  const layoutStorage = useLocalLayoutStorage();
+  //FIXME: support for remote layout storage
 
   const loadInitialState = useAsync(async (): Promise<PanelsState | undefined> => {
     try {

--- a/packages/studio-base/src/services/LayoutStorage.ts
+++ b/packages/studio-base/src/services/LayoutStorage.ts
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+
+// We use "brand" tags to prevent confusion between string types with distinct meanings
+// https://github.com/microsoft/TypeScript/issues/4895
+export type UserID = string & { __brand: "UserID" };
+export type LayoutID = string & { __brand: "LayoutID" };
+export type ISO8601Timestamp = string & { __brand: "ISO8601Timestamp" };
+
+export type UserMetadata = {
+  id: UserID;
+  name: string;
+  email: string;
+};
+
+/** Metadata that describes a panel layout. */
+export type LayoutMetadata = {
+  id: LayoutID;
+  name: string;
+  path: string[];
+  creator: UserMetadata | undefined;
+  createdAt: ISO8601Timestamp | undefined;
+  updatedAt: ISO8601Timestamp | undefined;
+  permission: "creator_write" | "org_read" | "org_write";
+};
+
+export type Layout = {
+  name: string;
+  data: PanelsState;
+  metadata: LayoutMetadata;
+};
+
+export interface LayoutStorage {
+  getLayouts(): Promise<LayoutMetadata[]>;
+
+  getLayout(id: LayoutID): Promise<Layout | undefined>;
+
+  saveNewLayout(params: { path: string[]; name: string; data: PanelsState }): Promise<void>;
+
+  updateLayout(params: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+    targetID: LayoutID;
+  }): Promise<void>;
+
+  supportsSharing: boolean;
+
+  shareLayout(params: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+  }): Promise<void>;
+
+  updateSharedLayout(params: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+    targetID: LayoutID;
+  }): Promise<void>;
+
+  deleteLayout(params: { id: LayoutID }): Promise<void>;
+
+  renameLayout(params: { id: LayoutID; name: string; path: string[] }): Promise<void>;
+}

--- a/packages/studio-base/src/services/LocalLayoutStorage.ts
+++ b/packages/studio-base/src/services/LocalLayoutStorage.ts
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { RemoteLayoutMetadata } from "@foxglove/studio-base/services/RemoteLayoutStorage";
+
+export type LocalLayout = {
+  id: string;
+  name: string;
+  state: PanelsState | undefined;
+
+  /** Last known metadata from the server for this layout */
+  serverMetadata?: RemoteLayoutMetadata;
+  /** Whether the user deleted this layout locally, and it should be deleted on the server */
+  locallyDeleted?: boolean;
+  /** Whether the user modified this layout locally, and it should be uploaded to the server */
+  locallyModified?: boolean;
+};
+
+export interface LocalLayoutStorage {
+  list(): Promise<LocalLayout[]>;
+  get(id: string): Promise<LocalLayout | undefined>;
+  put(layout: LocalLayout): Promise<void>;
+  delete(id: string): Promise<void>;
+}

--- a/packages/studio-base/src/services/LocalOnlyLayoutStorage.ts
+++ b/packages/studio-base/src/services/LocalOnlyLayoutStorage.ts
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { v4 as uuidv4 } from "uuid";
+
+import Logger from "@foxglove/log";
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import {
+  Layout,
+  LayoutID,
+  LayoutMetadata,
+  LayoutStorage,
+} from "@foxglove/studio-base/services/LayoutStorage";
+import { LocalLayout, LocalLayoutStorage } from "@foxglove/studio-base/services/LocalLayoutStorage";
+
+const log = Logger.getLogger(__filename);
+
+function getMetadata(layout: LocalLayout): LayoutMetadata {
+  if (layout.serverMetadata) {
+    log.warn(`Local-only layout ${layout.id} has unexpected server metadata`);
+  }
+  return {
+    id: layout.id as LayoutID,
+    name: layout.name,
+    path: [],
+    creator: undefined,
+    createdAt: undefined,
+    updatedAt: undefined,
+    permission: "creator_write",
+  };
+}
+
+/**
+ * A LayoutStorage that's backed solely by a LocalLayoutStorage. This is used when centralized
+ * layout storage is not available because the user is not logged in to an account.
+ *
+ * Any `serverMetadata` on the local layout is ignored and generally is not expected to be present.
+ */
+export default class LocalOnlyLayoutStorage implements LayoutStorage {
+  supportsSharing = false;
+
+  constructor(private storage: LocalLayoutStorage) {}
+
+  async getLayouts(): Promise<LayoutMetadata[]> {
+    return (await this.storage.list()).map(getMetadata);
+  }
+
+  async getLayout(id: LayoutID): Promise<Layout | undefined> {
+    const localLayout = await this.storage.get(id);
+    if (!localLayout || !localLayout.state) {
+      return undefined;
+    }
+    return {
+      name: localLayout.name,
+      data: localLayout.state,
+      metadata: getMetadata(localLayout),
+    };
+  }
+
+  async saveNewLayout({
+    path,
+    name,
+    data,
+  }: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+  }): Promise<void> {
+    if (path.length !== 0) {
+      throw new Error("Layout paths are not supported in local-only storage");
+    }
+    const id = uuidv4() as LayoutID;
+    await this.storage.put({ id, name, state: data });
+  }
+
+  async updateLayout({
+    path,
+    name,
+    data,
+    targetID,
+  }: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+    targetID: LayoutID;
+  }): Promise<void> {
+    if (path.length !== 0) {
+      throw new Error("Layout paths are not supported in local-only storage");
+    }
+    await this.storage.put({ id: targetID, name, state: data });
+  }
+
+  async shareLayout(_: unknown): Promise<void> {
+    throw new Error("Sharing is not supported in local-only storage");
+  }
+
+  async updateSharedLayout(_: unknown): Promise<void> {
+    throw new Error("Sharing is not supported in local-only storage");
+  }
+
+  async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
+    await this.storage.delete(id);
+  }
+
+  async renameLayout({
+    id,
+    name,
+    path,
+  }: {
+    id: LayoutID;
+    name: string;
+    path: string[];
+  }): Promise<void> {
+    if (path.length !== 0) {
+      throw new Error("Layout paths are not supported in local-only storage");
+    }
+    const target = await this.storage.get(id);
+    if (!target) {
+      throw new Error(`Layout id ${id} not found`);
+    }
+    await this.storage.put({ id, name, state: target.state });
+  }
+}

--- a/packages/studio-base/src/services/MockRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/MockRemoteLayoutStorage.ts
@@ -1,0 +1,226 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { isEqual } from "lodash";
+import { v4 as uuidv4 } from "uuid";
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import {
+  LayoutID,
+  ISO8601Timestamp,
+  UserID,
+  UserMetadata,
+} from "@foxglove/studio-base/services/LayoutStorage";
+import {
+  RemoteLayout,
+  RemoteLayoutMetadata,
+  RemoteLayoutStorage,
+} from "@foxglove/studio-base/services/RemoteLayoutStorage";
+
+const FAKE_USER: UserMetadata = {
+  id: "fakeuser" as UserID,
+  email: "fakeuser@example.com",
+  name: "Fake User",
+};
+
+export default class MockRemoteLayoutStorage implements RemoteLayoutStorage {
+  private layoutsById = new Map<LayoutID, RemoteLayout>();
+
+  async getLayouts(): Promise<RemoteLayoutMetadata[]> {
+    return Array.from(this.layoutsById.values(), (layout) => layout.metadata);
+  }
+
+  async getLayout(id: LayoutID): Promise<RemoteLayout | undefined> {
+    return this.layoutsById.get(id);
+  }
+
+  async saveNewLayout({
+    path,
+    name,
+    data,
+  }: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+  }): Promise<{ status: "success"; newMetadata: RemoteLayoutMetadata } | { status: "conflict" }> {
+    for (const { metadata } of this.layoutsById.values()) {
+      if (
+        isEqual(path, metadata.path) &&
+        name === metadata.name &&
+        metadata.permission === "creator_write"
+      ) {
+        return { status: "conflict" };
+      }
+    }
+    const id = uuidv4() as LayoutID;
+    const now = new Date().toISOString() as ISO8601Timestamp;
+    const newMetadata: RemoteLayoutMetadata = {
+      id,
+      name,
+      path,
+      permission: "creator_write",
+      creator: FAKE_USER,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.layoutsById.set(id, { data, metadata: newMetadata });
+    return { status: "success", newMetadata };
+  }
+
+  async updateLayout({
+    path,
+    name,
+    data,
+    targetID,
+    ifUnmodifiedSince,
+  }: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+    targetID: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }): Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  > {
+    const target = this.layoutsById.get(targetID);
+    if (!target) {
+      return { status: "conflict" };
+    }
+    if (Date.parse(target.metadata.updatedAt) !== Date.parse(ifUnmodifiedSince)) {
+      return { status: "precondition-failed" };
+    }
+    const now = new Date().toISOString() as ISO8601Timestamp;
+    const newMetadata: RemoteLayoutMetadata = {
+      ...target.metadata,
+      path,
+      name,
+      updatedAt: now,
+    };
+    this.layoutsById.set(targetID, { ...target, data, metadata: newMetadata });
+    return { status: "success", newMetadata };
+  }
+
+  async shareLayout({
+    sourceID,
+    path,
+    name,
+    permission,
+  }: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+  }): Promise<{ status: "success"; newMetadata: RemoteLayoutMetadata } | { status: "conflict" }> {
+    const source = this.layoutsById.get(sourceID);
+    if (!source) {
+      return { status: "conflict" };
+    }
+    for (const { metadata } of this.layoutsById.values()) {
+      if (
+        isEqual(path, metadata.path) &&
+        name === metadata.name &&
+        metadata.permission !== "creator_write"
+      ) {
+        return { status: "conflict" };
+      }
+    }
+    const id = uuidv4() as LayoutID;
+    const now = new Date().toISOString() as ISO8601Timestamp;
+    const newMetadata: RemoteLayoutMetadata = {
+      id,
+      name,
+      path,
+      permission,
+      creator: FAKE_USER,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.layoutsById.set(id, { data: source.data, metadata: newMetadata });
+    return { status: "success", newMetadata };
+  }
+
+  async updateSharedLayout({
+    sourceID,
+    path,
+    name,
+    permission,
+    targetID,
+    ifUnmodifiedSince,
+  }: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+    targetID: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }): Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  > {
+    const source = this.layoutsById.get(sourceID);
+    if (!source) {
+      return { status: "conflict" };
+    }
+    const target = this.layoutsById.get(targetID);
+    if (!target) {
+      return { status: "conflict" };
+    }
+    if (Date.parse(target.metadata.updatedAt) !== Date.parse(ifUnmodifiedSince)) {
+      return { status: "precondition-failed" };
+    }
+    const now = new Date().toISOString() as ISO8601Timestamp;
+    const newMetadata: RemoteLayoutMetadata = {
+      ...target.metadata,
+      name,
+      path,
+      permission,
+      updatedAt: now,
+    };
+    this.layoutsById.set(targetID, { ...target, data: source.data, metadata: newMetadata });
+    return { status: "success", newMetadata };
+  }
+
+  async deleteLayout({
+    id,
+    ifUnmodifiedSince,
+  }: {
+    id: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }): Promise<{ status: "success" | "precondition-failed" }> {
+    const target = this.layoutsById.get(id);
+    if (!target) {
+      return { status: "success" };
+    }
+    if (Date.parse(target.metadata.updatedAt) !== Date.parse(ifUnmodifiedSince)) {
+      return { status: "precondition-failed" };
+    }
+    this.layoutsById.delete(id);
+    return { status: "success" };
+  }
+
+  async renameLayout({
+    id,
+    name,
+    path,
+    ifUnmodifiedSince,
+  }: {
+    id: LayoutID;
+    name: string;
+    path: string[];
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }): Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  > {
+    const target = this.layoutsById.get(id);
+    if (!target) {
+      return { status: "conflict" };
+    }
+    return this.updateLayout({ targetID: id, name, path, ifUnmodifiedSince, data: target.data });
+  }
+}

--- a/packages/studio-base/src/services/RemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/RemoteLayoutStorage.ts
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import {
+  ISO8601Timestamp,
+  LayoutID,
+  LayoutMetadata,
+} from "@foxglove/studio-base/services/LayoutStorage";
+
+/**
+ * Metadata that describes a panel layout on a remote server.
+ *
+ * @note Optional values in `LayoutMetadata` are required when layouts are loaded from a server, to
+ * enable permissions and consistency checks.
+ */
+export type RemoteLayoutMetadata = {
+  [K in keyof LayoutMetadata]-?: NonNullable<LayoutMetadata[K]>;
+};
+
+/**
+ * A panel layout stored on a remote server.
+ */
+export type RemoteLayout = {
+  data: PanelsState;
+  metadata: RemoteLayoutMetadata;
+};
+
+export interface RemoteLayoutStorage {
+  getLayouts: () => Promise<RemoteLayoutMetadata[]>;
+
+  getLayout: (id: LayoutID) => Promise<RemoteLayout | undefined>;
+
+  saveNewLayout: (params: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+  }) => Promise<{ status: "success"; newMetadata: RemoteLayoutMetadata } | { status: "conflict" }>;
+
+  updateLayout: (params: {
+    path: string[];
+    name: string;
+    data: PanelsState;
+    targetID: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }) => Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  >;
+
+  shareLayout: (params: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+  }) => Promise<{ status: "success"; newMetadata: RemoteLayoutMetadata } | { status: "conflict" }>;
+
+  updateSharedLayout: (params: {
+    sourceID: LayoutID;
+    path: string[];
+    name: string;
+    permission: "org_read" | "org_write";
+    targetID: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }) => Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  >;
+
+  deleteLayout: (params: {
+    id: LayoutID;
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }) => Promise<{ status: "success" | "precondition-failed" }>;
+
+  renameLayout: (params: {
+    id: LayoutID;
+    name: string;
+    path: string[];
+    ifUnmodifiedSince: ISO8601Timestamp;
+  }) => Promise<
+    | { status: "success"; newMetadata: RemoteLayoutMetadata }
+    | { status: "conflict" }
+    | { status: "precondition-failed" }
+  >;
+}

--- a/web/src/components/NoOpLayoutStorageProvider.tsx
+++ b/web/src/components/NoOpLayoutStorageProvider.tsx
@@ -4,27 +4,29 @@
 
 import { PropsWithChildren, useState } from "react";
 
-import { LayoutStorageContext, LayoutStorage } from "@foxglove/studio-base";
+import { LocalLayoutStorage, LocalLayoutStorageContext } from "@foxglove/studio-base";
 
 export default function NoOpLayoutStorageProvider(props: PropsWithChildren<unknown>): JSX.Element {
-  const [ctx] = useState<LayoutStorage>(() => {
+  const [ctx] = useState<LocalLayoutStorage>(() => {
     return {
-      list() {
-        return Promise.resolve([]);
+      async list() {
+        return [];
       },
-      get() {
-        return Promise.resolve();
+      async get() {
+        return undefined;
       },
-      put() {
-        return Promise.resolve();
+      async put() {
+        return undefined;
       },
-      delete() {
-        return Promise.resolve();
+      async delete() {
+        return undefined;
       },
-    } as LayoutStorage;
+    };
   });
 
   return (
-    <LayoutStorageContext.Provider value={ctx}>{props.children}</LayoutStorageContext.Provider>
+    <LocalLayoutStorageContext.Provider value={ctx}>
+      {props.children}
+    </LocalLayoutStorageContext.Provider>
   );
 }


### PR DESCRIPTION
The existing LayoutStorage is renamed to LocalLayoutStorage. It's still the only storage interface being used in the app right now, but will be combined in a future PR with remote storage to form a local cache implementation.

The new RemoteLayoutStorage interface demonstrates what operations a layout storage server with sharing features will be expected to implement. This may change a little in the near future, but has largely solidified after discussions and prototyping work on the server side.

The new LayoutStorage interface is what will power the forthcoming layout sidebar UI. It's a simplified version of RemoteLayoutStorage that doesn't require the caller to know about cached metadata for conflict resolution (a concrete "cached remote storage" implementation will automatically populate the ifUnmodifiedSince field by reading the locally cached metadata). Rather than returning errors from the method calls, conflict info will probably be available via a separate event emitter channel.

### User impact

None yet! 🔜