### PR TITLE
Fix renaming and deleting nodes in Node Playground

### DIFF
--- a/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
@@ -122,7 +122,7 @@ export type SET_GLOBAL_DATA = {
   };
 };
 
-export type SET_STUDIO_NODES = { type: "SET_USER_NODES"; payload: UserNodes };
+export type SET_STUDIO_NODES = { type: "SET_USER_NODES"; payload: Partial<UserNodes> };
 
 export type SET_LINKED_GLOBAL_VARIABLES = {
   type: "SET_LINKED_GLOBAL_VARIABLES";

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -66,7 +66,7 @@ export interface CurrentLayout {
     loadLayout: (payload: LoadLayoutPayload) => void;
     overwriteGlobalVariables: (payload: { [key: string]: unknown }) => void;
     setGlobalVariables: (payload: { [key: string]: unknown }) => void;
-    setUserNodes: (payload: UserNodes) => void;
+    setUserNodes: (payload: Partial<UserNodes>) => void;
     setLinkedGlobalVariables: (payload: LinkedGlobalVariables) => void;
     setPlaybackConfig: (payload: Partial<PlaybackConfig>) => void;
     closePanel: (payload: ClosePanelPayload) => void;

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -14,7 +14,7 @@
 import { Stack } from "@fluentui/react";
 import ArrowLeftIcon from "@mdi/svg/svg/arrow-left.svg";
 import PlusIcon from "@mdi/svg/svg/plus.svg";
-import { Suspense, useEffect } from "react";
+import { Suspense } from "react";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -14,8 +14,7 @@
 import { Stack } from "@fluentui/react";
 import ArrowLeftIcon from "@mdi/svg/svg/arrow-left.svg";
 import PlusIcon from "@mdi/svg/svg/plus.svg";
-import { omit } from "lodash";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import styled from "styled-components";
 import { v4 as uuidv4 } from "uuid";
 
@@ -251,7 +250,7 @@ function NodePlayground(props: Props) {
             saveConfig({ selectedNodeId: nodeId });
           }}
           deleteNode={(nodeId) => {
-            setUserNodes(omit(userNodes, nodeId));
+            setUserNodes({ ...userNodes, [nodeId]: undefined });
             saveConfig({ selectedNodeId: undefined });
           }}
           selectedNodeId={selectedNodeId}

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -793,12 +793,14 @@ const panelsReducer = function (panelsState: PanelsState, action: PanelsActions)
 
     case "SET_USER_NODES": {
       const userNodes = { ...newPanelsState.userNodes, ...action.payload };
-      Object.keys(action.payload).forEach((key) => {
+      Object.keys(userNodes).forEach((key) => {
         if (userNodes[key] === undefined) {
           delete userNodes[key];
         }
       });
-      newPanelsState.userNodes = userNodes;
+      newPanelsState.userNodes = userNodes as {
+        [K in keyof typeof userNodes]-?: NonNullable<typeof userNodes[K]>;
+      };
       break;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed issues with renaming and deleting Node Playground nodes.

**Description**
Deleting: a bug introduced in #1026. By using `omit` instead of an actual `undefined` value for the node id, I prevented the node from being deleted.

Renaming: a bug caused by binding the initial value of the `save` function inside `editorDidMount`. The cmd-S action wasn't getting updated when the useCallback returned a newly bound function. Thanks @defunctzombie for debugging help.