### PR TITLE
Remove th,tr,td from global.scss

### DIFF
--- a/packages/studio-base/src/styles/global.scss
+++ b/packages/studio-base/src/styles/global.scss
@@ -195,36 +195,3 @@ button {
     padding: 4px 8px;
   }
 }
-
-th {
-  color: $text-normal;
-
-  tr:first-child & {
-    padding-top: 4px;
-    padding-bottom: 4px;
-  }
-}
-
-th,
-td {
-  border: 1px solid $divider;
-  padding: 0 0.3em;
-  line-height: 1.3em;
-}
-
-tr {
-  svg {
-    opacity: 0.6;
-  }
-}
-
-tr:hover {
-  td {
-    background-color: $dark4;
-    cursor: pointer;
-  }
-
-  svg {
-    opacity: 0.8;
-  }
-}


### PR DESCRIPTION
Global css rules can have unintended effects on innocent html elements. We
prefer to scope our css to individual components.

Related https://github.com/foxglove/studio/issues/986
