### PR TITLE
Move loading state into selectedLayout so id can be read even when layout is loading

### DIFF
--- a/packages/studio-base/src/PanelAPI/useConfigById.ts
+++ b/packages/studio-base/src/PanelAPI/useConfigById.ts
@@ -25,7 +25,7 @@ export default function useConfigById<Config extends Record<string, unknown>>(
       if (panelId == undefined) {
         return undefined;
       }
-      return state.selectedLayout?.data.configById?.[panelId] as Config | undefined;
+      return state.selectedLayout?.data?.configById?.[panelId] as Config | undefined;
     },
     [panelId],
   );

--- a/packages/studio-base/src/components/MessageOrderControls.tsx
+++ b/packages/studio-base/src/components/MessageOrderControls.tsx
@@ -21,7 +21,7 @@ const messageOrderLabel = {
 export default function MessageOrderControls(): JSX.Element {
   const theme = useTheme();
   const messageOrder = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.playbackConfig.messageOrder ?? "receiveTime",
+    (state) => state.selectedLayout?.data?.playbackConfig.messageOrder ?? "receiveTime",
   );
   const { setPlaybackConfig } = useCurrentLayoutActions();
 

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -308,7 +308,7 @@ export default function Panel<
     );
 
     const groupPanels = useCallback(() => {
-      const layout = getCurrentLayoutState().selectedLayout?.data.layout;
+      const layout = getCurrentLayoutState().selectedLayout?.data?.layout;
       if (layout == undefined) {
         return;
       }
@@ -321,7 +321,7 @@ export default function Panel<
     }, [getCurrentLayoutState, getSelectedPanelIds, createTabPanel, childId]);
 
     const createTabs = useCallback(() => {
-      const layout = getCurrentLayoutState().selectedLayout?.data.layout;
+      const layout = getCurrentLayoutState().selectedLayout?.data?.layout;
       if (layout == undefined) {
         return;
       }
@@ -342,7 +342,7 @@ export default function Panel<
     }, [closePanel, mosaicActions, mosaicWindowActions, tabId]);
 
     const splitPanel = useCallback(() => {
-      const savedProps = getCurrentLayoutState().selectedLayout?.data.configById;
+      const savedProps = getCurrentLayoutState().selectedLayout?.data?.configById;
       if (!savedProps) {
         return;
       }

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -185,7 +185,7 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
 
 export default function PanelLayout(): JSX.Element {
   const { changePanelLayout } = useCurrentLayoutActions();
-  const layoutLoading = useCurrentLayoutSelector((state) => state.loading);
+  const layoutLoading = useCurrentLayoutSelector((state) => state.selectedLayout?.loading);
   const selectedLayout = useCurrentLayoutSelector((state) => state.selectedLayout);
   const onChange = useCallback(
     (newLayout: MosaicNode<string> | undefined) => {
@@ -195,7 +195,7 @@ export default function PanelLayout(): JSX.Element {
     },
     [changePanelLayout],
   );
-  if (selectedLayout) {
+  if (selectedLayout?.data) {
     return <UnconnectedPanelLayout layout={selectedLayout.data.layout} onChange={onChange} />;
   } else if (layoutLoading === true) {
     return (

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -47,7 +47,7 @@ export default function PanelSettings(): JSX.Element {
 
   const [showShareModal, setShowShareModal] = useState(false);
   const shareModal = useMemo(() => {
-    const panelConfigById = getCurrentLayout().selectedLayout?.data.configById;
+    const panelConfigById = getCurrentLayout().selectedLayout?.data?.configById;
     if (selectedPanelId == undefined || !showShareModal || !panelConfigById) {
       return ReactNull;
     }

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -86,7 +86,7 @@ function StandardMenuItems({ tabId, isUnknownPanel }: { tabId?: string; isUnknow
         throw new Error("Trying to split unknown panel!");
       }
 
-      const config = getCurrentLayout().selectedLayout?.data.configById[id] ?? {};
+      const config = getCurrentLayout().selectedLayout?.data?.configById[id] ?? {};
       splitPanel({
         id,
         tabId,

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -53,7 +53,7 @@ const PlaybackTimeDisplayMethod = ({
 }): JSX.Element => {
   const timestampInputRef = useRef<HTMLInputElement>(ReactNull);
   const timeDisplayMethod = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.playbackConfig.timeDisplayMethod ?? "ROS",
+    (state) => state.selectedLayout?.data?.playbackConfig.timeDisplayMethod ?? "ROS",
   );
   const { setPlaybackConfig } = useCurrentLayoutActions();
   const setTimeDisplayMethod = useCallback(

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -28,7 +28,7 @@ function formatSpeed(val: number) {
 export default function PlaybackSpeedControls(): JSX.Element {
   const theme = useTheme();
   const configSpeed = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.playbackConfig.speed,
+    (state) => state.selectedLayout?.data?.playbackConfig.speed,
   );
   const speed = useMessagePipeline(
     useCallback(({ playerState }) => playerState.activeData?.speed, []),

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -363,11 +363,11 @@ export default function PlayerManager({
   });
 
   const messageOrder = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.playbackConfig.messageOrder,
+    (state) => state.selectedLayout?.data?.playbackConfig.messageOrder,
   );
-  const userNodes = useCurrentLayoutSelector((state) => state.selectedLayout?.data.userNodes);
+  const userNodes = useCurrentLayoutSelector((state) => state.selectedLayout?.data?.userNodes);
   const globalVariables = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.globalVariables ?? EMPTY_GLOBAL_VARIABLES,
+    (state) => state.selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES,
   );
 
   const globalVariablesRef = useRef<GlobalVariables>(globalVariables);

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -29,8 +29,13 @@ import {
 } from "./actions";
 
 export type LayoutState = Readonly<{
-  loading?: boolean;
-  selectedLayout: { id: LayoutID; data: PanelsState } | undefined;
+  selectedLayout:
+    | {
+        id: LayoutID;
+        loading?: boolean;
+        data: PanelsState | undefined;
+      }
+    | undefined;
 }>;
 
 /**
@@ -163,7 +168,7 @@ export function useSelectedPanels(): SelectedPanelActions {
 
   const selectAllPanels = useCallback(() => {
     // eslint-disable-next-line no-restricted-syntax
-    const panelIds = getLeaves(getCurrentLayout().selectedLayout?.data.layout ?? null);
+    const panelIds = getLeaves(getCurrentLayout().selectedLayout?.data?.layout ?? null);
     setSelectedPanelIds(panelIds);
   }, [getCurrentLayout, setSelectedPanelIds]);
 
@@ -171,7 +176,7 @@ export function useSelectedPanels(): SelectedPanelActions {
     (panelId: string, containingTabId: string | undefined) => {
       setSelectedPanelIds((selectedIds) => {
         const { selectedLayout } = getCurrentLayout();
-        if (!selectedLayout) {
+        if (!selectedLayout?.data) {
           return selectedIds;
         }
         return toggleSelectedPanel(

--- a/packages/studio-base/src/context/CurrentLayoutContext/useCurrentLayoutSelector.test.tsx
+++ b/packages/studio-base/src/context/CurrentLayoutContext/useCurrentLayoutSelector.test.tsx
@@ -17,7 +17,7 @@ describe("useCurrentLayoutSelector", () => {
       }),
       {
         initialProps: (layoutState: LayoutState) =>
-          layoutState.selectedLayout?.data.configById["foo"],
+          layoutState.selectedLayout?.data?.configById["foo"],
         wrapper({ children }) {
           return (
             <MockCurrentLayoutProvider initialState={{ configById: { foo: { value: 42 } } }}>
@@ -49,7 +49,7 @@ describe("useCurrentLayoutSelector", () => {
       }),
       {
         initialProps: (layoutState: LayoutState) =>
-          layoutState.selectedLayout?.data.configById["foo"],
+          layoutState.selectedLayout?.data?.configById["foo"],
         wrapper({ children }) {
           return (
             <MockCurrentLayoutProvider
@@ -71,7 +71,7 @@ describe("useCurrentLayoutSelector", () => {
       { value: 42 },
     ]);
 
-    rerender((layoutState) => layoutState.selectedLayout?.data.configById["bar"]);
+    rerender((layoutState) => layoutState.selectedLayout?.data?.configById["bar"]);
     expect(result.all.map((item) => (item instanceof Error ? undefined : item.value))).toEqual([
       { value: 42 },
       { otherValue: 0 },
@@ -101,7 +101,7 @@ describe("useCurrentLayoutSelector", () => {
       }),
       {
         initialProps: (layoutState: LayoutState) =>
-          layoutState.selectedLayout?.data.configById["foo"],
+          layoutState.selectedLayout?.data?.configById["foo"],
         wrapper({ children }) {
           return (
             <MockCurrentLayoutProvider

--- a/packages/studio-base/src/hooks/useGlobalVariables.ts
+++ b/packages/studio-base/src/hooks/useGlobalVariables.ts
@@ -27,7 +27,7 @@ export default function useGlobalVariables(): {
 } {
   const { setGlobalVariables, overwriteGlobalVariables } = useCurrentLayoutActions();
   const globalVariables = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.globalVariables ?? EMPTY_GLOBAL_VARIABLES,
+    (state) => state.selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES,
   );
   return { setGlobalVariables, overwriteGlobalVariables, globalVariables };
 }

--- a/packages/studio-base/src/hooks/usePanelDrag.tsx
+++ b/packages/studio-base/src/hooks/usePanelDrag.tsx
@@ -54,7 +54,7 @@ export default function usePanelDrag(props: {
       }
 
       const { selectedLayout } = getCurrentLayout();
-      if (!selectedLayout) {
+      if (!selectedLayout?.data) {
         // eslint-disable-next-line no-restricted-syntax
         return null;
       }

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -134,7 +134,7 @@ function NodePlayground(props: Props) {
   const [explorer, updateExplorer] = React.useState<Explorer>(undefined);
 
   const userNodes = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.userNodes ?? EMPTY_USER_NODES,
+    (state) => state.selectedLayout?.data?.userNodes ?? EMPTY_USER_NODES,
   );
   const {
     state: { nodeStates: userNodeDiagnostics, rosLib },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables.ts
@@ -35,7 +35,7 @@ export default function useLinkedGlobalVariables(): {
 } {
   const { setLinkedGlobalVariables } = useCurrentLayoutActions();
   const linkedGlobalVariables = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data.linkedGlobalVariables ?? EMPTY_VARIABLES,
+    (state) => state.selectedLayout?.data?.linkedGlobalVariables ?? EMPTY_VARIABLES,
   );
   const linkedGlobalVariablesByName = useMemo(() => {
     const linksByName: { [name: string]: LinkedGlobalVariable[] } = {};

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -127,9 +127,9 @@ describe("CurrentLayoutProvider", () => {
     expect(
       result.all.map((item) => (item instanceof Error ? undefined : item.layoutState)),
     ).toEqual([
-      { loading: true, selectedLayout: undefined },
-      { loading: true, selectedLayout: undefined },
-      { loading: false, selectedLayout: { id: "example", data: expectedState } },
+      { selectedLayout: undefined },
+      { selectedLayout: { loading: true, id: "example", data: undefined } },
+      { selectedLayout: { loading: false, id: "example", data: expectedState } },
     ]);
   });
 
@@ -173,11 +173,11 @@ describe("CurrentLayoutProvider", () => {
     expect(
       result.all.map((item) => (item instanceof Error ? undefined : item.layoutState)),
     ).toEqual([
-      { loading: true, selectedLayout: undefined },
-      { loading: true, selectedLayout: undefined },
-      { loading: false, selectedLayout: { id: "example", data: TEST_LAYOUT } },
-      { loading: true, selectedLayout: undefined },
-      { loading: false, selectedLayout: { id: "example2", data: newLayout } },
+      { selectedLayout: undefined },
+      { selectedLayout: { loading: true, id: "example", data: undefined } },
+      { selectedLayout: { loading: false, id: "example", data: TEST_LAYOUT } },
+      { selectedLayout: { loading: true, id: "example2", data: undefined } },
+      { selectedLayout: { loading: false, id: "example2", data: newLayout } },
     ]);
   });
 
@@ -186,7 +186,7 @@ describe("CurrentLayoutProvider", () => {
     const mockLayoutManager = makeMockLayoutManager();
     mockLayoutManager.getLayout.mockImplementation(async () => {
       return {
-        id: "TEST_ID",
+        id: "example",
         name: "Test layout",
         baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
       };
@@ -214,15 +214,15 @@ describe("CurrentLayoutProvider", () => {
     };
 
     expect(mockLayoutManager.updateLayout.mock.calls).toEqual([
-      [{ id: "TEST_ID", data: newState }],
+      [{ id: "example", data: newState }],
     ]);
     expect(
       result.all.map((item) => (item instanceof Error ? undefined : item.layoutState)),
     ).toEqual([
-      { loading: true, selectedLayout: undefined },
-      { loading: true, selectedLayout: undefined },
-      { loading: false, selectedLayout: { id: "TEST_ID", data: TEST_LAYOUT } },
-      { loading: false, selectedLayout: { id: "TEST_ID", data: newState } },
+      { selectedLayout: undefined },
+      { selectedLayout: { loading: true, id: "example", data: undefined } },
+      { selectedLayout: { loading: false, id: "example", data: TEST_LAYOUT } },
+      { selectedLayout: { loading: false, id: "example", data: newState } },
     ]);
   });
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -156,7 +156,7 @@ export default function CurrentLayoutProvider({
     (action: PanelsActions) => {
       if (
         layoutStateRef.current.selectedLayout?.data == undefined ||
-        layoutStateRef.current.selectedLayout.loading == undefined
+        layoutStateRef.current.selectedLayout.loading === true
       ) {
         return;
       }

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -170,7 +170,6 @@ export default function CurrentLayoutProvider({
 
       const newLayout = {
         id: layoutStateRef.current.selectedLayout.id,
-        loading: false,
         data: newData,
       };
 
@@ -198,7 +197,7 @@ export default function CurrentLayoutProvider({
       // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
       // configs (i.e. set default configs). These result in calls to performAction. To ensure the
       // debounced params are set in the proper order, we invoke setLayoutState at the end.
-      setLayoutState({ selectedLayout: newLayout });
+      setLayoutState({ selectedLayout: { ...newLayout, loading: false } });
     },
     [addToast, isMounted, layoutManager, setLayoutState],
   );

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -68,7 +68,6 @@ export default function CurrentLayoutProvider({
   }, []);
 
   const [layoutState, setLayoutStateInternal] = useState<LayoutState>({
-    loading: true,
     selectedLayout: undefined,
   });
   const layoutStateRef = useRef(layoutState);
@@ -110,21 +109,24 @@ export default function CurrentLayoutProvider({
       { saveToProfile = true }: { saveToProfile?: boolean } = {},
     ) => {
       if (id == undefined) {
-        setLayoutState({ loading: false, selectedLayout: undefined });
+        setLayoutState({ selectedLayout: undefined });
         return;
       }
       try {
-        setLayoutState({ loading: true, selectedLayout: undefined });
+        setLayoutState({ selectedLayout: { id, loading: true, data: undefined } });
         const layout = await layoutManager.getLayout(id);
         if (!isMounted()) {
           return;
         }
         if (layout == undefined) {
-          setLayoutState({ loading: false, selectedLayout: undefined });
+          setLayoutState({ selectedLayout: undefined });
         } else {
           setLayoutState({
-            loading: false,
-            selectedLayout: { id: layout.id, data: layout.working?.data ?? layout.baseline.data },
+            selectedLayout: {
+              loading: false,
+              id: layout.id,
+              data: layout.working?.data ?? layout.baseline.data,
+            },
           });
           if (saveToProfile) {
             setUserProfile({ currentLayoutId: id }).catch((error) => {
@@ -138,7 +140,7 @@ export default function CurrentLayoutProvider({
       } catch (error) {
         console.error(error);
         addToast(`The layout could not be loaded. ${error.toString()}`, { appearance: "error" });
-        setLayoutState({ loading: false, selectedLayout: undefined });
+        setLayoutState({ selectedLayout: undefined });
       }
     },
     [addToast, isMounted, layoutManager, setLayoutState, setUserProfile],
@@ -153,13 +155,13 @@ export default function CurrentLayoutProvider({
   const performAction = useCallback(
     (action: PanelsActions) => {
       if (
-        layoutStateRef.current.loading === true ||
-        layoutStateRef.current.selectedLayout == undefined
+        layoutStateRef.current.selectedLayout?.data == undefined ||
+        layoutStateRef.current.selectedLayout.loading == undefined
       ) {
         return;
       }
       const oldData = layoutStateRef.current.selectedLayout.data;
-      const newData = panelsReducer(layoutStateRef.current.selectedLayout.data, action);
+      const newData = panelsReducer(oldData, action);
 
       // the panel state did not change, so no need to perform layout state updates or layout manager updates
       if (isEqual(oldData, newData)) {
@@ -168,6 +170,7 @@ export default function CurrentLayoutProvider({
 
       const newLayout = {
         id: layoutStateRef.current.selectedLayout.id,
+        loading: false,
         data: newData,
       };
 
@@ -195,7 +198,7 @@ export default function CurrentLayoutProvider({
       // Some actions like CHANGE_PANEL_LAYOUT will cause further downstream effects to update panel
       // configs (i.e. set default configs). These result in calls to performAction. To ensure the
       // debounced params are set in the proper order, we invoke setLayoutState at the end.
-      setLayoutState({ loading: false, selectedLayout: newLayout });
+      setLayoutState({ selectedLayout: newLayout });
     },
     [addToast, isMounted, layoutManager, setLayoutState],
   );
@@ -210,8 +213,8 @@ export default function CurrentLayoutProvider({
         updatedLayout.id === layoutStateRef.current.selectedLayout.id
       ) {
         setLayoutState({
-          loading: false,
           selectedLayout: {
+            loading: false,
             id: updatedLayout.id,
             data: updatedLayout.working?.data ?? updatedLayout.baseline.data,
           },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Reduces visual delay when selecting a layout. Now the clicked row will be highlighted while the layout is loading.