### PR TITLE
Do not display Plot panel's title, if not set

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -356,7 +356,7 @@ function Plot(props: Props) {
   return (
     <Flex col clip center style={{ position: "relative" }}>
       <PanelToolbar helpContent={helpContent} floating />
-      <div>{title ?? "Untitled"}</div>
+      {title && <div>{title}</div>}
       <PlotChart
         isSynced={xAxisVal === "timestamp"}
         paths={yAxisPaths}


### PR DESCRIPTION
**User-Facing Changes**
Do not display "Untitled" above a plot, if a Plot panel's title is not set


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
