### PR TITLE
Fix implicit `any`s from React.useCallback

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -17,7 +17,7 @@ import TestUtils from "react-dom/test-utils";
 
 import signal from "@foxglove/studio-base/util/signal";
 
-import ChartComponent from ".";
+import ChartComponent, { OnClickArg } from ".";
 
 const dataPoint = {
   x: 0.000057603000000000004,
@@ -166,7 +166,7 @@ export const AllowsClickingOnDatalabels: Story = (_args, ctx) => {
     }
   }, [clickedDatalabel]);
 
-  const onClick = useCallback((ev) => {
+  const onClick = useCallback((ev: OnClickArg) => {
     setClickedDatalabel(ev.datalabel);
   }, []);
 

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -21,7 +21,7 @@ function makeChartJSWorker() {
   return new Worker(new URL("./worker/main", import.meta.url));
 }
 
-type OnClickArg = {
+export type OnClickArg = {
   datalabel?: unknown;
   // x-value in scale
   x: number | undefined;

--- a/packages/studio-base/src/components/GlobalVariablesTable/index.tsx
+++ b/packages/studio-base/src/components/GlobalVariablesTable/index.tsx
@@ -169,7 +169,7 @@ function LinkedGlobalVariableRow({ name }: { name: string }): ReactElement {
   );
 
   const unlink = useCallback(
-    (path) => {
+    (path: string) => {
       setLinkedGlobalVariables(
         linkedGlobalVariables.filter(
           ({ name: varName, topic, markerKeyPath }) =>

--- a/packages/studio-base/src/components/GradientPicker.tsx
+++ b/packages/studio-base/src/components/GradientPicker.tsx
@@ -62,7 +62,7 @@ export default function GradientPicker({
   const rgbMaxColor = defaultedRGBStringFromColorObj(maxColor);
 
   const drawGradient = useCallback(
-    (ctx, width, height) => {
+    (ctx: CanvasRenderingContext2D, width: number, height: number) => {
       const gradient = ctx.createLinearGradient(0, 0, width, 0);
       gradient.addColorStop(0, rgbMinColor);
       gradient.addColorStop(1, rgbMaxColor);

--- a/packages/studio-base/src/components/MessageOrderControls.tsx
+++ b/packages/studio-base/src/components/MessageOrderControls.tsx
@@ -19,6 +19,7 @@ import {
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
+import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 const messageOrderLabel = {
   receiveTime: "Receive time",
@@ -32,7 +33,7 @@ export default function MessageOrderControls(): JSX.Element {
   const { setPlaybackConfig } = useCurrentLayoutActions();
 
   const setMessageOrder = useCallback(
-    (newMessageOrder) => {
+    (newMessageOrder: TimestampMethod) => {
       setPlaybackConfig({ messageOrder: newMessageOrder });
     },
     [setPlaybackConfig],

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -89,7 +89,7 @@ export default function MockMessagePipelineProvider(props: {
     [allSubscriptions],
   );
   const setSubscriptions = useCallback(
-    (id, subs) => setAllSubscriptions((s) => ({ ...s, [id]: subs })),
+    (id: string, subs: SubscribePayload[]) => setAllSubscriptions((s) => ({ ...s, [id]: subs })),
     [setAllSubscriptions],
   );
 

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -68,7 +68,8 @@ const PlaybackTimeDisplayMethod = ({
   );
   const { setPlaybackConfig } = useCurrentLayoutActions();
   const setTimeDisplayMethod = useCallback(
-    (newTimeDisplayMethod) => setPlaybackConfig({ timeDisplayMethod: newTimeDisplayMethod }),
+    (newTimeDisplayMethod: "ROS" | "TOD" | undefined) =>
+      setPlaybackConfig({ timeDisplayMethod: newTimeDisplayMethod }),
     [setPlaybackConfig],
   );
 
@@ -87,7 +88,7 @@ const PlaybackTimeDisplayMethod = ({
   const [hasError, setHasError] = useState<boolean>(false);
 
   const onSubmit = useCallback(
-    (e) => {
+    (e: React.SyntheticEvent) => {
       e.preventDefault();
 
       if (inputText == undefined || inputText.length === 0) {

--- a/packages/studio-base/src/components/Radio.stories.tsx
+++ b/packages/studio-base/src/components/Radio.stories.tsx
@@ -60,8 +60,8 @@ function ControlledExample() {
   return (
     <Box
       title="clicked the 2nd option manually"
-      onMount={React.useCallback((el) => {
-        const secondOptionEl = el.querySelector("[data-test='second']");
+      onMount={React.useCallback((el: HTMLDivElement) => {
+        const secondOptionEl = el.querySelector<HTMLElement>("[data-test='second']");
         if (secondOptionEl) {
           secondOptionEl.click();
         }

--- a/packages/studio-base/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/studio-base/src/components/Sidebar/SidebarButton.tsx
@@ -33,7 +33,10 @@ export default function SidebarButton({
 }): JSX.Element {
   const theme = useTheme();
   const { ref: tooltipRef, tooltip } = useTooltip({ contents: title, placement: "right" });
-  const renderStack = useCallback((props) => <div {...props} ref={tooltipRef} />, [tooltipRef]);
+  const renderStack = useCallback(
+    (props: React.HTMLAttributes<HTMLElement>) => <div {...props} ref={tooltipRef} />,
+    [tooltipRef],
+  );
 
   return (
     <Stack style={{ position: "relative", flexGrow: 1 }} as={renderStack}>

--- a/packages/studio-base/src/components/TextField.tsx
+++ b/packages/studio-base/src/components/TextField.tsx
@@ -97,7 +97,7 @@ export default function TextField({
   }, [error, onError]);
 
   const validate = useCallback(
-    (val) => {
+    (val: string) => {
       const validationResult = validator(val);
       if (validationResult != undefined) {
         setError(validationResult);
@@ -110,7 +110,7 @@ export default function TextField({
   );
 
   const handleChange = useCallback(
-    ({ target }) => {
+    ({ target }: React.ChangeEvent<HTMLInputElement>) => {
       setInputStr(target.value);
       if (!validateOnBlur) {
         validate(target.value);

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -436,7 +436,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
     [clearHoverValue, hoverComponentId],
   );
   const setGlobalHoverTime = useCallback(
-    (value) =>
+    (value: number) =>
       setHoverValue({
         componentId: hoverComponentId,
         value,
@@ -797,7 +797,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
   );
 
   const onScalesUpdate = useCallback(
-    (scales: RpcScales, { userInteraction }) => {
+    (scales: RpcScales, { userInteraction }: { userInteraction: boolean }) => {
       if (userInteraction) {
         setHasUserPannedOrZoomed(true);
       }

--- a/packages/studio-base/src/components/ValidatedInput.tsx
+++ b/packages/studio-base/src/components/ValidatedInput.tsx
@@ -133,7 +133,7 @@ export function ValidatedInputBase({
   }, [value, stringify, memorizedInputValidation, isEditing]);
 
   const handleChange = useCallback(
-    (e) => {
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const val = e.currentTarget?.value;
       if (!isEditing) {
         setIsEditing(true);

--- a/packages/studio-base/src/context/HoverValueContext.tsx
+++ b/packages/studio-base/src/context/HoverValueContext.tsx
@@ -78,7 +78,7 @@ export function HoverValueProvider({ children }: React.PropsWithChildren<unknown
       rawSetHoverValue((oldValue) => (isEqual(newValue, oldValue) ? oldValue : newValue)),
     [],
   );
-  const clearHoverValue = useCallback((componentId) => {
+  const clearHoverValue = useCallback((componentId: string) => {
     rawSetHoverValue((currentValue) =>
       currentValue?.componentId === componentId ? undefined : currentValue,
     );

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -426,7 +426,7 @@ function ImageView(props: Props) {
     topics: cameraInfoTopic != undefined ? [cameraInfoTopic] : [],
     restore: useCallback((value) => value, []),
     addMessage: useCallback(
-      (_value, { message }: MessageEvent<unknown>) => message as CameraInfo,
+      (_value: CameraInfo | undefined, { message }: MessageEvent<unknown>) => message as CameraInfo,
       [],
     ),
   });

--- a/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
@@ -187,7 +187,7 @@ const Sidebar = ({
   const templatesSelected = explorer === "templates";
 
   const gotoUtils = React.useCallback(
-    (filePath) => {
+    (filePath: string) => {
       import(
         /* webpackChunkName: "monaco-api" */
         "monaco-editor/esm/vs/editor/editor.api"

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -196,8 +196,8 @@ function NodePlayground(props: Props) {
   );
 
   const saveNode = React.useCallback(
-    (script) => {
-      if (selectedNodeId == undefined || !script || !selectedNode) {
+    (script: string | undefined) => {
+      if (selectedNodeId == undefined || script == undefined || script === "" || !selectedNode) {
         return;
       }
       setUserNodes({ [selectedNodeId]: { ...selectedNode, sourceCode: script } });

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -95,7 +95,10 @@ export function ToolbarTab(props: Props): JSX.Element {
   const inputRef = useRef<HTMLInputElement>(ReactNull);
   const [title, setTitle] = useState<string>(tabTitle ?? "");
   const [editingTitle, setEditingTitle] = useState<boolean>(false);
-  const onChangeTitleInput = useCallback((ev) => setTitle(ev.target.value), []);
+  const onChangeTitleInput = useCallback(
+    (ev: React.ChangeEvent<HTMLInputElement>) => setTitle(ev.target.value),
+    [],
+  );
 
   const { selectTab, removeTab } = useMemo(
     () => ({

--- a/packages/studio-base/src/panels/Tab/index.tsx
+++ b/packages/studio-base/src/panels/Tab/index.tsx
@@ -57,13 +57,13 @@ function Tab({ config, saveConfig }: Props) {
 
   // Create the actions used by the tab
   const selectTab = useCallback(
-    (idx) => {
+    (idx: number) => {
       saveConfig({ activeTabIdx: idx });
     },
     [saveConfig],
   );
   const setTabTitle = useCallback(
-    (idx, title) => {
+    (idx: number, title: string) => {
       const newTabs = tabs.slice();
       newTabs[idx] = { ...tabs[idx], title };
       saveConfig({ tabs: newTabs });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/GlobalVariableStyles.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/GlobalVariableStyles.tsx
@@ -114,10 +114,10 @@ export default function GlobalVariableStyles(props: Props): JSX.Element {
   const linkedGlobalVariablesByName = groupBy(linkedGlobalVariables, ({ name }) => name);
 
   const updateSettingsForGlobalVariable = useCallback(
-    (globalVariableName, settings: ColorOverride, sourceIdx = 0) => {
+    (globalVariableName: string, settings: ColorOverride, sourceIdx: number = 0) => {
       const updatedSettings = new Array(2)
         .fill(0)
-        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
+        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i] ?? {});
       updatedSettings[sourceIdx] = settings;
       setColorOverrideBySourceIdxByVariable({
         ...colorOverrideBySourceIdxByVariable,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -565,9 +565,9 @@ export default function Layout({
   };
 
   const setColorOverrideBySourceIdxByVariable = useCallback(
-    (_colorOverrideBySourceIdxByVariable) => {
+    (newValue: ColorOverrideBySourceIdxByVariable) => {
       callbackInputsRef.current.saveConfig({
-        colorOverrideBySourceIdxByVariable: _colorOverrideBySourceIdxByVariable,
+        colorOverrideBySourceIdxByVariable: newValue,
       });
     },
     [],

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
@@ -194,7 +194,7 @@ export default function TreeNodeRow({
 
   const { setHoveredMarkerMatchers } = useContext(ThreeDimensionalVizContext);
   const updateHoveredMarkerMatchers = useCallback(
-    (columnIndex, visible) => {
+    (columnIndex: number, visible: boolean) => {
       if (visible) {
         const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
         if (!isNonEmptyOrUndefined(topic)) {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
@@ -109,7 +109,7 @@ function NamespaceNodeRow({
   );
 
   const updateHoveredMarkerMatchers = useCallback(
-    (columnIndex, visible) => {
+    (columnIndex: number, visible: boolean) => {
       if (visible) {
         const topic = [topicName, joinTopics(SECOND_SOURCE_PREFIX, topicName)][columnIndex];
         if (!isNonEmptyOrUndefined(topic)) {
@@ -132,7 +132,7 @@ function NamespaceNodeRow({
   }, [updateHoveredMarkerMatchers, onMouseLeave]);
 
   const onToggle = useCallback(
-    (columnIndex) => {
+    (columnIndex: number) => {
       toggleNamespaceChecked({ topicName, namespace, columnIndex });
       updateHoveredMarkerMatchers(columnIndex, !(visibleInSceneByColumn[columnIndex] ?? false));
     },
@@ -145,7 +145,7 @@ function NamespaceNodeRow({
     ],
   );
   const onAltToggle = useCallback(
-    (columnIndex) => {
+    (columnIndex: number) => {
       toggleCheckAllAncestors(nodeKey, columnIndex, topicName);
       updateHoveredMarkerMatchers(columnIndex, !(visibleInSceneByColumn[columnIndex] ?? false));
     },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
@@ -121,10 +121,10 @@ function StyleExpressionNode(props: {
 
   // Callbacks
   const updateSettingsForGlobalVariable = useCallback(
-    (globalVariableName, settings: ColorOverride, sourceIdx = 0) => {
+    (globalVariableName: string, settings: ColorOverride, sourceIdx: number = 0) => {
       const updatedSettings = new Array(2)
         .fill(0)
-        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i]);
+        .map((_, i) => colorOverrideBySourceIdxByVariable[globalVariableName]?.[i] ?? {});
       updatedSettings[sourceIdx] = settings;
       setColorOverrideBySourceIdxByVariable({
         ...colorOverrideBySourceIdxByVariable,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -473,7 +473,7 @@ export default function useTopicTree({
 
   // A namespace is checked by default if none of the namespaces are in the checkedKeys and the selection is not modified.
   const getIsNamespaceCheckedByDefault = useCallback(
-    (topicName: string, columnIndex) =>
+    (topicName: string, columnIndex: number) =>
       !modifiedNamespaceTopics.includes(topicName) &&
       !checkedNamespacesByTopicName[
         columnIndex === 1 ? `${SECOND_SOURCE_PREFIX}${topicName}` : topicName

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -13,6 +13,7 @@
 
 import { uniq, omit, debounce } from "lodash";
 import React, { useCallback, useMemo, useState, useRef, useEffect } from "react";
+import { CameraState } from "regl-worldview";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import {
@@ -146,7 +147,7 @@ function BaseRenderer(props: Props): JSX.Element {
   );
 
   const saveCameraState = useCallback(
-    (newCameraStateObj) => saveConfig({ cameraState: newCameraStateObj }),
+    (newCameraStateObj: Partial<CameraState>) => saveConfig({ cameraState: newCameraStateObj }),
     [saveConfig],
   );
   const saveCameraStateDebounced = useMemo(
@@ -155,7 +156,7 @@ function BaseRenderer(props: Props): JSX.Element {
   );
 
   const onCameraStateChange = useCallback(
-    (newCameraState) => {
+    (newCameraState: CameraState) => {
       const newCurrentCameraState = omit(newCameraState, ["target", "targetOrientation"]);
       setConfigCameraState(newCurrentCameraState);
 

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -15,7 +15,7 @@ import PinIcon from "@mdi/svg/svg/pin.svg";
 import cx from "classnames";
 import { compact } from "lodash";
 import { useCallback, useMemo } from "react";
-import { List, AutoSizer } from "react-virtualized";
+import { List, AutoSizer, ListRowProps } from "react-virtualized";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
@@ -124,7 +124,8 @@ function DiagnosticSummary(props: Props): JSX.Element {
   );
 
   const renderRow = useCallback(
-    ({ item, style, key }) => {
+    // eslint-disable-next-line react/no-unused-prop-types
+    ({ item, style, key }: ListRowProps & { item: DiagnosticInfo }) => {
       return (
         <div key={key} style={style}>
           <NodeRow
@@ -203,7 +204,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
             height={height}
             style={{ outline: "none" }}
             rowHeight={25}
-            rowRenderer={(rowProps) => renderRow({ ...rowProps, item: nodes[rowProps.index] })}
+            rowRenderer={(rowProps) => renderRow({ ...rowProps, item: nodes[rowProps.index]! })}
             rowCount={nodes.length}
             overscanRowCount={10}
           />

--- a/packages/studio-base/src/typings/react.d.ts
+++ b/packages/studio-base/src/typings/react.d.ts
@@ -10,6 +10,13 @@ declare global {
     // Add an extra overload so that call sites can use `useRef<T>(ReactNull)` instead of
     // `useRef<T | ReactNull>(ReactNull)`.
     function useRef<T>(_: ReactNull): MutableRefObject<T | ReactNull>;
+
+    // @types/react uses `any` here, which silences helpful TypeScript errors
+    // https://github.com/microsoft/TypeScript/issues/37595
+    function useCallback<T extends (...args: never[]) => unknown>(
+      callback: T,
+      deps: React.DependencyList,
+    ): T;
   }
 
   // This alias is used so that we can prevent null in most places, but still use it


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Due to an issue with `@types/react` (described in https://github.com/microsoft/TypeScript/issues/37595, and marked as a TODO in the type definitions) the argument types in a useCallback function would be `any` by default. This didn't trigger `noImplicitAny` errors because the `any` was explicit in the `@types/react` definitions.