### PR TITLE
Generate theme color palette procedurally

### DIFF
--- a/packages/studio-base/src/theme/index.ts
+++ b/packages/studio-base/src/theme/index.ts
@@ -24,6 +24,8 @@ import { SANS_SERIF } from "@foxglove/studio-base/styles/fonts";
 import styles from "@foxglove/studio-base/styles/variables.module.scss";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+const THEME_HUE = 247;
+
 // https://aka.ms/themedesigner
 export default createTheme({
   defaultFontStyle: {
@@ -160,8 +162,6 @@ export default createTheme({
     whiteTranslucent40: "#12121766",
   },
 });
-
-const THEME_HUE = 247;
 
 function themeColors(): Partial<IPalette> {
   const keys: (keyof IPalette)[] = [

--- a/packages/studio-base/src/theme/index.ts
+++ b/packages/studio-base/src/theme/index.ts
@@ -13,6 +13,10 @@ import {
   IColorPickerStyles,
   IToggleStyles,
   IStyle,
+  ISpinnerStyles,
+  IPalette,
+  hsl2rgb,
+  getColorFromRGBA,
 } from "@fluentui/react";
 import { createTheme } from "@fluentui/theme";
 
@@ -128,6 +132,16 @@ export default createTheme({
         },
       } as IToggleStyles,
     },
+    Spinner: {
+      styles: {
+        circle: {
+          animationTimingFunction: "linear",
+          borderWidth: 2,
+        },
+      } as Partial<ISpinnerStyles>,
+    },
+
+    // Custom (non-Fluent) components
     Titlebar: {
       styles: {
         root: {
@@ -138,29 +152,66 @@ export default createTheme({
   },
   isInverted: true,
   palette: {
-    themePrimary: "#b8aefd",
-    themeLighterAlt: "#c0b7fd",
-    themeLighter: "#c8c0fd",
-    themeLight: "#d0c9fd",
-    themeTertiary: "#d7d2fe",
-    themeSecondary: "#dfdafe",
-    themeDarkAlt: "#e7e3fe",
-    themeDark: "#efecfe",
-    themeDarker: "#f6f5ff",
-    neutralLighterAlt: "#1a1a21",
-    neutralLighter: "#22222a",
-    neutralLight: "#2e2e39",
-    neutralQuaternaryAlt: "#363642",
-    neutralQuaternary: "#3c3c49",
-    neutralTertiaryAlt: "#595968",
-    neutralTertiary: "#f3f3f3",
-    neutralSecondary: "#f5f5f5",
-    neutralPrimaryAlt: "#f7f7f7",
-    neutralPrimary: "#eeeeee",
-    neutralDark: "#fbfbfb",
+    ...themeColors(),
+    ...neutralColors(),
     black: "#fdfdfd",
     white: "#121217",
     blackTranslucent40: "#fdfdfd66",
     whiteTranslucent40: "#12121766",
   },
 });
+
+const THEME_HUE = 247;
+
+function themeColors(): Partial<IPalette> {
+  const keys: (keyof IPalette)[] = [
+    "themeDarker",
+    "themeDark",
+    "themeDarkAlt",
+    "themePrimary",
+    "themeSecondary",
+    "themeTertiary",
+    "themeLight",
+    "themeLighter",
+    "themeLighterAlt",
+  ];
+  keys.reverse(); // reverse because our theme is inverted
+
+  const result: Partial<IPalette> = Object.fromEntries(
+    keys.map((key, i) => {
+      const ratio = i / (keys.length - 1);
+      return [
+        key,
+        "#" +
+          getColorFromRGBA(hsl2rgb(THEME_HUE, Math.min(20 + ratio * 75, 75), 40 + ratio * 57)).hex,
+      ];
+    }),
+  );
+  return result;
+}
+
+function neutralColors(): Partial<IPalette> {
+  const keys: (keyof IPalette)[] = [
+    "neutralDark",
+    "neutralPrimary",
+    "neutralPrimaryAlt",
+    "neutralSecondary",
+    "neutralSecondaryAlt",
+    "neutralTertiary",
+    "neutralTertiaryAlt",
+    "neutralQuaternary",
+    "neutralQuaternaryAlt",
+    "neutralLight",
+    "neutralLighter",
+    "neutralLighterAlt",
+  ];
+  keys.reverse(); // reverse because our theme is inverted
+
+  const result: Partial<IPalette> = Object.fromEntries(
+    keys.map((key, i) => {
+      const ratio = i / (keys.length - 1);
+      return [key, "#" + getColorFromRGBA(hsl2rgb(THEME_HUE, 5, 10 + ratio * 85)).hex];
+    }),
+  );
+  return result;
+}


### PR DESCRIPTION
cc @2metres

For an inverted theme like ours, Fluent seems to intend that `themeDarker` should be light, and `themeLighter` should be dark, etc. When I started using `<Spinner/>` I noticed we were doing this wrong because the spinner looked weird (the two different colors on the right were basically identical). So I'm generating colors based on a HSV formula so that we can tweak it without worrying about how all the colors are derived from each other.

(The Fluent [theme designer tool](http://aka.ms/themedesigner) is a bit buggy, so you have to change the palette color *after* changing the foreground/background colors if you want to see it correctly generate inverted theme colors. Also, they do expose the [`ThemeGenerator`](https://github.com/microsoft/fluentui/blob/3118517319fb8d66a3ca44c43285d0cbd2d7c48d/packages/react/src/components/ThemeGenerator/ThemeGenerator.ts) API and [inheritance rules](https://github.com/microsoft/fluentui/blob/3118517319fb8d66a3ca44c43285d0cbd2d7c48d/packages/react/src/components/ThemeGenerator/ThemeRulesStandard.ts) that the theme designer uses, but I found it a bit confusing to use these, so opted to stick with a custom formula.)

User impact: minor app color changes