### PR TITLE
Reset all panels when player changes.

### DIFF
--- a/packages/studio-base/src/components/RemountOnValueChange.test.tsx
+++ b/packages/studio-base/src/components/RemountOnValueChange.test.tsx
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render } from "@testing-library/react";
+import { useLayoutEffect } from "react";
+
+import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
+
+describe("RemountOnValueChange", () => {
+  it("should render once with an initial value", () => {
+    let mountCount = 0;
+    const MountCount = () => {
+      useLayoutEffect(() => {
+        mountCount = mountCount + 1;
+      }, []);
+      return ReactNull;
+    };
+    const { rerender } = render(
+      <RemountOnValueChange value="some-value">
+        <MountCount />
+      </RemountOnValueChange>,
+    );
+
+    expect(mountCount).toEqual(1);
+
+    rerender(
+      <RemountOnValueChange value="some-value">
+        <MountCount />
+      </RemountOnValueChange>,
+    );
+    expect(mountCount).toEqual(1);
+  });
+
+  it("should remount again when value changes", () => {
+    let mountCount = 0;
+    const MountCount = () => {
+      useLayoutEffect(() => {
+        mountCount = mountCount + 1;
+      }, []);
+      return ReactNull;
+    };
+    const { rerender } = render(
+      <RemountOnValueChange value="some-value">
+        <MountCount />
+      </RemountOnValueChange>,
+    );
+    expect(mountCount).toEqual(1);
+
+    rerender(
+      <RemountOnValueChange value="some-new-value">
+        <MountCount />
+      </RemountOnValueChange>,
+    );
+    expect(mountCount).toEqual(2);
+  });
+});

--- a/packages/studio-base/src/components/RemountOnValueChange.tsx
+++ b/packages/studio-base/src/components/RemountOnValueChange.tsx
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useCallback } from "react";
+
+/**
+ * RemountOnValueChange will unmount and remount the children when _value_ changes.
+ * This is used when you want to "reset" the component tree for a specific value change.
+ *
+ * Note: Use sparingly and prefer hook dependencies to manage state updates. This should be a
+ * last resort nuclear option when you think that an entire subtree should be purged.
+ */
+export default function RemountOnValueChange(
+  props: PropsWithChildren<{ value: unknown }>,
+): JSX.Element {
+  // When the value changes, useCallback will create a new component by returning a new
+  // function instance. Since this is a completely new component it will remount its entire tree.
+  const Parent = useCallback(
+    ({ children }: PropsWithChildren<unknown>) => {
+      void props.value; // to suppress eslint complaining about the value in the deps list
+      return <>{children}</>;
+    },
+    [props.value],
+  );
+
+  return <Parent>{props.children}</Parent>;
+}

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -7,12 +7,15 @@ import { useToasts } from "react-toast-notifications";
 import { useAsync, useThrottle } from "react-use";
 import { v4 as uuidv4 } from "uuid";
 
+import Logger from "@foxglove/log";
 import CurrentLayoutContext from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { useLayoutCache } from "@foxglove/studio-base/context/LayoutCacheContext";
 import { useUserProfileStorage } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import CurrentLayoutState from "@foxglove/studio-base/providers/CurrentLayoutProvider/CurrentLayoutState";
+
+const log = Logger.getLogger(__filename);
 
 function migrateLegacyLayoutFromLocalStorage() {
   let result: PanelsState | undefined;
@@ -92,7 +95,7 @@ function CurrentLayoutProviderWithInitialState({
         state: throttledPanelsState,
       })
       .catch((error) => {
-        console.error(error);
+        log.error(error);
         addToast(`The current layout could not be saved. ${error.toString()}`, {
           appearance: "error",
           id: "CurrentLayoutProvider.layoutStorage.put",


### PR DESCRIPTION
Reverts foxglove/studio#1228

Use RemountOnValueChange to unmount/remount panel layouts when players change.
This clears any local cache or state management the components may have related
to stale messages, state, etc.

Fixes #1239

Users will see a flash of black when changing players. Users will no longer have stale images from a previous player.