### PR TITLE
Add testMatch to jest config to avoid running tests in studio-base/dist

### DIFF
--- a/packages/studio-base/jest.config.json
+++ b/packages/studio-base/jest.config.json
@@ -1,5 +1,6 @@
 {
   "//": "Note: we use babel-jest rather than ts-jest for performance reasons.",
+  "testMatch": ["<rootDir>/src/**/*.test.ts"],
   "transform": {
     "\\.tsx?$": "<rootDir>/src/test/transformers/typescriptTransformerWithRawImports.js",
     "\\.ne$": "<rootDir>/src/test/transformers/neTransformer.js",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
After `yarn build:packages`, running `yarn test` would fail when it tried to run tests from `studio-base/dist`. Our other packages use this `testMatch` setting, which we can use in studio-base too now that its structure is similar to the other packages.