### PR TITLE
Fix: tweak styling on RawMessage panel to align labels

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -436,7 +436,7 @@ function RawMessages(props: Props) {
                 nestedNode: ({ style }, keyPath) => {
                   const baseStyle = {
                     ...style,
-                    padding: "2px 0 2px 5px",
+                    padding: "2px 0 2px 0",
                     marginTop: 2,
                     textDecoration: "inherit",
                   };


### PR DESCRIPTION

**User-Facing Changes**
Labels in RawMessage panel are now aligned.

![image](https://user-images.githubusercontent.com/84792/131422255-4a7c91ee-318b-40aa-bfd2-bfab7ad3802a.png)


**Description**
The raw message panel labels for items with and without children
caused the two labels to be offset. This change fixes the alignment
so all labels appear vertically in-line.

Fixes #1726 

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
