### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/*]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Always run CI on push to `release/*` branches. This will be used during the release process.