### PR TITLE
Migrate old savedProps to configById when loading layouts

### DIFF
--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -121,7 +121,7 @@ export function migrateLayout(value: unknown): Layout {
   }
 
   function migrateData(data: PanelsState): PanelsState {
-    const result = { ...data, configById: data.configById ?? data.savedProps };
+    const result = { ...data, configById: data.configById ?? data.savedProps ?? {} };
     delete result.savedProps;
     return result;
   }

--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -120,12 +120,20 @@ export function migrateLayout(value: unknown): Layout {
     }
   }
 
+  function migrateData(data: PanelsState): PanelsState {
+    const result = { ...data, configById: data.configById ?? data.savedProps };
+    delete result.savedProps;
+    return result;
+  }
+
   return {
     id: layout.id,
     name: layout.name ?? `Unnamed (${now})`,
     permission: layout.permission ?? "creator_write",
-    working: layout.working,
-    baseline,
+    working: layout.working
+      ? { ...layout.working, data: migrateData(layout.working.data) }
+      : undefined,
+    baseline: { ...baseline, data: migrateData(baseline.data) },
     syncInfo: layout.syncInfo,
   };
 }


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash when loading layouts created with older versions of Foxglove Studio or Webviz.

**Description**
Some migration logic was removed 2 releases ago, in https://github.com/foxglove/studio/pull/1679. Reinstate some migrations so that we can still support old layouts.

Tested manually by importing an old layout that was previously crashing.