### PR TITLE
web: add ?demo url param to force loading welcome layout

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -28,7 +28,11 @@ import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 import "./styles/global.scss";
 
 type AppProps = {
-  alwaysLoadWelcomeLayoutOnMount?: boolean;
+  /**
+   * Set to true to force loading the welcome layout for demo mode. Normally the demo is only shown
+   * on first launch and not subsequent launches.
+   */
+  loadWelcomeLayout?: boolean;
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;
   deepLinks?: string[];
@@ -65,7 +69,7 @@ export default function App(props: AppProps): JSX.Element {
         <Suspense fallback={<></>}>
           <PanelCatalogProvider>
             <Workspace
-              alwaysLoadWelcomeLayoutOnMount={props.alwaysLoadWelcomeLayoutOnMount}
+              loadWelcomeLayout={props.loadWelcomeLayout}
               demoBagUrl={props.demoBagUrl}
               deepLinks={props.deepLinks}
               onToolbarDoubleClick={props.onFullscreenToggle}

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -28,6 +28,7 @@ import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 import "./styles/global.scss";
 
 type AppProps = {
+  alwaysLoadWelcomeLayoutOnMount?: boolean;
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;
   deepLinks?: string[];
@@ -64,6 +65,7 @@ export default function App(props: AppProps): JSX.Element {
         <Suspense fallback={<></>}>
           <PanelCatalogProvider>
             <Workspace
+              alwaysLoadWelcomeLayoutOnMount={props.alwaysLoadWelcomeLayoutOnMount}
               demoBagUrl={props.demoBagUrl}
               deepLinks={props.deepLinks}
               onToolbarDoubleClick={props.onFullscreenToggle}

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -141,7 +141,7 @@ function Variables() {
 const allowedDropExtensions = [".bag", ".foxe", ".urdf"];
 
 type WorkspaceProps = {
-  alwaysLoadWelcomeLayoutOnMount?: boolean;
+  loadWelcomeLayout?: boolean;
   demoBagUrl?: string;
   deepLinks?: string[];
   onToolbarDoubleClick?: () => void;
@@ -272,7 +272,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   useMount(() => {
     void (async () => {
       const welcomeLayoutShown = appConfiguration.get("onboarding.welcome-layout.shown");
-      if (welcomeLayoutShown !== true || props.alwaysLoadWelcomeLayoutOnMount === true) {
+      if (welcomeLayoutShown !== true || props.loadWelcomeLayout === true) {
         await appConfiguration.set("onboarding.welcome-layout.shown", true);
         await openWelcomeLayout();
       }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -13,7 +13,7 @@
 import { Stack } from "@fluentui/react";
 import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
 import { useToasts } from "react-toast-notifications";
-import { useMountedState } from "react-use";
+import { useMount, useMountedState } from "react-use";
 import styled from "styled-components";
 
 import Log from "@foxglove/log";
@@ -141,6 +141,7 @@ function Variables() {
 const allowedDropExtensions = [".bag", ".foxe", ".urdf"];
 
 type WorkspaceProps = {
+  alwaysLoadWelcomeLayoutOnMount?: boolean;
   demoBagUrl?: string;
   deepLinks?: string[];
   onToolbarDoubleClick?: () => void;
@@ -268,17 +269,15 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const { addToast } = useToasts();
 
   // Show welcome layout on first run
-  useEffect(() => {
+  useMount(() => {
     void (async () => {
       const welcomeLayoutShown = appConfiguration.get("onboarding.welcome-layout.shown");
-      if (welcomeLayoutShown == undefined || welcomeLayoutShown === false) {
-        // Set configuration *before* opening the layout to avoid infinite recursion when the player
-        // loading state causes us to re-render.
+      if (welcomeLayoutShown !== true || props.alwaysLoadWelcomeLayoutOnMount === true) {
         await appConfiguration.set("onboarding.welcome-layout.shown", true);
         await openWelcomeLayout();
       }
     })();
-  }, [appConfiguration, openWelcomeLayout]);
+  });
 
   // previously loaded files are tracked so support the "add bag" feature which loads a second bag
   // file when the user presses shift during a drag/drop

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -19,7 +19,11 @@ import ExtensionLoaderProvider from "./providers/ExtensionLoaderProvider";
 
 const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
 
-export function Root(): JSX.Element {
+export function Root({
+  alwaysLoadWelcomeLayoutOnMount,
+}: {
+  alwaysLoadWelcomeLayoutOnMount: boolean;
+}): JSX.Element {
   const playerSources: PlayerSourceDefinition[] = [
     {
       name: "Rosbridge (WebSocket)",
@@ -54,7 +58,11 @@ export function Root(): JSX.Element {
     <ThemeProvider>
       <ErrorBoundary>
         <MultiProvider providers={providers}>
-          <App demoBagUrl={DEMO_BAG_URL} availableSources={playerSources} />
+          <App
+            alwaysLoadWelcomeLayoutOnMount={alwaysLoadWelcomeLayoutOnMount}
+            demoBagUrl={DEMO_BAG_URL}
+            availableSources={playerSources}
+          />
         </MultiProvider>
       </ErrorBoundary>
     </ThemeProvider>

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -19,11 +19,7 @@ import ExtensionLoaderProvider from "./providers/ExtensionLoaderProvider";
 
 const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
 
-export function Root({
-  alwaysLoadWelcomeLayoutOnMount,
-}: {
-  alwaysLoadWelcomeLayoutOnMount: boolean;
-}): JSX.Element {
+export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX.Element {
   const playerSources: PlayerSourceDefinition[] = [
     {
       name: "Rosbridge (WebSocket)",
@@ -59,7 +55,7 @@ export function Root({
       <ErrorBoundary>
         <MultiProvider providers={providers}>
           <App
-            alwaysLoadWelcomeLayoutOnMount={alwaysLoadWelcomeLayoutOnMount}
+            loadWelcomeLayout={loadWelcomeLayout}
             demoBagUrl={DEMO_BAG_URL}
             availableSources={playerSources}
           />

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -34,6 +34,12 @@ if (!rootEl) {
 }
 
 async function main() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const demoMode = searchParams.get("demo") != undefined;
+  if (demoMode) {
+    searchParams.delete("demo");
+    history.replaceState(undefined, "", `${window.location.pathname}?${searchParams.toString()}`);
+  }
   const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
   const isChrome = chromeVersion !== 0;
@@ -61,7 +67,7 @@ async function main() {
   ReactDOM.render(
     <>
       {banner}
-      <Root />
+      <Root alwaysLoadWelcomeLayoutOnMount={demoMode} />
     </>,
     rootEl,
     renderCallback,

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -37,6 +37,7 @@ async function main() {
   const searchParams = new URLSearchParams(window.location.search);
   const demoMode = searchParams.get("demo") != undefined;
   if (demoMode) {
+    // Remove ?demo from the page URL so reloading the page doesn't save a new copy of the demo layout.
     searchParams.delete("demo");
     history.replaceState(undefined, "", `${window.location.pathname}?${searchParams.toString()}`);
   }
@@ -67,7 +68,7 @@ async function main() {
   ReactDOM.render(
     <>
       {banner}
-      <Root alwaysLoadWelcomeLayoutOnMount={demoMode} />
+      <Root loadWelcomeLayout={demoMode} />
     </>,
     rootEl,
     renderCallback,


### PR DESCRIPTION
**User-Facing Changes**
None (more for internal/marketing use)

**Description**
Fixes #1508 

If the `?demo` flag is present in the url, always load the welcome layout on first mount. Also do a `history.replaceState` to remove the demo flag.

(Note that this still means creating a _new_ layout each time.)
