### PR TITLE
Add dropdown with diagnostic level filters in Diagnostics – Summary panel

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -68,6 +68,7 @@ export function WithPinnedNodes(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
         overrideConfig={{
+          minLevel: 0,
           pinnedIds: [
             getDiagnosticId("hardware_id1", "name1"),
             getDiagnosticId("hardware_id4", "name4"),
@@ -85,6 +86,7 @@ export function WithoutSorting(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
         overrideConfig={{
+          minLevel: 0,
           pinnedIds: [],
           topicToRender: "/diagnostics",
           hardwareIdFilter: "",
@@ -100,6 +102,7 @@ export function Filtered(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
         overrideConfig={{
+          minLevel: 0,
           pinnedIds: [],
           topicToRender: "/diagnostics",
           hardwareIdFilter: "filter",

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -71,7 +71,25 @@ export function WithPinnedNodes(): JSX.Element {
           minLevel: 0,
           pinnedIds: [
             getDiagnosticId("hardware_id1", "name1"),
-            getDiagnosticId("hardware_id4", "name4"),
+            getDiagnosticId("hardware_id3/filter", "name3"),
+          ],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "",
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function WithPinnedNodesAndFilter(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        overrideConfig={{
+          minLevel: 2,
+          pinnedIds: [
+            getDiagnosticId("hardware_id1", "name1"),
+            getDiagnosticId("hardware_id3/filter", "name3"),
           ],
           topicToRender: "/diagnostics",
           hardwareIdFilter: "",
@@ -97,12 +115,44 @@ export function WithoutSorting(): JSX.Element {
   );
 }
 
-export function Filtered(): JSX.Element {
+export function FilteredByHardwareId(): JSX.Element {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticSummary
         overrideConfig={{
           minLevel: 0,
+          pinnedIds: [],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "filter",
+          sortByLevel: false,
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function FilteredByLevel(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        overrideConfig={{
+          minLevel: 2,
+          pinnedIds: [],
+          topicToRender: "/diagnostics",
+          hardwareIdFilter: "",
+          sortByLevel: false,
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function FilteredByHardwareIdAndLevel(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticSummary
+        overrideConfig={{
+          minLevel: 2,
           pinnedIds: [],
           topicToRender: "/diagnostics",
           hardwareIdFilter: "filter",

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { mergeStyleSets } from "@fluentui/merge-styles";
+import { Dropdown, IDropdownOption, ISelectableOption } from "@fluentui/react";
 import PinIcon from "@mdi/svg/svg/pin.svg";
 import cx from "classnames";
 import { compact } from "lodash";
@@ -149,6 +150,7 @@ class NodeRow extends React.PureComponent<NodeRowProps> {
 }
 
 type Config = {
+  minLevel: number;
   pinnedIds: DiagnosticId[];
   topicToRender: string;
   hardwareIdFilter: string;
@@ -162,7 +164,7 @@ type Props = {
 function DiagnosticSummary(props: Props): JSX.Element {
   const { config, saveConfig } = props;
   const { topics } = useDataSourceInfo();
-  const { topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true } = config;
+  const { minLevel, topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true } = config;
   const { openSiblingPanel } = usePanelContext();
 
   const togglePinned = useCallback(
@@ -191,7 +193,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   const renderRow = useCallback(
     // eslint-disable-next-line react/no-unused-prop-types
     ({ item, style, key }: ListRowProps & { item: DiagnosticInfo }) => {
-      return (
+      return item.status.level >= minLevel ? (
         <div key={key} style={style}>
           <NodeRow
             info={item}
@@ -200,14 +202,22 @@ function DiagnosticSummary(props: Props): JSX.Element {
             onClickPin={togglePinned}
           />
         </div>
+      ) : (
+        ReactNull
       );
     },
-    [pinnedIds, showDetails, togglePinned],
+    [minLevel, pinnedIds, showDetails, togglePinned],
   );
 
   const hardwareFilter = (
     <LegacyInput
-      style={{ width: "100%", padding: "0", background: "transparent", opacity: "0.5" }}
+      style={{
+        width: "100%",
+        padding: "0",
+        background: "transparent",
+        opacity: "0.5",
+        marginLeft: "10px",
+      }}
       value={hardwareIdFilter}
       placeholder={"Filter hardware id"}
       onChange={(e) => saveConfig({ hardwareIdFilter: e.target.value })}
@@ -278,9 +288,42 @@ function DiagnosticSummary(props: Props): JSX.Element {
     );
   }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, topicToRender]);
 
+  const renderOption = (option: ISelectableOption | undefined) =>
+    option ? (
+      <div
+        className={cx({
+          [classes.ok]: option.text === "ok",
+          [classes.warn]: option.text === "warn",
+          [classes.error]: option.text === "error",
+          [classes.stale]: option.text === "stale",
+        })}
+      >
+        &gt;= {option?.text.toUpperCase() ?? ""}
+      </div>
+    ) : (
+      ReactNull
+    );
+
   return (
     <Flex col className={classes.panel}>
       <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
+        <Dropdown
+          styles={{ root: { minWidth: "100px" } }}
+          onRenderOption={renderOption}
+          onRenderTitle={(option: IDropdownOption[] | undefined) =>
+            option ? <>{option.map(renderOption)}</> : ReactNull
+          }
+          onChange={(_ev, option) => {
+            if (option) {
+              saveConfig({ minLevel: option.key as number });
+            }
+          }}
+          options={[0, 1, 2, 3].map((key: number) => ({
+            key,
+            text: LEVEL_NAMES[key] ?? "",
+          }))}
+          selectedKey={minLevel}
+        />
         {hardwareFilter}
       </PanelToolbar>
       <Flex col>{summary}</Flex>
@@ -293,6 +336,7 @@ const configSchema: PanelConfigSchema<Config> = [
 ];
 
 const defaultConfig: Config = {
+  minLevel: 0,
   pinnedIds: [],
   hardwareIdFilter: "",
   topicToRender: DIAGNOSTIC_TOPIC,

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -43,6 +43,7 @@ import {
   getDiagnosticsByLevel,
   filterAndSortDiagnostics,
   LEVEL_NAMES,
+  KNOWN_LEVELS,
 } from "./util";
 
 type NodeRowProps = {
@@ -193,7 +194,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   const renderRow = useCallback(
     // eslint-disable-next-line react/no-unused-prop-types
     ({ item, style, key }: ListRowProps & { item: DiagnosticInfo }) => {
-      return item.status.level >= minLevel ? (
+      return (
         <div key={key} style={style}>
           <NodeRow
             info={item}
@@ -202,11 +203,9 @@ function DiagnosticSummary(props: Props): JSX.Element {
             onClickPin={togglePinned}
           />
         </div>
-      ) : (
-        ReactNull
       );
     },
-    [minLevel, pinnedIds, showDetails, togglePinned],
+    [pinnedIds, showDetails, togglePinned],
   );
 
   const hardwareFilter = (
@@ -267,7 +266,9 @@ function DiagnosticSummary(props: Props): JSX.Element {
           pinnedIds,
         );
 
-    const nodes: DiagnosticInfo[] = [...compact(pinnedNodes), ...sortedNodes];
+    const nodes: DiagnosticInfo[] = [...compact(pinnedNodes), ...sortedNodes].filter(
+      ({ status }) => status.level >= minLevel,
+    );
     if (nodes.length === 0) {
       return ReactNull;
     }
@@ -286,7 +287,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
         )}
       </AutoSizer>
     );
-  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, topicToRender]);
+  }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, minLevel, topicToRender]);
 
   const renderOption = (option: ISelectableOption | undefined) =>
     option ? (
@@ -318,10 +319,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
               saveConfig({ minLevel: option.key as number });
             }
           }}
-          options={[0, 1, 2, 3].map((key: number) => ({
-            key,
-            text: LEVEL_NAMES[key] ?? "",
-          }))}
+          options={KNOWN_LEVELS.map((key: number) => ({ key, text: LEVEL_NAMES[key] ?? "" }))}
           selectedKey={minLevel}
         />
         {hardwareFilter}

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -40,6 +40,8 @@ export const LEVEL_NAMES: { [key: number]: string } = {
   3: "stale",
 };
 
+export const KNOWN_LEVELS = [0, 1, 2, 3];
+
 interface ToString {
   toString(): string;
 }


### PR DESCRIPTION
**User-Facing Changes**
Added a dropdwn menu with diagnostic level filters in the Diagnostics – Summary panel.

<img width="520" alt="Screen Shot 2021-09-15 at 11 25 15 PM" src="https://user-images.githubusercontent.com/6993359/133560716-dc5e0ec1-8fdd-466d-ac22-701bd41f10c1.png">
<img width="534" alt="Screen Shot 2021-09-15 at 11 25 20 PM" src="https://user-images.githubusercontent.com/6993359/133560723-54a55b72-880b-4273-9903-05388b59667d.png">


**Description**
Save the minimum diagnostic level in the panel's config.
Added storybook tests.

Follow up to https://github.com/foxglove/studio/pull/1838.
Resolves https://github.com/foxglove/studio/issues/1837.
