### PR TITLE
Fix: duplicate Welcome Layouts on first launch

### DIFF
--- a/packages/studio-base/src/PanelAPI/useConfig.ts
+++ b/packages/studio-base/src/PanelAPI/useConfig.ts
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
+  LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
@@ -23,6 +24,10 @@ export function useConfig<Config extends Record<string, unknown>>(): [
   return useConfigById(panelId);
 }
 
+function configByIdSelector(state: LayoutState) {
+  return state.selectedLayout?.data.configById;
+}
+
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels
  * directly, but is for use in internal code that's running outside of regular context providers.
@@ -32,13 +37,14 @@ export function useConfigById<Config extends Record<string, unknown>>(
 ): [Config | undefined, SaveConfig<Config>] {
   const { savePanelConfigs } = useCurrentLayoutActions();
 
-  // get the config from the current layout state
-  // if there is no config in the current layout state...then we would return undefined?
-  const config = useCurrentLayoutSelector((state) =>
-    panelId != undefined
-      ? (state.selectedLayout?.data.configById[panelId] as Config | undefined)
-      : undefined,
-  );
+  const configById = useCurrentLayoutSelector(configByIdSelector);
+
+  const config = useMemo(() => {
+    if (panelId == undefined) {
+      return undefined;
+    }
+    return configById?.[panelId] as Config | undefined;
+  }, [panelId, configById]);
 
   const saveConfig: SaveConfig<Config> = useCallback(
     (newConfig) => {

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -202,6 +202,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const { setSelectedLayout } = useCurrentLayoutActions();
 
   const openWelcomeLayout = useCallback(async () => {
+    log.info("loading welcome layout");
     const newLayout = await layoutStorage.saveNewLayout({
       name: welcomeLayout.name,
       data: welcomeLayout.data,

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -22,7 +22,6 @@ import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/
 import { useLayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
 import LayoutStorageDebuggingContext from "@foxglove/studio-base/context/LayoutStorageDebuggingContext";
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
-import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutMetadata } from "@foxglove/studio-base/services/ILayoutStorage";
@@ -138,15 +137,11 @@ export default function LayoutBrowser({
           return;
         }
       }
-      // If no existing layout could be selected, use the welcome layout
-      const newLayout = await layoutStorage.saveNewLayout({
-        name: welcomeLayout.name,
-        data: welcomeLayout.data,
-        permission: "creator_write",
-      });
-      await onSelectLayout(newLayout);
+
+      // no layouts left to select, show empty layout
+      setSelectedLayout(undefined);
     },
-    [currentLayoutId, layoutStorage, setSelectedLayout, onSelectLayout],
+    [currentLayoutId, layoutStorage, setSelectedLayout],
   );
 
   const analytics = useAnalytics();


### PR DESCRIPTION
**User-Facing Changes**
On first launch users end up with one welcome layout in the layout browser rather than two.

**Description**
TBD

Fixes: #1545

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
