### PR TITLE
Internal: add ready signal to plot stories

### DIFF
--- a/packages/studio-base/src/.storybook/preview.tsx
+++ b/packages/studio-base/src/.storybook/preview.tsx
@@ -2,12 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story } from "@storybook/react";
+import { Story, StoryContext } from "@storybook/react";
+import { useMemo } from "react";
 import { ToastProvider } from "react-toast-notifications";
 
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import { HoverValueProvider } from "@foxglove/studio-base/context/HoverValueContext";
 import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
+import ReadySignalContext from "@foxglove/studio-base/stories/ReadySignalContext";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import waitForFonts from "@foxglove/studio-base/util/waitForFonts";
 
@@ -16,9 +18,15 @@ import "./styles.scss";
 
 let loaded = false;
 
-function withContextProviders(Child: Story): JSX.Element {
+function WithContextProviders(Child: Story, ctx: StoryContext): JSX.Element {
+  const sig = ctx.parameters?.screenshot?.signal;
+  const readySignal = useMemo(() => {
+    return sig ? () => sig.resolve() : undefined;
+  }, [sig]);
+
   const providers = [
     /* eslint-disable react/jsx-key */
+    <ReadySignalContext.Provider value={readySignal} />,
     <ThemeProvider />,
     <ToastProvider>{undefined}</ToastProvider>,
     <HoverValueProvider />,
@@ -43,7 +51,7 @@ export const loaders = [
   },
 ];
 
-export const decorators = [withContextProviders];
+export const decorators = [WithContextProviders];
 
 export const parameters = {
   // Disable default padding around the page body

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -18,6 +18,8 @@ import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaE
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
 import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import PanelSetup, { triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import signal from "@foxglove/studio-base/util/signal";
 import { fromSec } from "@foxglove/studio-base/util/time";
 
 const float64StampedDefinition = `std_msgs/Header header
@@ -326,29 +328,59 @@ export default {
   },
 };
 
+function useResumeCount(count: number) {
+  const countRef = useRef(0);
+  const readySignal = useReadySignal();
+
+  const pauseFrame = useCallback(() => {
+    return () => {
+      countRef.current += 1;
+      if (countRef.current === count) {
+        readySignal();
+      }
+    };
+  }, [count, readySignal]);
+
+  return pauseFrame;
+}
+
 LineGraph.storyName = "line graph";
 export function LineGraph(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot overrideConfig={exampleConfig} />
     </PanelSetup>
   );
 }
+LineGraph.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 LineGraphWithLegendsHidden.storyName = "line graph with legends hidden";
 export function LineGraphWithLegendsHidden(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot overrideConfig={{ ...exampleConfig, showLegend: false }} />
     </PanelSetup>
   );
 }
+LineGraphWithLegendsHidden.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
   "in a line graph with multiple plots, x-axes are synced";
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
+  const pauseFrame = useResumeCount(8);
+
   return (
-    <PanelSetup fixture={fixture} style={{ flexDirection: "column" }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -376,10 +408,16 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
     </PanelSetup>
   );
 }
+InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 LineGraphAfterZoom.storyName = "line graph after zoom";
 export function LineGraphAfterZoom(): JSX.Element {
   const pauseState = useRef<"zoom" | "ready">("zoom");
+  const readyState = useReadySignal();
 
   const doZoom = useCallback(() => {
     const canvasEl = document.querySelector("canvas");
@@ -401,10 +439,11 @@ export function LineGraphAfterZoom(): JSX.Element {
           doZoom();
           break;
         default:
+          readyState();
           break;
       }
     };
-  }, [doZoom]);
+  }, [doZoom, readyState]);
 
   return (
     <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
@@ -412,11 +451,17 @@ export function LineGraphAfterZoom(): JSX.Element {
     </PanelSetup>
   );
 }
+LineGraphAfterZoom.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 TimestampMethodHeaderStamp.storyName = "timestampMethod: headerStamp";
 export function TimestampMethodHeaderStamp(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -433,11 +478,18 @@ export function TimestampMethodHeaderStamp(): JSX.Element {
     </PanelSetup>
   );
 }
+TimestampMethodHeaderStamp.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 LongPath.storyName = "long path";
 export function LongPath(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture} style={{ maxWidth: 250 }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 250 }}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -453,11 +505,18 @@ export function LongPath(): JSX.Element {
     </PanelSetup>
   );
 }
+LongPath.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 DisabledPath.storyName = "disabled path";
 export function DisabledPath(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -478,11 +537,18 @@ export function DisabledPath(): JSX.Element {
     </PanelSetup>
   );
 }
+DisabledPath.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 ReferenceLine.storyName = "reference line";
 export function ReferenceLine(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -500,11 +566,18 @@ export function ReferenceLine(): JSX.Element {
     </PanelSetup>
   );
 }
+ReferenceLine.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithMinAndMaxYValues.storyName = "with min and max Y values";
 export function WithMinAndMaxYValues(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -523,11 +596,18 @@ export function WithMinAndMaxYValues(): JSX.Element {
     </PanelSetup>
   );
 }
+WithMinAndMaxYValues.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMinYValueLessThanMinimumValue.storyName = "with just min Y value less than minimum value";
 export function WithJustMinYValueLessThanMinimumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -546,11 +626,18 @@ export function WithJustMinYValueLessThanMinimumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMinYValueLessThanMinimumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMinYValueMoreThanMinimumValue.storyName = "with just min Y value more than minimum value";
 export function WithJustMinYValueMoreThanMinimumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -569,11 +656,18 @@ export function WithJustMinYValueMoreThanMinimumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMinYValueMoreThanMinimumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMinYValueMoreThanMaximumValue.storyName = "with just min Y value more than maximum value";
 export function WithJustMinYValueMoreThanMaximumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -592,11 +686,18 @@ export function WithJustMinYValueMoreThanMaximumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMinYValueMoreThanMaximumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMaxYValueLessThanMaximumValue.storyName = "with just max Y value less than maximum value";
 export function WithJustMaxYValueLessThanMaximumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -615,11 +716,18 @@ export function WithJustMaxYValueLessThanMaximumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMaxYValueLessThanMaximumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMaxYValueMoreThanMaximumValue.storyName = "with just max Y value more than maximum value";
 export function WithJustMaxYValueMoreThanMaximumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -638,11 +746,18 @@ export function WithJustMaxYValueMoreThanMaximumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMaxYValueMoreThanMaximumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 WithJustMaxYValueLessThanMinimumValue.storyName = "with just max Y value less than minimum value";
 export function WithJustMaxYValueLessThanMinimumValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           xAxisVal: "timestamp",
@@ -661,12 +776,19 @@ export function WithJustMaxYValueLessThanMinimumValue(): JSX.Element {
     </PanelSetup>
   );
 }
+WithJustMaxYValueLessThanMinimumValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 ScatterPlotPlusLineGraphPlusReferenceLine.storyName =
   "scatter plot plus line graph plus reference line";
 export function ScatterPlotPlusLineGraphPlusReferenceLine(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -688,15 +810,24 @@ export function ScatterPlotPlusLineGraphPlusReferenceLine(): JSX.Element {
     </PanelSetup>
   );
 }
+ScatterPlotPlusLineGraphPlusReferenceLine.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 OpenXAxisDropdownMenu.storyName = "open x-axis dropdown menu";
 export function OpenXAxisDropdownMenu(): JSX.Element {
+  const readySignal = useReadySignal();
+
   const pauseFrame = useCallback(() => {
     return () => {
       const xAxisDropdown = document.querySelectorAll("[data-test=plot-legend-x-axis-menu]")[0];
       (xAxisDropdown as any).click();
+
+      readySignal();
     };
-  }, []);
+  }, [readySignal]);
 
   return (
     <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
@@ -704,11 +835,18 @@ export function OpenXAxisDropdownMenu(): JSX.Element {
     </PanelSetup>
   );
 }
+OpenXAxisDropdownMenu.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 IndexBasedXAxisForArray.storyName = "index-based x-axis for array";
 export function IndexBasedXAxisForArray(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -726,11 +864,18 @@ export function IndexBasedXAxisForArray(): JSX.Element {
     </PanelSetup>
   );
 }
+IndexBasedXAxisForArray.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 CustomXAxisTopic.storyName = "custom x-axis topic";
 export function CustomXAxisTopic(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -748,12 +893,19 @@ export function CustomXAxisTopic(): JSX.Element {
     </PanelSetup>
   );
 }
+CustomXAxisTopic.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 CurrentCustomXAxisTopic.storyName = "current custom x-axis topic";
 export function CurrentCustomXAxisTopic(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   // As above, but just shows a single point instead of the whole line.
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -771,12 +923,19 @@ export function CurrentCustomXAxisTopic(): JSX.Element {
     </PanelSetup>
   );
 }
+CurrentCustomXAxisTopic.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 CustomXAxisTopicWithMismatchedDataLengths.storyName =
   "custom x-axis topic with mismatched data lengths";
 export function CustomXAxisTopicWithMismatchedDataLengths(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -805,11 +964,19 @@ export function CustomXAxisTopicWithMismatchedDataLengths(): JSX.Element {
     </PanelSetup>
   );
 }
+CustomXAxisTopicWithMismatchedDataLengths.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 SuperCloseValues.storyName = "super close values";
 export function SuperCloseValues(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
     <PanelSetup
+      pauseFrame={pauseFrame}
       fixture={{
         datatypes: {
           "std_msgs/Float32": { fields: [{ name: "data", type: "float32", isArray: false }] },
@@ -846,11 +1013,18 @@ export function SuperCloseValues(): JSX.Element {
     </PanelSetup>
   );
 }
+SuperCloseValues.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 TimeValues.storyName = "time values";
 export function TimeValues(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -868,11 +1042,18 @@ export function TimeValues(): JSX.Element {
     </PanelSetup>
   );
 }
+TimeValues.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 PreloadedDataInBinaryBlocks.storyName = "preloaded data in binary blocks";
 export function PreloadedDataInBinaryBlocks(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
+    <PanelSetup pauseFrame={pauseFrame} fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -885,11 +1066,18 @@ export function PreloadedDataInBinaryBlocks(): JSX.Element {
     </PanelSetup>
   );
 }
+PreloadedDataInBinaryBlocks.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 MixedStreamedAndPreloadedData.storyName = "mixed streamed and preloaded data";
 export function MixedStreamedAndPreloadedData(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={withEndTime(fixture, { sec: 3, nsec: 0 })}>
+    <PanelSetup pauseFrame={pauseFrame} fixture={withEndTime(fixture, { sec: 3, nsec: 0 })}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -906,11 +1094,18 @@ export function MixedStreamedAndPreloadedData(): JSX.Element {
     </PanelSetup>
   );
 }
+MixedStreamedAndPreloadedData.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 PreloadedDataAndItsDerivative.storyName = "preloaded data and its derivative";
 export function PreloadedDataAndItsDerivative(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
+    <PanelSetup pauseFrame={pauseFrame} fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -927,11 +1122,18 @@ export function PreloadedDataAndItsDerivative(): JSX.Element {
     </PanelSetup>
   );
 }
+PreloadedDataAndItsDerivative.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 PreloadedDataAndItsNegative.storyName = "preloaded data and its negative";
 export function PreloadedDataAndItsNegative(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
+    <PanelSetup pauseFrame={pauseFrame} fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -948,11 +1150,18 @@ export function PreloadedDataAndItsNegative(): JSX.Element {
     </PanelSetup>
   );
 }
+PreloadedDataAndItsNegative.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 PreloadedDataAndItsAbsoluteValue.storyName = "preloaded data and its absolute value";
 export function PreloadedDataAndItsAbsoluteValue(): JSX.Element {
+  const pauseFrame = useResumeCount(4);
+
   return (
-    <PanelSetup fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
+    <PanelSetup pauseFrame={pauseFrame} fixture={withEndTime(fixture, { sec: 2, nsec: 0 })}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -969,6 +1178,11 @@ export function PreloadedDataAndItsAbsoluteValue(): JSX.Element {
     </PanelSetup>
   );
 }
+PreloadedDataAndItsAbsoluteValue.parameters = {
+  screenshot: {
+    signal: signal(),
+  },
+};
 
 export function Settings(): JSX.Element {
   return (

--- a/packages/studio-base/src/stories/ReadySignalContext.ts
+++ b/packages/studio-base/src/stories/ReadySignalContext.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+// ReadySignal is a function that indicates the story is ready
+type ReadySignal = () => void;
+
+const ReadySignalContext = createContext<ReadySignal | undefined>(undefined);
+
+function useReadySignal(): ReadySignal {
+  const readySignal = useContext(ReadySignalContext);
+  if (!readySignal) {
+    throw new Error("Add a signal to the story screenshot parameters");
+  }
+  return readySignal;
+}
+
+export { useReadySignal };
+export default ReadySignalContext;


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Since plots use workers we need to delay indicating the story is ready until the plot has rendered.

Fixes #1327
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
