### PR TITLE
Fix State Transitions y alignment for preloaded data

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -247,6 +247,7 @@ export function Blocks(): JSX.Element {
           paths: [
             { value: "/some/topic/with/state.state", timestampMethod: "receiveTime" },
             { value: "/blocks.state", timestampMethod: "receiveTime" },
+            { value: "/blocks.state", timestampMethod: "receiveTime" },
           ],
         }}
       />

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -270,8 +270,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       };
     }
 
-    let pathIndex = 0;
-    for (const path of paths) {
+    paths.forEach((path, pathIndex) => {
       // y axis values are set based on the path we are rendering
       // negative makes each path render below the previous
       const y = (pathIndex + 1) * 6 * -1;
@@ -296,7 +295,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
       // display the messages from blocks.
       const haveBlocksForPath = blocksForPath.some((item) => item != undefined);
       if (haveBlocksForPath) {
-        continue;
+        return;
       }
 
       const items = itemsByPath[path.value];
@@ -311,9 +310,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
         outDatasets.push(...newDataSets);
         outTooltips.push(...newTooltips);
       }
-
-      ++pathIndex;
-    }
+    });
 
     return {
       datasets: outDatasets,


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with State Transitions where multiple preloaded datasets would overlap.

**Description**
Fixes https://github.com/foxglove/studio/issues/1861, introduced in #1827. 