### PR TITLE
Fix: handle corrupt layouts in NativeStorageLayoutCache

### DIFF
--- a/desktop/renderer/services/NativeStorageLayoutCache.ts
+++ b/desktop/renderer/services/NativeStorageLayoutCache.ts
@@ -2,9 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Log from "@foxglove/log";
 import { CachedLayout, ILayoutCache } from "@foxglove/studio-base";
 
 import { Storage } from "../../common/types";
+
+const log = Log.getLogger(__filename);
 
 function assertLayout(value: unknown): asserts value is CachedLayout {
   if (typeof value !== "object" || value == undefined) {
@@ -35,10 +38,14 @@ export default class NativeStorageLayoutCache implements ILayoutCache {
         throw new Error("Invariant violation - layout item is not a buffer");
       }
 
-      const str = new TextDecoder().decode(item);
-      const parsed = JSON.parse(str);
-      assertLayout(parsed);
-      layouts.push(parsed);
+      try {
+        const str = new TextDecoder().decode(item);
+        const parsed = JSON.parse(str);
+        assertLayout(parsed);
+        layouts.push(parsed);
+      } catch (err) {
+        log.error(err);
+      }
     }
 
     return layouts;
@@ -56,7 +63,6 @@ export default class NativeStorageLayoutCache implements ILayoutCache {
     const str = new TextDecoder().decode(item);
     const parsed = JSON.parse(str);
     assertLayout(parsed);
-
     return parsed;
   }
 


### PR DESCRIPTION

**User-Facing Changes**
Original List:
<img width="209" alt="Screen Shot 2021-07-26 at 6 16 01 PM" src="https://user-images.githubusercontent.com/84792/127080414-1b4147fb-c457-403e-b222-1b912c179614.png">

Corrupt Sample Layout
<img width="850" alt="Screen Shot 2021-07-26 at 6 16 25 PM" src="https://user-images.githubusercontent.com/84792/127080256-e0610695-9007-4015-8145-cd395400dbec.png">

User can still switch to a different layout or add panels back to this one.

**Description**
In some cases the layout file on disk might become corrupt. Prior
to this change this would prevent the app from opening any other layouts. This change handles a corrupt layout and allows the list call
to return the valid layout entries.

Fixes: #1054

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
