### PR TITLE
Remove sendNotification from SceneBuilder

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -51,7 +51,6 @@ import { MarkerProvider, MarkerCollector, Scene } from "@foxglove/studio-base/ty
 import Bounds from "@foxglove/studio-base/util/Bounds";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 import { ThreeDimensionalVizHooks } from "./types";
 
@@ -443,12 +442,6 @@ export default class SceneBuilder implements MarkerProvider {
   _reportBadFrameId(topic: string): void {
     if (!this.reportedErrorTopics.topicsWithBadFrameIds.has(topic)) {
       this.reportedErrorTopics.topicsWithBadFrameIds.add(topic);
-      sendNotification(
-        `Topic ${topic} has bad frame`,
-        "Non-root transforms may be out of sync, since Foxglove Studio uses the latest transform message instead of the one matching header.stamp",
-        "user",
-        "warn",
-      );
     }
   }
 


### PR DESCRIPTION

**User-Facing Changes**
A user is able to open a bag which contains some markers and then some tf messages without being bombarded with global popup warnings about `Topic /foo has bad frame`. Instead the bag loads correctly and as frames are available markers are rendered. Any errors are localized to the 3d panel topic list.

**Description**
SceneBuilder would send a notification when a topic had a bad frame id. This notification
would popup for the user and persist even tho scene builder might receive more topics
and frames and internally clear the error.

This change removes the sendNotification and uses the already present per-topic
notification mechanism local to the 3d panel to inform the user if there are errors on
their topic. This mechanism properly clears itself when there are no errors on the topic.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
