### PR TITLE
Added nginx-based dockerfile for web studio

### DIFF
--- a/docker/Dockerfile.StaticWebStudio
+++ b/docker/Dockerfile.StaticWebStudio
@@ -1,0 +1,15 @@
+
+FROM node:latest AS builder
+
+WORKDIR /app
+
+COPY . /app
+
+RUN yarn install && yarn web:build:prod
+
+FROM nginx:latest
+
+RUN sed -i 's/listen  *80;/listen 8080;/g' /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+
+COPY --from=builder /app/web/.webpack /usr/share/nginx/html


### PR DESCRIPTION
**User-Facing Changes**


**Description**

Added nginx-based dockerfile (like it was done in webviz app) for web build of Foxglove Studio.

**Docs**

For building this image use next commands:

```bash
cd studio
docker build . -f=docker/Dockerfile.StaticWebStudio -t <your_tag>
```

