### PR TITLE
Fix: download image at original size

### DIFF
--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -81,6 +81,12 @@ export async function renderImage({
 
   try {
     const bitmap = await decodeMessageToBitmap(imageMessage, imageMessageDatatype, options);
+
+    if (options?.resizeCanvas === true) {
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+    }
+
     const dimensions = render(canvas, zoomMode, panZoom, bitmap, imageSmoothing, markerData);
     bitmap.close();
     return dimensions;

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -24,6 +24,10 @@ export type RenderOptions = {
   imageSmoothing?: boolean;
   minValue?: number;
   maxValue?: number;
+
+  // resize the canvas element to fit the bitmap
+  // default is false
+  resizeCanvas?: boolean;
 };
 
 export type Dimensions = { width: number; height: number };


### PR DESCRIPTION

**User-Facing Changes**
When a user clicks "download image" in the image panel - they get an image file that is the same size as their original image.

**Description**
The image panel provides a context menu option to download the shown
image. This option was exporting the entire canvas. Since we upsize
the canvas for the viewport (to provide for smooth marker rendering),
the resulting image file was not the original and contained transparent area.

This change fixes the image download by re-rendering the image onto a new canvas
that is appropriately sized for the original image. This new canvas is then
used to create the image file.


Fixes: #1487 

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
