### PR TITLE
Clicking a chart in the State Transitions panel will seek to the corresponding timestamp

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -13,23 +13,29 @@
 
 import { ChartOptions, ScaleOptions } from "chart.js";
 import { uniq } from "lodash";
-import { ComponentProps, useMemo, useState } from "react";
+import { ComponentProps, useCallback, useMemo, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import stringHash from "string-hash";
 import styled, { css } from "styled-components";
 import tinycolor from "tinycolor2";
 
 import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
+import { add as addTimes, fromSec } from "@foxglove/rostime";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Button from "@foxglove/studio-base/components/Button";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import useMessagesByPath from "@foxglove/studio-base/components/MessagePathSyntax/useMessagesByPath";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart, {
   getTooltipItemForMessageHistoryItem,
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
+import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { darkColor, lineColors } from "@foxglove/studio-base/util/plotColors";
 import { colors, fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -389,6 +395,18 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     refreshMode: "debounce",
   });
 
+  const seek = useMessagePipeline((ctx: MessagePipelineContext) => ctx.seekPlayback);
+  const onClick = useCallback(
+    ({ x: seekSeconds }: OnChartClickArgs) => {
+      if (seekSeconds == undefined) {
+        return;
+      }
+      const seekTime = addTimes(startTime, fromSec(seekSeconds));
+      seek(seekTime);
+    },
+    [seek, startTime],
+  );
+
   return (
     <SRoot>
       <PanelToolbar floating helpContent={helpContent} />
@@ -417,6 +435,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
             yAxes={yScale}
             plugins={plugins}
             tooltips={tooltips}
+            onClick={onClick}
           />
 
           {paths.map(({ value: path, timestampMethod }, index) => (

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -19,16 +19,12 @@ import stringHash from "string-hash";
 import styled, { css } from "styled-components";
 import tinycolor from "tinycolor2";
 
-import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
-import { add as addTimes, fromSec } from "@foxglove/rostime";
+import { add as addTimes, subtract as subtractTimes, toSec, fromSec } from "@foxglove/rostime";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Button from "@foxglove/studio-base/components/Button";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import useMessagesByPath from "@foxglove/studio-base/components/MessagePathSyntax/useMessagesByPath";
-import {
-  MessagePipelineContext,
-  useMessagePipeline,
-} from "@foxglove/studio-base/components/MessagePipeline";
+import { useMessagePipelineGetter } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart, {
@@ -395,16 +391,18 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
     refreshMode: "debounce",
   });
 
-  const seek = useMessagePipeline((ctx: MessagePipelineContext) => ctx.seekPlayback);
+  const messagePipeline = useMessagePipelineGetter();
   const onClick = useCallback(
     ({ x: seekSeconds }: OnChartClickArgs) => {
-      if (seekSeconds == undefined) {
+      const { startTime: start } = messagePipeline().playerState.activeData ?? {};
+      const { seekPlayback } = messagePipeline();
+      if (seekSeconds == undefined || start == undefined) {
         return;
       }
-      const seekTime = addTimes(startTime, fromSec(seekSeconds));
-      seek(seekTime);
+      const seekTime = addTimes(start, fromSec(seekSeconds));
+      seekPlayback(seekTime);
     },
-    [seek, startTime],
+    [messagePipeline],
   );
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
Clicking on a chart in the State Transitions panel will seek to the corresponding timestamp (similar to clicking on a chart in the Plot panel).

**Description**

- Used the `MessagePipelineContext`'s `seekPlayback` function to implement feature.
- Did some cleanup around the Plot panel's code for the same functionality (i.e. use `useMessagePipelineGetter` to ensure the `onClick` callback doesn't change unnecessarily).

<!-- add `docs` label if this PR requires documentation updates -->
