### PR TITLE
Always show extension marketplace sidebar item

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -10,6 +10,5 @@ export enum AppSetting {
   TIMEZONE = "timezone",
   UNLIMITED_MEMORY_CACHE = "experimental.unlimited-memory-cache",
   SHOW_DEBUG_PANELS = "showDebugPanels",
-  EXTENSION_MARKETPLACE = "extensionMarketplace",
   FAKE_REMOTE_LAYOUTS = "debug.useFakeRemoteLayouts",
 }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -17,7 +17,6 @@ import { useMountedState } from "react-use";
 import styled from "styled-components";
 
 import Log from "@foxglove/log";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AccountSettings from "@foxglove/studio-base/components/AccountSettingsSidebar/AccountSettings";
 import ConnectionList from "@foxglove/studio-base/components/ConnectionList";
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
@@ -52,7 +51,6 @@ import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext
 import { PanelSettingsContext } from "@foxglove/studio-base/context/PanelSettingsContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
@@ -398,17 +396,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     [selectedSidebarItem],
   );
 
-  const [showMarketplace = false] = useAppConfigurationValue<boolean>(
-    AppSetting.EXTENSION_MARKETPLACE,
-  );
-  const sidebarItems = useMemo(() => {
-    const filteredSidebarItems = new Map(SIDEBAR_ITEMS);
-    if (!showMarketplace) {
-      filteredSidebarItems.delete("extensions");
-    }
-    return filteredSidebarItems;
-  }, [showMarketplace]);
-
   return (
     <MultiProvider
       providers={[
@@ -448,7 +435,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           </SToolbarItem>
         </Toolbar>
         <Sidebar
-          items={sidebarItems}
+          items={SIDEBAR_ITEMS}
           bottomItems={SIDEBAR_BOTTOM_ITEMS}
           selectedKey={selectedSidebarItem}
           onSelectKey={setSelectedSidebarItem}

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -33,11 +33,6 @@ const features: Feature[] = [
     name: "Studio Debug Panels",
     description: <>Show Studio debug panels in the add panel list.</>,
   },
-  {
-    key: AppSetting.EXTENSION_MARKETPLACE,
-    name: "Extension Marketplace",
-    description: <>Enable the extension marketplace for installing/uninstalling extensions</>,
-  },
   ...(process.env.NODE_ENV !== "production"
     ? [
         {


### PR DESCRIPTION

**User-Facing Changes**
The extension marketplace sidebar item is always shown.

**Description**
Unflag the extension marketplace for easier discovery.

Fixes #1492


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
