### PR TITLE
Internal: use stable selector function for useConfigById

### DIFF
--- a/packages/studio-base/src/PanelAPI/useConfig.ts
+++ b/packages/studio-base/src/PanelAPI/useConfig.ts
@@ -5,6 +5,7 @@
 import { useCallback } from "react";
 
 import {
+  LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
@@ -32,13 +33,17 @@ export function useConfigById<Config extends Record<string, unknown>>(
 ): [Config | undefined, SaveConfig<Config>] {
   const { savePanelConfigs } = useCurrentLayoutActions();
 
-  // get the config from the current layout state
-  // if there is no config in the current layout state...then we would return undefined?
-  const config = useCurrentLayoutSelector((state) =>
-    panelId != undefined
-      ? (state.selectedLayout?.data.configById[panelId] as Config | undefined)
-      : undefined,
+  const configSelector = useCallback(
+    (state: LayoutState) => {
+      if (panelId == undefined) {
+        return undefined;
+      }
+      return state.selectedLayout?.data.configById?.[panelId] as Config | undefined;
+    },
+    [panelId],
   );
+
+  const config = useCurrentLayoutSelector(configSelector);
 
   const saveConfig: SaveConfig<Config> = useCallback(
     (newConfig) => {

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -128,13 +128,14 @@ export function useCurrentLayoutSelector<T>(selector: (layoutState: LayoutState)
         return;
       }
       const newValue = selectWithUnstableIdentityWarning(layoutState, selector);
-      if (newValue !== state.current?.value) {
-        forceUpdate();
+      if (newValue === state.current?.value) {
+        return;
       }
       state.current = {
         value: newValue,
         selector,
       };
+      forceUpdate();
     };
     // Update if necessary, i.e. if the state has changed between render and this effect
     listener(currentLayout.actions.getCurrentLayoutState());


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Avoid changing the selector function on every useConfigById invocation.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
