### PR TITLE
Fix: Legacy Plot properly displays datapoints from lazy messages

### DIFF
--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -148,7 +148,9 @@ function TwoDimensionalPlot(props: Props) {
         return undefined;
       }
 
-      const dataset = { data, showLine: true, fill: false, ...picked };
+      // since message might be a lazy message, we need to read the individual x/y fields from each item
+      const dataPoints = data.map((item) => ({ x: item.x, y: item.y }));
+      const dataset = { data: dataPoints, showLine: true, fill: false, ...picked };
       if (pointRadiusOverride != undefined) {
         dataset.pointRadius = parseFloat(pointRadiusOverride);
       }
@@ -162,7 +164,9 @@ function TwoDimensionalPlot(props: Props) {
         return undefined;
       }
 
-      const dataset = { data, showLine: true, fill: false, ...picked };
+      // since message might be a lazy message, we need to read the individual x/y fields from each item
+      const dataPoints = data.map((item) => ({ x: item.x, y: item.y }));
+      const dataset = { data: dataPoints, showLine: true, fill: false, ...picked };
       if (pointRadiusOverride != undefined) {
         dataset.pointRadius = parseFloat(pointRadiusOverride);
       }
@@ -176,7 +180,10 @@ function TwoDimensionalPlot(props: Props) {
         return undefined;
       }
 
-      const closedData = data[0] != undefined ? data.concat([data[0]]) : data;
+      // since message might be a lazy message, we need to read the individual x/y fields from each item
+      const dataPoints = data.map((item) => ({ x: item.x, y: item.y }));
+      const closedData =
+        dataPoints[0] != undefined ? dataPoints.concat([dataPoints[0]]) : dataPoints;
       const dataset = {
         data: closedData,
         fill: true,


### PR DESCRIPTION
**User-Facing Changes**
Legacy Plot works when reading data from bags and other data sources which use lazy messages.

**Description**
Lazy messages require explicit reading of the x/y values for datapoints since the datasets are then sent over RPC which cannot serialize complex datatypes like lazy messages.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
