### PR TITLE
Tweak "beta" label on ROS 2 connection

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -37,8 +37,9 @@ export default function Root(): ReactElement {
       type: "ros1-socket",
     },
     {
-      name: "ROS 2 [BETA]",
+      name: "ROS 2",
       type: "ros2-socket",
+      badgeText: "beta",
     },
     {
       name: "Rosbridge (WebSocket)",

--- a/packages/studio-base/src/components/ConnectionList.tsx
+++ b/packages/studio-base/src/components/ConnectionList.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { ActionButton, Icon, Text, useTheme } from "@fluentui/react";
+import { ActionButton, Icon, makeStyles, Text, useTheme } from "@fluentui/react";
 import { useCallback, useContext } from "react";
 
 import {
@@ -25,10 +25,24 @@ const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
 
 const emptyArray: PlayerProblem[] = [];
 
+const useStyles = makeStyles((theme) => ({
+  badge: {
+    textTransform: "uppercase",
+    fontSize: theme.fonts.small.fontSize,
+    fontWeight: 600,
+    backgroundColor: theme.palette.themePrimary,
+    color: theme.palette.neutralLighterAlt,
+    padding: `1px 8px`,
+    marginLeft: theme.spacing.m,
+    borderRadius: 100,
+  },
+}));
+
 export default function ConnectionList(): JSX.Element {
   const { selectSource, availableSources } = usePlayerSelection();
   const confirm = useConfirm();
   const modalHost = useContext(ModalContext);
+  const styles = useStyles();
 
   const playerProblems = useMessagePipeline(selectPlayerProblems) ?? emptyArray;
   const playerPresence = useMessagePipeline(selectPlayerPresence);
@@ -124,6 +138,7 @@ export default function ConnectionList(): JSX.Element {
               onClick={() => onSourceClick(source)}
             >
               {source.name}
+              {source.badgeText && <span className={styles.badge}>{source.badgeText}</span>}
             </ActionButton>
           </div>
         );

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -17,6 +17,7 @@ export type PlayerSourceDefinition = {
   name: string;
   type: SourceTypes;
   disabledReason?: string | JSX.Element;
+  badgeText?: string;
 };
 
 type FileSourceParams = {

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -42,8 +42,9 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
       ),
     },
     {
-      name: "ROS 2 [BETA]",
+      name: "ROS 2",
       type: "ros2-socket",
+      badgeText: "beta",
       disabledReason: (
         <>
           ROS 2 Native connections are only available in our desktop app.&nbsp;


### PR DESCRIPTION
**User-Facing Changes**
None (beta data source has not shipped in a release yet)

**Description**
<img width="184" alt="image" src="https://user-images.githubusercontent.com/14237/132053062-a1062ac2-0f65-4373-9f8d-e5b2da951425.png">
