### PR TITLE
Internal: prevent punycode from appearing in web builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   },
   "resolutions": {
     "@types/node": "15.3.0",
-    "esbuild-loader/esbuild": "0.12.18",
-    "node-libs-browser/punycode": "2.1.1"
+    "esbuild-loader/esbuild": "0.12.18"
   },
   "devDependencies": {
     "@actions/core": "1.4.0",

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -44,16 +44,12 @@ export function makeConfig(
       extensions: [".js", ".ts", ".jsx", ".tsx"],
       alias: {
         "@foxglove/studio-base": path.resolve(__dirname, "src"),
-        "react-dnd": require.resolve("react-dnd"),
-        "styled-components": require.resolve("styled-components"),
       },
       fallback: {
         path: require.resolve("path-browserify"),
         stream: require.resolve("readable-stream"),
         zlib: require.resolve("browserify-zlib"),
         crypto: require.resolve("crypto-browserify"),
-        fs: false,
-        pnpapi: false,
 
         // TypeScript tries to use this when running in node
         perf_hooks: false,
@@ -66,6 +62,14 @@ export function makeConfig(
         "@blueprintjs/core": false,
         "@blueprintjs/icons": false,
         domain: false,
+
+        // don't inject these things into our web build
+        fs: false,
+        pnpapi: false,
+
+        // punycode is a dependency for some older webpack v4 browser libs
+        // It adds unecessary bloat to the build so we make sure it isn't included
+        punycode: false,
       },
     },
     module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19923,7 +19923,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:2.1.1, punycode@npm:^2.1.0, punycode@npm:^2.1.1":
+"punycode@npm:^1.2.4":
+  version: 1.4.1
+  resolution: "punycode@npm:1.4.1"
+  checksum: fa6e698cb53db45e4628559e557ddaf554103d2a96a1d62892c8f4032cd3bc8871796cae9eabc1bc700e2b6677611521ce5bb1d9a27700086039965d0cf34518
+  languageName: node
+  linkType: hard
+
+"punycode@npm:^2.1.0, punycode@npm:^2.1.1":
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8


### PR DESCRIPTION
This module is a dependency for some older node libs with webpack v4,
it shouldn't end up in our builds.

**User-Facing Changes**
None

**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
