### PR TITLE
Fix: avoid sending chart rpc if the chart has unmounted

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -74,6 +74,12 @@ function rpcMouseEvent(event: React.MouseEvent<HTMLCanvasElement>) {
   };
 }
 
+type RpcSend = <T extends unknown>(
+  topic: string,
+  payload?: Record<string, unknown>,
+  transferables?: (Transferable | OffscreenCanvas)[],
+) => Promise<T>;
+
 // Chart component renders data using workers with chartjs offscreen canvas
 function Chart(props: Props): JSX.Element {
   const [id] = useState(() => uuidv4());
@@ -91,21 +97,14 @@ function Chart(props: Props): JSX.Element {
 
   const { type, data, options, width, height, onChartUpdate } = props;
 
-  type RpcSend = <T extends unknown>(
-    topic: string,
-    payload?: Record<string, unknown>,
-    transferables?: (Transferable | OffscreenCanvas)[],
-  ) => Promise<T>;
-
   const rpcSendRef = useRef<RpcSend | undefined>();
-  const rpcSend = rpcSendRef.current;
 
   useLayoutEffect(() => {
     if (initialized.current) {
       if (process.env.NODE_ENV === "development") {
         throw new Error("Chart does not support hot-reloading - please reload the panel");
       } else {
-        throw new Error("Chart has re-initialized expectedly");
+        throw new Error("Chart has re-initialized unexpectedly");
       }
     }
 
@@ -197,7 +196,7 @@ function Chart(props: Props): JSX.Element {
   }, [data, height, options, width]);
 
   const { error: updateError } = useAsync(async () => {
-    if (!rpcSend) {
+    if (!rpcSendRef.current) {
       return;
     }
 
@@ -220,7 +219,7 @@ function Chart(props: Props): JSX.Element {
       initialized.current = true;
 
       const offscreenCanvas = canvas.transferControlToOffscreen();
-      const scales = await rpcSend<RpcScales>(
+      const scales = await rpcSendRef.current<RpcScales>(
         "initialize",
         {
           node: offscreenCanvas,
@@ -248,14 +247,14 @@ function Chart(props: Props): JSX.Element {
       return;
     }
 
-    const scales = await rpcSend<RpcScales>("update", newUpdateMessage);
+    const scales = await rpcSendRef.current<RpcScales>("update", newUpdateMessage);
     if (!isMounted()) {
       return;
     }
 
     maybeUpdateScales(scales);
     onChartUpdate?.();
-  }, [getNewUpdateMessage, rpcSend, isMounted, maybeUpdateScales, onChartUpdate, type]);
+  }, [getNewUpdateMessage, isMounted, maybeUpdateScales, onChartUpdate, type]);
 
   useLayoutEffect(() => {
     const canvas = canvasRef.current;
@@ -268,12 +267,12 @@ function Chart(props: Props): JSX.Element {
     hammerManager.add(new Hammer.Pan({ threshold }));
 
     hammerManager.on("panstart", async (event) => {
-      if (!rpcSend) {
+      if (!rpcSendRef.current) {
         return;
       }
 
       const boundingRect = event.target.getBoundingClientRect();
-      await rpcSend<RpcScales>("panstart", {
+      await rpcSendRef.current<RpcScales>("panstart", {
         event: {
           cancelable: false,
           deltaY: event.deltaY,
@@ -290,12 +289,12 @@ function Chart(props: Props): JSX.Element {
     });
 
     hammerManager.on("panmove", async (event) => {
-      if (!rpcSend) {
+      if (!rpcSendRef.current) {
         return;
       }
 
       const boundingRect = event.target.getBoundingClientRect();
-      const scales = await rpcSend<RpcScales>("panmove", {
+      const scales = await rpcSendRef.current<RpcScales>("panmove", {
         event: {
           cancelable: false,
           deltaY: event.deltaY,
@@ -309,12 +308,12 @@ function Chart(props: Props): JSX.Element {
     });
 
     hammerManager.on("panend", async (event) => {
-      if (!rpcSend) {
+      if (!rpcSendRef.current) {
         return;
       }
 
       const boundingRect = event.target.getBoundingClientRect();
-      const scales = await rpcSend<RpcScales>("panend", {
+      const scales = await rpcSendRef.current<RpcScales>("panend", {
         event: {
           cancelable: false,
           deltaY: event.deltaY,
@@ -330,16 +329,16 @@ function Chart(props: Props): JSX.Element {
     return () => {
       hammerManager.destroy();
     };
-  }, [maybeUpdateScales, panEnabled, props.options.plugins?.zoom?.pan?.threshold, rpcSend]);
+  }, [maybeUpdateScales, panEnabled, props.options.plugins?.zoom?.pan?.threshold]);
 
   const onWheel = useCallback(
     async (event: React.WheelEvent<HTMLCanvasElement>) => {
-      if (!zoomEnabled || !rpcSend) {
+      if (!zoomEnabled || !rpcSendRef.current) {
         return;
       }
 
       const boundingRect = event.currentTarget.getBoundingClientRect();
-      const scales = await rpcSend<RpcScales>("wheel", {
+      const scales = await rpcSendRef.current<RpcScales>("wheel", {
         event: {
           cancelable: false,
           deltaY: event.deltaY,
@@ -353,36 +352,33 @@ function Chart(props: Props): JSX.Element {
       });
       maybeUpdateScales(scales, { userInteraction: true });
     },
-    [zoomEnabled, rpcSend, maybeUpdateScales],
+    [zoomEnabled, maybeUpdateScales],
   );
 
   const onMouseDown = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!rpcSend) {
+      if (!rpcSendRef.current) {
         return;
       }
 
-      const scales = await rpcSend<RpcScales>("mousedown", {
+      const scales = await rpcSendRef.current<RpcScales>("mousedown", {
         event: rpcMouseEvent(event),
       });
 
       maybeUpdateScales(scales);
     },
-    [maybeUpdateScales, rpcSend],
+    [maybeUpdateScales],
   );
 
-  const onMouseUp = useCallback(
-    async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!rpcSend) {
-        return;
-      }
+  const onMouseUp = useCallback(async (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!rpcSendRef.current) {
+      return;
+    }
 
-      return await rpcSend("mouseup", {
-        event: rpcMouseEvent(event),
-      });
-    },
-    [rpcSend],
-  );
+    return await rpcSendRef.current("mouseup", {
+      event: rpcMouseEvent(event),
+    });
+  }, []);
 
   // Since hover events are handled via rpc, we might get a response back when we've
   // already hovered away from the chart. We gate calling onHover by whether the mouse is still
@@ -393,11 +389,11 @@ function Chart(props: Props): JSX.Element {
   const onMouseMove = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
       if (onHover && mousePresentRef.current) {
-        if (!rpcSend) {
+        if (!rpcSendRef.current) {
           return;
         }
 
-        const elements = await rpcSend<RpcElement[]>("getElementsAtEvent", {
+        const elements = await rpcSendRef.current<RpcElement[]>("getElementsAtEvent", {
           event: rpcMouseEvent(event),
         });
 
@@ -408,7 +404,7 @@ function Chart(props: Props): JSX.Element {
         onHover(elements);
       }
     },
-    [onHover, rpcSend, isMounted],
+    [onHover, isMounted],
   );
 
   const onMouseEnter = useCallback(() => {
@@ -422,7 +418,7 @@ function Chart(props: Props): JSX.Element {
 
   const onClick = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>): Promise<void> => {
-      if (!props.onClick || !rpcSend) {
+      if (!props.onClick || !rpcSendRef.current) {
         return;
       }
 
@@ -432,7 +428,7 @@ function Chart(props: Props): JSX.Element {
 
       // maybe we should forward the click event and add support for datalabel listeners
       // the rpc channel doesn't have a way to send rpc back...
-      const datalabel = await rpcSend("getDatalabelAtEvent", {
+      const datalabel = await rpcSendRef.current("getDatalabelAtEvent", {
         event: { x: mouseX, y: mouseY, type: "click" },
       });
 
@@ -463,7 +459,7 @@ function Chart(props: Props): JSX.Element {
         y: yVal,
       });
     },
-    [isMounted, props, rpcSend],
+    [isMounted, props],
   );
 
   if (updateError) {

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -10,12 +10,15 @@
 
 import { ChartOptions, ChartData as ChartJsChartData, ScatterDataPoint } from "chart.js";
 import Hammer from "hammerjs";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
 import { v4 as uuidv4 } from "uuid";
 
+import Logger from "@foxglove/log";
 import { RpcElement, RpcScales } from "@foxglove/studio-base/components/Chart/types";
 import WebWorkerManager from "@foxglove/studio-base/util/WebWorkerManager";
+
+const log = Logger.getLogger(__filename);
 
 function makeChartJSWorker() {
   return new Worker(new URL("./worker/main", import.meta.url));
@@ -74,6 +77,7 @@ function rpcMouseEvent(event: React.MouseEvent<HTMLCanvasElement>) {
 // Chart component renders data using workers with chartjs offscreen canvas
 function Chart(props: Props): JSX.Element {
   const [id] = useState(() => uuidv4());
+
   const initialized = useRef(false);
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
   const isMounted = useMountedState();
@@ -87,30 +91,44 @@ function Chart(props: Props): JSX.Element {
 
   const { type, data, options, width, height, onChartUpdate } = props;
 
-  const rpc = useMemo(() => {
-    return webWorkerManager.registerWorkerListener(id);
-  }, [id]);
+  type RpcSend = <T extends unknown>(
+    topic: string,
+    payload?: Record<string, unknown>,
+    transferables?: (Transferable | OffscreenCanvas)[],
+  ) => Promise<T>;
 
-  // helper function to send rpc to our worker - all invocations need an _id_ so we inject it here
-  const rpcSend = useCallback(
-    async <T extends unknown>(
+  const rpcSendRef = useRef<RpcSend | undefined>();
+  const rpcSend = rpcSendRef.current;
+
+  useLayoutEffect(() => {
+    if (initialized.current) {
+      if (process.env.NODE_ENV === "development") {
+        throw new Error("Chart does not support hot-reloading - please reload the panel");
+      } else {
+        throw new Error("Chart has re-initialized expectedly");
+      }
+    }
+
+    log.info(`Register Chart ${id}`);
+    const rpc = webWorkerManager.registerWorkerListener(id);
+
+    // helper function to send rpc to our worker - all invocations need an _id_ so we inject it here
+    const sendWrapper = async <T extends unknown>(
       topic: string,
       payload?: Record<string, unknown>,
       transferables?: (Transferable | OffscreenCanvas)[],
     ) => {
       return await rpc.send<T>(topic, { id, ...payload }, transferables);
-    },
-    [id, rpc],
-  );
-
-  // when a layout changes - component is unmounted and a new chart is mounted
-  useLayoutEffect(() => {
-    const actualId = id;
-    return () => {
-      void rpcSend("destroy");
-      webWorkerManager.unregisterWorkerListener(actualId);
     };
-  }, [id, rpcSend]);
+    rpcSendRef.current = sendWrapper;
+
+    return () => {
+      log.info(`Unregister chart ${id}`);
+      rpcSendRef.current = undefined;
+      void sendWrapper("destroy");
+      webWorkerManager.unregisterWorkerListener(id);
+    };
+  }, [id]);
 
   // trigger when scales update
   const onScalesUpdateRef = useRef(props.onScalesUpdate);
@@ -179,6 +197,10 @@ function Chart(props: Props): JSX.Element {
   }, [data, height, options, width]);
 
   const { error: updateError } = useAsync(async () => {
+    if (!rpcSend) {
+      return;
+    }
+
     // first time initialization
     if (!initialized.current) {
       const canvas = canvasRef.current;
@@ -246,6 +268,10 @@ function Chart(props: Props): JSX.Element {
     hammerManager.add(new Hammer.Pan({ threshold }));
 
     hammerManager.on("panstart", async (event) => {
+      if (!rpcSend) {
+        return;
+      }
+
       const boundingRect = event.target.getBoundingClientRect();
       await rpcSend<RpcScales>("panstart", {
         event: {
@@ -264,6 +290,10 @@ function Chart(props: Props): JSX.Element {
     });
 
     hammerManager.on("panmove", async (event) => {
+      if (!rpcSend) {
+        return;
+      }
+
       const boundingRect = event.target.getBoundingClientRect();
       const scales = await rpcSend<RpcScales>("panmove", {
         event: {
@@ -279,6 +309,10 @@ function Chart(props: Props): JSX.Element {
     });
 
     hammerManager.on("panend", async (event) => {
+      if (!rpcSend) {
+        return;
+      }
+
       const boundingRect = event.target.getBoundingClientRect();
       const scales = await rpcSend<RpcScales>("panend", {
         event: {
@@ -300,7 +334,7 @@ function Chart(props: Props): JSX.Element {
 
   const onWheel = useCallback(
     async (event: React.WheelEvent<HTMLCanvasElement>) => {
-      if (!zoomEnabled) {
+      if (!zoomEnabled || !rpcSend) {
         return;
       }
 
@@ -324,6 +358,10 @@ function Chart(props: Props): JSX.Element {
 
   const onMouseDown = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!rpcSend) {
+        return;
+      }
+
       const scales = await rpcSend<RpcScales>("mousedown", {
         event: rpcMouseEvent(event),
       });
@@ -335,6 +373,10 @@ function Chart(props: Props): JSX.Element {
 
   const onMouseUp = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!rpcSend) {
+        return;
+      }
+
       return await rpcSend("mouseup", {
         event: rpcMouseEvent(event),
       });
@@ -351,6 +393,10 @@ function Chart(props: Props): JSX.Element {
   const onMouseMove = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
       if (onHover && mousePresentRef.current) {
+        if (!rpcSend) {
+          return;
+        }
+
         const elements = await rpcSend<RpcElement[]>("getElementsAtEvent", {
           event: rpcMouseEvent(event),
         });
@@ -376,7 +422,7 @@ function Chart(props: Props): JSX.Element {
 
   const onClick = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>): Promise<void> => {
-      if (!props.onClick) {
+      if (!props.onClick || !rpcSend) {
         return;
       }
 


### PR DESCRIPTION
**User-Facing Changes**
Ideally none - if a user does encounter this error in production we will have a better indication of why.

**Description**

This change alters the logic around initializing, registering, and unregistering rpc workers.

Previously, the Chart logic would register itself in a memo, and unregister in a layout effect. In development, hot reloading would cause the effect to run which destroyed the id and unregistered the id. The component remained mounted and future rpc calls would fail because the ID was destroyed.

The new logic puts rpc registration and unregistration in the same effect. It also adds checks to see if the chart has already been initialized and throws an error indicating this. In production we should not expect to see this error as the effect should only run once on initial mount. If the error does happen, we know something caused the effect to run and will need to investigate further.

Fixes: #1873






<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
