### PR TITLE
Use @foxglove/rosmsg-serialization (LazyMessageReader) in @foxglove/ros1

### DIFF
--- a/packages/ros1/src/Connection.ts
+++ b/packages/ros1/src/Connection.ts
@@ -2,9 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageReader } from "rosbag";
-
 import { RosMsgDefinition } from "@foxglove/rosmsg";
+import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 
 export interface ConnectionStats {
   bytesSent: number;
@@ -20,7 +19,7 @@ export interface Connection {
     listener: (
       header: Map<string, string>,
       msgDef: RosMsgDefinition[],
-      msgReader: MessageReader,
+      msgReader: LazyMessageReader,
     ) => void,
   ): this;
   on(eventName: "message", listener: (msg: unknown, data: Uint8Array) => void): this;
@@ -37,7 +36,7 @@ export interface Connection {
 
   messageDefinition(): RosMsgDefinition[];
 
-  messageReader(): MessageReader | undefined;
+  messageReader(): LazyMessageReader | undefined;
 
   close(): void;
 

--- a/packages/ros1/src/Subscription.ts
+++ b/packages/ros1/src/Subscription.ts
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { EventEmitter } from "eventemitter3";
-import { MessageReader } from "rosbag";
 
 import { RosMsgDefinition } from "@foxglove/rosmsg";
+import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 
 import { Connection } from "./Connection";
 import { PublisherLink } from "./PublisherLink";
@@ -41,7 +41,7 @@ export interface SubscriptionEvents {
   header: (
     header: Map<string, string>,
     msgDef: RosMsgDefinition[],
-    msgReader: MessageReader,
+    msgReader: LazyMessageReader,
   ) => void;
   message: (msg: unknown, data: Uint8Array, publisher: PublisherLink) => void;
 }

--- a/packages/ros1/src/TcpConnection.test.ts
+++ b/packages/ros1/src/TcpConnection.test.ts
@@ -93,9 +93,9 @@ describe("TcpConnection", () => {
       connection.on("error", reject);
     });
     await socket.connect();
-    const msg = await p;
+    const msg = (await p) as { toJSON: () => unknown };
 
-    expect(msg).toEqual({ b: 255, g: 86, r: 69 });
+    expect(msg.toJSON()).toEqual({ b: 255, g: 86, r: 69 });
 
     connection.close();
     await new Promise<void>((resolve, reject) =>

--- a/packages/ros1/src/TcpConnection.ts
+++ b/packages/ros1/src/TcpConnection.ts
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { EventEmitter } from "eventemitter3";
-import { MessageReader } from "rosbag";
 
 import { parse as parseMessageDefinition, RosMsgDefinition } from "@foxglove/rosmsg";
+import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 
 import { Connection, ConnectionStats } from "./Connection";
 import { LoggerService } from "./LoggerService";
@@ -17,7 +17,7 @@ export interface TcpConnectionEvents {
   header: (
     header: Map<string, string>,
     messageDefinition: RosMsgDefinition[],
-    messageReader: MessageReader,
+    messageReader: LazyMessageReader,
   ) => void;
   message: (msg: unknown, msgData: Uint8Array) => void;
   error: (err: Error) => void;
@@ -50,7 +50,7 @@ export class TcpConnection extends EventEmitter<TcpConnectionEvents> implements 
   };
   private _transformer = new RosTcpMessageStream();
   private _msgDefinition: RosMsgDefinition[] = [];
-  private _msgReader: MessageReader | undefined;
+  private _msgReader: LazyMessageReader | undefined;
   private _log?: LoggerService;
 
   constructor(
@@ -122,7 +122,7 @@ export class TcpConnection extends EventEmitter<TcpConnectionEvents> implements 
     return this._msgDefinition;
   }
 
-  messageReader(): MessageReader | undefined {
+  messageReader(): LazyMessageReader | undefined {
     return this._msgReader;
   }
 
@@ -212,7 +212,7 @@ export class TcpConnection extends EventEmitter<TcpConnectionEvents> implements 
 
       this._header = TcpConnection.ParseHeader(msgData);
       this._msgDefinition = parseMessageDefinition(this._header.get("message_definition") ?? "");
-      this._msgReader = new MessageReader(this._msgDefinition);
+      this._msgReader = new LazyMessageReader(this._msgDefinition);
       this.emit("header", this._header, this._msgDefinition, this._msgReader);
     } else {
       this._stats.messagesReceived++;

--- a/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
@@ -13,7 +13,7 @@
 
 import memoizeWeak from "memoize-weak";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { MessageReader } from "rosbag";
+import type { MessageReader } from "rosbag";
 import { v4 as uuidv4 } from "uuid";
 
 import { useShallowMemo } from "@foxglove/hooks";


### PR DESCRIPTION
**User-Facing Changes**

Internal cleanup only.

**Description**

This switches the ROS1 library from depending on rosbag (which was not listed as an explicit dependency before but it was used) to @foxglove/rosmsg-serialization. It is not an exact drop-in replacement since the message decoding is done with `LazyMessageReader` instead of `MessageReader` now, but since we use lazy messages for bag reading this should be a well tested path.