### PR TITLE
Fix: ignore remote layouts without a savedAt

### DIFF
--- a/packages/studio-base/src/providers/LayoutManagerProvider.tsx
+++ b/packages/studio-base/src/providers/LayoutManagerProvider.tsx
@@ -10,6 +10,7 @@ import LayoutManagerContext from "@foxglove/studio-base/context/LayoutManagerCon
 import { useLayoutStorage } from "@foxglove/studio-base/context/LayoutStorageContext";
 import LayoutStorageDebuggingContext from "@foxglove/studio-base/context/LayoutStorageDebuggingContext";
 import { useRemoteLayoutStorage } from "@foxglove/studio-base/context/RemoteLayoutStorageContext";
+import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import { ISO8601Timestamp, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import LayoutManager from "@foxglove/studio-base/services/LayoutManager";
 
@@ -26,7 +27,7 @@ export default function LayoutManagerProvider({
     [layoutStorage, remoteLayoutStorage],
   );
 
-  const sync = useCallback(async () => {
+  const sync = useCallbackWithToast(async () => {
     await layoutManager.syncWithRemote();
   }, [layoutManager]);
 

--- a/packages/studio-base/src/services/LayoutManager/computeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/computeLayoutSyncOperations.ts
@@ -50,10 +50,12 @@ export default function computeLayoutSyncOperations(
           ops.push({ local: false, type: "upload-updated", localLayout });
           break;
         case "tracked":
-          if (
-            localLayout.syncInfo.lastRemoteSavedAt !== remoteLayout.savedAt ||
-            !remoteLayout.savedAt
-          ) {
+          // if the server doesn't provide a savedAt we consider the layout old and ignore it
+          if (!remoteLayout.savedAt) {
+            break;
+          }
+
+          if (localLayout.syncInfo.lastRemoteSavedAt !== remoteLayout.savedAt) {
             ops.push({
               local: true,
               type: "update-baseline",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Treat remote layouts without a savedAt field as older than any local copy.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
