### PR TITLE
Fix: show title and axis labels for legacy plot

### DIFF
--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -117,7 +117,7 @@ function zoomOut(keyObj: any) {
 }
 
 export default {
-  title: "panels/TwoDimensonalPlot",
+  title: "panels/LegacyPlot",
   parameters: {
     chromatic: {
       delay: 2500,

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -224,7 +224,7 @@ function TwoDimensionalPlot(props: Props) {
         };
     return {
       grid: { color: gridColor },
-      scaleLabel: { display: yAxisLabel != undefined, labelString: yAxisLabel },
+      title: { display: yAxisLabel != undefined, text: yAxisLabel },
       ...minMax,
     };
   }, [allYs, getBufferedMinMax, gridColor, hasUserPannedOrZoomed, maxYVal, minYVal, yAxisLabel]);
@@ -241,7 +241,7 @@ function TwoDimensionalPlot(props: Props) {
 
     return {
       grid: { color: gridColor },
-      scaleLabel: { display: xAxisLabel != undefined, labelString: xAxisLabel },
+      title: { display: xAxisLabel != undefined, text: xAxisLabel },
       ...minMax,
     };
   }, [allXs, getBufferedMinMax, gridColor, hasUserPannedOrZoomed, maxXVal, minXVal, xAxisLabel]);
@@ -257,7 +257,6 @@ function TwoDimensionalPlot(props: Props) {
 
   const options = useMemo<ChartOptions>(
     () => ({
-      title: { display: title != undefined, text: title },
       scales: {
         y: yScale,
         x: xScale,
@@ -265,6 +264,7 @@ function TwoDimensionalPlot(props: Props) {
       color: colors.GRAY,
       animation: { duration: 0 },
       plugins: {
+        title: { display: title != undefined, text: title, color: "white" },
         tooltip: {
           intersect: false,
           mode: "nearest",


### PR DESCRIPTION
**User-Facing Changes**
The user will now see the title and axis labels from their message on the Legacy Plot.

**Description**
The title and axis labels were using the wrong configurations (chartjs v2 fields) and the types were not erroring. This change fixes the configuration for chartjs v3.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
