### PR TITLE
Refactor Amplitude and fix web analytics

### DIFF
--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -4,7 +4,6 @@
 
 import { init as initSentry } from "@sentry/electron";
 import { contextBridge, ipcRenderer } from "electron";
-import { machineId } from "node-machine-id";
 import os from "os";
 import { join as pathJoin } from "path";
 
@@ -73,10 +72,6 @@ window.addEventListener(
 
 const localFileStorage = new LocalFileStorage();
 
-// machineId() can sometimes take 500-2000ms on macOS
-// we fetch it early so that it is ready for Analytics.ts
-const machineIdPromise = machineId();
-
 const ctx: OsContext = {
   platform: process.platform,
   pid: process.pid,
@@ -97,9 +92,6 @@ const ctx: OsContext = {
       }
     }
     return output;
-  },
-  getMachineId: async (): Promise<string> => {
-    return await machineIdPromise;
   },
   getAppVersion: (): string => {
     return pkgInfo.version;

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "jest": "27.2.0",
     "jest-canvas-mock": "2.3.1",
     "license-checker": "25.0.1",
-    "node-machine-id": "1.1.12",
     "playwright": "1.14.1",
     "pngjs": "6.0.0",
     "prettier": "2.4.0",

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -41,7 +41,7 @@ export default function App(props: AppProps): JSX.Element {
 
   const providers = [
     /* eslint-disable react/jsx-key */
-    <AnalyticsProvider />,
+    <AnalyticsProvider amplitudeApiKey={process.env.AMPLITUDE_API_KEY} />,
     <LayoutManagerProvider />,
     <ModalHost />, // render modal elements inside the ThemeProvider
     <AssetsProvider loaders={assetLoaders} />,

--- a/packages/studio-base/src/OsContext.ts
+++ b/packages/studio-base/src/OsContext.ts
@@ -26,8 +26,6 @@ export interface OsContext {
   getHostname: () => string;
   // Get a listing for every network interface discovered on the system
   getNetworkInterfaces: () => NetworkInterface[];
-  // Get a unique identifier for the system from the operating system
-  getMachineId: () => Promise<string>;
   // Get the version string from package.json
   getAppVersion: () => string;
 }

--- a/packages/studio-base/src/context/AnalyticsProvider.tsx
+++ b/packages/studio-base/src/context/AnalyticsProvider.tsx
@@ -2,10 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PropsWithChildren, useMemo } from "react";
+import { PropsWithChildren, useEffect, useMemo } from "react";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AnalyticsContext from "@foxglove/studio-base/context/AnalyticsContext";
+import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { AmplitudeAnalytics } from "@foxglove/studio-base/services/AmplitudeAnalytics";
 
@@ -13,17 +14,18 @@ export default function AnalyticsProvider(
   props: PropsWithChildren<{ amplitudeApiKey?: string }>,
 ): React.ReactElement {
   const [enableTelemetry = true] = useAppConfigurationValue<boolean>(AppSetting.TELEMETRY_ENABLED);
-  const [enableCrashReporting = true] = useAppConfigurationValue<boolean>(
-    AppSetting.CRASH_REPORTING_ENABLED,
-  );
+  const { currentUser } = useCurrentUser();
 
   const analytics = useMemo(() => {
     return new AmplitudeAnalytics({
-      optOut: !enableTelemetry,
-      crashReportingOptOut: !(enableCrashReporting && typeof process.env.SENTRY_DSN === "string"),
-      amplitudeApiKey: props.amplitudeApiKey ?? process.env.AMPLITUDE_API_KEY,
+      enableTelemetry,
+      amplitudeApiKey: props.amplitudeApiKey,
     });
-  }, [props.amplitudeApiKey, enableTelemetry, enableCrashReporting]);
+  }, [props.amplitudeApiKey, enableTelemetry]);
+
+  useEffect(() => {
+    analytics.setUser(currentUser);
+  }, [analytics, currentUser]);
 
   return <AnalyticsContext.Provider value={analytics}>{props.children}</AnalyticsContext.Provider>;
 }

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -2,116 +2,63 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { addBreadcrumb as addSentryBreadcrumb, setUser as setSentryUser } from "@sentry/core";
+import { setUser as setSentryUser, addBreadcrumb as addSentryBreadcrumb } from "@sentry/core";
 import { Severity } from "@sentry/types";
-import amplitude from "amplitude-js";
-import { v4 as uuidv4 } from "uuid";
+import amplitude, { AmplitudeClient } from "amplitude-js";
 
-import Logger from "@foxglove/log";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
+import { User } from "@foxglove/studio-base/context/CurrentUserContext";
 import IAnalytics, {
   AppEvent,
   getEventBreadcrumbType,
   getEventCategory,
 } from "@foxglove/studio-base/services/IAnalytics";
-import Storage from "@foxglove/studio-base/util/Storage";
-
-const UUID_ZERO = "00000000-0000-0000-0000-000000000000";
-const USER_ID_KEY = "analytics_user_id";
-
-const log = Logger.getLogger(__filename);
 
 const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
 
 export class AmplitudeAnalytics implements IAnalytics {
-  private _amplitude: Promise<amplitude.AmplitudeClient | undefined>;
-  private _crashReporting: boolean;
-  private _storage = new Storage();
+  private _amp: AmplitudeClient;
 
-  constructor(options: {
-    optOut?: boolean;
-    crashReportingOptOut: boolean;
-    amplitudeApiKey: string | undefined;
-  }) {
-    const amplitudeApiKey = options.amplitudeApiKey;
-    const optOut = options.optOut ?? false;
+  constructor(options: { enableTelemetry: boolean; amplitudeApiKey?: string }) {
+    this._amp = amplitude.getInstance();
 
-    if (!optOut && amplitudeApiKey != undefined && amplitudeApiKey.length > 0) {
-      this._amplitude = this.createAmplitude(amplitudeApiKey);
-    } else {
-      this._amplitude = Promise.resolve(undefined);
+    if (options.amplitudeApiKey) {
+      this._amp.init(options.amplitudeApiKey);
     }
 
-    this._crashReporting = !(options.crashReportingOptOut ?? false);
-    if (this._crashReporting) {
-      this.getDeviceId()
-        .then((deviceId) => {
-          const id = this.getUserId();
-          setSentryUser({ id, deviceId });
-        })
-        .catch((err) => {
-          log.error("getDeviceId error:", err);
-        });
-    } else {
-      log.info("Crash reporting is disabled");
+    this._amp.setOptOut(!options.enableTelemetry);
+
+    if (os) {
+      this._amp.setVersionName(os.getAppVersion());
     }
 
     void this.logEvent(AppEvent.APP_INIT);
   }
 
-  private async createAmplitude(apiKey: string): Promise<amplitude.AmplitudeClient> {
-    const userId = this.getUserId();
-    const deviceId = await this.getDeviceId();
-    const appVersion = this.getAppVersion();
-    log.info(
-      `Initializing telemetry as user ${userId}, device ${deviceId} (version ${appVersion})`,
-    );
+  setUser(user?: User): void {
+    // Amplitude will continue to associate events with the last signed in user for this deviceId.
+    // It is possible to call regenerateDeviceId() after sign out, but this means future events
+    // will appear as a new unique user. We also don't want to call regenerateDeviceId() every time
+    // AnalyticsProvider is mounted for anonymous users.
+    // https://help.amplitude.com/hc/en-us/articles/115003135607-Tracking-unique-users
+    this._amp.setUserId(user?.id ?? null); // eslint-disable-line no-restricted-syntax
 
-    const amp = amplitude.getInstance();
-    amp.init(apiKey);
-    amp.setUserId(userId);
-    amp.setDeviceId(deviceId);
-    amp.setVersionName(appVersion);
-
-    return amp;
-  }
-
-  getAppVersion(): string {
-    return os?.getAppVersion() ?? "0.0.0";
-  }
-
-  getUserId(): string {
-    let userId = this._storage.getItem<string>(USER_ID_KEY);
-    if (userId == undefined) {
-      userId = uuidv4();
-      this._storage.setItem(USER_ID_KEY, userId);
-    }
-    return userId;
-  }
-
-  // OsContextSingleton.getMachineId() can take 500-2000ms on macOS
-  async getDeviceId(): Promise<string> {
-    return (await os?.getMachineId()) ?? UUID_ZERO;
+    // Update Sentry user, passing Amplitude deviceId
+    setSentryUser({ id: user?.id, device_id: this._amp.options.deviceId });
   }
 
   async logEvent(event: AppEvent, data?: { [key: string]: unknown }): Promise<void> {
-    const amp = await this._amplitude;
-    if (amp != undefined) {
-      await new Promise<void>((resolve) => {
-        amp.logEvent(event, data, () => resolve());
-      });
-    }
+    addSentryBreadcrumb({
+      type: getEventBreadcrumbType(event),
+      category: `studio.${getEventCategory(event).toLowerCase()}`,
+      message: event,
+      level: Severity.Info,
+      data,
+      timestamp: Date.now() / 1000,
+    });
 
-    // important that this happens after await amplitude (after setSentryUser() call)
-    if (this._crashReporting) {
-      addSentryBreadcrumb({
-        type: getEventBreadcrumbType(event),
-        category: `studio.${getEventCategory(event).toLowerCase()}`,
-        message: event,
-        level: Severity.Info,
-        data,
-        timestamp: Date.now() / 1000,
-      });
-    }
+    await new Promise<void>((resolve) => {
+      this._amp.logEvent(event, data, () => resolve());
+    });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12410,7 +12410,6 @@ __metadata:
     jest: 27.2.0
     jest-canvas-mock: 2.3.1
     license-checker: 25.0.1
-    node-machine-id: 1.1.12
     playwright: 1.14.1
     pngjs: 6.0.0
     prettier: 2.4.0
@@ -17472,13 +17471,6 @@ fsevents@^1.2.7:
     moment: ^2.18.1
     request: ">=2.76.0 <3.0.0"
   checksum: 7071604755a35fb4def96dad5f72374fb48cee72044f618baf878ba29736f4d514df151ffb3d32b253b1f4b162316568ae52b68f263c58eeeb4964cd432027e1
-  languageName: node
-  linkType: hard
-
-"node-machine-id@npm:1.1.12":
-  version: 1.1.12
-  resolution: "node-machine-id@npm:1.1.12"
-  checksum: e23088a0fb4a77a1d6484b7f09a22992fd3e0054d4f2e427692b4c7081e6cf30118ba07b6113b6c89f1ce46fd26ec5ab1d76dcaf6c10317717889124511283a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Amplitude was not working on web. Fixed and simplified analytics code.

Users can still opt out of analytics and/or crash reporting in the settings.

- Machine ID is no longer used, Amplitude already generates a Device ID
- Amplitude Device ID is passed to Sentry where relevant
- User ID is passed to Amplitude & Sentry where relevant
- Use Amplitude's existing opt out functionality instead of rolling our own
- Removed unnecessary logic around Sentry breadcrumbs (if crash reporting is opted out then Sentry is never initialized, but we can still call `Sentry.addBreadcrumb()` and it will be a no-op).

Closes https://github.com/foxglove/studio/issues/1622