### PR TITLE
Add all relevant topic visibility settings in Topic Graph panel

### DIFF
--- a/packages/studio-base/src/components/ExpandingToolbar.tsx
+++ b/packages/studio-base/src/components/ExpandingToolbar.tsx
@@ -55,6 +55,7 @@ type Props<T extends string> = {
   selectedTab?: T; // collapse the toolbar if selectedTab is undefined
   tooltip: string;
   style?: React.CSSProperties;
+  dataTest?: string;
 };
 
 export default function ExpandingToolbar<T extends string>({
@@ -65,10 +66,11 @@ export default function ExpandingToolbar<T extends string>({
   selectedTab,
   tooltip,
   style,
+  dataTest,
 }: Props<T>): JSX.Element {
   const expanded = selectedTab != undefined;
   if (!expanded) {
-    let selectedTabLocal = selectedTab;
+    let selectedTabLocal: T | undefined = selectedTab;
     // default to the first child's name if no tab is selected
     React.Children.forEach(children, (child) => {
       if (selectedTabLocal == undefined) {
@@ -76,7 +78,7 @@ export default function ExpandingToolbar<T extends string>({
       }
     });
     return (
-      <div className={className}>
+      <div data-test={dataTest} className={className}>
         <Button tooltip={tooltip} onClick={() => onSelectTab(selectedTabLocal)}>
           <Icon dataTest={`ExpandingToolbar-${tooltip}`}>{icon}</Icon>
         </Button>
@@ -90,7 +92,7 @@ export default function ExpandingToolbar<T extends string>({
     }
   });
   return (
-    <div className={cx(className, styles.expanded)}>
+    <div data-test={dataTest} className={cx(className, styles.expanded)}>
       <Flex row className={styles.tabBar}>
         {React.Children.map(children, (child) => {
           return (

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -26,7 +26,7 @@ export const Empty = (): JSX.Element => {
 function TopicsStory({
   topicVisibility: initialTopicVisibility,
 }: {
-  topicVisibility: "hide" | "show" | "show-only-with-subscribers";
+  topicVisibility: "none" | "all" | "subscribers";
 }) {
   const [fixture] = useState<Fixture>({
     frame: {},
@@ -41,7 +41,7 @@ function TopicsStory({
   });
 
   useAsync(async () => {
-    const clicks = { show: 0, hide: 1, "show-only-with-subscribers": 2 }[initialTopicVisibility];
+    const clicks = { all: 0, none: 1, subscribers: 2 }[initialTopicVisibility];
     for (let i = 0; i < clicks; i++) {
       await delay(10);
       document.querySelector<HTMLElement>(`[data-test="toggle-topics"]`)!.click();
@@ -55,11 +55,11 @@ function TopicsStory({
   );
 }
 
-export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="show" />;
+export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="all" />;
 export const TopicsWithSubscribers = (): JSX.Element => (
-  <TopicsStory topicVisibility="show-only-with-subscribers" />
+  <TopicsStory topicVisibility="subscribers" />
 );
-export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="hide" />;
+export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="none" />;
 
 // Adding new active data should cause the graph to re-layout
 export const ReLayout = (): JSX.Element => {

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -8,7 +8,7 @@ import { useAsync } from "react-use";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import delay from "@foxglove/studio-base/util/delay";
 
-import TopicGraph from "./index";
+import TopicGraph, { TopicVisibility } from "./index";
 
 export default {
   title: "panels/TopicGraph/index",
@@ -26,7 +26,7 @@ export const Empty = (): JSX.Element => {
 function TopicsStory({
   topicVisibility: initialTopicVisibility,
 }: {
-  topicVisibility: "none" | "all" | "subscribers";
+  topicVisibility: TopicVisibility;
 }) {
   const [fixture] = useState<Fixture>({
     frame: {},
@@ -41,10 +41,16 @@ function TopicsStory({
   });
 
   useAsync(async () => {
-    const clicks = { all: 0, none: 1, subscribers: 2 }[initialTopicVisibility];
-    for (let i = 0; i < clicks; i++) {
-      await delay(10);
-      document.querySelector<HTMLElement>(`[data-test="toggle-topics"]`)!.click();
+    await delay(10);
+    document.querySelector<HTMLElement>(`[data-test="set-topic-visibility"] button`)!.click();
+    const radioOption = document.querySelector<HTMLElement>(
+      `[data-test="${initialTopicVisibility}"]`,
+    );
+    if (radioOption) {
+      radioOption.click();
+      document
+        .querySelector<HTMLElement>(`[data-test="set-topic-visibility"] div button:last-child`)!
+        .click();
     }
   }, [initialTopicVisibility]);
 
@@ -57,7 +63,7 @@ function TopicsStory({
 
 export const AllTopics = (): JSX.Element => <TopicsStory topicVisibility="all" />;
 export const TopicsWithSubscribers = (): JSX.Element => (
-  <TopicsStory topicVisibility="subscribers" />
+  <TopicsStory topicVisibility="subscribed" />
 );
 export const TopicsHidden = (): JSX.Element => <TopicsStory topicVisibility="none" />;
 

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -103,7 +103,17 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
     },
   },
 ];
-const topicIdsToLabelsMap: Record<string, string> = {
+
+type TopicVisibility =
+  | "all"
+  | "none"
+  | "published"
+  | "subscribed"
+  | "connected"
+  | "disconnected-pub"
+  | "disconnected-sub";
+
+const topicVisibilityToLabelMap: Record<TopicVisibility, string> = {
   all: "All topics",
   none: "No topics",
   published: "Published topics",
@@ -138,7 +148,7 @@ function TopicGraph() {
 
   const [lrOrientation, setLROrientation] = useState<boolean>(false);
   const [showServices, setShowServices] = useState<boolean>(true);
-  const [topicVisibility, setTopicVisibility] = useState<string>("all");
+  const [topicVisibility, setTopicVisibility] = useState<TopicVisibility>("all");
 
   const textMeasure = useMemo(
     () =>
@@ -304,7 +314,7 @@ function TopicGraph() {
   }, [lrOrientation]);
 
   const topicVisibilityTooltip: string = useMemo(() => {
-    return `Showing ${(topicIdsToLabelsMap[topicVisibility] ?? "").toLowerCase()}`;
+    return `Showing ${(topicVisibilityToLabelMap[topicVisibility] ?? "").toLowerCase()}`;
   }, [topicVisibility]);
 
   const topicButtonColor = useMemo(() => {
@@ -367,11 +377,11 @@ function TopicGraph() {
               selectedId={topicVisibility}
               onChange={(id) => {
                 graph.current?.resetUserPanZoom();
-                setTopicVisibility(id);
+                setTopicVisibility(id as TopicVisibility);
               }}
-              options={Object.keys(topicIdsToLabelsMap).map((id) => ({
+              options={Object.keys(topicVisibilityToLabelMap).map((id) => ({
                 id,
-                label: topicIdsToLabelsMap[id] ?? "",
+                label: topicVisibilityToLabelMap[id as TopicVisibility] ?? "",
               }))}
             />
           </ToolGroup>

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -103,14 +103,6 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
     },
   },
 ];
-type TopicVisibilityOptions =
-  | "none"
-  | "all"
-  | "published"
-  | "subscribed"
-  | "connected"
-  | "disconnected-pub"
-  | "disconnected-sub";
 const topicIdsToLabelsMap: Record<string, string> = {
   none: "No topics",
   all: "All topics",
@@ -146,7 +138,7 @@ function TopicGraph() {
 
   const [lrOrientation, setLROrientation] = useState<boolean>(false);
   const [showServices, setShowServices] = useState<boolean>(true);
-  const [topicVisibility, setTopicVisibility] = useState<TopicVisibilityOptions>("all");
+  const [topicVisibility, setTopicVisibility] = useState<string>("all");
 
   const textMeasure = useMemo(
     () =>
@@ -157,24 +149,18 @@ function TopicGraph() {
     [],
   );
 
-  const getTopicDetails = useCallback(
+  const topicPassesConditions = useCallback(
     ({
       topicIdWithSubscriptions,
       topic,
     }: {
       topicIdWithSubscriptions: Set<string>;
       topic: string;
-    }) => {
+    }): boolean => {
       const publishedTopicsWithFallback = publishedTopics ?? new Map([]);
       const published = publishedTopicsWithFallback.has(topic);
       const subscribed = topicIdWithSubscriptions.has(topic);
-      return { published, subscribed };
-    },
-    [publishedTopics],
-  );
 
-  const passesConditions = useCallback(
-    ({ published, subscribed }: { published: boolean; subscribed: boolean }): boolean => {
       if (topicVisibility === "none") {
         return false;
       }
@@ -187,7 +173,7 @@ function TopicGraph() {
         (topicVisibility === "disconnected-sub" && subscribed && !published)
       );
     },
-    [topicVisibility],
+    [publishedTopics, topicVisibility],
   );
 
   const elements = useMemo<cytoscape.ElementDefinition[]>(() => {
@@ -225,8 +211,7 @@ function TopicGraph() {
     }
     if (topicVisibility !== "none") {
       for (const topic of topicIds) {
-        const { published, subscribed } = getTopicDetails({ topicIdWithSubscriptions, topic });
-        if (!passesConditions({ published, subscribed })) {
+        if (!topicPassesConditions({ topicIdWithSubscriptions, topic })) {
           continue;
         }
         output.push({
@@ -265,8 +250,7 @@ function TopicGraph() {
       default:
         if (publishedTopics != undefined) {
           for (const [topic, publishers] of publishedTopics.entries()) {
-            const { published, subscribed } = getTopicDetails({ topicIdWithSubscriptions, topic });
-            if (!passesConditions({ published, subscribed })) {
+            if (!topicPassesConditions({ topicIdWithSubscriptions, topic })) {
               continue;
             }
 
@@ -304,8 +288,7 @@ function TopicGraph() {
     subscribedTopics,
     services,
     topicVisibility,
-    getTopicDetails,
-    passesConditions,
+    topicPassesConditions,
     showServices,
   ]);
 
@@ -384,7 +367,6 @@ function TopicGraph() {
               selectedId={topicVisibility}
               onChange={(id) => {
                 graph.current?.resetUserPanZoom();
-                // @ts-ignore
                 setTopicVisibility(id);
               }}
               options={Object.keys(topicIdsToLabelsMap).map((id) => ({

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -11,11 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import ArrowDownIcon from "@mdi/svg/svg/arrow-down-bold.svg";
-import ArrowRightIcon from "@mdi/svg/svg/arrow-right-bold.svg";
+import ArrowLeftRightIcon from "@mdi/svg/svg/arrow-left-right.svg";
+import ArrowUpDownIcon from "@mdi/svg/svg/arrow-up-down.svg";
 import FitToPageIcon from "@mdi/svg/svg/fit-to-page-outline.svg";
-import ServiceIcon from "@mdi/svg/svg/ray-end.svg";
-import TopicIcon from "@mdi/svg/svg/transit-connection-horizontal.svg";
+import ServiceIcon from "@mdi/svg/svg/rectangle-outline.svg";
+import TopicIcon from "@mdi/svg/svg/rhombus.svg";
 import Cytoscape from "cytoscape";
 import { useCallback, useMemo, useRef, useState } from "react";
 import textMetrics from "text-metrics";
@@ -298,7 +298,16 @@ function TopicGraph() {
     }
 
     return output;
-  }, [textMeasure, publishedTopics, subscribedTopics, services, topicVisibility, showServices]);
+  }, [
+    textMeasure,
+    publishedTopics,
+    subscribedTopics,
+    services,
+    topicVisibility,
+    getTopicDetails,
+    passesConditions,
+    showServices,
+  ]);
 
   const graph = useRef<GraphMutation>();
 
@@ -312,11 +321,11 @@ function TopicGraph() {
   }, [lrOrientation]);
 
   const topicVisibilityTooltip: string = useMemo(() => {
-    return topicIdsToLabelsMap[topicVisibility] ?? "";
+    return `Showing ${(topicIdsToLabelsMap[topicVisibility] ?? "").toLowerCase()}`;
   }, [topicVisibility]);
 
   const topicButtonColor = useMemo(() => {
-    return topicVisibility === "none" ? "white" : colors.accent;
+    return topicVisibility === "none" ? "white" : colors.lightPurple;
   }, [topicVisibility]);
 
   const toggleShowServices = useCallback(() => {
@@ -345,14 +354,14 @@ function TopicGraph() {
           </Button>
           <Button tooltip="Orientation" onClick={toggleOrientation}>
             <Icon style={{ color: "white" }} small>
-              {lrOrientation ? <ArrowRightIcon /> : <ArrowDownIcon />}
+              {lrOrientation ? <ArrowLeftRightIcon /> : <ArrowUpDownIcon />}
             </Icon>
           </Button>
           <Button
-            tooltip={showServices ? "Hide Services" : "Show Services"}
+            tooltip={showServices ? "Showing services" : "Hiding services"}
             onClick={toggleShowServices}
           >
-            <Icon style={{ color: showServices ? colors.accent : "white" }} small>
+            <Icon style={{ color: showServices ? colors.red : "white" }} small>
               <ServiceIcon />
             </Icon>
           </Button>

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -22,10 +22,12 @@ import textMetrics from "text-metrics";
 
 import Button from "@foxglove/studio-base/components/Button";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import ExpandingToolbar, { ToolGroup } from "@foxglove/studio-base/components/ExpandingToolbar";
 import Icon from "@foxglove/studio-base/components/Icon";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import Radio from "@foxglove/studio-base/components/Radio";
 import styles from "@foxglove/studio-base/panels/ThreeDimensionalViz/Layout.module.scss";
 import colors from "@foxglove/studio-base/styles/colors.module.scss";
 
@@ -101,6 +103,23 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
     },
   },
 ];
+type TopicVisibilityOptions =
+  | "none"
+  | "all"
+  | "published"
+  | "subscribed"
+  | "connected"
+  | "disconnected-pub"
+  | "disconnected-sub";
+const topicIdsToLabelsMap: Record<string, string> = {
+  none: "No topics",
+  all: "All topics",
+  published: "Published topics",
+  subscribed: "Subscribed topics",
+  connected: "Connected topics",
+  "disconnected-pub": "Disconnected published topics",
+  "disconnected-sub": "Disconnected subscribed topics",
+};
 
 function unionInto<T>(dest: Set<T>, ...iterables: Set<T>[]): void {
   for (const iterable of iterables) {
@@ -111,6 +130,8 @@ function unionInto<T>(dest: Set<T>, ...iterables: Set<T>[]): void {
 }
 
 function TopicGraph() {
+  const [selectedTab, setSelectedTab] = useState<"Topics" | undefined>(undefined);
+
   const publishedTopics = useMessagePipeline(
     useCallback((ctx) => ctx.playerState.activeData?.publishedTopics, []),
   );
@@ -124,12 +145,8 @@ function TopicGraph() {
   );
 
   const [lrOrientation, setLROrientation] = useState<boolean>(false);
-
-  const [topicVisibility, setTopicVisibility] = useState<
-    "hide" | "show" | "show-only-with-subscribers"
-  >("show");
-
   const [showServices, setShowServices] = useState<boolean>(true);
+  const [topicVisibility, setTopicVisibility] = useState<TopicVisibilityOptions>("all");
 
   const textMeasure = useMemo(
     () =>
@@ -138,6 +155,39 @@ function TopicGraph() {
         fontSize: "16px",
       }),
     [],
+  );
+
+  const getTopicDetails = useCallback(
+    ({
+      topicIdWithSubscriptions,
+      topic,
+    }: {
+      topicIdWithSubscriptions: Set<string>;
+      topic: string;
+    }) => {
+      const publishedTopicsWithFallback = publishedTopics ?? new Map([]);
+      const published = publishedTopicsWithFallback.has(topic);
+      const subscribed = topicIdWithSubscriptions.has(topic);
+      return { published, subscribed };
+    },
+    [publishedTopics],
+  );
+
+  const passesConditions = useCallback(
+    ({ published, subscribed }: { published: boolean; subscribed: boolean }): boolean => {
+      if (topicVisibility === "none") {
+        return false;
+      }
+      return (
+        topicVisibility === "all" ||
+        (topicVisibility === "published" && published) ||
+        (topicVisibility === "subscribed" && subscribed) ||
+        (topicVisibility === "connected" && published && subscribed) ||
+        (topicVisibility === "disconnected-pub" && published && !subscribed) ||
+        (topicVisibility === "disconnected-sub" && subscribed && !published)
+      );
+    },
+    [topicVisibility],
   );
 
   const elements = useMemo<cytoscape.ElementDefinition[]>(() => {
@@ -173,12 +223,10 @@ function TopicGraph() {
         data: { id: `n:${node}`, label: node, type: "node" },
       });
     }
-    if (topicVisibility !== "hide") {
+    if (topicVisibility !== "none") {
       for (const topic of topicIds) {
-        if (
-          topicVisibility === "show-only-with-subscribers" &&
-          !topicIdWithSubscriptions.has(topic)
-        ) {
+        const { published, subscribed } = getTopicDetails({ topicIdWithSubscriptions, topic });
+        if (!passesConditions({ published, subscribed })) {
           continue;
         }
         output.push({
@@ -197,16 +245,31 @@ function TopicGraph() {
     }
 
     switch (topicVisibility) {
-      case "show":
-      case "show-only-with-subscribers":
+      case "none":
+        if (publishedTopics == undefined || subscribedTopics == undefined) {
+          break;
+        }
+        for (const [topic, publishers] of publishedTopics.entries()) {
+          for (const pubNode of publishers) {
+            for (const subNode of subscribedTopics.get(topic) ?? []) {
+              if (subNode === pubNode) {
+                continue;
+              }
+              const source = `n:${pubNode}`;
+              const target = `n:${subNode}`;
+              output.push({ data: { id: `${source}-${target}`, source, target } });
+            }
+          }
+        }
+        break;
+      default:
         if (publishedTopics != undefined) {
           for (const [topic, publishers] of publishedTopics.entries()) {
-            if (
-              topicVisibility === "show-only-with-subscribers" &&
-              !topicIdWithSubscriptions.has(topic)
-            ) {
+            const { published, subscribed } = getTopicDetails({ topicIdWithSubscriptions, topic });
+            if (!passesConditions({ published, subscribed })) {
               continue;
             }
+
             for (const node of publishers) {
               const source = `n:${node}`;
               const target = `t:${topic}`;
@@ -220,24 +283,6 @@ function TopicGraph() {
             for (const node of subscribers) {
               const source = `t:${topic}`;
               const target = `n:${node}`;
-              output.push({ data: { id: `${source}-${target}`, source, target } });
-            }
-          }
-        }
-        break;
-
-      case "hide":
-        if (publishedTopics == undefined || subscribedTopics == undefined) {
-          break;
-        }
-        for (const [topic, publishers] of publishedTopics.entries()) {
-          for (const pubNode of publishers) {
-            for (const subNode of subscribedTopics.get(topic) ?? []) {
-              if (subNode === pubNode) {
-                continue;
-              }
-              const source = `n:${pubNode}`;
-              const target = `n:${subNode}`;
               output.push({ data: { id: `${source}-${target}`, source, target } });
             }
           }
@@ -266,40 +311,12 @@ function TopicGraph() {
     setLROrientation(!lrOrientation);
   }, [lrOrientation]);
 
-  const toggleShowTopics = useCallback(() => {
-    graph.current?.resetUserPanZoom();
-    setTopicVisibility((value) => {
-      switch (value) {
-        case "hide":
-          return "show-only-with-subscribers";
-        case "show-only-with-subscribers":
-          return "show";
-        case "show":
-          return "hide";
-      }
-    });
-  }, []);
-
-  const topicVisibilityTooltip = useMemo(() => {
-    switch (topicVisibility) {
-      case "hide":
-        return "Topics Hidden";
-      case "show-only-with-subscribers":
-        return "Showing Topics with Subscribers";
-      case "show":
-        return "Showing All Topics";
-    }
+  const topicVisibilityTooltip: string = useMemo(() => {
+    return topicIdsToLabelsMap[topicVisibility] ?? "";
   }, [topicVisibility]);
 
   const topicButtonColor = useMemo(() => {
-    switch (topicVisibility) {
-      case "hide":
-        return "white";
-      case "show-only-with-subscribers":
-        return colors.green;
-      case "show":
-        return colors.accent;
-    }
+    return topicVisibility === "none" ? "white" : colors.accent;
   }, [topicVisibility]);
 
   const toggleShowServices = useCallback(() => {
@@ -331,11 +348,6 @@ function TopicGraph() {
               {lrOrientation ? <ArrowRightIcon /> : <ArrowDownIcon />}
             </Icon>
           </Button>
-          <Button tooltip={topicVisibilityTooltip} onClick={toggleShowTopics}>
-            <Icon style={{ color: topicButtonColor }} small dataTest="toggle-topics">
-              <TopicIcon />
-            </Icon>
-          </Button>
           <Button
             tooltip={showServices ? "Hide Services" : "Show Services"}
             onClick={toggleShowServices}
@@ -345,6 +357,34 @@ function TopicGraph() {
             </Icon>
           </Button>
         </div>
+        <ExpandingToolbar
+          tooltip={topicVisibilityTooltip}
+          icon={
+            <Icon style={{ color: topicButtonColor }}>
+              <TopicIcon />
+            </Icon>
+          }
+          className={styles.buttons}
+          selectedTab={selectedTab}
+          onSelectTab={(newSelectedTab) => {
+            setSelectedTab(newSelectedTab);
+          }}
+        >
+          <ToolGroup name="Topics">
+            <Radio
+              selectedId={topicVisibility}
+              onChange={(id) => {
+                graph.current?.resetUserPanZoom();
+                // @ts-ignore
+                setTopicVisibility(id);
+              }}
+              options={Object.keys(topicIdsToLabelsMap).map((id) => ({
+                id,
+                label: topicIdsToLabelsMap[id] ?? "",
+              }))}
+            />
+          </ToolGroup>
+        </ExpandingToolbar>
       </Toolbar>
       <Graph
         style={STYLESHEET}

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -104,8 +104,8 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
   },
 ];
 const topicIdsToLabelsMap: Record<string, string> = {
-  none: "No topics",
   all: "All topics",
+  none: "No topics",
   published: "Published topics",
   subscribed: "Subscribed topics",
   connected: "Connected topics",

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -104,7 +104,7 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
   },
 ];
 
-type TopicVisibility =
+export type TopicVisibility =
   | "all"
   | "none"
   | "published"
@@ -360,6 +360,7 @@ function TopicGraph() {
           </Button>
         </div>
         <ExpandingToolbar
+          dataTest="set-topic-visibility"
           tooltip={topicVisibilityTooltip}
           icon={
             <Icon style={{ color: topicButtonColor }}>

--- a/packages/studio-base/src/styles/colors.module.scss
+++ b/packages/studio-base/src/styles/colors.module.scss
@@ -38,7 +38,7 @@ $dark4: #2d2d33;
 $green: #05d27d;
 $light-green: #5cd6a9;
 $yellow: #f5d358;
-$light-purple: #c1c5d6;
+$light-purple: #b79dca;
 $grey: #e7e9ef;
 $toolbar-fixed: #1f1e27;
 $accent: #248eff;


### PR DESCRIPTION
**User-Facing Changes**
- Adds all relevant topic visibility settings in Topic Graph panel
- Updates controls' icons & colors to be more intuitive and reflect graph UI
- Update tooltip text to be more intuitive (i.e. reflect current state, not what the effect of a click would be)

<img width="356" alt="Screen Shot 2021-07-15 at 10 45 03 PM" src="https://user-images.githubusercontent.com/6993359/125893216-c57c1b9d-435b-4a7f-945b-8dc23010d328.png">
<img width="356" alt="Screen Shot 2021-07-15 at 10 45 08 PM" src="https://user-images.githubusercontent.com/6993359/125893219-9012a112-d39a-4fc7-aa8e-2661f06477cb.png">
<img width="143" alt="Screen Shot 2021-07-15 at 10 45 15 PM" src="https://user-images.githubusercontent.com/6993359/125893220-79aaec2a-6dee-4502-9025-b2c2b3c2621f.png">
<img width="133" alt="Screen Shot 2021-07-15 at 10 45 31 PM" src="https://user-images.githubusercontent.com/6993359/125893222-ff1b366a-a5b6-4830-8115-66b4233cd75a.png">
<img width="133" alt="Screen Shot 2021-07-15 at 10 45 35 PM" src="https://user-images.githubusercontent.com/6993359/125893226-cd62820b-2bb0-4f9f-af8b-e4eb4d36e95f.png">
<img width="142" alt="Screen Shot 2021-07-15 at 10 45 41 PM" src="https://user-images.githubusercontent.com/6993359/125893227-bbcdb828-e0cf-4f76-a79e-4a2861f561ea.png">


**Description**

Resolves #1441, #1442