### PR TITLE
Window/panel styling cleanup

### DIFF
--- a/packages/studio-base/src/components/Panel.module.scss
+++ b/packages/studio-base/src/components/Panel.module.scss
@@ -41,21 +41,10 @@
   position: fixed;
   z-index: 100;
   border: 4px solid rgba(110, 81, 238, 0.3);
-  top: $topBarHeight;
-  left: 0;
-  right: 0;
-  bottom: $playbackControlHeight;
-}
-
-.notClickable {
-  position: fixed;
-  z-index: 100;
   top: 0;
   left: 0;
   right: 0;
-  height: $topBarHeight;
-  opacity: 0;
-  cursor: not-allowed;
+  bottom: $playbackControlHeight;
 }
 
 .tabActionsOverlay,
@@ -135,7 +124,7 @@
   justify-content: space-between;
 }
 
-.exitFullScreen {
+button.exitFullScreen {
   position: fixed;
   top: 75px;
   right: 8px;

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -519,7 +519,6 @@ export default function Panel<
               connectToolbarDragPreview(el);
             }}
           >
-            {fullScreen && <div className={styles.notClickable} />}
             {isSelected && !fullScreen && numSelectedPanelsIfSelected > 1 && (
               <div data-tab-options className={styles.tabActionsOverlay}>
                 <Button style={{ backgroundColor: colors.BLUE }} onClick={groupPanels}>

--- a/packages/studio-base/src/components/Tooltip.tsx
+++ b/packages/studio-base/src/components/Tooltip.tsx
@@ -51,9 +51,6 @@ export function useTooltip({
   );
   const theme = useTheme();
 
-  const titlebarHeight = (theme.components?.Titlebar?.styles as { root?: IRawStyleBase })?.root
-    ?.height;
-
   // Styles which ideally we would be able to set in the theme for all Tooltips:
   // https://github.com/microsoft/fluentui/discussions/17772
   const calloutProps: ICalloutProps & { styles: Partial<ICalloutContentStyles> } = {
@@ -66,21 +63,6 @@ export function useTooltip({
       beak: { background: theme.palette.neutralDark },
       beakCurtain: { background: theme.palette.neutralDark },
       calloutMain: { background: theme.palette.neutralDark },
-    },
-    // Customize bounds to leave space for the window traffic light icons
-    bounds: (_target, win) => {
-      if (!win) {
-        return undefined;
-      }
-      const rect = {
-        top: typeof titlebarHeight === "string" ? parseFloat(titlebarHeight) : 8,
-        left: 8,
-        bottom: win.innerHeight - 8,
-        right: win.innerWidth - 8,
-        width: win.innerWidth - 2 * 8,
-        height: win.innerHeight - 2 * 8,
-      };
-      return rect;
     },
   };
 

--- a/packages/studio-base/src/components/Tooltip.tsx
+++ b/packages/studio-base/src/components/Tooltip.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { IRawStyleBase } from "@fluentui/merge-styles";
 import {
   DirectionalHint,
   ICalloutProps,

--- a/packages/studio-base/src/styles/variables.module.scss
+++ b/packages/studio-base/src/styles/variables.module.scss
@@ -1,5 +1,1 @@
-$topBarHeight: 36px;
 $playbackControlHeight: 50px;
-:export {
-  topBarHeight: $topBarHeight;
-}

--- a/packages/studio-base/src/theme/index.ts
+++ b/packages/studio-base/src/theme/index.ts
@@ -12,7 +12,6 @@ import {
   ITooltipStyleProps,
   IColorPickerStyles,
   IToggleStyles,
-  IStyle,
   ISpinnerStyles,
   IPalette,
   hsl2rgb,
@@ -21,7 +20,6 @@ import {
 import { createTheme } from "@fluentui/theme";
 
 import { SANS_SERIF } from "@foxglove/studio-base/styles/fonts";
-import styles from "@foxglove/studio-base/styles/variables.module.scss";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 const THEME_HUE = 247;
@@ -142,15 +140,6 @@ export default createTheme({
           borderWidth: 2,
         },
       } as Partial<ISpinnerStyles>,
-    },
-
-    // Custom (non-Fluent) components
-    Titlebar: {
-      styles: {
-        root: {
-          height: styles.topBarHeight,
-        } as IStyle,
-      },
     },
   },
   isInverted: true,


### PR DESCRIPTION
**User-Facing Changes**
Fixed bugs with the appearance of full-screen panels.

**Description**
Remove topBarHeight and theme.components.Titlebar which is no longer relevant since #1677.

Fix some styling around the panel fullscreen feature, and fix the exit fullscreen button styles which probably broke in #1546 or related work.
