### PR TITLE
Only allow one emitState setTimeout to be running in live players

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -323,6 +323,10 @@ export default class Ros1Player implements Player {
     if (this._rosNode) {
       this._rosNode.shutdown();
     }
+    if (this._emitTimer != undefined) {
+      clearTimeout(this._emitTimer);
+      this._emitTimer = undefined;
+    }
     this._metricsCollector.close();
     this._hasReceivedMessage = false;
   }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -88,6 +88,7 @@ export default class Ros1Player implements Player {
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
   private _problems = new PlayerProblemManager();
+  private _emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({ url, hostname, metricsCollector }: Ros1PlayerOpts) {
     log.info(`initializing Ros1Player (url=${url})`);
@@ -272,7 +273,10 @@ export default class Ros1Player implements Player {
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
     if (this._presence === PlayerPresence.PRESENT) {
-      setTimeout(this._emitState, 100);
+      if (this._emitTimer != undefined) {
+        clearTimeout(this._emitTimer);
+      }
+      this._emitTimer = setTimeout(this._emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -300,6 +300,10 @@ export default class Ros2Player implements Player {
     if (this._rosNode) {
       void this._rosNode.shutdown();
     }
+    if (this._emitTimer != undefined) {
+      clearTimeout(this._emitTimer);
+      this._emitTimer = undefined;
+    }
     this._metricsCollector.close();
     this._hasReceivedMessage = false;
   }

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -73,6 +73,7 @@ export default class Ros2Player implements Player {
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
   private _problems = new PlayerProblemManager();
+  private _emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({ domainId, metricsCollector }: Ros2PlayerOpts) {
     log.info(`initializing Ros2Player (domainId=${domainId})`);
@@ -250,7 +251,10 @@ export default class Ros2Player implements Player {
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
     if (this._presence === PlayerPresence.PRESENT) {
-      setTimeout(this._emitState, 100);
+      if (this._emitTimer != undefined) {
+        clearTimeout(this._emitTimer);
+      }
+      this._emitTimer = setTimeout(this._emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -111,6 +111,9 @@ export default class RosbridgePlayer implements Player {
     if (this._closed) {
       return;
     }
+    if (this._rosClient != undefined) {
+      throw new Error(`Attempted to open a second Rosbridge connection`);
+    }
     this._problems.removeProblem("rosbridge:connection-failed");
     log.info(`Opening connection to ${this._url}`);
 
@@ -358,6 +361,10 @@ export default class RosbridgePlayer implements Player {
     this._closed = true;
     if (this._rosClient) {
       this._rosClient.close();
+    }
+    if (this._emitTimer != undefined) {
+      clearTimeout(this._emitTimer);
+      this._emitTimer = undefined;
     }
     this._metricsCollector.close();
     this._hasReceivedMessage = false;

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -90,6 +90,7 @@ export default class RosbridgePlayer implements Player {
   private _hasReceivedMessage = false;
   private _presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
   private _problems = new PlayerProblemManager();
+  private _emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({
     url,
@@ -309,7 +310,10 @@ export default class RosbridgePlayer implements Player {
     // When connected
     // Time is always moving forward even if we don't get messages from the server.
     if (this._presence === PlayerPresence.PRESENT) {
-      setTimeout(this._emitState, 100);
+      if (this._emitTimer != undefined) {
+        clearTimeout(this._emitTimer);
+      }
+      this._emitTimer = setTimeout(this._emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -247,6 +247,10 @@ export default class VelodynePlayer implements Player {
       void this._socket.dispose();
       this._socket = undefined;
     }
+    if (this._emitTimer != undefined) {
+      clearTimeout(this._emitTimer);
+      this._emitTimer = undefined;
+    }
     this._metricsCollector.close();
     this._totalBytesReceived = 0;
     this._seq = 0;

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -79,6 +79,7 @@ export default class VelodynePlayer implements Player {
   private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  private _emitTimer?: ReturnType<typeof setTimeout>;
 
   // track issues within the player
   private _problems: PlayerProblem[] = [];
@@ -195,7 +196,10 @@ export default class VelodynePlayer implements Player {
     // Time is always moving forward even if we don't get messages from the device.
     // If we are not connected, don't emit updates since we are not longer getting new data
     if (this._presence === PlayerPresence.PRESENT) {
-      setTimeout(this._emitState, 100);
+      if (this._emitTimer != undefined) {
+        clearTimeout(this._emitTimer);
+      }
+      this._emitTimer = setTimeout(this._emitState, 100);
     }
 
     const currentTime = fromMillis(Date.now());


### PR DESCRIPTION
**User-Facing Changes**

Reduced CPU usage when connected to a live data source.

**Description**

Previously, any received message in a live player would trigger a call to emitState (assuming it was not already concurrently running in which case it would be debounced). Each emitState call would in turn call setTimeout(), queuing up a new emitState call 100 ms later. This caused far more emitState calls than intended. The fix is to set and clear a timer handle so at most one setTimeout() call is scheduled.