### PR TITLE
Fix: avoid changing panel state for unchanged config

### DIFF
--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -52,9 +52,9 @@ export default function PlaybackSpeedControls(): JSX.Element {
   // Set the speed to the speed that we got from the config whenever we get a new Player.
   useEffect(() => {
     if (configSpeed != undefined) {
-      setSpeed(configSpeed);
+      setPlaybackSpeed(configSpeed);
     }
-  }, [configSpeed, setSpeed]);
+  }, [configSpeed, setPlaybackSpeed]);
 
   const displayedSpeed = speed ?? configSpeed;
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -189,8 +189,8 @@ describe("CurrentLayoutProvider", () => {
         baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
       };
     });
-    mockLayoutStorage.updateLayout.mockImplementation(async () => layoutStoragePutCalled.resolve());
 
+    mockLayoutStorage.updateLayout.mockImplementation(async () => layoutStoragePutCalled.resolve());
     const mockUserProfile = makeMockUserProfile();
     mockUserProfile.getUserProfile.mockResolvedValue({ currentLayoutId: "example" });
 
@@ -198,6 +198,7 @@ describe("CurrentLayoutProvider", () => {
       mockLayoutStorage,
       mockUserProfile,
     });
+
     await act(() => result.current.childMounted);
     act(() => result.current.actions.setPlaybackConfig({ timeDisplayMethod: "TOD" }));
     await act(() => layoutStoragePutCalled);

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { isEqual } from "lodash";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getNodeAtPath } from "react-mosaic-component";
 import { useToasts } from "react-toast-notifications";
@@ -155,6 +156,14 @@ export default function CurrentLayoutProvider({
       ) {
         return;
       }
+      const oldData = layoutStateRef.current.selectedLayout.data;
+      const newData = panelsReducer(layoutStateRef.current.selectedLayout.data, action);
+
+      // the panel state did not change, so no need to perform layout state updates or layout manager updates
+      if (isEqual(oldData, newData)) {
+        return;
+      }
+
       const newLayout = {
         id: layoutStateRef.current.selectedLayout.id,
         data: panelsReducer(layoutStateRef.current.selectedLayout.data, action),

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
@@ -707,6 +707,40 @@ describe("layout reducers", () => {
       configById: {},
     } as PanelsState;
 
+    it("keeps panel state identity stable when config is unchanged", () => {
+      const orig: PanelsState = {
+        ...emptyLayout,
+        layout: panelState.layout,
+      };
+
+      const panelConfig = {
+        id: "SecondPanel!2wydzut",
+        config: { foo: "bar" },
+        defaultConfig: { foo: "" },
+      };
+      const panels = panelsReducer(orig, {
+        type: "SAVE_PANEL_CONFIGS",
+        payload: {
+          configs: [
+            panelConfig,
+            { id: "FirstPanel!34otwwt", config: { baz: true }, defaultConfig: { baz: false } },
+          ],
+        },
+      });
+
+      const panelsTwo = panelsReducer(panels, {
+        type: "SAVE_PANEL_CONFIGS",
+        payload: {
+          configs: [
+            panelConfig,
+            { id: "FirstPanel!34otwwt", config: { baz: true }, defaultConfig: { baz: false } },
+          ],
+        },
+      });
+
+      expect(panelsTwo).toEqual(panels);
+    });
+
     it("removes a panel's configById when it is removed from the layout", () => {
       let panels: PanelsState = {
         ...emptyLayout,


### PR DESCRIPTION


**User-Facing Changes**
When the user changes layouts they would be shown that their layout is "dirty" and has unsaved changes even tho there were no actual changes to the layout. After this change the layout is not marked as dirty when just changing the layout.

**Description**
When a panel saves its config, this triggers a set of reducers
to run. If the config is unchanged from the previous config, the save
config reducer keeps the same state object to indicate there were
no changes to the state.

Fixes #1646

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
