### PR TITLE
Spike: add excludeOk setting for diagnostics summary panel

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -110,6 +110,22 @@ export function Filtered(): JSX.Element {
   );
 }
 
+export function FilteredByStatus(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        overrideConfig={{
+          pinnedIds: [],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "",
+          excludeOk: true,
+          sortByLevel: false,
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 export function Settings(): JSX.Element {
   return (
     <SchemaEditor

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -89,6 +89,7 @@ type Config = {
   topicToRender: string;
   hardwareIdFilter: string;
   sortByLevel?: boolean;
+  excludeOk?: boolean;
 };
 type Props = {
   config: Config;
@@ -98,7 +99,7 @@ type Props = {
 function DiagnosticSummary(props: Props): JSX.Element {
   const { config, saveConfig } = props;
   const { topics } = useDataSourceInfo();
-  const { topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true } = config;
+  const { topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true, excludeOk = false } = config;
   const { openSiblingPanel } = usePanelContext();
 
   const togglePinned = useCallback(
@@ -184,14 +185,10 @@ function DiagnosticSummary(props: Props): JSX.Element {
     const sortedNodes = sortByLevel
       ? ([] as DiagnosticInfo[]).concat(
           ...levels.map((level) =>
-            filterAndSortDiagnostics(nodesByLevel.get(level) ?? [], hardwareIdFilter, pinnedIds),
+            filterAndSortDiagnostics(nodesByLevel.get(level) ?? [], hardwareIdFilter, excludeOk, pinnedIds),
           ),
         )
-      : filterAndSortDiagnostics(
-          ([] as DiagnosticInfo[]).concat(...nodesByLevel.values()),
-          hardwareIdFilter,
-          pinnedIds,
-        );
+      : filterAndSortDiagnostics(([] as DiagnosticInfo[]).concat(...nodesByLevel.values()), hardwareIdFilter, excludeOk, pinnedIds);
 
     const nodes: DiagnosticInfo[] = [...compact(pinnedNodes), ...sortedNodes];
     if (nodes.length === 0) {
@@ -212,7 +209,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
         )}
       </AutoSizer>
     );
-  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, topicToRender]);
+  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, topicToRender, excludeOk]);
 
   return (
     <Flex col className={styles.panel}>
@@ -226,6 +223,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
 const configSchema: PanelConfigSchema<Config> = [
   { key: "sortByLevel", type: "toggle", title: "Sort by level" },
+  { key: "excludeOk", type: "toggle", title: "Exclude diagnostics with OK status" },
 ];
 
 const defaultConfig: Config = {
@@ -233,6 +231,7 @@ const defaultConfig: Config = {
   hardwareIdFilter: "",
   topicToRender: DIAGNOSTIC_TOPIC,
   sortByLevel: true,
+  excludeOk: false,
 };
 export default Panel(
   Object.assign(DiagnosticSummary, {

--- a/packages/studio-base/src/panels/diagnostics/util.test.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.test.ts
@@ -133,9 +133,9 @@ describe("diagnostics", () => {
       if (!nodes) {
         throw new Error("Missing level OK");
       }
-      expect(filterAndSortDiagnostics(nodes, "", [])).toStrictEqual([mctmLogger, watchdogStatus]);
-      expect(filterAndSortDiagnostics(nodes, "watchdog", [])).toStrictEqual([watchdogStatus]);
-      expect(filterAndSortDiagnostics(nodes, "mctm_logger", [])).toStrictEqual([mctmLogger]);
+      expect(filterAndSortDiagnostics(nodes, "", false, [])).toStrictEqual([mctmLogger, watchdogStatus]);
+      expect(filterAndSortDiagnostics(nodes, "watchdog", false, [])).toStrictEqual([watchdogStatus]);
+      expect(filterAndSortDiagnostics(nodes, "mctm_logger", false, [])).toStrictEqual([mctmLogger]);
     });
 
     it("returns filtered nodes ordered by match quality", () => {
@@ -145,16 +145,12 @@ describe("diagnostics", () => {
       const subsequenceButPinnedDiagnostic = { ...mctmLogger, displayName: "12asdfg3456", id: "3" };
       const notSubsequenceDiagnostic = { ...mctmLogger, displayName: "12345", id: "4" };
       expect(
-        filterAndSortDiagnostics(
-          [
+        filterAndSortDiagnostics([
             subsequenceButPinnedDiagnostic,
             notSubsequenceDiagnostic,
             subsequenceDiagnostic,
             prefixDiagnostic,
-          ],
-          hardwareIdFilter,
-          ["3"],
-        ),
+        ], hardwareIdFilter, false, ["3"]),
       ).toEqual([prefixDiagnostic, subsequenceDiagnostic]);
     });
   });

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -129,11 +129,14 @@ export function getDiagnosticsByLevel(buffer: DiagnosticsBuffer): Map<number, Di
 }
 
 export const filterAndSortDiagnostics = (
-  nodes: DiagnosticInfo[],
-  hardwareIdFilter: string,
-  pinnedIds: DiagnosticId[],
-): DiagnosticInfo[] => {
-  const unpinnedNodes = nodes.filter(({ id }) => !pinnedIds.includes(id));
+    nodes: DiagnosticInfo[],
+    hardwareIdFilter: string,
+    excludeOk: boolean = false,
+    pinnedIds: DiagnosticId[]): DiagnosticInfo[] => {
+  let unpinnedNodes = nodes.filter(({ id }) => !pinnedIds.includes(id));
+  if (excludeOk) {
+     unpinnedNodes = nodes.filter(({ status }) => status.hardware_id && status.level != LEVELS.OK);
+  }
   if (hardwareIdFilter.length === 0) {
     return sortBy(unpinnedNodes, (info) => info.displayName.replace(/^\//, ""));
   }


### PR DESCRIPTION
See https://github.com/foxglove/studio/issues/1837

This PR is a spike; I was exploring how to add new settings to a panel. I haven't run tests, and this probably isn't the right approach anyway.

Example of how this looks. The top panel is only "bad" diagnostics. The second panel is all diagnostics.

![Selection_689](https://user-images.githubusercontent.com/1159930/132929537-2065eb96-0fbe-4629-bd7b-968ab801e709.png)

