### PR TITLE
Revert "Revert "Configure SentryWebpackPlugin to associate commits with the release (#1659)""

### DIFF
--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -39,6 +39,10 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         release: `${process.env.SENTRY_PROJECT}@${packageJson.version}`,
+        setCommits:
+          process.env.SENTRY_REPO && process.env.SENTRY_CURRENT_COMMIT
+            ? { repo: process.env.SENTRY_REPO, commit: process.env.SENTRY_CURRENT_COMMIT }
+            : undefined,
 
         // Since the render config appears last in the list of webpack configs, we use it to upload
         // all the source maps under .webpack (main and renderer).

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -76,6 +76,10 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
         org: process.env.SENTRY_ORG,
         project: process.env.SENTRY_PROJECT,
         include: path.resolve(__dirname, ".webpack"),
+        setCommits:
+          process.env.SENTRY_REPO && process.env.SENTRY_CURRENT_COMMIT
+            ? { repo: process.env.SENTRY_REPO, commit: process.env.SENTRY_CURRENT_COMMIT }
+            : undefined,
       }),
     );
   }


### PR DESCRIPTION
This reverts commit a6db559e270b9b5a0b8b73900e97c85eaef88540.

The root cause of the sentry cli error was upstream in action-bump-version: https://github.com/foxglove/action-bump-version/pull/3