### PR TITLE
Checkout PR head sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           # Chromatic requires running build on the branch head, not PR merge commit
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           lfs: true
 
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           lfs: true
 
       - uses: actions/setup-node@v2


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Alternative to https://github.com/foxglove/studio/pull/1625. Instead of checking out the merge commit, check out the PR head (specified by `sha` instead of `ref` as directed by the [actions/checkout docs](https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit)).

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
