### PR TITLE
studio-base package: keep filename index.js for main entry point

### DIFF
--- a/packages/studio-base/webpack.config.ts
+++ b/packages/studio-base/webpack.config.ts
@@ -40,10 +40,11 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
 
     output: {
       publicPath: "",
+      filename: "index.js", // Referred to by package.json "browser" field
 
       // Output filenames should include content hashes in order to avoid caching issues with
       // downstream users of the studio-base package.
-      filename: "[name].[contenthash].js",
+      chunkFilename: "[name].[contenthash].js",
 
       path: path.resolve(__dirname, "assets"),
       library: {


### PR DESCRIPTION
**User-Facing Changes**
Fixed `@foxglove/studio-base` package.json's `"browser"` field pointing to a file that didn't exist.

**Description**
Fixes an issue introduced by #1690.