### PR TITLE
studio-base package: include content hash in chunk filenames

### DIFF
--- a/packages/studio-base/.gitignore
+++ b/packages/studio-base/.gitignore
@@ -1,0 +1,2 @@
+# Webpack build output
+/assets

--- a/packages/studio-base/webpack.config.ts
+++ b/packages/studio-base/webpack.config.ts
@@ -40,7 +40,11 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
 
     output: {
       publicPath: "",
-      filename: "index.js",
+
+      // Output filenames should include content hashes in order to avoid caching issues with
+      // downstream users of the studio-base package.
+      filename: "[name].[contenthash].js",
+
       path: path.resolve(__dirname, "assets"),
       library: {
         type: "umd",

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -226,6 +226,10 @@ export function makeConfig(
       new MonacoWebpackPlugin({
         // available options: https://github.com/Microsoft/monaco-editor-webpack-plugin#options
         languages: ["typescript", "javascript"],
+
+        // Output filenames should include content hashes in order to avoid caching issues with
+        // downstream users of the studio-base package.
+        filename: "[name].worker.[contenthash].js",
       }),
       new ForkTsCheckerWebpackPlugin({
         typescript: {


### PR DESCRIPTION
**User-Facing Changes**
`@foxglove/studio-base` asset filenames now include content hashes to help mitigate caching issues.

**Description**
The webpack chunks included in the studio-base package on npm are mostly named numerically:

```
00aa018e3ae78d50160b.ttf	4740.index.js			7633.index.js
1023.index.js			4788.index.js			7680.index.js
135.index.js			485.index.js			769.index.js
1406.index.js			499d4e4e5cf9fce93f3d.wasm	7690.index.js
1565.index.js			5271.index.js			7719.index.js
1651.index.js			5419.index.js			7833.index.js
1721.index.js			553.index.js			798.index.js
1977.index.js			5825.index.js			806.index.js
2287.index.js			5836.index.js			8247.index.js
2475.index.js			5842.index.js			8435.index.js
2501.index.js			5900.index.js			8569.index.js
2af8195e6a0ea862f9c4.wasm	5995.index.js			8621.index.js
3052.index.js			5bb75ff49a85d6b67f21.wasm	8765.index.js
3220.index.js			6069.index.js			9008.index.js
3246.index.js			6324.index.js			9456.index.js
3278.index.js			6460.index.js			9646.index.js
3715.index.js			657.index.js			9691.index.js
3914.index.js			6635.index.js			9856.index.js
3976.index.js			6837.index.js			9894.index.js
4019.index.js			7185.index.js			d6a81be6fe1edb49fdfd.glb
4046.index.js			7328.index.js			editor.worker.js
4281.index.js			7413.index.js			f4a990eab21714a17a87.bin
4327.index.js			7425.index.js			index.js
4440.index.js			7541.index.js			ts.worker.js
```

After the change, filenames are:

```
00aa018e3ae78d50160b.ttf	4788.b4429259a0dc41ff3b78.js	7796.9607bb194a59e1b8535a.js
1340.e24657c1c0592ce14d75.js	4844.757ab56d30fca5c51650.js	7833.4556290eb6154b96adbe.js
135.0ca0be4954324f5e6bd2.js	485.4e36c164ff16af7a6337.js	798.1e28f3ce8a1dd2eed91a.js
1406.f43216224176c726dd9f.js	499d4e4e5cf9fce93f3d.wasm	806.94379c5be51953e2f8fe.js
1565.06bd3e7dba844aa42d64.js	5271.9807e4908caedd75a558.js	8247.773178ebaf45da6f5eae.js
1651.e17fde871a86edc1a3f5.js	5419.12cb23af0ca38cb906cf.js	8435.0185196f06683f2a5cbd.js
1721.d77a814cac36b8020cff.js	553.94017bc69fa1feabe4b8.js	8551.9326e91cc2194b793089.js
1919.a455c29c40ca85546f55.js	5836.a7691cc719495a660f03.js	8569.fc47bb83f98de21c6fec.js
2005.520ae10f6032cadc3a9b.js	5900.1cd945954c595632025f.js	8621.035a3b91e53ebbffa2cb.js
2287.bf1786a08edc3aafc2d9.js	5995.8f9eb3f2410d1100e357.js	8765.b0cabfa4bedede741381.js
2501.757f5bfa6cd62c738fb8.js	6014.291c06d531f01f71bad9.js	9008.8f7f36e32c5cc6d353fa.js
2861.d4e8889a809bd16b86f2.js	6069.5d92f80ad4f4a0696420.js	9070.23e094271534db1f54ff.js
2af8195e6a0ea862f9c4.wasm	6324.85a03b52201a1623040e.js	9456.0646a82670c59504d6d2.js
3052.88169671ceb60bd4ca56.js	6460.cf0b8bd7c03c03fd844d.js	9586.43f161dd8f735bab57f2.js
3143.19b0f2a4e8a0ec962130.js	6534.089090e9bcef3bf1272f.js	9646.c30d32d99a60dd3e3a84.js
3220.deb156debc4619f7d9a9.js	657.75488b823bef403d5a6f.js	9691.36751408b45377ac5b92.js
3278.9248c556ff2165a67c9c.js	6635.108bf2c19fe3605c0acd.js	9856.fd2cebd7103b95aae704.js
3715.51f9635d770ec2c98055.js	7185.c7289f33991e1b1668b4.js	9894.a7bd27bfb90b30ccb681.js
3914.a73c4ad43792340005be.js	7413.01bed50fb8d5a1069590.js	d6a81be6fe1edb49fdfd.glb
3e857f31384de3997869.wasm	7425.76b224d2c657d4e62539.js	editor.worker.js
4019.1819d7105250ef78f9b9.js	7541.dc9ee5b74d7c4e9002f4.js	f4a990eab21714a17a87.bin
4046.bc1108da1234400daa2b.js	7680.f66717e1f193e98c6bdf.js	main.482f68abf3046173f40c.js
4281.577a6249dacf189d0a63.js	769.2ce3b8f0bf33f4413a6b.js	ts.worker.js
4440.30642937490a458e2f54.js	7690.215607e5c6bf2aa5f752.js
4740.d3f9fb360567e7d2b707.js	7719.e31b8ce49fc2a3c1f530.js
```