### PR TITLE
Require confirmation for revert operation for personal as well as shared layouts

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -298,16 +298,14 @@ export default function LayoutBrowser({
 
   const onRevertLayout = useCallbackWithToast(
     async (item: Layout) => {
-      if (layoutIsShared(item)) {
-        const response = await confirm({
-          title: `Revert “${item.name}”?`,
-          prompt: "Your changes will be permantly deleted. This cannot be undone.",
-          ok: "Discard changes",
-          variant: "danger",
-        });
-        if (response !== "ok") {
-          return;
-        }
+      const response = await confirm({
+        title: `Revert “${item.name}”?`,
+        prompt: "Your changes will be permantly deleted. This cannot be undone.",
+        ok: "Discard changes",
+        variant: "danger",
+      });
+      if (response !== "ok") {
+        return;
       }
       await layoutManager.revertLayout({ id: item.id });
       void analytics.logEvent(AppEvent.LAYOUT_REVERT, { permission: item.permission });


### PR DESCRIPTION
**User-Facing Changes**
Added a confirmation step before reverting changes to a layout.

**Description**
Resolves https://github.com/foxglove/studio/issues/1884.