### PR TITLE
Restore Roboto Mono font (backport to v0.13.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, release/*]
   pull_request:
-    branches: [main]
 
 jobs:
   test:

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -31,6 +31,7 @@ export type InitOpts = {
   data: ChartData;
   options: ChartOptions;
   devicePixelRatio: number;
+  fontLoaded: Promise<FontFace>;
 };
 
 // allows us to override the chart.ctx instance field which zoom plugin uses for adding event listeners
@@ -74,8 +75,17 @@ export default class ChartJSManager {
     void this.init(initOpts);
   }
 
-  async init({ id, node, type, data, options, devicePixelRatio }: InitOpts): Promise<void> {
-    log.debug(`ChartJSManager(${id}) init`);
+  async init({
+    id,
+    node,
+    type,
+    data,
+    options,
+    devicePixelRatio,
+    fontLoaded,
+  }: InitOpts): Promise<void> {
+    const font = await fontLoaded;
+    log.debug(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
 
     const fakeNode = {
       addEventListener: addEventListener(this._fakeNodeEvents),

--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -30,6 +30,7 @@ import {
 } from "chart.js";
 import AnnotationPlugin from "chartjs-plugin-annotation";
 
+import RobotoMono from "@foxglove/studio-base/styles/assets/latin-roboto-mono.woff2";
 import Rpc from "@foxglove/studio-base/util/Rpc";
 import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
 
@@ -48,6 +49,21 @@ type RpcUpdateDataEvent = {
   id: string;
   data: ChartData;
 };
+
+// Explicitly load the "Roboto Mono" font, since custom fonts from the main renderer are not
+// inherited by web workers. This is required to draw "Roboto Mono" on an OffscreenCanvas, and it
+// also appears to fix a crash a large portion of Windows users were seeing where the rendering
+// thread would crash in skia code related to DirectWrite font loading when the system display
+// scaling is set >100%.
+async function loadDefaultFont(): Promise<FontFace> {
+  const fontFace = new FontFace("Roboto Mono", `url(${RobotoMono}) format('woff2')`);
+  (self as unknown as WorkerGlobalScope).fonts.add(fontFace);
+  return await fontFace.load();
+}
+
+// Immediately start font loading in the Worker thread. Each ChartJSManager we instantiate will
+// wait on this promise before instantiating a new Chart instance, which kicks off rendering
+const fontLoaded = loadDefaultFont();
 
 // Register the features we support globally on our chartjs instance
 // Note: Annotation plugin must be registered, it does not work _inline_ (i.e. per instance)
@@ -83,6 +99,7 @@ export default class ChartJsMux {
     // create a new chartjs instance
     // this must be done before sending any other rpc requests to the instance
     rpc.receive("initialize", (args: InitOpts) => {
+      args.fontLoaded = fontLoaded;
       const manager = new ChartJSManager(args);
       this._managers.set(args.id, manager);
       return manager.getScales();

--- a/packages/studio-base/src/components/PlaybackControls/index.module.scss
+++ b/packages/studio-base/src/components/PlaybackControls/index.module.scss
@@ -115,7 +115,7 @@
   background-color: transparent;
   margin: 0px 4px;
   padding: 8px 4px;
-  @include ff-sans-serif;
+  @include ff-monospace;
   color: $light;
   opacity: 1;
 

--- a/packages/studio-base/src/styles/assets/latin-roboto-mono-bold-italic.woff2
+++ b/packages/studio-base/src/styles/assets/latin-roboto-mono-bold-italic.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:208cd5c0f1d791a16c74b58f96d65121f50f284a1f6542de292e5daeb98840ab
+size 13568

--- a/packages/studio-base/src/styles/assets/latin-roboto-mono-bold.woff2
+++ b/packages/studio-base/src/styles/assets/latin-roboto-mono-bold.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44a992792c34e226d5ecff616df4edcafaa833ba9b4e1fa9f0726a49778fa0f6
+size 12288

--- a/packages/studio-base/src/styles/assets/latin-roboto-mono-italic.woff2
+++ b/packages/studio-base/src/styles/assets/latin-roboto-mono-italic.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68b1c71dd7f4a26ee9e3184b593d688aa47750912b5e2ecb7379da7485b8800d
+size 13496

--- a/packages/studio-base/src/styles/assets/latin-roboto-mono.scss
+++ b/packages/studio-base/src/styles/assets/latin-roboto-mono.scss
@@ -1,0 +1,39 @@
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: italic;
+  font-weight: 400;
+  src: url("./assets/latin-roboto-mono-italic.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: italic;
+  font-weight: 700;
+  src: url("./assets/latin-roboto-mono-bold-italic.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: normal;
+  font-weight: 400;
+  src: url("./assets/latin-roboto-mono.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
+  font-style: normal;
+  font-weight: 700;
+  src: url("./assets/latin-roboto-mono-bold.woff2") format("woff2");
+  /* latin */
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F,
+    U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/packages/studio-base/src/styles/assets/latin-roboto-mono.woff2
+++ b/packages/studio-base/src/styles/assets/latin-roboto-mono.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1fd013ac18aebac28e366bf82aace3b2fb6900fecc4793303ed93aeadd31910
+size 12312

--- a/packages/studio-base/src/styles/fonts.module.scss
+++ b/packages/studio-base/src/styles/fonts.module.scss
@@ -24,18 +24,9 @@
   // Use fixed width numbers (important for numbers that update during playback)
   font-feature-settings: "tnum";
 }
+
+// We currently avoid monospace system fonts due to DWriteFont::Create electron crash
+// when rendering offscreen canvas (see comments in ChartJsMux.ts and https://github.com/foxglove/studio/pull/933).
 @mixin ff-monospace {
-  font-family:
-    // Apple
-    ui-monospace,
-    // Windows
-    "Cascadia Mono",
-    "Segoe UI Mono",
-    // Ubuntu
-    "Ubuntu Mono",
-    // Chrome OS and Android
-    "Roboto Mono",
-    // Fallback
-    "Menlo",
-    "Monaco", "Consolas", monospace;
+  font-family: "Roboto Mono";
 }

--- a/packages/studio-base/src/styles/fonts.ts
+++ b/packages/studio-base/src/styles/fonts.ts
@@ -5,4 +5,4 @@
 // Keep in sync with fonts.module.scss
 // We tried importing scss vars directly in JS, but style-loader doesn't support web workers
 export const SANS_SERIF = `-apple-system, BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Roboto", sans-serif`;
-export const MONOSPACE = `ui-monospace, "Cascadia Mono", "Segoe UI Mono", "Ubuntu Mono", "Roboto Mono", "Menlo", "Monaco", "Consolas", monospace`;
+export const MONOSPACE = `"Roboto Mono"`;

--- a/packages/studio-base/src/styles/global.scss
+++ b/packages/studio-base/src/styles/global.scss
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 @import "./reset.scss";
+@import "./assets/latin-roboto-mono.scss";
 @import "./mixins.module.scss";
 
 /* globally apply flex to containers outside our component hierarchy */


### PR DESCRIPTION

**User-Facing Changes**
Monospace font is Roboto Mono (instead of system monospace font) again.

**Description**
This reverts commit 3a949183ec0ae29e5be7823e391a32ef13d1352f.

We have seen a resurgence of `DWriteFont::Create` errors (e.g. https://github.com/foxglove/studio/issues/1552).

Typical stack trace:

```
OS Version: Windows 10.0.19043 (1023)
Report Version: 104

Crashed Thread: 2316

Application Specific Information:
Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ

Thread 2316 Crashed:
0   DWrite.dll                      0x7ffb8bf8c45b      DWriteFont::Create
1   DWrite.dll                      0x7ffb8bf8dd4c      DWriteFont::Create
2   DWrite.dll                      0x7ffb8bf710a5      DWriteFontFamily::GetFirstMatchingFont
3   Foxglove Studio.exe             0x7ff6767fccd0      SkFontStyleSet_DirectWrite::matchStyle (SkFontMgr_win_dw.cpp:1237)
4   Foxglove Studio.exe             0x7ff6767fcc5c      SkFontMgr_DirectWrite::onMatchFamilyStyle (SkFontMgr_win_dw.cpp:526)
5   Foxglove Studio.exe             0x7ff67754a985      blink::FontCache::CreateTypeface (font_cache_skia.cc:238)
6   Foxglove Studio.exe             0x7ff676efb77c      blink::FontCache::CreateFontPlatformData (font_cache_skia_win.cc:602)
7   Foxglove Studio.exe             0x7ff676ef5af8      blink::FontCache::GetFontPlatformData (font_cache.cc:204)
8   Foxglove Studio.exe             0x7ff677374176      blink::FontFallbackList::CompositeKey (font_fallback_list.cc:215)
9   Foxglove Studio.exe             0x7ff676ef075c      blink::FontFallbackList::GetShapeCache (font_fallback_list.h:80)
10  Foxglove Studio.exe             0x7ff67abac548      [inlined] blink::CachingWordShaper::GetShapeCache (caching_word_shaper.cc:40)
11  Foxglove Studio.exe             0x7ff67abac548      blink::CachingWordShaper::IndividualCharacterAdvances (caching_word_shaper.cc:142)
```

Closes #1552