### PR TITLE
Feature: add current time indicator to State Transitions

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -5,13 +5,13 @@
 import stringHash from "string-hash";
 
 import { Time, toSec } from "@foxglove/rostime";
+import { subtract as subtractTimes } from "@foxglove/rostime";
 import { ChartData } from "@foxglove/studio-base/components/Chart";
 import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import {
   getTooltipItemForMessageHistoryItem,
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
-import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
 import { darkColor, lineColors } from "@foxglove/studio-base/util/plotColors";
 import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -4,8 +4,7 @@
 
 import stringHash from "string-hash";
 
-import { Time, toSec } from "@foxglove/rostime";
-import { subtract as subtractTimes } from "@foxglove/rostime";
+import { Time, toSec, subtract as subtractTimes } from "@foxglove/rostime";
 import { ChartData } from "@foxglove/studio-base/components/Chart";
 import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import {


### PR DESCRIPTION
**User-Facing Changes**
Adds a vertical line indicating the current playback time in the State Transitions panel (just like the Plot panel).
<img width="127" alt="image" src="https://user-images.githubusercontent.com/14237/132780457-59e1d477-6063-47a8-8b12-d5b89fa6dd36.png">


**Description**
Fixes #1828. Follow up to #1827.
