### PR TITLE
CI: Checkout branch head instead of merge commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          # Chromatic requires running build on the branch head, not PR merge commit
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           lfs: true
       - name: Configure Node.js
@@ -80,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           lfs: true
       - name: Configure Node.js
         uses: actions/setup-node@v2.1.5


### PR DESCRIPTION
By default GitHub Actions checks out a commit merging main into the PR branch, and runs CI on this. While clever, in practice it doesn't help that much, and some tools (such as Chromatic) get confused since the commit we tested is not the one found at the head of the PR branch.

PR Checklist
- [ ] Add release notes <!-- If a release draft does not already exist, create one using [`release_template.md`](https://github.com/foxglove/studio/blob/main/release_template.md) -->
- [ ] Link to relevant GitHub issues <!-- Use format `Resolves #1000` to automatically link the issue -->
- [ ] Describe the changes made <!-- Describe tradeoffs considered, solution, implementation, user impact -->
- [ ] Open a GitHub issue [here](https://github.com/foxglove/website/issues) if docs need to be updated with your changes
