### PR TITLE
Fix: use Tooltip component for Playback Control buttons

### DIFF
--- a/packages/studio-base/src/components/HoverableIconButton.tsx
+++ b/packages/studio-base/src/components/HoverableIconButton.tsx
@@ -3,31 +3,53 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { IconButton, IButtonProps, IIconProps } from "@fluentui/react";
-import { useState } from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 
 type Props = {
   iconProps: {
     iconNameActive?: RegisteredIconNames | undefined;
   } & IIconProps;
-} & IButtonProps;
+} & Omit<IButtonProps, "allowDisabledFocus">;
 
-export default function HoverableIconButton({
-  iconProps: { iconName, iconNameActive, ...rest },
-  ...props
-}: Props): JSX.Element {
+const HoverableIconButton = forwardRef<HTMLElement, Props>((props, ref) => {
+  const {
+    iconProps: { iconName, iconNameActive, ...restIcon },
+    ...restProps
+  } = props;
+
   const [hovered, setHovered] = useState(false);
+
+  const onMouseOver = useCallback(() => {
+    if (props.disabled === true) {
+      return;
+    }
+    setHovered(true);
+  }, [props.disabled]);
+
+  const onMouseLeave = useCallback(() => {
+    setHovered(false);
+  }, []);
+
+  useEffect(() => {
+    if (props.disabled === true) {
+      setHovered(false);
+    }
+  }, [props.disabled]);
 
   return (
     <IconButton
-      {...props}
+      elementRef={ref}
+      {...restProps}
       iconProps={{
+        ...restIcon,
         iconName: iconNameActive != undefined ? (hovered ? iconNameActive : iconName) : iconName,
-        ...rest,
       }}
-      {...(props.disabled !== true && {
-        onMouseOver: () => setHovered(true),
-        onMouseLeave: () => setHovered(false),
-      })}
+      allowDisabledFocus={true /* required to support mouse leave events for disabled buttons */}
+      onMouseEnter={onMouseOver}
+      onMouseLeave={onMouseLeave}
     />
   );
-}
+});
+HoverableIconButton.displayName = "HoverableIconButton";
+
+export default HoverableIconButton;

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Stack, IButtonStyles, useTheme } from "@fluentui/react";
+import { Stack, IButtonStyles, useTheme, StackItem } from "@fluentui/react";
 import { merge } from "lodash";
 import { useCallback, useMemo, useState } from "react";
 
@@ -29,7 +29,7 @@ import {
   DIRECTION,
 } from "@foxglove/studio-base/components/PlaybackControls/sharedHelpers";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
-import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
+import Tooltip from "@foxglove/studio-base/components/Tooltip";
 
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
 import RepeatAdapter from "./RepeatAdapter";
@@ -101,10 +101,6 @@ export default function PlaybackControls(): JSX.Element {
     [msgPipeline, seek, togglePlayPause],
   );
 
-  const loopTooltip = useTooltip({ contents: "Loop playback" });
-  const seekBackwardTooltip = useTooltip({ contents: "Seek backward" });
-  const seekForwardTooltip = useTooltip({ contents: "Seek forward" });
-
   const iconButtonStyles: IButtonStyles = {
     icon: { height: 20 },
     root: {
@@ -146,9 +142,6 @@ export default function PlaybackControls(): JSX.Element {
 
   return (
     <div>
-      {loopTooltip.tooltip}
-      {seekBackwardTooltip.tooltip}
-      {seekForwardTooltip.tooltip}
       <RepeatAdapter
         play={play}
         pause={pause}
@@ -179,30 +172,35 @@ export default function PlaybackControls(): JSX.Element {
           }}
         >
           <Stack horizontal verticalAlign="center" tokens={{ childrenGap: theme.spacing.s2 }}>
-            <HoverableIconButton
-              elementRef={loopTooltip.ref}
-              checked={repeat}
-              disabled={!isActive}
-              onClick={toggleRepeat}
-              iconProps={{
-                iconName: repeat ? "LoopFilled" : "Loop",
-                iconNameActive: "LoopFilled",
-              }}
-              styles={merge(iconButtonStyles, {
-                rootDisabled: { background: "transparent" },
-              })}
-            />
-            <HoverableIconButton
-              disabled={!isActive}
-              onClick={isPlaying ? pause : resumePlay}
-              iconProps={{
-                iconName: isPlaying ? "Pause" : "Play",
-                iconNameActive: isPlaying ? "PauseFilled" : "PlayFilled",
-              }}
-              styles={merge(iconButtonStyles, {
-                rootDisabled: { background: "transparent" },
-              })}
-            />
+            <StackItem>
+              <Tooltip contents="Loop playback">
+                <HoverableIconButton
+                  checked={repeat}
+                  disabled={!isActive}
+                  onClick={toggleRepeat}
+                  iconProps={{
+                    iconName: repeat ? "LoopFilled" : "Loop",
+                    iconNameActive: "LoopFilled",
+                  }}
+                  styles={merge(iconButtonStyles, {
+                    rootDisabled: { background: "transparent" },
+                  })}
+                />
+              </Tooltip>
+            </StackItem>
+            <StackItem>
+              <HoverableIconButton
+                disabled={!isActive}
+                onClick={isPlaying ? pause : resumePlay}
+                iconProps={{
+                  iconName: isPlaying ? "Pause" : "Play",
+                  iconNameActive: isPlaying ? "PauseFilled" : "PlayFilled",
+                }}
+                styles={merge(iconButtonStyles, {
+                  rootDisabled: { background: "transparent" },
+                })}
+              />
+            </StackItem>
           </Stack>
           <Stack
             horizontal
@@ -215,32 +213,38 @@ export default function PlaybackControls(): JSX.Element {
           <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
         </Stack>
         <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 2 }}>
-          <HoverableIconButton
-            elementRef={seekBackwardTooltip.ref}
-            iconProps={{ iconName: "Previous", iconNameActive: "PreviousFilled" }}
-            disabled={!isActive}
-            onClick={() => {
-              const currentTime = msgPipeline().playerState.activeData?.currentTime;
-              if (!currentTime) {
-                return;
-              }
-              seek(jumpSeek(DIRECTION.BACKWARD, currentTime));
-            }}
-            styles={merge(seekIconButttonStyles({ left: true }), iconButtonStyles)}
-          />
-          <HoverableIconButton
-            elementRef={seekForwardTooltip.ref}
-            iconProps={{ iconName: "Next", iconNameActive: "NextFilled" }}
-            disabled={!isActive}
-            onClick={() => {
-              const currentTime = msgPipeline().playerState.activeData?.currentTime;
-              if (!currentTime) {
-                return;
-              }
-              seek(jumpSeek(DIRECTION.FORWARD, currentTime));
-            }}
-            styles={merge(seekIconButttonStyles({ right: true }), iconButtonStyles)}
-          />
+          <StackItem>
+            <Tooltip contents="Seek backward">
+              <HoverableIconButton
+                iconProps={{ iconName: "Previous", iconNameActive: "PreviousFilled" }}
+                disabled={!isActive}
+                onClick={() => {
+                  const currentTime = msgPipeline().playerState.activeData?.currentTime;
+                  if (!currentTime) {
+                    return;
+                  }
+                  seek(jumpSeek(DIRECTION.BACKWARD, currentTime));
+                }}
+                styles={merge(seekIconButttonStyles({ left: true }), iconButtonStyles)}
+              />
+            </Tooltip>
+          </StackItem>
+          <StackItem>
+            <Tooltip contents="Seek forward">
+              <HoverableIconButton
+                iconProps={{ iconName: "Next", iconNameActive: "NextFilled" }}
+                disabled={!isActive}
+                onClick={() => {
+                  const currentTime = msgPipeline().playerState.activeData?.currentTime;
+                  if (!currentTime) {
+                    return;
+                  }
+                  seek(jumpSeek(DIRECTION.FORWARD, currentTime));
+                }}
+                styles={merge(seekIconButttonStyles({ right: true }), iconButtonStyles)}
+              />
+            </Tooltip>
+          </StackItem>
         </Stack>
       </Stack>
     </div>

--- a/packages/studio-base/src/components/Tooltip.tsx
+++ b/packages/studio-base/src/components/Tooltip.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
   ICalloutContentStyles,
 } from "@fluentui/react";
-import { Fragment, useCallback, useRef, useState } from "react";
+import { useCallback, Fragment, useRef, useState } from "react";
 
 type Contents = React.ReactNode | (() => React.ReactNode);
 
@@ -150,6 +150,7 @@ export default function Tooltip(
   const { ref, tooltip } = useTooltip(props);
   const child = React.Children.only(children);
   const host = React.cloneElement(child, { ref });
+
   return (
     // When studio-base is packaged for npm, we saw strange issues where React would warn about
     // missing keys on these children, so we add explicit keys.


### PR DESCRIPTION
**User-Facing Changes**
Tooltips for playback controls no longer get stuck when you leave the button with your cursor.

**Description**
Fixes an issue with the tooltip getting stuck open on the playback
controls. This was due to mouse events not firing for disabled buttons.

This change sets the allowDisabledFocus flag for the HoverableIconButton and
uses forwardRef to allow the HoverableIconButton to exist in a <Tooltip> component parent.

Additionally, this change wraps each <Tooltip> in PlaybackControls within a <StackItem>. Since the
<Tooltip> adds a <span> component for the "layer", the gap setting on our <Stack> would result in
the buttons shifting around when the tooltip was active.

Fixes #1770


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
