### PR TITLE
Internal: remove unused reportedErrorTopics SceneBuilder code

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -85,10 +85,6 @@ export type SceneErrors = {
   rootTransformID: string;
 };
 
-type SceneErrorTopics = {
-  topicsWithBadFrameIds: Set<string>;
-};
-
 type SelectedNamespacesByTopic = {
   [topicName: string]: string[];
 };
@@ -196,9 +192,6 @@ export default class SceneBuilder implements MarkerProvider {
   errorsByTopic: {
     [topicName: string]: string[];
   } = {};
-  reportedErrorTopics: SceneErrorTopics = {
-    topicsWithBadFrameIds: new Set(),
-  };
   maps = [];
   flattenedZHeightPose?: Pose;
   scene = {};
@@ -261,7 +254,6 @@ export default class SceneBuilder implements MarkerProvider {
 
   setPlayerId(playerId: string): void {
     if (this._playerId !== playerId) {
-      this.reportedErrorTopics.topicsWithBadFrameIds.clear();
       this.errors = {
         rootTransformID: "",
         topicsMissingFrameIds: new Map(),
@@ -440,12 +432,6 @@ export default class SceneBuilder implements MarkerProvider {
     return some(this.enabledNamespaces, (ns) => ns.topic === topic && ns.name === name);
   }
 
-  _reportBadFrameId(topic: string): void {
-    if (!this.reportedErrorTopics.topicsWithBadFrameIds.has(topic)) {
-      this.reportedErrorTopics.topicsWithBadFrameIds.add(topic);
-    }
-  }
-
   _transformMarkerPose = (topic: string, marker: BaseMarker): MutablePose | undefined => {
     const frame_id = marker.header.frame_id;
 
@@ -463,7 +449,6 @@ export default class SceneBuilder implements MarkerProvider {
 
     // frame_id !== this.rootTransformID.
     // We continue to render these, though they may be inaccurate
-    this._reportBadFrameId(topic);
     const badFrameError = this._addError(this.errors.topicsWithBadFrameIds, topic);
     const namespace = marker.ns;
     badFrameError.namespaces.add(namespace);
@@ -656,7 +641,6 @@ export default class SceneBuilder implements MarkerProvider {
     }
 
     if (frame_id !== this.rootTransformID) {
-      this._reportBadFrameId(topic);
       const error = this._addError(this.errors.topicsWithBadFrameIds, topic);
       error.frameIds.add(frame_id);
     }


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
These code paths are unused for any error reporting.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
