### PR TITLE
Hover and click to seek in Map panel

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -24,7 +24,7 @@ import {
   useHoverValue,
   useSetHoverValue,
 } from "@foxglove/studio-base/context/HoverValueContext";
-import { PlayerState } from "@foxglove/studio-base/players/types";
+import { PlayerCapabilities, PlayerState } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fromSec, toSec } from "@foxglove/studio-base/util/time";
 
@@ -51,6 +51,14 @@ function selectRequestBackfill(ctx: MessagePipelineContext) {
   return ctx.requestBackfill;
 }
 
+function selectCapabilities(ctx: MessagePipelineContext) {
+  return ctx.playerState.capabilities;
+}
+
+function selectSeekPlayback(ctx: MessagePipelineContext) {
+  return ctx.seekPlayback;
+}
+
 /**
  * PanelExtensionAdapter renders a panel extension via initPanel
  *
@@ -64,6 +72,8 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
   const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
   const requestBackfill = useMessagePipeline(selectRequestBackfill);
+  const capabilities = useMessagePipeline(selectCapabilities);
+  const seekPlayback = useMessagePipeline(selectSeekPlayback);
 
   const [subscriberId] = useState(() => uuid());
 
@@ -235,9 +245,9 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
       saveState: saveConfig,
 
-      seekPlayback: (stamp: number) => {
-        latestPipelineContextRef.current?.seekPlayback(fromSec(stamp));
-      },
+      seekPlayback: capabilities.includes(PlayerCapabilities.playbackControl)
+        ? (stamp: number) => seekPlayback(fromSec(stamp))
+        : undefined,
 
       setPreviewTime: (stamp: number | undefined) => {
         if (stamp == undefined) {
@@ -295,10 +305,12 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       },
     };
   }, [
+    capabilities,
     clearHoverValue,
     renderPanel,
     requestBackfill,
     saveConfig,
+    seekPlayback,
     setHoverValue,
     setSubscriptions,
     subscriberId,

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -26,6 +26,7 @@ import {
 } from "@foxglove/studio-base/context/HoverValueContext";
 import { PlayerState } from "@foxglove/studio-base/players/types";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
+import { fromSec, toSec } from "@foxglove/studio-base/util/time";
 
 const log = Logger.getLogger(__filename);
 
@@ -174,13 +175,15 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       const hoverVal = hoverValueRef.current?.value;
 
       if (startTime != undefined && hoverVal != undefined) {
-        const startStamp = startTime.sec + startTime.nsec / 1e9;
-        const stamp = startStamp + hoverVal;
+        const stamp = toSec(startTime) + hoverVal;
         if (stamp !== renderState.previewTime) {
           shouldRender = true;
         }
         renderState.previewTime = stamp;
       } else {
+        if (renderState.previewTime != undefined) {
+          shouldRender = true;
+        }
         renderState.previewTime = undefined;
       }
     }
@@ -232,6 +235,10 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
       saveState: saveConfig,
 
+      seekPlayback: (stamp: number) => {
+        latestPipelineContextRef.current?.seekPlayback(fromSec(stamp));
+      },
+
       setPreviewTime: (stamp: number | undefined) => {
         if (stamp == undefined) {
           clearHoverValue("PanelExtensionAdatper");
@@ -243,7 +250,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
           if (!startTime) {
             return;
           }
-          const secondsFromStart = stamp - startTime.sec + startTime.nsec / 1e9;
+          const secondsFromStart = stamp - toSec(startTime);
           setHoverValue({
             type: "PLAYBACK_SECONDS",
             componentId: "PanelExtensionAdatper",

--- a/packages/studio-base/src/panels/Map/FilteredPointMarkers.tsx
+++ b/packages/studio-base/src/panels/Map/FilteredPointMarkers.tsx
@@ -1,26 +1,39 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { Map, LatLngBounds, LayerGroup, Circle } from "leaflet";
+import { Map, LatLngBounds, FeatureGroup, CircleMarker, PathOptions } from "leaflet";
 
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
 import { NavSatFixMsg } from "./types";
 
+export const POINT_MARKER_RADIUS = 3;
+
 type Args = {
   map: Map;
   bounds: LatLngBounds;
   color: string;
-  navSatMessageEvents: readonly MessageEvent<unknown>[];
+  navSatMessageEvents: readonly MessageEvent<NavSatFixMsg>[];
+  onHover?: (event: MessageEvent<NavSatFixMsg> | undefined) => void;
+  onClick?: (event: MessageEvent<NavSatFixMsg>) => void;
 };
+
+class PointMarker extends CircleMarker {
+  messageEvent?: MessageEvent<NavSatFixMsg>;
+}
 
 /**
  * Create a leaflet LayerGroup with filtered points
  */
-function FilteredPointLayer(args: Args): LayerGroup {
+function FilteredPointLayer(args: Args): FeatureGroup {
   const { navSatMessageEvents: points, bounds, map } = args;
+  const defaultStyle: PathOptions = {
+    stroke: false,
+    color: args.color,
+    fillOpacity: 1,
+  };
 
-  const markersLayer = new LayerGroup();
+  const markersLayer = new FeatureGroup();
 
   const localBounds = bounds;
 
@@ -28,8 +41,8 @@ function FilteredPointLayer(args: Args): LayerGroup {
   const sparse2d: (boolean | undefined)[][] = [];
 
   for (const messageEvent of points) {
-    const lat = (messageEvent.message as NavSatFixMsg).latitude;
-    const lon = (messageEvent.message as NavSatFixMsg).longitude;
+    const lat = messageEvent.message.latitude;
+    const lon = messageEvent.message.longitude;
 
     // if the point is outside the bounds, we don't include it
     if (!localBounds.contains([lat, lon])) {
@@ -46,12 +59,28 @@ function FilteredPointLayer(args: Args): LayerGroup {
 
     (sparse2d[x] = sparse2d[x] ?? [])[y] = true;
 
-    const marker = new Circle([lat, lon], {
-      radius: 0.1,
-      color: args.color,
-    });
+    const marker = new PointMarker([lat, lon], { ...defaultStyle, radius: POINT_MARKER_RADIUS });
+    marker.messageEvent = messageEvent;
     marker.addTo(markersLayer);
   }
+
+  markersLayer.on("mouseover", (event) => {
+    const marker = event.sourceTarget as PointMarker;
+    marker.setStyle({ color: "yellow" });
+    marker.bringToFront();
+    args.onHover?.(marker.messageEvent);
+  });
+  markersLayer.on("click", (event) => {
+    const marker = event.sourceTarget as PointMarker;
+    if (marker.messageEvent) {
+      args.onClick?.(marker.messageEvent);
+    }
+  });
+  markersLayer.on("mouseout", (event) => {
+    const marker = event.sourceTarget as PointMarker;
+    marker.setStyle(defaultStyle);
+    args.onHover?.(undefined);
+  });
 
   return markersLayer;
 }

--- a/packages/studio-base/src/panels/Map/FilteredPointMarkers.tsx
+++ b/packages/studio-base/src/panels/Map/FilteredPointMarkers.tsx
@@ -64,23 +64,27 @@ function FilteredPointLayer(args: Args): FeatureGroup {
     marker.addTo(markersLayer);
   }
 
-  markersLayer.on("mouseover", (event) => {
-    const marker = event.sourceTarget as PointMarker;
-    marker.setStyle({ color: "yellow" });
-    marker.bringToFront();
-    args.onHover?.(marker.messageEvent);
-  });
-  markersLayer.on("click", (event) => {
-    const marker = event.sourceTarget as PointMarker;
-    if (marker.messageEvent) {
-      args.onClick?.(marker.messageEvent);
-    }
-  });
-  markersLayer.on("mouseout", (event) => {
-    const marker = event.sourceTarget as PointMarker;
-    marker.setStyle(defaultStyle);
-    args.onHover?.(undefined);
-  });
+  if (args.onHover) {
+    markersLayer.on("mouseover", (event) => {
+      const marker = event.sourceTarget as PointMarker;
+      marker.setStyle({ color: "yellow" });
+      marker.bringToFront();
+      args.onHover?.(marker.messageEvent);
+    });
+    markersLayer.on("mouseout", (event) => {
+      const marker = event.sourceTarget as PointMarker;
+      marker.setStyle(defaultStyle);
+      args.onHover?.(undefined);
+    });
+  }
+  if (args.onClick) {
+    markersLayer.on("click", (event) => {
+      const marker = event.sourceTarget as PointMarker;
+      if (marker.messageEvent) {
+        args.onClick?.(marker.messageEvent);
+      }
+    });
+  }
 
   return markersLayer;
 }

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -87,7 +87,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
     const map = new LeafMap(mapContainerRef.current, {
       layers: [tileLayer],
-      // renderer: new Canvas({ tolerance: 10 }),
     });
 
     // the map must be initialized with some view before other features work
@@ -147,7 +146,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const onClick = useCallback(
     (messageEvent: MessageEvent<NavSatFixMsg>) => {
-      context.seekPlayback(toSec(messageEvent.receiveTime));
+      context.seekPlayback?.(toSec(messageEvent.receiveTime));
     },
     [context],
   );

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -2,14 +2,17 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Map as LeafMap, TileLayer, Control, LatLngBounds, Circle } from "leaflet";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Map as LeafMap, TileLayer, Control, LatLngBounds, CircleMarker } from "leaflet";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import { PanelExtensionContext, MessageEvent } from "@foxglove/studio";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
-import FilteredPointLayer from "@foxglove/studio-base/panels/Map/FilteredPointMarkers";
+import FilteredPointLayer, {
+  POINT_MARKER_RADIUS,
+} from "@foxglove/studio-base/panels/Map/FilteredPointMarkers";
 import { Topic } from "@foxglove/studio-base/players/types";
+import { toSec } from "@foxglove/studio-base/util/time";
 
 import { NavSatFixMsg, Point } from "./types";
 
@@ -31,8 +34,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   // Panel state management to update our set of messages
   // We use state to trigger a render on the panel
-  const [navMessages, setNavMessages] = useState<readonly MessageEvent<unknown>[]>([]);
-  const [allNavMessages, setAllNavMessages] = useState<readonly MessageEvent<unknown>[]>([]);
+  const [navMessages, setNavMessages] = useState<readonly MessageEvent<NavSatFixMsg>[]>([]);
+  const [allNavMessages, setAllNavMessages] = useState<readonly MessageEvent<NavSatFixMsg>[]>([]);
 
   // Panel state management to track the list of available topics
   const [topics, setTopics] = useState<readonly Topic[]>([]);
@@ -84,6 +87,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
     const map = new LeafMap(mapContainerRef.current, {
       layers: [tileLayer],
+      // renderer: new Canvas({ tolerance: 10 }),
     });
 
     // the map must be initialized with some view before other features work
@@ -118,11 +122,11 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
       // if there is no current frame, we keep the last frame we've seen
       if (renderState.currentFrame && renderState.currentFrame.length > 0) {
-        setNavMessages(renderState.currentFrame);
+        setNavMessages(renderState.currentFrame as readonly MessageEvent<NavSatFixMsg>[]);
       }
 
       if (renderState.allFrames) {
-        setAllNavMessages(renderState.allFrames);
+        setAllNavMessages(renderState.allFrames as readonly MessageEvent<NavSatFixMsg>[]);
       }
     };
 
@@ -131,6 +135,22 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       context.onRender = undefined;
     };
   }, [context]);
+
+  const onHover = useCallback(
+    (messageEvent?: MessageEvent<NavSatFixMsg>) => {
+      context.setPreviewTime(
+        messageEvent == undefined ? undefined : toSec(messageEvent.receiveTime),
+      );
+    },
+    [context],
+  );
+
+  const onClick = useCallback(
+    (messageEvent: MessageEvent<NavSatFixMsg>) => {
+      context.seekPlayback(toSec(messageEvent.receiveTime));
+    },
+    [context],
+  );
 
   /// --- the remaining code is unrelated to the extension api ----- ///
 
@@ -146,8 +166,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       }
 
       for (const messageEvent of allNavMessages) {
-        const lat = (messageEvent.message as NavSatFixMsg).latitude;
-        const lon = (messageEvent.message as NavSatFixMsg).longitude;
+        const lat = messageEvent.message.latitude;
+        const lon = messageEvent.message.longitude;
         const point: Point = {
           lat,
           lon,
@@ -158,8 +178,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
       for (const messageEvent of navMessages) {
         const point: Point = {
-          lat: (messageEvent.message as NavSatFixMsg).latitude,
-          lon: (messageEvent.message as NavSatFixMsg).longitude,
+          lat: messageEvent.message.latitude,
+          lon: messageEvent.message.longitude,
         };
 
         return point;
@@ -180,13 +200,15 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       navSatMessageEvents: allNavMessages,
       bounds: filterBounds ?? currentMap.getBounds(),
       color: "#6771ef",
+      onHover,
+      onClick,
     });
 
     currentMap?.addLayer(pointLayer);
     return () => {
       currentMap?.removeLayer(pointLayer);
     };
-  }, [allNavMessages, currentMap, filterBounds]);
+  }, [allNavMessages, currentMap, filterBounds, onClick, onHover]);
 
   // create a filtered marker layer for the current nav messages
   // this effect is added after the allNavMessages so the layer appears above
@@ -218,13 +240,13 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     let point: Point | undefined;
     let stampDelta = Number.MAX_VALUE;
     for (const msgEvent of allNavMessages) {
-      const stamp = msgEvent.receiveTime.sec + msgEvent.receiveTime.nsec / 1e9;
+      const stamp = toSec(msgEvent.receiveTime);
       const delta = previewTime - stamp;
       if (delta < stampDelta && delta >= 0) {
         stampDelta = delta;
         point = {
-          lat: (msgEvent.message as NavSatFixMsg).latitude,
-          lon: (msgEvent.message as NavSatFixMsg).longitude,
+          lat: msgEvent.message.latitude,
+          lon: msgEvent.message.longitude,
         };
       }
     }
@@ -232,9 +254,12 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       return;
     }
 
-    const marker = new Circle([point.lat, point.lon], {
-      radius: 0.1,
+    const marker = new CircleMarker([point.lat, point.lon], {
+      radius: POINT_MARKER_RADIUS,
       color: "yellow",
+      stroke: false,
+      fillOpacity: 1,
+      interactive: false,
     });
 
     marker.addTo(currentMap);

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -49,7 +49,7 @@ declare module "@foxglove/studio" {
      * i.e. A plot panel may set the preview time when a user is hovering over the plot to signal
      * to other panels where the user is currently hovering and allow them to render accordingly.
      */
-    previewTime?: number;
+    previewTime?: number | undefined;
   }
 
   export type PanelExtensionContext = {
@@ -81,6 +81,11 @@ declare module "@foxglove/studio" {
      * Set the active preview time. Setting the preview time to undefined clears the preview time.
      */
     setPreviewTime: (time: number | undefined) => void;
+
+    /**
+     * Seek playback to the given time. Behaves as if the user had clicked the playback bar to seek.
+     */
+    seekPlayback: (time: number) => void;
 
     /**
      * Process render events for the panel. Each render event receives a render state and a done callback.

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -85,7 +85,7 @@ declare module "@foxglove/studio" {
     /**
      * Seek playback to the given time. Behaves as if the user had clicked the playback bar to seek.
      */
-    seekPlayback: (time: number) => void;
+    seekPlayback?: (time: number) => void;
 
     /**
      * Process render events for the panel. Each render event receives a render state and a done callback.


### PR DESCRIPTION
**User-Facing Changes**
Hovering a point in the Map panel now highlights the corresponding time in the playback bar, and clicking on the point seeks playback to that time.

**Description**
Fixes #1394 #1247. Fixes a bug where un-hovering the playback bar didn't remove the highlighted point in the Map panel.