### PR TITLE
Feature: timestamp-based plot panels remain in-sync even after pan/zoom

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -794,6 +794,15 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     ) : undefined;
   }, [activeTooltip]);
 
+  // reset is shown if we have sync lock and there has been user interaction, or if we don't
+  // have sync lock and the user has manually interacted with the plot
+  //
+  // The reason we check for pan lock is to remove reset display from all sync'd plots once
+  // the range has been reset.
+  const showReset = useMemo(() => {
+    return panLock ? globalBounds?.userInteraction === true : hasUserPannedOrZoomed;
+  }, [globalBounds?.userInteraction, hasUserPannedOrZoomed, panLock]);
+
   // We don't memo this since each option itself is memo'd and this is just convenience to pass to
   // the component.
   const chartProps: ChartComponentProps = {
@@ -837,7 +846,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
           </div>
 
           <SResetZoom>
-            {hasUserPannedOrZoomed && (
+            {showReset && (
               <Button tooltip="(shortcut: double-click)" onClick={onResetZoom}>
                 reset view
               </Button>

--- a/packages/studio-base/src/components/TimeBasedChart/makeGlobalState.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/makeGlobalState.ts
@@ -4,6 +4,7 @@
 
 import { EventEmitter } from "eventemitter3";
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
+import { useLatest } from "react-use";
 
 // Create a "global" state hook
 // Calling _makeGlobalState_ will return a hook function that behaves similar to useState
@@ -38,26 +39,41 @@ function makeGlobalState<T>(): (options: {
       enabled ? existingValue : undefined,
     );
 
-    const setValue = useCallback((val: SetStateAction<T | undefined>) => {
-      const newValue = val instanceof Function ? val(existingValue) : val;
-      if (existingValue !== newValue) {
-        existingValue = newValue;
-        emitter.emit("change", existingValue);
-      }
-    }, []);
+    // Avoid re-creating the setValue callback when enabled changes.
+    // Instead use the latest value of enabled to deterimine if the setter should do anything
+    const enabledRef = useLatest(enabled);
+    const setValue = useCallback(
+      (val: SetStateAction<T | undefined>) => {
+        if (!enabledRef.current) {
+          return;
+        }
+
+        const newValue = val instanceof Function ? val(existingValue) : val;
+        if (existingValue !== newValue) {
+          existingValue = newValue;
+          emitter.emit("change", existingValue);
+        }
+      },
+      [enabledRef],
+    );
 
     useEffect(() => {
-      // when disabled the value gets set to undefined
-      if (!enabled) {
+      return () => {
+        // when unmounting, clear the global value to prevent stale entries
+        // without this, the previous global value is retained which may no longer be relevant
         setValue(undefined);
+      };
+    }, [setValue]);
+
+    useEffect(() => {
+      // when disabled the local value gets set to undefined
+      if (!enabled) {
+        setLocalValue(undefined);
         return;
       }
 
       emitter.on("change", setLocalValue);
       return () => {
-        // when unmounting, clear the global value to prevent stale entries
-        // without this, the previous global value is retained which may no longer be relevant
-        setValue(undefined);
         emitter.off("change", setLocalValue);
       };
     }, [enabled, setValue]);

--- a/packages/studio-base/src/components/TimeBasedChart/makeGlobalState.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/makeGlobalState.ts
@@ -47,7 +47,9 @@ function makeGlobalState<T>(): (options: {
     }, []);
 
     useEffect(() => {
+      // when disabled the value gets set to undefined
       if (!enabled) {
+        setValue(undefined);
         return;
       }
 

--- a/packages/studio-base/src/components/Tooltip.tsx
+++ b/packages/studio-base/src/components/Tooltip.tsx
@@ -144,10 +144,15 @@ export function useTooltip({
 }
 
 export default function Tooltip(
-  props: Props & { children: React.ReactElement },
+  props: Props & { children?: React.ReactElement },
 ): React.ReactElement | ReactNull {
   const { children } = props;
   const { ref, tooltip } = useTooltip(props);
+
+  if (!children) {
+    return tooltip;
+  }
+
   const child = React.Children.only(children);
   const host = React.cloneElement(child, { ref });
 

--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -114,7 +114,7 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
   }, [datasets]);
 
   return (
-    <div style={{ width: "100%", flexGrow: 1, overflow: "hidden" }} ref={sizeRef}>
+    <div style={{ width: "100%", flexGrow: 1, overflow: "hidden", padding: "2px" }} ref={sizeRef}>
       <TimeBasedChart
         key={xAxisVal}
         isSynced={isSynced}

--- a/packages/studio-base/src/panels/Plot/PlotLegend.module.scss
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.module.scss
@@ -22,7 +22,7 @@ $legend-item-height: 20px;
   $legend-root-left: 65px;
   position: absolute;
   left: $legend-root-left;
-  top: 25px;
+  top: 6px;
   background: $legend-highlight-color;
   color: #eee;
   max-width: calc(100% - #{$legend-root-left} - 25px); // Leave some space at the end for the "X".


### PR DESCRIPTION
**User-Facing Changes**
All timestamp-based plots remain synchronized even after manual pan/zoom.

**Description**
All Timestamp-based plots start our x-axis synchronized with other timestamp-based plots. As a user pan/zooms one plot, others pan/zoom to the same x-axis window. This facilitates zooming in to anomalous events on one plot and having other plots update to the same window without the user having to manually zoom each one.

The behavior prior to this change would "unlock" a plot from others after the user panned/zoomed that plot. This behavior is unexpected since panning/zooming that plot would continue to pan/zoom other plots. But if the user pan/zoomed another plot, the first one they pan/zoomed would no longer update.

Our thinking is that as a user the assumption is that plots remain in-sync regardless of the order they are panned. This change exhibits this behavior for plots. Plots always remain in-sync regardless of which is pan/zoomed and in what order.

Fixes #1732


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
