### PR TITLE
Expose filePath on PlayerState; setRepresentedFilename on macOS

### DIFF
--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -48,6 +48,7 @@ type DesktopExtension = {
 };
 
 interface Desktop {
+  /** https://www.electronjs.org/docs/tutorial/represented-file */
   setRepresentedFilename(path: string | undefined): Promise<void>;
 
   // Get an array of deep links provided on app launch

--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -48,6 +48,8 @@ type DesktopExtension = {
 };
 
 interface Desktop {
+  setRepresentedFilename(path: string | undefined): Promise<void>;
+
   // Get an array of deep links provided on app launch
   getDeepLinks: () => string[];
 

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -162,6 +162,11 @@ function main() {
     preloaderFileInputIsReady = true;
   });
 
+  ipcMain.handle("setRepresentedFilename", (ev, path: string | undefined) => {
+    const browserWindow = BrowserWindow.fromId(ev.sender.id);
+    browserWindow?.setRepresentedFilename(path ?? "");
+  });
+
   const openUrls: string[] = [];
 
   // works on osx - even when app is closed

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -107,6 +107,9 @@ const ctx: OsContext = {
 };
 
 const desktopBridge: Desktop = {
+  async setRepresentedFilename(path: string | undefined) {
+    await ipcRenderer.invoke("setRepresentedFilename", path);
+  },
   getDeepLinks(): string[] {
     return window.process.argv.filter((arg) => arg.startsWith("foxglove://"));
   },

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -24,6 +24,7 @@ import { Desktop } from "../common/types";
 import NativeAppMenuProvider from "./components/NativeAppMenuProvider";
 import NativeStorageAppConfigurationProvider from "./components/NativeStorageAppConfigurationProvider";
 import NativeStorageLayoutStorageProvider from "./components/NativeStorageLayoutStorageProvider";
+import NativeWindowProvider from "./components/NativeWindowProvider";
 import ExtensionLoaderProvider from "./providers/ExtensionLoaderProvider";
 
 const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
@@ -78,6 +79,7 @@ export default function Root(): ReactElement {
     <StudioToastProvider />,
     <NativeStorageLayoutStorageProvider />,
     <NativeAppMenuProvider />,
+    <NativeWindowProvider />,
     <UserProfileLocalStorageProvider />,
     <ExtensionLoaderProvider />,
     /* eslint-enable react/jsx-key */

--- a/desktop/renderer/components/NativeWindowProvider.tsx
+++ b/desktop/renderer/components/NativeWindowProvider.tsx
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PropsWithChildren, useMemo } from "react";
+
+import { NativeWindowContext, NativeWindow } from "@foxglove/studio-base";
+
+import { Desktop } from "../../common/types";
+
+const desktopBridge = (global as { desktopBridge?: Desktop }).desktopBridge;
+
+export default function NativeWindowProvider(props: PropsWithChildren<unknown>): JSX.Element {
+  const value = useMemo<NativeWindow>(() => {
+    return {
+      async setRepresentedFilename(path: string | undefined) {
+        await desktopBridge?.setRepresentedFilename(path);
+      },
+    };
+  }, []);
+
+  return (
+    <NativeWindowContext.Provider value={value}>{props.children}</NativeWindowContext.Provider>
+  );
+}

--- a/packages/studio-base/src/components/DocumentTitleAdapter.tsx
+++ b/packages/studio-base/src/components/DocumentTitleAdapter.tsx
@@ -8,21 +8,32 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { useNativeWindow } from "@foxglove/studio-base/context/NativeWindowContext";
 
 const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
+const selectPlayerFilePath = (ctx: MessagePipelineContext) => ctx.playerState.filePath;
 
 /**
  * DocumentTitleAdapter sets the document title based on the currently selected player
  */
 export default function DocumentTitleAdapter(): JSX.Element {
+  const nativeWindow = useNativeWindow();
   const playerName = useMessagePipeline(selectPlayerName);
+  const filePath = useMessagePipeline(selectPlayerFilePath);
 
   useEffect(() => {
     if (!playerName) {
       window.document.title = "Foxglove Studio";
       return;
     }
-    window.document.title = `${playerName} - Foxglove Studio`;
+    window.document.title = navigator.userAgent.includes("Mac")
+      ? playerName
+      : `${playerName} – Foxglove Studio`;
   }, [playerName]);
+
+  useEffect(() => {
+    nativeWindow?.setRepresentedFilename(filePath);
+  }, [filePath, nativeWindow]);
+
   return <></>;
 }

--- a/packages/studio-base/src/context/NativeWindowContext.ts
+++ b/packages/studio-base/src/context/NativeWindowContext.ts
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+export interface NativeWindow {
+  /** https://www.electronjs.org/docs/tutorial/represented-file */
+  setRepresentedFilename(filename: string | undefined): Promise<void>;
+}
+
+const NativeWindowContext = createContext<NativeWindow | undefined>(undefined);
+
+export function useNativeWindow(): NativeWindow | undefined {
+  return useContext(NativeWindowContext);
+}
+
+export default NativeWindowContext;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -27,6 +27,8 @@ export type { Layout, LayoutID, ISO8601Timestamp, ILayoutStorage } from "./servi
 export { migrateLayout } from "./services/ILayoutStorage";
 export { default as NativeAppMenuContext } from "./context/NativeAppMenuContext";
 export type { NativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";
+export { default as NativeWindowContext } from "./context/NativeWindowContext";
+export type { NativeWindow } from "./context/NativeWindowContext";
 export type { PlayerSourceDefinition } from "./context/PlayerSelectionContext";
 export { default as ThemeProvider } from "./theme/ThemeProvider";
 export { default as installDevtoolsFormatters } from "./util/installDevtoolsFormatters";

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -95,6 +95,7 @@ export type RandomAccessPlayerOptions = {
 // A `Player` that wraps around a tree of `RandomAccessDataProviders`.
 export default class RandomAccessPlayer implements Player {
   private _label?: string;
+  private _filePath?: string;
   _provider: RandomAccessDataProvider;
   _isPlaying: boolean = false;
   _wasPlayingBeforeTabSwitch = false;
@@ -148,6 +149,7 @@ export default class RandomAccessPlayer implements Player {
     { metricsCollector, seekToTime }: RandomAccessPlayerOptions,
   ) {
     this._label = providerDescriptor.label;
+    this._filePath = providerDescriptor.filePath;
     if (process.env.NODE_ENV === "test" && providerDescriptor.name === "TestProvider") {
       this._provider = providerDescriptor.args.provider;
     } else {
@@ -265,6 +267,7 @@ export default class RandomAccessPlayer implements Player {
     if (this._hasError) {
       return this._listener({
         name: this._label,
+        filePath: this._filePath,
         presence: PlayerPresence.ERROR,
         progress: {},
         capabilities: [],
@@ -311,6 +314,7 @@ export default class RandomAccessPlayer implements Player {
 
     const data: PlayerState = {
       name: this._label,
+      filePath: this._filePath,
       presence: this._reconnecting
         ? PlayerPresence.RECONNECTING
         : this._initializing

--- a/packages/studio-base/src/players/buildPlayer.ts
+++ b/packages/studio-base/src/players/buildPlayer.ts
@@ -23,8 +23,9 @@ export function buildPlayerFromDescriptor(
   childDescriptor: RandomAccessDataProviderDescriptor,
   options: BuildPlayerOptions,
 ): Player {
-  const rootDescriptor = {
+  const rootDescriptor: RandomAccessDataProviderDescriptor = {
     label: name,
+    filePath: childDescriptor.filePath,
     name: CoreDataProviders.ParseMessagesDataProvider,
     args: {},
     children: [

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -128,6 +128,9 @@ export type PlayerState = {
   // The player could set this value to represent the current connection, name, ports, etc.
   name?: string;
 
+  /** A path to a file on disk currently being accessed by the player */
+  filePath?: string;
+
   // Surface issues during playback or player initialization
   problems?: PlayerProblem[];
 

--- a/packages/studio-base/src/randomAccessDataProviders/standardDataProviderDescriptors.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/standardDataProviderDescriptors.ts
@@ -17,12 +17,19 @@ import { RandomAccessDataProviderDescriptor } from "@foxglove/studio-base/random
 function wrapInWorker(
   descriptor: RandomAccessDataProviderDescriptor,
 ): RandomAccessDataProviderDescriptor {
-  return { name: CoreDataProviders.WorkerDataProvider, args: {}, children: [descriptor] };
+  return {
+    label: descriptor.label,
+    filePath: descriptor.filePath,
+    name: CoreDataProviders.WorkerDataProvider,
+    args: {},
+    children: [descriptor],
+  };
 }
 
 export function getLocalBagDescriptor(file: File): RandomAccessDataProviderDescriptor {
   return wrapInWorker({
     name: CoreDataProviders.BagDataProvider,
+    filePath: (file as { path?: string }).path, // File.path is added by Electron
     args: { bagPath: { type: "file", file } },
     children: [],
   });

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -204,6 +204,7 @@ export type Connection = {
 // means that you can describe a chain of data providers that includes a Worker or a WebSocket.
 export type RandomAccessDataProviderDescriptor = {
   label?: string;
+  filePath?: string;
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any;


### PR DESCRIPTION
**User-Facing Changes**
On macOS, when a ROS 1 bag file is opened, the window title bar now references the file so you can see its location on the filesystem.

**Description**
- Add a `filePath` to player state and expose `File.path` (an electronism) for bag files. Unfortunately it only works for File, not FileSystemDirectoryHandle, so it doesn't work for ROS 2 bag folders. 🤷 
- Expose https://www.electronjs.org/docs/tutorial/represented-file via new NativeWindowContext and use it to show the player's filePath.