### PR TITLE
Feature: add publish rate setting to Teleop panel

### DIFF
--- a/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/DirectionalPad.stories.tsx
@@ -12,5 +12,5 @@ export default {
 };
 
 export const Basic = (): JSX.Element => {
-  return <DirectionalPad onClick={action("click")} />;
+  return <DirectionalPad onAction={action("click")} />;
 };

--- a/packages/studio-base/src/panels/Teleop/DirectionalPad.tsx
+++ b/packages/studio-base/src/panels/Teleop/DirectionalPad.tsx
@@ -111,12 +111,12 @@ export enum DirectionalPadAction {
 }
 
 type DirectionalPadProps = {
-  onClick?: (action: DirectionalPadAction) => void;
+  onAction?: (action?: DirectionalPadAction) => void;
   disableStop?: boolean;
 };
 
 function DirectionalPad(props: DirectionalPadProps): JSX.Element {
-  const { onClick, disableStop = true } = props;
+  const { onAction, disableStop = true } = props;
 
   const [currentAction, setCurrentAction] = useState<DirectionalPadAction | undefined>();
 
@@ -127,15 +127,23 @@ function DirectionalPad(props: DirectionalPadProps): JSX.Element {
   const handleMouseDown = useCallback(
     (action: DirectionalPadAction) => {
       setCurrentAction(action);
-      onClick?.(action);
+      onAction?.(action);
     },
-    [onClick],
+    [onAction],
   );
+
+  const handleMouseUp = useCallback(() => {
+    if (currentAction == undefined) {
+      return;
+    }
+    setCurrentAction(undefined);
+    onAction?.();
+  }, [onAction, currentAction]);
 
   const makeMouseHandlers = (action: DirectionalPadAction) => ({
     onMouseDown: () => handleMouseDown(action),
-    onMouseUp: () => setCurrentAction(undefined),
-    onMouseLeave: () => setCurrentAction(undefined),
+    onMouseUp: () => handleMouseUp(),
+    onMouseLeave: () => handleMouseUp(),
   });
 
   return (

--- a/packages/studio-base/src/panels/Teleop/Settings.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/Settings.stories.tsx
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { action } from "@storybook/addon-actions";
+
+import Settings from "./Settings";
+import { Config } from "./types";
+
+export default {
+  title: "panels/Teleop/Settings",
+  component: Settings,
+};
+
+export const Basic = (): JSX.Element => {
+  const config: Config = {
+    topic: "/topic",
+    publishRate: 1,
+    upButton: { field: "linear-x", value: 1 },
+    downButton: { field: "linear-x", value: -1 },
+    leftButton: { field: "angular-z", value: 1 },
+    rightButton: { field: "angular-z", value: -1 },
+  };
+  return (
+    <div>
+      <Settings topics={["/foo"]} onConfigChange={action("onConfigChange")} config={config} />
+    </div>
+  );
+};

--- a/packages/studio-base/src/panels/Teleop/Settings.tsx
+++ b/packages/studio-base/src/panels/Teleop/Settings.tsx
@@ -94,6 +94,33 @@ export default function Settings(props: SettingsProps): JSX.Element {
           />
         </Stack>
       </StackItem>
+      <StackItem>
+        <TextField
+          type="number"
+          label="Publish Rate (Hz)"
+          defaultValue={String(config.publishRate)}
+          styles={{ root: { width: 80 } }}
+          onGetErrorMessage={(value) => {
+            const num = +value;
+            if (isNaN(num)) {
+              return "Not a valid number";
+            } else if (num < 0) {
+              return "Must be a positive number";
+            }
+
+            return;
+          }}
+          onChange={(_ev, value) => {
+            if (!value || isNaN(+value)) {
+              return;
+            }
+
+            saveConfig({
+              publishRate: +value,
+            });
+          }}
+        />
+      </StackItem>
       <StackItem grow>
         <Stack horizontal verticalAlign="end" tokens={{ childrenGap: theme.spacing.m }}>
           <StackItem grow>

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -2,7 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Story, StoryContext } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -12,9 +13,9 @@ export default {
   title: "panels/Teleop/index",
   component: TeleopPanel,
   decorators: [
-    (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
+    (StoryComponent: Story): JSX.Element => {
       return (
-        <PanelSetup fixture={parameters.panelSetup?.fixture}>
+        <PanelSetup fixture={{ publish: action("publish") }}>
           <StoryComponent />
         </PanelSetup>
       );

--- a/packages/studio-base/src/panels/Teleop/types.ts
+++ b/packages/studio-base/src/panels/Teleop/types.ts
@@ -8,6 +8,7 @@ export type DeepPartial<T> = {
 
 export type Config = {
   topic?: string;
+  publishRate: number;
   upButton: {
     field: string;
     value: number;


### PR DESCRIPTION

**User-Facing Changes**
The user can change the publish rate within the settings of the Teleop panel. When the user clicks a directional button a message is published. If the user continues pressing a directional button, the message will continue to publish at their configured rate in Hz.

**Description**
The publish rate allows the user to configure how often the panel
will send the teleop message when the user continues to hold down
a particular directional button.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
