### PR TITLE
Don't load a new Welcome layout when deleting the last layout

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -21,7 +21,6 @@ import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import LayoutStorageDebuggingContext from "@foxglove/studio-base/context/LayoutStorageDebuggingContext";
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
-import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
@@ -121,18 +120,10 @@ export default function LayoutBrowser({
         setSelectedLayoutId(layout.id);
         return;
       }
-      // If no other layouts exist, use the welcome layout
-      // This call should probably be removed and consolidated with other calls to add the welcome layout:
-      // - https://github.com/foxglove/studio/issues/1545
-      // - https://github.com/foxglove/studio/pull/1575
-      const newLayout = await layoutStorage.saveNewLayout({
-        name: welcomeLayout.name,
-        data: welcomeLayout.data,
-        permission: "creator_write",
-      });
-      await onSelectLayout(newLayout);
+      // If no other layouts exist, just deselect the layout
+      setSelectedLayoutId(undefined);
     },
-    [analytics, currentLayoutId, layoutStorage, setSelectedLayoutId, onSelectLayout],
+    [analytics, currentLayoutId, layoutStorage, setSelectedLayoutId],
   );
 
   const createNewLayout = useCallback(async () => {

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -61,7 +61,7 @@ export interface ICurrentLayout {
      */
     getCurrentLayoutState: () => LayoutState;
 
-    setSelectedLayoutId: (id: LayoutID) => void;
+    setSelectedLayoutId: (id: LayoutID | undefined) => void;
 
     savePanelConfigs: (payload: SaveConfigsPayload) => void;
     updatePanelConfigs: (panelType: string, updater: (config: PanelConfig) => PanelConfig) => void;


### PR DESCRIPTION
**User-Facing Changes**
None worth mentioning in release notes

**Description**
Fixes #1545, closes #1570, closes #1575

There used to be 3 places where a welcome layout might be created: (a) on first app launch, (b) on every app launch when the list of layouts is empty, and (c) when deleting the last layout. (b) was removed in #1679. This PR removes (c), so there is now only 1 place that loads the welcome layout.

Deleting the last layout now results in _no_ layout being selected, rather than auto-loading the welcome layout.