### PR TITLE
Internal: delete open dropdown menu plot story

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -118,7 +118,6 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
           style={{ width: "auto", lineHeight: "normal", zIndex: 2 }}
         >
           <Dropdown
-            dataTest="plot-legend-x-axis-menu"
             value={xAxisVal}
             text={shortXAxisLabel(xAxisVal)}
             btnStyle={{ backgroundColor: "transparent", padding: 3 }}

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -816,31 +816,6 @@ ScatterPlotPlusLineGraphPlusReferenceLine.parameters = {
   },
 };
 
-OpenXAxisDropdownMenu.storyName = "open x-axis dropdown menu";
-export function OpenXAxisDropdownMenu(): JSX.Element {
-  const readySignal = useReadySignal();
-
-  const pauseFrame = useCallback(() => {
-    return () => {
-      const xAxisDropdown = document.querySelectorAll("[data-test=plot-legend-x-axis-menu]")[0];
-      (xAxisDropdown as any).click();
-
-      readySignal();
-    };
-  }, [readySignal]);
-
-  return (
-    <PanelSetup pauseFrame={pauseFrame} fixture={fixture}>
-      <Plot overrideConfig={exampleConfig} />
-    </PanelSetup>
-  );
-}
-OpenXAxisDropdownMenu.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
-};
-
 IndexBasedXAxisForArray.storyName = "index-based x-axis for array";
 export function IndexBasedXAxisForArray(): JSX.Element {
   const pauseFrame = useResumeCount(4);


### PR DESCRIPTION

**User-Facing Changes**
None.

**Description**
Testing functionality of the dropdown menu is better done within the dropdown component. Removes a test that is flaky since the menu may open at different speeds on different builds.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
