### PR TITLE
Use full product name in public-facing text

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -299,7 +299,7 @@ class StudioWindow {
 
     const id = browserWindow.webContents.id;
 
-    log.info(`New studio window ${id}`);
+    log.info(`New Foxglove Studio window ${id}`);
     StudioWindow.windowsByContentId.set(id, this);
 
     // when a window closes and it is the current application menu, clear the input sources

--- a/docs/fluentui-quickstart.md
+++ b/docs/fluentui-quickstart.md
@@ -1,6 +1,6 @@
 # `@fluentui/react` quick start guide
 
-[Fluent UI](https://developer.microsoft.com/en-us/fluentui) is a React component library for building UIs. This guide is meant to provide some useful tips to help you be productive with Fluent UI while working on Studio.
+[Fluent UI](https://developer.microsoft.com/en-us/fluentui) is a React component library for building UIs. This guide is meant to provide some useful tips to help you be productive with Fluent UI while working on Foxglove Studio.
 
 Fluent UI is developed as a [monorepo](https://github.com/microsoft/fluentui) containing many sub-packages, but most functions and components are re-exported from the base `@fluentui/react` package.
 

--- a/packages/studio-base/src/PanelAPI/README.md
+++ b/packages/studio-base/src/PanelAPI/README.md
@@ -1,6 +1,6 @@
 # PanelAPI
 
-The `PanelAPI` namespace contains React [Hooks](https://reactjs.org/docs/hooks-intro.html) and components which allow panel authors to access Studio data and metadata inside their panels. Using these APIs across all panels helps ensure that data appears consistent among panels, and makes it easier for panels to support advanced features (such as multiple simultaneous data sources).
+The `PanelAPI` namespace contains React [Hooks](https://reactjs.org/docs/hooks-intro.html) and components which allow panel authors to access Foxglove Studio data and metadata inside their panels. Using these APIs across all panels helps ensure that data appears consistent among panels, and makes it easier for panels to support advanced features (such as multiple simultaneous data sources).
 
 To use PanelAPI, it's recommended that you import the whole namespace, so that all usage sites look consistent, like `PanelAPI.useSomething()`.
 
@@ -10,7 +10,7 @@ import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 
 ## [`PanelAPI.useDataSourceInfo()`](useDataSourceInfo.js)
 
-"Data source info" encapsulates **rarely-changing** metadata about the sources from which Studio is loading data. (A data source might be a local [bag file](http://wiki.ros.org/Bags/Format) dropped into the browser, or a bag stored on a remote server; see [players](../players) and [dataSources](../dataSources) for more details.)
+"Data source info" encapsulates **rarely-changing** metadata about the sources from which Foxglove Studio is loading data. (A data source might be a local [bag file](http://wiki.ros.org/Bags/Format) dropped into the browser, or a bag stored on a remote server; see [players](../players) and [dataSources](../dataSources) for more details.)
 
 Using this hook inside a panel will cause the panel to re-render automatically when the metadata changes, but this won't happen very often or during playback.
 
@@ -63,7 +63,7 @@ These reducers should be wrapped in [`useCallback()`](https://reactjs.org/docs/h
 
 - `restore: (?T) => T`:
 
-  - Called with `undefined` to initialize a new state when the panel first renders, and when the user seeks to a different playback time (at which point Studio automatically clears out state across all panels).
+  - Called with `undefined` to initialize a new state when the panel first renders, and when the user seeks to a different playback time (at which point Foxglove Studio automatically clears out state across all panels).
   - Called with the previous state when the `restore` or `addMessage`/`addMessages` reducer functions change. This allows the panel an opportunity to reuse its previous state when a parameter changes, without totally discarding it (as in the case of a seek) and waiting for new messages to come in from the data source.
 
     For example, a panel that filters some incoming messages can use `restore` to create a filtered value immediately when the filter changes. To implement this, the caller might switch from unfiltered reducers:

--- a/packages/studio-base/src/PanelAPI/index.ts
+++ b/packages/studio-base/src/PanelAPI/index.ts
@@ -11,7 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-// This file contains hooks and components comprising the public API for Studio panel development.
+// This file contains hooks and components comprising the public API for
+// Foxglove Studio panel development.
 // Recommended use: import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 
 export { useDataSourceInfo } from "./useDataSourceInfo";

--- a/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
+++ b/packages/studio-base/src/PanelAPI/useDataSourceInfo.ts
@@ -52,7 +52,7 @@ export type DataSourceInfo = {
 
 /**
  * Data source info" encapsulates **rarely-changing** metadata about the source from which
- * Studio is loading data.
+ * Foxglove Studio is loading data.
  *
  * A data source might be a local file, a remote file, or a streaming source.
  */

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -31,7 +31,7 @@ const features: Feature[] = [
   {
     key: AppSetting.SHOW_DEBUG_PANELS,
     name: "Studio Debug Panels",
-    description: <>Show Studio debug panels in the add panel list.</>,
+    description: <>Show Foxglove Studio debug panels in the add panel list.</>,
   },
   {
     key: AppSetting.ENABLE_DRAWING_POLYGONS,
@@ -46,7 +46,7 @@ const features: Feature[] = [
   {
     key: AppSetting.ENABLE_CONSOLE_API_LAYOUTS,
     name: "Team Shared Layouts",
-    description: <>Enable team layout sharing when signed in to Studio.</>,
+    description: <>Enable team layout sharing when signed in to Foxglove Studio.</>,
   },
 ];
 

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -599,8 +599,8 @@ function ImageView(props: Props) {
           onClick={() => saveConfig({ transformMarkers: !transformMarkers })}
           tooltip={
             transformMarkers
-              ? "Markers are being transformed by Studio based on the camera model. Click to turn it off."
-              : `Markers can be transformed by Studio based on the camera model. Click to turn it on.`
+              ? "Markers are being transformed by Foxglove Studio based on the camera model. Click to turn it off."
+              : `Markers can be transformed by Foxglove Studio based on the camera model. Click to turn it on.`
           }
           fade
           medium

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/LogsSection.tsx
@@ -51,7 +51,8 @@ const LogsSection = ({ nodeId, logs, clearLogs }: Props): ReactElement => {
       <>
         <p>No logs to display.</p>
         <p>
-          Invoke <code>log(someValue)</code> in your Studio node code to see data printed here.
+          Invoke <code>log(someValue)</code> in your Foxglove Studio node code to see data printed
+          here.
         </p>
       </>
     );

--- a/packages/studio-base/src/panels/NodePlayground/theme/README.md
+++ b/packages/studio-base/src/panels/NodePlayground/theme/README.md
@@ -5,7 +5,7 @@ If you want to tweak the existing `vs-studio` theme, go to this [url](https://tm
 From there, you will be able to apply various colors. After you're done editing, execute the following steps before opening a PR:
 
 1. Download the `.tmTheme` file.
-2. Overwrite the existing `.tmTheme` file in the Studio code base.
+2. Overwrite the existing `.tmTheme` file in the Foxglove Studio code base.
 3. Go to this [site](https://bitwiser.in/monaco-themes/) and upload the `.tmFile`. It will convert it into the vs-code json definition of a theme.
-4. Save the new json into the Studio code base.
+4. Save the new json into the Foxglove Studio code base.
 5. Navigate to NodePlayground, profit.

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.help.md
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.help.md
@@ -14,7 +14,7 @@ The number of frames played per second. Though the player can play back at up to
 
 ## Bag frame time
 
-The duration in bag-time for the rendered frames in milliseconds. To "keep up" with playback, Studio will often emit "larger" frames.
+The duration in bag-time for the rendered frames in milliseconds. To "keep up" with playback, Foxglove Studio will often emit "larger" frames.
 
 ## Data throughput
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
@@ -34,8 +34,8 @@ const style: CSSProperties = {
 };
 
 // Looks at the regl stats and throws errors if it seems we're going over acceptable (arbitrary) max ranges.
-// The maxes are arbitrarily set to be an order of magnitude higher than the 'steady state' of a pretty loaded Studio scene to
-// allow for plenty of headroom.
+// The maxes are arbitrarily set to be an order of magnitude higher than the 'steady state' of a pretty loaded
+// Foxglove Studio scene to allow for plenty of headroom.
 function validate(stats: Stats) {
   if (stats.bufferCount > 500) {
     throw new Error(`Possible gl buffer leak detected. Buffer count: ${stats.bufferCount}`);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -445,7 +445,7 @@ export default class SceneBuilder implements MarkerProvider {
       this.reportedErrorTopics.topicsWithBadFrameIds.add(topic);
       sendNotification(
         `Topic ${topic} has bad frame`,
-        "Non-root transforms may be out of sync, since Studio uses the latest transform message instead of the one matching header.stamp",
+        "Non-root transforms may be out of sync, since Foxglove Studio uses the latest transform message instead of the one matching header.stamp",
         "user",
         "warn",
       );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
@@ -129,7 +129,7 @@ describe("<SearchText />", () => {
     it("sets a custom highlight color to the correct index", async () => {
       const setSearchTextMatches = jest.fn();
       const markers = [
-        createMarker("hello Studio"),
+        createMarker("hello foxglove"),
         createMarker("hello past"),
         createMarker("hello future"),
       ];

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateRosLib.test.ts.snap
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateRosLib.test.ts.snap
@@ -40,8 +40,8 @@ exports[`typegen generateRosLib basic snapshot 1`] = `
      * Input<\\"/your_input_topic_2\\">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Studio session, so if a datatype changes, your Node Playground node may
-     * not compile on the newly formatted bag.
+     * Foxglove Studio session, so if a datatype changes, your Node Playground
+     * node may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {
     topic: T;
@@ -292,8 +292,8 @@ exports[`typegen generateRosLib more complex snapshot 1`] = `
      * Input<\\"/your_input_topic_2\\">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Studio session, so if a datatype changes, your Node Playground node may
-     * not compile on the newly formatted bag.
+     * Foxglove Studio session, so if a datatype changes, your Node Playground
+     * node may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {
     topic: T;
@@ -332,8 +332,8 @@ exports[`typegen generateRosLib works with zero topics or datatypes 1`] = `
      * Input<\\"/your_input_topic_2\\">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Studio session, so if a datatype changes, your Node Playground node may
-     * not compile on the newly formatted bag.
+     * Foxglove Studio session, so if a datatype changes, your Node Playground
+     * node may not compile on the newly formatted bag.
      */
     export declare interface Input<T extends keyof TopicsToMessageDefinition> {
     topic: T;

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateRosLib.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateRosLib.ts
@@ -272,8 +272,8 @@ const generateRosLib = ({
      * Input<"/your_input_topic_2">'.
      *
      * These types are dynamically generated from the bag(s) currently in your
-     * Studio session, so if a datatype changes, your Node Playground node may
-     * not compile on the newly formatted bag.
+     * Foxglove Studio session, so if a datatype changes, your Node Playground
+     * node may not compile on the newly formatted bag.
      */
     ${printer.printNode(ts.EmitHint.Unspecified, typedMessage, sourceFile)}
   `;

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -198,7 +198,7 @@ describe("pipeline", () => {
       );
       expect(diagnostics[0]?.code).toEqual(ErrorCodes.Other.FILENAME);
     });
-    it.each(["const x: string = 'hello Studio'", "const num: number = 1222"])(
+    it.each(["const x: string = 'hello foxglove'", "const num: number = 1222"])(
       "can compile",
       (sourceCode) => {
         const { diagnostics } = compile({ ...baseNodeData, sourceCode });
@@ -264,7 +264,7 @@ describe("pipeline", () => {
 
     it.each([
       { sourceCode: "const x: string = 42;", errorCode: 2322 },
-      { sourceCode: "export const x: number = 'hello Studio';", errorCode: 2322 },
+      { sourceCode: "export const x: number = 'hello foxglove';", errorCode: 2322 },
       { sourceCode: "import { x } from './y'", errorCode: 2307 },
       { sourceCode: "const x: string = [];", errorCode: 2322 },
       {
@@ -335,13 +335,13 @@ describe("pipeline", () => {
       });
     });
 
-    it.each(["const x: string = 'hello Studio'"])("produces transpiled code", (sourceCode) => {
+    it.each(["const x: string = 'hello foxglove'"])("produces transpiled code", (sourceCode) => {
       const { transpiledCode, diagnostics } = compile({ ...baseNodeData, sourceCode });
       expect(typeof transpiledCode).toEqual("string");
       expect(diagnostics.length).toEqual(0);
     });
     it.each([
-      "const x: string = 'hello Studio'",
+      "const x: string = 'hello foxglove'",
       `
       import {norm} from "./pointClouds";
       const x = norm({x:1, y:2, z:3});
@@ -1312,7 +1312,7 @@ describe("pipeline", () => {
       {
         description: "Export a string as default export.",
         sourceCode: `
-          export default 'hello Studio';`,
+          export default 'hello foxglove';`,
         error: ErrorCodes.DatatypeExtraction.NON_FUNC_DEFAULT_EXPORT,
       },
       {

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/templates/README.md
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/templates/README.md
@@ -3,5 +3,3 @@
 ## Contributing
 
 Please feel free to add any template you like in this directory with a `*.ts` extension. Then reference that template in the `templates/index.js` file as is done with the other templates.
-
-Then open up a PR in the Studio repo. We'll make sure a team member looks at it in a timely manner! :)

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/README.md
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/README.md
@@ -8,14 +8,13 @@ import { compare } from "./time.ts";
 
 ## Contributing
 
-_Prequisites: You will need to have the Studio repo cloned locally to update these utilities. You just need to have node and yarn installed to get going though, follow those steps in the `developer-guide.md`._
+_Prequisites: You will need to have the Foxglove Studio repo cloned locally to update these utilities. You just need to have node and yarn installed to get going though, follow those steps in the `developer-guide.md`._
 
 ### TL;DR
 
 - Update utility
 - Add unit testing and a structured comment (as needed)
 - Run `yarn run test:user-utilities` (checks compilation and runs tests)
-- Open PR for Studio review
 
 If you'd like to add any reusable utilities, simply add (or tweak) the relevant file with the function/class/constant you'd like to expose! Make sure to mark your variable declaration with the `export` keyword so that it will be importable from other modules.
 
@@ -33,18 +32,12 @@ This structure will ensure your modules get coupled with inline documentation.
 
 We also have unit testing available for these modules! Please add releveant unit tests for all new/amended code, it'll help us keep the bar high for our consumers.
 
-Then open up a PR in the Studio repo. We'll make sure a team member looks at it in a timely manner! :)
-
 ### FAQ
 
 > Can I use third-party packages?
 
 Not at the moment, but please let us know if that would be useful for you! Be sure to specify which package(s) you would like and why you want them.
 
-> Can I use other Studio code here?
+> Can I use other Foxglove Studio code here?
 
-Studio has many utilities that you are free to copy and paste into this directory, as long as you also provide relevant unit testing. Keep in mind the rest of Studio is written in Flow, which, while very similar to Typescript, has a few discrepancies. Feel free to reach out to the Studio team if you're having any trouble with this!
-
-> Are these utilities versioned?
-
-Not currently. We would like to get around to this eventually, but wanted to harden this feature first.
+Foxglove Studio has many utilities that you are free to copy and paste into this directory, as long as you also provide relevant unit testing.

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -192,7 +192,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     if (emptyConnections.length > 0) {
       sendNotification(
         "Empty connections found",
-        `This bag has some empty connections, which Studio does not currently support. We'll try to play the remaining topics. Details:\n\n${JSON.stringify(
+        `This bag has some empty connections, which Foxglove Studio does not currently support. We'll try to play the remaining topics. Details:\n\n${JSON.stringify(
           emptyConnections,
         )}`,
         "user",

--- a/packages/studio-base/src/util/selectors.ts
+++ b/packages/studio-base/src/util/selectors.ts
@@ -75,7 +75,7 @@ export const constantsByDatatype = createSelector(
   },
 );
 
-// Studio enum annotations are of the form: "Foo__foxglove_enum" (notice double underscore)
+// Foxglove Studio enum annotations are of the form: "Foo__foxglove_enum" (notice double underscore)
 // This method returns type name from "Foo" or undefined name doesn't match this format
 export function extractTypeFromStudioEnumAnnotation(name: string): string | undefined {
   const match = /(.*)__(foxglove|webviz)_enum$/.exec(name);


### PR DESCRIPTION
**User-Facing Changes**
Update some strings from `Studio` to `Foxglove Studio`.

Just "Studio" alone looks awkward in sentences.