### PR TITLE
Fix new webpack warnings

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.module.scss
+++ b/packages/studio-base/src/components/Autocomplete.module.scss
@@ -65,5 +65,5 @@ $row-height: 24px;
 }
 
 :export {
-  rowHeight: $row-height / 1px;
+  rowHeight: div($row-height, 1px);
 }

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -163,7 +163,8 @@ export function makeConfig(
           // TypeScript uses dynamic requires()s when running in node. We can disable these when we
           // bundle it for the renderer.
           // https://github.com/microsoft/TypeScript/issues/39436
-          test: /[\\/]node_modules[\\/]typescript[\\/]lib[\\/]typescript\.js$/,
+          // Prettier's TS parser also bundles the same code: https://github.com/prettier/prettier/issues/11076
+          test: /[\\/]node_modules[\\/]typescript[\\/]lib[\\/]typescript\.js$|[\\/]node_modules[\\/]prettier[\\/]parser-typescript\.js$/,
           loader: "string-replace-loader",
           options: {
             multiple: [
@@ -173,8 +174,17 @@ export function makeConfig(
                   "throw new Error('[Foxglove] This module is not supported in the browser.');",
               },
               {
+                search: `typescript-etw";r=require(i)`,
+                replace: `typescript-etw";throw new Error('[Foxglove] This module is not supported in the browser.');`,
+              },
+              {
                 search:
                   "return { module: require(modulePath), modulePath: modulePath, error: undefined };",
+                replace:
+                  "throw new Error('[Foxglove] This module is not supported in the browser.');",
+              },
+              {
+                search: `return{module:require(n),modulePath:n,error:void 0}`,
                 replace:
                   "throw new Error('[Foxglove] This module is not supported in the browser.');",
               },


### PR DESCRIPTION
The dependency upgrade #1226 introduced new webpack warnings. This PR fixes them.

Opened an issue against Prettier https://github.com/prettier/prettier/issues/11076 to go along with the open issue against TypeScript https://github.com/microsoft/TypeScript/issues/39436 for these dynamic require() warnings.

No user impact.