### PR TITLE
Partially revert "Enable chromatic --only-changed flag (turbosnap)"

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -19,8 +19,8 @@
     "src"
   ],
   "scripts": {
-    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded --only-changed",
-    "storybook:build": "cross-env NODE_OPTIONS='--max-old-space-size=6144' TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --webpack-stats-json --config-dir src/.storybook"
+    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded",
+    "storybook:build": "cross-env NODE_OPTIONS='--max-old-space-size=6144' TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --config-dir src/.storybook"
   },
   "dependencies": {
     "@fluentui/react": "8.18.0",


### PR DESCRIPTION
Reverts foxglove/studio#1205

Broken on main: https://github.com/foxglove/studio/runs/2834196484

I'm keeping the `cross-env NODE_OPTIONS='--max-old-space-size=6144'` memory increase for now since that seems likely needed in the future anyway (and was already included when we run `start-storybook`).