### PR TITLE
internal: change build target to ESNext

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -88,6 +88,7 @@ overrides:
     parserOptions:
       project: ./tsconfig.eslint.json
     rules:
+      "@foxglove/no-private-identifier": off
       "@typescript-eslint/ban-ts-comment":
         - error
         - ts-expect-error: allow-with-description

--- a/desktop/main/tsconfig.json
+++ b/desktop/main/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*", "../common/*", "../../package.json"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "../../",
     "noEmit": true
   }

--- a/desktop/preload/tsconfig.json
+++ b/desktop/preload/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*", "../common/*", "../../package.json"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "../../",
     "noEmit": true,
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "esnext"],
     "useUnknownInCatchVariables": false
   }
 }

--- a/desktop/quicklook/tsconfig.json
+++ b/desktop/quicklook/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "../../",
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"]
+    "lib": ["dom", "dom.iterable", "esnext"]
   }
 }

--- a/desktop/renderer/tsconfig.json
+++ b/desktop/renderer/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*", "../common/**/*", "../../package.json"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "../../",
     "noEmit": true,
     "jsx": "react-jsx",
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"]
+    "lib": ["dom", "dom.iterable", "esnext", "webworker"]
   }
 }

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["*.ts", "common/**/*", "integration-test/**/*.ts", "../package.json"],
   "compilerOptions": {
     "module": "commonjs",
+    "target": "esnext",
     "noEmit": true
   }
 }

--- a/desktop/webpack.main.config.ts
+++ b/desktop/webpack.main.config.ts
@@ -64,7 +64,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [new ESBuildMinifyPlugin({ target: "esnext" })],
     },
 
     plugins: [

--- a/desktop/webpack.preload.config.ts
+++ b/desktop/webpack.preload.config.ts
@@ -47,7 +47,7 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [new ESBuildMinifyPlugin({ target: "esnext" })],
     },
 
     plugins: [

--- a/desktop/webpack.quicklook.config.ts
+++ b/desktop/webpack.quicklook.config.ts
@@ -59,7 +59,7 @@ export default (_env: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [new ESBuildMinifyPlugin({ target: "esnext" })],
     },
 
     plugins: [

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -73,7 +73,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
 
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [new ESBuildMinifyPlugin({ target: "esnext" })],
     },
 
     plugins: [

--- a/packages/den/tsconfig.json
+++ b/packages/den/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": ".",
     "outDir": "./dist"
   }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "./src",
     "outDir": "./dist",
-    "lib": ["dom", "es2020"]
+    "lib": ["dom", "esnext"]
   }
 }

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -11,34 +11,34 @@ class Logger {
   // default logger has an empty name
   static default = new Logger("");
 
-  private _name: string;
-  private _enabled = true;
+  #name: string;
+  #enabled = true;
 
   // all new loggers are created from the default logger
   private constructor(name: string) {
-    this._name = name;
-    this._updateHandlers();
+    this.#name = name;
+    this.#updateHandlers();
 
     channels.set(name, this);
   }
 
   // fully qualified name for the logger
   name() {
-    return this._name;
+    return this.#name;
   }
 
   isEnabled() {
-    return this._enabled;
+    return this.#enabled;
   }
 
   enable() {
-    this._enabled = true;
-    this._updateHandlers();
+    this.#enabled = true;
+    this.#updateHandlers();
   }
 
   disable() {
-    this._enabled = false;
-    this._updateHandlers();
+    this.#enabled = false;
+    this.#updateHandlers();
   }
 
   debug(..._args: unknown[]) {}
@@ -49,7 +49,7 @@ class Logger {
   // create a new logger under this logger's namespace
   getLogger(name: string): Logger {
     const shortName = name.replace(/^.+\.(asar|webpack)[\\/\\]/, "");
-    const channelName = this._name.length > 0 ? `${this._name}.${shortName}` : shortName;
+    const channelName = this.#name.length > 0 ? `${this.#name}.${shortName}` : shortName;
     const existing = channels.get(channelName);
     if (existing) {
       return existing;
@@ -65,9 +65,9 @@ class Logger {
     return Array.from(channels.values());
   }
 
-  private _updateHandlers() {
-    if (this._enabled) {
-      const prefix = this._name.length > 0 ? `[${this._name}]` : "";
+  #updateHandlers() {
+    if (this.#enabled) {
+      const prefix = this.#name.length > 0 ? `[${this.#name}]` : "";
       this.debug = console.debug.bind(global.console, `${prefix}`);
       this.info = console.info.bind(global.console, `${prefix}`);
       this.warn = console.warn.bind(global.console, `${prefix}`);

--- a/packages/log/tsconfig.json
+++ b/packages/log/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "./src",
     "outDir": "./dist"
   }

--- a/packages/mcap/tsconfig.json
+++ b/packages/mcap/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": ".",
     "outDir": "./dist",
-    "lib": ["es2020", "dom"]
+    "lib": ["esnext", "dom"]
   }
 }

--- a/packages/studio-base/tsconfig.cli.json
+++ b/packages/studio-base/tsconfig.cli.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "module": "commonjs",
-    "lib": ["es2020"]
+    "target": "esnext",
+    "lib": ["esnext"]
   }
 }

--- a/packages/studio-base/tsconfig.json
+++ b/packages/studio-base/tsconfig.json
@@ -2,10 +2,12 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./src/**/*", "./src/**/*.json", "./src/.storybook/**/*", "../package.json"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "rootDir": "./src",
     "baseUrl": "./src",
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "declarationMap": false,
     "sourceMap": false,
     "paths": {

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -187,7 +187,7 @@ export function makeConfig(
     },
     optimization: {
       removeAvailableModules: true,
-      minimizer: [new ESBuildMinifyPlugin({ target: "es2020" })],
+      minimizer: [new ESBuildMinifyPlugin({ target: "esnext" })],
     },
     plugins: [
       new CircularDependencyPlugin({

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -19,8 +19,10 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["**/*", "packages/studio-base/src/.storybook/**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "paths": {
       "@foxglove/studio-base/*": ["./packages/studio-base/src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   ],
   "compilerOptions": {
     "module": "commonjs",
+    "target": "esnext",
     "noEmit": true
   }
 }

--- a/web/src/tsconfig.json
+++ b/web/src/tsconfig.json
@@ -2,9 +2,11 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["./**/*"],
   "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
     "noEmit": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "es2020", "webworker"],
+    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "experimentalDecorators": true,
     "useUnknownInCatchVariables": false,
     "paths": {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["*.ts"],
   "compilerOptions": {
     "module": "commonjs",
+    "target": "esnext",
     "noEmit": true,
     "experimentalDecorators": true
   }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Enables the use of `#` private identifiers natively.