### PR TITLE
Fix: State transitions plot alignment

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -231,8 +231,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return [grey, ...lineColors];
   }, []);
 
-  const { datasets, tooltips, maxY } = useMemo(() => {
-    let outMaxY: number | undefined;
+  const { datasets, tooltips, minY } = useMemo(() => {
+    let outMinY: number | undefined;
 
     const outTooltips: TimeBasedChartTooltipData[] = [];
     const outDatasets: typeof data["datasets"] = [];
@@ -244,6 +244,12 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       let prevQueryValue;
       let previousTimestamp;
       let currentData: typeof outDatasets[0]["data"] = [];
+
+      // y axis values are set based on the path we are rendering
+      // negative makes each path render below the previous
+      const y = (pathIndex + 1) * 6 * -1;
+      outMinY = Math.min(outMinY ?? y, y - 3);
+
       for (const itemByPath of itemsByPath[pathValue] ?? []) {
         const item = getTooltipItemForMessageHistoryItem(itemByPath);
         const timestamp = timestampMethod === "headerStamp" ? item.headerStamp : item.receiveTime;
@@ -283,10 +289,6 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
           baseColors[positiveModulo(valueForColor, Object.values(baseColors).length)] ?? "grey";
 
         const x = toSec(subtractTimes(timestamp, startTime));
-
-        // y axis values are set based on the path we are rendering
-        const y = (pathIndex + 1) * 6;
-        outMaxY = Math.max(outMaxY ?? y, y + 3);
 
         const element = {
           x,
@@ -352,7 +354,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     return {
       datasets: outDatasets,
       tooltips: outTooltips,
-      maxY: outMaxY,
+      minY: outMinY,
     };
   }, [baseColors, itemsByPath, paths, startTime]);
 
@@ -367,10 +369,10 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         display: false,
       },
       type: "linear",
-      min: 3,
-      max: maxY,
+      min: minY,
+      max: -3,
     };
-  }, [maxY]);
+  }, [minY]);
 
   const xScale = useMemo<ScaleOptions>(() => {
     return {


### PR DESCRIPTION


**User-Facing Changes**
When a user adds multiple state transitions to the state transitions panel they will see the correct transition under the correct legend item.

**Description**
The state transition panel was incorrectly calculating the placement
of individual state transition items. It would place the chart items
under the wrong legend item. This change fixes the calculation
to properly place the correct chart dataset under the appropriate legend.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
