### PR TITLE
Fix: "show debug planels" app setting

### DIFF
--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -47,6 +47,9 @@ const builtin: PanelInfo[] = [
     module: async () => await import("./NodePlayground"),
   },
   { title: "Tab", type: TAB_PANEL_TYPE, module: async () => await import("./Tab") },
+];
+
+const debug: PanelInfo[] = [
   {
     title: "Studio - Playback Performance",
     type: "PlaybackPerformance",
@@ -72,4 +75,4 @@ const hidden: PanelInfo[] = [
   },
 ];
 
-export default { builtin, hidden };
+export default { builtin, debug, hidden };

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -64,7 +64,7 @@ export default function PanelCatalogProvider(
   const visiblePanels = useMemo(() => {
     // debug panels are hidden by default, users can enable them within app settings
     if (showDebugPanels) {
-      return [...panels.builtin, ...wrappedExtensionPanels];
+      return [...panels.builtin, ...panels.debug, ...wrappedExtensionPanels];
     }
 
     return [...panels.builtin, ...wrappedExtensionPanels];


### PR DESCRIPTION
**User-Facing Changes**
None - the regression was not in a release.

**Description**
The "show debug panels" app setting was recently broken in a change to
convert builtin panels to lazy loading. This fixes the app setting to
properly filter out debug panels when off.

Fixes #1498


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
