### PR TITLE
Internal: remove various uses of React.memo

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -162,9 +162,7 @@ type MessagePathInputBaseProps = {
   onTimestampMethodChange?: (arg0: TimestampMethod, index?: number) => void;
 };
 
-export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
-  props: MessagePathInputBaseProps,
-) {
+export default function MessagePathInput(props: MessagePathInputBaseProps): JSX.Element {
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
   const { datatypes, topics } = PanelAPI.useDataSourceInfo();
 
@@ -513,4 +511,4 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
       )}
     </div>
   );
-});
+}

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -581,7 +581,7 @@ export default function Panel<Config extends PanelConfig>(
     );
   }
 
-  return Object.assign(React.memo(ConnectedPanel), {
+  return Object.assign(ConnectedPanel, {
     defaultConfig: PanelComponent.defaultConfig,
     panelType: PanelComponent.panelType,
     displayName: `Panel(${PanelComponent.displayName ?? PanelComponent.name})`,

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -197,7 +197,7 @@ type PanelToolbarControlsProps = Pick<Props, "additionalIcons" | "floating"> & {
 
 // Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
 // whole PanelToolbar when only children change.
-const PanelToolbarControls = React.memo(function PanelToolbarControls({
+const PanelToolbarControls = function PanelToolbarControls({
   additionalIcons,
   showControls = false,
   floating = false,
@@ -236,12 +236,12 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
       )}
     </div>
   );
-});
+};
 
 // Panel toolbar should be added to any panel that's part of the
 // react-mosaic layout.  It adds a drag handle, remove/replace controls
 // and has a place to add custom controls via it's children property
-export default React.memo<Props>(function PanelToolbar({
+export default function PanelToolbar({
   additionalIcons,
   children,
   floating = false,
@@ -249,7 +249,7 @@ export default React.memo<Props>(function PanelToolbar({
   hideToolbars = false,
   isUnknownPanel = false,
   backgroundColor,
-}: Props) {
+}: Props): JSX.Element {
   const { supportsStrictMode = true } = useContext(PanelContext) ?? {};
   const [containsOpen, setContainsOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -283,7 +283,7 @@ export default React.memo<Props>(function PanelToolbar({
   });
 
   if (hideToolbars) {
-    return ReactNull;
+    return <></>;
   }
 
   // floating toolbars only show when hovered - but hovering over a context menu would hide the toolbar
@@ -314,4 +314,4 @@ export default React.memo<Props>(function PanelToolbar({
       </ChildToggleContainsOpen>
     </div>
   );
-});
+}

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -58,7 +58,7 @@ type Props = {
   componentId: string;
 };
 
-export default React.memo<Props>(function PlaybackBarHoverTicks({ componentId }: Props) {
+export default function PlaybackBarHoverTicks({ componentId }: Props): JSX.Element {
   const startTime = useMessagePipeline(getStartTime);
   const endTime = useMessagePipeline(getEndTime);
 
@@ -90,4 +90,4 @@ export default React.memo<Props>(function PlaybackBarHoverTicks({ componentId }:
       )}
     </div>
   );
-});
+}

--- a/packages/studio-base/src/components/SelectableTimestamp.tsx
+++ b/packages/studio-base/src/components/SelectableTimestamp.tsx
@@ -82,14 +82,14 @@ function getValidTime(timeStr: string, start: Time, end: Time, isRosTime: boolea
   return (validTime && clampTime(validTime, start, end)) || undefined;
 }
 
-export default React.memo<Props>(function SelectableTimestamp({
+export default function SelectableTimestamp({
   currentTime,
   startTime,
   endTime,
   seekPlayback,
   pausePlayback,
   timezone,
-}: Props) {
+}: Props): JSX.Element {
   const [rosTimeStr, setRosTimeStr] = React.useState<string>(
     `${currentTime.sec}.${currentTime.nsec}`,
   );
@@ -188,4 +188,4 @@ export default React.memo<Props>(function SelectableTimestamp({
       </TimestampWrapper>
     </SRoot>
   );
-});
+}

--- a/packages/studio-base/src/components/TimeBasedChart/HoverBar.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/HoverBar.tsx
@@ -33,12 +33,12 @@ type Props = {
   isTimestampScale: boolean;
 };
 
-export default React.memo<Props>(function HoverBar({
+export default function HoverBar({
   children,
   componentId,
   isTimestampScale,
   scales,
-}: Props) {
+}: Props): JSX.Element {
   const hoverValue = useHoverValue({ componentId, isTimestampScale });
 
   const positionX = useMemo(() => {
@@ -66,4 +66,4 @@ export default React.memo<Props>(function HoverBar({
   }, [positionX]);
 
   return <SWrapper style={{ visibility, transform }}>{children}</SWrapper>;
-});
+}

--- a/packages/studio-base/src/panels/Internals.tsx
+++ b/packages/studio-base/src/panels/Internals.tsx
@@ -88,7 +88,7 @@ type RecordedData = {
   };
 };
 
-const HistoryRecorder = React.memo(function HistoryRecorder({
+const HistoryRecorder = function HistoryRecorder({
   topicsByName,
   recordingTopics,
   recordedData,
@@ -103,7 +103,7 @@ const HistoryRecorder = React.memo(function HistoryRecorder({
     frame,
   };
   return ReactNull;
-});
+};
 
 // Display internal state for debugging and viewing topic dependencies.
 function Internals() {

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -238,7 +238,7 @@ const configSchema: PanelConfigSchema<Config> = [
 ];
 
 export default Panel(
-  Object.assign(React.memo(Publish), {
+  Object.assign(Publish, {
     panelType: "Publish",
     defaultConfig: {
       topicName: "",

--- a/packages/studio-base/src/panels/Rosout/LogMessage.tsx
+++ b/packages/studio-base/src/panels/Rosout/LogMessage.tsx
@@ -45,7 +45,7 @@ const classes = mergeStyleSets({
   },
 });
 
-export default React.memo(function LogMessage({ msg }: { msg: RosgraphMsgs$Log }) {
+export default function LogMessage({ msg }: { msg: RosgraphMsgs$Log }): JSX.Element {
   const altStr = `${msg.file}:${msg.line}`;
   const strLevel = LevelToString(msg.level);
   const levelClassName = logLevelColorsStyle[strLevel.toLocaleLowerCase()];
@@ -83,4 +83,4 @@ export default React.memo(function LogMessage({ msg }: { msg: RosgraphMsgs$Log }
       </div>
     </div>
   );
-});
+}

--- a/packages/studio-base/src/panels/Rosout/index.tsx
+++ b/packages/studio-base/src/panels/Rosout/index.tsx
@@ -38,7 +38,7 @@ type Props = {
   saveConfig: (arg0: Config) => void;
 };
 
-const RosoutPanel = React.memo(({ config, saveConfig }: Props) => {
+const RosoutPanel = ({ config, saveConfig }: Props) => {
   const { topics } = PanelAPI.useDataSourceInfo();
   const { minLogLevel, searchTerms } = config;
 
@@ -99,7 +99,7 @@ const RosoutPanel = React.memo(({ config, saveConfig }: Props) => {
       </Stack>
     </Stack>
   );
-});
+};
 
 RosoutPanel.displayName = "Rosout";
 

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -186,7 +186,7 @@ type Props = {
   saveConfig: (arg0: Partial<StateTransitionConfig>) => void;
 };
 
-const StateTransitions = React.memo(function StateTransitions(props: Props) {
+const StateTransitions = function StateTransitions(props: Props) {
   const { config, saveConfig } = props;
   const { paths } = config;
 
@@ -445,7 +445,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       </SChartContainerOuter>
     </SRoot>
   );
-});
+};
 
 export default Panel(
   Object.assign(StateTransitions, {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/index.tsx
@@ -39,7 +39,7 @@ function DrawingTools({
   onSetPolygons,
   polygonBuilder,
   showForTests,
-}: Props) {
+}: Props): JSX.Element {
   const [selectedTab, setSelectedTab] = React.useState<DrawingTabType | undefined>(
     defaultSelectedTab,
   );
@@ -48,7 +48,11 @@ function DrawingTools({
     AppSetting.ENABLE_DRAWING_POLYGONS,
   );
 
-  return enableDrawingPolygons || showForTests === true ? (
+  if (!enableDrawingPolygons && showForTests !== true) {
+    return <></>;
+  }
+
+  return (
     <ExpandingToolbar
       tooltip="Drawing tools"
       icon={
@@ -67,9 +71,7 @@ function DrawingTools({
         <Polygons onSetPolygons={onSetPolygons} polygonBuilder={polygonBuilder} />
       </ToolGroup>
     </ExpandingToolbar>
-  ) : (
-    ReactNull
   );
 }
 
-export default React.memo<Props>(DrawingTools);
+export default DrawingTools;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
@@ -51,7 +51,7 @@ type PropsWithConfig = Props & {
   saveConfig: SaveConfig<PanelConfig>;
 };
 
-const InteractionsBaseComponent = React.memo<PropsWithConfig>(function InteractionsBaseComponent({
+const InteractionsBaseComponent = function InteractionsBaseComponent({
   selectedObject,
   interactionsTabType,
   setInteractionsTabType,
@@ -121,7 +121,7 @@ const InteractionsBaseComponent = React.memo<PropsWithConfig>(function Interacti
       </ToolGroup>
     </ExpandingToolbar>
   );
-});
+};
 
 // Wrap the Interactions so that we don't rerender every time any part of the PanelContext config changes, but just the
 // one value that we care about.

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
@@ -86,7 +86,7 @@ function LayoutToolbar({
   targetPose,
   toggleSearchTextOpen,
   transforms,
-}: Props) {
+}: Props): JSX.Element {
   return (
     <>
       <MeasuringTool
@@ -158,4 +158,4 @@ function LayoutToolbar({
   );
 }
 
-export default React.memo<Props>(LayoutToolbar);
+export default LayoutToolbar;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
@@ -39,7 +39,7 @@ function MainToolbar({
   onToggleCameraMode,
   onToggleDebug,
   perspective = false,
-}: Props) {
+}: Props): JSX.Element {
   const cameraModeTip = perspective ? "Switch to 2D camera" : "Switch to 3D camera";
   const measureActive = measureState === "place-start" || measureState === "place-finish";
   return (
@@ -83,4 +83,4 @@ function MainToolbar({
   );
 }
 
-export default React.memo<Props>(MainToolbar);
+export default MainToolbar;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -214,7 +214,7 @@ export const useSearchMatches = ({
   ]);
 };
 
-const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
+const SearchText = function SearchText({
   searchTextOpen,
   toggleSearchTextOpen,
   searchText,
@@ -227,7 +227,7 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
   cameraState,
   transforms,
   rootTf,
-}: SearchTextComponentProps) {
+}: SearchTextComponentProps): JSX.Element {
   const currentMatch = searchTextMatches[selectedMatchIndex];
   const iterateCurrentIndex = useCallback(
     (iterator: number) => {
@@ -319,6 +319,6 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
       </Icon>
     </div>
   );
-});
+};
 
 export default SearchText;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
@@ -90,7 +90,7 @@ const SegmentedControlWrapper = styled.div`
   align-items: center;
 `;
 
-const RainbowText = React.memo(function RainbowText({ children }: { children: string }) {
+const RainbowText = function RainbowText({ children }: { children: string }) {
   return (
     <>
       {Array.from(children, (child, idx) => (
@@ -101,7 +101,7 @@ const RainbowText = React.memo(function RainbowText({ children }: { children: st
       ))}
     </>
   );
-});
+};
 
 export default function PointCloudSettingsEditor(
   props: TopicSettingsEditorProps<PointCloud2, PointCloudSettings>,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -14,7 +14,7 @@
 import { DefaultButton, Dialog, DialogFooter } from "@fluentui/react";
 import { isEmpty, omit } from "lodash";
 import Tabs, { TabPane } from "rc-tabs";
-import React, { useCallback } from "react";
+import { useCallback } from "react";
 
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
 import { RenderToBodyComponent } from "@foxglove/studio-base/components/RenderToBodyComponent";
@@ -91,7 +91,7 @@ function TopicSettingsModal({
   sceneBuilderMessage,
   setCurrentEditingTopic,
   settingsByKey,
-}: Props) {
+}: Props): JSX.Element {
   const topicSettingsKey = `t:${topicName}`;
   const onSettingsChange = useCallback(
     (
@@ -181,4 +181,4 @@ function TopicSettingsModal({
   );
 }
 
-export default React.memo<Props>(TopicSettingsModal);
+export default TopicSettingsModal;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
@@ -244,7 +244,7 @@ type BaseProps = SharedProps & {
   treeHeight: number;
 };
 
-function TopicTree({
+function TopicTreeInner({
   allKeys,
   availableNamespacesByTopic,
   checkedKeys,
@@ -466,7 +466,7 @@ function TopicTree({
 }
 
 // A wrapper that can be resized horizontally, and it dynamically calculates the width of the base topic tree component.
-function TopicTreeWrapper({
+function TopicTree({
   containerWidth,
   containerHeight,
   pinTopics,
@@ -475,7 +475,7 @@ function TopicTreeWrapper({
   saveConfig,
   setShowTopicTree,
   ...rest
-}: Props) {
+}: Props): JSX.Element {
   const defaultTreeWidth = clamp(containerWidth, DEFAULT_XS_WIDTH, DEFAULT_WIDTH);
   const renderTopicTree = pinTopics || showTopicTree;
 
@@ -514,7 +514,7 @@ function TopicTreeWrapper({
           unmountOnExit
         >
           <STopicTree onClick={(e) => e.stopPropagation()}>
-            <TopicTree
+            <TopicTreeInner
               {...rest}
               sceneErrorsByKey={sceneErrorsByKey}
               saveConfig={saveConfig}
@@ -533,4 +533,4 @@ function TopicTreeWrapper({
   );
 }
 
-export default React.memo<Props>(TopicTreeWrapper);
+export default TopicTree;


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
With hooks memoization happens within the component so doing additional memoization
checks on the component will end up checking properties that would later be
checked for hook dependency arrays as well.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
