### PR TITLE
Use fuzzy time parsing in PlaybackTimeDisplayMethod

### DIFF
--- a/packages/studio-base/src/util/formatTime.ts
+++ b/packages/studio-base/src/util/formatTime.ts
@@ -15,7 +15,8 @@ import momentDurationFormatSetup from "moment-duration-format";
 import moment from "moment-timezone";
 import { Time } from "rosbag";
 
-import { toDate, fromDate, getRosTimeFromString } from "./time";
+import parseFuzzyRosTime from "./parseFuzzyRosTime";
+import { toDate, fromDate } from "./time";
 
 // All time functions that require `moment` should live in this file.
 
@@ -88,9 +89,7 @@ export const getValidatedTimeAndMethodFromString = ({
   }
 
   return {
-    time: !isInvalidRosTime
-      ? getRosTimeFromString(text)
-      : parseTimeStr(`${date} ${text}`, timezone),
+    time: !isInvalidRosTime ? parseFuzzyRosTime(text) : parseTimeStr(`${date} ${text}`, timezone),
     method: isInvalidRosTime ? "TOD" : "ROS",
   };
 };

--- a/packages/studio-base/src/util/parseFuzzyRosTime.test.ts
+++ b/packages/studio-base/src/util/parseFuzzyRosTime.test.ts
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import parseFuzzyRosTime from "./parseFuzzyRosTime";
+
+describe("parseFuzzyRosTime", () => {
+  it.each([
+    ["1", { sec: 1, nsec: 0 }],
+    ["31525401600001", { sec: 31525401600, nsec: 0.001e9 }],
+    ["31556937600001", { sec: 31556937, nsec: 0.600001e9 }],
+    ["315569376000010", { sec: 315569376, nsec: 0.00001e9 }],
+    ["31556937600001000", { sec: 31556937, nsec: 0.600001e9 }],
+    ["31556937600001000000", { sec: 31556937, nsec: 0.600001e9 }],
+  ])("converts %s to %s", (input, expected) => {
+    expect(parseFuzzyRosTime(input)).toEqual(expected);
+  });
+});

--- a/packages/studio-base/src/util/parseFuzzyRosTime.ts
+++ b/packages/studio-base/src/util/parseFuzzyRosTime.ts
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Time } from "rosbag";
+
+const DIGITS_WITHOUT_DECIMAL_POINT_RE = /^\d+$/;
+const DIGITS_WITH_DECIMAL_POINT_RE = /^(?!\.$)(\d*)\.(\d*)$/;
+const THOUSAND_YEARS_IN_NANOSEC = 1000n * 365n * 24n * 60n * 60n * BigInt(1e9);
+
+/**
+ * Parses a ROS time (UNIX timestamp) containing a whole or floating point number of seconds. If
+ * more than 9 digits of nanoseconds are given, the rest will be truncated.
+ *
+ * Parsing is lenient: if the numeric value given is too large and contains no decimal point, assume
+ * it is ms, µs, ns instead of seconds (or a smaller unit, in powers of 1000).
+ */
+export default function parseFuzzyRosTime(stamp: string): Time | undefined {
+  stamp = stamp.trim();
+  if (DIGITS_WITHOUT_DECIMAL_POINT_RE.test(stamp)) {
+    // Start by assuming the input is in seconds, and convert to nanoseconds.
+    let nanos = BigInt(stamp) * BigInt(1e9);
+    while (nanos > THOUSAND_YEARS_IN_NANOSEC) {
+      nanos /= 1000n;
+    }
+    return { sec: Number(nanos / BigInt(1e9)), nsec: Number(nanos % BigInt(1e9)) };
+  }
+
+  const match = DIGITS_WITH_DECIMAL_POINT_RE.exec(stamp);
+  if (match?.[1] != undefined && match[2] != undefined) {
+    // There can be at most 9 digits of nanoseconds. Truncate any others.
+    return { sec: Number(match[1]), nsec: Number(match[2].substr(0, 9).padEnd(9, "0")) };
+  }
+
+  return undefined;
+}

--- a/packages/studio-base/src/util/time.test.ts
+++ b/packages/studio-base/src/util/time.test.ts
@@ -339,13 +339,3 @@ describe("time.getSeekTimeFromSpec", () => {
     expect(time.getSeekTimeFromSpec({ type: "fraction", fraction: 2 }, start, end)).toEqual(end);
   });
 });
-
-describe("time.getRosTimeFromString", () => {
-  it("takes a stringified number and returns time object", () => {
-    expect(time.getRosTimeFromString("")).toEqual(undefined);
-    expect(time.getRosTimeFromString("abc")).toEqual(undefined);
-    expect(time.getRosTimeFromString("123456.000000000")).toEqual({ sec: 123456, nsec: 0 });
-    expect(time.getRosTimeFromString("123456.100000000")).toEqual({ sec: 123456, nsec: 100000000 });
-    expect(time.getRosTimeFromString("123456.123456789")).toEqual({ sec: 123456, nsec: 123456789 });
-  });
-});

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -314,11 +314,3 @@ export function getTimestampForMessage(message: unknown): Time | undefined {
 
   return undefined;
 }
-
-export const getRosTimeFromString = (text: string): Time | undefined => {
-  if (text.length === 0 || isNaN(+text)) {
-    return undefined;
-  }
-  const textAsNum = Number(text);
-  return { sec: Math.floor(textAsNum), nsec: textAsNum * 1e9 - Math.floor(textAsNum) * 1e9 };
-};


### PR DESCRIPTION
Moved from https://github.com/foxglove/rostime/pull/1

**User-Facing Changes**
Timestamps typed into the playback bar can now be in milliseconds, microseconds, or nanoseconds.


https://user-images.githubusercontent.com/14237/124209830-20360b00-da9f-11eb-9326-2c3053bcdfc6.mov



**Description**

This logic will parse `31556937.600001`, `31556937600001`, and `31556937600001000` to the same value: `{ sec: 31556937, nsec: 600001000 }`.
