### PR TITLE
Simplify overwriteFetch error message

### DIFF
--- a/packages/studio-base/src/util/overwriteFetch.test.ts
+++ b/packages/studio-base/src/util/overwriteFetch.test.ts
@@ -32,9 +32,7 @@ describe("overwriteFetch", () => {
     }
     // We should have replaced the original error with our new error.
     expect(error).not.toBe(originalError);
-    expect(error?.message).toEqual(
-      "Failed to fetch: url: url This likely means there was a CORS issue, which can happen when the server is down.",
-    );
+    expect(error?.message).toEqual("Failed to fetch: url");
   });
 
   it("does not touch unrelated errrors", async () => {

--- a/packages/studio-base/src/util/overwriteFetch.ts
+++ b/packages/studio-base/src/util/overwriteFetch.ts
@@ -17,9 +17,7 @@ export default function overwriteFetch(): void {
   const originalFetch = global.fetch;
   global.fetch = (url: RequestInfo, init?: RequestInit) => {
     // Use this replacement error instead of the original one, because this one will have the correct stack trace.
-    const replacementError = new TypeError(
-      `Failed to fetch: url: ${url} This likely means there was a CORS issue, which can happen when the server is down.`,
-    );
+    const replacementError = new TypeError(`Failed to fetch: ${url}`);
     return originalFetch(url, init).catch((error) => {
       if (error.message === "Failed to fetch") {
         throw replacementError;


### PR DESCRIPTION
**User-Facing Changes**
Not significant

**Description**
This error message refers to an unknown "the server" and was worded in a way that assumes users know what CORS means. Just simplify and keep only the URL as part of the error message without the note about CORS.