### PR TITLE
Add banner for unsupported browsers + outdated Chrome versions

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -25,8 +25,6 @@ import PanelCatalogProvider from "@foxglove/studio-base/providers/PanelCatalogPr
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 
-import "./styles/global.scss";
-
 type AppProps = {
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -25,6 +25,8 @@ import PanelCatalogProvider from "@foxglove/studio-base/providers/PanelCatalogPr
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 
+import "./styles/global.scss";
+
 type AppProps = {
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -19,7 +19,7 @@ import ExtensionLoaderProvider from "./providers/ExtensionLoaderProvider";
 
 const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
 
-export default function Root(): JSX.Element {
+export function Root(): JSX.Element {
   const playerSources: PlayerSourceDefinition[] = [
     {
       name: "Rosbridge (WebSocket)",

--- a/web/src/VersionBanner.tsx
+++ b/web/src/VersionBanner.tsx
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { useState, ReactElement } from "react";
+import styled from "styled-components";
+
+import "@foxglove/studio-base/styles/global.scss";
+
+const MINIMUM_CHROME_VERSION = 91;
+const StyledBanner = styled.div`
+  text-align: center;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100vw;
+  padding: 10px;
+  background-color: rgba(99, 102, 241, 0.9);
+  z-index: 100;
+`;
+
+const VersionBanner = function ({
+  isChrome,
+  currentVersion,
+}: {
+  isChrome: boolean;
+  currentVersion: number;
+}): ReactElement | ReactNull {
+  const [showBanner, setShowBanner] = useState(true);
+
+  if (!showBanner || currentVersion >= MINIMUM_CHROME_VERSION) {
+    return ReactNull;
+  }
+
+  const prompt = isChrome
+    ? `Update Chrome to version ${MINIMUM_CHROME_VERSION}+ to continue.`
+    : `You're using an unsupported browser. Use Chrome ${MINIMUM_CHROME_VERSION}+ to continue.`;
+  const fixText = isChrome ? "Update Chrome" : "Download Chrome";
+  const continueText = isChrome
+    ? "Continue with unsupported version"
+    : "Continue with unsupported browser";
+
+  return (
+    <StyledBanner>
+      <div>
+        <p>{prompt} </p>
+        {isChrome ? undefined : (
+          <p>
+            Check out our browser support progress in{" "}
+            <a href="https://github.com/foxglove/studio/issues/1422">this GitHub issue</a>.
+          </p>
+        )}
+      </div>
+
+      <div style={{ paddingTop: "20px" }}>
+        <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer">
+          <button>{fixText}</button>
+        </a>
+        <button onClick={() => setShowBanner(false)}>{continueText}</button>
+      </div>
+    </StyledBanner>
+  );
+};
+
+export default VersionBanner;

--- a/web/src/VersionBanner.tsx
+++ b/web/src/VersionBanner.tsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 
 import "@foxglove/studio-base/styles/global.scss";
 
-const MINIMUM_CHROME_VERSION = 91;
+const MINIMUM_CHROME_VERSION = 76;
 const StyledBanner = styled.div`
   text-align: center;
   position: absolute;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -3,64 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { init as initSentry } from "@sentry/browser";
-import { useState } from "react";
 import ReactDOM from "react-dom";
-import styled from "styled-components";
 
 import Logger from "@foxglove/log";
 
-import "@foxglove/studio-base/styles/global.scss";
+import VersionBanner from "./VersionBanner";
 
 const log = Logger.getLogger(__filename);
-const MINIMUM_CHROME_VERSION = 91;
-const StyledBanner = styled.div`
-  text-align: center;
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  width: 100vw;
-  padding: 10px;
-  background-color: rgba(99, 102, 241, 0.9);
-  z-index: 100;
-`;
-
-const VersionBanner = function ({ isChrome }: { isChrome: boolean }) {
-  const [showBanner, setShowBanner] = useState(true);
-
-  if (!showBanner) {
-    return ReactNull;
-  }
-
-  const prompt = isChrome
-    ? `Update Chrome to version ${MINIMUM_CHROME_VERSION}+ to continue.`
-    : `You're using an unsupported browser. Use Chrome ${MINIMUM_CHROME_VERSION}+ to continue.`;
-  const fixText = isChrome ? "Update Chrome" : "Download Chrome";
-  const continueText = isChrome
-    ? "Continue with unsupported version"
-    : "Continue with unsupported browser";
-
-  return (
-    <StyledBanner>
-      <div>
-        <p>{prompt} </p>
-        {isChrome ? undefined : (
-          <p>
-            Check out our browser support progress in{" "}
-            <a href="https://github.com/foxglove/studio/issues/1422">this GitHub issue</a>.
-          </p>
-        )}
-      </div>
-
-      <div style={{ paddingTop: "20px" }}>
-        <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer">
-          <button>{fixText}</button>
-        </a>
-        <button onClick={() => setShowBanner(false)}>{continueText}</button>
-      </div>
-    </StyledBanner>
-  );
-};
-
 log.debug("initializing");
 
 if (typeof process.env.SENTRY_DSN === "string") {
@@ -89,17 +38,14 @@ async function main() {
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
   const isChrome = chromeVersion !== 0;
 
+  const banner = <VersionBanner isChrome={isChrome} currentVersion={chromeVersion} />;
+  const renderCallback = () => {
+    // Integration tests look for this console log to indicate the app has rendered once
+    log.debug("App rendered");
+  };
+
   if (!isChrome) {
-    ReactDOM.render(
-      <>
-        <VersionBanner isChrome={false} />
-      </>,
-      rootEl,
-      () => {
-        // Integration tests look for this console log to indicate the app has rendered once
-        log.debug("App rendered");
-      },
-    );
+    ReactDOM.render(banner, rootEl, renderCallback);
     return;
   }
 
@@ -112,24 +58,13 @@ async function main() {
   await waitForFonts();
 
   const { Root } = await import("./Root");
-  if (chromeVersion >= MINIMUM_CHROME_VERSION) {
-    ReactDOM.render(<Root />, rootEl, () => {
-      // Integration tests look for this console log to indicate the app has rendered once
-      log.debug("App rendered");
-    });
-    return;
-  }
-
   ReactDOM.render(
     <>
-      <VersionBanner isChrome={true} />
+      {banner}
       <Root />
     </>,
     rootEl,
-    () => {
-      // Integration tests look for this console log to indicate the app has rendered once
-      log.debug("App rendered");
-    },
+    renderCallback,
   );
 }
 

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -3,14 +3,63 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { init as initSentry } from "@sentry/browser";
+import { useState } from "react";
 import ReactDOM from "react-dom";
+import styled from "styled-components";
 
 import Logger from "@foxglove/log";
-import { installDevtoolsFormatters, overwriteFetch, waitForFonts } from "@foxglove/studio-base";
 
-import Root from "./Root";
+import "@foxglove/studio-base/styles/global.scss";
 
 const log = Logger.getLogger(__filename);
+const MINIMUM_CHROME_VERSION = 91;
+const StyledBanner = styled.div`
+  text-align: center;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 100vw;
+  padding: 10px;
+  background-color: rgba(99, 102, 241, 0.9);
+  z-index: 100;
+`;
+
+const VersionBanner = function ({ isChrome }: { isChrome: boolean }) {
+  const [showBanner, setShowBanner] = useState(true);
+
+  if (!showBanner) {
+    return ReactNull;
+  }
+
+  const prompt = isChrome
+    ? `Update Chrome to version ${MINIMUM_CHROME_VERSION}+ to continue.`
+    : `You're using an unsupported browser. Use Chrome ${MINIMUM_CHROME_VERSION}+ to continue.`;
+  const fixText = isChrome ? "Update Chrome" : "Download Chrome";
+  const continueText = isChrome
+    ? "Continue with unsupported version"
+    : "Continue with unsupported browser";
+
+  return (
+    <StyledBanner>
+      <div>
+        <p>{prompt} </p>
+        {isChrome ? undefined : (
+          <p>
+            Check out our browser support progress in{" "}
+            <a href="https://github.com/foxglove/studio/issues/1422">this GitHub issue</a>.
+          </p>
+        )}
+      </div>
+
+      <div style={{ paddingTop: "20px" }}>
+        <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer">
+          <button>{fixText}</button>
+        </a>
+        <button onClick={() => setShowBanner(false)}>{continueText}</button>
+      </div>
+    </StyledBanner>
+  );
+};
 
 log.debug("initializing");
 
@@ -30,22 +79,58 @@ if (typeof process.env.SENTRY_DSN === "string") {
   });
 }
 
-installDevtoolsFormatters();
-overwriteFetch();
-
 const rootEl = document.getElementById("root");
 if (!rootEl) {
   throw new Error("missing #root element");
 }
 
 async function main() {
+  const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
+  const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
+  const isChrome = chromeVersion !== 0;
+
+  if (!isChrome) {
+    ReactDOM.render(
+      <>
+        <VersionBanner isChrome={false} />
+      </>,
+      rootEl,
+      () => {
+        // Integration tests look for this console log to indicate the app has rendered once
+        log.debug("App rendered");
+      },
+    );
+    return;
+  }
+
+  const { installDevtoolsFormatters, overwriteFetch, waitForFonts } = await import(
+    "@foxglove/studio-base"
+  );
+  installDevtoolsFormatters();
+  overwriteFetch();
   // consider moving waitForFonts into App to display an app loading screen
   await waitForFonts();
 
-  ReactDOM.render(<Root />, rootEl, () => {
-    // Integration tests look for this console log to indicate the app has rendered once
-    log.debug("App rendered");
-  });
+  const { Root } = await import("./Root");
+  if (chromeVersion >= MINIMUM_CHROME_VERSION) {
+    ReactDOM.render(<Root />, rootEl, () => {
+      // Integration tests look for this console log to indicate the app has rendered once
+      log.debug("App rendered");
+    });
+    return;
+  }
+
+  ReactDOM.render(
+    <>
+      <VersionBanner isChrome={true} />
+      <Root />
+    </>,
+    rootEl,
+    () => {
+      // Integration tests look for this console log to indicate the app has rendered once
+      log.debug("App rendered");
+    },
+  );
 }
 
 void main();


### PR DESCRIPTION
**User-Facing Changes**
Alert users to when their Chrome version is outdated, or when they're using an unsupported browser (i.e. not Chrome).

**Description**
Example of banner in Safari:

<img width="729" alt="Screen Shot 2021-07-19 at 2 28 02 PM" src="https://user-images.githubusercontent.com/6993359/126229942-d5381cc0-354a-430d-ad3f-d47016cbd3f3.png">

Resolves #1511.
