### PR TITLE
Use consistent casing throughout app

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -378,10 +378,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     const SIDEBAR_ITEMS = new Map<SidebarItemKey, SidebarItem>([
       ["connection", connectionItem],
       ["layouts", { iconName: "FiveTileGrid", title: "Layouts", component: LayoutBrowser }],
-      ["add-panel", { iconName: "RectangularClipping", title: "Add Panel", component: AddPanel }],
+      ["add-panel", { iconName: "RectangularClipping", title: "Add panel", component: AddPanel }],
       [
         "panel-settings",
-        { iconName: "SingleColumnEdit", title: "Panel Settings", component: PanelSettings },
+        { iconName: "SingleColumnEdit", title: "Panel settings", component: PanelSettings },
       ],
       ["variables", { iconName: "Variable2", title: "Variables", component: Variables }],
       ["preferences", { iconName: "Settings", title: "Preferences", component: Preferences }],

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -78,7 +78,7 @@ export default function PanelSettings(): JSX.Element {
 
   if (error) {
     return (
-      <SidebarContent title={`Panel Settings`}>
+      <SidebarContent title="Panel settings">
         <Text styles={{ root: { color: theme.semanticColors.errorText } }}>{error.message}</Text>
       </SidebarContent>
     );
@@ -86,7 +86,7 @@ export default function PanelSettings(): JSX.Element {
 
   if (selectedPanelId == undefined) {
     return (
-      <SidebarContent title={`Panel Settings`}>
+      <SidebarContent title="Panel settings">
         <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>
           Select a panel to edit its settings.
         </Text>
@@ -101,7 +101,7 @@ export default function PanelSettings(): JSX.Element {
 
   if (!config) {
     return (
-      <SidebarContent title={`Panel Settings`}>
+      <SidebarContent title="Panel settings">
         <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>
           loading panel settings...
         </Text>
@@ -110,7 +110,7 @@ export default function PanelSettings(): JSX.Element {
   }
 
   return (
-    <SidebarContent title={`${panelInfo.title} Panel Settings`}>
+    <SidebarContent title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack tokens={{ childrenGap: theme.spacing.m }}>
         <Stack.Item>

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -364,7 +364,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
     return (
       <div className={styles.zoomContextMenu} data-zoom-menu>
         <div className={cx(styles.menuItem, styles.notInteractive)}>
-          Use mousewheel or buttons to zoom
+          Scroll or use the buttons below to zoom
         </div>
         <div className={cx(styles.menuItem, styles.borderBottom)}>
           <LegacyButton className={styles.round} onClick={zoomOut} data-panel-minus-zoom>

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -354,7 +354,7 @@ function ImageView(props: Props) {
           toggleComponent={
             <ToggleComponent
               dataTest={"topics-dropdown"}
-              text={cameraTopic ? cameraTopic : "no image topics"}
+              text={cameraTopic ? cameraTopic : "No image topics"}
               disabled
             />
           }
@@ -407,7 +407,7 @@ function ImageView(props: Props) {
         toggleComponent={
           <ToggleComponent
             dataTest={"topics-dropdown"}
-            text={cameraTopic.length > 0 ? cameraTopic : "select a topic"}
+            text={cameraTopic.length > 0 ? cameraTopic : "Select a topic"}
           />
         }
         value={cameraTopic}
@@ -486,7 +486,7 @@ function ImageView(props: Props) {
         closeOnChange={false}
         onChange={onToggleMarkerName}
         value={enabledMarkerTopics}
-        text={availableAndEnabledMarkerTopics.length > 0 ? "markers" : "no markers"}
+        text={availableAndEnabledMarkerTopics.length > 0 ? "Markers" : "No markers"}
         btnClassname={style.dropdown}
       >
         {availableAndEnabledMarkerTopics.map((topic) => (

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -331,7 +331,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   return (
     <div style={{ width: "100%", height: "100%" }}>
-      {!center && <EmptyState>Waiting for first gps point...</EmptyState>}
+      {!center && <EmptyState>Waiting for first GPS point...</EmptyState>}
       <div
         ref={mapContainerRef}
         style={{ width: "100%", height: "100%", visibility: center ? "visible" : "hidden" }}

--- a/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Sidebar.tsx
@@ -110,7 +110,7 @@ type NodesListProps = {
 const NodesList = ({ nodes, selectNode, deleteNode, collapse, selectedNodeId }: NodesListProps) => {
   return (
     <Flex col>
-      <SidebarTitle title={"nodes"} collapse={collapse} />
+      <SidebarTitle title="Nodes" collapse={collapse} />
       {Object.keys(nodes).map((nodeId) => {
         return (
           <ListItem
@@ -154,9 +154,9 @@ const SidebarTitle = ({
   collapse: () => void;
 }) => (
   <Flex row style={{ alignItems: "center", color: colors.DARK9, padding: "5px" }}>
-    <h3 style={{ textTransform: "uppercase" }}>{title}</h3>
+    <h3>{title}</h3>
     {tooltip && (
-      <Icon style={{ cursor: "unset", marginLeft: "5px" }} size="medium" tooltip={tooltip}>
+      <Icon style={{ cursor: "unset", marginLeft: "5px" }} size="xsmall" tooltip={tooltip}>
         <HelpCircleIcon />
       </Icon>
     )}
@@ -218,7 +218,7 @@ const Sidebar = ({
       ),
       docs: (
         <SFlex>
-          <SidebarTitle title={"docs"} collapse={() => updateExplorer(undefined)} />
+          <SidebarTitle title="Docs" collapse={() => updateExplorer(undefined)} />
           <TextContent style={{ backgroundColor: "transparent" }}>
             {otherMarkdownDocsForTest ?? nodePlaygroundDocs}
           </TextContent>
@@ -228,7 +228,7 @@ const Sidebar = ({
         <Flex col style={{ position: "relative" }}>
           <SidebarTitle
             collapse={() => updateExplorer(undefined)}
-            title={"utilities"}
+            title="Utilities"
             tooltip={`You can import any of these modules into your node using the following syntax: 'import { .. } from "./pointClouds.ts".\n\nWant to contribute? Scroll to the bottom of the docs for details!`}
           />
           {utilityFiles.map(({ fileName, filePath }) => (
@@ -246,7 +246,7 @@ const Sidebar = ({
       templates: (
         <Flex col>
           <SidebarTitle
-            title={"templates"}
+            title="Templates"
             tooltip={"Create nodes from these templates"}
             collapse={() => updateExplorer(undefined)}
           />
@@ -279,7 +279,7 @@ const Sidebar = ({
           dataTest="node-explorer"
           onClick={() => updateExplorer(nodesSelected ? undefined : "nodes")}
           size="large"
-          tooltip={"nodes"}
+          tooltip="Nodes"
           style={{ color: nodesSelected ? "inherit" : colors.DARK9, position: "relative" }}
         >
           <FileMultipleIcon />
@@ -288,7 +288,7 @@ const Sidebar = ({
           dataTest="utils-explorer"
           onClick={() => updateExplorer(utilsSelected ? undefined : "utils")}
           size="large"
-          tooltip={"utilities"}
+          tooltip="Utilities"
           style={{ color: utilsSelected ? "inherit" : colors.DARK9 }}
         >
           <HammerWrenchIcon />
@@ -297,7 +297,7 @@ const Sidebar = ({
           dataTest="templates-explorer"
           onClick={() => updateExplorer(templatesSelected ? undefined : "templates")}
           size="large"
-          tooltip={"templates"}
+          tooltip="Templates"
           style={{ color: templatesSelected ? "inherit" : colors.DARK9 }}
         >
           <TemplateIcon />
@@ -306,7 +306,7 @@ const Sidebar = ({
           dataTest="docs-explorer"
           onClick={() => updateExplorer(docsSelected ? undefined : "docs")}
           size="large"
-          tooltip={"docs"}
+          tooltip="Docs"
           style={{ color: docsSelected ? "inherit" : colors.DARK9 }}
         >
           <HelpCircleIcon />

--- a/packages/studio-base/src/panels/Rosout/FilterBar.tsx
+++ b/packages/studio-base/src/panels/Rosout/FilterBar.tsx
@@ -98,7 +98,7 @@ export default function FilterBar(props: FilterBarProps): JSX.Element {
       <Stack grow>
         <TagPicker
           inputProps={{
-            placeholder: "node name or message text",
+            placeholder: "Node name or message text",
           }}
           styles={{
             text: { minWidth: 0 },

--- a/packages/studio-base/src/panels/Teleop/Settings.tsx
+++ b/packages/studio-base/src/panels/Teleop/Settings.tsx
@@ -69,7 +69,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
   return (
     <Stack verticalFill tokens={{ childrenGap: theme.spacing.m }}>
       <Stack.Item>
-        <Text>Publish Topic</Text>
+        <Text>Publish topic</Text>
         <Stack
           tokens={{
             padding: `${theme.spacing.s1} 0`,
@@ -96,7 +96,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
       <Stack.Item>
         <TextField
           type="number"
-          label="Publish Rate (Hz)"
+          label="Publish rate (Hz)"
           defaultValue={String(config.publishRate)}
           styles={{ root: { width: 80 } }}
           onGetErrorMessage={(value) => {
@@ -123,7 +123,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
       <Stack.Item grow>
         <Stack horizontal verticalAlign="end" tokens={{ childrenGap: theme.spacing.m }}>
           <Stack.Item grow>
-            <Label>Up Button:</Label>
+            <Label>Up button:</Label>
           </Stack.Item>
           <Dropdown
             label="Field"
@@ -160,7 +160,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
       <Stack.Item>
         <Stack horizontal verticalAlign="center" tokens={{ childrenGap: theme.spacing.m }}>
           <Stack.Item grow>
-            <Label>Down Button:</Label>
+            <Label>Down button:</Label>
           </Stack.Item>
           <Dropdown
             selectedKey={config.downButton.field}
@@ -195,7 +195,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
       <Stack.Item>
         <Stack horizontal verticalAlign="center" tokens={{ childrenGap: theme.spacing.m }}>
           <Stack.Item grow>
-            <Label>Left Button:</Label>
+            <Label>Left button:</Label>
           </Stack.Item>
           <Dropdown
             selectedKey={config.leftButton.field}
@@ -230,7 +230,7 @@ export default function Settings(props: SettingsProps): JSX.Element {
       <Stack.Item>
         <Stack horizontal verticalAlign="center" tokens={{ childrenGap: theme.spacing.m }}>
           <Stack.Item grow>
-            <Label>Right Button:</Label>
+            <Label>Right button:</Label>
           </Stack.Item>
           <Dropdown
             selectedKey={config.rightButton.field}

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -199,11 +199,11 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
             icon: { height: 20 },
           }}
         >
-          Panel Settings
+          Panel settings
         </HoverableIconButton>
       </Stack>
       <Dialog
-        dialogContentProps={{ title: "Teleop Panel Settings", showCloseButton: true }}
+        dialogContentProps={{ title: "Teleop panel settings", showCloseButton: true }}
         hidden={!showSettings}
         onDismiss={() => setShowSettings(false)}
         maxWidth={480}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
@@ -73,7 +73,7 @@ const InteractionsBaseComponent = React.memo<PropsWithConfig>(function Interacti
 
   return (
     <ExpandingToolbar
-      tooltip="Inspect Objects"
+      tooltip="Inspect objects"
       icon={
         <Icon style={{ color: "white" }}>
           <CursorDefault />

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
@@ -57,7 +57,7 @@ function MainToolbar({
         disabled={perspective}
         tooltip={
           perspective
-            ? "Switch to 2D Camera to Measure Distance"
+            ? "Switch to 2D camera to measure distance"
             : measureActive
             ? "Cancel Measuring"
             : "Measure Distance"

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -261,7 +261,7 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
   if (!searchTextOpen) {
     return (
       <Button className={styles.iconButton} onClick={() => toggleSearchTextOpen(!searchTextOpen)}>
-        <Icon tooltip="search text markers">
+        <Icon tooltip="Search text markers">
           <SearchIcon />
         </Icon>
       </Button>

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -375,7 +375,7 @@ function TopicGraph() {
       <PanelToolbar floating helpContent={helpContent} />
       <Toolbar>
         <div className={styles.buttons}>
-          <Button className={styles.iconButton} tooltip="Zoom Fit" onClick={onZoomFit}>
+          <Button className={styles.iconButton} tooltip="Zoom fit" onClick={onZoomFit}>
             <Icon style={{ color: "white" }} size="small">
               <FitToPageIcon />
             </Icon>


### PR DESCRIPTION
**User-Facing Changes**
Use sentence-casing for text throughout app. Main exception is the panel list, which still capitalizes each word in panel names (e.g. "Node Playground").

**Description**
Same as above.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
