### PR TITLE
Remove reference to nonexistent Slack channel in Node Playground docs

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/index.help.md
+++ b/packages/studio-base/src/panels/NodePlayground/index.help.md
@@ -15,8 +15,6 @@ Here are some resources to get yourself ramped up:
 - [Basic Types](https://www.typescriptlang.org/docs/handbook/basic-types.html)
 - [Gitbook](https://basarat.gitbooks.io/typescript/content/docs/why-typescript.html)
 
-Post in #typescript for TypeScript questions.
-
 ### Writing Your First Node
 
 Every node must declare 3 exports that determine how it should execute:


### PR DESCRIPTION
**User-Facing Changes**
Node Playground docs no longer include an outdated reference to a Webviz Slack channel.

**Description**
Removed outdated reference to a Webviz Slack channel from the Node Playground docs.