### PR TITLE
Update RawMessage panel to allow filtering on any field

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/RawMessagesIcons.tsx
+++ b/packages/studio-base/src/panels/RawMessages/RawMessagesIcons.tsx
@@ -13,7 +13,7 @@
 import ChartBubbleIcon from "@mdi/svg/svg/chart-bubble.svg";
 import ChartLineVariantIcon from "@mdi/svg/svg/chart-line-variant.svg";
 import DotsHorizontalIcon from "@mdi/svg/svg/dots-horizontal.svg";
-import TargetIcon from "@mdi/svg/svg/target.svg";
+import FilterIcon from "@mdi/svg/svg/filter.svg";
 import { ReactElement, useCallback } from "react";
 
 import Icon from "@foxglove/studio-base/components/Icon";
@@ -40,6 +40,8 @@ export default function RawMessagesIcons({
   onTopicPathChange,
   openSiblingPanel,
 }: Props): ReactElement {
+  const { singleSlicePath, multiSlicePath, primitiveType, filterPath } = valueAction;
+
   const openPlotPanel = useCallback(
     (pathSuffix: string) => () => {
       openSiblingPlotPanel(openSiblingPanel, `${basePath}${pathSuffix}`);
@@ -52,27 +54,24 @@ export default function RawMessagesIcons({
     },
     [basePath, openSiblingPanel],
   );
-  const onPivot = useCallback(
-    () =>
-      onTopicPathChange(`${basePath}${valueAction.type === "pivot" ? valueAction.pivotPath : ""}`),
-    [basePath, onTopicPathChange, valueAction],
+  const onFilter = useCallback(
+    () => onTopicPathChange(`${basePath}${filterPath}`),
+    [basePath, filterPath, onTopicPathChange],
   );
-  if (valueAction.type === "pivot") {
-    return (
-      <Icon
-        fade
-        className={styles.icon}
-        onClick={onPivot}
-        tooltip="Pivot on this value"
-        key="pivot"
-      >
-        <TargetIcon />
-      </Icon>
-    );
-  }
-  const { singleSlicePath, multiSlicePath, primitiveType } = valueAction;
+
   return (
     <span>
+      {filterPath.length > 0 && (
+        <Icon
+          fade
+          className={styles.icon}
+          onClick={onFilter}
+          tooltip="filter on this value"
+          key="filter"
+        >
+          <FilterIcon />
+        </Icon>
+      )}
       {plotableRosTypes.includes(primitiveType) && (
         <Icon
           fade

--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -28,7 +28,7 @@ describe("getValueActionForValue", () => {
     expect(getAction({}, structureItem, [])).toEqual(undefined);
   });
 
-  it("returns a pivot path when pointed at an id inside an array", () => {
+  it("returns paths for an id inside an array", () => {
     const structureItem = {
       structureType: "array",
       next: {
@@ -45,8 +45,10 @@ describe("getValueActionForValue", () => {
       datatype: "",
     };
     expect(getAction([{ some_id: 123 }], structureItem, [0, "some_id"])).toEqual({
-      type: "pivot",
-      pivotPath: "[:]{some_id==123}",
+      filterPath: "[:]{some_id==123}",
+      multiSlicePath: "[:].some_id",
+      primitiveType: "uint32",
+      singleSlicePath: "[:]{some_id==123}.some_id",
     });
   });
 
@@ -63,7 +65,7 @@ describe("getValueActionForValue", () => {
       datatype: "",
     };
     expect(getAction({ some_id: 123 }, structureItem, ["some_id"])).toEqual({
-      type: "primitive",
+      filterPath: "",
       singleSlicePath: ".some_id",
       multiSlicePath: ".some_id",
       primitiveType: "uint32",
@@ -87,7 +89,7 @@ describe("getValueActionForValue", () => {
       datatype: "",
     };
     expect(getAction([{ some_value: 456 }], structureItem, [0, "some_value"])).toEqual({
-      type: "primitive",
+      filterPath: "[:]{some_value==456}",
       singleSlicePath: "[0].some_value",
       multiSlicePath: "[:].some_value",
       primitiveType: "uint32",
@@ -118,7 +120,7 @@ describe("getValueActionForValue", () => {
     expect(
       getAction([{ some_id: 123, some_value: 456 }], structureItem, [0, "some_value"]),
     ).toEqual({
-      type: "primitive",
+      filterPath: "[:]{some_value==456}",
       singleSlicePath: "[:]{some_id==123}.some_value",
       multiSlicePath: "[:].some_value",
       primitiveType: "uint32",
@@ -128,10 +130,10 @@ describe("getValueActionForValue", () => {
   it("returns value when looking inside a 'json' primitive", () => {
     const structureItem = { structureType: "primitive", primitiveType: "json", datatype: "" };
     expect(getAction({ abc: 0, def: 0 }, structureItem, ["abc"])).toEqual({
+      filterPath: "",
       multiSlicePath: ".abc",
       primitiveType: "json",
       singleSlicePath: ".abc",
-      type: "primitive",
     });
   });
 
@@ -154,7 +156,7 @@ describe("getValueActionForValue", () => {
         "nested_key",
       ]),
     ).toEqual({
-      type: "primitive",
+      filterPath: "",
       singleSlicePath: "[0].outer_key.nested_key",
       multiSlicePath: "[:].outer_key.nested_key",
       primitiveType: "json",
@@ -183,7 +185,7 @@ describe("getValueActionForValue", () => {
       datatype: "",
     };
     expect(getAction({ some_id: 123 }, structureItem, ["some_id"])).toEqual({
-      type: "primitive",
+      filterPath: "",
       singleSlicePath: ".some_id",
       multiSlicePath: ".some_id",
       primitiveType: "json",
@@ -226,7 +228,7 @@ describe("getValueActionForValue", () => {
       datatype: "msgs/nodeArray",
     };
     expect(getAction(rootValue, rootStructureItem, ["status", 0, "level"])).toEqual({
-      type: "primitive",
+      filterPath: ".status[:]{level==0}",
       singleSlicePath: '.status[:]{node_id=="/my_node"}.level',
       multiSlicePath: ".status[:].level",
       primitiveType: "int8",


### PR DESCRIPTION
**User-Facing Changes**

Previously the RawMessage panel would limit when a user could "pivot"
a field to certain conditions. This change removes those restrictions
and allows a user to select any field within an array of objects as
the filter value.

This change renames the "pivot" tooltip to "filter" as that better conveys
what the action does.

<img width="429" alt="Screen Shot 2021-06-23 at 3 30 40 PM" src="https://user-images.githubusercontent.com/84792/123176850-1118e280-d439-11eb-96e0-e9d0a894c6c3.png">
<img width="431" alt="Screen Shot 2021-06-23 at 3 27 59 PM" src="https://user-images.githubusercontent.com/84792/123176853-11b17900-d439-11eb-9263-2a4e65c3a61c.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
