### PR TITLE
Reduce install size by removing .map files from ASAR

### DIFF
--- a/desktop/integration-test/build.ts
+++ b/desktop/integration-test/build.ts
@@ -18,9 +18,12 @@ export default async (): Promise<void> => {
   const compiler = webpack(
     webpackConfig.map((config) => {
       if (typeof config === "function") {
-        return config(undefined, { mode: "production" });
+        const cfg = config(undefined, { mode: "production" });
+        cfg.devtool = false;
+        return cfg;
       }
 
+      config.devtool = false;
       return config;
     }),
   );

--- a/desktop/integration-test/buildSize.test.ts
+++ b/desktop/integration-test/buildSize.test.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 
 // Adjust this byte size as needed if the app is growing for a valid reason.
 // This check is here to catch unexpected ballooning of the build size
-const MAX_BUILD_SIZE = 120_000_000;
+const MAX_BUILD_SIZE = 34_000_000;
 
 async function getAllFiles(dirPath: string, arrayOfFiles: string[] = []): Promise<string[]> {
   const files = await readdir(dirPath, { withFileTypes: true });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "package:win": "yarn package --win",
     "package:darwin": "yarn package --mac",
     "package:linux": "yarn package --linux",
-    "package": "cross-env NODE_OPTIONS='-r ts-node/register' electron-builder build --publish never",
+    "package": "cross-env NODE_OPTIONS='-r ts-node/register' electron-builder build --publish never && rimraf desktop/.webpack/**.map",
     "package:e2e": "yarn && yarn clean && yarn build:prod && yarn package",
     "release:bump-nightly-version": "node -r ts-node/register ./ci/bump-nightly-version.ts",
     "storybook": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' yarn workspace @foxglove/studio-base run start-storybook --config-dir src/.storybook",


### PR DESCRIPTION
We already upload these files directly to Sentry, they do not need to be in the app installation images as well. Map files take up two thirds of the uncompressed ASAR disk space.
