### PR TITLE
Handle bigints in getValueActionForValue generated filter strings

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -52,6 +52,30 @@ describe("getValueActionForValue", () => {
     });
   });
 
+  it("returns paths with bigints", () => {
+    const structureItem = {
+      structureType: "array",
+      next: {
+        structureType: "message",
+        nextByName: {
+          some_id: {
+            structureType: "primitive",
+            primitiveType: "uint64",
+            datatype: "",
+          },
+        },
+        datatype: "",
+      },
+      datatype: "",
+    };
+    expect(getAction([{ some_id: 18446744073709552000n }], structureItem, [0, "some_id"])).toEqual({
+      filterPath: "[:]{some_id==18446744073709552000}",
+      multiSlicePath: "[:].some_id",
+      primitiveType: "uint64",
+      singleSlicePath: "[:]{some_id==18446744073709552000}.some_id",
+    });
+  });
+
   it("returns slice paths when pointing at a number (even when it looks like an id)", () => {
     const structureItem = {
       structureType: "message",

--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
@@ -98,8 +98,11 @@ export function getValueActionForValue(
         value != undefined &&
         typeof typicalFilterName === "string"
       ) {
+        const filterValue = (value as Record<string, unknown>)[typicalFilterName];
         singleSlicePath += `[:]{${typicalFilterName}==${
-          JSON.stringify((value as Record<string, unknown>)[typicalFilterName]) ?? ""
+          typeof filterValue === "bigint"
+            ? filterValue.toString()
+            : JSON.stringify(filterValue) ?? ""
         }}`;
       } else {
         singleSlicePath += `[${pathItem}]`;


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash when hovering on int64/uint64 values inside arrays in Raw Messages. (#1597)

**Description**
Fixes #1597 by checking for `typeof value === "bigint"`.
(This was partly fixed in https://github.com/foxglove/studio/pull/1297, but a unit test wasn't added to cover the bigint case — if it had this issue would have come up as well.)

Related: #1445.