### PR TITLE
studio-base package is public

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -3,7 +3,6 @@
   "version": "0.13.2-dev",
   "description": "Core components of Foxglove Studio",
   "license": "MPL-2.0",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/foxglove/studio.git"


### PR DESCRIPTION
**User-Facing Changes**
`@foxglove/studio-base` has been published at https://www.npmjs.com/package/@foxglove/studio-base
