### PR TITLE
RosbridgePlayer: detect ROS version automatically based on datatype names

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -33,12 +33,8 @@ export default function Root(): ReactElement {
       type: "ros1-socket",
     },
     {
-      name: "ROS 1 Rosbridge (WebSocket)",
-      type: "ros1-rosbridge-websocket",
-    },
-    {
-      name: "ROS 2 Rosbridge (WebSocket)",
-      type: "ros2-rosbridge-websocket",
+      name: "Rosbridge (WebSocket)",
+      type: "rosbridge-websocket",
     },
     {
       name: "ROS 1 Bag (local)",

--- a/packages/studio-base/src/components/ConnectionList.tsx
+++ b/packages/studio-base/src/components/ConnectionList.tsx
@@ -57,8 +57,7 @@ export default function ConnectionList(): JSX.Element {
           case "ros1-socket":
             iconName = "studio.ROS";
             break;
-          case "ros1-rosbridge-websocket":
-          case "ros2-rosbridge-websocket":
+          case "rosbridge-websocket":
             iconName = "Flow";
             break;
           case "ros1-remote-bagfile":

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -296,24 +296,11 @@ async function rosbridgeSource(options: FactoryOptions) {
     return undefined;
   }
 
-  let rosVersion: 1 | 2;
-  switch (options.source.type) {
-    case "ros1-rosbridge-websocket":
-      rosVersion = 1;
-      break;
-    case "ros2-rosbridge-websocket":
-      rosVersion = 2;
-      break;
-    default:
-      throw new Error(`Invalid source type for rosbridge: ${options.source.type}`);
-  }
-
   const url = maybeUrl;
   options.storage.setItem(storageCacheKey, url);
   return async (playerOptions: BuildPlayerOptions) => ({
     player: new RosbridgePlayer({
       url,
-      rosVersion,
       metricsCollector: playerOptions.metricsCollector,
     }),
     sources: [url],
@@ -505,8 +492,7 @@ export default function PlayerManager({
         return localRosbag2FolderSource;
       case "ros1-socket":
         return roscoreSource;
-      case "ros1-rosbridge-websocket":
-      case "ros2-rosbridge-websocket":
+      case "rosbridge-websocket":
         return rosbridgeSource;
       case "ros1-remote-bagfile":
         return remoteBagFileSource;

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -8,8 +8,7 @@ type SourceTypes =
   | "ros1-local-bagfile"
   | "ros2-local-bagfile"
   | "ros1-socket"
-  | "ros1-rosbridge-websocket"
-  | "ros2-rosbridge-websocket"
+  | "rosbridge-websocket"
   | "ros1-remote-bagfile"
   | "velodyne-device";
 

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -136,7 +136,6 @@ describe("RosbridgePlayer", () => {
   beforeEach(() => {
     player = new RosbridgePlayer({
       url: "ws://some-url",
-      rosVersion: 1,
       metricsCollector: new NoopMetricsCollector(),
     });
   });

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -192,12 +192,7 @@ export default class RosbridgePlayer implements Player {
       // Automatically detect the ROS version based on the datatypes.
       // The rosbridge server itself publishes /rosout so the topic should be reliably present.
       let rosVersion: 1 | 2;
-      if (
-        // We have to check for rcl_interfaces/Log because the rcl get_topic_names_and_types API
-        // returns the datatype names without /msg/, and the rosbridge server simply forwards them.
-        result.types.includes("rcl_interfaces/msg/Log") ||
-        result.types.includes("rcl_interfaces/Log")
-      ) {
+      if (result.types.includes("rcl_interfaces/msg/Log")) {
         rosVersion = 2;
         this._problems.removeProblem("unknownRosVersion");
       } else if (result.types.includes("rosgraph_msgs/Log")) {

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -193,6 +193,8 @@ export default class RosbridgePlayer implements Player {
       // The rosbridge server itself publishes /rosout so the topic should be reliably present.
       let rosVersion: 1 | 2;
       if (
+        // We have to check for rcl_interfaces/Log because the rcl get_topic_names_and_types API
+        // returns the datatype names without /msg/, and the rosbridge server simply forwards them.
         result.types.includes("rcl_interfaces/msg/Log") ||
         result.types.includes("rcl_interfaces/Log")
       ) {

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -58,7 +58,6 @@ const CAPABILITIES = [PlayerCapabilities.advertise];
 // unmarshalls into plain JS objects.
 export default class RosbridgePlayer implements Player {
   private _url: string; // WebSocket URL.
-  private _rosVersion: 1 | 2;
   private _rosClient?: roslib.Ros; // The roslibjs client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player.
   private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
@@ -94,17 +93,14 @@ export default class RosbridgePlayer implements Player {
 
   constructor({
     url,
-    rosVersion,
     metricsCollector,
   }: {
     url: string;
-    rosVersion: 1 | 2;
     metricsCollector: PlayerMetricsCollectorInterface;
   }) {
     this._presence = PlayerPresence.CONSTRUCTING;
     this._metricsCollector = metricsCollector;
     this._url = url;
-    this._rosVersion = rosVersion;
     this._start = fromMillis(Date.now());
     this._metricsCollector.playerConstructed();
     this._open();
@@ -193,6 +189,26 @@ export default class RosbridgePlayer implements Player {
       const datatypeDescriptions = [];
       const messageReaders: Record<string, LazyMessageReader | ROS2MessageReader> = {};
 
+      // Automatically detect the ROS version based on the datatypes.
+      // The rosbridge server itself publishes /rosout so the topic should be reliably present.
+      let rosVersion: 1 | 2;
+      if (
+        result.types.includes("rcl_interfaces/msg/Log") ||
+        result.types.includes("rcl_interfaces/Log")
+      ) {
+        rosVersion = 2;
+        this._problems.removeProblem("unknownRosVersion");
+      } else if (result.types.includes("rosgraph_msgs/Log")) {
+        rosVersion = 1;
+        this._problems.removeProblem("unknownRosVersion");
+      } else {
+        rosVersion = 1;
+        this._problems.addProblem("unknownRosVersion", {
+          severity: "warn",
+          message: "Unable to detect ROS version, assuming ROS 1",
+        });
+      }
+
       for (let i = 0; i < result.topics.length; i++) {
         const topicName = result.topics[i]!;
         const type = result.types[i];
@@ -205,10 +221,10 @@ export default class RosbridgePlayer implements Player {
         topics.push({ name: topicName, datatype: type });
         datatypeDescriptions.push({ type, messageDefinition });
         const parsedDefinition = parseMessageDefinition(messageDefinition, {
-          ros2: this._rosVersion === 2,
+          ros2: rosVersion === 2,
         });
         messageReaders[type] ??=
-          this._rosVersion === 1
+          rosVersion === 1
             ? new LazyMessageReader(parsedDefinition)
             : new ROS2MessageReader(parsedDefinition);
         this._parsedMessageDefinitionsByTopic[topicName] = parsedDefinition;
@@ -236,7 +252,7 @@ export default class RosbridgePlayer implements Player {
 
       this._providerTopics = sortedTopics;
       this._providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
-        ros2: this._rosVersion === 2,
+        ros2: rosVersion === 2,
       });
       this._messageReadersByDatatype = messageReaders;
 

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -37,12 +37,8 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
       ),
     },
     {
-      name: "ROS 1 Rosbridge (WebSocket)",
-      type: "ros1-rosbridge-websocket",
-    },
-    {
-      name: "ROS 2 Rosbridge (WebSocket)",
-      type: "ros2-rosbridge-websocket",
+      name: "Rosbridge (WebSocket)",
+      type: "rosbridge-websocket",
     },
     {
       name: "ROS 1 Bag (local)",


### PR DESCRIPTION
**User-Facing Changes**
None (not shipped yet)

**Description**
Resolves #1654. Use the datatype names to detect ROS version.

~We have to check for `rcl_interfaces/Log` rather than `rcl_interfaces/msg/Log` because the rcl `get_topic_names_and_types` API returns the datatype names in this format, and the rosbridge server simply forwards them. So although https://github.com/RobotWebTools/rosbridge_suite/pull/584 included `/msg/` in the type definitions, the top-level type _names_ do not include it. 😕~ This is fixed in https://github.com/RobotWebTools/rosbridge_suite/pull/591 and will be released in https://github.com/ros/rosdistro/pull/30499.