### PR TITLE
Add URL handler to re-focus app after successful signin

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -180,6 +180,7 @@ function main() {
     ev.preventDefault();
 
     if (url.startsWith("foxglove://signin-complete")) {
+      // When completing sign in from Console, the browser can launch this URL to re-focus the app.
       app.focus({ steal: true });
     } else if (app.isReady()) {
       new StudioWindow([url]).load();

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -179,7 +179,9 @@ function main() {
 
     ev.preventDefault();
 
-    if (app.isReady()) {
+    if (url.startsWith("foxglove://signin-complete")) {
+      app.focus({ steal: true });
+    } else if (app.isReady()) {
       new StudioWindow([url]).load();
     } else {
       openUrls.push(url);


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Related: https://github.com/foxglove/studio/issues/1747

Add a `foxglove://signin-complete` URL handler which Console can use to re-focus the app after sign in.