### PR TITLE
Configure SentryWebpackPlugin to associate commits with the release

### DIFF
--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -39,9 +39,10 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         release: `${process.env.SENTRY_PROJECT}@${packageJson.version}`,
-        setCommits: process.env.SENTRY_CURRENT_COMMIT
-          ? { repo: "foxglove/studio", commit: process.env.SENTRY_CURRENT_COMMIT }
-          : undefined,
+        setCommits:
+          process.env.SENTRY_REPO && process.env.SENTRY_CURRENT_COMMIT
+            ? { repo: process.env.SENTRY_REPO, commit: process.env.SENTRY_CURRENT_COMMIT }
+            : undefined,
 
         // Since the render config appears last in the list of webpack configs, we use it to upload
         // all the source maps under .webpack (main and renderer).

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -39,6 +39,9 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         release: `${process.env.SENTRY_PROJECT}@${packageJson.version}`,
+        setCommits: process.env.SENTRY_CURRENT_COMMIT
+          ? { repo: "foxglove/studio", commit: process.env.SENTRY_CURRENT_COMMIT }
+          : undefined,
 
         // Since the render config appears last in the list of webpack configs, we use it to upload
         // all the source maps under .webpack (main and renderer).

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -76,6 +76,9 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         include: path.resolve(__dirname, ".webpack"),
+        setCommits: process.env.SENTRY_CURRENT_COMMIT
+          ? { repo: "foxglove/studio", commit: process.env.SENTRY_CURRENT_COMMIT }
+          : undefined,
       }),
     );
   }

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -76,9 +76,10 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         include: path.resolve(__dirname, ".webpack"),
-        setCommits: process.env.SENTRY_CURRENT_COMMIT
-          ? { repo: "foxglove/studio", commit: process.env.SENTRY_CURRENT_COMMIT }
-          : undefined,
+        setCommits:
+          process.env.SENTRY_REPO && process.env.SENTRY_CURRENT_COMMIT
+            ? { repo: process.env.SENTRY_REPO, commit: process.env.SENTRY_CURRENT_COMMIT }
+            : undefined,
       }),
     );
   }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Trying to get commits associated with our Sentry releases, as described in: https://docs.sentry.io/product/releases/suspect-commits/