### PR TITLE
Refactor HelpModal to use @fluentui/react Modal

### DIFF
--- a/packages/studio-base/src/components/HelpModal.tsx
+++ b/packages/studio-base/src/components/HelpModal.tsx
@@ -11,35 +11,63 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { IconButton, Modal, makeStyles, useTheme } from "@fluentui/react";
 import { PropsWithChildren, ReactElement } from "react";
-import styled, { CSSProperties } from "styled-components";
 
-import Modal from "@foxglove/studio-base/components/Modal";
 import TextContent from "@foxglove/studio-base/components/TextContent";
 
-const SRoot = styled.div`
-  max-width: 700px; // Px value because beyond a certain absolute width the lines become harder to read.
-  width: calc(100vw - 30px);
-  max-height: calc(100vh - 30px);
-  overflow-y: auto;
-  padding: 2.5em;
-`;
-
-type Props = {
-  onRequestClose: () => void;
-  rootStyle?: CSSProperties;
-};
+const useStyles = makeStyles((theme) => ({
+  content: {
+    padding: theme.spacing.l1,
+  },
+  header: {
+    backgroundColor: theme.semanticColors.bodyBackground,
+    display: "flex",
+    flexDirection: "space-between",
+    justifyContent: "flex-end",
+    padding: theme.spacing.s1,
+    position: "sticky",
+    top: 0,
+  },
+}));
 
 export default function HelpModal({
   onRequestClose,
   children,
-  rootStyle,
-}: PropsWithChildren<Props>): ReactElement {
+}: PropsWithChildren<{ onRequestClose: () => void }>): ReactElement {
+  const classes = useStyles();
+  const theme = useTheme();
+
   return (
-    <Modal onRequestClose={onRequestClose}>
-      <SRoot {...(rootStyle ? { style: rootStyle } : undefined)}>
+    <Modal
+      isOpen
+      onDismiss={onRequestClose}
+      styles={{
+        scrollableContent: {
+          maxWidth: 700,
+          maxHeight: `calc(100vh - ${theme.spacing.l2})`,
+        },
+      }}
+    >
+      <div className={classes.header}>
+        <IconButton
+          styles={{
+            root: {
+              color: theme.palette.neutralSecondary,
+              margin: 0, // TODO: remove this once global.scss is removed
+            },
+            rootHovered: {
+              color: theme.palette.neutralSecondaryAlt,
+            },
+          }}
+          ariaLabel="Close help modal"
+          iconProps={{ iconName: "Clear" }}
+          onClick={onRequestClose}
+        />
+      </div>
+      <div className={classes.content}>
         <TextContent allowMarkdownHtml={true}>{children}</TextContent>
-      </SRoot>
+      </div>
     </Modal>
   );
 }

--- a/packages/studio-base/src/components/HelpModal.tsx
+++ b/packages/studio-base/src/components/HelpModal.tsx
@@ -1,15 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
 import { IconButton, Modal, makeStyles, useTheme } from "@fluentui/react";
 import { PropsWithChildren, ReactElement } from "react";
@@ -21,19 +12,19 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing.l1,
   },
   header: {
-    backgroundColor: theme.semanticColors.bodyBackground,
     display: "flex",
     flexDirection: "space-between",
     justifyContent: "flex-end",
-    padding: theme.spacing.s1,
-    position: "sticky",
+    padding: theme.spacing.l1,
+    position: "absolute",
     top: 0,
+    right: 0,
   },
 }));
 
 export default function HelpModal({
-  onRequestClose,
   children,
+  onRequestClose,
 }: PropsWithChildren<{ onRequestClose: () => void }>): ReactElement {
   const classes = useStyles();
   const theme = useTheme();

--- a/packages/studio-base/src/components/ShortcutsModal.tsx
+++ b/packages/studio-base/src/components/ShortcutsModal.tsx
@@ -30,7 +30,7 @@ type Props = {
 export default function ShortcutsModal({ onRequestClose }: Props): React.ReactElement {
   return (
     <RenderToBodyComponent>
-      <HelpModal rootStyle={{ maxWidth: 480, minWidth: 320 }} onRequestClose={onRequestClose}>
+      <HelpModal onRequestClose={onRequestClose}>
         <h2>Keyboard shortcuts</h2>
         <STitle>Global</STitle>
         <KeyboardShortcut description="Save layouts" keys={[COMMAND, "s"]} />


### PR DESCRIPTION
**User-Facing Changes**
| Before | After |
| ------ | ----- |
| <img width="1312" alt="Screen Shot 2021-06-30 at 1 25 52 pm" src="https://user-images.githubusercontent.com/924528/123897485-cc47fb00-d9a6-11eb-81ff-06ffe295c662.png"> | <img width="1312" alt="Screen Shot 2021-07-01 at 8 46 24 am" src="https://user-images.githubusercontent.com/924528/124040785-edf9be80-da48-11eb-9ae7-43e897819b7d.png"> |

Closes #1335 
