### PR TITLE
Add version:all script to bump all package versions

### DIFF
--- a/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5938a221e123f45c7277f02f9225c1657c142805111890e78607c31c36b884c6
+size 48671

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
+changesetBaseRefs:
+  - main
+  - origin/main
+
 defaultSemverRangePrefix: ""
 
 nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,5 +13,7 @@ plugins:
     spec: "@yarnpkg/plugin-typescript"
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
     spec: "@yarnpkg/plugin-version"
+  - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+    spec: "@yarnpkg/plugin-workspace-tools"
 
 yarnPath: .yarn/yarn-wrapper.js

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "package:e2e": "yarn && yarn clean && yarn build:prod && yarn package",
     "release:bump-nightly-version": "node -r ts-node/register ./ci/bump-nightly-version.ts",
     "storybook": "cross-env NODE_OPTIONS='--max-old-space-size=6144' TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn workspace @foxglove/studio-base run start-storybook --config-dir src/.storybook",
-    "storybook:ci": "ts-node ./ci/storybook.ts"
+    "storybook:ci": "ts-node ./ci/storybook.ts",
+    "version:all": "yarn workspaces foreach version"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add script to enable bumping version numbers across all workspaces in the repo. Required to enable our future NPM workflows.

This is intended to behave similarly to lerna's fixed/locked mode, i.e. all packages in the repo use the same version number and are bumped in lockstep. Independently versioned packages should live in separate repos where we can more explicitly think through their independent semantic changes.

FWIW I also looked into using lerna, but it doesn't work with yarn 2 workspaces (https://github.com/lerna/lerna/issues/2564), depiste the yarn 2 marketing site claming that "[Yarn workspaces and Lerna don't compete. In fact, Lerna will use Yarn's workspaces if possible](https://yarnpkg.com/features/workspaces#yarn-workspaces-vs-lerna)". Besides, lerna supports a whole bunch of local npm package publishing stuff that we don't need, since we will publish packages from CI.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
