### PR TITLE
Internal: set explicit stacktrace for PanelExtensionAdapterStory

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -16,7 +16,12 @@ export const CatchRenderError = (): JSX.Element => {
     context.watch("topics");
 
     context.onRender = () => {
-      throw new Error("sample render error");
+      const err = new Error("sample render error");
+      // The default stacktrace contains paths from the webpack bundle. These paths have the bundle
+      // identifier/hash and change whenever the bundle changes. This makes the story change.
+      // To avoid the story changing we set the stacktrace explicitly.
+      err.stack = "sample stacktrace";
+      throw err;
     };
   };
 


### PR DESCRIPTION
The default stacktrace contains paths from webpack. These change when the bundle
changes and makes the story different every time. This requires approving each
change in screenshot testing. Instead we explicitly set the stack so the story
is unchanged when the bundle changes.

No user facing changes.
