### PR TITLE
Fix: plot panel synchronizes only when xaxis is timestamp

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -55,6 +55,7 @@ function getAnnotations(paths: PlotPath[]) {
 }
 
 type PlotChartProps = {
+  isSynced: boolean;
   paths: PlotPath[];
   minYValue: number;
   maxYValue: number;
@@ -74,6 +75,7 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
     maxYValue,
     datasets,
     onClick,
+    isSynced,
     tooltips,
     xAxisVal,
   } = props;
@@ -115,7 +117,7 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
     <div style={{ width: "100%", flexGrow: 1, overflow: "hidden" }} ref={sizeRef}>
       <TimeBasedChart
         key={xAxisVal}
-        isSynced
+        isSynced={isSynced}
         zoom
         width={width ?? 0}
         height={height ?? 0}

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -356,6 +356,7 @@ function Plot(props: Props) {
     <Flex col clip center style={{ position: "relative" }}>
       <PanelToolbar helpContent={helpContent} floating />
       <PlotChart
+        isSynced={xAxisVal === "timestamp"}
         paths={yAxisPaths}
         minYValue={parseFloat((minYValue ?? "")?.toString())}
         maxYValue={parseFloat((maxYValue ?? "")?.toString())}


### PR DESCRIPTION


**User-Facing Changes**
When using plots with different xaxis values only plots with timestamp values will synchronize.

**Description**
Prior to this change the plot panel would synchronize all plots regardless
of xaxis value. This is incorrect. The plot should only synchronize when
the xaxis value is timestamp. Other xaxis values will have a different xaxis
min/max that differs from timestamp plots.

Fixes #1722

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
