### PR TITLE
Revert "Switch to external @foxglove/rosmsg package"

### DIFF
--- a/packages/ros1/package.json
+++ b/packages/ros1/package.json
@@ -28,7 +28,7 @@
     "typescript": "4.3.4"
   },
   "dependencies": {
-    "@foxglove/rosmsg": "0.1.1",
+    "@foxglove/rosmsg": "workspace:packages/rosmsg",
     "@foxglove/rosmsg-serialization": "workspace:packages/rosmsg-serialization",
     "@foxglove/xmlrpc": "workspace:*",
     "eventemitter3": "4.0.7",

--- a/packages/rosmsg-msgs-common/package.json
+++ b/packages/rosmsg-msgs-common/package.json
@@ -22,7 +22,7 @@
     "prepack": "node -r esbuild-runner/register src/index.ts"
   },
   "dependencies": {
-    "@foxglove/rosmsg": "0.1.1"
+    "@foxglove/rosmsg": "workspace:*"
   },
   "devDependencies": {
     "@types/prettier": "2.3.0",

--- a/packages/rosmsg-msgs-foxglove/package.json
+++ b/packages/rosmsg-msgs-foxglove/package.json
@@ -21,7 +21,7 @@
     "prepack": "node -r esbuild-runner/register src/index.ts"
   },
   "dependencies": {
-    "@foxglove/rosmsg": "0.1.1"
+    "@foxglove/rosmsg": "workspace:*"
   },
   "devDependencies": {
     "@types/prettier": "2.3.0",

--- a/packages/rosmsg-serialization/src/MessageWriter.test.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.test.ts
@@ -97,6 +97,65 @@ describe("MessageWriter", () => {
       expect(writer.writeMessage({ name: "test" })).toEqual(buff);
     });
 
+    it("writes JSON", () => {
+      const writer = new MessageWriter(
+        parseMessageDefinition("#pragma rosbag_parse_json\nstring dummy"),
+      );
+      const buff = getStringBytes('{"foo":123,"bar":{"nestedFoo":456}}');
+      expect(
+        writer.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+        }),
+      ).toEqual(buff);
+
+      const writerWithNestedComplexType = new MessageWriter(
+        parseMessageDefinition(`#pragma rosbag_parse_json
+      string dummy
+      Account account
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `),
+      );
+      expect(
+        writerWithNestedComplexType.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+          account: { name: '{"first":"First","last":"Last"}}', id: 100 },
+        }),
+      ).toEqual(
+        concat([
+          buff,
+          getStringBytes('{"first":"First","last":"Last"}}'),
+          new Uint8Array([100, 0x00]),
+        ]),
+      );
+
+      const writerWithTrailingPragmaComment = new MessageWriter(
+        parseMessageDefinition(`#pragma rosbag_parse_json
+      string dummy
+      Account account
+      #pragma rosbag_parse_json
+      ============
+      MSG: custom_type/Account
+      string name
+      uint16 id
+      `),
+      );
+      expect(
+        writerWithTrailingPragmaComment.writeMessage({
+          dummy: { foo: 123, bar: { nestedFoo: 456 } },
+          account: { name: '{"first":"First","last":"Last"}}', id: 100 },
+        }),
+      ).toEqual(
+        concat([
+          buff,
+          getStringBytes('{"first":"First","last":"Last"}}'),
+          new Uint8Array([100, 0x00]),
+        ]),
+      );
+    });
+
     it("writes time", () => {
       const writer = new MessageWriter(parseMessageDefinition("time right_now"));
       const buff = new Uint8Array(8);

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -48,9 +48,6 @@ class StandardTypeOffsetCalculator {
   // The following are used in the StandardTypeWriter.
   string(value: string): number {
     // int32 length
-    if (typeof value !== "string") {
-      throw new Error(`Expected string but got ${typeof value}`);
-    }
     const length = 4 + value.length;
     return this._incrementAndReturn(length);
   }

--- a/packages/rosmsg/README.md
+++ b/packages/rosmsg/README.md
@@ -1,0 +1,12 @@
+# rosmsg
+
+Parse ROS message definitions
+
+```Typescript
+import { parse } from "@foxglove/rosmsg";
+
+const parsedMsgDef = parse(`
+    string name
+    int32 var
+`);
+```

--- a/packages/rosmsg/jest.config.json
+++ b/packages/rosmsg/jest.config.json
@@ -1,0 +1,8 @@
+{
+  "testMatch": ["<rootDir>/src/**/*.test.ts"],
+  "transform": {
+    "\\.[jt]sx?$": ["babel-jest", { "rootMode": "upward" }]
+  },
+  "//": "Native find is slow because it does not exclude files: https://github.com/facebook/jest/pull/11264#issuecomment-825377579",
+  "haste": { "forceNodeFilesystemAPI": true }
+}

--- a/packages/rosmsg/package.json
+++ b/packages/rosmsg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foxglove/rosmsg-serialization",
+  "name": "@foxglove/rosmsg",
   "license": "MPL-2.0",
   "private": true,
   "repository": {
@@ -21,9 +21,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/prettier": "2.3.0",
     "jest": "27.0.5",
-    "prettier": "2.3.1",
     "typescript": "4.3.4"
   }
 }

--- a/packages/rosmsg/src/index.ts
+++ b/packages/rosmsg/src/index.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export * from "./parse";
+export * from "./stringify";
+export * from "./types";

--- a/packages/rosmsg/src/parse.test.ts
+++ b/packages/rosmsg/src/parse.test.ts
@@ -1,0 +1,297 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { parse } from "./parse";
+
+describe("parseMessageDefinition", () => {
+  it("parses a single field from a single message", () => {
+    const types = parse("string name");
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "name",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("resolves unqualified names", () => {
+    const messageDefinition = `
+      Point[] points
+      ============
+      MSG: geometry_msgs/Point
+      float64 x
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: true,
+            isComplex: true,
+            name: "points",
+            type: "geometry_msgs/Point",
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "x",
+            type: "float64",
+          },
+        ],
+        name: "geometry_msgs/Point",
+      },
+    ]);
+  });
+
+  it("normalizes aliases", () => {
+    const types = parse("char x\nbyte y");
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "x",
+            type: "uint8",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "y",
+            type: "int8",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("ignores comment lines", () => {
+    const messageDefinition = `
+    # your first name goes here
+    string firstName
+
+    # last name here
+    ### foo bar baz?
+    string lastName
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "firstName",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "lastName",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses variable length string array", () => {
+    const types = parse("string[] names");
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: true,
+            isComplex: false,
+            name: "names",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses fixed length string array", () => {
+    const types = parse("string[3] names");
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: 3,
+            isArray: true,
+            isComplex: false,
+            name: "names",
+            type: "string",
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("parses nested complex types", () => {
+    const messageDefinition = `
+    string username
+    Account account
+    ============
+    MSG: custom_type/Account
+    string name
+    uint16 id
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "username",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: true,
+            name: "account",
+            type: "custom_type/Account",
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "name",
+            type: "string",
+          },
+          {
+            arrayLength: undefined,
+            isArray: false,
+            isComplex: false,
+            name: "id",
+            type: "uint16",
+          },
+        ],
+        name: "custom_type/Account",
+      },
+    ]);
+  });
+
+  it("returns constants", () => {
+    const messageDefinition = `
+      uint32 foo = 55
+      int32 bar=-11 # Comment # another comment
+      float32 baz= \t -32.25
+      bool someBoolean = 0
+      string fooStr = Foo    ${""}
+      string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            name: "foo",
+            type: "uint32",
+            isConstant: true,
+            value: 55,
+          },
+          {
+            name: "bar",
+            type: "int32",
+            isConstant: true,
+            value: -11,
+          },
+          {
+            name: "baz",
+            type: "float32",
+            isConstant: true,
+            value: -32.25,
+          },
+          {
+            name: "someBoolean",
+            type: "bool",
+            isConstant: true,
+            value: false,
+          },
+          {
+            name: "fooStr",
+            type: "string",
+            isConstant: true,
+            value: "Foo",
+          },
+          {
+            name: "EXAMPLE",
+            type: "string",
+            isConstant: true,
+            value: '"#comments" are ignored, and leading and trailing whitespace removed',
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+
+  it("works with python boolean values", () => {
+    const messageDefinition = `
+      bool Alive=True
+      bool Dead=False
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            name: "Alive",
+            type: "bool",
+            isConstant: true,
+            value: true,
+          },
+          {
+            name: "Dead",
+            type: "bool",
+            isConstant: true,
+            value: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/rosmsg/src/parse.ts
+++ b/packages/rosmsg/src/parse.ts
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { RosMsgField, RosMsgDefinition } from "./types";
+
+// Set of built-in ros types. See http://wiki.ros.org/msg#Field_Types
+export const rosPrimitiveTypes: Set<string> = new Set([
+  "string",
+  "bool",
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "float32",
+  "float64",
+  "int64",
+  "uint64",
+  "time",
+  "duration",
+  "json",
+]);
+
+function normalizeType(type: string) {
+  // Normalize deprecated aliases.
+  let normalizedType = type;
+  if (type === "char") {
+    normalizedType = "uint8";
+  }
+  if (type === "byte") {
+    normalizedType = "int8";
+  }
+  return normalizedType;
+}
+
+// represents a single line in a message definition type
+// e.g. 'string name' 'CustomType[] foo' 'string[3] names'
+function newArrayDefinition(
+  type: string,
+  name: string,
+  arrayLength: number | undefined,
+): RosMsgField {
+  const normalizedType = normalizeType(type);
+  return {
+    type: normalizedType,
+    name,
+    isArray: true,
+    arrayLength: arrayLength,
+    isComplex: !rosPrimitiveTypes.has(normalizedType),
+  };
+}
+
+function newDefinition(type: string, name: string): RosMsgField {
+  const normalizedType = normalizeType(type);
+  return {
+    type: normalizedType,
+    name,
+    isArray: false,
+    isComplex: !rosPrimitiveTypes.has(normalizedType),
+  };
+}
+
+const buildType = (lines: { isJson: boolean; line: string }[]): RosMsgDefinition => {
+  const definitions: RosMsgField[] = [];
+  let complexTypeName: string | undefined;
+  lines.forEach(({ isJson, line }) => {
+    // remove comments and extra whitespace from each line
+    const splits = line
+      .replace(/#.*/gi, "")
+      .split(" ")
+      .filter((word) => word);
+
+    const type = splits[0]?.trim();
+    const name = splits[1]?.trim();
+    if (type == undefined || name == undefined) {
+      return;
+    }
+
+    if (type === "MSG:") {
+      complexTypeName = name;
+    } else if (name.includes("=") || splits.includes("=")) {
+      // constant type parsing
+      const matches = line.match(/(\S+)\s*=\s*(.*)\s*/);
+      if (!matches || matches[1] == undefined || matches[2] == undefined) {
+        throw new Error("Malformed line: " + line);
+      }
+      let match: string = matches[2];
+      let value: string | number | boolean = match;
+      if (type !== "string") {
+        // handle special case of python bool values
+        match = match.replace(/True/gi, "true");
+        match = match.replace(/False/gi, "false");
+        value = match;
+        try {
+          value = JSON.parse(match.replace(/\s*#.*/g, ""));
+        } catch (error) {
+          console.warn(`Error in this constant definition: ${line}`);
+          throw error;
+        }
+        if (type === "bool") {
+          value = Boolean(value);
+        }
+      }
+      if (
+        (type.includes("int") && Number(value) > Number.MAX_SAFE_INTEGER) ||
+        Number(value) < Number.MIN_SAFE_INTEGER
+      ) {
+        console.warn(`Found integer constant outside safe integer range: ${line}`);
+      }
+      definitions.push({
+        type: normalizeType(type),
+        name: matches[1],
+        isConstant: true,
+        value,
+      });
+    } else if (type.indexOf("]") === type.length - 1) {
+      // array type parsing
+      const typeSplits = type.split("[");
+      const baseType = typeSplits[0];
+      const len = typeSplits[1]?.replace("]", "");
+      if (baseType == undefined) {
+        throw new Error("Error in array type parsing: baseType not defined");
+      }
+      definitions.push(
+        newArrayDefinition(
+          baseType,
+          name,
+          len != undefined && len.length > 0 ? parseInt(len, 10) : undefined,
+        ),
+      );
+    } else {
+      definitions.push(newDefinition(isJson ? "json" : type, name));
+    }
+  });
+  return { name: complexTypeName, definitions };
+};
+
+const findTypeByName = (types: RosMsgDefinition[], name: string): RosMsgDefinition => {
+  const matches = types.filter((type) => {
+    const typeName = type.name ?? "";
+    // if the search is empty, return unnamed types
+    if (name.length === 0) {
+      return typeName.length === 0;
+    }
+    // return if the search is in the type name
+    // or matches exactly if a fully-qualified name match is passed to us
+    const nameEnd = name.includes("/") ? name : `/${name}`;
+    return typeName.endsWith(nameEnd);
+  });
+  if (matches[0] == undefined) {
+    throw new Error(
+      `Expected 1 top level type definition for '${name}' but found ${matches.length}`,
+    );
+  }
+  return matches[0];
+};
+
+// Given a raw message definition string, parse it into an object representation.
+// Example return value:
+// [{
+//   name: undefined,
+//   definitions: [
+//     {
+//       arrayLength: undefined,
+//       isArray: false,
+//       isComplex: false,
+//       name: "name",
+//       type: "string",
+//     }, ...
+//   ],
+// }, ... ]
+//
+// See unit tests for more examples.
+export function parse(messageDefinition: string): RosMsgDefinition[] {
+  // read all the lines and remove empties
+  const allLines = messageDefinition
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line);
+
+  let definitionLines: { isJson: boolean; line: string }[] = [];
+  const types: RosMsgDefinition[] = [];
+  let nextDefinitionIsJson = false;
+  // group lines into individual definitions
+  allLines.forEach((line) => {
+    // ignore comment lines unless they start with #pragma rosbag_parse_json
+    if (line.startsWith("#")) {
+      if (line.startsWith("#pragma rosbag_parse_json")) {
+        nextDefinitionIsJson = true;
+      }
+      return;
+    }
+
+    // definitions are split by equal signs
+    if (line.startsWith("==")) {
+      nextDefinitionIsJson = false;
+      types.push(buildType(definitionLines));
+      definitionLines = [];
+    } else {
+      definitionLines.push({ isJson: nextDefinitionIsJson, line });
+      nextDefinitionIsJson = false;
+    }
+  });
+  types.push(buildType(definitionLines));
+
+  // Fix up complex type names
+  types.forEach(({ definitions }) => {
+    definitions.forEach((definition) => {
+      if (definition.isComplex ?? false) {
+        const foundName = findTypeByName(types, definition.type).name;
+        if (foundName === undefined) {
+          throw new Error(`Missing type definition for ${definition.type}`);
+        }
+        definition.type = foundName;
+      }
+    });
+  });
+
+  return types;
+}

--- a/packages/rosmsg/src/stringify.test.ts
+++ b/packages/rosmsg/src/stringify.test.ts
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { parse } from "./parse";
+import { stringify } from "./stringify";
+
+describe("stringify", () => {
+  it("round trips a definition into canonical format", () => {
+    const messageDefinition = `
+      uint32 foo = 55
+      int32 bar=-11 # Comment # another comment
+      string test
+      float32 baz= \t -32.25
+      bool someBoolean = 0
+      Point[] points
+      string fooStr = Foo    ${""}
+      string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
+      ============
+      MSG: geometry_msgs/Point
+      float64 x
+    `;
+    const types = parse(messageDefinition);
+
+    const output = stringify(types);
+    expect(output).toEqual(`uint32 foo = 55
+int32 bar = -11
+float32 baz = -32.25
+bool someBoolean = false
+string fooStr = Foo
+string EXAMPLE = "#comments" are ignored, and leading and trailing whitespace removed
+
+string test
+geometry_msgs/Point[] points
+
+================================================================================
+MSG: geometry_msgs/Point
+
+float64 x
+`);
+  });
+});

--- a/packages/rosmsg/src/stringify.ts
+++ b/packages/rosmsg/src/stringify.ts
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { RosMsgDefinition } from "./types";
+
+// Converts a ROS message definition (http://wiki.ros.org/msg) into a canonical
+// message description format that is suitable for MD5 checksum generation
+export function stringify(msgDefs: RosMsgDefinition[]): string {
+  let output = "";
+  for (let i = 0; i < msgDefs.length; i++) {
+    const msgDef = msgDefs[i] as RosMsgDefinition;
+    const constants = msgDef.definitions.filter(({ isConstant }) => isConstant);
+    const variables = msgDef.definitions.filter(
+      ({ isConstant }) => isConstant == undefined || !isConstant,
+    );
+
+    if (i > 0) {
+      output +=
+        "\n================================================================================\n";
+      output += `MSG: ${msgDef.name ?? ""}\n`;
+    }
+
+    for (const def of constants) {
+      output += `${def.type} ${def.name} = ${def.value}\n`;
+    }
+    if (variables.length > 0) {
+      output += "\n";
+      for (const def of variables) {
+        output += `${def.type}${def.isArray === true ? "[]" : ""} ${def.name}\n`;
+      }
+    }
+  }
+
+  return output;
+}

--- a/packages/rosmsg/src/types.ts
+++ b/packages/rosmsg/src/types.ts
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+export type RosMsgField = {
+  type: string;
+  name: string;
+  isComplex?: boolean;
+
+  // For arrays
+  isArray?: boolean;
+  arrayLength?: number | undefined;
+
+  // For constants
+  isConstant?: boolean;
+  value?: string | number | boolean | undefined;
+};
+
+export type RosMsgDefinition = {
+  name?: string;
+  definitions: RosMsgField[];
+};

--- a/packages/rosmsg/tsconfig.json
+++ b/packages/rosmsg/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@foxglove/tsconfig/tsconfig.base.json",
+  "include": ["./src/**/*"],
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,7 +2604,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/ros1@workspace:packages/ros1"
   dependencies:
-    "@foxglove/rosmsg": 0.1.1
+    "@foxglove/rosmsg": "workspace:packages/rosmsg"
     "@foxglove/rosmsg-serialization": "workspace:packages/rosmsg-serialization"
     "@foxglove/xmlrpc": "workspace:*"
     esbuild-runner: 2.2.0
@@ -2620,7 +2620,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/rosmsg-msgs-common@workspace:packages/rosmsg-msgs-common"
   dependencies:
-    "@foxglove/rosmsg": 0.1.1
+    "@foxglove/rosmsg": "workspace:*"
     "@types/prettier": 2.3.0
     esbuild-runner: 2.2.0
     prettier: 2.3.1
@@ -2632,7 +2632,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/rosmsg-msgs-foxglove@workspace:packages/rosmsg-msgs-foxglove"
   dependencies:
-    "@foxglove/rosmsg": 0.1.1
+    "@foxglove/rosmsg": "workspace:*"
     "@types/prettier": 2.3.0
     esbuild-runner: 2.2.0
     prettier: 2.3.1
@@ -2644,7 +2644,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/rosmsg-serialization@workspace:packages/rosmsg-serialization"
   dependencies:
-    "@foxglove/rosmsg": 0.1.1
     "@types/prettier": 2.3.0
     jest: 27.0.5
     prettier: 2.3.1
@@ -2652,15 +2651,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/rosmsg@npm:0.1.1":
-  version: 0.1.1
-  resolution: "@foxglove/rosmsg@npm:0.1.1"
+"@foxglove/rosmsg@workspace:*, @foxglove/rosmsg@workspace:packages/rosmsg":
+  version: 0.0.0-use.local
+  resolution: "@foxglove/rosmsg@workspace:packages/rosmsg"
   dependencies:
-    moo: ^0.5.1
-    nearley: ^2.20.1
-  checksum: 54309a60a8c590c7c35aa2dcf039831f5a0ba041bbc40288a92d6c769fbfafe1fae588332530ad966c7430f521717323bd7f6fc3b71c2b50cf6e4695653f0db4
-  languageName: node
-  linkType: hard
+    jest: 27.0.5
+    typescript: 4.3.4
+  languageName: unknown
+  linkType: soft
 
 "@foxglove/studio-base@workspace:*, @foxglove/studio-base@workspace:packages/studio-base":
   version: 0.0.0-use.local
@@ -18678,7 +18676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moo@npm:^0.5.0, moo@npm:^0.5.1":
+"moo@npm:^0.5.0":
   version: 0.5.1
   resolution: "moo@npm:0.5.1"
   checksum: 2d8c013f1f9aad8e5c7a9d4a03dbb4eecd91b9fe5e9446fbc7561fd38d4d161c742434acff385722542fe7b360fce9c586da62442379e62e4158ad49c7e1a6b7
@@ -18850,7 +18848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nearley@npm:2.20.1, nearley@npm:^2.20.1, nearley@npm:^2.7.10":
+"nearley@npm:2.20.1, nearley@npm:^2.7.10":
   version: 2.20.1
   resolution: "nearley@npm:2.20.1"
   dependencies:


### PR DESCRIPTION
Reverts foxglove/studio#1304

Certain bags are not properly handled because message definitions cannot be parsed. Example failing definition: `time time_ref`