### PR TITLE
Topic Graph: add setting to hide topics without subscribers

### DIFF
--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -3,8 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useEffect, useState } from "react";
+import { useAsync } from "react-use";
 
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
+import delay from "@foxglove/studio-base/util/delay";
 
 import TopicGraph from "./index";
 
@@ -21,7 +23,11 @@ export const Empty = (): JSX.Element => {
   );
 };
 
-export const OneTopic = (): JSX.Element => {
+function TopicsStory({
+  topicVisibility: initialTopicVisibility,
+}: {
+  topicVisibility: "hide" | "show" | "show-only-with-subscribers";
+}) {
   const [fixture] = useState<Fixture>({
     frame: {},
     topics: [{ name: "/topic", datatype: "std_msgs/Header" }],
@@ -29,6 +35,7 @@ export const OneTopic = (): JSX.Element => {
       publishedTopics: new Map(
         Object.entries({
           "/topic": new Set(["pub-1", "pub-2"]),
+          "/topic_without_subscriber": new Set(["pub-1", "pub-2"]),
         }),
       ),
       subscribedTopics: new Map(
@@ -39,12 +46,26 @@ export const OneTopic = (): JSX.Element => {
     },
   });
 
+  useAsync(async () => {
+    const clicks = { show: 0, hide: 1, "show-only-with-subscribers": 2 }[initialTopicVisibility];
+    for (let i = 0; i < clicks; i++) {
+      await delay(10);
+      document.querySelector<HTMLElement>(`[data-test="toggle-topics"]`)!.click();
+    }
+  }, [initialTopicVisibility]);
+
   return (
     <PanelSetup fixture={fixture}>
       <TopicGraph />
     </PanelSetup>
   );
-};
+}
+
+export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="show" />;
+export const TopicsWithSubscribers = (): JSX.Element => (
+  <TopicsStory topicVisibility="show-only-with-subscribers" />
+);
+export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="hide" />;
 
 // Adding new active data should cause the graph to re-layout
 export const ReLayout = (): JSX.Element => {

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -32,17 +32,11 @@ function TopicsStory({
     frame: {},
     topics: [{ name: "/topic", datatype: "std_msgs/Header" }],
     activeData: {
-      publishedTopics: new Map(
-        Object.entries({
-          "/topic": new Set(["pub-1", "pub-2"]),
-          "/topic_without_subscriber": new Set(["pub-1", "pub-2"]),
-        }),
-      ),
-      subscribedTopics: new Map(
-        Object.entries({
-          "/topic": new Set(["sub-1"]),
-        }),
-      ),
+      publishedTopics: new Map([
+        ["/topic", new Set(["pub-1", "pub-2"])],
+        ["/topic_without_subscriber", new Set(["pub-1", "pub-2"])],
+      ]),
+      subscribedTopics: new Map([["/topic", new Set(["sub-1"])]]),
     },
   });
 
@@ -73,16 +67,8 @@ export const ReLayout = (): JSX.Element => {
     frame: {},
     topics: [{ name: "/topic", datatype: "std_msgs/Header" }],
     activeData: {
-      publishedTopics: new Map(
-        Object.entries({
-          "/topic": new Set(["pub-1", "pub-2"]),
-        }),
-      ),
-      subscribedTopics: new Map(
-        Object.entries({
-          "/topic": new Set(["sub-1"]),
-        }),
-      ),
+      publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
+      subscribedTopics: new Map([["/topic", new Set(["sub-1"])]]),
     },
   });
 
@@ -92,16 +78,8 @@ export const ReLayout = (): JSX.Element => {
         frame: {},
         topics: [{ name: "/topic", datatype: "std_msgs/Header" }],
         activeData: {
-          publishedTopics: new Map(
-            Object.entries({
-              "/topic": new Set(["pub-1", "pub-2"]),
-            }),
-          ),
-          subscribedTopics: new Map(
-            Object.entries({
-              "/topic": new Set(["sub-1", "sub-2"]),
-            }),
-          ),
+          publishedTopics: new Map([["/topic", new Set(["pub-1", "pub-2"])]]),
+          subscribedTopics: new Map([["/topic", new Set(["sub-1", "sub-2"])]]),
         },
       });
     }, 100);


### PR DESCRIPTION
**User-Facing Changes**
The Topic Graph panel now allows hiding topics with no subscribers.

Showing all topics:
<img width="707" alt="Screen Shot 2021-07-09 at 2 07 26 PM" src="https://user-images.githubusercontent.com/14237/125138030-b8954680-e0c2-11eb-9781-3e1fc9cce969.png">

Showing only topics with subscribers:
<img width="593" alt="Screen Shot 2021-07-09 at 2 07 38 PM" src="https://user-images.githubusercontent.com/14237/125138034-baf7a080-e0c2-11eb-8948-3306dea00ac7.png">
