### PR TITLE
Increase timeout for integration test

### DIFF
--- a/desktop/integration-test/startup.test.ts
+++ b/desktop/integration-test/startup.test.ts
@@ -40,5 +40,5 @@ describe("startup", () => {
     });
 
     await electronApp.close();
-  });
+  }, 10_000);
 });


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
I've had this test time out on me several times in CI. Re-running always makes it work. Hopefully doubling the timeout will reduce how often this happens.