### PR TITLE
Remove paragraph styling from global.scss

### DIFF
--- a/packages/studio-base/src/styles/global.scss
+++ b/packages/studio-base/src/styles/global.scss
@@ -147,13 +147,6 @@ strong {
   @extend %bold;
 }
 
-p {
-  margin: 1em 0;
-  &:last-child {
-    margin-bottom: 0;
-  }
-}
-
 hr {
   border: none;
   display: block;


### PR DESCRIPTION
Global css rules can have unintended effects on innocent html elements. We
prefer to scope our css to individual components.

Related #986