### PR TITLE
Change: remove sendNotification from all randomAccessDataProviders

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.test.ts
@@ -14,7 +14,6 @@ import { MessageEvent } from "@foxglove/studio-base/players/types";
 import ApiCheckerDataProvider from "@foxglove/studio-base/randomAccessDataProviders/ApiCheckerDataProvider";
 import MemoryDataProvider from "@foxglove/studio-base/randomAccessDataProviders/MemoryDataProvider";
 import { mockExtensionPoint } from "@foxglove/studio-base/randomAccessDataProviders/mockExtensionPoint";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 function getProvider(isRoot: boolean = false) {
   const memoryDataProvider = new MemoryDataProvider({
@@ -97,10 +96,6 @@ describe("ApiCheckerDataProvider", () => {
     });
 
     describe("failure", () => {
-      afterEach(() => {
-        sendNotification.expectCalledDuringTest();
-      });
-
       it("throws when calling twice", async () => {
         const { provider } = getProvider();
         await provider.initialize(mockExtensionPoint().extensionPoint);
@@ -166,9 +161,6 @@ describe("ApiCheckerDataProvider", () => {
     });
 
     describe("failure", () => {
-      afterEach(() => {
-        sendNotification.expectCalledDuringTest();
-      });
       it("throws when calling getMessages before initialize", async () => {
         const { provider } = getProvider();
         await expect(
@@ -311,9 +303,6 @@ describe("ApiCheckerDataProvider", () => {
     });
 
     describe("failure", () => {
-      afterEach(() => {
-        sendNotification.expectCalledDuringTest();
-      });
       it("throws when calling close before initialize", async () => {
         const { provider } = getProvider();
         await expect(provider.close()).rejects.toThrow();

--- a/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
@@ -25,7 +25,6 @@ import {
   GetMessagesTopics,
   InitializationResult,
 } from "@foxglove/studio-base/randomAccessDataProviders/types";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 // We wrap every RandomAccessDataProvider in an ApiCheckerDataProvider to strictly enforce
@@ -231,10 +230,10 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
 
   async close(): Promise<void> {
     if (!this._initializationResult) {
-      this._warn("close was called before initialize finished");
+      throw new Error("close was called before initialize finished");
     }
     if (this._closed) {
-      this._warn("close was called twice");
+      throw new Error("close was called twice");
     }
     this._closed = true;
     return await this._provider?.close();
@@ -242,12 +241,9 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
 
   _warn(message: string): void {
     const prefixedMessage = `ApiCheckerDataProvider(${this._name}): ${message}`;
-    sendNotification("Internal data provider assertion failed", prefixedMessage, "app", "warn");
 
-    if (process.env.NODE_ENV !== "production") {
-      // In tests and local development, also throw a hard message so we'll be more
-      // likely to notice it / fail CI.
-      throw Error(`ApiCheckerDataProvider assertion failed: ${prefixedMessage}`);
-    }
+    // fixme - maybe we shouldn't have the Apichecker at all - this is adding quite the additional
+    // overhead to a processing pipeline
+    throw new Error(`Internal data provider assertion failed: ${prefixedMessage}`);
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
@@ -20,7 +20,6 @@ import BagDataProvider, {
   statsAreAdjacent,
   TimedDataThroughput,
 } from "@foxglove/studio-base/randomAccessDataProviders/BagDataProvider";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 const dummyExtensionPoint = {
   progressCallback() {
@@ -166,7 +165,6 @@ describe("BagDataProvider", () => {
     const sortedTimestamps = [...timestamps];
     sortedTimestamps.sort(compare);
     expect(timestamps).toEqual(sortedTimestamps);
-    sendNotification.expectCalledDuringTest();
   });
 });
 

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -35,7 +35,6 @@ import CachedFilelike, { FileReader } from "@foxglove/studio-base/util/CachedFil
 import { bagConnectionsToTopics } from "@foxglove/studio-base/util/bagConnectionsHelper";
 import { getBagChunksOverlapCount } from "@foxglove/studio-base/util/bags";
 import { UserError } from "@foxglove/studio-base/util/errors";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 import Bzip2 from "@foxglove/wasm-bz2";
 
 type BagPath = { type: "file"; file: Blob } | { type: "remoteBagUrl"; url: string };
@@ -43,17 +42,6 @@ type BagPath = { type: "file"; file: Blob } | { type: "remoteBagUrl"; url: strin
 type Options = { bagPath: BagPath; cacheSizeInBytes?: number };
 
 const log = Logger.getLogger(__filename);
-
-type ReadResult = Parameters<Parameters<Bag["readMessages"]>[1]>[0];
-
-function reportMalformedError(operation: string, error: Error): void {
-  sendNotification(
-    `Error during ${operation}`,
-    `An error was encountered during ${operation}. This usually happens if the bag is somehow malformed.\n\n${error.stack}`,
-    "user",
-    "error",
-  );
-}
 
 export type TimedDataThroughput = {
   startTime: Time;
@@ -143,12 +131,26 @@ export default class BagDataProvider implements RandomAccessDataProvider {
         try {
           await remoteReader.open(); // Important that we call this first, because it might throw an error if the file can't be read.
         } catch (err) {
-          sendNotification("Fetching remote bag failed", (err as Error).message, "user", "error");
-          return await new Promise(() => {}); // Just never finish initializing.
+          return {
+            problems: [
+              {
+                severity: "error",
+                message: "Fetching remote bag failed",
+                error: err,
+              },
+            ],
+          };
         }
         if (remoteReader.size() === 0) {
-          sendNotification("Cannot play invalid bag", "Bag is 0 bytes in size.", "user", "error");
-          return await new Promise(() => {}); // Just never finish initializing.
+          return {
+            problems: [
+              {
+                severity: "error",
+                message: "Empty bag file",
+                error: new Error("Bag is 0 bytes in size"),
+              },
+            ],
+          };
         }
 
         this._bag = new Bag(new BagReader(remoteReader));
@@ -156,7 +158,15 @@ export default class BagDataProvider implements RandomAccessDataProvider {
         try {
           await this._bag.open();
         } catch (err) {
-          sendNotification("Opening remote bag failed", (err as Error).message, "user", "error");
+          return {
+            problems: [
+              {
+                severity: "error",
+                message: "Opening remote bag failed",
+                error: err,
+              },
+            ],
+          };
           return await new Promise(() => {}); // Just never finish initializing.
         }
       } else {
@@ -190,6 +200,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
       }
     }
     if (emptyConnections.length > 0) {
+      // fixme - add to problems?
       sendNotification(
         "Empty connections found",
         `This bag has some empty connections, which Foxglove Studio does not currently support. We'll try to play the remaining topics. Details:\n\n${JSON.stringify(
@@ -201,17 +212,22 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     }
 
     if (!startTime || !endTime || connections.length === 0) {
-      // This will abort video generation:
-      sendNotification("Cannot play invalid bag", "Bag is empty or corrupt.", "user", "error");
-      return await new Promise(() => {
-        // no-op
-      }); // Just never finish initializing.
+      return {
+        problems: [
+          {
+            severity: "error",
+            message: "Cannot play invalid bag",
+            error: new Error("Bag is empty or corrupt"),
+          },
+        ],
+      };
     }
     const chunksOverlapCount = getBagChunksOverlapCount(chunkInfos);
     // If >25% of the chunks overlap, show a warning. It's common for a small number of chunks to overlap
     // since it looks like `rosbag record` has a bit of a race condition, and that's not too terrible, so
     // only warn when there's a more serious slowdown.
     if (chunksOverlapCount > chunkInfos.length * 0.25) {
+      // fixme - add to problems
       sendNotification(
         "Bag is unsorted, which is slow",
         `This bag has many overlapping chunks (${chunksOverlapCount} out of ${chunkInfos.length}), which means that we have to decompress many chunks in order to load a particular time range. This is slow. Ideally, fix this where you're generating your bags, by sorting the messages by receive time, e.g. using a script like this: https://gist.github.com/janpaul123/deaa92338d5e8309ef7aa7a55d625152`,
@@ -301,29 +317,15 @@ export default class BagDataProvider implements RandomAccessDataProvider {
           if (!this.bzip2) {
             throw new Error("bzip2 not initialized");
           }
-          try {
-            return this.bzip2.decompress(buffer, size, { small: false });
-          } catch (error) {
-            reportMalformedError("bz2 decompression", error);
-            throw error;
-          }
+          return Buffer.from(this.bzip2.decompress(buffer, size, { small: false }));
         },
         lz4: (...args: unknown[]) => {
-          try {
-            return decompressLZ4(...args);
-          } catch (error) {
-            reportMalformedError("lz4 decompression", error);
-            throw error;
-          }
+          return decompressLZ4(...args);
         },
       },
     };
-    try {
-      await this._bag?.readMessages(options, onMessage);
-    } catch (error) {
-      reportMalformedError("bag parsing", error);
-      throw error;
-    }
+
+    await this._bag?.readMessages(options, onMessage);
     messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
     // Range end is inclusive.
     const duration = add(subtractTimes(end, start), { sec: 0, nsec: 1 });

--- a/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.test.ts
@@ -41,7 +41,6 @@ import {
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import delay from "@foxglove/studio-base/util/delay";
 import { SECOND_SOURCE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 // reusable providers
 function provider1(initiallyLoaded = false) {
@@ -359,7 +358,6 @@ describe("CombinedDataProvider", () => {
         { parsedMessages: ["/some_topic"] },
       );
       expect(messagesResult).toEqual({ parsedMessages: [message] });
-      sendNotification.expectCalledDuringTest();
     });
   });
 

--- a/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
@@ -34,7 +34,6 @@ import {
 } from "@foxglove/studio-base/randomAccessDataProviders/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { deepIntersect } from "@foxglove/studio-base/util/ranges";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 import rawMessageDefinitionsToParsed from "./rawMessageDefinitionsToParsed";
 
@@ -267,9 +266,12 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
         const { start, end, topics } = outcome.value;
         return { start, end, topicSet: new Set(topics.map((t) => t.name)) };
       }
-      sendNotification("Data unavailable", outcome.reason, "user", "warn");
+      // fixme - make problems?
+      //sendNotification("Data unavailable", outcome.reason, "user", "warn");
       return undefined;
     });
+
+    // fixme - make problems
     if (initializeOutcomes.every(({ status }) => status === "rejected")) {
       return await new Promise(() => {
         // no-op

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.test.ts
@@ -20,7 +20,6 @@ import { CoreDataProviders } from "@foxglove/studio-base/randomAccessDataProvide
 import { mockExtensionPoint } from "@foxglove/studio-base/randomAccessDataProviders/mockExtensionPoint";
 import delay from "@foxglove/studio-base/util/delay";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 import MemoryCacheDataProvider, {
   getBlocksToKeep,
@@ -362,7 +361,6 @@ describe("MemoryCacheDataProvider", () => {
       { parsedMessages: ["/foo"] },
     );
     await delay(10);
-    sendNotification.expectCalledDuringTest();
   });
 
   // TODO(JP): We test getBlocksToKeep separately, but never as part of MemoryCacheDataProvider.

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -91,10 +91,7 @@ export type MessageDefinitions =
 export interface RandomAccessDataProvider {
   // Do any up-front initializing of the provider, and takes an optional extension point for
   // callbacks that only some implementations care about. May only be called once. If there's an
-  // error during initialization, it must be reported using `sendNotification` (even in Web Workers).
-  // If the error is unrecoverable, just never resolve the promise.
-  // TODO(JP): It would be better to reject the promise explicitly in case of unrecoverable errors,
-  // so we can update the UI appropriately.
+  // error during initialization, it is reported on the problem field of InitializationResult
   initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult>;
   // Get messages for a time range inclusive of start and end matching any of the provided topics.
   // May only be called after `initialize` has finished. Returned messages must be ordered by


### PR DESCRIPTION

**User-Facing Changes**
Users will see errors surfaced from these data providers via the appropriate player. These errors will clear when the player changes.

**Description**
Rather than using sendNotification, we add problems to initializationResult
and throw where appropriate within individual methods.

Rather than assuming a global notification flow, these non-ui classes expose
their error and allow the callers to handle it for display. This also allows
the callers to clear the error if it is no longer relevant.

I'm also hoping this cuts down on sentry errors related to out-of-bounds bag reads or other possibly corrupt data reading. If users encounter such errors its better for them to see them and surface them to us since they will be able to provide the bag file or data source to help reproduce if it is a bug.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
