### PR TITLE
Don't sync layouts when feature flag is disabled

### DIFF
--- a/packages/studio-base/src/providers/ConsoleApiLayoutStorageProvider.tsx
+++ b/packages/studio-base/src/providers/ConsoleApiLayoutStorageProvider.tsx
@@ -60,7 +60,8 @@ export default function ConsoleApiLayoutStorageProvider({
   const visibilityState = useVisibilityState();
 
   // Sync periodically when logged in, online, and the app is not hidden
-  const enableSyncing = currentUser != undefined && online && visibilityState === "visible";
+  const enableSyncing =
+    enableConsoleApiLayouts && currentUser != undefined && online && visibilityState === "visible";
   useEffect(() => {
     if (enableSyncing) {
       void sync();


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
@wkalt and @defunctzombie discovered a bug where if the user had previously logged in but then disabled the team layouts feature flag, syncing would still occur. Fix by disabling syncing when the feature flag is disabled.