### PR TITLE
Internal: Provide a default NullAnalytics context

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -24,7 +24,7 @@ import LayoutStorageDebuggingContext from "@foxglove/studio-base/context/LayoutS
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
-import AppEvent from "@foxglove/studio-base/services/AppEvent";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutMetadata } from "@foxglove/studio-base/services/ILayoutStorage";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 
@@ -169,7 +169,7 @@ export default function LayoutBrowser({
     });
     void onSelectLayout(newLayout);
 
-    analytics.logEvent(AppEvent.LAYOUT_CREATE);
+    void analytics.logEvent(AppEvent.LAYOUT_CREATE);
   }, [currentDateForStorybook, layoutStorage, analytics, onSelectLayout]);
 
   const onExportLayout = useCallback(
@@ -178,7 +178,7 @@ export default function LayoutBrowser({
       if (layout) {
         const content = JSON.stringify(layout.data, undefined, 2);
         downloadTextFile(content, `${item.name}.json`);
-        analytics.logEvent(AppEvent.LAYOUT_EXPORT);
+        void analytics.logEvent(AppEvent.LAYOUT_EXPORT);
       }
     },
     [layoutStorage, analytics],
@@ -251,7 +251,7 @@ export default function LayoutBrowser({
     });
     void onSelectLayout(newLayout);
 
-    analytics.logEvent(AppEvent.LAYOUT_IMPORT);
+    void analytics.logEvent(AppEvent.LAYOUT_IMPORT);
   }, [addToast, isMounted, layoutStorage, analytics, onSelectLayout]);
 
   const createLayoutTooltip = useTooltip({ contents: "Create new layout" });

--- a/packages/studio-base/src/context/AnalyticsContext.ts
+++ b/packages/studio-base/src/context/AnalyticsContext.ts
@@ -4,16 +4,13 @@
 
 import { createContext, useContext } from "react";
 
-import { Analytics } from "@foxglove/studio-base/services/Analytics";
+import IAnalytics from "@foxglove/studio-base/services/IAnalytics";
+import NullAnalytics from "@foxglove/studio-base/services/NullAnalytics";
 
-const AnalyticsContext = createContext<Analytics | undefined>(undefined);
+const AnalyticsContext = createContext<IAnalytics>(new NullAnalytics());
 
-export function useAnalytics(): Analytics {
-  const analytics = useContext(AnalyticsContext);
-  if (analytics == undefined) {
-    throw new Error("An AnalyticsContext provider is required to useAnalytics");
-  }
-  return analytics;
+export function useAnalytics(): IAnalytics {
+  return useContext(AnalyticsContext);
 }
 
 export default AnalyticsContext;

--- a/packages/studio-base/src/context/AnalyticsProvider.tsx
+++ b/packages/studio-base/src/context/AnalyticsProvider.tsx
@@ -7,7 +7,7 @@ import { PropsWithChildren, useMemo } from "react";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AnalyticsContext from "@foxglove/studio-base/context/AnalyticsContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
-import { Analytics } from "@foxglove/studio-base/services/Analytics";
+import { AmplitudeAnalytics } from "@foxglove/studio-base/services/AmplitudeAnalytics";
 
 export default function AnalyticsProvider(
   props: PropsWithChildren<{ amplitudeApiKey?: string }>,
@@ -18,7 +18,7 @@ export default function AnalyticsProvider(
   );
 
   const analytics = useMemo(() => {
-    return new Analytics({
+    return new AmplitudeAnalytics({
       optOut: !enableTelemetry,
       crashReportingOptOut: !(enableCrashReporting && typeof process.env.SENTRY_DSN === "string"),
       amplitudeApiKey: props.amplitudeApiKey ?? process.env.AMPLITUDE_API_KEY,

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -9,8 +9,7 @@ import {
   PlayerMetricsCollectorInterface,
   SubscribePayload,
 } from "@foxglove/studio-base/players/types";
-import { Analytics } from "@foxglove/studio-base/services/Analytics";
-import AppEvent from "@foxglove/studio-base/services/AppEvent";
+import IAnalytics, { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 
 const log = Log.getLogger(__filename);
 
@@ -19,9 +18,9 @@ type EventData = { [key: string]: string | number | boolean };
 export default class AnalyticsMetricsCollector implements PlayerMetricsCollectorInterface {
   metadata: EventData = {};
   playerType?: PlayerSourceDefinition;
-  private _analytics: Analytics;
+  private _analytics: IAnalytics;
 
-  constructor(analytics: Analytics) {
+  constructor(analytics: IAnalytics) {
     log.debug("New AnalyticsMetricsCollector");
     this._analytics = analytics;
   }
@@ -31,7 +30,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
   }
 
   logEvent(event: AppEvent, data?: EventData): void {
-    this._analytics.logEvent(event, { ...this.metadata, ...data });
+    void this._analytics.logEvent(event, { ...this.metadata, ...data });
   }
 
   playerConstructed(): void {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/CurrentLayoutState.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/CurrentLayoutState.ts
@@ -30,7 +30,7 @@ import {
 import panelsReducer, {
   defaultPlaybackConfig,
 } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
-import AppEvent from "@foxglove/studio-base/services/AppEvent";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import UndoRedo from "@foxglove/studio-base/util/UndoRedo";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import Logger from "@foxglove/log";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
-import AppEvent from "@foxglove/studio-base/services/AppEvent";
+import IAnalytics, { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import Storage from "@foxglove/studio-base/util/Storage";
 
 const UUID_ZERO = "00000000-0000-0000-0000-000000000000";
@@ -17,7 +17,7 @@ const USER_ID_KEY = "analytics_user_id";
 
 const log = Logger.getLogger(__filename);
 
-export class Analytics {
+export class AmplitudeAnalytics implements IAnalytics {
   private _amplitude: Promise<amplitude.AmplitudeClient | undefined>;
   private _crashReporting: boolean;
   private _storage = new Storage();
@@ -50,7 +50,7 @@ export class Analytics {
       log.info("Crash reporting is disabled");
     }
 
-    this.logEvent(AppEvent.APP_INIT);
+    void this.logEvent(AppEvent.APP_INIT);
   }
 
   private async createAmplitude(apiKey: string): Promise<amplitude.AmplitudeClient> {
@@ -88,7 +88,6 @@ export class Analytics {
     return (await OsContextSingleton?.getMachineId()) ?? UUID_ZERO;
   }
 
-  logEvent(event: AppEvent, data?: { [key: string]: unknown }): void;
   async logEvent(event: AppEvent, data?: { [key: string]: unknown }): Promise<void> {
     const amp = await this._amplitude;
     if (amp != undefined) {

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -22,4 +22,9 @@ enum AppEvent {
   LAYOUT_REMOVE_PANEL = "LAYOUT_REMOVE_PANEL",
 }
 
-export default AppEvent;
+interface IAnalytics {
+  logEvent(event: AppEvent, data?: { [key: string]: unknown }): void | Promise<void>;
+}
+
+export { AppEvent };
+export default IAnalytics;

--- a/packages/studio-base/src/services/NullAnalytics.ts
+++ b/packages/studio-base/src/services/NullAnalytics.ts
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import IAnalytics from "@foxglove/studio-base/services/IAnalytics";
+
+export default class NullAnalytics implements IAnalytics {
+  logEvent(): void | Promise<void> {}
+}


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Allows for tests and stories to use components that have analytics
without having to inject analytics providers. Lowers the boilerplate
for writing the tests and stories.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
