### PR TITLE
Fix: interaction padding tweaks to align labels

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/ObjectDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/ObjectDetails.tsx
@@ -147,7 +147,7 @@ function ObjectDetailsInner({ interactionData, objectToDisplay }: Props) {
         labelRenderer={(markerKeyPath, _p1, _p2, hasChildren) => {
           const label = first(markerKeyPath);
           if (!hasChildren) {
-            return <span style={{ padding: "0 4px" }}>{label}</span>;
+            return <span style={{ padding: "0 4px 0 0" }}>{label}</span>;
           }
 
           let objectForPath: Record<string, unknown> | undefined = sortedDataObject;


### PR DESCRIPTION
**User-Facing Changes**
Labels in marker interaction view line up.

Before:
![image](https://user-images.githubusercontent.com/84792/131381527-c0e9dccc-935e-4d83-8067-f8bd8910dff5.png)


After: 
![image](https://user-images.githubusercontent.com/84792/131381467-a0a75918-7500-4ad5-9fe3-8b5d4cbd5921.png)


**Description**
The labels in marker interaction view had an incorrect left padding which made them appear offset from their expandable siblings. Now all the labels (expandable or not) line up.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
