### PR TITLE
Improve ErrorBoundary appearance

### DIFF
--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -15,17 +15,17 @@ import { storiesOf } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
-import ErrorBoundary from "./ErrorBoundary";
+import ErrorBoundary, { HideErrorSourceLocations } from "./ErrorBoundary";
 
 class Broken extends React.Component {
   override render() {
-    throw {
+    throw Object.assign(new Error("Hello!"), {
       stack: `
   an error occurred
   it's caught by this component
   now the user sees
       `,
-    };
+    });
     return ReactNull;
   }
 }
@@ -33,9 +33,11 @@ class Broken extends React.Component {
 storiesOf("components/ErrorBoundary", module).add("examples", () => {
   return (
     <DndProvider backend={HTML5Backend}>
-      <ErrorBoundary hideSourceLocations>
-        <Broken />
-      </ErrorBoundary>
+      <HideErrorSourceLocations.Provider value={true}>
+        <ErrorBoundary>
+          <Broken />
+        </ErrorBoundary>
+      </HideErrorSourceLocations.Provider>
     </DndProvider>
   );
 });

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -1,97 +1,159 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
+import { makeStyles, MessageBar, MessageBarType, Stack, Text, useTheme } from "@fluentui/react";
 import { captureException } from "@sentry/core";
-import { ErrorInfo } from "react";
-import styled from "styled-components";
+import { createContext, ErrorInfo, useContext } from "react";
 
-import Button from "@foxglove/studio-base/components/Button";
-import Flex from "@foxglove/studio-base/components/Flex";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { AppError } from "@foxglove/studio-base/util/errors";
 
-const Heading = styled.div`
-  font-size: 1.2em;
-  font-weight: bold;
-  color: coral;
-  margin-top: 0.5em;
-`;
+const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    overflow: "hidden",
+  },
+  header: {
+    fontWeight: "bold",
+    marginBottom: theme.spacing.s1,
+  },
+  content: {
+    overflow: "auto",
+    padding: theme.spacing.s1,
+    backgroundColor: theme.palette.neutralLighterAlt,
+  },
+  stack: {
+    fontSize: theme.fonts.small.fontSize,
+    marginLeft: theme.spacing.m,
+    lineHeight: "1.3em",
+  },
+  sourceLocation: {
+    color: theme.palette.neutralLight,
+  },
+}));
 
-const ErrorBanner = styled.div`
-  flex: 1 1 auto;
-  display: flex;
-  align-items: center;
-  color: white;
-  background-color: red;
-  padding: 2px 5px;
-`;
+function ErrorDisplay(props: ErrorRendererProps) {
+  const styles = useStyles();
+  return (
+    <Stack className={styles.wrapper}>
+      <MessageBar
+        messageBarType={MessageBarType.error}
+        dismissIconProps={{ iconName: "Refresh" }}
+        dismissButtonAriaLabel="Reset"
+        onDismiss={props.onDismiss}
+      >
+        {props.error.toString()}
+      </MessageBar>
+      {defaultRenderErrorDetails(props)}
+    </Stack>
+  );
+}
 
-type State = {
-  error?: Error;
-  errorInfo?: ErrorInfo;
+function sanitizeStack(stack: string) {
+  return stack
+    .replace(/\s+\(.+\)$/gm, " (some location)")
+    .replace(/\s+https?:\/\/.+$/gm, " some location");
+}
+
+function ErrorStack({ stack }: { stack: string }) {
+  const hideSourceLocations = useContext(HideErrorSourceLocations);
+  const styles = useStyles();
+  const lines = (hideSourceLocations ? sanitizeStack(stack) : stack)
+    .trim()
+    .replace(/^\s*at /gm, "")
+    .split("\n")
+    .map((line) => line.trim());
+  return (
+    <pre className={styles.stack}>
+      {lines.map((line, i) => {
+        const match = /^(.+)\s(\(.+$)/.exec(line);
+        if (!match) {
+          return line + "\n";
+        }
+        return (
+          <span key={i}>
+            <span>{match[1]} </span>
+            <span className={styles.sourceLocation}>{match[2]}</span>
+            {"\n"}
+          </span>
+        );
+      })}
+    </pre>
+  );
+}
+
+function ErrorDetailsDisplay({ error, errorInfo }: ErrorRendererProps) {
+  const styles = useStyles();
+  const theme = useTheme();
+  let stackWithoutMessage = error.stack ?? "";
+  const errorString = error.toString() ?? "";
+  if (stackWithoutMessage.startsWith(errorString)) {
+    stackWithoutMessage = stackWithoutMessage.substring(errorString.length);
+  }
+  return (
+    <Stack className={styles.content} tokens={{ childrenGap: theme.spacing.m }}>
+      <Stack.Item>
+        <Text block className={styles.header} variant="large" as="h2">
+          Error stack:
+        </Text>
+        <ErrorStack stack={stackWithoutMessage} />
+      </Stack.Item>
+      <Stack.Item>
+        <Text block className={styles.header} variant="large" as="h2">
+          Component stack:
+        </Text>
+        <ErrorStack stack={errorInfo.componentStack} />
+      </Stack.Item>
+    </Stack>
+  );
+}
+
+export type ErrorRendererProps = {
+  error: Error;
+  errorInfo: ErrorInfo;
+  onDismiss: () => void;
+  defaultRenderError: (_: ErrorRendererProps) => JSX.Element;
+  defaultRenderErrorDetails: (_: ErrorRendererProps) => JSX.Element;
 };
 
-export default class ErrorBoundary extends React.Component<
-  { children: React.ReactNode; hideSourceLocations?: boolean },
-  State
-> {
+type Props = {
+  children: React.ReactNode;
+  renderError: (_: ErrorRendererProps) => React.ReactNode;
+};
+type State = {
+  currentError: { error: Error; errorInfo: ErrorInfo } | undefined;
+};
+
+function defaultRenderError(props: ErrorRendererProps): JSX.Element {
+  return <ErrorDisplay {...props} />;
+}
+function defaultRenderErrorDetails(props: ErrorRendererProps): JSX.Element {
+  return <ErrorDetailsDisplay {...props} />;
+}
+
+export const HideErrorSourceLocations = createContext(false);
+
+export default class ErrorBoundary extends React.Component<Props, State> {
   override state: State = {
-    error: undefined,
-    errorInfo: undefined,
+    currentError: undefined,
+  };
+
+  static defaultProps = {
+    renderError: defaultRenderError,
   };
 
   override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     captureException(new AppError(error, errorInfo));
-    this.setState({ error, errorInfo });
+    this.setState({ currentError: { error, errorInfo } });
   }
 
   override render(): React.ReactNode {
-    const { error, errorInfo } = this.state;
-    if (error) {
-      let name = "this panel";
-      if (errorInfo && typeof errorInfo.componentStack === "string") {
-        const matches = errorInfo.componentStack.match(/^\s*at ([\w()]+) \(/);
-        if (matches && matches.length > 1) {
-          name = matches[1] as string;
-        }
-      }
-      return (
-        <Flex col style={{ maxHeight: "100%", maxWidth: "100%" }}>
-          <PanelToolbar>
-            <ErrorBanner>
-              <div style={{ flexGrow: 1 }}>An error occurred in {name}.</div>
-              <Button
-                style={{ background: "rgba(255, 255, 255, 0.5)" }}
-                onClick={() => this.setState({ error: undefined, errorInfo: undefined })}
-              >
-                Reload Panel
-              </Button>
-            </ErrorBanner>
-          </PanelToolbar>
-          <Flex col scroll scrollX style={{ padding: "2px 6px" }}>
-            <Heading>Error stack:</Heading>
-            <pre>{error.stack}</pre>
-            <Heading>Component stack:</Heading>
-            <pre>
-              {this.props.hideSourceLocations ?? false
-                ? errorInfo?.componentStack
-                    .replace(/\s+\(.+\)$/gm, "")
-                    .replace(/\s+https?:\/\/.+$/gm, "")
-                : errorInfo?.componentStack}
-            </pre>
-          </Flex>
-        </Flex>
-      );
+    if (this.state.currentError) {
+      return this.props.renderError({
+        ...this.state.currentError,
+        onDismiss: () => this.setState({ currentError: undefined }),
+        defaultRenderError,
+        defaultRenderErrorDetails,
+      });
     }
     return this.props.children;
   }

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { MessageBar, MessageBarType, Stack, useTheme } from "@fluentui/react";
 import BorderAllIcon from "@mdi/svg/svg/border-all.svg";
 import CloseIcon from "@mdi/svg/svg/close.svg";
 import ExpandAllOutlineIcon from "@mdi/svg/svg/expand-all-outline.svg";
@@ -45,12 +46,13 @@ import styled from "styled-components";
 
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import Button from "@foxglove/studio-base/components/Button";
-import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
+import ErrorBoundary, { ErrorRendererProps } from "@foxglove/studio-base/components/ErrorBoundary";
 import Flex from "@foxglove/studio-base/components/Flex";
 import Icon from "@foxglove/studio-base/components/Icon";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
+import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   useCurrentLayoutActions,
   useSelectedPanels,
@@ -101,6 +103,25 @@ type ComponentConstructorType<P> = { displayName?: string } & (
   | { new (props: P): React.Component<unknown, unknown> }
   | { (props: P): React.ReactElement<unknown> | ReactNull }
 );
+
+function ErrorToolbar(errorProps: ErrorRendererProps): JSX.Element {
+  const theme = useTheme();
+  return (
+    <Stack style={{ overflow: "hidden" }}>
+      <PanelToolbar backgroundColor={theme.semanticColors.errorBackground}>
+        <MessageBar
+          messageBarType={MessageBarType.error}
+          dismissIconProps={{ iconName: "Refresh" }}
+          dismissButtonAriaLabel="Reset"
+          onDismiss={errorProps.onDismiss}
+        >
+          {errorProps.error.toString()}
+        </MessageBar>
+      </PanelToolbar>
+      {errorProps.defaultRenderErrorDetails(errorProps)}
+    </Stack>
+  );
+}
 
 // HOC that wraps panel in an error boundary and flex box.
 // Gives panel a `config` and `saveConfig`.
@@ -554,7 +575,7 @@ export default function Panel<Config extends PanelConfig>(
                 <CloseIcon /> <span>Exit fullscreen</span>
               </button>
             )}
-            <ErrorBoundary>
+            <ErrorBoundary renderError={(errorProps) => <ErrorToolbar {...errorProps} />}>
               {PanelComponent.supportsStrictMode ?? true ? (
                 <React.StrictMode>{child}</React.StrictMode>
               ) : (

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -13,8 +13,11 @@
 
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
+import { createGlobalStyle } from "styled-components";
 
+import { HideErrorSourceLocations } from "@foxglove/studio-base/components/ErrorBoundary";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
+import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelCatalog, PanelInfo } from "@foxglove/studio-base/context/PanelCatalogContext";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PanelConfigSchemaEntry } from "@foxglove/studio-base/types/panels";
@@ -23,6 +26,22 @@ import PanelLayout from "./PanelLayout";
 
 const allPanels: PanelInfo[] = [
   { title: "Some Panel", type: "Sample1", module: async () => await new Promise(() => {}) },
+  {
+    title: "Broken Panel",
+    type: "Sample2",
+    module: async () => {
+      return {
+        default: Panel(
+          Object.assign(
+            function BrokenPanel() {
+              throw new Error("I don't work!");
+            },
+            { panelType: "Sample2", defaultConfig: {} },
+          ),
+        ),
+      };
+    },
+  },
 ];
 
 class MockPanelCatalog implements PanelCatalog {
@@ -62,6 +81,29 @@ export const PanelNotFound = (): JSX.Element => {
       >
         <PanelLayout />
       </PanelSetup>
+    </DndProvider>
+  );
+};
+
+const PanelToolbarShown = createGlobalStyle`
+  .panelToolbarHovered {
+    display: flex !important;
+  }
+`;
+
+export const PanelWithError = (): JSX.Element => {
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <HideErrorSourceLocations.Provider value={true}>
+        <PanelToolbarShown />
+        <PanelSetup
+          panelCatalog={new MockPanelCatalog()}
+          fixture={{ topics: [], datatypes: {}, frame: {}, layout: "Sample2!4co6n9d" }}
+          omitDragAndDrop
+        >
+          <PanelLayout />
+        </PanelSetup>
+      </HideErrorSourceLocations.Provider>
     </DndProvider>
   );
 };

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -50,6 +50,7 @@ type Props = {
   additionalIcons?: React.ReactNode;
   hideToolbars?: boolean;
   isUnknownPanel?: boolean;
+  backgroundColor?: string;
 };
 
 // separated into a sub-component so it can always skip re-rendering
@@ -247,6 +248,7 @@ export default React.memo<Props>(function PanelToolbar({
   helpContent,
   hideToolbars = false,
   isUnknownPanel = false,
+  backgroundColor,
 }: Props) {
   const { supportsStrictMode = true } = useContext(PanelContext) ?? {};
   const [containsOpen, setContainsOpen] = useState(false);
@@ -298,7 +300,7 @@ export default React.memo<Props>(function PanelToolbar({
             [styles.floating!]: floating,
             [styles.hasChildren!]: Boolean(children),
           })}
-          style={showToolbar ? { display: "flex" } : {}}
+          style={showToolbar ? { display: "flex", backgroundColor } : { backgroundColor }}
         >
           {children}
           <PanelToolbarControls

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -68,6 +68,7 @@ const icons: {
   RectangularClipping: <Icons.RectangularClippingIcon />,
   Loop: <LoopIcon strokeWidth={1.375} />,
   LoopFilled: <LoopIcon strokeWidth={1.875} />,
+  Refresh: <Icons.RefreshIcon />,
   Rename: <Icons.RenameIcon />,
   Settings: <Icons.SettingsIcon />,
   Share: <Icons.ShareIcon />,

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -52,6 +52,7 @@ declare global {
     | "Previous"
     | "PreviousFilled"
     | "RectangularClipping"
+    | "Refresh"
     | "Rename"
     | "Settings"
     | "Share"


### PR DESCRIPTION
User-facing changes: not worth mentioning

Bring some FluentUI love to ErrorBoundary. Also integrate better with PanelToolbar for panel errors.

Still could use some spacing/alignment cleanup but I think this can wait until the global.scss changes settle down.