### PR TITLE
Run CI on PR merge commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          # Chromatic requires running build on the branch head, not PR merge commit
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           lfs: true
 
@@ -70,8 +68,9 @@ jobs:
 
       - run: ${{ matrix.config.command }}
         env:
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Chromatic fails to run on PR merge ref unless head BRANCH and SHA are passed explicitly
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   integration:
@@ -87,7 +86,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           lfs: true
 
       - uses: actions/setup-node@v2


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
PRs submitted from a fork repo don't have a valid `github.event.pull_request.head.ref`. For example https://github.com/foxglove/studio/pull/1524 failed with:

```sh
Determining the checkout info
  /usr/bin/git branch --list --remote origin/feature/add_web_build_command
  /usr/bin/git tag --list feature/add_web_build_command
  Error: A branch or tag with the name 'feature/add_web_build_command' could not be found
```

It's possible this could be fixed by checking out `head.sha` instead of `head.ref`. However, we originally switched to the head commit because Chromatic claimed to need it, but I'm fairly confident that is not the case. 

There are also advantages to testing the PR merge commit (PR merged with latest main) - it means the likelihood of a CI failure post-merge is reduced.

Therefore, switching back to using Github's default behavior. There is still some outstanding work to make PRs work completely from fork repos (Chromatic token isn't accessible - see https://github.com/foxglove/studio/pull/1608), but this at least gets us one step closer.

Closes #1626 
Closes #1627