### PR TITLE
Migrate lowercase layout permission constants to uppercase

### DIFF
--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -129,7 +129,8 @@ export function migrateLayout(value: unknown): Layout {
   return {
     id: layout.id,
     name: layout.name ?? `Unnamed (${now})`,
-    permission: layout.permission ?? "CREATOR_WRITE",
+    permission:
+      (layout.permission?.toUpperCase() as LayoutPermission | undefined) ?? "CREATOR_WRITE",
     working: layout.working
       ? { ...layout.working, data: migrateData(layout.working.data) }
       : undefined,


### PR DESCRIPTION
**User-Facing Changes**
Team Layouts beta: fixed an issue where personal layouts created with older version of Studio would incorrectly become "team" layouts upon first login.

**Description**
These constants were changed from lowercase to uppercase in #1866, which was before we invited users to the team layouts beta. However, users may have created local personal layouts (which would still have the lowercase values) with older versions of the app before signing up for the beta. Due to an implementation detail, these old layouts were showing up under the "team" section and not getting uploaded to the server. Adding this migration ensures they are correctly treated as personal layouts and uploaded.