### PR TITLE
Fix: prevent late hover events from triggering chart hover

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -342,22 +342,37 @@ function Chart(props: Props): JSX.Element {
     [rpcSend],
   );
 
+  // Since hover events are handled via rpc, we might get a response back when we've
+  // already hovered away from the chart. We gate calling onHover by whether the mouse is still
+  // present on the component
+  const mousePresetRef = useRef(false);
+
   const { onHover } = props;
   const onMouseMove = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (onHover) {
+      if (onHover && mousePresetRef.current) {
         const elements = await rpcSend<RpcElement[]>("getElementsAtEvent", {
           event: rpcMouseEvent(event),
         });
 
-        if (!isMounted()) {
+        if (!isMounted() || !mousePresetRef.current) {
           return;
         }
+
         onHover(elements);
       }
     },
     [onHover, rpcSend, isMounted],
   );
+
+  const onMouseEnter = useCallback(() => {
+    mousePresetRef.current = true;
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    mousePresetRef.current = false;
+    onHover?.([]);
+  }, [onHover]);
 
   const onClick = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>): Promise<void> => {
@@ -418,6 +433,8 @@ function Chart(props: Props): JSX.Element {
       onClick={onClick}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+      onMouseEnter={onMouseEnter}
       onMouseUp={onMouseUp}
       style={{ width, height }}
     />

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -350,12 +350,12 @@ function Chart(props: Props): JSX.Element {
   const { onHover } = props;
   const onMouseMove = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (onHover && mousePresetRef.current) {
+      if (onHover && mousePresentRef.current) {
         const elements = await rpcSend<RpcElement[]>("getElementsAtEvent", {
           event: rpcMouseEvent(event),
         });
 
-        if (!isMounted() || !mousePresetRef.current) {
+        if (!isMounted() || !mousePresentRef.current) {
           return;
         }
 
@@ -366,11 +366,11 @@ function Chart(props: Props): JSX.Element {
   );
 
   const onMouseEnter = useCallback(() => {
-    mousePresetRef.current = true;
+    mousePresentRef.current = true;
   }, []);
 
   const onMouseLeave = useCallback(() => {
-    mousePresetRef.current = false;
+    mousePresentRef.current = false;
     onHover?.([]);
   }, [onHover]);
 

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -345,7 +345,7 @@ function Chart(props: Props): JSX.Element {
   // Since hover events are handled via rpc, we might get a response back when we've
   // already hovered away from the chart. We gate calling onHover by whether the mouse is still
   // present on the component
-  const mousePresetRef = useRef(false);
+  const mousePresentRef = useRef(false);
 
   const { onHover } = props;
   const onMouseMove = useCallback(

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -169,6 +169,8 @@ export function CleansUpTooltipOnUnmount(_args: unknown): JSX.Element | ReactNul
     const { top, left } = canvas!.getBoundingClientRect();
     // wait for chart to render before triggering tooltip
     let tooltip: Element | undefined;
+
+    TestUtils.Simulate.mouseEnter(canvas!);
     for (let i = 0; !tooltip && i < 20; i++) {
       TestUtils.Simulate.mouseMove(canvas!, { clientX: 333 + left, clientY: 650 + top });
       await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
**User-Facing Changes**
Tooltips appear and disappear as the user hovers over the plot and between plots.

**Description**
 Fix: prevent late hover events from triggering chart hover
    
 Ignore hover responses from the rpc endpoint if the mouse is no longer on the chart component. This prevents late hover events from triggering onHover and showing tooltips in downstream TimeBasedChart component.
    
Fixes: #1860

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
