### PR TITLE
Fix: Remove ROS1 and Velodyne from the web build

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -22,10 +22,6 @@ const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo
 export default function Root(): JSX.Element {
   const playerSources: PlayerSourceDefinition[] = [
     {
-      name: "ROS 1",
-      type: "ros1-socket",
-    },
-    {
       name: "Rosbridge (WebSocket)",
       type: "ros-ws",
     },
@@ -40,10 +36,6 @@ export default function Root(): JSX.Element {
     {
       name: "ROS 2 Bag Folder (local)",
       type: "ros2-folder",
-    },
-    {
-      name: "Velodyne LIDAR",
-      type: "velodyne-device",
     },
   ];
 


### PR DESCRIPTION


**User-Facing Changes**
ROS 1 and Velodyne won't show up in the web build.

**Description**
These were erroneously added when Velodyne support was added.

Fixes #1470


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
