### PR TITLE
Fix: filter plot panel datasets to view bounds

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -758,7 +758,9 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
 
   const downsampledData = useMemo(() => {
     if (resumeFrame.current) {
-      log.warn("force resumed paused frame");
+      if (process.env.NODE_ENV === "development") {
+        log.warn("force resumed paused frame");
+      }
       resumeFrame.current();
     }
     // during streaming the message pipeline should not give us any more data until we finish

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -232,7 +232,6 @@ function getDatasetAndTooltipsFromMessagePlotPath(
   const dataset: DataSet = {
     borderColor,
     label: path.value ? path.value : uuidv4(),
-    key: datasetKey,
     showLine,
     fill: false,
     borderWidth: 1,

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -397,7 +397,7 @@ InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
 
 LineGraphAfterZoom.storyName = "line graph after zoom";
 export function LineGraphAfterZoom(): JSX.Element {
-  const pauseState = useRef<"zoom" | "ready">("zoom");
+  const pauseState = useRef<"init" | "zoom" | "ready">("init");
   const readyState = useReadySignal();
 
   const doZoom = useCallback(() => {
@@ -416,6 +416,9 @@ export function LineGraphAfterZoom(): JSX.Element {
   const pauseFrame = useCallback(() => {
     return () => {
       switch (pauseState.current) {
+        case "init":
+          pauseState.current = "zoom";
+          break;
         case "zoom":
           doZoom();
           break;

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -11,7 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { TooltipItem } from "@foxglove/studio-base/components/TimeBasedChart";
+import { ComponentProps } from "react";
+
+import TimeBasedChart, { TooltipItem } from "@foxglove/studio-base/components/TimeBasedChart";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 export type BasePlotPath = {
@@ -28,19 +30,7 @@ export type PlotChartPoint = {
   y: number;
 };
 
-export type DataSet = {
-  borderColor: string;
-  borderWidth: number;
-  data: Array<PlotChartPoint>;
-  fill: boolean;
-  key: string;
-  label: string;
-  pointBackgroundColor: string;
-  pointBorderColor: string;
-  pointHoverRadius: number;
-  pointRadius: number;
-  showLine: boolean;
-};
+export type DataSet = ComponentProps<typeof TimeBasedChart>["data"]["datasets"][0];
 
 export type PlotDataByPath = {
   [path: string]: readonly (readonly TooltipItem[])[];


### PR DESCRIPTION
**User-Facing Changes**
When using a streaming data source and a follow window size, the plot panel no longer lags as the datasource continues to stream.

**Description**
Rather than sending the entire dataset to the PlotChart and subsequent
TimeBasedChart and Chart components, filter the dataset down to the
items in the settings display.

Fixes: #1641

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
