### PR TITLE
Fix: TextField warning for uncontrolled input

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -200,7 +200,7 @@ const PlaybackTimeDisplayMethod = ({
           />
         </form>
       ) : (
-        <TextField disabled size={13} styles={textFieldStyles} value="–" />
+        <TextField disabled size={13} styles={textFieldStyles} defaultValue="–" />
       )}
       <DefaultButton
         menuProps={{


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Annoying warning in devtools about TextField value specified without onChange is gone.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
