### PR TITLE
Update @foxglove/studio to v0.11.0

### DIFF
--- a/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
+++ b/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
@@ -13,11 +13,12 @@
 
 import { useMemo } from "react";
 
-import { DataSourceInfo } from "@foxglove/studio";
+import { Time, Topic } from "@foxglove/studio";
 import {
   useMessagePipeline,
   MessagePipelineContext,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 function selectDatatypes(ctx: MessagePipelineContext) {
   return ctx.datatypes;
@@ -38,6 +39,16 @@ function selectCapabilities(ctx: MessagePipelineContext) {
 function selectPlayerId(ctx: MessagePipelineContext) {
   return ctx.playerState.playerId;
 }
+
+// Metadata about the source of data currently being displayed.
+// This is not expected to change often, usually when changing data sources.
+export type DataSourceInfo = {
+  topics: readonly Topic[];
+  datatypes: RosDatatypes;
+  capabilities: string[];
+  startTime?: Time; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
+  playerId: string;
+};
 
 /**
  * Data source info" encapsulates **rarely-changing** metadata about the source from which

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -3,42 +3,17 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 declare module "@foxglove/studio" {
-  import { Time } from "rosbag";
+  export interface Time {
+    sec: number;
+    nsec: number;
+  }
 
-  import { RosMsgField } from "@foxglove/rosmsg";
-
-  export type RosDatatype = {
-    fields: RosMsgField[];
-  };
-
-  export type RosDatatypes = {
-    [key: string]: RosDatatype;
-  };
-
-  // Represents a ROS topic, though the actual data does not need to come from a ROS system.
+  // A topic is a namespace for specific types of messages
   export type Topic = {
-    // Of ROS topic format, i.e. "/some/topic". We currently depend on this slashes format a bit in
-    // `<MessageHistroy>`, though we could relax this and support arbitrary strings. It's nice to have
-    // a consistent representation for topics that people recognize though.
+    // topic name i.e. "/some/topic"
     name: string;
-    // Name of the datatype (see `type PlayerStateActiveData` for details).
+    // topic datatype
     datatype: string;
-    // The original topic name, if the topic name was at some point renamed, e.g. in
-    // RenameDataProvider.
-    originalTopic?: string;
-    // The number of messages present on the topic. Valid only for sources with a fixed number of
-    // messages, such as bags.
-    numMessages?: number;
-  };
-
-  // Metadata about the source of data currently being displayed.
-  // This is not expected to change often, usually when changing data sources.
-  export type DataSourceInfo = {
-    topics: readonly Topic[];
-    datatypes: RosDatatypes;
-    capabilities: string[];
-    startTime?: Time; // Only `startTime`, since `endTime` can change rapidly when connected to a live system.
-    playerId: string;
   };
 
   /**

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/studio",
-  "version": "0.1.0",
+  "version": "0.11.0",
   "license": "MPL-2.0",
   "main": "",
   "types": "index.d.ts"


### PR DESCRIPTION
Bump @foxglove/studio version to v0.11.0

- Remove unused type definitions for DataSourceInfo

This will be the first version we publish to npm so we can start authoring extensions
