### PR TITLE
Disable minification of identifiers in prod builds

### DIFF
--- a/desktop/integration-test/buildSize.test.ts
+++ b/desktop/integration-test/buildSize.test.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 
 // Adjust this byte size as needed if the app is growing for a valid reason.
 // This check is here to catch unexpected ballooning of the build size
-const MAX_BUILD_SIZE = 140_000_000;
+const MAX_BUILD_SIZE = 180_000_000;
 
 async function getAllFiles(dirPath: string, arrayOfFiles: string[] = []): Promise<string[]> {
   const files = await readdir(dirPath, { withFileTypes: true });

--- a/desktop/webpack.main.config.ts
+++ b/desktop/webpack.main.config.ts
@@ -64,7 +64,12 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: "es2020",
+          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+        }),
+      ],
     },
 
     plugins: [

--- a/desktop/webpack.preload.config.ts
+++ b/desktop/webpack.preload.config.ts
@@ -47,7 +47,12 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: "es2020",
+          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+        }),
+      ],
     },
 
     plugins: [

--- a/desktop/webpack.quicklook.config.ts
+++ b/desktop/webpack.quicklook.config.ts
@@ -70,7 +70,12 @@ export default (_env: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: "es2020",
+          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+        }),
+      ],
     },
 
     plugins: [

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -74,7 +74,12 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: "es2020",
+          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+        }),
+      ],
     },
 
     plugins: [

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -223,7 +223,12 @@ export function makeConfig(
     },
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: "es2020",
+          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+        }),
+      ],
     },
     plugins: [
       new CircularDependencyPlugin({


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
While we do have source maps sent to Sentry, it can be frustrating when an error boundary or other stack trace shows minified names instead of real function names.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ts.worker.905cdde0893ccfe4c3d3d52f504bbf5c.js (4.58 MiB)
  main.js (5.33 MiB)
  9691.js (523 KiB)
  4048.js (3.38 MiB)
  f4a990eab21714a17a87.bin (1.75 MiB)
  1271.js (361 KiB)
  78e0e3ce0190f1d1017d.wasm (279 KiB)
  5634.js (328 KiB)
  7185.js (389 KiB)
  6079.js (2.76 MiB)
  8411.js (559 KiB)
  5562.js (257 KiB)
  6974.js (423 KiB)
  8101.js (271 KiB)
  e46cedbe043b399854ef.wasm (1.06 MiB)
  6952.js (2.58 MiB)
  144.js (3.13 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (5.33 MiB)
      main.js

</td>
<td>

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  editor.worker.a85ce25ec6767b7d9d2d3d88291dd6eb.js (313 KiB)
  ts.worker.905cdde0893ccfe4c3d3d52f504bbf5c.js (8.88 MiB)
  main.js (10 MiB)
  4112.js (346 KiB)
  9691.js (776 KiB)
  4048.js (5.29 MiB)
  8871.js (431 KiB)
  f4a990eab21714a17a87.bin (1.75 MiB)
  8243.js (583 KiB)
  1271.js (758 KiB)
  78e0e3ce0190f1d1017d.wasm (279 KiB)
  5634.js (639 KiB)
  7185.js (397 KiB)
  6079.js (5.68 MiB)
  8411.js (1.21 MiB)
  5562.js (701 KiB)
  4131.js (435 KiB)
  6974.js (1010 KiB)
  2392.js (256 KiB)
  8101.js (545 KiB)
  e46cedbe043b399854ef.wasm (1.06 MiB)
  8809.js (301 KiB)
  6952.js (7.98 MiB)
  144.js (7.14 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (10 MiB)
      main.js

</td>
</tr>
</table>