### PR TITLE
Remove version property from non-public packages

### DIFF
--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@foxglove/den",
   "description": "Incubation area for code that may be released under future @foxglove packages",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/electron-socket/package.json
+++ b/packages/electron-socket/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/electron-socket",
-  "version": "0.12.0-dev",
   "description": "Networking sockets for Electron apps",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/hooks",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/just-fetch/package.json
+++ b/packages/just-fetch/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/just-fetch",
-  "version": "0.12.0-dev",
   "description": "Isomorphic ponyfill wrapping native browser fetch and node-fetch",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/log",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/ros1-turtlesim-test/package.json
+++ b/packages/ros1-turtlesim-test/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/ros1-turtlesim-test",
-  "version": "0.12.0-dev",
   "description": "Example @foxglove/ros1 client that interacts with turtlesim",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/ros1/package.json
+++ b/packages/ros1/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/ros1",
-  "version": "0.12.0-dev",
   "description": "TypeScript library for interfacing with ROS1",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/rosmsg-msgs-common/package.json
+++ b/packages/rosmsg-msgs-common/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/rosmsg-msgs-common",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/rosmsg-msgs-foxglove/package.json
+++ b/packages/rosmsg-msgs-foxglove/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/rosmsg-msgs-foxglove",
-  "version": "0.12.0-dev",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/rosmsg-serialization/package.json
+++ b/packages/rosmsg-serialization/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/rosmsg-serialization",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/rosmsg/package.json
+++ b/packages/rosmsg/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/rosmsg",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/studio-firebase/package.json
+++ b/packages/studio-firebase/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/studio-firebase",
-  "version": "0.12.0-dev",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/velodyne-cloud/package.json
+++ b/packages/velodyne-cloud/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/velodyne-cloud",
-  "version": "0.12.0-dev",
   "description": "TypeScript library for converting Velodyne LIDAR packet data to point clouds",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/wasm-bz2/package.json
+++ b/packages/wasm-bz2/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/wasm-bz2",
-  "version": "0.12.0-dev",
   "description": "Bzip2 decompression compiled to WebAssembly",
   "license": "MPL-2.0",
   "private": true,

--- a/packages/xmlrpc/package.json
+++ b/packages/xmlrpc/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@foxglove/xmlrpc",
-  "version": "0.12.0-dev",
   "description": "TypeScript library implementing a XMLRPC client and server with pluggable server backend.",
   "license": "MPL-2.0",
   "private": true,


### PR DESCRIPTION
**User-Facing Changes**
N/A

**Description**
My intention is that everything in the studio repo will be versioned and released together (e.g. studio-base, studio, etc). However, it doesn't make sense to claim version numbers for our "incubation" packages, because when we eventually break these out they will have their own version numbers.

For now, npm/yarn don't care whether or not there is a version string, and it makes the release process slightly more sane if we don't have version numbers listed in the first place (so there is no version number for the release script to bump).

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
