### PR TITLE
Add alpha field to ColorPicker

### DIFF
--- a/packages/studio-base/src/components/ColorPicker/index.tsx
+++ b/packages/studio-base/src/components/ColorPicker/index.tsx
@@ -80,7 +80,7 @@ export default function ColorPicker({
         >
           <Picker
             color={colorObjToIColor(color)}
-            alphaType="none"
+            alphaType="alpha"
             onChange={(_event, newValue) => onChange(getColorFromIRGB(newValue))}
           />
         </Callout>


### PR DESCRIPTION
**User-Facing Changes**
Adds back alpha field when selecting a color inside the 3D panel's topic settings editor.

**Description**
Updated `alpha` prop being passed into FluentUI's ColorPicker component to show an alpha field.

<!-- link relevant github issues -->
Resolves #1295 
<!-- add `docs` label if this PR requires documentation updates -->
