### PR TITLE
Fetch latest server copy when layout update is rejected; fix renames

### DIFF
--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -211,20 +211,15 @@ class ConsoleApi {
     name: string | undefined;
     permission: "creator_write" | "org_read" | "org_write" | undefined;
     data: Record<string, unknown> | undefined;
-  }): Promise<ConsoleApiLayout> {
+  }): Promise<{ status: "success"; newLayout: ConsoleApiLayout } | { status: "conflict" }> {
     const { status, json: newLayout } = await this.patch<ConsoleApiLayout>(
       `/v1/layouts/${layout.id}`,
       layout,
     );
-    if (status === 409) {
-      const existingLayout = await this.getLayout(layout.id, { includeData: true });
-      if (!existingLayout) {
-        throw new Error(`Update rejected but layout is not present on server: ${layout.id}`);
-      }
-      log.info(`Layout update rejected, overwriting with server version: ${layout.id}`);
-      return existingLayout;
+    if (status === 200) {
+      return { status: "success", newLayout };
     } else {
-      return newLayout;
+      return { status: "conflict" };
     }
   }
 

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import Logger from "@foxglove/log";
 
 type CurrentUser = {
   id: string;
@@ -58,6 +59,8 @@ export type ConsoleApiLayout = {
 };
 
 type ApiResponse<T> = { status: number; json: T };
+
+const log = Logger.getLogger(__filename);
 
 class ConsoleApi {
   private _baseUrl: string;
@@ -119,14 +122,16 @@ class ConsoleApi {
     ).json;
   }
 
-  private async patch<T>(apiPath: string, body?: unknown): Promise<T> {
-    return (
-      await this.request<T>(apiPath, {
+  private async patch<T>(apiPath: string, body?: unknown): Promise<ApiResponse<T>> {
+    return await this.request<T>(
+      apiPath,
+      {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
-      })
-    ).json;
+      },
+      { allowedStatuses: [409] },
+    );
   }
 
   private async delete<T>(
@@ -207,7 +212,20 @@ class ConsoleApi {
     permission: "creator_write" | "org_read" | "org_write" | undefined;
     data: Record<string, unknown> | undefined;
   }): Promise<ConsoleApiLayout> {
-    return await this.patch<ConsoleApiLayout>(`/v1/layouts/${layout.id}`, layout);
+    const { status, json: newLayout } = await this.patch<ConsoleApiLayout>(
+      `/v1/layouts/${layout.id}`,
+      layout,
+    );
+    if (status === 409) {
+      const existingLayout = await this.getLayout(layout.id, { includeData: true });
+      if (!existingLayout) {
+        throw new Error(`Update rejected but layout is not present on server: ${layout.id}`);
+      }
+      log.info(`Layout update rejected, overwriting with server version: ${layout.id}`);
+      return existingLayout;
+    } else {
+      return newLayout;
+    }
   }
 
   async deleteLayout(id: LayoutID): Promise<boolean> {

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import Logger from "@foxglove/log";
 
 type CurrentUser = {
   id: string;
@@ -59,8 +58,6 @@ export type ConsoleApiLayout = {
 };
 
 type ApiResponse<T> = { status: number; json: T };
-
-const log = Logger.getLogger(__filename);
 
 class ConsoleApi {
   private _baseUrl: string;

--- a/packages/studio-base/src/services/ConsoleApiRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/ConsoleApiRemoteLayoutStorage.ts
@@ -68,9 +68,14 @@ export default class ConsoleApiRemoteLayoutStorage implements IRemoteLayoutStora
     data?: PanelsState;
     permission?: "creator_write" | "org_read" | "org_write";
     savedAt: ISO8601Timestamp;
-  }): Promise<RemoteLayout> {
+  }): Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }> {
     const result = await this.api.updateLayout({ id, name, data, permission, saved_at: savedAt });
-    return convertLayout(result);
+    switch (result.status) {
+      case "success":
+        return { status: "success", newLayout: convertLayout(result.newLayout) };
+      case "conflict":
+        return result;
+    }
   }
 
   async deleteLayout(id: LayoutID): Promise<boolean> {

--- a/packages/studio-base/src/services/IRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/IRemoteLayoutStorage.ts
@@ -45,7 +45,7 @@ export interface IRemoteLayoutStorage {
     data?: PanelsState;
     permission?: LayoutPermission;
     savedAt: ISO8601Timestamp;
-  }) => Promise<RemoteLayout>;
+  }) => Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }>;
 
   /** Returns true if the layout existed and was deleted, false if the layout did not exist. */
   deleteLayout: (id: LayoutID) => Promise<boolean>;

--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -23,12 +23,38 @@ import {
   LayoutPermission,
   layoutPermissionIsShared,
 } from "@foxglove/studio-base/services/ILayoutStorage";
-import { IRemoteLayoutStorage } from "@foxglove/studio-base/services/IRemoteLayoutStorage";
+import {
+  IRemoteLayoutStorage,
+  RemoteLayout,
+} from "@foxglove/studio-base/services/IRemoteLayoutStorage";
 import computeLayoutSyncOperations, {
   SyncOperation,
 } from "@foxglove/studio-base/services/LayoutManager/computeLayoutSyncOperations";
 
 const log = Logger.getLogger(__filename);
+
+/**
+ * Try to perform the given updateLayout operation on remote storage. If a conflict is returned,
+ * fetch the most recent version of the layout and return that instead.
+ */
+async function updateOrFetchLayout(
+  remote: IRemoteLayoutStorage,
+  params: Parameters<IRemoteLayoutStorage["updateLayout"]>[0],
+): Promise<RemoteLayout> {
+  const response = await remote.updateLayout(params);
+  switch (response.status) {
+    case "success":
+      return response.newLayout;
+    case "conflict": {
+      const remoteLayout = await remote.getLayout(params.id);
+      if (!remoteLayout) {
+        throw new Error(`Update rejected but layout is not present on server: ${params.id}`);
+      }
+      log.info(`Layout update rejected, using server version: ${params.id}`);
+      return remoteLayout;
+    }
+  }
+}
 
 /**
  * A wrapper around ILayoutStorage for a particular namespace.
@@ -252,7 +278,7 @@ export default class LayoutManager implements ILayoutManager {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
-      const updatedBaseline = await this.remote.updateLayout({ id, name, savedAt: now });
+      const updatedBaseline = await updateOrFetchLayout(this.remote, { id, name, savedAt: now });
       const result = await this.local.runExclusive(
         async (local) =>
           await local.put({
@@ -334,7 +360,7 @@ export default class LayoutManager implements ILayoutManager {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
-      const updatedBaseline = await this.remote.updateLayout({
+      const updatedBaseline = await updateOrFetchLayout(this.remote, {
         id,
         data: localLayout.working?.data ?? localLayout.baseline.data,
         savedAt: now,
@@ -557,7 +583,7 @@ export default class LayoutManager implements ILayoutManager {
           case "upload-updated": {
             const { localLayout } = operation;
             log.debug(`Uploading updated layout ${localLayout.id}`);
-            const newBaseline = await remote.updateLayout({
+            const newBaseline = await updateOrFetchLayout(remote, {
               id: localLayout.id,
               name: localLayout.name,
               data: localLayout.baseline.data,

--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -567,6 +567,7 @@ export default class LayoutManager implements ILayoutManager {
             return async (local) =>
               await local.put({
                 ...localLayout,
+                name: newBaseline.name,
                 baseline: { ...localLayout.baseline, savedAt: newBaseline.savedAt },
                 syncInfo: { status: "tracked", lastRemoteSavedAt: newBaseline.savedAt },
               });


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
When a 409 is received from `PATCH /layout/[id]`, we GET the server copy of the layout so the app can proceed with that.

Also fixes an issue where the new layout name from the server was being ignored, so client renames appeared to succeed when the server actually had rejected the update.