### PR TITLE
Allow drag & drop of .urdf.xacro

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -112,7 +112,7 @@ function Variables() {
 }
 
 // file types we support for drag/drop
-const allowedDropExtensions = [".bag", ".foxe", ".urdf"];
+const allowedDropExtensions = [".bag", ".foxe", ".urdf", ".xacro"];
 
 type WorkspaceProps = {
   loadWelcomeLayout?: boolean;


### PR DESCRIPTION
**User-Facing Changes**
`.urdf.xacro` files can now be opened by drag & drop, not just double-click.

**Description**
Fixes #1711 
