### PR TITLE
Feature: add dataSourceType to extension api RenderState

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -208,6 +208,13 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       }
     }
 
+    if (watchedFieldsRef.current.has("dataSourceType")) {
+      if (renderState.dataSourceType !== ctx.playerState.type) {
+        renderState.dataSourceType = ctx.playerState.type;
+        shouldRender = true;
+      }
+    }
+
     if (!shouldRender) {
       return;
     }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -260,6 +260,7 @@ export default class Ros1Player implements Player {
     if (!providerTopics || !start) {
       return this._listener({
         presence: this._presence,
+        type: "ros1",
         progress: {},
         capabilities: CAPABILITIES,
         playerId: this._id,
@@ -279,6 +280,7 @@ export default class Ros1Player implements Player {
     this._parsedMessages = [];
     return this._listener({
       presence: this._presence,
+      type: "ros1",
       progress: {},
       capabilities: CAPABILITIES,
       playerId: this._id,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -90,6 +90,7 @@ export default class RosbridgePlayer implements Player {
   private _hasReceivedMessage = false;
   private _presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
   private _problems = new PlayerProblemManager();
+  private _rosVersion: 1 | 2 = 1;
 
   constructor({
     url,
@@ -191,15 +192,14 @@ export default class RosbridgePlayer implements Player {
 
       // Automatically detect the ROS version based on the datatypes.
       // The rosbridge server itself publishes /rosout so the topic should be reliably present.
-      let rosVersion: 1 | 2;
       if (result.types.includes("rcl_interfaces/msg/Log")) {
-        rosVersion = 2;
+        this._rosVersion = 2;
         this._problems.removeProblem("unknownRosVersion");
       } else if (result.types.includes("rosgraph_msgs/Log")) {
-        rosVersion = 1;
+        this._rosVersion = 1;
         this._problems.removeProblem("unknownRosVersion");
       } else {
-        rosVersion = 1;
+        this._rosVersion = 1;
         this._problems.addProblem("unknownRosVersion", {
           severity: "warn",
           message: "Unable to detect ROS version, assuming ROS 1",
@@ -218,10 +218,10 @@ export default class RosbridgePlayer implements Player {
         topics.push({ name: topicName, datatype: type });
         datatypeDescriptions.push({ type, messageDefinition });
         const parsedDefinition = parseMessageDefinition(messageDefinition, {
-          ros2: rosVersion === 2,
+          ros2: this._rosVersion === 2,
         });
         messageReaders[type] ??=
-          rosVersion === 1
+          this._rosVersion === 1
             ? new LazyMessageReader(parsedDefinition)
             : new ROS2MessageReader(parsedDefinition);
         this._parsedMessageDefinitionsByTopic[topicName] = parsedDefinition;
@@ -249,7 +249,7 @@ export default class RosbridgePlayer implements Player {
 
       this._providerTopics = sortedTopics;
       this._providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
-        ros2: rosVersion === 2,
+        ros2: this._rosVersion === 2,
       });
       this._messageReadersByDatatype = messageReaders;
 
@@ -297,6 +297,7 @@ export default class RosbridgePlayer implements Player {
     if (!_providerTopics || !_providerDatatypes || !_start) {
       return this._listener({
         presence: this._presence,
+        type: this._rosVersion === 2 ? "ros2" : "ros1",
         progress: {},
         capabilities: CAPABILITIES,
         playerId: this._id,
@@ -316,6 +317,7 @@ export default class RosbridgePlayer implements Player {
     this._parsedMessages = [];
     return this._listener({
       presence: this._presence,
+      type: this._rosVersion === 2 ? "ros2" : "ros1",
       progress: {},
       capabilities: CAPABILITIES,
       playerId: this._id,

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -210,6 +210,7 @@ export default class VelodynePlayer implements Player {
     this._parsedMessages = [];
     return this._listener({
       presence: this._presence,
+      type: "velodyne",
       progress: {},
       capabilities: CAPABILITIES,
       playerId: this._id,

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -112,6 +112,9 @@ export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.
   presence: PlayerPresence;
 
+  // Optional player type
+  type?: string;
+
   // Show some sort of progress indication in the playback bar; see `type Progress` for more details.
   // TODO(JP): Maybe we should unify some progress and the other initialization fields above into
   // one "status" object?

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -50,6 +50,14 @@ declare module "@foxglove/studio" {
      * to other panels where the user is currently hovering and allow them to render accordingly.
      */
     previewTime?: number | undefined;
+
+    /**
+     * Indicates the type of the data source when a data source is present. The type varies by data source.
+     *
+     * I.E. A data source would indicate "ros1" or "ros2" if it is a ROS 1 or 2 data source. This
+     * allows logic to condition on specific data sources.
+     */
+    dataSourceType?: string;
   }
 
   export type PanelExtensionContext = {


### PR DESCRIPTION
**User-Facing Changes**
Extension authors can subscribe to changes on dataSourceType to conditionally support different data sources.

**Description**
Some panels need to configure support for different data sources in different ways. For example the Teleop panel
needs to know whether the data source is ros1 or ros2 to select the correct datatype for publishing.

This change adds a `dataSourceType` field to RenderState. This field is a freeform string which the datasource is able
to populate with an arbitrary value. It is up to the data source to specify which values it provides and up to panels to
handle those values.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
