### PR TITLE
Add Plot panel setting for title

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -152,6 +152,7 @@ function selectEndTime(ctx: MessagePipelineContext) {
 function Plot(props: Props) {
   const { saveConfig, config } = props;
   const {
+    title,
     followingViewWidth,
     paths: yAxisPaths,
     minYValue,
@@ -355,6 +356,7 @@ function Plot(props: Props) {
   return (
     <Flex col clip center style={{ position: "relative" }}>
       <PanelToolbar helpContent={helpContent} floating />
+      <div>{title ?? "Untitled"}</div>
       <PlotChart
         isSynced={xAxisVal === "timestamp"}
         paths={yAxisPaths}
@@ -380,6 +382,7 @@ function Plot(props: Props) {
 }
 
 const configSchema: PanelConfigSchema<PlotConfig> = [
+  { key: "title", type: "text", title: "Title", placeholder: "Untitled" },
   { key: "maxYValue", type: "number", title: "Y max", placeholder: "auto", allowEmpty: true },
   { key: "minYValue", type: "number", title: "Y min", placeholder: "auto", allowEmpty: true },
   {
@@ -393,6 +396,7 @@ const configSchema: PanelConfigSchema<PlotConfig> = [
 ];
 
 const defaultConfig: PlotConfig = {
+  title: undefined,
   paths: [{ value: "", enabled: true, timestampMethod: "receiveTime" }],
   minYValue: "",
   maxYValue: "",

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -12,6 +12,7 @@ export type PlotXAxisVal =
   | "currentCustom"; // Message path data. One "current" message at playback time.
 
 export type PlotConfig = {
+  title?: string;
   paths: PlotPath[];
   minYValue?: string | number;
   maxYValue?: string | number;


### PR DESCRIPTION
**User-Facing Changes**
All Plot panels can now be given a human-readable title in the panel settings. Will default to being displayed as "Untitled".

<img width="905" alt="Screen Shot 2021-09-10 at 7 51 55 AM" src="https://user-images.githubusercontent.com/6993359/132873585-1208a14a-6928-44f5-9146-47f0b4828e61.png">
<img width="906" alt="Screen Shot 2021-09-10 at 7 51 48 AM" src="https://user-images.githubusercontent.com/6993359/132873594-3c32b58a-efd3-4bb7-9fe8-af3dd75996aa.png">


**Description**
Empty titles will default to being displayed as "Untitled". In the future, this title bar can be used to include other state controls (e.g. https://github.com/foxglove/studio/issues/1732).

<!-- link relevant github issues -->
Resolves https://github.com/foxglove/studio/issues/1820.

<!-- add `docs` label if this PR requires documentation updates -->
