### PR TITLE
Import local layouts as personal layouts when logging in

### DIFF
--- a/desktop/renderer/services/NativeStorageLayoutStorage.ts
+++ b/desktop/renderer/services/NativeStorageLayoutStorage.ts
@@ -65,7 +65,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
     return await this._ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
   }
 
-  async migrateLocalLayouts(namespace: string): Promise<void> {
+  async migrateUnnamespacedLayouts(namespace: string): Promise<void> {
     // Layouts were previously stored in a single un-namespaced store named "layouts".
     const items = await this._ctx.all(NativeStorageLayoutStorage.LEGACY_STORE_NAME);
     for (const item of items) {

--- a/desktop/renderer/services/NativeStorageLayoutStorage.ts
+++ b/desktop/renderer/services/NativeStorageLayoutStorage.ts
@@ -9,6 +9,16 @@ import { Storage } from "../../common/types";
 
 const log = Log.getLogger(__filename);
 
+function parseAndMigrateLayout(item: string | Uint8Array): Layout {
+  if (!(item instanceof Uint8Array)) {
+    throw new Error("Invariant violation - layout item is not a buffer");
+  }
+
+  const str = new TextDecoder().decode(item);
+  const parsed = JSON.parse(str);
+  return migrateLayout(parsed);
+}
+
 // Implement a LayoutStorage interface over OsContext
 export default class NativeStorageLayoutStorage implements ILayoutStorage {
   private static STORE_PREFIX = "layouts-";
@@ -25,14 +35,8 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
 
     const layouts: Layout[] = [];
     for (const item of items) {
-      if (!(item instanceof Uint8Array)) {
-        throw new Error("Invariant violation - layout item is not a buffer");
-      }
-
       try {
-        const str = new TextDecoder().decode(item);
-        const parsed = JSON.parse(str);
-        layouts.push(migrateLayout(parsed));
+        layouts.push(parseAndMigrateLayout(item));
       } catch (err) {
         log.error(err);
       }
@@ -46,13 +50,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
     if (item == undefined) {
       return undefined;
     }
-    if (!(item instanceof Uint8Array)) {
-      throw new Error("Invariant violation - layout item is not a buffer");
-    }
-
-    const str = new TextDecoder().decode(item);
-    const parsed = JSON.parse(str);
-    return migrateLayout(parsed);
+    return parseAndMigrateLayout(item);
   }
 
   async put(namespace: string, layout: Layout): Promise<Layout> {
@@ -63,6 +61,32 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
 
   async delete(namespace: string, id: LayoutID): Promise<void> {
     return await this._ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + namespace, id);
+  }
+
+  async importLayouts({
+    fromNamespace,
+    toNamespace,
+  }: {
+    fromNamespace: string;
+    toNamespace: string;
+  }): Promise<void> {
+    const keys = await this._ctx.list(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace);
+    for (const key of keys) {
+      try {
+        const item = await this._ctx.get(
+          NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace,
+          key,
+        );
+        if (item == undefined) {
+          continue;
+        }
+        const layout = parseAndMigrateLayout(item);
+        await this.put(toNamespace, layout);
+        await this._ctx.delete(NativeStorageLayoutStorage.STORE_PREFIX + fromNamespace, key);
+      } catch (error) {
+        log.error(error);
+      }
+    }
   }
 
   async migrateUnnamespacedLayouts(namespace: string): Promise<void> {

--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -64,6 +64,11 @@ export interface ILayoutStorage {
    * layouts into the new namespace used for local layouts.
    */
   migrateUnnamespacedLayouts?(namespace: string): Promise<void>;
+
+  /**
+   * The layout manager will call this method to convert any local layouts to personal layouts when logging in.
+   */
+  importLayouts(params: { fromNamespace: string; toNamespace: string }): Promise<void>;
 }
 
 export function layoutPermissionIsShared(

--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -63,7 +63,7 @@ export interface ILayoutStorage {
    * If applicable, the layout manager will call this method to migrate any old existing local
    * layouts into the new namespace used for local layouts.
    */
-  migrateLocalLayouts?(namespace: string): Promise<void>;
+  migrateUnnamespacedLayouts?(namespace: string): Promise<void>;
 }
 
 export function layoutPermissionIsShared(

--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -38,10 +38,10 @@ class NamespacedLayoutStorage {
   constructor(
     private storage: ILayoutStorage,
     private namespace: string,
-    { migrateLocalLayouts }: { migrateLocalLayouts: boolean },
+    { migrateUnnamespacedLayouts }: { migrateUnnamespacedLayouts: boolean },
   ) {
-    if (migrateLocalLayouts) {
-      this.migration = storage.migrateLocalLayouts?.(namespace).catch((error) => {
+    if (migrateUnnamespacedLayouts) {
+      this.migration = storage.migrateUnnamespacedLayouts?.(namespace).catch((error) => {
         log.error("Migration failed:", error);
       });
     }
@@ -123,7 +123,7 @@ export default class LayoutManager implements ILayoutManager {
         remote
           ? LayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX + remote.namespace
           : LayoutManager.LOCAL_STORAGE_NAMESPACE,
-        { migrateLocalLayouts: true },
+        { migrateUnnamespacedLayouts: true },
       ),
     );
     this.remote = remote;

--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -34,17 +34,31 @@ const log = Logger.getLogger(__filename);
  * A wrapper around ILayoutStorage for a particular namespace.
  */
 class NamespacedLayoutStorage {
-  private migration?: Promise<void>;
+  private migration: Promise<void>;
   constructor(
     private storage: ILayoutStorage,
     private namespace: string,
-    { migrateUnnamespacedLayouts }: { migrateUnnamespacedLayouts: boolean },
+    {
+      migrateUnnamespacedLayouts,
+      importFromNamespace,
+    }: { migrateUnnamespacedLayouts: boolean; importFromNamespace: string | undefined },
   ) {
-    if (migrateUnnamespacedLayouts) {
-      this.migration = storage.migrateUnnamespacedLayouts?.(namespace).catch((error) => {
-        log.error("Migration failed:", error);
-      });
-    }
+    this.migration = (async function () {
+      if (migrateUnnamespacedLayouts) {
+        await storage
+          .migrateUnnamespacedLayouts?.(namespace)
+          .catch((error) => log.error("Migration failed:", error));
+      }
+
+      if (importFromNamespace != undefined) {
+        await storage
+          .importLayouts({
+            fromNamespace: importFromNamespace,
+            toNamespace: namespace,
+          })
+          .catch((error) => log.error("Import failed:", error));
+      }
+    })();
   }
 
   async list(): Promise<readonly Layout[]> {
@@ -123,7 +137,12 @@ export default class LayoutManager implements ILayoutManager {
         remote
           ? LayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX + remote.namespace
           : LayoutManager.LOCAL_STORAGE_NAMESPACE,
-        { migrateUnnamespacedLayouts: true },
+        {
+          migrateUnnamespacedLayouts: true,
+
+          // Convert existing local layouts into cloud personal layouts
+          importFromNamespace: remote ? LayoutManager.LOCAL_STORAGE_NAMESPACE : undefined,
+        },
       ),
     );
     this.remote = remote;

--- a/packages/studio-base/src/services/MockLayoutStorage.ts
+++ b/packages/studio-base/src/services/MockLayoutStorage.ts
@@ -35,4 +35,6 @@ export default class MockLayoutStorage implements ILayoutStorage {
   async delete(namespace: string, id: string): Promise<void> {
     this.layoutsByIdByNamespace.get(namespace)?.delete(id);
   }
+
+  async importLayouts(): Promise<void> {}
 }

--- a/web/src/components/LocalStorageLayoutStorageProvider.tsx
+++ b/web/src/components/LocalStorageLayoutStorageProvider.tsx
@@ -55,6 +55,35 @@ export default function LocalStorageLayoutStorageProvider(
         localStorage.removeItem(`${KEY_PREFIX}.${namespace}.${id}`);
       },
 
+      async importLayouts({
+        fromNamespace,
+        toNamespace,
+      }: {
+        fromNamespace: string;
+        toNamespace: string;
+      }): Promise<void> {
+        const keysToMigrate: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key?.startsWith(`${KEY_PREFIX}.${fromNamespace}.`) === true) {
+            keysToMigrate.push(key);
+          }
+        }
+        for (const key of keysToMigrate) {
+          const layout = localStorage.getItem(key);
+          if (layout == undefined) {
+            continue;
+          }
+          try {
+            const { id } = migrateLayout(JSON.parse(layout));
+            localStorage.setItem(`${KEY_PREFIX}.${toNamespace}.${id}`, layout);
+            localStorage.removeItem(key);
+          } catch (err) {
+            log.error(err);
+          }
+        }
+      },
+
       async migrateUnnamespacedLayouts(namespace: string) {
         // Layouts were previously stored with the un-namespaced prefix "studio.layout-cache".
         const legacyKeys = filterMap(new Array(localStorage.length), (_, i) => {

--- a/web/src/components/LocalStorageLayoutStorageProvider.tsx
+++ b/web/src/components/LocalStorageLayoutStorageProvider.tsx
@@ -55,7 +55,7 @@ export default function LocalStorageLayoutStorageProvider(
         localStorage.removeItem(`${KEY_PREFIX}.${namespace}.${id}`);
       },
 
-      async migrateLocalLayouts(namespace: string) {
+      async migrateUnnamespacedLayouts(namespace: string) {
         // Layouts were previously stored with the un-namespaced prefix "studio.layout-cache".
         const legacyKeys = filterMap(new Array(localStorage.length), (_, i) => {
           const key = localStorage.key(i) ?? undefined;


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
When logged in, migrate any existing local layouts to personal layouts. This improves the first sign in experience because the user's layouts will not disappear.