### PR TITLE
Revert "RosbridgePlayer: detect ROS version automatically based on datatype names (#1656)"

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -42,8 +42,12 @@ export default function Root(): ReactElement {
       badgeText: "beta",
     },
     {
-      name: "Rosbridge (WebSocket)",
-      type: "rosbridge-websocket",
+      name: "ROS 1 Rosbridge (WebSocket)",
+      type: "ros1-rosbridge-websocket",
+    },
+    {
+      name: "ROS 2 Rosbridge (WebSocket)",
+      type: "ros2-rosbridge-websocket",
     },
     {
       name: "ROS 1 Bag (local)",

--- a/packages/studio-base/src/components/ConnectionList.tsx
+++ b/packages/studio-base/src/components/ConnectionList.tsx
@@ -107,7 +107,8 @@ export default function ConnectionList(): JSX.Element {
           case "ros2-socket":
             iconName = "studio.ROS";
             break;
-          case "rosbridge-websocket":
+          case "ros1-rosbridge-websocket":
+          case "ros2-rosbridge-websocket":
             iconName = "Flow";
             break;
           case "ros1-remote-bagfile":

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -206,10 +206,23 @@ async function rosbridgeSource(options: FactoryOptions): Promise<Player | undefi
     return undefined;
   }
 
+  let rosVersion: 1 | 2;
+  switch (options.source.type) {
+    case "ros1-rosbridge-websocket":
+      rosVersion = 1;
+      break;
+    case "ros2-rosbridge-websocket":
+      rosVersion = 2;
+      break;
+    default:
+      throw new Error(`Invalid source type for rosbridge: ${options.source.type}`);
+  }
+
   const url = maybeUrl;
   options.storage.setItem(storageCacheKey, url);
   return new RosbridgePlayer({
     url,
+    rosVersion,
     metricsCollector: options.playerOptions.metricsCollector,
   });
 }
@@ -423,7 +436,8 @@ export default function PlayerManager({
         return ros1Source;
       case "ros2-socket":
         return ros2Source;
-      case "rosbridge-websocket":
+      case "ros1-rosbridge-websocket":
+      case "ros2-rosbridge-websocket":
         return rosbridgeSource;
       case "ros1-remote-bagfile":
         return remoteBagFileSource;

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -9,7 +9,8 @@ type SourceTypes =
   | "ros2-local-bagfile"
   | "ros1-socket"
   | "ros2-socket"
-  | "rosbridge-websocket"
+  | "ros1-rosbridge-websocket"
+  | "ros2-rosbridge-websocket"
   | "ros1-remote-bagfile"
   | "velodyne-device";
 

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -136,6 +136,7 @@ describe("RosbridgePlayer", () => {
   beforeEach(() => {
     player = new RosbridgePlayer({
       url: "ws://some-url",
+      rosVersion: 1,
       metricsCollector: new NoopMetricsCollector(),
     });
   });

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -58,6 +58,7 @@ const CAPABILITIES = [PlayerCapabilities.advertise];
 // unmarshalls into plain JS objects.
 export default class RosbridgePlayer implements Player {
   private _url: string; // WebSocket URL.
+  private _rosVersion: 1 | 2;
   private _rosClient?: roslib.Ros; // The roslibjs client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player.
   private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
@@ -94,14 +95,17 @@ export default class RosbridgePlayer implements Player {
 
   constructor({
     url,
+    rosVersion,
     metricsCollector,
   }: {
     url: string;
+    rosVersion: 1 | 2;
     metricsCollector: PlayerMetricsCollectorInterface;
   }) {
     this._presence = PlayerPresence.INITIALIZING;
     this._metricsCollector = metricsCollector;
     this._url = url;
+    this._rosVersion = rosVersion;
     this._start = fromMillis(Date.now());
     this._metricsCollector.playerConstructed();
     this._open();
@@ -193,23 +197,6 @@ export default class RosbridgePlayer implements Player {
       const datatypeDescriptions = [];
       const messageReaders: Record<string, LazyMessageReader | ROS2MessageReader> = {};
 
-      // Automatically detect the ROS version based on the datatypes.
-      // The rosbridge server itself publishes /rosout so the topic should be reliably present.
-      let rosVersion: 1 | 2;
-      if (result.types.includes("rcl_interfaces/msg/Log")) {
-        rosVersion = 2;
-        this._problems.removeProblem("unknownRosVersion");
-      } else if (result.types.includes("rosgraph_msgs/Log")) {
-        rosVersion = 1;
-        this._problems.removeProblem("unknownRosVersion");
-      } else {
-        rosVersion = 1;
-        this._problems.addProblem("unknownRosVersion", {
-          severity: "warn",
-          message: "Unable to detect ROS version, assuming ROS 1",
-        });
-      }
-
       for (let i = 0; i < result.topics.length; i++) {
         const topicName = result.topics[i]!;
         const type = result.types[i];
@@ -222,10 +209,10 @@ export default class RosbridgePlayer implements Player {
         topics.push({ name: topicName, datatype: type });
         datatypeDescriptions.push({ type, messageDefinition });
         const parsedDefinition = parseMessageDefinition(messageDefinition, {
-          ros2: rosVersion === 2,
+          ros2: this._rosVersion === 2,
         });
         messageReaders[type] ??=
-          rosVersion === 1
+          this._rosVersion === 1
             ? new LazyMessageReader(parsedDefinition)
             : new ROS2MessageReader(parsedDefinition);
         this._parsedMessageDefinitionsByTopic[topicName] = parsedDefinition;
@@ -253,7 +240,7 @@ export default class RosbridgePlayer implements Player {
 
       this._providerTopics = sortedTopics;
       this._providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
-        ros2: rosVersion === 2,
+        ros2: this._rosVersion === 2,
       });
       this._messageReadersByDatatype = messageReaders;
 

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -55,8 +55,12 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
       ),
     },
     {
-      name: "Rosbridge (WebSocket)",
-      type: "rosbridge-websocket",
+      name: "ROS 1 Rosbridge (WebSocket)",
+      type: "ros1-rosbridge-websocket",
+    },
+    {
+      name: "ROS 2 Rosbridge (WebSocket)",
+      type: "ros2-rosbridge-websocket",
     },
     {
       name: "ROS 1 Bag (local)",


### PR DESCRIPTION
**User-Facing Changes**
Now you can choose between ROS 1 and ROS 2 when establishing a Rosbridge connection (previously the version was detected automatically).

**Description**
This reverts commit 305b8ce701ddc987a6ebc505732fddfb04fb215c / #1656.
