### PR TITLE
Change: use org slug claim in id token for signin

### DIFF
--- a/packages/studio-base/src/components/AccountSettingsSidebar/DeviceCodeDialog.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/DeviceCodeDialog.tsx
@@ -11,15 +11,14 @@ import {
   DialogFooter,
   PrimaryButton,
   useTheme,
-  Spinner,
   Link,
 } from "@fluentui/react";
 import { useEffect, useMemo } from "react";
-import { useAsync, useAsyncFn, useMountedState } from "react-use";
+import { useAsync, useMountedState } from "react-use";
 
 import Logger from "@foxglove/log";
 import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
-import { DeviceCodeResponse, Org, Session } from "@foxglove/studio-base/services/ConsoleApi";
+import { DeviceCodeResponse, Session } from "@foxglove/studio-base/services/ConsoleApi";
 
 const log = Logger.getLogger(__filename);
 
@@ -81,108 +80,39 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
     throw new Error("Timeout waiting for activation");
   }, [api, deviceCode, isMounted]);
 
-  const [{ value: session, error: signinError }, onOrgSelect] = useAsyncFn(
-    async (org: Org) => {
-      if (!deviceResponse) {
-        throw new Error("Unable to signin");
-      }
-
-      return await api.signin({
-        id_token: deviceResponse.id_token,
-        org_slug: org.slug,
-      });
-    },
-    [api, deviceResponse],
-  );
-
-  const { value: orgs, error: orgsError } = useAsync(async () => {
-    const idToken = deviceResponse?.id_token;
-    if (idToken == undefined) {
+  const { value: session, error: signinError } = useAsync(async () => {
+    if (!deviceResponse) {
       return;
     }
 
-    api.setAuthHeader(`IdToken ${idToken}`);
-    return await api.orgs();
+    return await api.signin({
+      id_token: deviceResponse.id_token,
+    });
   }, [api, deviceResponse]);
 
-  const dialogTitle = useMemo(() => {
-    if (orgs) {
-      return "Select an org";
-    }
-
-    if (deviceResponse) {
-      return "Loading your orgs";
-    }
-
-    return "Complete Sign in";
-  }, [orgs, deviceResponse]);
-
   const dialogContent = useMemo(() => {
-    if (deviceResponse) {
-      if (!orgs) {
-        return (
-          <Stack>
-            <Spinner />
-          </Stack>
-        );
-      }
-
-      if (orgs.length === 0) {
-        return (
-          <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
-            <StackItem>
-              <Text>You are not a member of any orgs.</Text>
-            </StackItem>
-            <StackItem>
-              <Text>
-                Please ask your Org adminstrator to invite you or visit{" "}
-                <Link href="https://console.foxglove.dev/signin" target="_blank" rel="noreferrer">
-                  console.foxglove.dev/signin
-                </Link>{" "}
-                to sign up and create an org.
-              </Text>
-            </StackItem>
-          </Stack>
-        );
-      }
-
-      return (
-        <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
-          {orgs?.map((org) => {
-            return (
-              <StackItem
-                key={org.id}
-                onClick={async () => await onOrgSelect(org)}
-                className={classes.orgItem}
-              >
-                <Text variant="large">{org.display_name ?? org.slug}</Text>
-              </StackItem>
-            );
-          })}
-        </Stack>
-      );
-    }
-
     return (
       <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
-        <Text variant="large">Your sign-in code is</Text>
+        <Text variant="large">Finish sign-in in your web browser.</Text>
         <StackItem className={classes.text}>
           <Text variant="xLarge">{userCode} </Text>
         </StackItem>
 
         <StackItem>
-          <Text variant="large">Visit the link below to confirm the code</Text>
+          <Text variant="large">
+            If your browser did not automatically open, use the link below.
+          </Text>
         </StackItem>
         <StackItem className={classes.text}>
           <Text variant="large">
-            <Link href={`${verificationUrl}?code=${userCode}`}>{verificationUrl}</Link>
+            <Link href={`${verificationUrl}?user_code=${userCode}`}>{verificationUrl}</Link>
           </Text>
         </StackItem>
 
-        <Text variant="large">Waiting for activation...</Text>
+        <Text variant="large">Waiting for browser sign-in...</Text>
       </Stack>
     );
-  }, [onOrgSelect, orgs, classes, deviceResponse, userCode, verificationUrl, theme]);
+  }, [classes, userCode, verificationUrl, theme]);
 
   useEffect(() => {
     if (session) {
@@ -190,10 +120,10 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
     }
   }, [onClose, session]);
 
-  if (orgsError || deviceResponseError || signinError) {
+  if (deviceResponseError || signinError) {
     return (
       <Dialog hidden={false} title="Error">
-        {orgsError?.message ?? deviceResponseError?.message ?? signinError?.message}
+        {deviceResponseError?.message ?? signinError?.message}
         <DialogFooter>
           <PrimaryButton text="close" onClick={() => onClose?.()} />
         </DialogFooter>
@@ -202,7 +132,7 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
   }
 
   return (
-    <Dialog hidden={false} maxWidth="100%" title={dialogTitle}>
+    <Dialog hidden={false} maxWidth="100%" title="Complete Sign in">
       {dialogContent}
       <DialogFooter>
         <PrimaryButton text="cancel" onClick={() => onClose?.()} />

--- a/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
@@ -54,6 +54,19 @@ export default function SigninForm(): JSX.Element {
     [setBearerToken],
   );
 
+  // open new window with the device code to facilitate user signin flow
+  useEffect(() => {
+    if (!deviceCode) {
+      return;
+    }
+
+    const url = new URL(deviceCode.verification_uri);
+    url.searchParams.append("user_code", deviceCode.user_code);
+    const href = url.toString();
+
+    window.open(href, "_blank");
+  }, [deviceCode]);
+
   const modal = useMemo(() => {
     if (deviceCode) {
       return <DeviceCodeDialog deviceCode={deviceCode} onClose={onClose} />;

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -8,7 +8,6 @@ type CurrentUser = {
 
 type SigninArgs = {
   id_token: string;
-  org_slug: string;
 };
 
 type Session = {


### PR DESCRIPTION


**User-Facing Changes**
After clicking the "signin" button, the user is presented with the device code dialog and their browser automatically opened to the device code authorization page. The web flow takes over from there and adds an org slug claim to the id token. When the polling endpoint for studio returns an id token, studio is able to immediately use that token to sign in rather than asking the user to select an org.

This simplifies the number of actions the user needs to take within studio to sign in.

**Description**
The new browser sign-in flow adds an org slug claim to the id token.
This removes the need to select an org inside studio thus simplifying
the sign-in process for studio.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
