### PR TITLE
Enable chromatic --only-changed flag (turbosnap)

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -19,8 +19,8 @@
     "src"
   ],
   "scripts": {
-    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded",
-    "storybook:build": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --config-dir src/.storybook"
+    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded --only-changed",
+    "storybook:build": "cross-env NODE_OPTIONS='--max-old-space-size=6144' TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --webpack-stats-json --config-dir src/.storybook"
   },
   "dependencies": {
     "@fluentui/react": "8.18.0",
@@ -146,6 +146,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.2",
     "argparse": "2.0.1",
     "chromatic": "5.9.1",
+    "cross-env": "7.0.3",
     "enzyme": "3.11.0",
     "fetch-mock": "9.11.0",
     "http-server": "0.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,6 +2719,7 @@ __metadata:
     chartjs-plugin-zoom: "github:foxglove/chartjs-plugin-zoom#656541279943f00dce600288435f83c436293146"
     chromatic: 5.9.1
     classnames: 2.3.1
+    cross-env: 7.0.3
     cytoscape: 3.19.0
     cytoscape-dagre: 2.3.2
     enzyme: 3.11.0


### PR DESCRIPTION
Screenshot tests are only run based on changed files. Changed files are detected based on webpack dependency tree.

No user facing change.

Docs: https://www.chromatic.com/docs/turbosnap