### PR TITLE
Automatically close stale issues + PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-issue-message: "This issue has been marked as stale because it has been open for 180 days with no activity. Please remove the stale label or add a comment to keep it open."
+          stale-issue-label: stale
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+
+          stale-pr-message: "This PR has been marked as stale because it has been open for 90 days with no activity. Please remove the stale label or add a comment to keep it open. Thank you for your contribution."
+          stale-pr-label: stale
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          delete-branch: true


### PR DESCRIPTION
**User-Facing Changes**
No changes to studio, only Github users.

**Description**
- Automatically comment on stale PRs with no activity for 90 days and close after another 14 days
- Automatically comment on stale issues with no activity for 180 days and close after another 30 days

Open to discussion on these parameters. I set them pretty relaxed compared to most projects I see since I find these can be annoying.

~~We might want to consider closing stale `feature` issues too. At some point it's not worth keeping an infinitely growing list of feature requests around if no one is actively campaigning for or implementing them.~~ Edit: I updated this to include `feature` issues too, and increased the warning period to 30 days.