### PR TITLE
Change: append `Dev` to product name in local development

### DIFF
--- a/desktop/webpack.config.ts
+++ b/desktop/webpack.config.ts
@@ -18,7 +18,12 @@ interface WebpackConfiguration extends Configuration {
   devServer?: WebpackDevServerConfiguration;
 }
 
-// Use a single devServer configuration across all our multi-compiler configs
+const isRelease = process.env.RELEASE != undefined;
+
+// The appdata directory is derived from the product name. To have a separate directory
+// for our production and development builds we change the product name when using dev or serve.
+const productName = isRelease ? packageJson.productName : `${packageJson.productName} Dev`;
+
 const devServerConfig: WebpackConfiguration = {
   // Use empty entry to avoid webpack default fallback to /src
   entry: {},
@@ -54,7 +59,7 @@ const devServerConfig: WebpackConfiguration = {
       templateContent: JSON.stringify({
         main: "main/main.js",
         name: packageJson.name,
-        productName: packageJson.productName,
+        productName,
         version: packageJson.version,
         description: packageJson.description,
         productDescription: packageJson.productDescription,


### PR DESCRIPTION


**User-Facing Changes**
Users of a dev build of studio will have a different appdata directory. Effectively - no change for users since we don't advertise this appdata directory.

**Description**
Electron uses the product name to derive the appdata directory. We want to
use a separate directory for local development appdata and production appdata.

This change alters the product name when using `yarn serve` or when working with
a dev build.

Fixes #1531


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
