### PR TITLE
Fix layout being deleted when renamed before first upload

### DIFF
--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -256,7 +256,10 @@ export default class LayoutManager implements ILayoutManager {
 
             // If the name is being changed, we will need to upload to the server
             syncInfo:
-              this.remote && name != undefined
+              this.remote &&
+              name != undefined &&
+              localLayout.syncInfo &&
+              localLayout.syncInfo?.status !== "new"
                 ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
                 : localLayout.syncInfo,
           }),


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Fixes #1769
A rename before a layout was synced would change the layout's state from `new` to `updated`, so the next sync would notice the layout absent from the `GET /layouts` response and think it had been deleted on the server.