### PR TITLE
Fix MessagePathInput autocompleteRange with filters

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -335,12 +335,8 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
       } else {
         // Exclude any initial filters ("/topic{foo=='bar'}") from the range that will be replaced
         // when the user chooses a new message path.
-        const initialFilterLength = rosPath.messagePath.reduce((prev, item) => {
-          if (item.type === "filter") {
-            return prev + item.repr.length + 2; // add { and }
-          }
-          return prev;
-        }, 0);
+        const initialFilterLength =
+          rosPath.messagePath[0]?.type === "filter" ? rosPath.messagePath[0].repr.length + 2 : 0;
 
         return {
           autocompleteItems: messagePathsForDatatype(


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where selecting a message path from the auto-complete dropdown in the Plot panel would replace the wrong text range, resulting in an invalid message path.

**Description**
The `autocompleteRange` (the range of text to be replaced when an item was selected) was incorrect due to a bug introduced in https://github.com/foxglove/studio/pull/1569. The code

```ts
let initialFilterLength = 0;
for (const item of rosPath.messagePath) {
  if (item.type === "filter") {
    initialFilterLength += item.repr.length + 2; // add { and }
  } else {
    break;
  }
}
```
was incorrectly refactored to
```ts
const initialFilterLength = rosPath.messagePath.reduce((prev, item) => {
  if (item.type === "filter") {
    return prev + item.repr.length + 2; // add { and }
  }
  return prev;
}, 0);
```

which ignored the effects of the `break;` (only the first item of the array should be considered).

This PR rewrites the logic to use `[0]` so the intent is more clear.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
