### PR TITLE
Skip logEvent if Amplitude API key is missing

### DIFF
--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -17,12 +17,12 @@ import IAnalytics, {
 const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
 
 export class AmplitudeAnalytics implements IAnalytics {
-  private _amp: AmplitudeClient;
+  private _amp?: AmplitudeClient;
 
   constructor(options: { enableTelemetry: boolean; amplitudeApiKey?: string }) {
-    this._amp = amplitude.getInstance();
-
     if (options.amplitudeApiKey) {
+      this._amp = amplitude.getInstance();
+
       // Capitalize platform name
       let platform = os?.platform ?? "web";
       platform = platform.charAt(0).toUpperCase() + platform.slice(1);
@@ -30,15 +30,15 @@ export class AmplitudeAnalytics implements IAnalytics {
       this._amp.init(options.amplitudeApiKey, undefined, {
         platform,
       });
+
+      this._amp.setOptOut(!options.enableTelemetry);
+
+      if (os) {
+        this._amp.setVersionName(os.getAppVersion());
+      }
+
+      void this.logEvent(AppEvent.APP_INIT);
     }
-
-    this._amp.setOptOut(!options.enableTelemetry);
-
-    if (os) {
-      this._amp.setVersionName(os.getAppVersion());
-    }
-
-    void this.logEvent(AppEvent.APP_INIT);
   }
 
   setUser(user?: User): void {
@@ -47,10 +47,10 @@ export class AmplitudeAnalytics implements IAnalytics {
     // will appear as a new unique user. We also don't want to call regenerateDeviceId() every time
     // AnalyticsProvider is mounted for anonymous users.
     // https://help.amplitude.com/hc/en-us/articles/115003135607-Tracking-unique-users
-    this._amp.setUserId(user?.id ?? null); // eslint-disable-line no-restricted-syntax
+    this._amp?.setUserId(user?.id ?? null); // eslint-disable-line no-restricted-syntax
 
     // Update Sentry user, passing Amplitude deviceId
-    setSentryUser({ id: user?.id, device_id: this._amp.options.deviceId });
+    setSentryUser({ id: user?.id, device_id: this._amp?.options.deviceId });
   }
 
   async logEvent(event: AppEvent, data?: { [key: string]: unknown }): Promise<void> {
@@ -64,7 +64,11 @@ export class AmplitudeAnalytics implements IAnalytics {
     });
 
     await new Promise<void>((resolve) => {
-      this._amp.logEvent(event, data, () => resolve());
+      if (this._amp) {
+        this._amp.logEvent(event, data, () => resolve());
+      } else {
+        resolve();
+      }
     });
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix Amplitude console warning that was only happening during local development about calling `logEvent()` without calling `init()`. 

Fixes https://github.com/foxglove/studio/issues/1898