### PR TITLE
Internal: remove explicit chunk names from NodePlayground panel

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
@@ -15,6 +15,7 @@ import ArrowLeftBoldIcon from "@mdi/svg/svg/arrow-left-bold.svg";
 import DeleteIcon from "@mdi/svg/svg/delete.svg";
 import FileMultipleIcon from "@mdi/svg/svg/file-multiple.svg";
 import HelpCircleIcon from "@mdi/svg/svg/help-circle.svg";
+import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
 import styled from "styled-components";
 
 import Flex from "@foxglove/studio-base/components/Flex";
@@ -188,27 +189,20 @@ const Sidebar = ({
 
   const gotoUtils = React.useCallback(
     (filePath: string) => {
-      import(
-        /* webpackChunkName: "monaco-api" */
-        "monaco-editor/esm/vs/editor/editor.api"
-      )
-        .then((monacoApi) => {
-          const monacoFilePath = monacoApi.Uri.parse(`file://${filePath}`);
-          const requestedModel = monacoApi.editor.getModel(monacoFilePath);
-          if (!requestedModel) {
-            return;
-          }
-          setScriptOverride(
-            {
-              filePath: requestedModel.uri.path,
-              code: requestedModel.getValue(),
-              readOnly: true,
-              selection: undefined,
-            },
-            2,
-          );
-        })
-        .catch(console.error);
+      const monacoFilePath = monacoApi.Uri.parse(`file://${filePath}`);
+      const requestedModel = monacoApi.editor.getModel(monacoFilePath);
+      if (!requestedModel) {
+        return;
+      }
+      setScriptOverride(
+        {
+          filePath: requestedModel.uri.path,
+          code: requestedModel.getValue(),
+          readOnly: true,
+          selection: undefined,
+        },
+        2,
+      );
     },
     [setScriptOverride],
   );

--- a/packages/studio-base/src/panels/NodePlayground/getPrettifiedCode.ts
+++ b/packages/studio-base/src/panels/NodePlayground/getPrettifiedCode.ts
@@ -11,25 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-// Takes in a string of Typescript code and returns
-// beautified, formatted string of Typescript code
+// Takes in a string of Typescript code and returns beautified, formatted string of Typescript code
 async function getPrettifiedCode(code: string): Promise<string> {
-  let prettier, parserPlugin;
-
-  // Dynamic imports don't work in node-based jest tests, so require() them instead
-  if (process.env.NODE_ENV === "test") {
-    prettier = require("prettier/standalone");
-    parserPlugin = require("prettier/parser-typescript");
-  } else {
-    prettier = await import(
-      /* webpackChunkName: "prettier" */
-      "prettier/standalone"
-    );
-    parserPlugin = await import(
-      /* webpackChunkName: "prettier" */
-      "prettier/parser-typescript"
-    );
-  }
+  // use dynamic imports to avoid loading prettier unless the function is invoked
+  const prettier = await import("prettier/standalone");
+  const parserPlugin = await import("prettier/parser-typescript");
 
   return prettier.format(code, { parser: "typescript", plugins: [parserPlugin] });
 }


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
We prefer to allow webpack to decide how to split the chunks rather
than forcing specific chunk names.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
