### PR TITLE
Move "About" info & relevant links to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # <img src="resources/icon/icon.png" width="40" height="40" align="top"> Foxglove Studio
 
-Foxglove Studio ([foxglove.dev](https://foxglove.dev)) is an integrated visualization and diagnosis tool for robotics.
+Foxglove Studio ([foxglove.dev](https://foxglove.dev)) is an integrated visualization and diagnosis tool for robotics. It began as a fork and evolution of[Webviz](https://github.com/cruise-automation/webviz), an open source project developed by [Cruise](https://getcruise.com/).
+
+To learn more about Foxglove, visit [foxglove.dev/about](https://foxglove.dev/about), read our [documentation](https://foxglove.dev/docs) and [release notes](https://github.com/foxglove/studio/releases), or check out [our blog](https://foxglove.dev/blog).
+
+You can also follow us on [Twitter](https://twitter.com/foxglovedev) to stay up-to-date on what our team is working on.
 
 <p align="center">
   <a href="https://foxglove.dev"><img alt="Foxglove Studio screenshot" src="/resources/screenshot.jpg"></a>
@@ -53,11 +57,3 @@ $ yarn lint         # lint all files
 $ yarn test         # run all tests
 $ yarn test:watch   # run tests on changed files
 ```
-
-## About
-
-Foxglove Studio began as a fork and evolution of [Webviz](https://github.com/cruise-automation/webviz), an open source project developed by [Cruise](https://getcruise.com/).
-
-To learn more about Foxglove, visit [foxglove.dev/about](https://foxglove.dev/about) or view our [documentation](https://foxglove.dev/docs) and [release notes](https://github.com/foxglove/studio/releases).
-
-You can also check out [our blog](https://foxglove.dev/blog) or follow us on [Twitter](https://twitter.com/foxglovedev) to stay up-to-date on what our team is working on.


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
- Moved "About" info and relevant links to docs, Twitter, etc. to the top of the Github repo README

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
