### PR TITLE
Fix layout bug when cancelling drag operations out of tab panels

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { isEmpty, isEqual, dropRight, pick } from "lodash";
+import { isEmpty, isEqual, pick } from "lodash";
 import {
   updateTree,
   createDragToUpdates,
@@ -607,6 +607,7 @@ const startDrag = (
   panelsState: PanelsState,
   { path, sourceTabId }: StartDragPayload,
 ): PanelsState => {
+  // Collapse or remove the panel being dragged so it's temporarily hidden from the layout.
   if (path.length > 0) {
     if (sourceTabId != undefined) {
       const tabConfig = panelsState.configById[sourceTabId] as TabPanelConfig;
@@ -737,10 +738,9 @@ const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsS
     return changePanelLayout(panelsState, { layout: newLayout, trimConfigById: false });
   }
 
-  const newLayout = updateTree(originalLayout, [
-    { path: dropRight(ownPath), spec: { splitPercentage: { $set: undefined } } },
-  ]);
-  return changePanelLayout(panelsState, { layout: newLayout, trimConfigById: false });
+  // The drag was canceled; restore the original layout to re-show/re-add the dragged panel.
+  // This undoes the effects of startDrag().
+  return { ...panelsState, layout: originalLayout, configById: originalSavedProps };
 };
 
 export default function (panelsState: PanelsState, action: PanelsActions): PanelsState {


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where panels would sometimes permanently disappear from the layout when being dragged out of Tab layouts.

**Description**
Fixes https://github.com/foxglove/studio/issues/1639

The logic in startDrag() hides a panel for the duration of the drag operation by adjusting the split percentage to 0/100. If the panel is at the root of a nested mosaic (a tab panel) then the panel is completely removed, because there's no split percentage setting at the root.

The logic in endDrag() was able to readjust the split percentage for normal cases, but did not properly support canceling drags from inside tab panels. In some cases this would cause a crash and in some cases it would result in the panel silently disappearing.

I started fixing the edge cases, but then realized `originalLayout` and `originalSavedProps` are already included in the endDrag payload, so it seems cleaner to just revert the layout to exactly the state it was in before startDrag(). The likelihood that other updates happen in between to make the originalLayout/originalSavedProps stale seems low since a drag is (from the user perspective) a synchronous operation.
