### PR TITLE
Change: call to action to use desktop version on extension installs

### DIFF
--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -58,7 +58,7 @@ export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown
 }
 
 async function downloadExtension(_url: string): Promise<Uint8Array> {
-  throw new Error("Please use the desktop version to use extensions");
+  throw new Error("Please download the desktop app to use extensions");
 }
 
 async function installExtension(_foxeFileData: Uint8Array): Promise<ExtensionInfo> {

--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -57,14 +57,12 @@ export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown
   );
 }
 
-async function downloadExtension(url: string): Promise<Uint8Array> {
-  const res = await fetch(url);
-  return new Uint8Array(await res.arrayBuffer());
+async function downloadExtension(_url: string): Promise<Uint8Array> {
+  throw new Error("Please use the desktop version to use extensions");
 }
 
 async function installExtension(_foxeFileData: Uint8Array): Promise<ExtensionInfo> {
-  // The web view can load extensions, but can't install them
-  throw new Error("Extensions cannot be installed from the web viewer");
+  throw new Error("Please use the desktop version to use extensions");
 }
 
 async function uninstallExtension(_id: string): Promise<boolean> {

--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -62,7 +62,7 @@ async function downloadExtension(_url: string): Promise<Uint8Array> {
 }
 
 async function installExtension(_foxeFileData: Uint8Array): Promise<ExtensionInfo> {
-  throw new Error("Please use the desktop version to use extensions");
+  throw new Error("Please download the desktop app to use extensions");
 }
 
 async function uninstallExtension(_id: string): Promise<boolean> {


### PR DESCRIPTION

**User-Facing Changes**
When a user clicks "install" for an extension in the web version they see an error that indicates extensions are only supported in the desktop version.

**Description**
The web version cannot download extensions at this time so we make the
error message more clear that the user should use the desktop version.

Fixes https://github.com/foxglove/studio/issues/1515

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->

![image](https://user-images.githubusercontent.com/84792/126405184-93e8e654-b2fe-49b9-8275-917962b0459e.png)
