### PR TITLE
Fix: styling on time based chart hover bar

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -105,14 +105,10 @@ const SBar = styled.div<{ xAxisIsPlaybackTime: boolean }>`
   position: absolute;
   top: 0;
   bottom: 0;
-  width: 9px;
-  margin-left: -4px;
+  width: 1px;
+  margin-left: -1px;
   display: block;
-  border-style: solid;
-  border-color: #f7be00 transparent;
-  background: ${(props) =>
-    props.xAxisIsPlaybackTime ? "#F7BE00 padding-box" : "#248EFF padding-box"};
-  border-width: ${(props) => (props.xAxisIsPlaybackTime ? "4px" : "0px 4px")};
+  background-color: ${(props) => (props.xAxisIsPlaybackTime ? "#F7BE00" : "#248EFF")};
 `;
 
 type ChartComponentProps = ComponentProps<typeof ChartComponent>;


### PR DESCRIPTION


**User-Facing Changes**
The hover bar for plot and state transitions no longer has the chevrons above and below. Instead we have a simple vertical line.

**Description**
On some browsers the styling for the hover bar is broken due to how
css is handled for the border width and padding border. Instead we use
a simple 1px wide line for the hover bar.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
