### PR TITLE
Internal: Remove /builtinextensions.js fetch from web ExtensionLoaderProvider

### DIFF
--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -16,29 +16,12 @@ export default function ExtensionRegistryProvider(props: PropsWithChildren<unkno
     log.info("Fetching builtin extensions");
 
     try {
-      const builtinExtensionFetch = await fetch("/builtinextensions.js");
-
-      const extensions: ExtensionInfo[] = [
-        {
-          id: "foxglove.builtin",
-          name: "builtin",
-          displayName: "Built-In Extensions",
-          description: "Foxglove Studio built-in extensions",
-          publisher: "Foxglove",
-          homepage: "https://github.com/foxglove/studio",
-          license: "MPL-2.0",
-          version: "0.0.0",
-          keywords: [],
-        },
-      ];
+      const extensions: ExtensionInfo[] = [];
 
       const loader: ExtensionLoader = {
         getExtensions: () => Promise.resolve(extensions),
-        loadExtension: (id: string): Promise<string> => {
-          if (id === "foxglove.builtin") {
-            return builtinExtensionFetch.text();
-          }
-          throw new Error(`Cannot load ${id}, extension loading is not currently supported on web`);
+        loadExtension: (_id: string): Promise<string> => {
+          throw new Error(`not implemented`);
         },
         downloadExtension,
         installExtension,


### PR DESCRIPTION

**User-Facing Changes**
No more `404` errors for buildinextensions.js when using `yarn serve` from the web folder. We don't publish a web build yet so in practice there are no user facing changes.

**Description**
This was stale code from an extension loading experiment that is no longer relevant.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
