### PR TITLE
Fix: always keep dataset endpoints when downsampling

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import downsample from "@foxglove/studio-base/components/TimeBasedChart/downsample";
+
+describe("downsample", () => {
+  const bounds = { width: 100, height: 100, x: { min: 0, max: 100 }, y: { min: 0, max: 100 } };
+
+  it("merges nearby points", () => {
+    const result = downsample(
+      {
+        data: [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 20, y: 0 },
+          { x: 20, y: 1 },
+          { x: 20, y: 10 },
+          { x: 20, y: 20 },
+        ],
+      },
+      bounds,
+    );
+    expect(result).toEqual({
+      data: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 10 },
+        { x: 20, y: 20 },
+      ],
+    });
+  });
+
+  it("always keeps first and last point", () => {
+    const result = downsample(
+      {
+        data: [
+          { x: 0, y: 0 },
+          { x: 0, y: 0.1 },
+          { x: 0, y: 0.2 },
+        ],
+      },
+      bounds,
+    );
+    expect(result).toEqual({
+      data: [
+        { x: 0, y: 0 },
+        { x: 0, y: 0.2 },
+      ],
+    });
+  });
+});

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -40,7 +40,8 @@ export default function downsample(dataset: DataSet, bounds: DownsampleBounds): 
   const threshold = 2;
 
   let prevPoint: { x: number; y: number } | undefined = undefined;
-  const downsampled = filterMap(dataset.data, (datum) => {
+  const endIndex = dataset.data.length - 1;
+  const downsampled = filterMap(dataset.data, (datum, index) => {
     if (!datum) {
       return datum;
     }
@@ -48,6 +49,11 @@ export default function downsample(dataset: DataSet, bounds: DownsampleBounds): 
     const point = { x: datum.x * pixelPerXValue, y: datum.y * pixelPerYValue };
     if (!prevPoint) {
       prevPoint = point;
+      return datum;
+    }
+
+    // Always keep the last data point
+    if (index === endIndex) {
       return datum;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
Improved plot downsampling algorithm to avoid introducing gaps with adjacent datasets.

**Description**
The downsampling algorithm would sometimes drop the last datum in a dataset, which tends to introduce visual artifacts in the State Transtions panel because most of its datasets are immediately adjacent to each other.

Change the downsampling algorithm to always keep the last point (and add unit tests).

Before:
<img width="189" alt="image" src="https://user-images.githubusercontent.com/14237/132781599-99d9ea26-ff13-46cb-821b-67d315a18e38.png">
After:
<img width="182" alt="image" src="https://user-images.githubusercontent.com/14237/132781573-0c026549-719b-40f0-85d1-e72317b65d56.png">