### PR TITLE
Lower resumeCount to 6 in x-axes story

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -377,7 +377,7 @@ LineGraphWithLegendsHidden.parameters = {
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
   "in a line graph with multiple plots, x-axes are synced";
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
-  const pauseFrame = useResumeCount(8);
+  const pauseFrame = useResumeCount(6);
 
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>


### PR DESCRIPTION
This now times out occasionally, which is worse than capturing a different snapshot because I can't manually approve the change