### PR TITLE
Show alpha option for PoseStamped settings editor only

### DIFF
--- a/packages/studio-base/src/components/ColorPicker/index.tsx
+++ b/packages/studio-base/src/components/ColorPicker/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   onChange: (newColor: Color) => void;
   buttonShape?: "circle" | "default";
   circleSize?: number;
+  alphaType?: "alpha" | "none";
 };
 
 // Returns a button that pops out an ColorPicker in a fluent callout.
@@ -27,6 +28,7 @@ export default function ColorPicker({
   circleSize = 25,
   onChange,
   buttonShape,
+  alphaType,
 }: Props): JSX.Element {
   const fluentColor = colorObjToIColor(color);
   const colorButtonRef = useRef<HTMLElement>(ReactNull);
@@ -80,7 +82,7 @@ export default function ColorPicker({
         >
           <Picker
             color={colorObjToIColor(color)}
-            alphaType="alpha"
+            alphaType={alphaType ?? "none"}
             onChange={(_event, newValue) => onChange(getColorFromIRGB(newValue))}
           />
         </Callout>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -81,6 +81,7 @@ export default function PoseSettingsEditor(
             <ColorPicker
               color={settings.overrideColor}
               onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+              alphaType="alpha"
             />
             <SLabel>Shaft width</SLabel>
             <SInput


### PR DESCRIPTION
- Follow-up to PR https://github.com/foxglove/studio/pull/1561 
- Resolves https://github.com/foxglove/studio/issues/1295

**User-Facing Changes**
Shows alpha option when selecting a color for PostStamped messages in the 3D panel's topic settings editor.

**Description**
Previously, in https://github.com/foxglove/studio/pull/1561, I added an alpha field to all color pickers in the 3D panel. However, there isn't built-in support for alpha fields in all 3D panel markers. Reverting earlier change, and only adding alpha field to the PoseSettingsEditor.

Verified storybook tests for PoseMarkers with different alpha values still works.