### PR TITLE
Move account sidebar under Team Shared Layouts feature flag & make feature flag available in prod

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -48,6 +48,11 @@ const features: Feature[] = [
     name: "Legacy Plot Panel",
     description: <>Enable the legacy plot panel.</>,
   },
+  {
+    key: AppSetting.ENABLE_CONSOLE_API_LAYOUTS,
+    name: "Team shared layouts",
+    description: <>Enable team layout sharing when signed in to Studio.</>,
+  },
   ...(process.env.NODE_ENV !== "production"
     ? [
         {
@@ -59,11 +64,6 @@ const features: Feature[] = [
               functionality.
             </>
           ),
-        },
-        {
-          key: AppSetting.ENABLE_CONSOLE_API_LAYOUTS,
-          name: "Team shared layouts",
-          description: <>Enable team layout sharing when signed in to Studio.</>,
         },
       ]
     : []),

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -50,7 +50,7 @@ const features: Feature[] = [
   },
   {
     key: AppSetting.ENABLE_CONSOLE_API_LAYOUTS,
-    name: "Team shared layouts",
+    name: "Team Shared Layouts",
     description: <>Enable team layout sharing when signed in to Studio.</>,
   },
   ...(process.env.NODE_ENV !== "production"


### PR DESCRIPTION
**User-Facing Changes**
Adds a new feature flag for Team Shared Layouts.

**Description**
Related to #1528 

Previously the flag was only available in dev builds; now it is available in prod builds.