### PR TITLE
Workaround for React key warning on tooltips

### DIFF
--- a/packages/studio-base/src/components/Tooltip.tsx
+++ b/packages/studio-base/src/components/Tooltip.tsx
@@ -10,7 +10,7 @@ import {
   useTheme,
   ICalloutContentStyles,
 } from "@fluentui/react";
-import { useCallback, useRef, useState } from "react";
+import { Fragment, useCallback, useRef, useState } from "react";
 
 type Contents = React.ReactNode | (() => React.ReactNode);
 
@@ -170,9 +170,11 @@ export default function Tooltip(
   const child = React.Children.only(children);
   const host = React.cloneElement(child, { ref });
   return (
+    // When studio-base is packaged for npm, we saw strange issues where React would warn about
+    // missing keys on these children, so we add explicit keys.
     <>
-      {host}
-      {tooltip}
+      <Fragment key="host">{host}</Fragment>
+      <Fragment key="tooltip">{tooltip}</Fragment>
     </>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
When studio-base is packaged for npm, we saw strange issues where React would warn about missing keys on these children, so we add explicit keys.