### PR TITLE
Duplicate Rosbridge connection for ROS 1 and ROS 2

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -37,12 +37,16 @@ export default function Root(): ReactElement {
       type: "ros1-socket",
     },
     {
+      name: "ROS 1 Rosbridge (WebSocket)",
+      type: "rosbridge-websocket",
+    },
+    {
       name: "ROS 2",
       type: "ros2-socket",
       badgeText: "beta",
     },
     {
-      name: "Rosbridge (WebSocket)",
+      name: "ROS 2 Rosbridge (WebSocket)",
       type: "rosbridge-websocket",
     },
     {

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -42,6 +42,10 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
       ),
     },
     {
+      name: "ROS 1 Rosbridge (WebSocket)",
+      type: "rosbridge-websocket",
+    },
+    {
       name: "ROS 2",
       type: "ros2-socket",
       badgeText: "beta",
@@ -55,7 +59,7 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
       ),
     },
     {
-      name: "Rosbridge (WebSocket)",
+      name: "ROS 2 Rosbridge (WebSocket)",
       type: "rosbridge-websocket",
     },
     {


### PR DESCRIPTION
**User-Facing Changes**
Not worth mentioning in release notes

**Description**
The auto-detection logic remains in place. We add a separate "ROS 2 Rosbridge" item in the data source list so users are not drawn away from Rosbridge by the other "ROS 2" data sources, although it is functionally no different to click the ROS 1 button.
