### PR TITLE
Change datatype-dependent logic to recognize ROS 2 datatype names

### DIFF
--- a/packages/studio-base/src/components/TopicToRenderMenu.stories.tsx
+++ b/packages/studio-base/src/components/TopicToRenderMenu.stories.tsx
@@ -22,7 +22,7 @@ const topics = [
   },
   {
     name: "/studio_source_2/foo",
-    datatype: "abc_msgs/foo",
+    datatype: "abc_msgs/bar",
   },
   {
     name: "/studio_source_2/foo",
@@ -30,44 +30,8 @@ const topics = [
   },
 ];
 
-const topicsGroups = [
-  {
-    key: "foo",
-    suffix: "/foo",
-    datatype: "abc_msgs/foo",
-  },
-  {
-    key: "bar",
-    suffix: "/bar",
-    datatype: "abc_msgs/bar",
-  },
-];
-
 storiesOf("components/TopicToRenderMenu", module)
-  .add("example (have topicsGroups)", () => {
-    return (
-      <PanelSetup
-        fixture={{ topics: [], datatypes: new Map(), frame: {} }}
-        onMount={(el: any) => {
-          const topicSet = el.querySelector("[data-test=topic-set]");
-          if (topicSet) {
-            topicSet.click();
-          }
-        }}
-      >
-        <TopicToRenderMenu
-          onChange={() => {
-            // no-op
-          }}
-          topicToRender=""
-          topics={topics}
-          topicsGroups={topicsGroups}
-          defaultTopicToRender=""
-        />
-      </PanelSetup>
-    );
-  })
-  .add("example (have singleTopicDatatype)", () => {
+  .add("example", () => {
     return (
       <PanelSetup
         fixture={{ topics: [], datatypes: new Map(), frame: {} }}
@@ -84,7 +48,7 @@ storiesOf("components/TopicToRenderMenu", module)
           }}
           topicToRender="/foo"
           topics={topics}
-          singleTopicDatatype={"abc_msgs/foo"}
+          allowedDatatypes={["abc_msgs/foo", "abc_msgs/bar"]}
           defaultTopicToRender="/foo"
         />
       </PanelSetup>
@@ -107,59 +71,13 @@ storiesOf("components/TopicToRenderMenu", module)
           }}
           topicToRender="/studio_source_2/foo"
           topics={topics}
-          singleTopicDatatype={"abc_msgs/foo"}
+          allowedDatatypes={["abc_msgs/foo", "abc_msgs/bar"]}
           defaultTopicToRender="/foo"
         />
       </PanelSetup>
     );
   })
-  .add("no bag loaded, defaultTopicToRender === topicToRender (have topicsGroups)", () => {
-    return (
-      <PanelSetup
-        fixture={{ topics: [], datatypes: new Map(), frame: {} }}
-        onMount={(el: any) => {
-          const topicSet = el.querySelector("[data-test=topic-set]");
-          if (topicSet) {
-            topicSet.click();
-          }
-        }}
-      >
-        <TopicToRenderMenu
-          onChange={() => {
-            // no-op
-          }}
-          topicToRender=""
-          topics={[]}
-          topicsGroups={topicsGroups}
-          defaultTopicToRender=""
-        />
-      </PanelSetup>
-    );
-  })
-  .add("no bag loaded, defaultTopicToRender !== topicToRender (have topicsGroups)", () => {
-    return (
-      <PanelSetup
-        fixture={{ topics: [], datatypes: new Map(), frame: {} }}
-        onMount={(el: any) => {
-          const topicSet = el.querySelector("[data-test=topic-set]");
-          if (topicSet) {
-            topicSet.click();
-          }
-        }}
-      >
-        <TopicToRenderMenu
-          onChange={() => {
-            // no-op
-          }}
-          topicToRender="/studio_source_2"
-          topics={[]}
-          topicsGroups={topicsGroups}
-          defaultTopicToRender=""
-        />
-      </PanelSetup>
-    );
-  })
-  .add("bag loaded but topicToRender is not available (have singleTopicDatatype)", () => {
+  .add("bag loaded but topicToRender is not available", () => {
     return (
       <PanelSetup
         fixture={{ topics: [], datatypes: new Map(), frame: {} }}
@@ -176,13 +94,13 @@ storiesOf("components/TopicToRenderMenu", module)
           }}
           topicToRender="/abc"
           topics={topics}
-          singleTopicDatatype={"abc_msgs/foo"}
+          allowedDatatypes={["abc_msgs/foo", "abc_msgs/bar"]}
           defaultTopicToRender="/foo"
         />
       </PanelSetup>
     );
   })
-  .add("bag loaded but defaultTopicToRender is not available (have singleTopicDatatype)", () => {
+  .add("bag loaded but defaultTopicToRender is not available", () => {
     return (
       <PanelSetup
         fixture={{ topics: [], datatypes: new Map(), frame: {} }}
@@ -199,7 +117,7 @@ storiesOf("components/TopicToRenderMenu", module)
           }}
           topicToRender="/bar"
           topics={topics}
-          singleTopicDatatype={"abc_msgs/foo"}
+          allowedDatatypes={["abc_msgs/foo", "abc_msgs/bar"]}
           defaultTopicToRender="/bar"
         />
       </PanelSetup>

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -35,6 +35,7 @@ import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipe
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
+import { IMAGE_DATATYPES } from "@foxglove/studio-base/panels/ImageView/renderImage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import colors from "@foxglove/studio-base/styles/colors.module.scss";
@@ -279,9 +280,7 @@ function ImageView(props: Props) {
 
   // Namespaces represent marker topics based on the camera topic prefix (e.g. "/camera_front_medium")
   const { allCameraNamespaces, imageTopicsByNamespace } = useMemo(() => {
-    const imageTopics = (topics ?? []).filter(({ datatype }) =>
-      ["sensor_msgs/Image", "sensor_msgs/CompressedImage"].includes(datatype),
-    );
+    const imageTopics = (topics ?? []).filter(({ datatype }) => IMAGE_DATATYPES.includes(datatype));
     const topicsByNamespace = groupTopics(imageTopics);
     return {
       imageTopicsByNamespace: topicsByNamespace,
@@ -293,10 +292,14 @@ function ImageView(props: Props) {
     () => [
       // Single marker
       "visualization_msgs/ImageMarker",
+      "visualization_msgs/msg/ImageMarker",
       // Marker arrays
       "foxglove_msgs/ImageMarkerArray",
+      "foxglove_msgs/msg/ImageMarkerArray",
       "studio_msgs/ImageMarkerArray",
+      "studio_msgs/msg/ImageMarkerArray",
       "visualization_msgs/ImageMarkerArray",
+      "visualization_msgs/msg/ImageMarkerArray",
       // backwards compat with webviz
       "webviz_msgs/ImageMarkerArray",
     ],

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -37,7 +37,13 @@ import {
 } from "./decodings";
 import { buildMarkerData, Dimensions, RawMarkerData, MarkerData, RenderOptions } from "./util";
 
-const IMAGE_DATATYPES = ["sensor_msgs/CompressedImage", "sensor_msgs/Image"];
+const UNCOMPRESSED_IMAGE_DATATYPES = ["sensor_msgs/Image", "sensor_msgs/msg/Image"];
+export const IMAGE_DATATYPES = [
+  "sensor_msgs/Image",
+  "sensor_msgs/msg/Image",
+  "sensor_msgs/CompressedImage",
+  "sensor_msgs/msg/CompressedImage",
+];
 
 // Just globally keep track of if we've shown an error in rendering, since typically when you get
 // one error, you'd then get a whole bunch more, which is spammy.
@@ -130,7 +136,11 @@ function decodeMessageToBitmap(
   // compressed verisons of topics, in which case the message datatype can
   // differ from the one recorded during initialization. So here we just check
   // for properties consistent with either datatype, and render accordingly.
-  if (datatype === "sensor_msgs/Image" && "encoding" in imageMessage && imageMessage.encoding) {
+  if (
+    UNCOMPRESSED_IMAGE_DATATYPES.includes(datatype) &&
+    "encoding" in imageMessage &&
+    imageMessage.encoding
+  ) {
     const { is_bigendian, width, height, encoding } = imageMessage as Image;
     image = new ImageData(width, height);
     switch (encoding) {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -53,7 +53,11 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   useEffect(() => {
     // The map only supports sensor_msgs/NavSatFix
     const eligibleTopics = topics
-      .filter((topic) => topic.datatype === "sensor_msgs/NavSatFix")
+      .filter(
+        (topic) =>
+          topic.datatype === "sensor_msgs/NavSatFix" ||
+          topic.datatype === "sensor_msgs/msg/NavSatFix",
+      )
       .map((topic) => topic.name);
 
     context.subscribe(eligibleTopics);

--- a/packages/studio-base/src/panels/Rosout/index.tsx
+++ b/packages/studio-base/src/panels/Rosout/index.tsx
@@ -71,7 +71,7 @@ const RosoutPanel = React.memo(({ config, saveConfig }: Props) => {
       topicToRender={config.topicToRender}
       onChange={(topicToRender) => saveConfig({ ...config, topicToRender })}
       topics={topics}
-      singleTopicDatatype="rosgraph_msgs/Log"
+      allowedDatatypes={["rosgraph_msgs/Log", "rcl_interfaces/msg/Log"]}
       defaultTopicToRender={"/rosout"}
     />
   );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
@@ -15,16 +15,7 @@ import { ComponentType } from "react";
 
 import GridSettingsEditor from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/GridSettingsEditor";
 import { TopicSettingsEditorProps } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/types";
-import {
-  FOXGLOVE_GRID_DATATYPE,
-  NAV_MSGS_PATH_DATATYPE,
-  POINT_CLOUD_DATATYPE,
-  POSE_STAMPED_DATATYPE,
-  SENSOR_MSGS_LASER_SCAN_DATATYPE,
-  VELODYNE_SCAN_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_DATATYPE,
-} from "@foxglove/studio-base/util/globalConstants";
+import { FOXGLOVE_GRID_DATATYPE } from "@foxglove/studio-base/util/globalConstants";
 
 import LaserScanSettingsEditor from "./LaserScanSettingsEditor";
 import MarkerSettingsEditor from "./MarkerSettingsEditor";
@@ -40,13 +31,20 @@ export function topicSettingsEditorForDatatype(datatype: string):
   | undefined {
   const editors = new Map<string, unknown>([
     [FOXGLOVE_GRID_DATATYPE, GridSettingsEditor],
-    [POINT_CLOUD_DATATYPE, PointCloudSettingsEditor],
-    [VELODYNE_SCAN_DATATYPE, PointCloudSettingsEditor],
-    [POSE_STAMPED_DATATYPE, PoseSettingsEditor],
-    [SENSOR_MSGS_LASER_SCAN_DATATYPE, LaserScanSettingsEditor],
-    [VISUALIZATION_MSGS_MARKER_DATATYPE, MarkerSettingsEditor],
-    [VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE, MarkerSettingsEditor],
-    [NAV_MSGS_PATH_DATATYPE, MarkerSettingsEditor],
+    ["sensor_msgs/PointCloud2", PointCloudSettingsEditor],
+    ["sensor_msgs/msg/PointCloud2", PointCloudSettingsEditor],
+    ["velodyne_msgs/VelodyneScan", PointCloudSettingsEditor],
+    ["velodyne_msgs/msg/VelodyneScan", PointCloudSettingsEditor],
+    ["geometry_msgs/PoseStamped", PoseSettingsEditor],
+    ["geometry_msgs/msg/PoseStamped", PoseSettingsEditor],
+    ["sensor_msgs/LaserScan", LaserScanSettingsEditor],
+    ["sensor_msgs/msg/LaserScan", LaserScanSettingsEditor],
+    ["visualization_msgs/Marker", MarkerSettingsEditor],
+    ["visualization_msgs/msg/Marker", MarkerSettingsEditor],
+    ["visualization_msgs/MarkerArray", MarkerSettingsEditor],
+    ["visualization_msgs/msg/MarkerArray", MarkerSettingsEditor],
+    ["nav_msgs/Path", MarkerSettingsEditor],
+    ["nav_msgs/msg/Path", MarkerSettingsEditor],
   ]);
 
   return editors.get(datatype) as

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -78,22 +78,11 @@ import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { Color, Marker } from "@foxglove/studio-base/types/Messages";
 import filterMap from "@foxglove/studio-base/util/filterMap";
 import {
-  COLOR_RGBA_DATATYPE,
   FOXGLOVE_GRID_TOPIC,
-  GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE,
-  NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
-  NAV_MSGS_PATH_DATATYPE,
-  POINT_CLOUD_DATATYPE,
-  POSE_STAMPED_DATATYPE,
   SECOND_SOURCE_PREFIX,
-  SENSOR_MSGS_LASER_SCAN_DATATYPE,
-  TF_DATATYPE,
-  TF2_DATATYPE,
+  TF_DATATYPES,
   TRANSFORM_TOPIC,
-  VELODYNE_SCAN_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_DATATYPE,
-  TRANSFORM_STAMPED_DATATYPE,
+  TRANSFORM_STAMPED_DATATYPES,
 } from "@foxglove/studio-base/util/globalConstants";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 import { joinTopics } from "@foxglove/studio-base/util/topicUtils";
@@ -153,22 +142,30 @@ export type ColorOverride = {
 };
 export type ColorOverrideBySourceIdxByVariable = Record<GlobalVariableName, ColorOverride[]>;
 
-const SUPPORTED_MARKER_DATATYPES = {
-  // generally supported datatypes
-  VISUALIZATION_MSGS_MARKER_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
-  POSE_STAMPED_DATATYPE,
-  POINT_CLOUD_DATATYPE,
-  VELODYNE_SCAN_DATATYPE,
-  SENSOR_MSGS_LASER_SCAN_DATATYPE,
-  COLOR_RGBA_DATATYPE,
-  NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
-  NAV_MSGS_PATH_DATATYPE,
-  GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE,
-  TF_DATATYPE,
-  TF2_DATATYPE,
-};
-const SUPPORTED_MARKER_DATATYPES_SET = new Set(Object.values(SUPPORTED_MARKER_DATATYPES));
+// generally supported datatypes
+const SUPPORTED_MARKER_DATATYPES_SET = new Set([
+  "visualization_msgs/Marker",
+  "visualization_msgs/msg/Marker",
+  "visualization_msgs/MarkerArray",
+  "visualization_msgs/msg/MarkerArray",
+  "geometry_msgs/PoseStamped",
+  "geometry_msgs/msg/PoseStamped",
+  "sensor_msgs/PointCloud2",
+  "sensor_msgs/msg/PointCloud2",
+  "velodyne_msgs/VelodyneScan",
+  "velodyne_msgs/msg/VelodyneScan",
+  "sensor_msgs/LaserScan",
+  "sensor_msgs/msg/LaserScan",
+  "std_msgs/ColorRGBA",
+  "std_msgs/msg/ColorRGBA",
+  "nav_msgs/OccupancyGrid",
+  "nav_msgs/msg/OccupancyGrid",
+  "nav_msgs/Path",
+  "nav_msgs/msg/Path",
+  "geometry_msgs/PolygonStamped",
+  "geometry_msgs/msg/PolygonStamped",
+  ...TF_DATATYPES,
+]);
 
 function isTopicRenderable(topic: Topic): boolean {
   const datatype = topic.datatype;
@@ -281,19 +278,6 @@ export default function Layout({
   } = useMemo(
     () => ({
       blacklistTopicsSet: new Set(),
-      supportedMarkerDatatypesSet: new Set([
-        VISUALIZATION_MSGS_MARKER_DATATYPE,
-        VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
-        POSE_STAMPED_DATATYPE,
-        POINT_CLOUD_DATATYPE,
-        VELODYNE_SCAN_DATATYPE,
-        SENSOR_MSGS_LASER_SCAN_DATATYPE,
-        NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
-        NAV_MSGS_PATH_DATATYPE,
-        GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE,
-        TF_DATATYPE,
-        TF2_DATATYPE,
-      ]),
       topicTreeConfig: {
         name: "root",
         children: [
@@ -373,9 +357,8 @@ export default function Layout({
     // Subscribe to all TF topics
     for (const topic of memoizedTopics) {
       if (
-        topic.datatype === TF_DATATYPE ||
-        topic.datatype === TF2_DATATYPE ||
-        topic.datatype === TRANSFORM_STAMPED_DATATYPE
+        TF_DATATYPES.includes(topic.datatype) ||
+        TRANSFORM_STAMPED_DATATYPES.includes(topic.datatype)
       ) {
         allTopics.add(topic.name);
       }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -67,6 +67,11 @@ import Transforms, {
 import TransformsBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/TransformsBuilder";
 import World from "@foxglove/studio-base/panels/ThreeDimensionalViz/World";
 import {
+  TF_DATATYPES,
+  TRANSFORM_STAMPED_DATATYPES,
+  TRANSFORM_TOPIC,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
+import {
   TargetPose,
   getInteractionData,
   getObject,
@@ -80,9 +85,6 @@ import filterMap from "@foxglove/studio-base/util/filterMap";
 import {
   FOXGLOVE_GRID_TOPIC,
   SECOND_SOURCE_PREFIX,
-  TF_DATATYPES,
-  TRANSFORM_TOPIC,
-  TRANSFORM_STAMPED_DATATYPES,
 } from "@foxglove/studio-base/util/globalConstants";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 import { joinTopics } from "@foxglove/studio-base/util/topicUtils";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
@@ -18,7 +18,8 @@ import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedConte
 import { ThreeDimensionalVizContext } from "@foxglove/studio-base/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
 import { TREE_SPACING } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/constants";
 import { TopicTreeContext } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/useTopicTree";
-import { SECOND_SOURCE_PREFIX, TRANSFORM_TOPIC } from "@foxglove/studio-base/util/globalConstants";
+import { TRANSFORM_TOPIC } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
+import { SECOND_SOURCE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 import { joinTopics } from "@foxglove/studio-base/util/topicUtils";
 
 import NamespaceMenu from "./NamespaceMenu";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
@@ -16,8 +16,8 @@ import { mount } from "enzyme";
 import { omit } from "lodash";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import { TRANSFORM_TOPIC } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 import { Namespace } from "@foxglove/studio-base/types/Messages";
-import { TRANSFORM_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 
 import { UseSceneBuilderAndTransformsDataInput } from "./types";
 import useSceneBuilderAndTransformsData from "./useSceneBuilderAndTransformsData";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.ts
@@ -17,7 +17,7 @@ import { useMemo, useRef } from "react";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import useChangeDetector from "@foxglove/studio-base/hooks/useChangeDetector";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
-import { TRANSFORM_TOPIC } from "@foxglove/studio-base/util/globalConstants";
+import { TRANSFORM_TOPIC } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 
 import {
   UseSceneBuilderAndTransformsDataInput,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/constants.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/constants.ts
@@ -21,3 +21,10 @@ export const LAYER_INDEX_DEFAULT_BASE = 0;
 export const LAYER_INDEX_HIGHLIGHT_OVERLAY = 500;
 export const LAYER_INDEX_HIGHLIGHT_BASE = 1000;
 export const LAYER_INDEX_DIFF_MODE_BASE_PER_PASS = 100;
+
+export const TRANSFORM_TOPIC = "/tf";
+export const TRANSFORM_STAMPED_DATATYPES = [
+  "geometry_msgs/TransformStamped",
+  "geometry_msgs/msg/TransformStamped",
+];
+export const TF_DATATYPES = ["tf/tfMessage", "tf2_msgs/TFMessage", "tf2_msgs/msg/TFMessage"];

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -14,12 +14,12 @@
 import { useMemo, useRef } from "react";
 
 import Transforms from "@foxglove/studio-base/panels/ThreeDimensionalViz/Transforms";
-import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
-import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
 import {
   TF_DATATYPES,
   TRANSFORM_STAMPED_DATATYPES,
-} from "@foxglove/studio-base/util/globalConstants";
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
+import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
+import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
 
 type TfMessage = { transforms: TF[] };
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -17,9 +17,8 @@ import Transforms from "@foxglove/studio-base/panels/ThreeDimensionalViz/Transfo
 import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
 import {
-  TF2_DATATYPE,
-  TF_DATATYPE,
-  TRANSFORM_STAMPED_DATATYPE,
+  TF_DATATYPES,
+  TRANSFORM_STAMPED_DATATYPES,
 } from "@foxglove/studio-base/util/globalConstants";
 
 type TfMessage = { transforms: TF[] };
@@ -95,18 +94,12 @@ function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): 
       }
 
       // Process all TF topics (ex: /tf and /tf_static)
-      switch (datatype) {
-        case TF_DATATYPE:
-        case TF2_DATATYPE:
-          consumeTfs(msgs as MessageEvent<TfMessage>[], transforms);
-          updated = true;
-
-          break;
-        case TRANSFORM_STAMPED_DATATYPE:
-          consumeSingleTfs(msgs as MessageEvent<TF>[], transforms);
-          updated = true;
-
-          break;
+      if (TF_DATATYPES.includes(datatype)) {
+        consumeTfs(msgs as MessageEvent<TfMessage>[], transforms);
+        updated = true;
+      } else if (TRANSFORM_STAMPED_DATATYPES.includes(datatype)) {
+        consumeSingleTfs(msgs as MessageEvent<TF>[], transforms);
+        updated = true;
       }
     }
     if (!updated) {

--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -149,7 +149,9 @@ function URDFViewer({ config, saveConfig }: Props) {
   const { topics } = PanelAPI.useDataSourceInfo();
   const topicOptions = useMemo(() => {
     const options = filterMap(topics, ({ name, datatype }) =>
-      datatype === "sensor_msgs/JointState" ? { key: name, text: name } : undefined,
+      datatype === "sensor_msgs/JointState" || datatype === "sensor_msgs/msg/JointState"
+        ? { key: name, text: name }
+        : undefined,
     );
     // Include a custom option that may not be present (yet) in the list of topics
     if (

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -77,7 +77,7 @@ function DiagnosticStatusPanel(props: Props) {
       topicToRender={topicToRender}
       onChange={(newTopicToRender) => saveConfig({ topicToRender: newTopicToRender })}
       topics={topics}
-      singleTopicDatatype={"diagnostic_msgs/DiagnosticArray"}
+      allowedDatatypes={["diagnostic_msgs/DiagnosticArray", "diagnostic_msgs/msg/DiagnosticArray"]}
       defaultTopicToRender={DIAGNOSTIC_TOPIC}
     />
   );

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -155,7 +155,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
       topicToRender={topicToRender}
       onChange={(newTopicToRender) => saveConfig({ topicToRender: newTopicToRender })}
       topics={topics}
-      singleTopicDatatype={"diagnostic_msgs/DiagnosticArray"}
+      allowedDatatypes={["diagnostic_msgs/DiagnosticArray", "diagnostic_msgs/msg/DiagnosticArray"]}
       defaultTopicToRender={DIAGNOSTIC_TOPIC}
     />
   );

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -45,7 +45,15 @@ export const BUFFER_DURATION_SECS = 1.0;
 const getTopicsWithHeader = memoizeWeak((topics: Topic[], datatypes: RosDatatypes) => {
   return topics.filter(({ datatype }) => {
     const fields = datatypes.get(datatype)?.definitions;
-    return fields?.find((field) => field.type === "std_msgs/Header");
+    return (
+      // An unqualified "Header" is resolved as std_msgs/Header, per http://wiki.ros.org/msg
+      (fields?.[0]?.name === "header" && fields[0].type === "Header") ||
+      fields?.find(
+        (field) =>
+          field.name === "header" &&
+          (field.type === "std_msgs/Header" || field.type === "std_msgs/msg/Header"),
+      )
+    );
   });
 });
 

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -23,7 +23,6 @@ import {
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import debouncePromise from "@foxglove/studio-base/util/debouncePromise";
-import { VELODYNE_SCAN_DATATYPE } from "@foxglove/studio-base/util/globalConstants";
 import {
   fromMillis,
   addTimes,
@@ -40,7 +39,7 @@ export const DEFAULT_VELODYNE_PORT = 2369;
 const RPM = 600;
 const PROBLEM_SOCKET_ERROR = "SOCKET_ERROR";
 const TOPIC = "/velodyne_points";
-const TOPICS: Topic[] = [{ name: TOPIC, datatype: VELODYNE_SCAN_DATATYPE }];
+const TOPICS: Topic[] = [{ name: TOPIC, datatype: "velodyne_msgs/VelodyneScan" }];
 const DATATYPES: RosDatatypes = new Map(
   Object.entries({
     "velodyne_msgs/VelodyneScan": {

--- a/packages/studio-base/src/util/globalConstants.ts
+++ b/packages/studio-base/src/util/globalConstants.ts
@@ -18,26 +18,16 @@ export const TRANSFORM_TOPIC = "/tf";
 export const DIAGNOSTIC_TOPIC = "/diagnostics";
 export const SECOND_SOURCE_PREFIX = "/studio_source_2";
 
-export const COLOR_RGBA_DATATYPE = "std_msgs/ColorRGBA";
-export const GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE = "geometry_msgs/PolygonStamped";
-export const NAV_MSGS_OCCUPANCY_GRID_DATATYPE = "nav_msgs/OccupancyGrid";
-export const NAV_MSGS_PATH_DATATYPE = "nav_msgs/Path";
-export const POINT_CLOUD_DATATYPE = "sensor_msgs/PointCloud2";
-export const POSE_STAMPED_DATATYPE = "geometry_msgs/PoseStamped";
-export const SENSOR_MSGS_LASER_SCAN_DATATYPE = "sensor_msgs/LaserScan";
-export const TRANSFORM_STAMPED_DATATYPE = "geometry_msgs/TransformStamped";
-export const TF_DATATYPE = "tf/tfMessage";
-export const TF2_DATATYPE = "tf2_msgs/TFMessage";
-export const VELODYNE_SCAN_DATATYPE = "velodyne_msgs/VelodyneScan";
-export const VISUALIZATION_MSGS_MARKER_DATATYPE = "visualization_msgs/Marker";
-export const VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE = "visualization_msgs/MarkerArray";
+export const TRANSFORM_STAMPED_DATATYPES = [
+  "geometry_msgs/TransformStamped",
+  "geometry_msgs/msg/TransformStamped",
+];
+export const TF_DATATYPES = ["tf/tfMessage", "tf2_msgs/TFMessage", "tf2_msgs/msg/TFMessage"];
 
 export const FOXGLOVE_GRID_TOPIC = "/foxglove/grid";
 export const FOXGLOVE_GRID_DATATYPE = "foxglove/Grid";
 
 export const ROBOT_DESCRIPTION_PARAM = "/robot_description";
-
-export const MARKER_ARRAY_DATATYPES = [VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE];
 
 export const COLORS = {
   RED: { r: 1.0, g: 0.2, b: 0.2, a: 1.0 },

--- a/packages/studio-base/src/util/globalConstants.ts
+++ b/packages/studio-base/src/util/globalConstants.ts
@@ -14,15 +14,8 @@ import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 export const DEFAULT_STUDIO_NODE_PREFIX = "/studio_node/";
 
-export const TRANSFORM_TOPIC = "/tf";
 export const DIAGNOSTIC_TOPIC = "/diagnostics";
 export const SECOND_SOURCE_PREFIX = "/studio_source_2";
-
-export const TRANSFORM_STAMPED_DATATYPES = [
-  "geometry_msgs/TransformStamped",
-  "geometry_msgs/msg/TransformStamped",
-];
-export const TF_DATATYPES = ["tf/tfMessage", "tf2_msgs/TFMessage", "tf2_msgs/msg/TFMessage"];
 
 export const FOXGLOVE_GRID_TOPIC = "/foxglove/grid";
 export const FOXGLOVE_GRID_DATATYPE = "foxglove/Grid";

--- a/packages/studio-base/src/util/rosDatatypesToMessageDefinitions.test.ts
+++ b/packages/studio-base/src/util/rosDatatypesToMessageDefinitions.test.ts
@@ -14,10 +14,6 @@
 import { uniqBy } from "lodash";
 
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
-import {
-  VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
-  VISUALIZATION_MSGS_MARKER_DATATYPE,
-} from "@foxglove/studio-base/util/globalConstants";
 
 import { basicDatatypes } from "./datatypes";
 import rosDatatypesToMessageDefinition from "./rosDatatypesToMessageDefinition";
@@ -25,14 +21,14 @@ import rosDatatypesToMessageDefinition from "./rosDatatypesToMessageDefinition";
 describe("rosDatatypesToMessageDefinition", () => {
   it(`Includes all of the definitions for "visualization_msgs/StudioMarkerArray"`, () => {
     expect(
-      rosDatatypesToMessageDefinition(basicDatatypes, VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE),
+      rosDatatypesToMessageDefinition(basicDatatypes, "visualization_msgs/MarkerArray"),
     ).toMatchSnapshot();
   });
 
   it("produces a correct message definition", () => {
     const definitions = rosDatatypesToMessageDefinition(
       basicDatatypes,
-      VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE,
+      "visualization_msgs/MarkerArray",
     );
     // Should have 1 definition without a name, the root datatype.
     expect(definitions.filter(({ name }) => name == undefined).length).toEqual(1);
@@ -43,14 +39,14 @@ describe("rosDatatypesToMessageDefinition", () => {
   it("Errors if it can't find the definition", () => {
     const datatypes: RosDatatypes = new Map(
       Object.entries({
-        [VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE]: {
+        ["visualization_msgs/MarkerArray"]: {
           definitions: [
             {
               isArray: true,
               isComplex: true,
               arrayLength: undefined,
               name: "markers",
-              type: VISUALIZATION_MSGS_MARKER_DATATYPE,
+              type: "visualization_msgs/Marker",
             },
             {
               isArray: false,
@@ -63,9 +59,9 @@ describe("rosDatatypesToMessageDefinition", () => {
       }),
     );
     expect(() =>
-      rosDatatypesToMessageDefinition(datatypes, VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE),
+      rosDatatypesToMessageDefinition(datatypes, "visualization_msgs/MarkerArray"),
     ).toThrow(
-      `While searching datatypes for "${VISUALIZATION_MSGS_MARKER_ARRAY_DATATYPE}", could not find datatype "std_msgs/CustomHeader"`,
+      'While searching datatypes for "visualization_msgs/MarkerArray", could not find datatype "std_msgs/CustomHeader"',
     );
   });
 });


### PR DESCRIPTION
**User-Facing Changes**
Panels that support only certain datatypes now recognize ROS 2–style datatype names (for example `sensor_msgs/msg/Image` instead of `sensor_msgs/Image`). This improves compatibility with ROS 2 WebSocket connections, bags, and forthcoming native connections.

**Description**
Fixes #1633 by changing various hard-coded definitions to include /msg/ as well.

See also:
- https://github.com/foxglove/rosmsg/pull/12
- https://github.com/RobotWebTools/rosbridge_suite/pull/584