### PR TITLE
Feature: allow bags with empty message definitions

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
@@ -18,7 +18,6 @@ import BagDataProvider, {
   statsAreAdjacent,
   TimedDataThroughput,
 } from "@foxglove/studio-base/randomAccessDataProviders/BagDataProvider";
-import delay from "@foxglove/studio-base/util/delay";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 const dummyExtensionPoint = {
@@ -145,31 +144,6 @@ describe("BagDataProvider", () => {
     const sortedTimestamps = [...timestamps];
     sortedTimestamps.sort(compare);
     expect(timestamps).toEqual(sortedTimestamps);
-    sendNotification.expectCalledDuringTest();
-  });
-
-  // Regression test for https://github.com/cruise-automation/studio/issues/373
-  it("treats an empty message definition as a non-existent connection (therefore thinking this bag is empty)", async () => {
-    const provider = new BagDataProvider(
-      {
-        bagPath: {
-          type: "file",
-          file: `${__dirname}/../test/fixtures/bag-with-empty-message-definition.bag`,
-        },
-      },
-      [],
-    );
-    void provider.initialize(dummyExtensionPoint);
-    await delay(100); // Call above returns promise that never resolves.
-    expect((sendNotification as any).mock.calls).toEqual([
-      [
-        "Empty connections found",
-        'This bag has some empty connections, which Studio does not currently support. We\'ll try to play the remaining topics. Details:\n\n[{"conn":0,"topic":"/led_array_status","type":"led_array_msgs/Status","md5sum":"53a14e6cadee4d14930b099922d25397","messageDefinition":"","callerid":"/led_array_node","latching":false,"offset":5254,"dataOffset":5310,"end":5475,"length":221}]',
-        "user",
-        "warn",
-      ],
-      ["Cannot play invalid bag", "Bag is empty or corrupt.", "user", "error"],
-    ]);
     sendNotification.expectCalledDuringTest();
   });
 });

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -68,10 +68,7 @@ export const statsAreAdjacent = (a: TimedDataThroughput, b: TimedDataThroughput)
   );
 };
 
-export const mergeStats = (
-  a: TimedDataThroughput,
-  b: TimedDataThroughput,
-): TimedDataThroughput => ({
+const mergeStats = (a: TimedDataThroughput, b: TimedDataThroughput): TimedDataThroughput => ({
   startTime: a.startTime,
   endTime: b.endTime,
   data: {
@@ -190,7 +187,6 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     for (const [connId, connection] of this._bag.connections) {
       const { messageDefinition, md5sum, topic, type, callerid } = connection;
       if (
-        isNonEmptyOrUndefined(messageDefinition) &&
         isNonEmptyOrUndefined(md5sum) &&
         isNonEmptyOrUndefined(topic) &&
         isNonEmptyOrUndefined(type)
@@ -207,9 +203,6 @@ export default class BagDataProvider implements RandomAccessDataProvider {
       }
     }
     if (emptyConnections.length > 0) {
-      // TODO(JP): Actually support empty message definitions (e.g. "std_msgs/Empty"). For that we
-      // ideally need an actual use case, and then we need to make sure that we don't naively do
-      // `if (messageDefinition)` in a bunch of places.
       sendNotification(
         "Empty connections found",
         `This bag has some empty connections, which Studio does not currently support. We'll try to play the remaining topics. Details:\n\n${JSON.stringify(

--- a/packages/studio-base/src/test/fixtures/bag-with-empty-message-definition.bag
+++ b/packages/studio-base/src/test/fixtures/bag-with-empty-message-definition.bag
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3c8c6a351e5109da990e75741b560fcf62b92a3ce901984c89a49be6c8d3b3f
-size 5591


### PR DESCRIPTION


**User-Facing Changes**
Bags containing empty message definitions (std_msgs/Empty) are loadable.

**Description**
An empty message definition is a valid message definition. This
change allows bags that have topics with empty message definitions
to load and play. Since the definition is empty, such topics are
not deserialized.

Alters the fix performed in webviz in response to https://github.com/cruise-automation/webviz/issues/373
where the app would previously crash when there was an empty message definition.

This change removes a flaky test for the notification when loading such
a bag since it is valid to load such a bag.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
