### PR TITLE
Update cross-browser github issue link

### DIFF
--- a/web/src/VersionBanner.tsx
+++ b/web/src/VersionBanner.tsx
@@ -46,7 +46,7 @@ const VersionBanner = function ({
         {isChrome ? undefined : (
           <p>
             Check out our browser support progress in{" "}
-            <a href="https://github.com/foxglove/studio/issues/1422">this GitHub issue</a>.
+            <a href="https://github.com/foxglove/studio/issues/1511">this GitHub issue</a>.
           </p>
         )}
       </div>


### PR DESCRIPTION
**User-Facing Changes**
Change which github issue the cross-browser warning banner links to

Follow up from https://github.com/foxglove/studio/pull/1502