### PR TITLE
Disable chromatic turbosnap (--only-changed)

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -19,7 +19,7 @@
     "src"
   ],
   "scripts": {
-    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded --only-changed",
+    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded",
     "storybook:build": "cross-env NODE_OPTIONS='--max-old-space-size=6144' TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --config-dir src/.storybook"
   },
   "dependencies": {


### PR DESCRIPTION
We are seeing issues with turbosnap not correctly detecting changed files. Creating this PR in case we want to disable it on main while we debug.