### PR TITLE
Internal: fix useReadySignal

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -122,11 +122,9 @@ export default {
 };
 
 export const Basic: Story = (_args) => {
-  const readySignal = useReadySignal();
-
   return (
     <div style={divStyle}>
-      <ChartComponent {...props} onChartUpdate={readySignal} />
+      <ChartComponent {...props} />
     </div>
   );
 };

--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -122,9 +122,11 @@ export default {
 };
 
 export const Basic: Story = (_args) => {
+  const readySignal = useReadySignal();
+
   return (
     <div style={divStyle}>
-      <ChartComponent {...props} />
+      <ChartComponent {...props} onChartUpdate={readySignal} />
     </div>
   );
 };

--- a/patches/storybook-react.patch
+++ b/patches/storybook-react.patch
@@ -2,16 +2,17 @@ diff --git a/dist/esm/client/preview/render.js b/dist/esm/client/preview/render.
 index 5883ed6c7e9db640cd8f209a3b840efb1d54c6a7..03c377000bdc7eb620c2f9107a2635e820d69247 100644
 --- a/dist/esm/client/preview/render.js
 +++ b/dist/esm/client/preview/render.js
-@@ -44,9 +44,12 @@ var document = global.document,
+@@ -44,9 +44,13 @@ var document = global.document,
      FRAMEWORK_OPTIONS = global.FRAMEWORK_OPTIONS;
  var rootEl = document ? document.getElementById('root') : null;
 
 -var render = function render(node, el) {
 +var render = function render(node, el, storyContext) {
-+  var maybeSignal = storyContext.parameters?.storyReady;
    return new Promise(function (resolve) {
 -    ReactDOM.render(node, el, resolve);
 +    ReactDOM.render(node, el, () => {
++      // access the parameters in the render callback to allow decorators to set storyReady
++      var maybeSignal = storyContext.parameters?.storyReady;
 +      maybeSignal ? maybeSignal.then(resolve) : resolve();
 +    });
    });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4431,7 +4431,7 @@ __metadata:
 
 "@storybook/react@patch:@storybook/react@6.3.7#../../patches/storybook-react.patch::locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base":
   version: 6.3.7
-  resolution: "@storybook/react@patch:@storybook/react@npm%3A6.3.7#../../patches/storybook-react.patch::version=6.3.7&hash=54a7b9&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
+  resolution: "@storybook/react@patch:@storybook/react@npm%3A6.3.7#../../patches/storybook-react.patch::version=6.3.7&hash=6fc641&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
   dependencies:
     "@babel/preset-flow": ^7.12.1
     "@babel/preset-react": ^7.12.10
@@ -4469,7 +4469,7 @@ __metadata:
     build-storybook: bin/build.js
     start-storybook: bin/index.js
     storybook-server: bin/index.js
-  checksum: 82e0faf74ffdd96f574c8abb80d5ff7d6f64365ef18a976f49a3cc166b484804566f8054781f4fe1c41dd01ee3946036f99f5d3061bd1363f5dccef95f39eda2
+  checksum: f37182c25088d7d6715138661a4dfabb76643f25d40cf088bd6436cc112ca7e03a61ab77d08477aac0a6145b88fa329acce2161459ad4259d75d36d6f1b6dab2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Through the tragedy of console.log I erroneously thought it was ok to access the story parameters before rendering. This doesn't actually work when the parameters are changed by a decorator. This change fixes useReadySignal handling within @storybook/react by checking the parameters within the ReactDOM render callback and waiting on any promise added to the parameters.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
