### PR TITLE
Update message path filter syntax to correctly filter bigints

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/constants.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/constants.ts
@@ -35,7 +35,7 @@ export const rosPrimitives = Object.keys(RosPrimitives) as RosPrimitive[];
 export type MessagePathFilter = {
   type: "filter";
   path: string[];
-  value?: number | string | { variableName: string; startLoc: number };
+  value?: number | string | bigint | { variableName: string; startLoc: number };
   nameLoc: number;
   valueLoc: number;
   repr: string; // the original string representation of the filter

--- a/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
+++ b/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
@@ -24,8 +24,7 @@ id -> [a-zA-Z0-9_]:+
 
 # Integer.
 integer
-   -> [0-9]:+      {% (d) => ({ value: parseInt(d[0].join("")), repr: d[0].join("") }) %}
-    | "-" [0-9]:+  {% (d) => ({ value: -parseInt(d[1].join("")), repr: `-${d[1].join("")}` }) %}
+   -> "-":? [0-9]:+  {% (d) => ({ value: BigInt((d[0] ?? "") + d[1].join("")), repr: (d[0] ?? "") + d[1].join("") }) %}
 
 # String of the form 'hi' or "hi". No escaping supported.
 string
@@ -68,7 +67,7 @@ name -> id
   {% (d) => ({ type: "name", name: d[0] }) %}
 
 # Slice part; can be a single array index `[0]` or multiple `[0:10]`, or even infinite `[:]`.
-sliceVal -> integer {% (d) => (d[0].value) %} | variable {% (d) => (d[0].value) %}
+sliceVal -> integer {% (d) => Number(d[0].value) %} | variable {% (d) => (d[0].value) %}
 slice -> "[" sliceVal "]"
             {% (d) => ({ type: "slice", start: d[1], end: d[1] }) %}
        | "[" sliceVal:? ":" sliceVal:? "]"

--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
@@ -200,7 +200,7 @@ describe("parseRosPath", () => {
         {
           type: "filter",
           path: ["bar"],
-          value: 3,
+          value: 3n,
           nameLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==".length,
           repr: "bar==3",
@@ -209,7 +209,7 @@ describe("parseRosPath", () => {
         {
           type: "filter",
           path: ["bar"],
-          value: -1,
+          value: -1n,
           nameLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{".length,
           valueLoc: "/topic.foo{bar=='baz'}.a{bar==\"baz\"}.b{bar==3}.c{bar==".length,
           repr: "bar==-1",
@@ -256,7 +256,7 @@ describe("parseRosPath", () => {
         {
           type: "filter",
           path: ["baz"],
-          value: 2,
+          value: 2n,
           nameLoc: "/topic{foo=='bar'}{".length,
           valueLoc: "/topic{foo=='bar'}{baz==".length,
           repr: "baz==2",
@@ -361,7 +361,7 @@ describe("parseRosPath", () => {
         {
           type: "filter",
           path: [],
-          value: 1,
+          value: 1n,
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{==".length,
           repr: "==1",
@@ -376,7 +376,7 @@ describe("parseRosPath", () => {
         {
           type: "filter",
           path: [],
-          value: -3,
+          value: -3n,
           nameLoc: "/topic.foo{".length,
           valueLoc: "/topic.foo{==".length,
           repr: "==-3",

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -644,6 +644,61 @@ describe("useCachedGetMessagePathDataItems", () => {
         ],
       ]);
     });
+
+    it("filters correctly with bigints", () => {
+      const messages: MessageEvent<unknown>[] = [
+        {
+          topic: "/some/topic",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: { str_field: "A", num_field: 18446744073709551616n },
+        },
+        {
+          topic: "/some/topic",
+          receiveTime: { sec: 0, nsec: 0 },
+          message: { str_field: "B", num_field: 18446744073709552020n },
+        },
+      ];
+      const topics: Topic[] = [{ name: "/some/topic", datatype: "some_datatype" }];
+      const datatypes: RosDatatypes = {
+        some_datatype: {
+          fields: [{ name: "num_field", type: "uint64" }],
+        },
+      };
+
+      expect(
+        addValuesWithPathsToItems(
+          messages,
+          "/some/topic{num_field==18446744073709551616}.num_field",
+          topics,
+          datatypes,
+        ),
+      ).toEqual([
+        [
+          {
+            value: 18446744073709551616n,
+            path: "/some/topic{num_field==18446744073709551616}.num_field",
+          },
+        ],
+        [],
+      ]);
+
+      expect(
+        addValuesWithPathsToItems(
+          messages,
+          "/some/topic{num_field==18446744073709552020}.num_field",
+          topics,
+          datatypes,
+        ),
+      ).toEqual([
+        [],
+        [
+          {
+            value: 18446744073709552020n,
+            path: "/some/topic{num_field==18446744073709552020}.num_field",
+          },
+        ],
+      ]);
+    });
   });
 });
 

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -141,7 +141,7 @@ function filterMatches(filter: MessagePathFilter, value: any) {
   }
 
   // Test equality using `==` so we can be forgiving for comparing booleans with integers,
-  // comparing numbers with strings, and so on.
+  // comparing numbers with strings, bigints with numbers, and so on.
   // eslint-disable-next-line @foxglove/strict-equality
   return currentValue == filter.value;
 }


### PR DESCRIPTION
**User-Facing Changes**
Message path filtering now works more reliably for int64/uint64 values. Previously, filter values were incorrectly rounded before comparing with message data.

**Description**
Follow up from #1297. Parse all filters as bigints. Since we use `==` for comparison, this continues to work with <=int32 fields. Added a (previously failing) test to check that filters work correctly for bigint fields.