### PR TITLE
Internal: simplify storybook ready signal use

### DIFF
--- a/packages/studio-base/src/.storybook/preview.tsx
+++ b/packages/studio-base/src/.storybook/preview.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Story, StoryContext } from "@storybook/react";
-import { useMemo } from "react";
 import { ToastProvider } from "react-toast-notifications";
 
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
@@ -11,6 +10,7 @@ import { HoverValueProvider } from "@foxglove/studio-base/context/HoverValueCont
 import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
 import ReadySignalContext from "@foxglove/studio-base/stories/ReadySignalContext";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import signal from "@foxglove/studio-base/util/signal";
 import waitForFonts from "@foxglove/studio-base/util/waitForFonts";
 
 import "@foxglove/studio-base/styles/global.scss";
@@ -19,10 +19,15 @@ import "./styles.scss";
 let loaded = false;
 
 function WithContextProviders(Child: Story, ctx: StoryContext): JSX.Element {
-  const sig = ctx.parameters?.screenshot?.signal;
-  const readySignal = useMemo(() => {
-    return sig ? () => sig.resolve() : undefined;
-  }, [sig]);
+  if (ctx.parameters?.useReadySignal) {
+    const sig = signal();
+    ctx.parameters.storyReady = sig;
+    ctx.parameters.readySignal = () => {
+      sig.resolve();
+    };
+  }
+
+  const readySignal = ctx.parameters.readySignal;
 
   const providers = [
     /* eslint-disable react/jsx-key */

--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -15,7 +15,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { useState, useCallback, ComponentProps, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
-import signal from "@foxglove/studio-base/util/signal";
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 
 import ChartComponent, { OnClickArg } from ".";
 
@@ -121,43 +121,36 @@ export default {
   },
 };
 
-export const Basic: Story = (_args, ctx) => {
-  const storyRendered = () => {
-    ctx.parameters.screenshot.signal.resolve();
-  };
+export const Basic: Story = (_args) => {
+  const readySignal = useReadySignal();
 
   return (
     <div style={divStyle}>
-      <ChartComponent {...props} onChartUpdate={storyRendered} />
+      <ChartComponent {...props} onChartUpdate={readySignal} />
     </div>
   );
 };
 Basic.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
-export const WithDatalabels: Story = (_args, ctx) => {
-  const storyRendered = () => {
-    ctx.parameters.screenshot.signal.resolve();
-  };
+export const WithDatalabels: Story = (_args) => {
+  const readySignal = useReadySignal();
 
   return (
     <div style={divStyle}>
-      <ChartComponent {...propsWithDatalabels} onChartUpdate={storyRendered} />
+      <ChartComponent {...propsWithDatalabels} onChartUpdate={readySignal} />
     </div>
   );
 };
 
 WithDatalabels.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
-export const AllowsClickingOnDatalabels: Story = (_args, ctx) => {
+export const AllowsClickingOnDatalabels: Story = (_args) => {
   const [clickedDatalabel, setClickedDatalabel] = useState<any>(undefined);
+  const readySignal = useReadySignal();
 
   const doClick = useCallback(() => {
     if (!clickedDatalabel) {
@@ -172,9 +165,9 @@ export const AllowsClickingOnDatalabels: Story = (_args, ctx) => {
 
   useEffect(() => {
     if (clickedDatalabel) {
-      ctx.parameters.screenshot.signal.resolve();
+      readySignal();
     }
-  }, [ctx, clickedDatalabel]);
+  }, [clickedDatalabel, readySignal]);
 
   return (
     <div style={divStyle}>
@@ -189,7 +182,5 @@ export const AllowsClickingOnDatalabels: Story = (_args, ctx) => {
 };
 
 AllowsClickingOnDatalabels.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -19,8 +19,8 @@ import CurrentLayoutState, {
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import MockLayoutCache from "@foxglove/studio-base/services/MockLayoutCache";
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import delay from "@foxglove/studio-base/util/delay";
-import signal, { Signal } from "@foxglove/studio-base/util/signal";
 
 import LayoutBrowser from "./index";
 
@@ -105,14 +105,16 @@ export function LayoutList(): JSX.Element {
   return <LayoutBrowser />;
 }
 
-AddLayout.parameters = { screenshot: { signal: signal() } };
-export function AddLayout(_args: unknown, ctx: StoryContext): JSX.Element {
+AddLayout.parameters = { useReadySignal: true };
+export function AddLayout(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelector<HTMLElement>(`[data-test="add-layout"]`)!.click();
     await delay(10);
-    ctx.parameters.screenshot.signal.resolve();
-  }, [ctx.parameters.screenshot.signal]);
+    readySignal();
+  }, [readySignal]);
   return (
     <LayoutBrowser
       currentDateForStorybook={useMemo(() => new Date("2021-06-16T04:28:33.549Z"), [])}
@@ -120,33 +122,39 @@ export function AddLayout(_args: unknown, ctx: StoryContext): JSX.Element {
   );
 }
 
-MenuOpen.parameters = { screenshot: { signal: signal() } };
-export function MenuOpen(_args: unknown, ctx: StoryContext): JSX.Element {
+MenuOpen.parameters = { useReadySignal: true };
+export function MenuOpen(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
     await delay(10);
-    ctx.parameters.screenshot.signal.resolve();
-  }, [ctx.parameters.screenshot.signal]);
+    readySignal();
+  }, [readySignal]);
 
   return <LayoutBrowser />;
 }
 
-EditingName.parameters = { screenshot: { signal: signal() } };
-export function EditingName(_args: unknown, ctx: StoryContext): JSX.Element {
+EditingName.parameters = { useReadySignal: true };
+export function EditingName(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
     await delay(10);
     document.querySelector<HTMLElement>(`[data-test="rename-layout"]`)!.click();
-    ctx.parameters.screenshot.signal.resolve();
-  }, [ctx.parameters.screenshot.signal]);
+    readySignal();
+  }, [readySignal]);
 
   return <LayoutBrowser />;
 }
 
-CancelRenameWithEscape.parameters = { screenshot: { signal: signal() } };
-export function CancelRenameWithEscape(_args: unknown, ctx: StoryContext): JSX.Element {
+CancelRenameWithEscape.parameters = { useReadySignal: true };
+export function CancelRenameWithEscape(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
@@ -155,14 +163,16 @@ export function CancelRenameWithEscape(_args: unknown, ctx: StoryContext): JSX.E
     await delay(10);
     TestUtils.Simulate.keyDown(document.activeElement!, { key: "Escape" });
     await delay(10);
-    ctx.parameters.screenshot.signal.resolve();
-  }, [ctx.parameters.screenshot.signal]);
+    readySignal();
+  }, [readySignal]);
 
   return <LayoutBrowser />;
 }
 
-CancelRenameWithButton.parameters = { screenshot: { signal: signal() } };
-export function CancelRenameWithButton(_args: unknown, ctx: StoryContext): JSX.Element {
+CancelRenameWithButton.parameters = { useReadySignal: true };
+export function CancelRenameWithButton(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
@@ -171,14 +181,16 @@ export function CancelRenameWithButton(_args: unknown, ctx: StoryContext): JSX.E
     await delay(10);
     document.querySelector<HTMLElement>(`[data-test="cancel-rename"]`)!.click();
     await delay(10);
-    ctx.parameters.screenshot.signal.resolve();
-  }, [ctx.parameters.screenshot.signal]);
+    readySignal();
+  }, [readySignal]);
 
   return <LayoutBrowser />;
 }
 
-CommitRenameWithSubmit.parameters = { screenshot: { signal: signal() } };
-export function CommitRenameWithSubmit(_args: unknown, ctx: StoryContext): JSX.Element {
+CommitRenameWithSubmit.parameters = { useReadySignal: true };
+export function CommitRenameWithSubmit(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
@@ -194,7 +206,7 @@ export function CommitRenameWithSubmit(_args: unknown, ctx: StoryContext): JSX.E
   useEffect(() => {
     void layoutCache.list().then((layouts) => {
       if (layouts.some((layout) => layout.name === "New name")) {
-        ctx.parameters.screenshot.signal.resolve();
+        readySignal();
       }
     });
   });
@@ -202,8 +214,8 @@ export function CommitRenameWithSubmit(_args: unknown, ctx: StoryContext): JSX.E
   return <LayoutBrowser />;
 }
 
-CommitRenameWithButton.parameters = { screenshot: { signal: signal() } };
-export function CommitRenameWithButton(_args: unknown, ctx: StoryContext): JSX.Element {
+CommitRenameWithButton.parameters = { useReadySignal: true };
+export function CommitRenameWithButton(_args: unknown): JSX.Element {
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
@@ -216,10 +228,12 @@ export function CommitRenameWithButton(_args: unknown, ctx: StoryContext): JSX.E
   }, []);
 
   const layoutCache = useLayoutCache();
+  const readySignal = useReadySignal();
+
   useEffect(() => {
     void layoutCache.list().then((layouts) => {
       if (layouts.some((layout) => layout.name === "New name")) {
-        ctx.parameters.screenshot.signal.resolve();
+        readySignal();
       }
     });
   });
@@ -227,9 +241,11 @@ export function CommitRenameWithButton(_args: unknown, ctx: StoryContext): JSX.E
   return <LayoutBrowser />;
 }
 
-Duplicate.parameters = { screenshot: { signal: signal() } };
-export function Duplicate(_args: unknown, ctx: StoryContext): JSX.Element {
+Duplicate.parameters = { useReadySignal: true };
+export function Duplicate(_args: unknown): JSX.Element {
   const layoutCache = useLayoutCache();
+  const readySignal = useReadySignal();
+
   useAsyncThrowing(async () => {
     await delay(100);
     document.querySelectorAll<HTMLElement>(`[data-test="layout-actions"]`)[1]!.click();
@@ -238,11 +254,11 @@ export function Duplicate(_args: unknown, ctx: StoryContext): JSX.Element {
     await delay(10);
 
     if ((await layoutCache.list()).some((layout) => layout.name === "Current Layout copy")) {
-      ctx.parameters.screenshot.signal.resolve();
+      readySignal();
     } else {
       throw new Error("Duplicate failed");
     }
-  }, [ctx.parameters.screenshot.signal, layoutCache]);
+  }, [readySignal, layoutCache]);
 
   return <LayoutBrowser />;
 }
@@ -254,7 +270,7 @@ function DeleteStory({
 }: {
   index: number;
   name: string;
-  signal: Signal<void>;
+  signal: () => void;
 }) {
   const layoutCache = useLayoutCache();
   useAsyncThrowing(async () => {
@@ -267,7 +283,7 @@ function DeleteStory({
     await delay(10);
 
     if (!(await layoutCache.list()).some((layout) => layout.name === name)) {
-      sig.resolve();
+      sig();
     } else {
       throw new Error("Delete failed");
     }
@@ -276,18 +292,25 @@ function DeleteStory({
   return <LayoutBrowser />;
 }
 
-DeleteLayout.parameters = { screenshot: { signal: signal() } };
-export function DeleteLayout(_args: unknown, ctx: StoryContext): JSX.Element {
-  return <DeleteStory index={0} name="Another Layout" signal={ctx.parameters.screenshot.signal} />;
+export function DeleteLayout(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+  return <DeleteStory index={0} name="Another Layout" signal={readySignal} />;
 }
+DeleteLayout.parameters = { useReadySignal: true };
 
-DeleteSelectedLayout.parameters = { screenshot: { signal: signal() } };
-export function DeleteSelectedLayout(_args: unknown, ctx: StoryContext): JSX.Element {
-  return <DeleteStory index={1} name="Current Layout" signal={ctx.parameters.screenshot.signal} />;
+export function DeleteSelectedLayout(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+  return <DeleteStory index={1} name="Current Layout" signal={readySignal} />;
 }
+DeleteSelectedLayout.parameters = { useReadySignal: true };
 
+export function DeleteLastLayout(_args: unknown): JSX.Element {
+  const readySignal = useReadySignal();
+
+  return <DeleteStory index={0} name="Current Layout" signal={readySignal} />;
+}
 DeleteLastLayout.parameters = {
-  screenshot: { signal: signal() },
+  useReadySignal: true,
   mockLayouts: [
     {
       id: "test-id",
@@ -297,6 +320,3 @@ DeleteLastLayout.parameters = {
     },
   ],
 };
-export function DeleteLastLayout(_args: unknown, ctx: StoryContext): JSX.Element {
-  return <DeleteStory index={0} name="Current Layout" signal={ctx.parameters.screenshot.signal} />;
-}

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -18,8 +18,8 @@ import { useMemo } from "react";
 import ImageView, { Config } from "@foxglove/studio-base/panels/ImageView";
 import ImageCanvas from "@foxglove/studio-base/panels/ImageView/ImageCanvas";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { CameraInfo, ImageMarker } from "@foxglove/studio-base/types/Messages";
-import signal from "@foxglove/studio-base/util/signal";
 
 const cameraInfo: CameraInfo = {
   width: 400,
@@ -407,8 +407,9 @@ export default {
   },
 };
 
-export const MarkersOriginal: Story = (_args, ctx) => {
+export const MarkersOriginal: Story = (_args) => {
   const imageMessage = useImageMessage();
+  const readySignal = useReadySignal();
 
   return (
     <div style={{ height: "400px" }}>
@@ -422,20 +423,19 @@ export const MarkersOriginal: Story = (_args, ctx) => {
         }}
         config={config}
         saveConfig={noop}
-        onStartRenderImage={() => () => ctx.parameters.screenshot.signal.resolve()}
+        onStartRenderImage={() => readySignal}
       />
     </div>
   );
 };
 
 MarkersOriginal.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
-export const MarkersTransformed: Story = (_args, ctx) => {
+export const MarkersTransformed: Story = (_args) => {
   const imageMessage = useImageMessage();
+  const readySignal = useReadySignal();
 
   return (
     <div style={{ height: "400px" }}>
@@ -449,21 +449,20 @@ export const MarkersTransformed: Story = (_args, ctx) => {
         }}
         config={config}
         saveConfig={noop}
-        onStartRenderImage={() => () => ctx.parameters.screenshot.signal.resolve()}
+        onStartRenderImage={() => readySignal}
       />
     </div>
   );
 };
 
 MarkersTransformed.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 // markers with different original image size
-export const MarkersImageSize: Story = (_args, ctx) => {
+export const MarkersImageSize: Story = (_args) => {
   const imageMessage = useImageMessage();
+  const readySignal = useReadySignal();
 
   return (
     <div style={{ height: "400px" }}>
@@ -477,16 +476,14 @@ export const MarkersImageSize: Story = (_args, ctx) => {
         }}
         config={config}
         saveConfig={noop}
-        onStartRenderImage={() => () => ctx.parameters.screenshot.signal.resolve()}
+        onStartRenderImage={() => readySignal}
       />
     </div>
   );
 };
 
 MarkersImageSize.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -20,7 +20,6 @@ import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/Memo
 import PanelSetup, { triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import useResumeCount from "@foxglove/studio-base/stories/useResumeCount";
-import signal from "@foxglove/studio-base/util/signal";
 import { fromSec } from "@foxglove/studio-base/util/time";
 
 const float64StampedDefinition = `std_msgs/Header header
@@ -339,9 +338,7 @@ export function LineGraph(): JSX.Element {
   );
 }
 LineGraph.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 LineGraphWithLegendsHidden.storyName = "line graph with legends hidden";
@@ -354,9 +351,7 @@ export function LineGraphWithLegendsHidden(): JSX.Element {
   );
 }
 LineGraphWithLegendsHidden.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
@@ -394,9 +389,7 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
   );
 }
 InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 LineGraphAfterZoom.storyName = "line graph after zoom";
@@ -437,9 +430,7 @@ export function LineGraphAfterZoom(): JSX.Element {
   );
 }
 LineGraphAfterZoom.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 TimestampMethodHeaderStamp.storyName = "timestampMethod: headerStamp";
@@ -464,9 +455,7 @@ export function TimestampMethodHeaderStamp(): JSX.Element {
   );
 }
 TimestampMethodHeaderStamp.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 LongPath.storyName = "long path";
@@ -491,9 +480,7 @@ export function LongPath(): JSX.Element {
   );
 }
 LongPath.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 DisabledPath.storyName = "disabled path";
@@ -523,9 +510,7 @@ export function DisabledPath(): JSX.Element {
   );
 }
 DisabledPath.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 ReferenceLine.storyName = "reference line";
@@ -552,9 +537,7 @@ export function ReferenceLine(): JSX.Element {
   );
 }
 ReferenceLine.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithMinAndMaxYValues.storyName = "with min and max Y values";
@@ -582,9 +565,7 @@ export function WithMinAndMaxYValues(): JSX.Element {
   );
 }
 WithMinAndMaxYValues.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMinYValueLessThanMinimumValue.storyName = "with just min Y value less than minimum value";
@@ -612,9 +593,7 @@ export function WithJustMinYValueLessThanMinimumValue(): JSX.Element {
   );
 }
 WithJustMinYValueLessThanMinimumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMinYValueMoreThanMinimumValue.storyName = "with just min Y value more than minimum value";
@@ -642,9 +621,7 @@ export function WithJustMinYValueMoreThanMinimumValue(): JSX.Element {
   );
 }
 WithJustMinYValueMoreThanMinimumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMinYValueMoreThanMaximumValue.storyName = "with just min Y value more than maximum value";
@@ -672,9 +649,7 @@ export function WithJustMinYValueMoreThanMaximumValue(): JSX.Element {
   );
 }
 WithJustMinYValueMoreThanMaximumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMaxYValueLessThanMaximumValue.storyName = "with just max Y value less than maximum value";
@@ -702,9 +677,7 @@ export function WithJustMaxYValueLessThanMaximumValue(): JSX.Element {
   );
 }
 WithJustMaxYValueLessThanMaximumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMaxYValueMoreThanMaximumValue.storyName = "with just max Y value more than maximum value";
@@ -732,9 +705,7 @@ export function WithJustMaxYValueMoreThanMaximumValue(): JSX.Element {
   );
 }
 WithJustMaxYValueMoreThanMaximumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 WithJustMaxYValueLessThanMinimumValue.storyName = "with just max Y value less than minimum value";
@@ -762,9 +733,7 @@ export function WithJustMaxYValueLessThanMinimumValue(): JSX.Element {
   );
 }
 WithJustMaxYValueLessThanMinimumValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 ScatterPlotPlusLineGraphPlusReferenceLine.storyName =
@@ -796,9 +765,7 @@ export function ScatterPlotPlusLineGraphPlusReferenceLine(): JSX.Element {
   );
 }
 ScatterPlotPlusLineGraphPlusReferenceLine.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 IndexBasedXAxisForArray.storyName = "index-based x-axis for array";
@@ -825,9 +792,7 @@ export function IndexBasedXAxisForArray(): JSX.Element {
   );
 }
 IndexBasedXAxisForArray.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 CustomXAxisTopic.storyName = "custom x-axis topic";
@@ -854,9 +819,7 @@ export function CustomXAxisTopic(): JSX.Element {
   );
 }
 CustomXAxisTopic.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 CurrentCustomXAxisTopic.storyName = "current custom x-axis topic";
@@ -884,9 +847,7 @@ export function CurrentCustomXAxisTopic(): JSX.Element {
   );
 }
 CurrentCustomXAxisTopic.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 CustomXAxisTopicWithMismatchedDataLengths.storyName =
@@ -925,9 +886,7 @@ export function CustomXAxisTopicWithMismatchedDataLengths(): JSX.Element {
   );
 }
 CustomXAxisTopicWithMismatchedDataLengths.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 SuperCloseValues.storyName = "super close values";
@@ -974,9 +933,7 @@ export function SuperCloseValues(): JSX.Element {
   );
 }
 SuperCloseValues.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 TimeValues.storyName = "time values";
@@ -1003,9 +960,7 @@ export function TimeValues(): JSX.Element {
   );
 }
 TimeValues.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 PreloadedDataInBinaryBlocks.storyName = "preloaded data in binary blocks";
@@ -1027,9 +982,7 @@ export function PreloadedDataInBinaryBlocks(): JSX.Element {
   );
 }
 PreloadedDataInBinaryBlocks.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 MixedStreamedAndPreloadedData.storyName = "mixed streamed and preloaded data";
@@ -1055,9 +1008,7 @@ export function MixedStreamedAndPreloadedData(): JSX.Element {
   );
 }
 MixedStreamedAndPreloadedData.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 PreloadedDataAndItsDerivative.storyName = "preloaded data and its derivative";
@@ -1083,9 +1034,7 @@ export function PreloadedDataAndItsDerivative(): JSX.Element {
   );
 }
 PreloadedDataAndItsDerivative.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 PreloadedDataAndItsNegative.storyName = "preloaded data and its negative";
@@ -1111,9 +1060,7 @@ export function PreloadedDataAndItsNegative(): JSX.Element {
   );
 }
 PreloadedDataAndItsNegative.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 PreloadedDataAndItsAbsoluteValue.storyName = "preloaded data and its absolute value";
@@ -1139,9 +1086,7 @@ export function PreloadedDataAndItsAbsoluteValue(): JSX.Element {
   );
 }
 PreloadedDataAndItsAbsoluteValue.parameters = {
-  screenshot: {
-    signal: signal(),
-  },
+  useReadySignal: true,
 };
 
 export function Settings(): JSX.Element {

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -15,7 +15,6 @@ import TestUtils from "react-dom/test-utils";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import useResumeCount from "@foxglove/studio-base/stories/useResumeCount";
-import signal from "@foxglove/studio-base/util/signal";
 
 import StateTransitions from "./index";
 
@@ -96,7 +95,7 @@ export default {
   },
 };
 
-OnePath.parameters = { screenshot: { signal: signal() } };
+OnePath.parameters = { useReadySignal: true };
 export function OnePath(): JSX.Element {
   const pauseFrame = useResumeCount(3);
   return (
@@ -110,7 +109,7 @@ export function OnePath(): JSX.Element {
   );
 }
 
-MultiplePaths.parameters = { screenshot: { signal: signal() } };
+MultiplePaths.parameters = { useReadySignal: true };
 export function MultiplePaths(): JSX.Element {
   const pauseFrame = useResumeCount(3);
   return (
@@ -127,7 +126,7 @@ export function MultiplePaths(): JSX.Element {
   );
 }
 
-MultiplePathsWithHover.parameters = { screenshot: { signal: signal() } };
+MultiplePathsWithHover.parameters = { useReadySignal: true };
 export function MultiplePathsWithHover(): JSX.Element {
   const pauseFrame = useResumeCount(3);
   return (
@@ -154,7 +153,7 @@ export function MultiplePathsWithHover(): JSX.Element {
   );
 }
 
-LongPath.parameters = { screenshot: { signal: signal() } };
+LongPath.parameters = { useReadySignal: true };
 export function LongPath(): JSX.Element {
   const pauseFrame = useResumeCount(3);
   return (
@@ -168,7 +167,7 @@ export function LongPath(): JSX.Element {
   );
 }
 
-JsonPath.parameters = { screenshot: { signal: signal() } };
+JsonPath.parameters = { useReadySignal: true };
 export function JsonPath(): JSX.Element {
   const pauseFrame = useResumeCount(3);
   return (
@@ -184,7 +183,7 @@ export function JsonPath(): JSX.Element {
 
 WithAHoveredTooltip.parameters = {
   chromatic: { delay: 200 },
-  screenshot: { signal: signal() },
+  useReadySignal: true,
 };
 export function WithAHoveredTooltip(): JSX.Element {
   const pauseFrame = useResumeCount(3);

--- a/patches/storybook-react.patch
+++ b/patches/storybook-react.patch
@@ -2,12 +2,13 @@ diff --git a/dist/esm/client/preview/render.js b/dist/esm/client/preview/render.
 index 5883ed6c7e9db640cd8f209a3b840efb1d54c6a7..03c377000bdc7eb620c2f9107a2635e820d69247 100644
 --- a/dist/esm/client/preview/render.js
 +++ b/dist/esm/client/preview/render.js
-@@ -44,9 +44,11 @@ var document = global.document,
+@@ -44,9 +44,12 @@ var document = global.document,
      FRAMEWORK_OPTIONS = global.FRAMEWORK_OPTIONS;
  var rootEl = document ? document.getElementById('root') : null;
- 
+
 -var render = function render(node, el) {
-+var render = function render(node, el, maybeSignal) {
++var render = function render(node, el, storyContext) {
++  var maybeSignal = storyContext.parameters?.storyReady;
    return new Promise(function (resolve) {
 -    ReactDOM.render(node, el, resolve);
 +    ReactDOM.render(node, el, () => {
@@ -15,13 +16,13 @@ index 5883ed6c7e9db640cd8f209a3b840efb1d54c6a7..03c377000bdc7eb620c2f9107a2635e8
 +    });
    });
  };
- 
+
 @@ -137,7 +139,7 @@ function _renderMain() {
              }
- 
+
              _context.next = 7;
 -            return render(element, rootEl);
-+            return render(element, rootEl, storyContext.parameters?.screenshot?.signal);
- 
++            return render(element, rootEl, storyContext);
+
            case 7:
            case "end":

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,7 +4496,7 @@ __metadata:
 
 "@storybook/react@patch:@storybook/react@6.3.4#../../patches/storybook-react.patch::locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base":
   version: 6.3.4
-  resolution: "@storybook/react@patch:@storybook/react@npm%3A6.3.4#../../patches/storybook-react.patch::version=6.3.4&hash=10b770&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
+  resolution: "@storybook/react@patch:@storybook/react@npm%3A6.3.4#../../patches/storybook-react.patch::version=6.3.4&hash=54a7b9&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
@@ -4534,7 +4534,7 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: ceeefe723565ec7937a9b70389bff29d83676b36ea0d928bf761bb8cfd987ed9d9566b242bb7fb6ca7619dd6b085786f0bb5e9865bbf1f316b6a147579e9bbc1
+  checksum: 5f886b95da37fe8da7dea572b82131d2b964fec839ff2a05e924cd5ca60e8578911125748419723227595ff931374a93ba30b2ca329af0e4feeae2bad7fc7f0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
* Change all stories to the useReadySignal hook
* Change screenshot.signal parameter to useReadySignal parameter

The useReadySignal parameter instructs storybook to create a suitable
ready signal function rather than the user having to provide a promise.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
