### PR TITLE
Internal: Tweak issue template header size

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,22 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: "Bug: Bug description here"
-labels: ""
-assignees: ""
+name: Bug
+about: Report an issue
 ---
 
-### Current Behavior
+**Description**
 
-<!--- Describe what currently happens instead of the expected behavior. -->
 
-### Expected Behavior
+- Version:
+- OS:
 
-<!--- Describe what you expect to happen. -->
-
-### Steps to Reproduce
-
-<!--- Provide an unambiguous set of steps to reproduce this bug. -->
+**Steps To Reproduce**
 <!--- Include code, screenshots, and an example data source (i.e. a `.bag` file), if relevant. -->
 
-### Context
 
-<!--- What are you trying to accomplish? How has this issue affected you? -->
+**Expected Behavior**
 
-### Description
 
-<!--- Summarize the change you are proposing. -->
+**Actual Behavior**
 
-### Possible Solution
 
-<!--- (Optional) Suggest 1) a fix or reason for the bug, and 2) an idea for implementing the change. -->
-
-### Specs
-
-- Foxglove Studio version
-- Platform (Linux, macOS, Windows)
-- OS version
+**Current Behavior**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug
 about: Report an issue
+labels: "bug"
 ---
 
 **Description**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,32 +6,32 @@ labels: ""
 assignees: ""
 ---
 
-# Current Behavior
+### Current Behavior
 
 <!--- Describe what currently happens instead of the expected behavior. -->
 
-# Expected Behavior
+### Expected Behavior
 
 <!--- Describe what you expect to happen. -->
 
-# Steps to Reproduce
+### Steps to Reproduce
 
 <!--- Provide an unambiguous set of steps to reproduce this bug. -->
 <!--- Include code, screenshots, and an example data source (i.e. a `.bag` file), if relevant. -->
 
-# Context
+### Context
 
 <!--- What are you trying to accomplish? How has this issue affected you? -->
 
-# Description
+### Description
 
 <!--- Summarize the change you are proposing. -->
 
-# Possible Solution
+### Possible Solution
 
 <!--- (Optional) Suggest 1) a fix or reason for the bug, and 2) an idea for implementing the change. -->
 
-# Specs
+### Specs
 
 - Foxglove Studio version
 - Platform (Linux, macOS, Windows)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,28 +1,7 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: "Feature request: Request description here"
-labels: ""
-assignees: ""
+name: Feature Request
+about: Request a new feature
+labels: "feature"
 ---
 
-### Current Behavior
-
-<!--- Describe what currently happens instead of the desired behavior. -->
-
-### Desired Behavior
-
-<!--- Describe what you want to happen. -->
-
-### Context
-
-<!--- What are you trying to accomplish? How would this feature request help you? -->
-
-### Description
-
-<!--- Summarize the change you are proposing. -->
-<!--- Include an example data source (i.e. a `.bag` file) to develop the feature against, if relevant. -->
-
-### Possible Implementation
-
-<!--- (Optional) Suggest 1) applications for this feature outside your specific use case, and 2) an idea for implementing the change. -->
+<!--- Include code, screenshots, and an example data source (i.e. a `.bag` file), if relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,23 +6,23 @@ labels: ""
 assignees: ""
 ---
 
-# Current Behavior
+### Current Behavior
 
 <!--- Describe what currently happens instead of the desired behavior. -->
 
-# Desired Behavior
+### Desired Behavior
 
 <!--- Describe what you want to happen. -->
 
-# Context
+### Context
 
 <!--- What are you trying to accomplish? How would this feature request help you? -->
 
-# Description
+### Description
 
 <!--- Summarize the change you are proposing. -->
 <!--- Include an example data source (i.e. a `.bag` file) to develop the feature against, if relevant. -->
 
-# Possible Implementation
+### Possible Implementation
 
 <!--- (Optional) Suggest 1) applications for this feature outside your specific use case, and 2) an idea for implementing the change. -->


### PR DESCRIPTION
H1 headers are rather large for issue templates. H3 look more balanced.

User impact: None for the app. Github issue creation will be less intense \o/

Before
<img width="468" alt="Screen Shot 2021-06-15 at 6 37 45 AM" src="https://user-images.githubusercontent.com/84792/122062497-50de2b00-cda4-11eb-948a-488ef5aadb2f.png">

After
<img width="505" alt="Screen Shot 2021-06-15 at 6 38 05 AM" src="https://user-images.githubusercontent.com/84792/122062511-5471b200-cda4-11eb-914e-6e890085125d.png">