### PR TITLE
Change: use fluentui spinner for lazy loaded panels

### DIFF
--- a/packages/studio-base/src/context/PanelCatalogContext.ts
+++ b/packages/studio-base/src/context/PanelCatalogContext.ts
@@ -7,29 +7,33 @@ import { ComponentType, createContext, useContext } from "react";
 import { PanelStatics } from "@foxglove/studio-base/components/Panel";
 import { PanelConfig, PanelConfigSchema } from "@foxglove/studio-base/types/panels";
 
-type PanelComponent = ComponentType<{ childId?: string; tabId?: string }> &
+export type PanelComponent = ComponentType<{ childId?: string; tabId?: string }> &
   PanelStatics<PanelConfig>;
 
 export type PanelInfo = {
   title: string;
   type: string;
 
-  // The panel module is a function to load the panel.
-  // This is to support our lazy built-in panels
+  /**
+   * The panel module is a function to load the panel.
+   * This is to support our lazy built-in panels
+   */
   module: () => Promise<{ default: PanelComponent }>;
 };
 
-// PanelCatalog describes the interface for getting available panels
+/** PanelCatalog describes the interface for getting available panels */
 export interface PanelCatalog {
-  // get a list of the available panels
+  /** get a list of the available panels */
   getPanels(): readonly PanelInfo[];
 
-  // Get panel information for a specific panel type (i.e. 3d, map, image, etc)
+  /** Get panel information for a specific panel type (i.e. 3d, map, image, etc) */
   getPanelByType(type: string): PanelInfo | undefined;
 
-  // Get the configuration schema for a specific panel type
-  //
-  // This is async to support lazy loading our builtin panels
+  /**
+   * Get the configuration schema for a specific panel type
+   *
+   * This is async to support lazy loading our builtin panels
+   */
   getConfigSchema(type: string): Promise<PanelConfigSchema<Record<string, unknown>> | undefined>;
 }
 


### PR DESCRIPTION
**User-Facing Changes**
When panel code is loading for the first time the user is briefly shown a spinner.

**Description**
Panels load lazily so we can keep the amount of code loaded on first render smaller. This helps with app startup perception.

Fixes #1504

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
