### PR TITLE
Fix speed/playback bugs when no layout is present

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.test.tsx
@@ -47,7 +47,7 @@ function Hook(_props: WrapperProps) {
   return useMessagePipeline(useCallback((value) => value, []));
 }
 
-function Wrapper({ children, maybePlayer, globalVariables }: PropsWithChildren<WrapperProps>) {
+function Wrapper({ children, maybePlayer, globalVariables = {} }: PropsWithChildren<WrapperProps>) {
   const [config] = useState(() => makeConfiguration());
   return (
     <AppConfigurationContext.Provider value={config}>

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -95,12 +95,12 @@ type ProviderProps = {
   // information is passed in and merged with other player state.
   maybePlayer?: MaybePlayer;
 
-  globalVariables?: GlobalVariables;
+  globalVariables: GlobalVariables;
 };
 export function MessagePipelineProvider({
   children,
   maybePlayer = {},
-  globalVariables = {},
+  globalVariables,
 }: ProviderProps): React.ReactElement {
   const currentPlayer = useRef<Player | undefined>(undefined);
   const [rawPlayerState, setRawPlayerState] = useState<PlayerState>(defaultPlayerState);

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -41,7 +41,7 @@ export default function PlaybackSpeedControls(): JSX.Element {
   );
   const { setPlaybackConfig } = useCurrentLayoutActions();
   const setSpeed = useCallback(
-    (newSpeed) => {
+    (newSpeed: number) => {
       setPlaybackConfig({ speed: newSpeed });
       if (canSetSpeed) {
         setPlaybackSpeed(newSpeed);
@@ -51,7 +51,11 @@ export default function PlaybackSpeedControls(): JSX.Element {
   );
 
   // Set the speed to the speed that we got from the config whenever we get a new Player.
-  useEffect(() => setSpeed(configSpeed), [configSpeed, setSpeed]);
+  useEffect(() => {
+    if (configSpeed != undefined) {
+      setSpeed(configSpeed);
+    }
+  }, [configSpeed, setSpeed]);
 
   const displayedSpeed = speed ?? configSpeed;
   let speedText = `–`;

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -335,10 +335,10 @@ export default function PlayerManager({
   );
   const userNodes = useCurrentLayoutSelector((state) => state.selectedLayout?.data.userNodes);
   const globalVariables = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.globalVariables,
+    (state) => state.selectedLayout?.data.globalVariables ?? EMPTY_GLOBAL_VARIABLES,
   );
 
-  const globalVariablesRef = useRef<GlobalVariables>(globalVariables ?? EMPTY_GLOBAL_VARIABLES);
+  const globalVariablesRef = useRef<GlobalVariables>(globalVariables);
   const [maybePlayer, setMaybePlayer] = useState<MaybePlayer<OrderedStampPlayer>>({});
   const [currentSourceName, setCurrentSourceName] = useState<string | undefined>(undefined);
   const isMounted = useMountedState();
@@ -379,7 +379,7 @@ export default function PlayerManager({
           userNodePlayer,
           initialMessageOrder ?? DEFAULT_MESSAGE_ORDER,
         );
-        headerStampPlayer.setGlobalVariables(globalVariablesRef.current ?? EMPTY_GLOBAL_VARIABLES);
+        headerStampPlayer.setGlobalVariables(globalVariablesRef.current);
         setMaybePlayer({ player: headerStampPlayer });
       } catch (error) {
         setMaybePlayer({ error });

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -588,10 +588,10 @@ export default class RandomAccessPlayer implements Player {
   }
 
   requestBackfill(): void {
-    if (this._isPlaying || this._initializing) {
+    if (this._isPlaying || this._initializing || !this._currentTime) {
       return;
     }
-    this.seekPlayback(this._nextReadStartTime);
+    this.seekPlayback(this._currentTime);
   }
 
   setPublishers(_publishers: AdvertisePayload[]): void {


### PR DESCRIPTION
**User-Facing Changes**
None (bugs only manifested when the app was already in a bad/unintended state)

**Description**
Prior to #1433, the web build experienced some bugs with the playback bar because there was no layout object:
1. a repeated backfill was triggered by setGlobalVariables, which happened because of a new `{}` empty global variable object being recreated frequently.
2. each backfill would cause playback to tick forward 1ns at a time (even while paused) because `_nextReadStartTime` was used instead of `_currentTime` (changed in #381).
3. clicking play would show NaN in the playback bar, because of a useCallback parameter that was silently `any`. (Related to this TS ticket: https://github.com/microsoft/TypeScript/issues/37595)