### PR TITLE
Fix: Display bigint (uint64 or int64) values in RawMessage

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/DiffSpan.tsx
+++ b/packages/studio-base/src/panels/RawMessages/DiffSpan.tsx
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import styled from "styled-components";
+
+const DiffSpan = styled.span`
+  padding: 0px 4px;
+  text-decoration: inherit;
+  white-space: pre-line;
+`;
+
+export default DiffSpan;

--- a/packages/studio-base/src/panels/RawMessages/HighlightedValue.tsx
+++ b/packages/studio-base/src/panels/RawMessages/HighlightedValue.tsx
@@ -11,22 +11,16 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useCallback, useState } from "react";
-import styled from "styled-components";
-
-import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import { diffLabels, diffArrow } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 
-// Strings longer than this many characters will start off collapsed.
-const COLLAPSE_TEXT_OVER_LENGTH = 512;
+import DiffSpan from "./DiffSpan";
+import MaybeCollapsedValue from "./MaybeCollapsedValue";
 
-export const SDiffSpan = styled.span`
-  padding: 0px 4px;
-  text-decoration: inherit;
-  white-space: pre-line;
-`;
+type Props = {
+  itemLabel: string;
+};
 
-export function HighlightedValue({ itemLabel }: { itemLabel: string }): JSX.Element {
+export default function HighlightedValue({ itemLabel }: Props): JSX.Element {
   const diffArrowStr = ` ${diffArrow} `;
   // react-json-tree's valueRenderer only gets called for primitives, so diff before/after values must be at same level by the time it gets to the tree
   const splitItemLabel = `${itemLabel}`.split(diffArrowStr);
@@ -36,33 +30,17 @@ export function HighlightedValue({ itemLabel }: { itemLabel: string }): JSX.Elem
     const beforeText = JSON.parse(JSON.stringify(before));
     const afterText = JSON.parse(JSON.stringify(after));
     return (
-      <SDiffSpan style={{ color: diffLabels.CHANGED.color }}>
+      <DiffSpan style={{ color: diffLabels.CHANGED.color }}>
         <MaybeCollapsedValue itemLabel={beforeText} />
         {diffArrowStr}
         <MaybeCollapsedValue itemLabel={afterText} />
-      </SDiffSpan>
+      </DiffSpan>
     );
   }
 
   return (
-    <SDiffSpan>
+    <DiffSpan>
       <MaybeCollapsedValue itemLabel={itemLabel} />
-    </SDiffSpan>
-  );
-}
-
-export function MaybeCollapsedValue({ itemLabel }: { itemLabel: string }): JSX.Element {
-  const lengthOverLimit = itemLabel.length >= COLLAPSE_TEXT_OVER_LENGTH;
-  const [showingEntireLabel, setShowingEntireLabel] = useState(!lengthOverLimit);
-  const itemLabelToShow = showingEntireLabel
-    ? itemLabel
-    : itemLabel.slice(0, COLLAPSE_TEXT_OVER_LENGTH);
-  const expandText = useCallback(() => setShowingEntireLabel(true), []);
-  return (
-    <Tooltip contents={!showingEntireLabel ? "Text was truncated, click to see all" : ""}>
-      <span onClick={expandText} style={{ cursor: !showingEntireLabel ? "pointer" : "inherit" }}>
-        {`${itemLabelToShow}${!showingEntireLabel ? "..." : ""}`}
-      </span>
-    </Tooltip>
+    </DiffSpan>
   );
 }

--- a/packages/studio-base/src/panels/RawMessages/MaybeCollapsedValue.tsx
+++ b/packages/studio-base/src/panels/RawMessages/MaybeCollapsedValue.tsx
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { useCallback, useState } from "react";
+
+import Tooltip from "@foxglove/studio-base/components/Tooltip";
+
+// Strings longer than this many characters will start off collapsed.
+const COLLAPSE_TEXT_OVER_LENGTH = 512;
+
+type Props = { itemLabel: string };
+
+export default function MaybeCollapsedValue({ itemLabel }: Props): JSX.Element {
+  const lengthOverLimit = itemLabel.length >= COLLAPSE_TEXT_OVER_LENGTH;
+
+  const [showingEntireLabel, setShowingEntireLabel] = useState(!lengthOverLimit);
+
+  const expandText = useCallback(() => setShowingEntireLabel(true), []);
+
+  const truncatedItemText = showingEntireLabel
+    ? itemLabel
+    : itemLabel.slice(0, COLLAPSE_TEXT_OVER_LENGTH);
+
+  return (
+    <Tooltip contents={!showingEntireLabel ? "Text was truncated, click to see all" : undefined}>
+      <span onClick={expandText} style={{ cursor: !showingEntireLabel ? "pointer" : "inherit" }}>
+        {`${truncatedItemText}${!showingEntireLabel ? "..." : ""}`}
+      </span>
+    </Tooltip>
+  );
+}

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -7,7 +7,7 @@ import ConsoleLineIcon from "@mdi/svg/svg/console-line.svg";
 import Icon from "@foxglove/studio-base/components/Icon";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 
-import { HighlightedValue } from "./Diff";
+import HighlightedValue from "./HighlightedValue";
 import RawMessagesIcons from "./RawMessagesIcons";
 import { ValueAction } from "./getValueActionForValue";
 import styles from "./index.module.scss";

--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -20,6 +20,7 @@ export const fixture = {
     { name: "/foo", datatype: "std_msgs/String" },
     { name: `${SECOND_SOURCE_PREFIX}/foo`, datatype: "std_msgs/String" },
     { name: "/baz/num", datatype: "baz/num" },
+    { name: "/baz/bigint", datatype: "baz/bigint" },
     { name: "/baz/text", datatype: "baz/text" },
     { name: "/baz/array", datatype: "baz/array" },
     { name: "/baz/array/obj", datatype: "baz/array/obj" },
@@ -86,6 +87,18 @@ export const fixture = {
         message: { value: 3425363211 },
       },
     ],
+    "/baz/bigint": [
+      {
+        topic: "/baz/bigint",
+        receiveTime: { sec: 123, nsec: 456789012 },
+        message: { value: 18446744073709551615n },
+      },
+      {
+        topic: "/baz/bigint",
+        receiveTime: { sec: 123, nsec: 456789013 },
+        message: { value: 18446744073709551616n },
+      },
+    ],
     "/baz/text": [
       {
         topic: "/baz/text",
@@ -134,6 +147,7 @@ export const fixture = {
   },
   datatypes: {
     "baz/num": { fields: [{ name: "value", type: "float64" }] },
+    "baz/bigint": { fields: [{ name: "value", type: "uint64" }] },
     "baz/text": {
       fields: [
         { name: "value", type: "string" },

--- a/packages/studio-base/src/panels/RawMessages/getDiff.ts
+++ b/packages/studio-base/src/panels/RawMessages/getDiff.ts
@@ -172,9 +172,11 @@ export default function getDiff(
       [diffLabels.DELETED.labelText]: { ...idLabelObj, ...(before as DiffObject) },
     };
   }
+
+  const beforeText = typeof before === "bigint" ? before.toString() : JSON.stringify(before);
+  const afterText = typeof after === "bigint" ? after.toString() : JSON.stringify(after);
+
   return {
-    [diffLabels.CHANGED.labelText]: `${JSON.stringify(before) ?? ""} ${diffArrow} ${
-      JSON.stringify(after) ?? ""
-    }`,
+    [diffLabels.CHANGED.labelText]: `${beforeText} ${diffArrow} ${afterText}`,
   };
 }

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -75,6 +75,20 @@ storiesOf("panels/RawMessages/index", module)
       </PanelSetup>
     );
   })
+  .add("display message with bigint value", () => {
+    return (
+      <PanelSetup fixture={fixture} style={{ width: 350 }}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  })
+  .add("display bigint value", () => {
+    return (
+      <PanelSetup fixture={fixture} style={{ width: 350 }}>
+        <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
+      </PanelSetup>
+    );
+  })
   .add("display big value – text", () => {
     return (
       <PanelSetup fixture={fixture} style={{ width: 350 }}>
@@ -214,6 +228,21 @@ storiesOf("panels/RawMessages/index", module)
         <RawMessages
           overrideConfig={{
             topicPath: "/foo",
+            diffMethod: PREV_MSG_METHOD,
+            diffTopicPath: "",
+            diffEnabled: true,
+            showFullMessageForDiff: true,
+          }}
+        />
+      </PanelSetup>
+    );
+  })
+  .add("diff consecutive messages with bigint", () => {
+    return (
+      <PanelSetup fixture={fixture} style={{ width: 350 }} onMount={expandAll}>
+        <RawMessages
+          overrideConfig={{
+            topicPath: "/baz/bigint",
             diffMethod: PREV_MSG_METHOD,
             diffTopicPath: "",
             diffEnabled: true,


### PR DESCRIPTION
**User-Facing Changes**
Prior to this change, the RawMessage panel would display <BigInt>
when viewing a message with int64/uint64 fields which were de-serialized
into a bigint. This change updates the value display to special case
bigint values to display the actual value.

![image](https://user-images.githubusercontent.com/84792/123136022-52909a00-d407-11eb-92bd-ce84c32a53c4.png)

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
