### PR TITLE
Catch render errors from panel extensions

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PanelExtensionContext } from "@foxglove/studio";
+import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+export default {
+  title: "PanelExtensionAdapter",
+  component: PanelExtensionAdapter,
+};
+
+export const CatchRenderError = (): JSX.Element => {
+  const initPanel = (context: PanelExtensionContext) => {
+    context.watch("topics");
+
+    context.onRender = () => {
+      throw new Error("sample render error");
+    };
+  };
+
+  return (
+    <PanelSetup
+      fixture={{
+        topics: [
+          {
+            name: "/topic",
+            datatype: "test_msgs/Sample",
+          },
+        ],
+        datatypes: {},
+        frame: {},
+        layout: "UnknownPanel!4co6n9d",
+      }}
+    >
+      <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+    </PanelSetup>
+  );
+};

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -52,6 +52,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
   const requestBackfill = useMessagePipeline(selectRequestBackfill);
 
+  const [error, setError] = useState<Error | undefined>();
   const watchedFieldsRef = useRef(new Set<keyof RenderState>());
   const subscribedTopicsRef = useRef(new Set<string>());
   const panelElementRef = useRef<HTMLDivElement>(ReactNull);
@@ -141,9 +142,14 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
     // tell the panel to render and lockout future renders until rendering is complete
     renderingRef.current = true;
-    panelContext.onRender(newRenderState, () => {
-      renderingRef.current = false;
-    });
+    try {
+      setError(undefined);
+      panelContext.onRender(newRenderState, () => {
+        renderingRef.current = false;
+      });
+    } catch (err) {
+      setError(err);
+    }
   }
 
   useMessagePipeline((ctx) => {
@@ -229,6 +235,10 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     style.borderColor = "orange";
     style.borderWidth = "1px";
     style.borderStyle = "solid";
+  }
+
+  if (error) {
+    throw error;
   }
 
   return (


### PR DESCRIPTION
Catch render call errors and re-throw them within the render call
for error boundaries to handle.