### PR TITLE
Force any browser window navigation outside the app into external browser

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -100,6 +100,18 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     shell.openExternal(url);
   });
 
+  browserWindow.webContents.on("will-navigate", (event, reqUrl) => {
+    // if the target url is not the same as our host then force open in a browser
+    // URL.host includes the port - so this works for localhost servers vs webpack dev server
+    const targetHost = new URL(reqUrl).host;
+    const currentHost = new URL(browserWindow.webContents.getURL()).host;
+    const isExternal = targetHost !== currentHost;
+    if (isExternal) {
+      event.preventDefault();
+      shell.openExternal(reqUrl);
+    }
+  });
+
   browserWindow.webContents.on("ipc-message", (_event: unknown, channel: string) => {
     if (channel === "window.toolbar-double-clicked") {
       const action: string =

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -106,9 +106,7 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
         <IconButton iconProps={{ iconName: "ChevronLeft" }} onClick={onClose} />,
       ]}
     >
-      <ExtensionId href={extension.homepage} target="_blank">
-        {extension.id}
-      </ExtensionId>
+      <ExtensionId href={extension.homepage}>{extension.id}</ExtensionId>
       <Version>{`v${extension.version}`}</Version>
       <License>{extension.license}</License>
       <Publisher>{extension.publisher}</Publisher>

--- a/packages/studio-base/src/components/Modal.stories.tsx
+++ b/packages/studio-base/src/components/Modal.stories.tsx
@@ -74,7 +74,7 @@ storiesOf("components/Modal", module)
     <Modal onRequestClose={() => action("close")()}>
       <div style={{ padding: 20 }}>
         <TextContent>
-          <a href="https://google.com" target="_blank" rel="noopener noreferrer">
+          <a href="https://google.com" rel="noopener noreferrer">
             link
           </a>
           <div>this is a floating, fixed position modal</div>

--- a/packages/studio-base/src/components/TextContent.tsx
+++ b/packages/studio-base/src/components/TextContent.tsx
@@ -35,7 +35,6 @@ export default function TextContent(props: PropsWithChildren<Props>): React.Reac
       return (
         <a
           href={linkProps.href}
-          target="_blank"
           rel="noopener noreferrer"
           onClick={(event) => handleLink(event, linkProps.href ?? "")}
         >

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -81,7 +81,6 @@ export default function Metadata({
       {!diffMessage && datatype && (
         <a
           style={{ color: "inherit" }}
-          target="_blank"
           rel="noopener noreferrer"
           href={getMessageDocumentationLink(datatype)}
         >

--- a/packages/studio-base/src/panels/WelcomePanel/index.tsx
+++ b/packages/studio-base/src/panels/WelcomePanel/index.tsx
@@ -43,7 +43,7 @@ function WelcomePanel() {
 
   const [submitState, submit] = useAsyncFn(async () => {
     if (slackInviteChecked && process.env.SLACK_INVITE_URL != undefined) {
-      open(process.env.SLACK_INVITE_URL, "_blank");
+      open(process.env.SLACK_INVITE_URL);
     }
     if (subscribeChecked) {
       await subscribeToNewsletter(emailValue);


### PR DESCRIPTION

**User-Facing Changes**
None. All links that used an explicit _blank target will continue to open in external browser.

**Description**
Rather than allowing the browser window to navigate away from the
studio app, handle the will-navigate event and send to external browser.

This prevents anchor tags or other navigation from inadvertently replacing
the studio window contents with another web page.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
