### PR TITLE
Cleanup 'Settings > Experimental Features' styling

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -51,25 +51,45 @@ const features: Feature[] = [
 ];
 
 function ExperimentalFeatureItem(props: { feature: Feature }) {
+  const theme = useTheme();
   const { feature } = props;
 
   const [enabled, setEnabled] = useAppConfigurationValue<boolean>(feature.key);
   return (
-    <Stack>
-      <Stack horizontal>
-        <Stack grow>
-          <Text as="h2" variant="medium">
-            {feature.name}
-          </Text>
-        </Stack>
-        <Toggle
-          checked={enabled}
-          onChange={(_, checked) => void setEnabled(checked)}
-          onText="Enabled"
-          offText="Disabled"
-        />
+    <Stack
+      horizontal
+      verticalAlign="start"
+      tokens={{ childrenGap: theme.spacing.m }}
+      styles={{
+        root: {
+          ":not(:first-child)": {
+            paddingTop: theme.spacing.m,
+            borderTop: `1px solid ${theme.semanticColors.bodyDivider}`,
+          },
+        },
+      }}
+    >
+      <Stack grow tokens={{ childrenGap: theme.spacing.s2 }}>
+        <Text variant="medium" styles={{ root: { fontWeight: 600 } }}>
+          {feature.name}
+        </Text>
+        <Text
+          variant="smallPlus"
+          styles={{
+            root: {
+              color: theme.semanticColors.bodySubtext,
+            },
+          }}
+        >
+          {feature.description}
+        </Text>
       </Stack>
-      <div>{feature.description}</div>
+      <Toggle
+        checked={enabled}
+        onChange={(_, checked) => void setEnabled(checked)}
+        onText="Enabled"
+        offText="Disabled"
+      />
     </Stack>
   );
 }

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -87,8 +87,13 @@ function ExperimentalFeatureItem(props: { feature: Feature }) {
       <Toggle
         checked={enabled}
         onChange={(_, checked) => void setEnabled(checked)}
-        onText="Enabled"
+        onText="Enabled "
         offText="Disabled"
+        styles={{
+          text: {
+            minWidth: 60,
+          },
+        }}
       />
     </Stack>
   );


### PR DESCRIPTION
**User-Facing Changes**
| With dividers | Without Dividers |
|---|---|
|<img width="388" alt="Screen Shot 2021-09-08 at 5 46 33 pm" src="https://user-images.githubusercontent.com/924528/132468422-5ab1274f-062a-4bc9-b59d-be213009e7d7.png"> | <img width="383" alt="Screen Shot 2021-09-08 at 5 48 00 pm" src="https://user-images.githubusercontent.com/924528/132468425-41d1f568-576f-465b-936e-ddfe03bc1331.png"> |

@defunctzombie @jtbandes Which version do you prefer? Divider or no dividers?

**Description**
Style tidy up on Experimental Features Settings

Closes #1794
