### PR TITLE
Link out to external pages for remaining in-app docs

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -252,16 +252,16 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
         click: () => browserWindow.webContents.send("open-welcome-layout"),
       },
       {
-        label: "Message Path Syntax",
+        label: "Message path syntax",
         click: () => browserWindow.webContents.send("open-message-path-syntax-help"),
       },
       {
-        label: "Keyboard Shortcuts",
+        label: "Keyboard shortcuts",
         accelerator: "CommandOrControl+/",
         click: () => browserWindow.webContents.send("open-keyboard-shortcuts"),
       },
       {
-        label: "Learn More",
+        label: "Learn more",
         click: async () => await shell.openExternal("https://foxglove.dev"),
       },
       ...(isMac

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -23,7 +23,7 @@ import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropL
 import DropOverlay from "@foxglove/studio-base/components/DropOverlay";
 import ExtensionsSidebar from "@foxglove/studio-base/components/ExtensionsSidebar";
 import GlobalVariablesTable from "@foxglove/studio-base/components/GlobalVariablesTable";
-import variablesHelp from "@foxglove/studio-base/components/GlobalVariablesTable/index.help.md";
+import variablesHelpContent from "@foxglove/studio-base/components/GlobalVariablesTable/index.help.md";
 import HelpModal from "@foxglove/studio-base/components/HelpModal";
 import LayoutBrowser from "@foxglove/studio-base/components/LayoutBrowser";
 import messagePathHelp from "@foxglove/studio-base/components/MessagePathSyntax/index.help.md";
@@ -34,6 +34,7 @@ import {
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import PanelLayout from "@foxglove/studio-base/components/PanelLayout";
 import PanelList from "@foxglove/studio-base/components/PanelList";
+import panelsHelpContent from "@foxglove/studio-base/components/PanelList/index.help.md";
 import PanelSettings from "@foxglove/studio-base/components/PanelSettings";
 import PlaybackControls from "@foxglove/studio-base/components/PlaybackControls";
 import Preferences from "@foxglove/studio-base/components/Preferences";
@@ -98,7 +99,7 @@ function AddPanel() {
   const addPanel = useAddPanel();
 
   return (
-    <SidebarContent noPadding title="Add panel">
+    <SidebarContent noPadding title="Add panel" helpContent={panelsHelpContent}>
       <PanelList onPanelSelect={addPanel} />
     </SidebarContent>
   );
@@ -106,7 +107,7 @@ function AddPanel() {
 
 function Variables() {
   return (
-    <SidebarContent title="Variables" helpContent={variablesHelp}>
+    <SidebarContent title="Variables" helpContent={variablesHelpContent}>
       <GlobalVariablesTable />
     </SidebarContent>
   );

--- a/packages/studio-base/src/components/MessagePathSyntax/index.help.md
+++ b/packages/studio-base/src/components/MessagePathSyntax/index.help.md
@@ -1,18 +1,39 @@
 # Message path syntax
 
-The message path syntax can be used in several panels to find the exact messages in topics that you need.
+Message path syntax is used throughout Studio to help you drill down to the exact information you want to inspect in your data.
 
-- First you specify the topic name: `/some/topic`
-- Then you point to the value within that topic, using dots: `/some/topic.some.deep.value`
-- You can also index into an array, like this: `/some/topic.many.values[0].x`
-- Slices are also allowed, and will return an array of values: `/some/topic.many.values[1:3].x` or even `/some/topic.many.values[:].x` to get all values.
-- Negative slices are allowed, and work backwards from the end of the array, e.g. `[-1]` to get the last element, or `[-2:-1]` to get the last two elements.
-- You can also slice on a global variable, which you can set in the Global Variables Panel: `/some/topic.many.values[$my_custom_start_idx:$my_custom_end_idx]`
-- Filter on particular values, usually in combination with slices: `/some/topic.many.values[:]{some_id==123}.x` — for now only equality is supported.
-- You can also filter on a global variable, which you can set in the Global Variables Panel: `/some/topic.many.values[:]{some_id==$my_custom_id}`
-- Filters can be applied to fields in the top-level message, in which case entire messages that don't match the filter will be skipped: `/some/topic{foo.bar==123}`
-- You can use multiple filters at once, in which case only messages that satisfy all filters will be returned (like an "and" expression): `/some/topic.many.values[:]{a==1}{b==2}.x`
+## Topic
 
-When filtering, you can use booleans `{value==true}`; numbers `{value==123}`; and strings `{value="foo"}`.
+- `/some/topic`
 
-We don't support escaping quotation marks in strings, but you can use either single or double quotes, which should allow you to express most strings: `{value='string which has "some" double quotes'}`.
+## Nested values
+
+- `/some_topic.some_value`
+- `/some_topic.some_value.some_nested_value`
+
+## Slices
+
+- Single element
+  - `/some_topic.many_values[0]`
+  - `/some_topic.many_values[1].width`
+  - `/some_topic.many_values[-1]`
+- Ranges
+  - `/some_topic.many_values[1:3].x`
+  - `/some_topic.many_values[:].x`
+  - `/some_topic.many_values[-2:-1]`
+  - `/some_topic.many_values[$my_start_idx:$my_end_idx]`
+- With variables
+  - `/some_topic.many_values[$my_start_idx:$my_end_idx]`
+
+## Filters
+
+- Top-level topic
+  - `/some_topic{foo.bar==123}`
+- Nested values
+  - `/some_topic.many_values[:]{id==123}.x`
+- With variables
+  - `/some_topic.many_values[:]{id==$my_id}`
+- Multiple filters
+  - `/some_topic.many_values[:]{some_str_field=="abc"}{some_num_field==5}{some_boolean_field==false}.x`
+
+[Learn more](https://foxglove.dev/docs/app-concepts/message-path-syntax).

--- a/packages/studio-base/src/components/PanelList/index.help.md
+++ b/packages/studio-base/src/components/PanelList/index.help.md
@@ -1,0 +1,11 @@
+# Panels
+
+Panels are modular visualization interfaces that can be configured and arranged into Studio layouts.
+
+## Shortcuts
+
+- `Cmd` + click – Select panels to group into a Tab panel
+- `Cmd` + `a` – Select all panels in the current layout
+- Hover on panel + `` ` `` – Show panel shortcuts, with ability to view full-screen
+
+[Learn more](https://foxglove.dev/docs/app-concepts/panels).

--- a/packages/studio-base/src/components/PlaybackControls/index.help.md
+++ b/packages/studio-base/src/components/PlaybackControls/index.help.md
@@ -1,0 +1,9 @@
+# Playback
+
+Navigate the timeline of a pre-recorded data source (e.g. a local or remote `.bag` file) using the playback bar controls.
+
+## Shortcuts
+
+- `Space` – Pause or play
+- `←` – Seek backward 100ms
+- `→` – Seek forward 100ms

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -24,6 +24,7 @@ import {
   useMessagePipeline,
   useMessagePipelineGetter,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import HelpButton from "@foxglove/studio-base/components/PanelToolbar/HelpButton";
 import {
   jumpSeek,
   DIRECTION,
@@ -34,6 +35,7 @@ import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
 import RepeatAdapter from "./RepeatAdapter";
 import Scrubber from "./Scrubber";
+import helpContent from "./index.help.md";
 
 const selectPause = (ctx: MessagePipelineContext) => ctx.pausePlayback;
 const selectPlay = (ctx: MessagePipelineContext) => ctx.startPlayback;
@@ -245,6 +247,7 @@ export default function PlaybackControls(): JSX.Element {
               />
             </Tooltip>
           </StackItem>
+          <HelpButton iconStyle={{ width: "18px", height: "18px" }}>{helpContent}</HelpButton>
         </Stack>
       </Stack>
     </div>

--- a/packages/studio-base/src/components/ShortcutsModal.tsx
+++ b/packages/studio-base/src/components/ShortcutsModal.tsx
@@ -21,7 +21,6 @@ const STitle = styled.h3`
 `;
 
 const COMMAND = "⌘";
-const SHIFT = "⇧";
 
 type Props = {
   onRequestClose: () => void;
@@ -31,20 +30,20 @@ export default function ShortcutsModal({ onRequestClose }: Props): React.ReactEl
     <HelpModal onRequestClose={onRequestClose}>
       <h2>Keyboard shortcuts</h2>
       <STitle>Global</STitle>
-      <KeyboardShortcut description="Save layouts" keys={[COMMAND, "s"]} />
-      <KeyboardShortcut description="Import/export layouts" keys={[COMMAND, "e"]} />
-      <KeyboardShortcut description="Open a file" keys={[COMMAND, "o"]} />
-      <KeyboardShortcut description="Add a second bag" keys={[COMMAND, SHIFT, "o"]} />
-      <KeyboardShortcut description="Select all panels" keys={[COMMAND, "a"]} />
-      <KeyboardShortcut description="Show help and resources" keys={[SHIFT, "/"]} />
       <KeyboardShortcut description="Show shortcuts" keys={[COMMAND, "/"]} />
+
+      <STitle>Panels</STitle>
+      <KeyboardShortcut
+        description="Select panel to group into a Tab panel"
+        keys={[COMMAND, "click"]}
+      />
+      <KeyboardShortcut description="Select all panels" keys={[COMMAND, "a"]} />
+      <KeyboardShortcut description="View panel shortcuts" keys={["hover", "~"]} />
+
+      <STitle>Playback bar</STitle>
       <KeyboardShortcut description="Pause or play" keys={["Space"]} />
       <KeyboardShortcut description="Seek forward 100ms" keys={["⇢"]} />
       <KeyboardShortcut description="Seek backward 100ms" keys={["⇠"]} />
-
-      <STitle>Panel</STitle>
-      <KeyboardShortcut description="Hovering over a panel to view panel shortcut" keys={["~"]} />
-      <KeyboardShortcut description="Hold to lock panel in full screen" keys={["~", SHIFT]} />
     </HelpModal>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Link to external doc pages on foxglove.dev from:
- "Message path syntax" modal
- "Add panel" sidebar tab
- Playback controls

Use sentence-case for app menu options.
Pare down "Keyboard shortcuts" modal – remove unsupported shortcuts, arrange into meaningful sections.

Resolves https://github.com/foxglove/studio/issues/1822