### PR TITLE
Fix: show the tooltip for the nearest plot point

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -259,8 +259,8 @@ export default class ChartJSManager {
     const elements =
       this._chartInstance?.getElementsAtEventForMode(
         ev as unknown as Event,
-        this._chartInstance.options.hover?.mode ?? "intersect",
-        this._chartInstance.options.hover ?? {},
+        this._chartInstance.options.interaction?.mode ?? "intersect",
+        this._chartInstance.options.interaction ?? {},
         false,
       ) ?? [];
 
@@ -281,6 +281,18 @@ export default class ChartJSManager {
         data,
       });
     }
+
+    // sort elemtents by proximity to the cursor
+    out.sort((itemA, itemB) => {
+      const dxA = event.clientX - itemA.view.x;
+      const dyA = event.clientY - itemA.view.y;
+      const dxB = event.clientX - itemB.view.x;
+      const dyB = event.clientY - itemB.view.y;
+      const distSquaredA = dxA * dxA + dyA * dyA;
+      const distSquaredB = dxB * dxB + dyB * dyB;
+
+      return distSquaredA - distSquaredB;
+    });
 
     return out;
   }

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -501,8 +501,6 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
         display: false,
       },
       tooltip: {
-        intersect: false,
-        mode: "x",
         enabled: false, // Disable native tooltips since we use custom ones.
       },
       zoom: {
@@ -770,7 +768,7 @@ export default memo<Props>(function TimeBasedChart(props: Props) {
       animation: false,
       // Disable splines, they seem to cause weird rendering artifacts:
       elements: { line: { tension: 0 } },
-      hover: {
+      interaction: {
         intersect: false,
         mode: "x",
       },


### PR DESCRIPTION


**User-Facing Changes**
Hovering near a point will show the tooltip event if there are other points at the same x-axis location.

**Description**
When hovering over the plot, the tooltip will show data from the nearest point.

Previously, if there were multiple points at the same x-axis coordinate, there was
no way to see a tooltip for the other points. Now a tooltip appears for the nearest.

Fixes: #1113

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
