### PR TITLE
Hide the 3D panel's polygon drawing behind a feature flag

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -12,4 +12,5 @@ export enum AppSetting {
   SHOW_DEBUG_PANELS = "showDebugPanels",
   FAKE_REMOTE_LAYOUTS = "debug.useFakeRemoteLayouts",
   ENABLE_CONSOLE_API_LAYOUTS = "enableConsoleApiLayouts",
+  ENABLE_DRAWING_POLYGONS = "enableDrawingPolygons",
 }

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -33,6 +33,11 @@ const features: Feature[] = [
     name: "Studio Debug Panels",
     description: <>Show Studio debug panels in the add panel list.</>,
   },
+  {
+    key: AppSetting.ENABLE_DRAWING_POLYGONS,
+    name: "Drawing polygons in 3D panel",
+    description: <>Show sidebar control to draw polygons in the 3D panel.</>,
+  },
   ...(process.env.NODE_ENV !== "production"
     ? [
         {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.stories.tsx
@@ -58,6 +58,7 @@ const DEFAULT_PROPS = {
   updatePanelConfig: () => {
     // no-op
   },
+  showForTests: true,
 };
 
 storiesOf("panels/ThreeDimensionalViz/DrawingTools", module).add("Polygon", () => {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
@@ -13,6 +13,7 @@
 import PencilIcon from "@mdi/svg/svg/pencil.svg";
 import { PolygonBuilder, Polygon } from "regl-worldview";
 
+import { useAppConfigurationValue, AppSetting } from "@foxglove/studio-base";
 import ExpandingToolbar, { ToolGroup } from "@foxglove/studio-base/components/ExpandingToolbar";
 import Icon from "@foxglove/studio-base/components/Icon";
 import styles from "@foxglove/studio-base/panels/ThreeDimensionalViz/Layout.module.scss";
@@ -41,7 +42,11 @@ function DrawingTools({
     defaultSelectedTab,
   );
 
-  return (
+  const [enableDrawingPolygons = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_DRAWING_POLYGONS,
+  );
+
+  return enableDrawingPolygons ? (
     <ExpandingToolbar
       tooltip="Drawing tools"
       icon={
@@ -60,6 +65,8 @@ function DrawingTools({
         <Polygons onSetPolygons={onSetPolygons} polygonBuilder={polygonBuilder} />
       </ToolGroup>
     </ExpandingToolbar>
+  ) : (
+    ReactNull
   );
 }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
@@ -29,6 +29,7 @@ type Props = {
   polygonBuilder: PolygonBuilder;
   onSetDrawingTabType: (arg0?: DrawingTabType) => void;
   defaultSelectedTab?: DrawingTabType; // for UI testing
+  showForTests?: boolean;
 };
 
 // add more drawing shapes later, e.g. Grid, Axes, Crosshairs
@@ -37,6 +38,7 @@ function DrawingTools({
   onSetDrawingTabType,
   onSetPolygons,
   polygonBuilder,
+  showForTests,
 }: Props) {
   const [selectedTab, setSelectedTab] = React.useState<DrawingTabType | undefined>(
     defaultSelectedTab,
@@ -46,7 +48,7 @@ function DrawingTools({
     AppSetting.ENABLE_DRAWING_POLYGONS,
   );
 
-  return enableDrawingPolygons ? (
+  return enableDrawingPolygons || showForTests === true ? (
     <ExpandingToolbar
       tooltip="Drawing tools"
       icon={

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.help.md
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.help.md
@@ -1,24 +1,24 @@
 # 3D
 
-Plots visualization messages in a 3D scene.  You can select topics using the left-hand topic list; you can toggle the ability to follow orientation and manually select the frame you follow in the right-hand controls.  Selected topics will have their messages visualized within the 3D scene.  Topic selection is part of the configuration and will be saved between reloads and can be shared with `Import / Export Layout`.  This panel can be expanded / collapsed by clicking on the caret icon to the left of it.
+Plots visualization messages in a 3D scene. You can select topics using the left-hand topic list; you can toggle the ability to follow orientation and manually select the frame you follow in the right-hand controls. Selected topics will have their messages visualized within the 3D scene. Topic selection is part of the configuration and will be saved between reloads and can be shared with `Import / Export Layout`. This panel can be expanded / collapsed by clicking on the caret icon to the left of it.
 
-By default the scene will follow the center of a frame.  When you move the camera, the camera will be offset from the center of that frame, but stay relative to that center.
+By default the scene will follow the center of a frame. When you move the camera, the camera will be offset from the center of that frame, but stay relative to that center.
 
 You can toggle between a 3D perspective camera and a top-down, 2D orthographic camera of the scene by clicking on the _toggle 2D / 3D_ button in the top left of the 3D view panel.
 
-`Left-click + drag` on the scene to move the camera position parallel to the ground.  If 'follow' mode is on this will disengage it.
+`Left-click + drag` on the scene to move the camera position parallel to the ground. If 'follow' mode is on this will disengage it.
 
-`Right-click + drag` on the scene to pan and rotate the camera.  Dragging left/right will rotate the camera around the Z axis, and in 3D camera mode dragging top/bottom will pan the camera around the world's x/y axis.
+`Right-click + drag` on the scene to pan and rotate the camera. Dragging left/right will rotate the camera around the Z axis, and in 3D camera mode dragging top/bottom will pan the camera around the world's x/y axis.
 
-`Mouse-wheel` controls the 'zoom' of the camera.  Wheeling "up" will zoom the camera closer in while wheeling "down" will zoom the camera farther away.
+`Mouse-wheel` controls the 'zoom' of the camera. Wheeling "up" will zoom the camera closer in while wheeling "down" will zoom the camera farther away.
 
-Holding down `shift` in while performing any interaction with the camera will adjust values by 1/10th of their normal adjustments.  This allows precision movements and adjustments to the camera.
+Holding down `shift` in while performing any interaction with the camera will adjust values by 1/10th of their normal adjustments. This allows precision movements and adjustments to the camera.
 
 _tip: If you get 'lost' in the scene and end up looking into infinite blank space and can't find your way back try clicking on 'follow' to snap the camera back to the default position._
 
 ## Keyboard shortcuts
 
-In 3D camera mode, you can also use "shooter controls" (like those found in most popular desktop first-person shooter games) of `w` `a` `s` `d` to move the camera forward / left / backwards / right respective to the camera's position, and use `z` `x` to zoom in and out.  It's easy to get lost when using these controls as there is nothing anchoring the camera to the scene.
+In 3D camera mode, you can also use "shooter controls" (like those found in most popular desktop first-person shooter games) of `w` `a` `s` `d` to move the camera forward / left / backwards / right respective to the camera's position, and use `z` `x` to zoom in and out. It's easy to get lost when using these controls as there is nothing anchoring the camera to the scene.
 
 You can use `t` to open the Topic Tree and `Esc` to close it again.
 
@@ -33,14 +33,3 @@ Clicking on a point in a point cloud offers additional information, such as the 
 It's possible to link fields from a selected marker to global variables. In the "Selected object" tab of the "Interactions" panel, hover over a key in the JSON view of the marker. A button should appear that, when clicked, opens a dialog box that allows linking the field to a global variable.
 
 When a global variable is linked, selecting another marker that contains the same key will update the global variable. For example, with the tracked object "id" field linked to the global variable "$trackedObjectId", clicking another tracked object will update the "$trackedObjectId" field. This makes it easy to use the information about selected markers in other panels.
-
-## Drawing Polygons
-
-- To start a drawing, hold `ctrl` and click on the canvas. This will place the first point of the polygon. Continue holding ctrl and click as may times as you want to create a `string` of points connected by lines. To terminate your drawing release `ctrl` and click a final time. This will place one final point at the mouse location and 'close' the polygon. The polygon will still be selected until you click "off" of the polygon to anywhere else on the canvas.
-- To select a polygon, click it once.
-- To select a point within a polygon click it once.
-- To move a polygon you have drawn you can click + drag on the polygon.
-- To resize a polygon you can click + drag on an individual point within the polygon to move it. This will resize the polygon: all the points will remain connected to one another.
-- To place a new point within an existing polygon, double click on a line within the polygon. This will bisect the line at the current double-click position, inserting a new point you may drag around to move.
-- To delete the entire polygon, press the `delete` key when the polygon is selected.
-- To delete an existing point in a polygon, double-click it, or press `delete` with a point selected.


### PR DESCRIPTION
**User-Facing Changes**
The sidebar controls for drawing polygons in the 3D panel are hidden, unless the feature is explicitly turned on in the app settings.

**Description**
Hides polygon drawing feature behind feature flag; removes documentation. Will essentially sunset this feature, barring any active use cases that come up during this process.

Resolves #723.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
