### PR TITLE
Fix: drag and drop panels from panel list into empty layout

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -118,6 +118,9 @@ function DraggablePanelItem({
       // dropping outside mosaic does nothing. If we have a tabId, but no
       // position or path, we're dragging into an empty tab.
       if ((position == undefined || path == undefined) && tabId == undefined) {
+        // when dragging a panel into an empty layout treat it link clicking the panel
+        // mosaic doesn't give us a position or path to invoke onDrop
+        onClick();
         return;
       }
       const { type, config, relatedConfigs } = panel;


### PR DESCRIPTION


**User-Facing Changes**
User is able to drag-drop a panel from the panel list into an empty layout.

**Description**
Draw and drop into an empty layout would not do anything. This change
alters the behavior to mimic that of a click selection of the panel
list item which adds it to the layout.

Fixes: #1035

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
