### PR TITLE
Don't show update-delete conflict state for personal layouts

### DIFF
--- a/packages/studio-base/src/services/LayoutManager/computeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/computeLayoutSyncOperations.ts
@@ -85,10 +85,14 @@ export default function computeLayoutSyncOperations(
           ops.push({ local: false, type: "upload-new", localLayout });
           break;
         case "updated":
-          ops.push({ local: true, type: "mark-deleted", localLayout });
+          if (!layoutIsShared(localLayout)) {
+            ops.push({ local: true, type: "delete-local", localLayout });
+          } else {
+            ops.push({ local: true, type: "mark-deleted", localLayout });
+          }
           break;
         case "tracked":
-          if (localLayout.working == undefined) {
+          if (localLayout.working == undefined || !layoutIsShared(localLayout)) {
             ops.push({ local: true, type: "delete-local", localLayout });
           } else {
             ops.push({ local: true, type: "mark-deleted", localLayout });


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Fixes https://github.com/foxglove/studio/issues/1792
For personal layouts, deletes performed on the server are not surprising to the user, so rather than showing an update-vs-delete conflict state, we just delete the local copy.