### PR TITLE
Fix: save the latest layout state

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -166,13 +166,13 @@ export default function CurrentLayoutProvider({
 
       const newLayout = {
         id: layoutStateRef.current.selectedLayout.id,
-        data: panelsReducer(layoutStateRef.current.selectedLayout.data, action),
+        data: newData,
       };
-      setLayoutState({ loading: false, selectedLayout: newLayout });
 
       debouncedSaveParams.current = newLayout;
       debouncedSaveTimeout.current ??= setTimeout(() => {
         const params = debouncedSaveParams.current;
+
         debouncedSaveParams.current = undefined;
         debouncedSaveTimeout.current = undefined;
         if (!params) {
@@ -188,6 +188,11 @@ export default function CurrentLayoutProvider({
           }
         });
       }, SAVE_INTERVAL_MS);
+
+      // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
+      // configs (i.e. set default configs). These result in calls to performAction. To ensure the
+      // debounced params are set in the proper order, we invoke setLayoutState at the end.
+      setLayoutState({ loading: false, selectedLayout: newLayout });
     },
     [addToast, isMounted, layoutManager, setLayoutState],
   );


### PR DESCRIPTION


**User-Facing Changes**
When a user "splits" a panel and then saves the layout their saved panel would still appear as "unsaved" when navigating away/back to the layout. This change fixes that behavior so when a layout is saved after splitting a panel it does not appear unsaved after navigation away/to.

**Description**
Some actions would cause re-entrant behavior to performAction which
resulted in the wrong version of layout state being saved. This change
moves setLayoutState to the end of performAction to serialize updates
to the outgoing layout state.

Fixes #1646 
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
