### PR TITLE
Miscellaneous copy edits and improvements

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -36,7 +36,7 @@ const features: Feature[] = [
   {
     key: AppSetting.SHOW_DEBUG_PANELS,
     name: "Studio debug panels",
-    description: <>Show Foxglove Studio debug panels in the add panel list.</>,
+    description: <>Show Foxglove Studio debug panels in the &ldquo;Add panel&rdquo; list.</>,
   },
   {
     key: AppSetting.ENABLE_DRAWING_POLYGONS,

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -241,7 +241,7 @@ export default function Preferences(): React.ReactElement {
           </Stack>
         </Stack.Item>
         <Stack.Item>
-          <SectionHeader>Experimental Features</SectionHeader>
+          <SectionHeader>Experimental features</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
             <Text style={{ color: theme.palette.neutralSecondary }}>
               These features are unstable and not recommended for daily use.

--- a/packages/studio-base/src/panels/Plot/index.help.md
+++ b/packages/studio-base/src/panels/Plot/index.help.md
@@ -1,6 +1,6 @@
 # Plot
 
-Plot arbitrary values from topics using [message path syntax](#help:message-path-syntax).
+Plot arbitrary values from topic paths, specified using [message path syntax](#help:message-path-syntax).
 
 ## Shortcuts
 

--- a/packages/studio-base/src/panels/RawMessages/index.help.md
+++ b/packages/studio-base/src/panels/RawMessages/index.help.md
@@ -2,6 +2,6 @@
 
 Display incoming topic data in an easy-to-read collapsible JSON tree format.
 
-Use [message path syntax](/docs/app-concepts/message-path-syntax) to specify the data you want to inspect. Enter diff mode to compare messages across timestamps, data sources, and topics.
+Use [message path syntax](#help:message-path-syntax) to specify the data you want to inspect. Enter diff mode to compare messages across timestamps, data sources, and topics.
 
 [Learn more](https://foxglove.dev/docs/panels/raw-messages).

--- a/packages/studio-base/src/panels/StateTransitions/index.help.md
+++ b/packages/studio-base/src/panels/StateTransitions/index.help.md
@@ -1,8 +1,6 @@
 # State Transitions
 
-Track when the discrete values of incoming topics change.
-
-Specify the data you want to track using [message path syntax](#help:message-path-syntax).
+Track when the discrete values of topic paths, specified using [message path syntax](#help:message-path-syntax), change.
 
 ## Shortcuts
 

--- a/packages/studio-base/src/panels/Table/index.help.md
+++ b/packages/studio-base/src/panels/Table/index.help.md
@@ -2,6 +2,6 @@
 
 Display topic data in a tabular format.
 
-Use [message path syntax](/docs/app-concepts/message-path-syntax) to determine the data to display. Click a column's header to sort by that column; hold `Shift` to click multiple columns.
+Use [message path syntax](#help:message-path-syntax) to determine the data to display. Click a column's header to sort by that column; hold `Shift` to click multiple columns.
 
 [Learn more](https://foxglove.dev/docs/panels/table).


### PR DESCRIPTION
**User-Facing Changes**
Miscellaneous copy edits and improvements:
- Use proper casing for experimental features header and  'Add panel' list reference
- Open the in-app docs whenever message path syntax is mentioned
- Update tagline for Plot and State Transitions panels to match external docs

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
