### PR TITLE
Disable "Update team layout" from unsaved changes prompt while offline

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.stories.tsx
@@ -32,12 +32,19 @@ const dummyLayout: Layout = {
 };
 
 export function Default(): JSX.Element {
-  return <UnsavedChangesPrompt layout={dummyLayout} onComplete={action("onComplete")} />;
+  return <UnsavedChangesPrompt isOnline layout={dummyLayout} onComplete={action("onComplete")} />;
+}
+
+export function Offline(): JSX.Element {
+  return (
+    <UnsavedChangesPrompt isOnline={false} layout={dummyLayout} onComplete={action("onComplete")} />
+  );
 }
 
 export function Overwrite(): JSX.Element {
   return (
     <UnsavedChangesPrompt
+      isOnline
       layout={dummyLayout}
       onComplete={action("onComplete")}
       defaultSelectedKey="overwrite"
@@ -48,6 +55,7 @@ export function Overwrite(): JSX.Element {
 export function MakePersonal(): JSX.Element {
   return (
     <UnsavedChangesPrompt
+      isOnline
       layout={dummyLayout}
       onComplete={action("onComplete")}
       defaultSelectedKey="makePersonal"
@@ -58,6 +66,7 @@ export function MakePersonal(): JSX.Element {
 export function MakePersonalWithEmptyField(): JSX.Element {
   return (
     <UnsavedChangesPrompt
+      isOnline
       layout={dummyLayout}
       onComplete={action("onComplete")}
       defaultSelectedKey="makePersonal"

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -71,7 +71,7 @@ export default function LayoutBrowser({
   const { openAccountSettings } = useWorkspace();
   const styles = useStyles();
   const confirm = useConfirm();
-  const openUnsavedChangesPrompt = useUnsavedChangesPrompt();
+  const { unsavedChangesPrompt, openUnsavedChangesPrompt } = useUnsavedChangesPrompt();
 
   const currentLayoutId = useCurrentLayoutSelector((state) => state.selectedLayout?.id);
   const { setSelectedLayoutId } = useCurrentLayoutActions();
@@ -422,6 +422,7 @@ export default function LayoutBrowser({
         </IconButton>,
       ]}
     >
+      {unsavedChangesPrompt}
       <Stack verticalFill>
         <Stack.Item>
           <LayoutSection


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Disable the radio button to save a team layout from the unsaved changes prompt while offline.

To accomplish this without adding a useLayoutManager dependency to the UnsavedChangesPrompt component itself (which would require a fake layout manager in storybook), I reworked the `useUnsavedChangesPrompt` hook so instead of using the ModalHost imperative API (which would make it hard to dynamically update the disabled state), the hook manages the state itself and **returns** the react element for the prompt which can be rendered anywhere in the tree by the caller.

<img width="338" alt="Screen Shot 2021-09-16 at 9 36 11 AM" src="https://user-images.githubusercontent.com/14237/133651330-ead57776-8479-4e02-9fd8-0b5e2e97e9d8.png">
