### PR TITLE
Fix Image panel saveConfig infinite loop

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -237,7 +237,9 @@ export default function ImageCanvas(props: Props): JSX.Element {
   const {
     setPan,
     setZoom,
-    pan: panValue,
+    // panX/panY need to be split apart because the pan object's identity may change on each render,
+    // and we want to avoid unnecessary updates to useEffects/useMemos below
+    pan: { x: panX, y: panY },
     zoom: scaleValue,
     setContainer,
     panZoomHandlers,
@@ -277,8 +279,8 @@ export default function ImageCanvas(props: Props): JSX.Element {
     const targetHeight = height * devicePixelRatio;
 
     const computedViewbox = {
-      x: panValue.x * devicePixelRatio,
-      y: panValue.y * devicePixelRatio,
+      x: panX * devicePixelRatio,
+      y: panY * devicePixelRatio,
       scale: scaleValue,
     };
 
@@ -307,8 +309,8 @@ export default function ImageCanvas(props: Props): JSX.Element {
     width,
     height,
     devicePixelRatio,
-    panValue.x,
-    panValue.y,
+    panX,
+    panY,
     scaleValue,
     image?.message,
     onStartRenderImage,
@@ -353,10 +355,10 @@ export default function ImageCanvas(props: Props): JSX.Element {
 
   useLayoutEffect(() => {
     saveConfig({
-      pan: panValue,
+      pan: { x: panX, y: panY },
       zoom: scaleValue,
     });
-  }, [panValue, saveConfig, scaleValue]);
+  }, [panX, panY, saveConfig, scaleValue]);
 
   const zoomContextMenu = useMemo(() => {
     return (


### PR DESCRIPTION
**User-Facing Changes**
None (the bug was introduced recently and never shipped in a release)

**Description**
Fixes #1713 

The Image panel called saveConfig in an effect which had a dependency on the `pan` value from usePanZoom. Unfortunately usePanZoom [does not memoize the pan object](https://github.com/wouterraateland/use-pan-and-zoom/blob/ec2ffaf50739db7f3a50539de0baf7a9ea1f0019/src/index.ts#L352), so even if the x and y values don't change, the object identity changes on each panel render. A deep `isEqual` when saving layouts was removed in #1679, which exposed this issue, since the saveConfig now triggers another render, which triggers another saveConfig due to the pan object's identity changing.

To fix the issue, simply destructure the x and y values from the pan object and treat them as separate dependencies.

Also add a unit test to ensure the `actions` from CurrentLayoutProvider do not change when updating the layout — which I originally thought was going to be the cause of this bug, but it wasn't.