### PR TITLE
Change: put "Foxglove Studio" after the current source name

### DIFF
--- a/packages/studio-base/src/components/DocumentTitleAdapter.tsx
+++ b/packages/studio-base/src/components/DocumentTitleAdapter.tsx
@@ -17,7 +17,7 @@ export default function DocumentTitleAdapter(): JSX.Element {
       window.document.title = "Foxglove Studio";
       return;
     }
-    window.document.title = `Foxglove Studio - ${currentSourceName}`;
+    window.document.title = `${currentSourceName} - Foxglove Studio`;
   }, [currentSourceName]);
   return <></>;
 }


### PR DESCRIPTION
User Facing Changes:
The window title has "Foxglove Studio" after the current source name

Description:
To be consistent with other apps, put the app name after the current source name in the titlebar title.