### PR TITLE
Fix: plot properly resizes when its container size changes

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -201,19 +201,30 @@ export default class ChartJSManager {
       instance.options.scales = merge(instance.options.scales, options.scales);
     }
 
-    if (width != undefined && height != undefined) {
+    if (width != undefined || height != undefined) {
+      let shouldResize = false;
+      const wholeWidth = Math.floor(width ?? instance.width);
+      const wholeHeight = Math.floor(height ?? instance.height);
+
       // Internally chartjs rounds width and height before updating the instance.
       // If our update has decimal width and height that will cause a resize on every update.
       // To avoid this we truncate the decimal from the width and height to present chartjs with whole
       // numbers.
-      const wholeWidth = Math.floor(width);
-      const wholeHeight = Math.floor(height);
-      if (
-        Math.abs(instance.width - wholeWidth) > Number.EPSILON ||
-        Math.abs(instance.height - wholeHeight) > Number.EPSILON
-      ) {
-        instance.canvas.width = wholeWidth;
-        instance.canvas.height = wholeHeight;
+      if (width != undefined) {
+        if (Math.abs(instance.width - wholeWidth) > Number.EPSILON) {
+          instance.canvas.width = wholeWidth;
+          shouldResize = true;
+        }
+      }
+
+      if (height != undefined) {
+        if (Math.abs(instance.height - wholeHeight) > Number.EPSILON) {
+          instance.canvas.height = wholeHeight;
+          shouldResize = true;
+        }
+      }
+
+      if (shouldResize) {
         instance.resize(wholeWidth, wholeHeight);
       }
     }


### PR DESCRIPTION


**User-Facing Changes**
Plots properly resize and redraw when the layout is resized.

**Description**
https://github.com/foxglove/studio/pull/1705 introduced a regression
where plots would not resize when their container size changed.

The problem occurred because the getNewUpdateMessage logic only includes
changed fields in the update rpc message but the chart worker resize handling
assumed that both width and height would be present for a resize.

This change fixes that assumption and allows the chart to resize when either
width or height change.

Fixes #1714


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
