### PR TITLE
Feature: add a _schema_ field to Topic type

### DIFF
--- a/packages/studio-base/src/util/rosDatatypeToSchema.test.ts
+++ b/packages/studio-base/src/util/rosDatatypeToSchema.test.ts
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { parse, RosMsgDefinition } from "@foxglove/rosmsg";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import { rosDatatypeToSchema } from "@foxglove/studio-base/util/rosDatatypeToSchema";
+
+function rosMsgDefinitionsToDatatypes(
+  rootName: string,
+  definitions: RosMsgDefinition[],
+): RosDatatypes {
+  const datatypes: RosDatatypes = new Map();
+
+  const definitionZero = definitions[0];
+  if (definitionZero) {
+    definitionZero.name ??= rootName;
+  }
+
+  for (const definition of definitions) {
+    const name = definition.name;
+    if (!name) {
+      continue;
+    }
+    datatypes.set(name, definition);
+  }
+
+  return datatypes;
+}
+
+describe("rosDatatypesToSchema", () => {
+  it("should schema std_msgs/Header", () => {
+    const msg = `
+        uint32 seq
+        time stamp
+        string frame_id
+    `;
+
+    const datatypes = rosMsgDefinitionsToDatatypes("std_msgs/Header", parse(msg));
+    const schema = rosDatatypeToSchema("std_msgs/Header", datatypes);
+
+    expect(schema).toEqual({
+      name: "std_msgs/Header",
+      type: "record",
+      fields: [
+        {
+          name: "seq",
+          type: "integer",
+        },
+        {
+          name: "stamp",
+          type: "record",
+          fields: [
+            { name: "sec", type: "integer" },
+            { name: "nsec", type: "integer" },
+          ],
+        },
+        {
+          name: "frame_id",
+          type: "string",
+        },
+      ],
+    });
+  });
+});

--- a/packages/studio-base/src/util/rosDatatypeToSchema.ts
+++ b/packages/studio-base/src/util/rosDatatypeToSchema.ts
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Schema, SchemaType } from "@foxglove/studio";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+
+// http://wiki.ros.org/msg
+
+// https://www.tutorialspoint.com/avro/avro_schemas.htm
+
+function rosTypeToSchemaType(rosType: string): SchemaType {
+  switch (rosType) {
+    case "bool":
+      return "boolean";
+    case "char":
+    case "byte":
+    case "int8":
+    case "uint8":
+    case "int16":
+    case "uint16":
+    case "int32":
+    case "uint32":
+    case "int64":
+    case "uint64":
+      return "integer";
+    case "float32":
+    case "float64":
+      return "number";
+    case "string":
+      return "string";
+    case "time":
+    case "duration":
+      return "record";
+  }
+  return "record";
+}
+
+function rosDatatypeToSchema(datatype: string, datatypes: RosDatatypes): Schema | undefined {
+  const rosMsgDef = datatypes.get(datatype);
+  if (!rosMsgDef) {
+    return undefined;
+  }
+
+  const fields: Schema[] = [];
+  const schema: Schema = {
+    name: datatype,
+    type: "record",
+    fields,
+  };
+
+  for (const definition of rosMsgDef.definitions) {
+    // skip constants
+    if (definition.isConstant === true) {
+      continue;
+    }
+
+    const itemType = rosTypeToSchemaType(definition.type);
+
+    const isArray = definition.isArray === true;
+    const field: Schema = {
+      name: definition.name,
+      type: isArray ? "array" : itemType,
+    };
+
+    if (isArray) {
+      field.items = itemType;
+    }
+
+    // For complex types, make a schema to get the fields
+    if (definition.isComplex === true) {
+      const fieldSchema = rosDatatypeToSchema(definition.type, datatypes);
+      if (!fieldSchema) {
+        continue;
+      }
+      field.fields = fieldSchema.fields;
+    } else if (definition.type === "time" || definition.type === "duration") {
+      // _time_ and _duration_ are builtin record types
+      field.fields = [
+        { name: "sec", type: "integer" },
+        { name: "nsec", type: "integer" },
+      ];
+    }
+
+    fields.push(field);
+  }
+
+  return schema;
+}
+
+export { rosDatatypeToSchema };

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -8,12 +8,35 @@ declare module "@foxglove/studio" {
     nsec: number;
   }
 
+  export type SchemaType = "record" | "array" | "string" | "integer" | "number" | "boolean";
+
+  export type Schema = {
+    // The name of the schema. For top level schemas this is typically the name of the schema
+    // for field schemas this is the name of the field.
+    name: string;
+
+    // The type of the schema. For type "record", the _fields_ property describes the record
+    type: SchemaType;
+
+    // For type "array", this contains the type of each individual item
+    // If the item type is "record", the _fields_ property describes the record
+    items?: SchemaType;
+
+    // For schema type "record", this contains the fields of the record
+    fields?: Schema[];
+
+    // For field schemas of record types, this indicates whether the field is optional.
+    optional?: boolean;
+  };
+
   // A topic is a namespace for specific types of messages
   export type Topic = {
     // topic name i.e. "/some/topic"
     name: string;
     // topic datatype
     datatype: string;
+    // datatype schema
+    schema?: Schema;
   };
 
   /**


### PR DESCRIPTION
**User-Facing Changes**
TBD

**Description**
The Topic schema field provides a schema for messages on the topic. The schema describes the fields within the message.
    
Fixes: #1923

---
I've opened this PR to start discussion on how to expose the message definitions for topics to panel extensions. My initial proposal here exposes the definitions under a new _schema_ field within the Topic type. The schema field is an _ast like_ object rather than a string so downstream users don't need to do any parsing. The scope of the _ast like_ object is not to be a lossless representation of the message definition from the original format but instead to provide the rough shape of the messages on the topic (i.e. which fields are present, what their general javascript types are).

For examples of ROS messages and their schema counterparts - see the test file in the PR.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
