### PR TITLE
Enable and fix `no-param-reassign`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -51,6 +51,7 @@ rules:
       location: anywhere
 
   no-unused-expressions: error
+  no-param-reassign: error
 
   no-useless-rename: error
   object-shorthand: error

--- a/packages/ros1/src/TcpConnection.test.ts
+++ b/packages/ros1/src/TcpConnection.test.ts
@@ -62,8 +62,8 @@ describe("TcpConnection", () => {
   it("Connects and reads a parsed message", async () => {
     // Create the TCP listening socket
     const server = net.createServer((client) => {
-      client.on("data", (data) => {
-        data = data.subarray(4);
+      client.on("data", (fullData) => {
+        const data = fullData.subarray(4);
         expect(data.byteLength).toEqual(102);
         expect(TcpConnection.ParseHeader(data)).toEqual(CLIENT_HEADER);
 

--- a/packages/rosmsg-serialization/src/LazyMessageReaderFactory.ts
+++ b/packages/rosmsg-serialization/src/LazyMessageReaderFactory.ts
@@ -13,10 +13,11 @@ const builtinSizes = {
   },
   fixedArray: (
     view: DataView,
-    offset: number,
+    startOffset: number,
     len: number,
     typeSize: (view: DataView, offset: number) => number,
   ): number => {
+    let offset = startOffset;
     let size = 0;
     for (let idx = 0; idx < len; ++idx) {
       const elementSize = typeSize(view, offset);
@@ -27,9 +28,10 @@ const builtinSizes = {
   },
   array: (
     view: DataView,
-    offset: number,
+    startOffset: number,
     typeSize: (view: DataView, offset: number) => number,
   ): number => {
+    let offset = startOffset;
     const len = view.getUint32(offset, true);
 
     let size = 4;

--- a/packages/rosmsg-serialization/src/MessageWriter.ts
+++ b/packages/rosmsg-serialization/src/MessageWriter.ts
@@ -173,17 +173,11 @@ class StandardTypeWriter {
   }
 
   int64(value: bigint | number): void {
-    if (typeof value !== "bigint") {
-      value = BigInt(value);
-    }
-    this.view.setBigInt64(this.offsetCalculator.int64(), value, true);
+    this.view.setBigInt64(this.offsetCalculator.int64(), BigInt(value), true);
   }
 
   uint64(value: bigint | number): void {
-    if (typeof value !== "bigint") {
-      value = BigInt(value);
-    }
-    this.view.setBigUint64(this.offsetCalculator.uint64(), value, true);
+    this.view.setBigUint64(this.offsetCalculator.uint64(), BigInt(value), true);
   }
 
   time(time: Time): void {
@@ -358,10 +352,6 @@ export class MessageWriter {
 
   // output is optional - if it is not provided, a Uint8Array will be generated.
   writeMessage(message: unknown, output?: Uint8Array): Uint8Array {
-    if (output == undefined) {
-      const dataSize = this.calculateByteSize(message);
-      output = new Uint8Array(dataSize);
-    }
-    return this.writer(message, output);
+    return this.writer(message, output ?? new Uint8Array(this.calculateByteSize(message)));
   }
 }

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -180,9 +180,10 @@ class MessagePathInputUnconnected extends React.PureComponent<
     this.state = { focused: false };
   }
 
-  _onChange = (event: React.SyntheticEvent<HTMLInputElement>, value: string) => {
+  _onChange = (event: React.SyntheticEvent<HTMLInputElement>, rawValue: string) => {
     // When typing a "{" character, also  insert a "}", so you get an
     // autocomplete window immediately for selecting a filter name.
+    let value = rawValue;
     if ((event.nativeEvent as InputEvent).data === "{") {
       const target = event.target as HTMLInputElement;
       const newCursorPosition = target.selectionEnd ?? 0;
@@ -200,11 +201,12 @@ class MessagePathInputUnconnected extends React.PureComponent<
   };
 
   _onSelect = (
-    value: string,
+    rawValue: string,
     autocomplete: Autocomplete<string>,
     autocompleteType: ("topicName" | "messagePath" | "globalVariables") | undefined,
     autocompleteRange: { start: number; end: number },
   ) => {
+    let value = rawValue;
     // If we're dealing with a topic name, and we cannot validly end in a message type,
     // add a "." so the user can keep typing to autocomplete the message path.
     const keepGoingAfterTopicName =

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -198,9 +198,10 @@ export type StructureTraversalResult = {
 // does not) and does not hold onto objects as strongly (it uses WeakMap).
 export const traverseStructure = memoizeWeak(
   (
-    structureItem: MessagePathStructureItem | undefined,
+    initialStructureItem: MessagePathStructureItem | undefined,
     messagePath: MessagePathPart[],
   ): StructureTraversalResult => {
+    let structureItem = initialStructureItem;
     if (!structureItem) {
       return { valid: false, msgPathPart: undefined, structureItem: undefined };
     }

--- a/packages/studio-base/src/components/PanelSettings/SchemaEntryEditor.tsx
+++ b/packages/studio-base/src/components/PanelSettings/SchemaEntryEditor.tsx
@@ -89,9 +89,9 @@ export default function SchemaEntryEditor({
                 return undefined; // onChange will not be called
               }}
               onChange={(_event, inputValue) => {
-                inputValue = nonEmptyOrUndefined(inputValue?.trim());
-                if ((inputValue != undefined && !isNaN(+inputValue)) || allowEmpty) {
-                  setValue(inputValue != undefined ? +inputValue : undefined);
+                const sanitizedInput = nonEmptyOrUndefined(inputValue?.trim());
+                if ((sanitizedInput != undefined && !isNaN(+sanitizedInput)) || allowEmpty) {
+                  setValue(sanitizedInput != undefined ? +sanitizedInput : undefined);
                 }
               }}
             />

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -440,14 +440,9 @@ export default function PlayerManager({
           throw new Error(`Could not create a player for ${selectedSource.name}`);
         }
 
-        if (!params) {
-          params = {};
-        }
-        params.rosHostname = rosHostname;
-
         const playerBuilder = await createPlayerBuilder({
           source: selectedSource,
-          sourceOptions: params,
+          sourceOptions: { ...params, rosHostname },
           prompt,
           storage,
         });

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -25,8 +25,10 @@ export function SidebarContent({
 }>): JSX.Element {
   const theme = useTheme();
 
+  let trailingItemsWithHelp = trailingItems;
+
   if (helpContent != undefined) {
-    (trailingItems ??= []).push(
+    (trailingItemsWithHelp ??= []).push(
       <HelpButton iconStyle={{ width: "18px", height: "18px" }}>{helpContent}</HelpButton>,
     );
   }
@@ -62,9 +64,9 @@ export function SidebarContent({
             {title}
           </Text>
         </Stack.Item>
-        {trailingItems && (
+        {trailingItemsWithHelp && (
           <Stack horizontal verticalAlign="center">
-            {trailingItems.map((item, i) => (
+            {trailingItemsWithHelp.map((item, i) => (
               <Stack.Item key={i}>{item}</Stack.Item>
             ))}
           </Stack>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
@@ -54,8 +54,8 @@ export class Transform {
     return this._hasValidMatrix || this.id === rootId;
   }
 
-  isChildOfTransform(rootId: string): boolean {
-    rootId = stripLeadingSlash(rootId);
+  isChildOfTransform(unsanitizedRootId: string): boolean {
+    const rootId = stripLeadingSlash(unsanitizedRootId);
     if (!this.parent) {
       return this.id === rootId;
     }
@@ -69,8 +69,8 @@ export class Transform {
     return this.parent.rootTransform();
   }
 
-  apply(output: MutablePose, input: Pose, rootId: string): MutablePose | undefined {
-    rootId = stripLeadingSlash(rootId);
+  apply(output: MutablePose, input: Pose, unsanitizedRootId: string): MutablePose | undefined {
+    const rootId = stripLeadingSlash(unsanitizedRootId);
     if (!this.isValid(rootId)) {
       return undefined;
     }
@@ -138,8 +138,8 @@ export class Transform {
 class TfStore {
   private _storage = new Map<string, Transform>();
 
-  get(key: string): Transform {
-    key = stripLeadingSlash(key);
+  get(unsanitizedKey: string): Transform {
+    const key = stripLeadingSlash(unsanitizedKey);
     let result = this._storage.get(key);
     if (result) {
       return result;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
@@ -40,12 +40,11 @@ function getRange(min: number, max: number): number {
 
 // returns the linear interpolation between a and b based on unit-range variable t
 function lerp(t: number, a: number, b: number): number {
-  // Clamp t to (0, 1)
-  t = Math.min(Math.max(t, 0.0), 1.0);
   if (a === b) {
     return a;
   }
-  return a + t * (b - a);
+  // Clamp t to (0, 1)
+  return a + Math.min(Math.max(t, 0.0), 1.0) * (b - a);
 }
 
 export type ClickedInfo = {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
@@ -121,13 +121,14 @@ function PoseMarkers({ markers, layerIndex }: PoseMarkerProps): ReactElement {
       }
       case "arrow":
       default: {
+        let newMarker = marker;
         if (settings?.overrideColor != undefined) {
-          marker = { ...marker, color: settings.overrideColor };
+          newMarker = { ...newMarker, color: settings.overrideColor };
         }
 
         if (settings?.size) {
-          marker = {
-            ...marker,
+          newMarker = {
+            ...newMarker,
             scale: {
               x: settings.size.shaftWidth ?? marker.scale.x,
               y: settings.size.headWidth ?? marker.scale.y,
@@ -136,13 +137,16 @@ function PoseMarkers({ markers, layerIndex }: PoseMarkerProps): ReactElement {
           };
         }
 
-        const pos = pointToVec3(marker.pose.position);
-        const orientation = orientationToVec4(marker.pose.orientation);
+        const pos = pointToVec3(newMarker.pose.position);
+        const orientation = orientationToVec4(newMarker.pose.orientation);
         const dir = vec3.transformQuat([0, 0, 0], [1, 0, 0], orientation);
         // the total length of the arrow is 4.7, we move the tail backwards by 0.88 (prev implementation)
         const tipPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, 3.82);
         const tailPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, -0.88);
-        arrowMarkers.push({ ...marker, points: [vec3ToPoint(tailPoint), vec3ToPoint(tipPoint)] });
+        arrowMarkers.push({
+          ...newMarker,
+          points: [vec3ToPoint(tailPoint), vec3ToPoint(tipPoint)],
+        });
 
         break;
       }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/drawToolUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/drawToolUtils.ts
@@ -43,15 +43,14 @@ export function getFormattedString(polygonPoints: Point2D[][]): string {
 
 // calculate the sum of the line distances
 export function getPolygonLineDistances(polygonPoints: Point2D[][]): number {
-  return polygonPoints.reduce((memo, polyPoints) => {
-    if (polyPoints.length > 1) {
-      for (let i = 0; i < polyPoints.length - 1; i++) {
-        memo += Math.hypot(
-          polyPoints[i + 1]!.x - polyPoints[i]!.x,
-          polyPoints[i + 1]!.y - polyPoints[i]!.y,
-        );
-      }
+  let distance = 0;
+  for (const polyPoints of polygonPoints) {
+    for (let i = 0; i < polyPoints.length - 1; i++) {
+      distance += Math.hypot(
+        polyPoints[i + 1]!.x - polyPoints[i]!.x,
+        polyPoints[i + 1]!.y - polyPoints[i]!.y,
+      );
     }
-    return memo;
-  }, 0);
+  }
+  return distance;
 }

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -96,8 +96,9 @@ export function computeDiagnosticInfo(
   stamp: Time,
 ): DiagnosticInfo {
   const displayName = getDisplayName(status.hardware_id, status.name);
+  let validatedStatus = status;
   if (status.values?.some(({ value }) => value.length > MAX_STRING_LENGTH)) {
-    status = {
+    validatedStatus = {
       ...status,
       values: status.values?.map((kv) =>
         kv.value.length > MAX_STRING_LENGTH
@@ -107,7 +108,7 @@ export function computeDiagnosticInfo(
     };
   }
   return {
-    status,
+    status: validatedStatus,
     stamp,
     id: getDiagnosticId(status.hardware_id, status.name),
     displayName,

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -390,8 +390,8 @@ export default class Ros1Player implements Player {
       return;
     }
 
-    publishers = publishers.filter(({ topic }) => topic.length > 0 && topic !== "/");
-    const topics = new Set<string>(publishers.map(({ topic }) => topic));
+    const validPublishers = publishers.filter(({ topic }) => topic.length > 0 && topic !== "/");
+    const topics = new Set<string>(validPublishers.map(({ topic }) => topic));
 
     // Clear all problems related to publishing
     this._clearPublishProblems(true);
@@ -404,7 +404,7 @@ export default class Ros1Player implements Player {
     }
 
     // Unadvertise any topics where the dataType changed
-    for (const { topic, datatype } of publishers) {
+    for (const { topic, datatype } of validPublishers) {
       const existingPub = this._rosNode.publications.get(topic);
       if (existingPub != undefined && existingPub.dataType !== datatype) {
         this._rosNode.unadvertise(topic);
@@ -412,7 +412,7 @@ export default class Ros1Player implements Player {
     }
 
     // Advertise new topics
-    for (const { topic, datatype: dataType, datatypes } of publishers) {
+    for (const { topic, datatype: dataType, datatypes } of validPublishers) {
       if (this._rosNode.publications.has(topic)) {
         continue;
       }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -289,7 +289,7 @@ export const constructDatatypes = (
   depth: number = 1,
   currentTypeParamMap: TypeMap = {},
 ): { outputDatatype: string; datatypes: RosDatatypes } => {
-  if (++depth > MAX_DEPTH) {
+  if (depth > MAX_DEPTH) {
     throw new Error(`Max AST traversal depth exceeded.`);
   }
 

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
@@ -79,10 +79,9 @@ function flattenDiagnosticMessageText(
     }
   }
   result += diag.messageText;
-  indent++;
   if (diag.next) {
     for (const kid of diag.next) {
-      result += flattenDiagnosticMessageText(kid, newLine, indent);
+      result += flattenDiagnosticMessageText(kid, newLine, indent + 1);
     }
   }
   return result;

--- a/packages/studio-base/src/players/automatedRun/AutomatedRunPlayer.ts
+++ b/packages/studio-base/src/players/automatedRun/AutomatedRunPlayer.ts
@@ -149,9 +149,9 @@ export default class AutomatedRunPlayer implements Player {
     if (parsedTopics.length === 0) {
       return { parsedMessages: [] };
     }
-    start = clampTime(start, this._providerResult.start, this._providerResult.end);
-    end = clampTime(end, this._providerResult.start, this._providerResult.end);
-    const messages = await this._provider.getMessages(start, end, {
+    const clampedStart = clampTime(start, this._providerResult.start, this._providerResult.end);
+    const clampedEnd = clampTime(end, this._providerResult.start, this._providerResult.end);
+    const messages = await this._provider.getMessages(clampedStart, clampedEnd, {
       parsedMessages: parsedTopics,
     });
     const { parsedMessages, rosBinaryMessages } = messages;

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -85,14 +85,12 @@ class ConsoleApi {
   }
 
   protected async get<T>(apiPath: string, query?: Record<string, string>): Promise<T> {
-    if (query != undefined) {
-      apiPath += "?";
-      apiPath += new URLSearchParams(query).toString();
-    }
-
-    return this.request<T>(apiPath, {
-      method: "GET",
-    });
+    return this.request<T>(
+      query == undefined ? apiPath : `${apiPath}?${new URLSearchParams(query).toString()}`,
+      {
+        method: "GET",
+      },
+    );
   }
 
   protected async post<T>(apiPath: string, body?: unknown): Promise<T> {

--- a/packages/studio-base/src/test/mouseEventsHelper.ts
+++ b/packages/studio-base/src/test/mouseEventsHelper.ts
@@ -23,10 +23,9 @@ export function findCanvas(): HTMLCanvasElement {
 
 export async function simulateMouseMove(
   point: number[] = [0, 0],
-  canvas: HTMLCanvasElement | undefined,
+  canvas: HTMLCanvasElement | undefined = findCanvas(),
 ): Promise<void> {
   const [clientX, clientY] = point;
-  canvas = canvas ?? findCanvas();
   canvas.dispatchEvent(
     new MouseEvent("mousemove", {
       bubbles: true,
@@ -38,10 +37,9 @@ export async function simulateMouseMove(
 
 export async function simulateDragClick(
   point: number[] = [0, 0],
-  canvas?: HTMLCanvasElement,
+  canvas: HTMLCanvasElement = findCanvas(),
 ): Promise<void> {
   const [clientX, clientY] = point;
-  canvas = canvas ?? findCanvas();
   canvas.dispatchEvent(
     new MouseEvent("mousedown", {
       bubbles: true,

--- a/packages/studio-base/src/util/RpcWorkerUtils.ts
+++ b/packages/studio-base/src/util/RpcWorkerUtils.ts
@@ -30,8 +30,7 @@ export function setupSendReportNotificationHandler(rpc: Rpc): void {
       severity: NotificationSeverity,
     ) => {
       if (!(details instanceof Error || typeof details === "string")) {
-        console.warn("Invalid Error type");
-        details = JSON.stringify(details) ?? "<<unknown error>>";
+        console.warn("Invalid Error type", details);
       }
       void rpc.send("sendNotification", {
         message,

--- a/packages/studio-base/src/util/parseFuzzyRosTime.ts
+++ b/packages/studio-base/src/util/parseFuzzyRosTime.ts
@@ -16,17 +16,17 @@ const THOUSAND_YEARS_IN_NANOSEC = 1000n * 365n * 24n * 60n * 60n * BigInt(1e9);
  * it is ms, µs, ns instead of seconds (or a smaller unit, in powers of 1000).
  */
 export default function parseFuzzyRosTime(stamp: string): Time | undefined {
-  stamp = stamp.trim();
-  if (DIGITS_WITHOUT_DECIMAL_POINT_RE.test(stamp)) {
+  const trimmedStamp = stamp.trim();
+  if (DIGITS_WITHOUT_DECIMAL_POINT_RE.test(trimmedStamp)) {
     // Start by assuming the input is in seconds, and convert to nanoseconds.
-    let nanos = BigInt(stamp) * BigInt(1e9);
+    let nanos = BigInt(trimmedStamp) * BigInt(1e9);
     while (nanos > THOUSAND_YEARS_IN_NANOSEC) {
       nanos /= 1000n;
     }
     return { sec: Number(nanos / BigInt(1e9)), nsec: Number(nanos % BigInt(1e9)) };
   }
 
-  const match = DIGITS_WITH_DECIMAL_POINT_RE.exec(stamp);
+  const match = DIGITS_WITH_DECIMAL_POINT_RE.exec(trimmedStamp);
   if (match?.[1] != undefined && match[2] != undefined) {
     // There can be at most 9 digits of nanoseconds. Truncate any others.
     return { sec: Number(match[1]), nsec: Number(match[2].substr(0, 9).padEnd(9, "0")) };

--- a/packages/studio-base/src/util/ranges.ts
+++ b/packages/studio-base/src/util/ranges.ts
@@ -63,16 +63,17 @@ export function mergeNewRangeIntoUnsortedNonOverlappingList(
   newRange: Range,
   unsortedNonOverlappingRanges: readonly Range[],
 ): Range[] {
+  let firstRange = newRange;
   const newRanges = [];
   for (const range of unsortedNonOverlappingRanges) {
-    if (isOverlappingSimple(newRange, range) || isMeeting(newRange, range)) {
-      newRange = {
-        start: Math.min(range.start, newRange.start),
-        end: Math.max(range.end, newRange.end),
+    if (isOverlappingSimple(firstRange, range) || isMeeting(firstRange, range)) {
+      firstRange = {
+        start: Math.min(range.start, firstRange.start),
+        end: Math.max(range.end, firstRange.end),
       };
     } else {
       newRanges.push(range);
     }
   }
-  return [newRange, ...newRanges];
+  return [firstRange, ...newRanges];
 }

--- a/packages/studio-base/src/util/url.ts
+++ b/packages/studio-base/src/util/url.ts
@@ -22,12 +22,8 @@ export function parseInputUrl(
     return undefined;
   }
 
-  if (!str.includes("://")) {
-    str = `${defaultProtocol}//${str}`;
-  }
-
   try {
-    let url = new URL(str);
+    let url = new URL(str.includes("://") ? str : `${defaultProtocol}//${str}`);
 
     // Check if the protocol exists in the passed in map of allowed protocols
     const proto = protocols[url.protocol];

--- a/packages/velodyne-cloud/src/Calibration.ts
+++ b/packages/velodyne-cloud/src/Calibration.ts
@@ -25,9 +25,8 @@ export class Calibration {
   readonly cosRotTable: number[];
   readonly vls128LaserAzimuthCache: number[];
 
-  constructor(model: Model, calibrationData?: CalibrationData) {
+  constructor(model: Model, calibrationData: CalibrationData = loadCalibrationData(model)) {
     this.model = model;
-    calibrationData = calibrationData ?? loadCalibrationData(model);
     this.laserCorrections = calibrationData.lasers.map((v) => {
       return {
         laserId: v.laser_id,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
We require const for unmodified variables. Function parameters can't be annotated let/const, so it's better to treat them as const by default than non-const by default. (Ability to annotate them is tracked as a TypeScript feature request at https://github.com/microsoft/TypeScript/issues/18497)