### PR TITLE
UI improvements to Diagnostic Summary panel's header

### DIFF
--- a/packages/studio-base/src/panels/Rosout/FilterBar.tsx
+++ b/packages/studio-base/src/panels/Rosout/FilterBar.tsx
@@ -92,6 +92,7 @@ export default function FilterBar(props: FilterBarProps): JSX.Element {
   return (
     <Stack grow horizontal tokens={{ childrenGap: theme.spacing.s1 }}>
       <Dropdown
+        styles={{ title: { background: "transparent" } }}
         onRenderOption={renderOption}
         onRenderTitle={renderTitle}
         onChange={(_ev, option) => {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -213,12 +213,13 @@ function DiagnosticSummary(props: Props): JSX.Element {
       style={{
         width: "100%",
         padding: "0",
-        background: "transparent",
+        backgroundColor: "transparent",
         opacity: "0.5",
         marginLeft: "10px",
+        fontSize: "14px",
       }}
       value={hardwareIdFilter}
-      placeholder={"Filter hardware id"}
+      placeholder="Filter hardware id"
       onChange={(e) => saveConfig({ hardwareIdFilter: e.target.value })}
     />
   );
@@ -309,7 +310,10 @@ function DiagnosticSummary(props: Props): JSX.Element {
     <Flex col className={classes.panel}>
       <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
         <Dropdown
-          styles={{ root: { minWidth: "100px" } }}
+          styles={{
+            root: { minWidth: "100px" },
+            title: { backgroundColor: "transparent" },
+          }}
           onRenderOption={renderOption}
           onRenderTitle={(option: IDropdownOption[] | undefined) =>
             option ? <>{option.map(renderOption)}</> : ReactNull


### PR DESCRIPTION
**User-Facing Changes**
In the Diagnostics Summary panel:
- Made the dropdown menu's bg color with the header bg color
- Made the font size consistent across the header

In the Rosout panel:
- Made analogous change for the dropdown menu's background color
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
