### PR TITLE
Fix: use id for MosaicWindow key

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -122,7 +122,7 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
       const mosaicWindow = (
         <MosaicWindow
           title=""
-          key={path.join("-")}
+          key={id}
           path={path}
           createNode={createTile}
           renderPreview={() => undefined as unknown as JSX.Element}


### PR DESCRIPTION
**User-Facing Changes**
When a user splits a panel that has state but doesn't persist that state to the layout (i.e. the user has expanded fields in the RawMessage panel tree), the existing panel is kept mounted and the user's modifications are kept.

**Description**
When changing the layout, the mosaic path for a panel changes. The previous behavior used path as the key for mosaicWindow which results in re-mounting the panel (and losing any un-persisted state). The new behavior uses the id as the key which avoids re-mounting the panel.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
