### PR TITLE
Feature: add advertise and publish to the extension api

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -17,7 +17,7 @@ import {
   PlayerState,
   Player,
   SubscribePayload,
-  AdvertisePayload,
+  AdvertiseOptions,
   PlayerPresence,
   ParameterValue,
 } from "@foxglove/studio-base/players/types";
@@ -26,7 +26,7 @@ export default class FakePlayer implements Player {
   listener?: (arg0: PlayerState) => Promise<void>;
   playerId: string = "test";
   subscriptions: SubscribePayload[] = [];
-  publishers: AdvertisePayload[] | undefined;
+  publishers: AdvertiseOptions[] | undefined;
   _capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
@@ -65,7 +65,7 @@ export default class FakePlayer implements Player {
   publish = (): void => {
     // no-op
   };
-  setPublishers = (pubs: AdvertisePayload[]): void => {
+  setPublishers = (pubs: AdvertiseOptions[]): void => {
     this.publishers = pubs;
   };
   setParameter(_key: string, _value: ParameterValue): void {

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -17,7 +17,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { useShallowMemo } from "@foxglove/hooks";
 import { Time, isLessThan } from "@foxglove/rostime";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   ParameterValue,
   PlayerPresence,
@@ -47,7 +47,7 @@ export default function MockMessagePipelineProvider(props: {
   messages?: MessageEvent<unknown>[];
   problems?: PlayerProblem[];
   publish?: (request: PublishPayload) => void;
-  setPublishers?: (arg0: string, arg1: AdvertisePayload[]) => void;
+  setPublishers?: (arg0: string, arg1: AdvertiseOptions[]) => void;
   setSubscriptions?: (arg0: string, arg1: SubscribePayload[]) => void;
   setParameter?: (key: string, value: ParameterValue) => void;
   noActiveData?: boolean;

--- a/packages/studio-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.test.tsx
@@ -221,23 +221,13 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
       initialProps: { maybePlayer: { player } },
     });
 
-    act(() =>
-      result.current.setPublishers("test", [
-        { topic: "/studio/test", datatype: "test", datatypes: new Map() },
-      ]),
-    );
-    expect(result.current.publishers).toEqual([
-      { topic: "/studio/test", datatype: "test", datatypes: new Map() },
-    ]);
+    act(() => result.current.setPublishers("test", [{ topic: "/studio/test", datatype: "test" }]));
+    expect(result.current.publishers).toEqual([{ topic: "/studio/test", datatype: "test" }]);
 
-    act(() =>
-      result.current.setPublishers("bar", [
-        { topic: "/studio/test2", datatype: "test2", datatypes: new Map() },
-      ]),
-    );
+    act(() => result.current.setPublishers("bar", [{ topic: "/studio/test2", datatype: "test2" }]));
     expect(result.current.publishers).toEqual([
-      { topic: "/studio/test", datatype: "test", datatypes: new Map() },
-      { topic: "/studio/test2", datatype: "test2", datatypes: new Map() },
+      { topic: "/studio/test", datatype: "test" },
+      { topic: "/studio/test2", datatype: "test2" },
     ]);
 
     const lastPublishers = result.current.publishers;
@@ -391,18 +381,12 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
     });
     act(() => result.current.setSubscriptions("test", [{ topic: "/studio/test" }]));
     act(() => result.current.setSubscriptions("bar", [{ topic: "/studio/test2" }]));
-    act(() =>
-      result.current.setPublishers("test", [
-        { topic: "/studio/test", datatype: "test", datatypes: new Map() },
-      ]),
-    );
+    act(() => result.current.setPublishers("test", [{ topic: "/studio/test", datatype: "test" }]));
 
     const player2 = new FakePlayer();
     rerender({ maybePlayer: { player: player2 } });
     expect(player2.subscriptions).toEqual([{ topic: "/studio/test" }, { topic: "/studio/test2" }]);
-    expect(player2.publishers).toEqual([
-      { topic: "/studio/test", datatype: "test", datatypes: new Map() },
-    ]);
+    expect(player2.publishers).toEqual([{ topic: "/studio/test", datatype: "test" }]);
   });
 
   it("keeps activeData when closing a player", async () => {

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -21,7 +21,7 @@ import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConf
 import useContextSelector from "@foxglove/studio-base/hooks/useContextSelector";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   Frame,
   ParameterValue,
   Player,
@@ -50,9 +50,9 @@ export type MessagePipelineContext = {
   sortedTopics: Topic[];
   datatypes: RosDatatypes;
   subscriptions: SubscribePayload[];
-  publishers: AdvertisePayload[];
+  publishers: AdvertiseOptions[];
   setSubscriptions: (id: string, subscriptionsForId: SubscribePayload[]) => void;
-  setPublishers: (id: string, publishersForId: AdvertisePayload[]) => void;
+  setPublishers: (id: string, publishersForId: AdvertiseOptions[]) => void;
   setParameter: (key: string, value: ParameterValue) => void;
   publish: (request: PublishPayload) => void;
   startPlayback: () => void;
@@ -141,7 +141,7 @@ export function MessagePipelineProvider({
     () => flatten(Object.values(subscriptionsById)),
     [subscriptionsById],
   );
-  const publishers: AdvertisePayload[] = useMemo(
+  const publishers: AdvertiseOptions[] = useMemo(
     () => flatten(Object.values(publishersById)),
     [publishersById],
   );
@@ -264,7 +264,7 @@ export function MessagePipelineProvider({
     [setAllSubscriptions],
   );
   const setPublishers = useCallback(
-    (id: string, publishersForId: AdvertisePayload[]) => {
+    (id: string, publishersForId: AdvertiseOptions[]) => {
       setAllPublishers((p) => ({ ...p, [id]: publishersForId }));
     },
     [setAllPublishers],

--- a/packages/studio-base/src/components/PanelExtensionAdapter.test.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.test.tsx
@@ -1,0 +1,306 @@
+/** @jest-environment jsdom */
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { mount } from "enzyme";
+
+import { PanelExtensionContext } from "@foxglove/studio";
+import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import { HoverValueProvider } from "@foxglove/studio-base/context/HoverValueContext";
+import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
+
+describe("PanelExtensionAdapter", () => {
+  it("should call initPanel", (done) => {
+    expect.assertions(1);
+
+    const initPanel = (context: PanelExtensionContext) => {
+      expect(context).toBeDefined();
+      done();
+    };
+
+    const config = {};
+    const saveConfig = () => {};
+
+    const Wrapper = () => {
+      return (
+        <HoverValueProvider>
+          <PanelSetup>
+            <PanelExtensionAdapter config={config} saveConfig={saveConfig} initPanel={initPanel} />
+          </PanelSetup>
+        </HoverValueProvider>
+      );
+    };
+
+    const handle = mount(<Wrapper />);
+
+    // force a re-render to make sure we call init panel once
+    handle.setProps({});
+  });
+
+  it("should support advertising on a topic", (done) => {
+    const initPanel = (context: PanelExtensionContext) => {
+      context.advertise("/some/topic", "some_datatype");
+    };
+
+    mount(
+      <HoverValueProvider>
+        <PanelSetup
+          fixture={{
+            topics: [],
+            datatypes: new Map(),
+            frame: {},
+            layout: "UnknownPanel!4co6n9d",
+            setPublishers: (id, advertisements) => {
+              expect(id).toBeDefined();
+              expect(advertisements).toEqual(
+                expect.arrayContaining([
+                  {
+                    topic: "/some/topic",
+                    datatype: "some_datatype",
+                    options: undefined,
+                  },
+                ]),
+              );
+              done();
+            },
+          }}
+        >
+          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+        </PanelSetup>
+      </HoverValueProvider>,
+    );
+  });
+
+  it("should support advertising on multiple topics", (done) => {
+    let count = 0;
+
+    const initPanel = (context: PanelExtensionContext) => {
+      context.advertise("/some/topic", "some_datatype");
+      context.advertise("/another/topic", "another_datatype");
+    };
+
+    mount(
+      <HoverValueProvider>
+        <PanelSetup
+          fixture={{
+            topics: [],
+            datatypes: new Map(),
+            frame: {},
+            layout: "UnknownPanel!4co6n9d",
+            setPublishers: (id, advertisements) => {
+              expect(id).toBeDefined();
+              ++count;
+
+              if (count === 1) {
+                // eslint-disable-next-line jest/no-conditional-expect
+                expect(advertisements).toEqual(
+                  expect.arrayContaining([
+                    {
+                      topic: "/some/topic",
+                      datatype: "some_datatype",
+                      options: undefined,
+                    },
+                  ]),
+                );
+              } else if (count === 2) {
+                // eslint-disable-next-line jest/no-conditional-expect
+                expect(advertisements).toEqual(
+                  expect.arrayContaining([
+                    {
+                      topic: "/some/topic",
+                      datatype: "some_datatype",
+                      options: undefined,
+                    },
+                    {
+                      topic: "/another/topic",
+                      datatype: "another_datatype",
+                      options: undefined,
+                    },
+                  ]),
+                );
+                done();
+              }
+            },
+          }}
+        >
+          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+        </PanelSetup>
+      </HoverValueProvider>,
+    );
+  });
+
+  it("should support publishing on a topic", (done) => {
+    expect.assertions(3);
+
+    const initPanel = (context: PanelExtensionContext) => {
+      context.advertise("/some/topic", "some_datatype");
+      context.publish("/some/topic", {
+        foo: "bar",
+      });
+    };
+
+    mount(
+      <HoverValueProvider>
+        <PanelSetup
+          fixture={{
+            topics: [],
+            datatypes: new Map(),
+            frame: {},
+            layout: "UnknownPanel!4co6n9d",
+            setPublishers: (id, advertisements) => {
+              expect(id).toBeDefined();
+              expect(advertisements).toEqual(
+                expect.arrayContaining([
+                  {
+                    topic: "/some/topic",
+                    datatype: "some_datatype",
+                    options: undefined,
+                  },
+                ]),
+              );
+            },
+            publish: (request) => {
+              expect(request).toEqual({ topic: "/some/topic", msg: { foo: "bar" } });
+              done();
+            },
+          }}
+        >
+          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+        </PanelSetup>
+      </HoverValueProvider>,
+    );
+  });
+
+  it("should support unadvertising", (done) => {
+    let count = 0;
+
+    const initPanel = (context: PanelExtensionContext) => {
+      context.advertise("/some/topic", "some_datatype");
+      context.advertise("/another/topic", "another_datatype");
+      context.unadvertise("/some/topic");
+    };
+
+    mount(
+      <HoverValueProvider>
+        <PanelSetup
+          fixture={{
+            topics: [],
+            datatypes: new Map(),
+            frame: {},
+            layout: "UnknownPanel!4co6n9d",
+            setPublishers: (id, advertisements) => {
+              expect(id).toBeDefined();
+              ++count;
+
+              if (count === 1) {
+                // eslint-disable-next-line jest/no-conditional-expect
+                expect(advertisements).toEqual(
+                  expect.arrayContaining([
+                    {
+                      topic: "/some/topic",
+                      datatype: "some_datatype",
+                      options: undefined,
+                    },
+                  ]),
+                );
+              } else if (count === 2) {
+                // eslint-disable-next-line jest/no-conditional-expect
+                expect(advertisements).toEqual(
+                  expect.arrayContaining([
+                    {
+                      topic: "/some/topic",
+                      datatype: "some_datatype",
+                      options: undefined,
+                    },
+                    {
+                      topic: "/another/topic",
+                      datatype: "another_datatype",
+                      options: undefined,
+                    },
+                  ]),
+                );
+              } else if (count === 3) {
+                // eslint-disable-next-line jest/no-conditional-expect
+                expect(advertisements).toEqual(
+                  expect.arrayContaining([
+                    {
+                      topic: "/another/topic",
+                      datatype: "another_datatype",
+                      options: undefined,
+                    },
+                  ]),
+                );
+
+                done();
+              }
+            },
+          }}
+        >
+          <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+        </PanelSetup>
+      </HoverValueProvider>,
+    );
+  });
+
+  it("should unadvertise when unmounting", (done) => {
+    expect.assertions(5);
+    let count = 0;
+
+    const initPanel = (context: PanelExtensionContext) => {
+      expect(context).toBeDefined();
+      context.advertise("/some/topic", "some_datatype");
+    };
+
+    const fixture: Fixture = {
+      topics: [],
+      datatypes: new Map(),
+      frame: {},
+      layout: "UnknownPanel!4co6n9d",
+      setPublishers: (id, advertisements) => {
+        expect(id).toBeDefined();
+        ++count;
+
+        if (count === 1) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(advertisements).toEqual(
+            expect.arrayContaining([
+              {
+                topic: "/some/topic",
+                datatype: "some_datatype",
+                options: undefined,
+              },
+            ]),
+          );
+        } else if (count === 2) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(advertisements).toEqual(expect.arrayContaining([]));
+          done();
+        }
+      },
+    };
+
+    const config = {};
+    const saveConfig = () => {};
+
+    const Wrapper = ({ mounted = true }: { mounted?: boolean }) => {
+      return (
+        <HoverValueProvider>
+          <PanelSetup fixture={fixture}>
+            {mounted && (
+              <PanelExtensionAdapter
+                config={config}
+                saveConfig={saveConfig}
+                initPanel={initPanel}
+              />
+            )}
+          </PanelSetup>
+        </HoverValueProvider>
+      );
+    };
+
+    const handle = mount(<Wrapper mounted />);
+    handle.setProps({ mounted: false });
+  });
+});

--- a/packages/studio-base/src/hooks/usePublisher.tsx
+++ b/packages/studio-base/src/hooks/usePublisher.tsx
@@ -41,7 +41,7 @@ export default function usePublisher({
   const setPublishers = useMessagePipeline((context) => context.setPublishers);
   useEffect(() => {
     if (canPublish) {
-      setPublishers(id, [{ topic, datatype, datatypes, advertiser: name }]);
+      setPublishers(id, [{ topic, datatype, options: { datatypes } }]);
       return () => setPublishers(id, []);
     } else {
       return undefined;

--- a/packages/studio-base/src/panels/Internals.tsx
+++ b/packages/studio-base/src/panels/Internals.tsx
@@ -29,7 +29,7 @@ import {
   Topic,
   MessageEvent,
   SubscribePayload,
-  AdvertisePayload,
+  AdvertiseOptions,
 } from "@foxglove/studio-base/players/types";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 import { nonEmptyOrUndefined } from "@foxglove/studio-base/util/emptyOrUndefined";
@@ -74,8 +74,12 @@ function getSubscriptionGroup({ requester }: SubscribePayload): string {
   }
 }
 
-function getPublisherGroup({ advertiser }: AdvertisePayload): string {
-  return advertiser == undefined ? "<unknown>" : advertiser;
+function getPublisherGroup({ options }: AdvertiseOptions): string {
+  const name = options?.["name"];
+  if (typeof name !== "string") {
+    return "<Studio>";
+  }
+  return name;
 }
 
 type RecordedData = {

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -17,7 +17,7 @@ import { Time, add, compare, isLessThan } from "@foxglove/rostime";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   PublishPayload,
   SubscribePayload,
   Player,
@@ -151,7 +151,7 @@ export default class OrderedStampPlayer implements Player {
   setSubscriptions = (subscriptions: SubscribePayload[]): void =>
     this._player.setSubscriptions(subscriptions);
   close = (): void => this._player.close();
-  setPublishers = (publishers: AdvertisePayload[]): void => this._player.setPublishers(publishers);
+  setPublishers = (publishers: AdvertiseOptions[]): void => this._player.setPublishers(publishers);
   setParameter = (key: string, value: ParameterValue): void =>
     this._player.setParameter(key, value);
   publish = (request: PublishPayload): void => this._player.publish(request);

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from "uuid";
 import { Time, add, areEqual, compare } from "@foxglove/rostime";
 import NoopMetricsCollector from "@foxglove/studio-base/players/NoopMetricsCollector";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   Player,
   PlayerCapabilities,
@@ -594,7 +594,7 @@ export default class RandomAccessPlayer implements Player {
     this.seekPlayback(this._currentTime);
   }
 
-  setPublishers(_publishers: AdvertisePayload[]): void {
+  setPublishers(_publishers: AdvertiseOptions[]): void {
     // no-op
   }
 

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -12,7 +12,7 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   ParameterValue,
   Player,
@@ -385,7 +385,7 @@ export default class Ros1Player implements Player {
     this._emitState();
   };
 
-  setPublishers(publishers: AdvertisePayload[]): void {
+  setPublishers(publishers: AdvertiseOptions[]): void {
     if (!this._rosNode || this._closed) {
       return;
     }
@@ -412,7 +412,9 @@ export default class Ros1Player implements Player {
     }
 
     // Advertise new topics
-    for (const { topic, datatype: dataType, datatypes } of validPublishers) {
+    for (const advertiseOptions of validPublishers) {
+      const { topic, datatype: dataType, options } = advertiseOptions;
+
       if (this._rosNode.publications.has(topic)) {
         continue;
       }
@@ -423,6 +425,10 @@ export default class Ros1Player implements Player {
       // Try to retrieve the ROS message definition for this topic
       let msgdef: RosMsgDefinition[];
       try {
+        const datatypes = options?.["datatypes"] as RosDatatypes | undefined;
+        if (!datatypes || !(datatypes instanceof Map)) {
+          throw new Error("The datatypes option is required for publishing");
+        }
         msgdef = rosDatatypesToMessageDefinition(datatypes, dataType);
       } catch (error) {
         this._addProblem(msgdefProblemId, {

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -22,7 +22,7 @@ import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
 import { Time } from "@foxglove/rostime";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   Player,
   PlayerCapabilities,
@@ -83,7 +83,7 @@ export default class RosbridgePlayer implements Player {
   // active publishers for the current connection
   private _topicPublishers = new Map<string, roslib.Topic>();
   // which topics we want to advertise to other nodes
-  private _advertisements: AdvertisePayload[] = [];
+  private _advertisements: AdvertiseOptions[] = [];
   private _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
   private _parsedTopics: Set<string> = new Set();
   private _receivedBytes: number = 0;
@@ -418,7 +418,7 @@ export default class RosbridgePlayer implements Player {
     }
   }
 
-  setPublishers(publishers: AdvertisePayload[]): void {
+  setPublishers(publishers: AdvertiseOptions[]): void {
     // Since `setPublishers` is rarely called, we can get away with just throwing away the old
     // Roslib.Topic objects and creating new ones.
     for (const publisher of this._topicPublishers.values()) {

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -30,7 +30,7 @@ import {
 } from "@foxglove/studio-base/players/UserNodePlayer/types";
 import { hasTransformerErrors } from "@foxglove/studio-base/players/UserNodePlayer/utils";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   Player,
   PlayerState,
   PlayerStateActiveData,
@@ -720,7 +720,7 @@ export default class UserNodePlayer implements Player {
     }
   };
 
-  setPublishers = (publishers: AdvertisePayload[]): void => this._player.setPublishers(publishers);
+  setPublishers = (publishers: AdvertiseOptions[]): void => this._player.setPublishers(publishers);
   setParameter = (key: string, value: ParameterValue): void =>
     this._player.setParameter(key, value);
   publish = (request: PublishPayload): void => this._player.publish(request);

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -9,7 +9,7 @@ import Logger from "@foxglove/log";
 import { Time } from "@foxglove/rostime";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   ParameterValue,
   Player,
@@ -259,7 +259,7 @@ export default class VelodynePlayer implements Player {
 
   setSubscriptions(_subscriptions: SubscribePayload[]): void {}
 
-  setPublishers(_publishers: AdvertisePayload[]): void {
+  setPublishers(_publishers: AdvertiseOptions[]): void {
     // no-op
   }
 

--- a/packages/studio-base/src/players/automatedRun/AutomatedRunPlayer.ts
+++ b/packages/studio-base/src/players/automatedRun/AutomatedRunPlayer.ts
@@ -18,7 +18,7 @@ import { v4 as uuidv4 } from "uuid";
 import Logger from "@foxglove/log";
 import { Time, add, isLessThan } from "@foxglove/rostime";
 import {
-  AdvertisePayload,
+  AdvertiseOptions,
   MessageEvent,
   ParameterValue,
   Player,
@@ -409,7 +409,7 @@ export default class AutomatedRunPlayer implements Player {
     // no-op
   }
 
-  setPublishers(_publishers: AdvertisePayload[]): void {
+  setPublishers(_publishers: AdvertiseOptions[]): void {
     // no-op
   }
 

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -65,7 +65,7 @@ export interface Player {
   // Set a new set of subscriptions/advertisers. This might trigger fetching
   // new data, which might in turn trigger a backfill of messages.
   setSubscriptions(subscriptions: SubscribePayload[]): void;
-  setPublishers(publishers: AdvertisePayload[]): void;
+  setPublishers(publishers: AdvertiseOptions[]): void;
   // Modify a remote parameter such as a rosparam.
   setParameter(key: string, value: ParameterValue): void;
   // If the Player supports publishing (i.e. PlayerState#capabilities contains
@@ -276,19 +276,15 @@ export type SubscribePayload = {
 };
 
 // Represents a single topic publisher, for use in `setPublishers`.
-export type AdvertisePayload = {
+export type AdvertiseOptions = {
   // The topic name
   topic: string;
 
   // The datatype name
   datatype: string;
 
-  // A map of datatype names to ROS message definitions. This must include
-  // message definitions for all types referenced by `datatype` and its children.
-  datatypes: RosDatatypes;
-
-  // Optionally indicate the name of the advertiser
-  advertiser?: string;
+  // Additional advertise options
+  options?: Record<string, unknown>;
 };
 
 // The actual message to publish.

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -43,7 +43,7 @@ import {
   PlayerStateActiveData,
   Progress,
   PublishPayload,
-  AdvertisePayload,
+  AdvertiseOptions,
 } from "@foxglove/studio-base/players/types";
 import CurrentLayoutState, {
   DEFAULT_LAYOUT_FOR_TESTS,
@@ -68,7 +68,7 @@ export type Fixture = {
   userNodeRosLib?: string;
   savedProps?: SavedProps;
   publish?: (request: PublishPayload) => void;
-  setPublishers?: (arg0: string, arg1: AdvertisePayload[]) => void;
+  setPublishers?: (publisherId: string, advertisements: AdvertiseOptions[]) => void;
 };
 
 type Props = {

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -88,14 +88,6 @@ declare module "@foxglove/studio" {
     seekPlayback?: (time: number) => void;
 
     /**
-     * Process render events for the panel. Each render event receives a render state and a done callback.
-     * Render events occur frequently (60hz, 30hz, etc).
-     *
-     * The done callback should be called once the panel has rendered the render state.
-     */
-    onRender?: (renderState: Readonly<RenderState>, done: () => void) => void;
-
-    /**
      * Subscribe to an array of topic names.
      */
     subscribe(topics: string[]): void;
@@ -104,6 +96,34 @@ declare module "@foxglove/studio" {
      * Unsubscribe from all topics.
      */
     unsubscribeAll(): void;
+
+    /**
+     * Indicate intent to advertise on a specific topic and datatype.
+     *
+     * The options object is passed to the current data source for additional configuration.
+     */
+    advertise(topic: string, datatype: string, options?: Record<string, unknown>): void;
+
+    /**
+     * Indicate that you no longer want to advertise on this topic.
+     */
+    unadvertise(topic: string): void;
+
+    /**
+     * Publish a message on a given topic. You must first advertise on the topic before publishing.
+     *
+     * @param topic The name of the topic to publish the message on
+     * @param message The message to publish
+     */
+    publish(topic: string, message: unknown): void;
+
+    /**
+     * Process render events for the panel. Each render event receives a render state and a done callback.
+     * Render events occur frequently (60hz, 30hz, etc).
+     *
+     * The done callback should be called once the panel has rendered the render state.
+     */
+    onRender?: (renderState: Readonly<RenderState>, done: () => void) => void;
   };
 
   export type ExtensionPanelRegistration = {


### PR DESCRIPTION
## User-Facing Changes
Panels authored via the extension api are able to advertise datatypes on topics.
Panels authored via the extension api are able to publish messages on advertised topics.

### Advertise
The advertise method on the panel extension context allows a panel to indicate an intent to publish a specific datatype on a topic. The panel would need to call advertise before being able to publish on the topic.

```typescript
context.advertise(topic: string, datatype: string, options?: Record<string, unknown>);
```

Options are specific to the current data source. Some data sources make use of specific options while others do not.

### Unadvertise 
Remove advertising for a topic/datatype pair.

### Publish
The publish function publishes a message on a previously advertised topic. If the topic is not advertised or otherwise malformed, the function will throw.

```typescript
context.publish(topic: string, message: Record<string, unknown>);
```

This function is fire-and-forget.

## Description
The user facing changes capture the scope of the PR.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
