### PR TITLE
Automatically accept chromatic changes on main

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "prepack": "yarn build:webpack && yarn build:tsc",
-    "chromatic": "chromatic --project-token $CHROMATIC_PROJECT_TOKEN --build-script-name storybook:build --exit-once-uploaded",
+    "chromatic": "chromatic --build-script-name storybook:build --auto-accept-changes main --exit-once-uploaded",
     "storybook:build": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' build-storybook --config-dir src/.storybook",
     "build:tsc": "ttsc --module es2020 --project tsconfig.json",
     "build:webpack": "cross-env TS_NODE_PROJECT=\"tsconfig.cli.json\" webpack --mode production --progress"


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Automatically accept Chromatic changes on main. This avoids unrelated visual diffs showing up in PRs.

In theory this could mean we miss a conflict where two incompatible PRs are merged sequentially. However, right now no one is monitoring chromatic on main so we are not catching these anyway.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
