### PR TITLE
Internal: move global styles to App.tsx

### DIFF
--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -8,8 +8,6 @@
 import { init as initSentry } from "@sentry/electron";
 import ReactDOM from "react-dom";
 
-import "@foxglove/studio-base/styles/global.scss";
-
 import { Sockets } from "@foxglove/electron-socket/renderer";
 import Logger from "@foxglove/log";
 import { installDevtoolsFormatters, overwriteFetch, waitForFonts } from "@foxglove/studio-base";

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -25,6 +25,8 @@ import PanelCatalogProvider from "@foxglove/studio-base/providers/PanelCatalogPr
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 
+import "@foxglove/studio-base/styles/global.scss";
+
 type AppProps = {
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -5,8 +5,6 @@
 import { init as initSentry } from "@sentry/browser";
 import ReactDOM from "react-dom";
 
-import "@foxglove/studio-base/styles/global.scss";
-
 import Logger from "@foxglove/log";
 import { installDevtoolsFormatters, overwriteFetch, waitForFonts } from "@foxglove/studio-base";
 


### PR DESCRIPTION
**User-Facing Changes**
Downstream users of studio-base don't need to import the global styles.
App adds them for the user.

**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
