### PR TITLE
Reduce default memory cache size to 1gb

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -53,8 +53,12 @@ export const MIN_MEM_CACHE_BLOCK_SIZE_NS = 0.1e9; // Messages are laid out in bl
 // less flexible, so we may want to move away from a single-level block structure in the future.
 export const MAX_BLOCKS = 400;
 const READ_AHEAD_NS = 3e9; // Number of nanoseconds to read ahead from the last `getMessages` call.
-const DEFAULT_CACHE_SIZE_BYTES = 2.5e9; // Number of bytes that we aim to keep in the cache.
 export const MAX_BLOCK_SIZE_BYTES = 50e6; // Number of bytes in a block before we show an error.
+
+// Number of bytes that we aim to keep in the cache.
+// Setting this to higher than 1.5GB caused the renderer process to crash on linux on certain bags.
+// See: https://github.com/foxglove/studio/pull/1733
+const DEFAULT_CACHE_SIZE_BYTES = 1.0e9;
 
 // For each memory block we store the actual messages (grouped by topic), and a total byte size of
 // the underlying ArrayBuffers.


### PR DESCRIPTION
**User-Facing Changes**
Fixes https://github.com/foxglove/studio/issues/1500 (app crash on certain bags, particularly on linux)

**Description**
Opening certain bags (such as [this](https://storage.googleapis.com/cartographer-public-data/bags/backpack_3d/with_intensities/b3-2016-04-05-14-14-00.bag) could cause Electron's renderer process to crash (desktop), or the Chrome browser tab to crash (browser), both with `SIGILL`. Occasionally, `BrowserWindow Unresponsive` errors were seen too.

This reliably happened on Linux (desktop and browser), despite having ample system memory. It appears to be due to the v8 heap size (`--max-old-space-size`), but after debugging with @defunctzombie we could not find any way to increase this (we tried several solutions from https://github.com/electron/electron/issues/2056 and https://github.com/electron/electron/issues/22705: electron cli flag, `webPreferences`, and `app.commandLine.appendSwitch` - none actually seem to increase the renderer heap size).

Notably, on linux my process tended to crash when `rss` reached 2.4GB, despite the max heap size being 4GB.

The current default did not cause a crash on macOS (ARM or Intel). However, we were still able to reproduce the crash by increasing this setting to 10GB.

After discussion, it was decided that we should be more responsible with our memory cache and reduce it to 1GB max. In the future, we should make better use of disk caching. It would also be nice to adjust this setting based on available system memory (assuming we can find a way to increase heap size).

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
