### PR TITLE
Adjust sign in flow to make loading states more visible

### DIFF
--- a/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
@@ -3,50 +3,24 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { PrimaryButton, Stack, Text, useTheme } from "@fluentui/react";
-import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
-import { useToasts } from "react-toast-notifications";
-import { useAsyncFn, useLocalStorage } from "react-use";
+import { useCallback, useState } from "react";
+import { useLocalStorage } from "react-use";
 
-import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
-import { DeviceCodeResponse } from "@foxglove/studio-base/services/ConsoleApi";
+import { Session } from "@foxglove/studio-base/services/ConsoleApi";
 
 import AccountSyncGraphic from "./AccountSyncGraphic";
 import DeviceCodeDialog from "./DeviceCodeDialog";
 
 export default function SigninForm(): JSX.Element {
   const theme = useTheme();
-  const { addToast } = useToasts();
-  const api = useConsoleApi();
   const [_, setBearerToken] = useLocalStorage<string>("fox.bearer-token");
-  const [deviceCode, setDeviceCode] = useState<DeviceCodeResponse | undefined>(undefined);
+  const [modalOpen, setModalOpen] = useState(false);
 
-  const [{ value: deviceCodeResponse, error: deviceCodeError, loading }, getDeviceCode] =
-    useAsyncFn(async () => {
-      return await api.deviceCode({
-        client_id: process.env.OAUTH_CLIENT_ID!,
-      });
-    }, [api]);
+  const handleOnSigninClick = useCallback(() => setModalOpen(true), []);
 
-  useEffect(() => {
-    setDeviceCode(deviceCodeResponse);
-  }, [deviceCodeResponse]);
-
-  const handleOnSigninClick = useCallback(() => {
-    void getDeviceCode();
-  }, [getDeviceCode]);
-
-  useEffect(() => {
-    if (deviceCodeError != undefined) {
-      addToast(deviceCodeError.message, {
-        appearance: "error",
-      });
-    }
-  }, [addToast, deviceCodeError]);
-
-  type OnClose = ComponentProps<typeof DeviceCodeDialog>["onClose"];
-  const onClose = useCallback<NonNullable<OnClose>>(
-    (session) => {
-      setDeviceCode(undefined);
+  const onClose = useCallback(
+    (session?: Session) => {
+      setModalOpen(false);
       if (session != undefined) {
         setBearerToken(session.bearer_token);
         window.location.reload();
@@ -55,51 +29,32 @@ export default function SigninForm(): JSX.Element {
     [setBearerToken],
   );
 
-  // open new window with the device code to facilitate user signin flow
-  useEffect(() => {
-    if (deviceCode == undefined) {
-      return;
-    }
-
-    const url = new URL(deviceCode.verification_uri);
-    url.searchParams.append("user_code", deviceCode.user_code);
-    const href = url.toString();
-
-    window.open(href, "_blank");
-  }, [deviceCode]);
-
-  const modal = useMemo(() => {
-    if (deviceCode != undefined) {
-      return <DeviceCodeDialog deviceCode={deviceCode} onClose={onClose} />;
-    }
-
-    return ReactNull;
-  }, [deviceCode, onClose]);
-
   return (
-    <Stack tokens={{ childrenGap: theme.spacing.l1 }} styles={{ root: { lineHeight: "1.3" } }}>
-      <Stack horizontal horizontalAlign="center" styles={{ root: { color: theme.palette.accent } }}>
-        <AccountSyncGraphic width={192} />
-      </Stack>
-      <Text variant="mediumPlus">
-        Sign in to access collaboration features like shared layouts.
-      </Text>
-      {modal}
+    <>
+      {modalOpen && <DeviceCodeDialog onClose={onClose} />}
+      <Stack tokens={{ childrenGap: theme.spacing.l1 }} styles={{ root: { lineHeight: "1.3" } }}>
+        <Stack
+          horizontal
+          horizontalAlign="center"
+          styles={{ root: { color: theme.palette.accent } }}
+        >
+          <AccountSyncGraphic width={192} />
+        </Stack>
+        <Text variant="mediumPlus">
+          Sign in to Foxglove to access collaboration features like shared layouts.
+        </Text>
 
-      <PrimaryButton
-        disabled={loading}
-        text="Sign in"
-        onClick={handleOnSigninClick}
-        styles={{
-          root: {
-            marginLeft: 0,
-            marginRight: 0,
-          },
-          rootDisabled: {
-            cursor: "wait !important",
-          },
-        }}
-      />
-    </Stack>
+        <PrimaryButton
+          text="Sign in"
+          onClick={handleOnSigninClick}
+          styles={{
+            root: {
+              marginLeft: 0,
+              marginRight: 0,
+            },
+          }}
+        />
+      </Stack>
+    </>
   );
 }

--- a/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
@@ -40,7 +40,7 @@ export default function SigninForm(): JSX.Element {
         >
           <AccountSyncGraphic width={192} />
         </Stack>
-        <Text variant="mediumPlus">
+        <Text variant="medium">
           Sign in to Foxglove to access collaboration features like shared layouts.
         </Text>
 


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Partially addresses #1747

Open dialog immediately when button is pressed. Show a spinner while waiting for device code.
<img width="516" alt="Screen Shot 2021-09-04 at 1 12 43 PM" src="https://user-images.githubusercontent.com/14237/132107102-9de018d9-cd22-4bf4-96af-74a4ca3abe9f.png">

Show a spinner while polling for token.
<img width="473" alt="Screen Shot 2021-09-04 at 1 18 27 PM" src="https://user-images.githubusercontent.com/14237/132107098-3ce6ed3d-a1d8-4618-8ec0-cca5547d850b.png">
