### PR TITLE
Fix: RawMessage panel Copy msg to handle lazy messages, bigints, and typed arrays

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/CopyMessageButton.tsx
+++ b/packages/studio-base/src/panels/RawMessages/CopyMessageButton.tsx
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import ClipboardOutlineIcon from "@mdi/svg/svg/clipboard-outline.svg";
+import { useCallback, MouseEvent } from "react";
+
+import Icon from "@foxglove/studio-base/components/Icon";
+import clipboard from "@foxglove/studio-base/util/clipboard";
+
+import { copyMessageReplacer } from "./copyMessageReplacer";
+
+type Props = {
+  text: string;
+  data: unknown;
+};
+
+export default function CopyMessageButton({ text, data }: Props): JSX.Element {
+  const onClick = useCallback(
+    (ev: MouseEvent<HTMLElement>) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+      void clipboard.copy(JSON.stringify(data, copyMessageReplacer, 2) ?? "");
+    },
+    [data],
+  );
+
+  return (
+    <a onClick={onClick} href="#" style={{ textDecoration: "none", cursor: "pointer" }}>
+      <Icon tooltip="Copy entire message to clipboard" style={{ position: "relative", top: -1 }}>
+        <ClipboardOutlineIcon style={{ verticalAlign: "middle" }} />
+      </Icon>{" "}
+      {text}
+    </a>
+  );
+}

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -10,16 +10,12 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import ClipboardOutlineIcon from "@mdi/svg/svg/clipboard-outline.svg";
-import { cloneDeepWith } from "lodash";
-import React, { useCallback } from "react";
 import styled from "styled-components";
 
-import Icon from "@foxglove/studio-base/components/Icon";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
-import clipboard from "@foxglove/studio-base/util/clipboard";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
+import CopyMessageButton from "./CopyMessageButton";
 import { getMessageDocumentationLink } from "./utils";
 
 const SMetadata = styled.div`
@@ -37,23 +33,6 @@ type Props = {
   diffMessage?: MessageEvent<unknown>;
 };
 
-function CopyMessageButton({
-  text,
-  onClick,
-}: {
-  text: string;
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
-}) {
-  return (
-    <a onClick={onClick} href="#" style={{ textDecoration: "none" }}>
-      <Icon tooltip="Copy entire message to clipboard" style={{ position: "relative", top: -1 }}>
-        <ClipboardOutlineIcon style={{ verticalAlign: "middle" }} />
-      </Icon>{" "}
-      {text}
-    </a>
-  );
-}
-
 export default function Metadata({
   data,
   diffData,
@@ -62,20 +41,6 @@ export default function Metadata({
   message,
   diffMessage,
 }: Props): JSX.Element {
-  const onClickCopy = useCallback(
-    (dataToCopy: unknown) => (e: React.MouseEvent<HTMLElement>) => {
-      e.stopPropagation();
-      e.preventDefault();
-      const dataWithoutLargeArrays = cloneDeepWith(dataToCopy, (value) => {
-        if (typeof value === "object" && value.buffer) {
-          return "<buffer>";
-        }
-        return undefined;
-      });
-      void clipboard.copy(JSON.stringify(dataWithoutLargeArrays, undefined, 2) ?? "");
-    },
-    [],
-  );
   return (
     <SMetadata>
       {!diffMessage && datatype && (
@@ -88,14 +53,14 @@ export default function Metadata({
         </a>
       )}
       {diffMessage ? " base" : ""} @ {formatTimeRaw(message.receiveTime)} ROS{" "}
-      <CopyMessageButton onClick={onClickCopy(data)} text="Copy msg" />
+      <CopyMessageButton data={data} text="Copy msg" />
       {diffMessage?.receiveTime && (
         <>
           <div>
             {`diff @ ${formatTimeRaw(diffMessage.receiveTime)} ROS `}
-            <CopyMessageButton onClick={onClickCopy(diffData)} text="Copy msg" />
+            <CopyMessageButton data={diffData} text="Copy msg" />
           </div>
-          <CopyMessageButton onClick={onClickCopy(diff)} text="Copy diff of msgs" />
+          <CopyMessageButton data={diff} text="Copy diff of msgs" />
         </>
       )}
     </SMetadata>

--- a/packages/studio-base/src/panels/RawMessages/copyMessageReplacer.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/copyMessageReplacer.test.ts
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { copyMessageReplacer } from "@foxglove/studio-base/panels/RawMessages/copyMessageReplacer";
+
+describe("copyMessageReplaceer", () => {
+  it.each([
+    {
+      name: "bigint fields to strings",
+      input: { foo: 100n },
+      out: { foo: "100" },
+    },
+    {
+      name: "Int8Array to array of numbers",
+      input: { foo: new Int8Array([10, 20]) },
+      out: { foo: [10, 20] },
+    },
+    {
+      name: "BigInt64Array to array of strings",
+      input: { foo: new BigInt64Array([10n, 20n]) },
+      out: { foo: ["10", "20"] },
+    },
+  ])("should stringify $name", ({ input, out }) => {
+    expect(JSON.stringify(input, copyMessageReplacer)).toEqual(JSON.stringify(out));
+  });
+});

--- a/packages/studio-base/src/panels/RawMessages/copyMessageReplacer.ts
+++ b/packages/studio-base/src/panels/RawMessages/copyMessageReplacer.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { isTypedArray as lodashIsTypedArray } from "lodash";
+
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
+
+function isTypedArray(value: unknown): value is TypedArray {
+  return lodashIsTypedArray(value);
+}
+
+/** A JSON.stringify replacer to support bigints and typed arrays */
+export function copyMessageReplacer(_key: unknown, value: unknown): unknown {
+  if (value == undefined) {
+    return;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (isTypedArray(value)) {
+    return Array.from<unknown>(value);
+  }
+  return value;
+}


### PR DESCRIPTION


**User-Facing Changes**
Users can now click `Copy Msg` in the Raw Message panel without the app erroring.

**Description**
Previously, the Copy msg feature of RawMessage would attempt to deep clone
the data before invoking JSON.stringify. This doesn't work for lazy messages as
they are not trivially deep clonable.

This change passes the data directory to JSON.stringify which understands `.toJSON`
functions on objects and uses that if available. Additionally, a replacer is provided
which handles bigint and typed arrays.

Fixes https://github.com/foxglove/studio/issues/1432

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
