### PR TITLE
Cleanup .prettierrc.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 .github/**/*.md
+.yarn/plugins
+.yarn/releases

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,11 +1,2 @@
-arrowParens: always
 printWidth: 100
-trailingComma: "all"
-tabWidth: 2
-semi: true
-
-# For TS 4.3: https://github.com/prettier/prettier/issues/10642#issuecomment-849879761
-overrides:
-  - files: ["*.ts", "*.tsx"]
-    options:
-      parser: babel-ts
+trailingComma: all

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,15 @@
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  // enable intellisense in custom snippets (see snippets.code-snippets)
+  "editor.suggest.snippetsPreventQuickSuggestions": false,
+  "eslint.options": {
+    "reportUnusedDisableDirectives": true
+  },
   "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
   "prettier.prettierPath": "./node_modules/prettier",
   "search.exclude": {
     "**/*.code-search": true,
@@ -18,10 +26,5 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "eslint.options": {
-    "reportUnusedDisableDirectives": true
-  },
-  "jest.autoRun": { "watch": false, "onSave": "test-file" },
-  // enable intellisense in custom snippets (see snippets.code-snippets)
-  "editor.suggest.snippetsPreventQuickSuggestions": false
+  "jest.autoRun": { "watch": false, "onSave": "test-file" }
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
- Remove `babel-ts` config which links to an issue that seems to have been fixed in recent versions of prettier
- Remove redundant prettierrc configuration which specifies defaults
- Enable `files.insertFinalNewline` and `files.trimFinalNewlines` in vscode settings to catch files which prettier does not support