### PR TITLE
Fix: keep the user signed in when opening the app offline

### DIFF
--- a/packages/studio-base/src/providers/ConsoleApiCurrentUserProvider.tsx
+++ b/packages/studio-base/src/providers/ConsoleApiCurrentUserProvider.tsx
@@ -2,13 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PropsWithChildren, useCallback, useState } from "react";
+import { PropsWithChildren, useCallback, useMemo } from "react";
 import { useAsync, useLocalStorage } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
 import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
-import CurrentUserContext from "@foxglove/studio-base/context/CurrentUserContext";
+import CurrentUserContext, { User } from "@foxglove/studio-base/context/CurrentUserContext";
 
 const log = Logger.getLogger(__filename);
 
@@ -22,31 +22,57 @@ export default function ConsoleApiCurrentUserProvider(
   const api = useConsoleApi();
   const [bearerToken, setBearerToken, removeBearerToken] =
     useLocalStorage<string>("fox.bearer-token");
-  const [completedFirstLoad, setCompletedFirstLoad] = useState(false);
 
-  const { value: currentUser } = useAsync(async () => {
+  // We want to support starting the app while offline. Various children components of the provider
+  // use the presence of the user as an indicator of sign-in state. We cache the user to provide a
+  // stale-while-loading value so the app can open with no connection and update the cached record
+  // once online.
+  const [cachedCurrentUser, setCachedCurrentUser, removeCachedCurrentUser] = useLocalStorage<User>(
+    "fox.current-user",
+    undefined,
+    {
+      raw: false,
+      serializer: (value: User) => JSON.stringify(value),
+      deserializer: (value: string) => JSON.parse(value) as User,
+    },
+  );
+
+  // We need to set the api auth header info before any other parts of the app can use the api
+  useMemo(() => {
+    if (!bearerToken) {
+      return;
+    }
+    api.setAuthHeader(`Bearer ${bearerToken}`);
+  }, [api, bearerToken]);
+
+  const { loading } = useAsync(async () => {
     try {
       if (!bearerToken) {
         return undefined;
       }
-      api.setAuthHeader(`Bearer ${bearerToken}`);
-      return await api.me();
+      const me = await api.me();
+      setCachedCurrentUser(me);
+      return me;
     } catch (error) {
       log.error(error);
       return undefined;
-    } finally {
-      setCompletedFirstLoad(true);
     }
-  }, [api, bearerToken]);
+  }, [api, bearerToken, setCachedCurrentUser]);
 
   const signOut = useCallback(async () => {
     removeBearerToken();
+    removeCachedCurrentUser();
     await api.signout();
-  }, [api, removeBearerToken]);
+  }, [api, removeBearerToken, removeCachedCurrentUser]);
+
+  const currentUser = useMemo<User | undefined>(() => {
+    return cachedCurrentUser;
+  }, [cachedCurrentUser]);
 
   const value = useShallowMemo({ currentUser, setBearerToken, signOut });
 
-  if (!completedFirstLoad) {
+  // Wait for first time loading to complete
+  if (!currentUser && loading) {
     return <></>;
   }
 

--- a/packages/studio-base/src/providers/ConsoleApiCurrentUserProvider.tsx
+++ b/packages/studio-base/src/providers/ConsoleApiCurrentUserProvider.tsx
@@ -14,7 +14,9 @@ const log = Logger.getLogger(__filename);
 
 /**
  * CurrentUserProvider attempts to load the current user's profile if there is an authenticated
- * session
+ * session.
+ *
+ * The provider also exposes function to set and clear the current session token.
  */
 export default function ConsoleApiCurrentUserProvider(
   props: PropsWithChildren<unknown>,
@@ -37,7 +39,8 @@ export default function ConsoleApiCurrentUserProvider(
     },
   );
 
-  // We need to set the api auth header info before any other parts of the app can use the api
+  // When we have a valid token, we need to set the api auth header so child components can make
+  // authenticated requests
   useMemo(() => {
     if (!bearerToken) {
       return;
@@ -65,14 +68,10 @@ export default function ConsoleApiCurrentUserProvider(
     await api.signout();
   }, [api, removeBearerToken, removeCachedCurrentUser]);
 
-  const currentUser = useMemo<User | undefined>(() => {
-    return cachedCurrentUser;
-  }, [cachedCurrentUser]);
-
-  const value = useShallowMemo({ currentUser, setBearerToken, signOut });
+  const value = useShallowMemo({ currentUser: cachedCurrentUser, setBearerToken, signOut });
 
   // Wait for first time loading to complete
-  if (!currentUser && loading) {
+  if (!cachedCurrentUser && loading) {
     return <></>;
   }
 


### PR DESCRIPTION


**User-Facing Changes**
None - unreleased feature

**Description**
If the user is currently offline, studio will still open and show their
account information.

Fixes: #1819

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
