### PR TITLE
Internal: move visualization marker constants to ImageViewPanel

### DIFF
--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -41,13 +41,6 @@ import { CameraInfo, StampedMessage } from "@foxglove/studio-base/types/Messages
 import { PanelConfigSchema, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { nonEmptyOrUndefined } from "@foxglove/studio-base/util/emptyOrUndefined";
 import filterMap from "@foxglove/studio-base/util/filterMap";
-import {
-  FOXGLOVE_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-  STUDIO_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-  VISUALIZATION_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-  VISUALIZATION_MSGS_IMAGE_MARKER_DATATYPE,
-  WEBVIZ_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-} from "@foxglove/studio-base/util/globalConstants";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 import { colors as sharedColors } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -299,12 +292,13 @@ function ImageView(props: Props) {
   const imageMarkerDatatypes = useMemo(
     () => [
       // Single marker
-      VISUALIZATION_MSGS_IMAGE_MARKER_DATATYPE,
+      "visualization_msgs/ImageMarker",
       // Marker arrays
-      FOXGLOVE_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-      STUDIO_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-      VISUALIZATION_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
-      WEBVIZ_MSGS_IMAGE_MARKER_ARRAY_DATATYPE,
+      "foxglove_msgs/ImageMarkerArray",
+      "studio_msgs/ImageMarkerArray",
+      "visualization_msgs/ImageMarkerArray",
+      // backwards compat with webviz
+      "webviz_msgs/ImageMarkerArray",
     ],
     [],
   );

--- a/packages/studio-base/src/util/globalConstants.ts
+++ b/packages/studio-base/src/util/globalConstants.ts
@@ -32,11 +32,6 @@ export const TF2_DATATYPE = "tf2_msgs/TFMessage";
 export const VELODYNE_SCAN_DATATYPE = "velodyne_msgs/VelodyneScan";
 export const VISUALIZATION_MSGS_MARKER_DATATYPE = "visualization_msgs/Marker";
 export const VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE = "visualization_msgs/MarkerArray";
-export const VISUALIZATION_MSGS_IMAGE_MARKER_DATATYPE = "visualization_msgs/ImageMarker";
-export const FOXGLOVE_MSGS_IMAGE_MARKER_ARRAY_DATATYPE = "foxglove_msgs/ImageMarkerArray";
-export const STUDIO_MSGS_IMAGE_MARKER_ARRAY_DATATYPE = "studio_msgs/ImageMarkerArray";
-export const VISUALIZATION_MSGS_IMAGE_MARKER_ARRAY_DATATYPE = "visualization_msgs/ImageMarkerArray";
-export const WEBVIZ_MSGS_IMAGE_MARKER_ARRAY_DATATYPE = "webviz_msgs/ImageMarkerArray";
 
 export const FOXGLOVE_GRID_TOPIC = "/foxglove/grid";
 export const FOXGLOVE_GRID_DATATYPE = "foxglove/Grid";


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than putting these in globalConstants, move them to the image
panel since it alone determines which datatypes it supports.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
