### PR TITLE
Convert private and underscored fields to native private fields

### DIFF
--- a/packages/den/async/LazilyInitialized.ts
+++ b/packages/den/async/LazilyInitialized.ts
@@ -9,18 +9,18 @@
 export default class LazilyInitialized<T> {
   // The promise and compute function are held separately so the function can be garbage collected
   // when it is no longer needed.
-  private state: { promise: Promise<T> } | { promise?: undefined; compute: () => Promise<T> };
+  #state: { promise: Promise<T> } | { promise?: undefined; compute: () => Promise<T> };
 
   constructor(compute: () => Promise<T>) {
-    this.state = { compute };
+    this.#state = { compute };
   }
 
   async get(): Promise<T> {
-    if (this.state.promise) {
-      return await this.state.promise;
+    if (this.#state.promise) {
+      return await this.#state.promise;
     }
-    const promise = this.state.compute();
-    this.state = { promise };
+    const promise = this.#state.compute();
+    this.#state = { promise };
     return await promise;
   }
 }

--- a/packages/den/async/MutexLocked.ts
+++ b/packages/den/async/MutexLocked.ts
@@ -11,10 +11,10 @@ import { Mutex } from "async-mutex";
  * access to be protected by the mutex.
  */
 export default class MutexLocked<T> {
-  private mutex = new Mutex();
+  #mutex = new Mutex();
   constructor(private value: T) {}
 
   async runExclusive<Result>(body: (value: T) => Promise<Result>): Promise<Result> {
-    return await this.mutex.runExclusive(async () => await body(this.value));
+    return await this.#mutex.runExclusive(async () => await body(this.value));
   }
 }

--- a/packages/mcap/src/McapReader.ts
+++ b/packages/mcap/src/McapReader.ts
@@ -44,25 +44,25 @@ type McapReaderOptions = {
  * ```
  */
 export default class McapReader {
-  private buffer = new StreamBuffer(MCAP_MAGIC.length * 2);
-  private decompressHandlers;
-  private includeChunks;
-  private doneReading = false;
-  private generator = this.read();
+  #buffer = new StreamBuffer(MCAP_MAGIC.length * 2);
+  #decompressHandlers;
+  #includeChunks;
+  #doneReading = false;
+  #generator = this.read();
 
   constructor({ includeChunks = false, decompressHandlers = {} }: McapReaderOptions = {}) {
-    this.includeChunks = includeChunks;
-    this.decompressHandlers = decompressHandlers;
+    this.#includeChunks = includeChunks;
+    this.#decompressHandlers = decompressHandlers;
   }
 
   /** @returns True if a valid, complete mcap file has been parsed. */
   done(): boolean {
-    return this.doneReading;
+    return this.#doneReading;
   }
 
   /** @returns The number of bytes that have been received by `append()` but not yet parsed. */
   bytesRemaining(): number {
-    return this.buffer.bytesRemaining();
+    return this.#buffer.bytesRemaining();
   }
 
   /**
@@ -70,10 +70,10 @@ export default class McapReader {
    * call `nextRecord()` again to parse any records that are now available.
    */
   append(data: Uint8Array): void {
-    if (this.doneReading) {
+    if (this.#doneReading) {
       throw new Error("Already done reading");
     }
-    this.buffer.append(data);
+    this.#buffer.append(data);
   }
 
   /**
@@ -84,12 +84,12 @@ export default class McapReader {
    * reader is in an unspecified state and should no longer be used.
    */
   nextRecord(): McapRecord | undefined {
-    if (this.doneReading) {
+    if (this.#doneReading) {
       return undefined;
     }
-    const result = this.generator.next();
+    const result = this.#generator.next();
     if (result.done === true) {
-      this.doneReading = true;
+      this.#doneReading = true;
     }
     return result.value;
   }
@@ -97,20 +97,20 @@ export default class McapReader {
   private *read(): Generator<McapRecord | undefined, McapRecord | undefined, void> {
     {
       let magic, usedBytes;
-      while ((({ magic, usedBytes } = parseMagic(this.buffer.view, 0)), !magic)) {
+      while ((({ magic, usedBytes } = parseMagic(this.#buffer.view, 0)), !magic)) {
         yield;
       }
-      this.buffer.consume(usedBytes);
+      this.#buffer.consume(usedBytes);
     }
 
     for (;;) {
       let record;
       {
         let usedBytes;
-        while ((({ record, usedBytes } = parseRecord(this.buffer.view, 0)), !record)) {
+        while ((({ record, usedBytes } = parseRecord(this.#buffer.view, 0)), !record)) {
           yield;
         }
-        this.buffer.consume(usedBytes);
+        this.#buffer.consume(usedBytes);
       }
       switch (record.type) {
         case "ChannelInfo":
@@ -121,12 +121,12 @@ export default class McapReader {
           break;
 
         case "Chunk": {
-          if (this.includeChunks) {
+          if (this.#includeChunks) {
             yield record;
           }
           let buffer = new Uint8Array(record.data);
           if (record.compression !== "") {
-            const decompress = this.decompressHandlers[record.compression];
+            const decompress = this.#decompressHandlers[record.compression];
             if (!decompress) {
               throw new Error(`Unsupported compression ${record.compression}`);
             }
@@ -162,14 +162,14 @@ export default class McapReader {
         case "Footer":
           {
             let magic, usedBytes;
-            while ((({ magic, usedBytes } = parseMagic(this.buffer.view, 0)), !magic)) {
+            while ((({ magic, usedBytes } = parseMagic(this.#buffer.view, 0)), !magic)) {
               yield;
             }
-            this.buffer.consume(usedBytes);
+            this.#buffer.consume(usedBytes);
           }
-          if (this.buffer.bytesRemaining() !== 0) {
+          if (this.#buffer.bytesRemaining() !== 0) {
             throw new Error(
-              `${this.buffer.bytesRemaining()} bytes remaining after MCAP footer and trailing magic`,
+              `${this.#buffer.bytesRemaining()} bytes remaining after MCAP footer and trailing magic`,
             );
           }
           return record;

--- a/packages/mcap/src/StreamBuffer.ts
+++ b/packages/mcap/src/StreamBuffer.ts
@@ -6,12 +6,12 @@
  * A growable buffer for use when processing a stream of data.
  */
 export default class StreamBuffer {
-  private buffer: ArrayBuffer;
+  #buffer: ArrayBuffer;
   public view: DataView;
 
   constructor(initialCapacity = 0) {
-    this.buffer = new ArrayBuffer(initialCapacity);
-    this.view = new DataView(this.buffer, 0, 0);
+    this.#buffer = new ArrayBuffer(initialCapacity);
+    this.view = new DataView(this.#buffer, 0, 0);
   }
 
   bytesRemaining(): number {
@@ -21,7 +21,7 @@ export default class StreamBuffer {
   /** Mark some data as consumed, so the memory can be reused when new data is appended. */
   consume(count: number): void {
     this.view = new DataView(
-      this.buffer,
+      this.#buffer,
       this.view.byteOffset + count,
       this.view.byteLength - count,
     );
@@ -29,34 +29,34 @@ export default class StreamBuffer {
 
   /** Add data to the buffer, shifting existing data or reallocating if necessary. */
   append(data: Uint8Array): void {
-    if (this.view.byteOffset + this.view.byteLength + data.byteLength <= this.buffer.byteLength) {
+    if (this.view.byteOffset + this.view.byteLength + data.byteLength <= this.#buffer.byteLength) {
       // Data fits by appending only
       const array = new Uint8Array(this.view.buffer, this.view.byteOffset);
       array.set(data, this.view.byteLength);
       this.view = new DataView(
-        this.buffer,
+        this.#buffer,
         this.view.byteOffset,
         this.view.byteLength + data.byteLength,
       );
-    } else if (this.view.byteLength + data.byteLength <= this.buffer.byteLength) {
+    } else if (this.view.byteLength + data.byteLength <= this.#buffer.byteLength) {
       // Data fits in allocated buffer but requires moving existing data to start of buffer
-      const oldData = new Uint8Array(this.buffer, this.view.byteOffset, this.view.byteLength);
-      const array = new Uint8Array(this.buffer);
+      const oldData = new Uint8Array(this.#buffer, this.view.byteOffset, this.view.byteLength);
+      const array = new Uint8Array(this.#buffer);
       array.set(oldData, 0);
       array.set(data, oldData.byteLength);
-      this.view = new DataView(this.buffer, 0, this.view.byteLength + data.byteLength);
+      this.view = new DataView(this.#buffer, 0, this.view.byteLength + data.byteLength);
     } else {
       // New data doesn't fit, copy to a new buffer
 
       // Currently, the new buffer size may be smaller than the old size. For future optimizations,
       // we could consider making the buffer size increase monotonically.
 
-      const oldData = new Uint8Array(this.buffer, this.view.byteOffset, this.view.byteLength);
-      this.buffer = new ArrayBuffer((this.view.byteLength + data.byteLength) * 2);
-      const array = new Uint8Array(this.buffer);
+      const oldData = new Uint8Array(this.#buffer, this.view.byteOffset, this.view.byteLength);
+      this.#buffer = new ArrayBuffer((this.view.byteLength + data.byteLength) * 2);
+      const array = new Uint8Array(this.#buffer);
       array.set(oldData, 0);
       array.set(data, oldData.byteLength);
-      this.view = new DataView(this.buffer, 0, this.view.byteLength + data.byteLength);
+      this.view = new DataView(this.#buffer, 0, this.view.byteLength + data.byteLength);
     }
   }
 }

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -154,9 +154,9 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   AutocompleteProps<T>,
   AutocompleteState
 > {
-  _autocomplete: RefObject<ReactAutocomplete>;
-  _ignoreFocus: boolean = false;
-  _ignoreBlur: boolean = false;
+  #autocomplete: RefObject<ReactAutocomplete>;
+  #ignoreFocus: boolean = false;
+  #ignoreBlur: boolean = false;
 
   static defaultProps = {
     getItemText: defaultGetText("getItemText"),
@@ -168,7 +168,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
 
   constructor(props: AutocompleteProps<T>) {
     super(props);
-    this._autocomplete = React.createRef<ReactAutocomplete>();
+    this.#autocomplete = React.createRef<ReactAutocomplete>();
     this.state = { focused: false, showAllItems: false };
   }
 
@@ -177,8 +177,8 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   // reference to the highlighted element, which can cause an error if we hide it.
   override componentDidUpdate(): void {
     if (
-      (this._autocomplete.current?.refs.menu as Element)?.scrollHeight <=
-        (this._autocomplete.current?.refs.menu as Element)?.clientHeight &&
+      (this.#autocomplete.current?.refs.menu as Element)?.scrollHeight <=
+        (this.#autocomplete.current?.refs.menu as Element)?.clientHeight &&
       this.state.showAllItems
     ) {
       this.setState({ showAllItems: false });
@@ -186,8 +186,8 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   }
 
   setSelectionRange(selectionStart: number, selectionEnd: number): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).setSelectionRange(
+    if (this.#autocomplete.current?.refs.input) {
+      (this.#autocomplete.current.refs.input as HTMLInputElement).setSelectionRange(
         selectionStart,
         selectionEnd,
       );
@@ -196,30 +196,30 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   }
 
   focus(): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).focus();
+    if (this.#autocomplete.current?.refs.input) {
+      (this.#autocomplete.current.refs.input as HTMLInputElement).focus();
     }
   }
 
   blur(): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).blur();
+    if (this.#autocomplete.current?.refs.input) {
+      (this.#autocomplete.current.refs.input as HTMLInputElement).blur();
     }
-    this._ignoreBlur = false;
+    this.#ignoreBlur = false;
     this.setState({ focused: false });
     if (this.props.onBlur) {
       this.props.onBlur();
     }
   }
 
-  _onFocus = (): void => {
-    if (this._ignoreFocus) {
+  #onFocus = (): void => {
+    if (this.#ignoreFocus) {
       return;
     }
     const { clearOnFocus } = this.props;
     if (
-      this._autocomplete.current?.refs.input &&
-      document.activeElement === this._autocomplete.current.refs.input
+      this.#autocomplete.current?.refs.input &&
+      document.activeElement === this.#autocomplete.current.refs.input
     ) {
       this.setState({ focused: true });
       if (clearOnFocus) {
@@ -231,7 +231,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   // Wait for a mouseup event, and check in the mouseup event if anything was actually selected, or
   // if it just was a click without a drag. In the latter case, select everything. This is very
   // similar to how, say, the browser bar in Chrome behaves.
-  _onMouseDown = (_event: React.MouseEvent<HTMLInputElement>): void => {
+  #onMouseDown = (_event: React.MouseEvent<HTMLInputElement>): void => {
     if (this.props.disableAutoSelect ?? false) {
       return;
     }
@@ -242,14 +242,14 @@ export default class Autocomplete<T = unknown> extends PureComponent<
       document.removeEventListener("mouseup", onMouseUp, true);
 
       if (
-        this._autocomplete.current?.refs.input && // Make sure that the element is actually still focused.
-        document.activeElement === this._autocomplete.current.refs.input
+        this.#autocomplete.current?.refs.input && // Make sure that the element is actually still focused.
+        document.activeElement === this.#autocomplete.current.refs.input
       ) {
         if (
-          (this._autocomplete.current.refs.input as HTMLInputElement).selectionStart ===
-          (this._autocomplete.current.refs.input as HTMLInputElement).selectionEnd
+          (this.#autocomplete.current.refs.input as HTMLInputElement).selectionStart ===
+          (this.#autocomplete.current.refs.input as HTMLInputElement).selectionEnd
         ) {
-          (this._autocomplete.current.refs.input as HTMLInputElement).select();
+          (this.#autocomplete.current.refs.input as HTMLInputElement).select();
           e.stopPropagation();
           e.preventDefault();
         }
@@ -260,13 +260,13 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     document.addEventListener("mouseup", onMouseUp, true);
   };
 
-  _onBlur = (): void => {
-    if (this._ignoreBlur) {
+  #onBlur = (): void => {
+    if (this.#ignoreBlur) {
       return;
     }
     if (
-      this._autocomplete.current?.refs.input &&
-      document.activeElement === this._autocomplete.current.refs.input
+      this.#autocomplete.current?.refs.input &&
+      document.activeElement === this.#autocomplete.current.refs.input
     ) {
       // Bail if we actually still are focused.
       return;
@@ -277,7 +277,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     }
   };
 
-  _onChange = (event: React.SyntheticEvent<HTMLInputElement>): void => {
+  #onChange = (event: React.SyntheticEvent<HTMLInputElement>): void => {
     if (this.props.onChange) {
       this.props.onChange(event, (event.target as HTMLInputElement).value);
     } else {
@@ -288,9 +288,9 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   // Make sure the input field gets focused again after selecting, in case we're doing multiple
   // autocompletes. We pass in `this` to `onSelect` in case the user of this component wants to call
   // `blur()`.
-  _onSelect = (value: string, item: T): void => {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).focus();
+  #onSelect = (value: string, item: T): void => {
+    if (this.#autocomplete.current?.refs.input) {
+      (this.#autocomplete.current.refs.input as HTMLInputElement).focus();
       this.setState({ focused: true, value: undefined }, () => {
         this.props.onSelect(value, item, this);
       });
@@ -299,7 +299,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
 
   // When scrolling down by even a little bit, just show all items. In most cases people won't
   // do this and instead will type more text to narrow down their autocomplete.
-  _onScroll = (event: React.MouseEvent<HTMLDivElement>): void => {
+  #onScroll = (event: React.MouseEvent<HTMLDivElement>): void => {
     if (event.currentTarget.scrollTop > 0) {
       // Never set `showAllItems` to false here, as `<ReactAutocomplete>` may have a reference to
       // the highlighted element. We only set it back to false in `componentDidUpdate`.
@@ -307,7 +307,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     }
   };
 
-  _onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+  #onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === "Escape" || (event.key === "Enter" && this.props.items.length === 0)) {
       this.blur();
     }
@@ -340,7 +340,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
 
     const open = this.state.focused && autocompleteItems.length > 0;
     if (!open) {
-      this._ignoreBlur = false;
+      this.#ignoreBlur = false;
     }
 
     const selectedItemValue = selectedItem != undefined ? getItemValue(selectedItem) : undefined;
@@ -366,8 +366,8 @@ export default class Autocomplete<T = unknown> extends PureComponent<
             </div>
           );
         }}
-        onChange={this._onChange}
-        onSelect={this._onSelect}
+        onChange={this.#onChange}
+        onSelect={this.#onSelect}
         value={value ?? ""}
         inputProps={{
           className: cx(classes.input, {
@@ -389,10 +389,10 @@ export default class Autocomplete<T = unknown> extends PureComponent<
                 )
               : "100%",
           },
-          onFocus: this._onFocus,
-          onBlur: this._onBlur,
-          onMouseDown: this._onMouseDown,
-          onKeyDown: this._onKeyDown,
+          onFocus: this.#onFocus,
+          onBlur: this.#onBlur,
+          onMouseDown: this.#onMouseDown,
+          onKeyDown: this.#onKeyDown,
         }}
         renderMenu={(menuItems, _val, style) => {
           // Hacky virtualization. Either don't show all menuItems (typical when the user is still
@@ -431,13 +431,13 @@ export default class Autocomplete<T = unknown> extends PureComponent<
                       right: 0,
                     }
               }
-              onScroll={this._onScroll}
+              onScroll={this.#onScroll}
             >
               {/* Have to wrap onMouseEnter and onMouseLeave in a separate <div>, as react-autocomplete
                * would override them on the root <div>. */}
               <div
-                onMouseEnter={() => (this._ignoreBlur = true)}
-                onMouseLeave={() => (this._ignoreBlur = false)}
+                onMouseEnter={() => (this.#ignoreBlur = true)}
+                onMouseLeave={() => (this.#ignoreBlur = false)}
               >
                 {menuItemsToShow}
               </div>
@@ -446,7 +446,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
         }}
         // @ts-expect-error renderMenuWrapper added in the fork but we don't have typings for it
         renderMenuWrapper={(menu: React.ReactNode) => createPortal(menu, document.body)}
-        ref={this._autocomplete}
+        ref={this.#autocomplete}
         wrapperStyle={{ flex: "1 1 auto", overflow: "hidden", marginLeft: 6 }}
       />
     );

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -65,10 +65,10 @@ type ZoomableChart = Chart & {
 };
 
 export default class ChartJSManager {
-  private _chartInstance?: Chart;
-  private _fakeNodeEvents = new EventEmitter();
-  private _fakeDocumentEvents = new EventEmitter();
-  private _lastDatalabelClickContext?: DatalabelContext;
+  #chartInstance?: Chart;
+  #fakeNodeEvents = new EventEmitter();
+  #fakeDocumentEvents = new EventEmitter();
+  #lastDatalabelClickContext?: DatalabelContext;
 
   constructor(initOpts: InitOpts) {
     log.info(`new ChartJSManager(id=${initOpts.id})`);
@@ -88,11 +88,11 @@ export default class ChartJSManager {
     log.debug(`ChartJSManager(${id}) init, default font "${font.family}" status=${font.status}`);
 
     const fakeNode = {
-      addEventListener: addEventListener(this._fakeNodeEvents),
-      removeEventListener: removeEventListener(this._fakeNodeEvents),
+      addEventListener: addEventListener(this.#fakeNodeEvents),
+      removeEventListener: removeEventListener(this.#fakeNodeEvents),
       ownerDocument: {
-        addEventListener: addEventListener(this._fakeDocumentEvents),
-        removeEventListener: removeEventListener(this._fakeDocumentEvents),
+        addEventListener: addEventListener(this.#fakeDocumentEvents),
+        removeEventListener: removeEventListener(this.#fakeDocumentEvents),
       },
     };
 
@@ -126,55 +126,55 @@ export default class ChartJSManager {
     });
 
     ZoomPlugin.start = origZoomStart;
-    this._chartInstance = chartInstance;
+    this.#chartInstance = chartInstance;
   }
 
   wheel(event: WheelEvent): RpcScales {
     const target = event.target as Element & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    this._fakeNodeEvents.emit("wheel", event);
+    this.#fakeNodeEvents.emit("wheel", event);
     return this.getScales();
   }
 
   mousedown(event: MouseEvent): RpcScales {
     const target = event.target as Element & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    this._fakeNodeEvents.emit("mousedown", event);
+    this.#fakeNodeEvents.emit("mousedown", event);
     return this.getScales();
   }
 
   mousemove(event: MouseEvent): RpcScales {
     const target = event.target as Element & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    this._fakeNodeEvents.emit("mousemove", event);
+    this.#fakeNodeEvents.emit("mousemove", event);
     return this.getScales();
   }
 
   mouseup(event: MouseEvent): RpcScales {
     const target = event.target as Element & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    this._fakeDocumentEvents.emit("mouseup", event);
+    this.#fakeDocumentEvents.emit("mouseup", event);
     return this.getScales();
   }
 
   panstart(event: HammerInput): RpcScales {
     const target = event.target as HTMLElement & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    (this._chartInstance as ZoomableChart)?.$zoom.panStartHandler(event);
+    (this.#chartInstance as ZoomableChart)?.$zoom.panStartHandler(event);
     return this.getScales();
   }
 
   panmove(event: HammerInput): RpcScales {
     const target = event.target as HTMLElement & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    (this._chartInstance as ZoomableChart)?.$zoom.panHandler(event);
+    (this.#chartInstance as ZoomableChart)?.$zoom.panHandler(event);
     return this.getScales();
   }
 
   panend(event: HammerInput): RpcScales {
     const target = event.target as HTMLElement & { boundingClientRect: DOMRect };
     target.getBoundingClientRect = () => target.boundingClientRect;
-    (this._chartInstance as ZoomableChart)?.$zoom.panEndHandler(event);
+    (this.#chartInstance as ZoomableChart)?.$zoom.panEndHandler(event);
     return this.getScales();
   }
 
@@ -189,7 +189,7 @@ export default class ChartJSManager {
     height?: number;
     data?: ChartData;
   }): RpcScales {
-    const instance = this._chartInstance;
+    const instance = this.#chartInstance;
     if (instance == undefined) {
       return {};
     }
@@ -244,7 +244,7 @@ export default class ChartJSManager {
   }
 
   destroy(): void {
-    this._chartInstance?.destroy();
+    this.#chartInstance?.destroy();
   }
 
   getElementsAtEvent({ event }: { event: MouseEvent }): RpcElement[] {
@@ -257,17 +257,17 @@ export default class ChartJSManager {
     // ev is cast to any because the typings for getElementsAtEventForMode are wrong
     // ev is specified as a dom Event - but the implementation does not require it for the basic platform
     const elements =
-      this._chartInstance?.getElementsAtEventForMode(
+      this.#chartInstance?.getElementsAtEventForMode(
         ev as unknown as Event,
-        this._chartInstance.options.interaction?.mode ?? "intersect",
-        this._chartInstance.options.interaction ?? {},
+        this.#chartInstance.options.interaction?.mode ?? "intersect",
+        this.#chartInstance.options.interaction ?? {},
         false,
       ) ?? [];
 
     const out = new Array<RpcElement>();
 
     for (const element of elements) {
-      const data = this._chartInstance?.data.datasets[element.datasetIndex]?.data[element.index];
+      const data = this.#chartInstance?.data.datasets[element.datasetIndex]?.data[element.index];
       if (data == undefined || typeof data === "number") {
         continue;
       }
@@ -298,11 +298,11 @@ export default class ChartJSManager {
   }
 
   getDatalabelAtEvent({ event }: { event: Event }): unknown {
-    this._chartInstance?.notifyPlugins("beforeEvent", { event });
+    this.#chartInstance?.notifyPlugins("beforeEvent", { event });
 
     // clear the stored click context - we have consumed it
-    const context = this._lastDatalabelClickContext;
-    this._lastDatalabelClickContext = undefined;
+    const context = this.#lastDatalabelClickContext;
+    this.#lastDatalabelClickContext = undefined;
 
     return context?.dataset.data[context.dataIndex];
   }
@@ -313,7 +313,7 @@ export default class ChartJSManager {
     const scales: RpcScales = {};
 
     // fill our rpc scales - we only support x and y scales for now
-    const xScale = this._chartInstance?.scales.x;
+    const xScale = this.#chartInstance?.scales.x;
     if (xScale) {
       scales.x = {
         pixelMin: xScale.left,
@@ -323,7 +323,7 @@ export default class ChartJSManager {
       };
     }
 
-    const yScale = this._chartInstance?.scales.y;
+    const yScale = this.#chartInstance?.scales.y;
     if (yScale) {
       scales.y = {
         pixelMin: yScale.bottom,
@@ -344,7 +344,7 @@ export default class ChartJSManager {
       // maybe we contribute a patch upstream with the explanation for web-worker use
       config.plugins.datalabels.listeners = {
         click: (context: DatalabelContext) => {
-          this._lastDatalabelClickContext = context;
+          this.#lastDatalabelClickContext = context;
         },
       };
 

--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -82,14 +82,14 @@ Chart.register(
 // Since we use a capped number of web-workers, a single web-worker may be running multiple chartjs instances
 // The ChartJsWorkerMux forwards an rpc request for a specific chartjs instance id to the appropriate instance
 export default class ChartJsMux {
-  private _rpc: Rpc;
-  private _managers = new Map<string, ChartJSManager>();
+  #rpc: Rpc;
+  #managers = new Map<string, ChartJSManager>();
 
   constructor(rpc: Rpc) {
-    this._rpc = rpc;
+    this.#rpc = rpc;
 
-    if (this._rpc instanceof Rpc) {
-      setupWorker(this._rpc);
+    if (this.#rpc instanceof Rpc) {
+      setupWorker(this.#rpc);
     }
 
     // create a new chartjs instance
@@ -97,7 +97,7 @@ export default class ChartJsMux {
     rpc.receive("initialize", (args: InitOpts) => {
       args.fontLoaded = fontLoaded;
       const manager = new ChartJSManager(args);
-      this._managers.set(args.id, manager);
+      this.#managers.set(args.id, manager);
       return manager.getScales();
     });
     rpc.receive("wheel", (args: RpcEvent<WheelEvent>) => this._getChart(args.id).wheel(args.event));
@@ -122,10 +122,10 @@ export default class ChartJsMux {
 
     rpc.receive("update", (args: RpcUpdateEvent) => this._getChart(args.id).update(args));
     rpc.receive("destroy", (args: RpcEvent<void>) => {
-      const manager = this._managers.get(args.id);
+      const manager = this.#managers.get(args.id);
       if (manager) {
         manager.destroy();
-        this._managers.delete(args.id);
+        this.#managers.delete(args.id);
       }
     });
     rpc.receive("getElementsAtEvent", (args: RpcEvent<MouseEvent>) =>
@@ -137,7 +137,7 @@ export default class ChartJsMux {
   }
 
   private _getChart(id: string): ChartJSManager {
-    const chart = this._managers.get(id);
+    const chart = this.#managers.get(id);
     if (!chart) {
       throw new Error(`Could not find chart with id ${id}`);
     }

--- a/packages/studio-base/src/components/Menu/SubMenu.tsx
+++ b/packages/studio-base/src/components/Menu/SubMenu.tsx
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export default class SubMenu extends React.Component<Props, State> {
-  _unmounted: boolean = false;
+  #unmounted: boolean = false;
 
   override state = {
     open: false,
@@ -43,7 +43,7 @@ export default class SubMenu extends React.Component<Props, State> {
   };
 
   toggle = (): void => {
-    if (this._unmounted) {
+    if (this.#unmounted) {
       return;
     }
     this.setState(({ open }) => ({ open: !open }));
@@ -51,7 +51,7 @@ export default class SubMenu extends React.Component<Props, State> {
 
   override componentWillUnmount(): void {
     // the submenu might unmount on click, so don't update state if its gone
-    this._unmounted = true;
+    this.#unmounted = true;
   }
 
   override render(): JSX.Element {

--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -28,7 +28,7 @@ export default class FakePlayer implements Player {
   playerId: string = "test";
   subscriptions: SubscribePayload[] = [];
   publishers: AdvertiseOptions[] | undefined;
-  _capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
+  #capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.listener = listener;
@@ -48,7 +48,7 @@ export default class FakePlayer implements Player {
     return await this.listener({
       playerId: this.playerId,
       presence: presence ?? PlayerPresence.PRESENT,
-      capabilities: this._capabilities,
+      capabilities: this.#capabilities,
       progress: {},
       activeData,
     });
@@ -78,7 +78,7 @@ export default class FakePlayer implements Player {
   setCapabilities = (
     capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][],
   ): void => {
-    this._capabilities = capabilities;
+    this.#capabilities = capabilities;
   };
   startPlayback = (): void => {
     // no-op

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -19,17 +19,17 @@ import { renderImage } from "./renderImage";
 import { Dimensions, RawMarkerData, RenderOptions } from "./util";
 
 class ImageCanvasWorker {
-  _idToCanvas: {
+  #idToCanvas: {
     [key: string]: OffscreenCanvas;
   } = {};
-  _rpc: Rpc;
+  #rpc: Rpc;
 
   constructor(rpc: Rpc) {
     setupWorker(rpc);
-    this._rpc = rpc;
+    this.#rpc = rpc;
 
     rpc.receive("initialize", async ({ id, canvas }: { id: string; canvas: OffscreenCanvas }) => {
-      this._idToCanvas[id] = canvas;
+      this.#idToCanvas[id] = canvas;
     });
 
     rpc.receive(
@@ -57,7 +57,7 @@ class ImageCanvasWorker {
           options,
         } = args;
 
-        const canvas = this._idToCanvas[id];
+        const canvas = this.#idToCanvas[id];
         if (!canvas) {
           return Promise.resolve(undefined);
         }

--- a/packages/studio-base/src/panels/ImageView/PinholeCameraModel.ts
+++ b/packages/studio-base/src/panels/ImageView/PinholeCameraModel.ts
@@ -25,7 +25,7 @@ type DistortionState = typeof DISTORTION_STATE[keyof typeof DISTORTION_STATE];
 // fromCameraInfo() and unrectifyPoint()
 // http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html
 export default class PinholeCameraModel {
-  private _distortionState: DistortionState = DISTORTION_STATE.NONE;
+  #distortionState: DistortionState = DISTORTION_STATE.NONE;
   D: readonly number[] = [];
   K: readonly number[] = [];
   P: readonly number[] = [];
@@ -41,7 +41,7 @@ export default class PinholeCameraModel {
     //                  of distortion_model is one of the union values
     if (distortion_model === "") {
       // Allow CameraInfo with no model to indicate no distortion
-      this._distortionState = DISTORTION_STATE.NONE;
+      this.#distortionState = DISTORTION_STATE.NONE;
       return;
     }
 
@@ -68,7 +68,7 @@ export default class PinholeCameraModel {
 
     // Figure out how to handle the distortion
     if (distortion_model === "plumb_bob" || distortion_model === "rational_polynomial") {
-      this._distortionState = D[0] === 0.0 ? DISTORTION_STATE.NONE : DISTORTION_STATE.CALIBRATED;
+      this.#distortionState = D[0] === 0.0 ? DISTORTION_STATE.NONE : DISTORTION_STATE.CALIBRATED;
     } else {
       throw new Error(
         "Failed to initialize camera model: distortion_model is unknown, only plumb_bob and rational_polynomial are supported.",
@@ -81,7 +81,7 @@ export default class PinholeCameraModel {
   }
 
   unrectifyPoint({ x: rectX, y: rectY }: Point): { x: number; y: number } {
-    if (this._distortionState === DISTORTION_STATE.NONE) {
+    if (this.#distortionState === DISTORTION_STATE.NONE) {
       return { x: rectX, y: rectY };
     }
 

--- a/packages/studio-base/src/panels/Rosout/LogList.stories.tsx
+++ b/packages/studio-base/src/panels/Rosout/LogList.stories.tsx
@@ -48,23 +48,23 @@ type State = {
 };
 
 class Example extends Component<Props, State> {
-  _intervalId?: ReturnType<typeof setInterval>;
+  #intervalId?: ReturnType<typeof setInterval>;
   override state = { items: generateData(MSG_BATCH_SIZE), paused: true };
 
   override componentDidMount() {
     if (!this.state.paused) {
-      this._startTimer();
+      this.#startTimer();
     }
   }
 
   override componentWillUnmount() {
-    if (this._intervalId) {
-      clearInterval(this._intervalId);
+    if (this.#intervalId) {
+      clearInterval(this.#intervalId);
     }
   }
 
-  _startTimer = () => {
-    this._intervalId = setInterval(() => {
+  #startTimer = () => {
+    this.#intervalId = setInterval(() => {
       const newData = generateData(MSG_BATCH_SIZE);
       const items = [...this.state.items, ...newData];
       this.setState({ items });
@@ -74,11 +74,11 @@ class Example extends Component<Props, State> {
   togglePause = () => {
     const paused = !this.state.paused;
     if (paused) {
-      if (this._intervalId) {
-        clearInterval(this._intervalId);
+      if (this.#intervalId) {
+        clearInterval(this.#intervalId);
       }
     } else {
-      this._startTimer();
+      this.#startTimer();
     }
     this.setState({ paused });
   };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/MeasuringTool.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/MeasuringTool.ts
@@ -54,11 +54,11 @@ export default class MeasuringTool extends React.Component<Props> {
     });
   };
 
-  _canvasMouseDownHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
+  #canvasMouseDownHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
     this.mouseDownCoords = [e.clientX, e.clientY];
   };
 
-  _canvasMouseUpHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
+  #canvasMouseUpHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
     const mouseUpCoords = [e.clientX, e.clientY];
     const { measureState, measurePoints, onMeasureInfoChange } = this.props;
 
@@ -77,7 +77,7 @@ export default class MeasuringTool extends React.Component<Props> {
     }
   };
 
-  _canvasMouseMoveHandler = (_e: MouseEvent, clickInfo: ReglClickInfo): void => {
+  #canvasMouseMoveHandler = (_e: MouseEvent, clickInfo: ReglClickInfo): void => {
     const { measureState, measurePoints, onMeasureInfoChange } = this.props;
     switch (measureState) {
       case "place-start":
@@ -109,7 +109,7 @@ export default class MeasuringTool extends React.Component<Props> {
       return undefined;
     }
 
-    return this._canvasMouseMoveHandler;
+    return this.#canvasMouseMoveHandler;
   }
 
   get onMouseUp(): ((arg0: MouseEvent, arg1: ReglClickInfo) => void) | undefined {
@@ -117,7 +117,7 @@ export default class MeasuringTool extends React.Component<Props> {
       return undefined;
     }
 
-    return this._canvasMouseUpHandler;
+    return this.#canvasMouseUpHandler;
   }
 
   get onMouseDown(): ((arg0: MouseEvent, arg1: ReglClickInfo) => void) | undefined {
@@ -125,7 +125,7 @@ export default class MeasuringTool extends React.Component<Props> {
       return undefined;
     }
 
-    return this._canvasMouseDownHandler;
+    return this.#canvasMouseDownHandler;
   }
 
   get measureActive(): boolean {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.ts
@@ -24,28 +24,28 @@ import { FOXGLOVE_GRID_TOPIC } from "@foxglove/studio-base/util/globalConstants"
 
 export default class GridBuilder implements MarkerProvider {
   grid: InstancedLineListMarker;
-  private _visible = true;
-  private _settings: GridSettings = {};
+  #visible = true;
+  #settings: GridSettings = {};
 
   constructor() {
-    this.grid = GridBuilder.BuildGrid(this._settings);
+    this.grid = GridBuilder.BuildGrid(this.#settings);
   }
 
   renderMarkers = (add: MarkerCollector): void => {
-    if (this._visible) {
+    if (this.#visible) {
       add.instancedLineList(this.grid);
     }
   };
 
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setVisible(isVisible: boolean): void {
-    this._visible = isVisible;
+    this.#visible = isVisible;
   }
 
   setSettingsByKey(settings: TopicSettingsCollection): void {
     const newSettings = settings[`t:${FOXGLOVE_GRID_TOPIC}`] ?? {};
-    if (!isEqual(newSettings, this._settings)) {
-      this._settings = newSettings;
+    if (!isEqual(newSettings, this.#settings)) {
+      this.#settings = newSettings;
       this.grid = GridBuilder.BuildGrid(newSettings);
     }
   }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -468,10 +468,7 @@ export default class SceneBuilder implements MarkerProvider {
     return pose;
   };
 
-  private _consumeMarkerArray = (
-    topic: string,
-    message: { markers: readonly BaseMarker[] },
-  ): void => {
+  #consumeMarkerArray = (topic: string, message: { markers: readonly BaseMarker[] }): void => {
     for (const marker of message.markers) {
       this._consumeMarker(topic, marker);
     }
@@ -712,10 +709,10 @@ export default class SceneBuilder implements MarkerProvider {
       header: { frame_id: "", stamp: msg.receiveTime, seq: 0 },
       color: { r: color.r / 255, g: color.g / 255, b: color.b / 255, a: color.a ?? 1 },
     };
-    this._consumeNonMarkerMessage(msg.topic, newMessage, 110);
+    this.#consumeNonMarkerMessage(msg.topic, newMessage, 110);
   };
 
-  private _consumeNonMarkerMessage = (
+  #consumeNonMarkerMessage = (
     topic: string,
     drawData: StampedMessage,
     type: number,
@@ -788,7 +785,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
     for (const topic of this.topicsToRender) {
       try {
-        this._consumeTopic(topic);
+        this.#consumeTopic(topic);
       } catch (error) {
         log.error(error);
         this._setTopicError(topic, error.toString());
@@ -807,7 +804,7 @@ export default class SceneBuilder implements MarkerProvider {
         break;
       case "visualization_msgs/MarkerArray":
       case "visualization_msgs/msg/MarkerArray":
-        this._consumeMarkerArray(topic, message as { markers: BaseMarker[] });
+        this.#consumeMarkerArray(topic, message as { markers: BaseMarker[] });
 
         break;
       case "geometry_msgs/PoseStamped":
@@ -846,24 +843,24 @@ export default class SceneBuilder implements MarkerProvider {
           scale: { x: 0.2 },
           color: topicSettings?.overrideColor ?? { r: 0.5, g: 0.5, b: 1, a: 1 },
         };
-        this._consumeNonMarkerMessage(topic, newMessage, 4 /* line strip */, message);
+        this.#consumeNonMarkerMessage(topic, newMessage, 4 /* line strip */, message);
         break;
       }
       case "sensor_msgs/PointCloud2":
       case "sensor_msgs/msg/PointCloud2":
-        this._consumeNonMarkerMessage(topic, message as StampedMessage, 102);
+        this.#consumeNonMarkerMessage(topic, message as StampedMessage, 102);
         break;
       case "velodyne_msgs/VelodyneScan":
       case "velodyne_msgs/msg/VelodyneScan": {
         const converted = this._velodyneCloudConverter.decode(message as VelodyneScan);
         if (converted) {
-          this._consumeNonMarkerMessage(topic, converted, 102);
+          this.#consumeNonMarkerMessage(topic, converted, 102);
         }
         break;
       }
       case "sensor_msgs/LaserScan":
       case "sensor_msgs/msg/LaserScan":
-        this._consumeNonMarkerMessage(topic, message as StampedMessage, 104);
+        this.#consumeNonMarkerMessage(topic, message as StampedMessage, 104);
         break;
       case "std_msgs/ColorRGBA":
       case "std_msgs/msg/ColorRGBA":
@@ -884,7 +881,7 @@ export default class SceneBuilder implements MarkerProvider {
           scale: { x: 0.2 },
           color: { r: 0, g: 1, b: 0, a: 1 },
         };
-        this._consumeNonMarkerMessage(
+        this.#consumeNonMarkerMessage(
           topic,
           newMessage,
           4,
@@ -902,7 +899,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
   };
 
-  private _consumeTopic = (topic: string) => {
+  #consumeTopic = (topic: string): void => {
     if (!this.frame) {
       return;
     }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -198,23 +198,23 @@ export default class SceneBuilder implements MarkerProvider {
   collectors: {
     [key: string]: MessageCollector;
   } = {};
-  _clock?: Time;
-  _playerId?: string;
-  _settingsByKey: TopicSettingsCollection = {};
-  _onForceUpdate?: () => void;
+  #clock?: Time;
+  #playerId?: string;
+  #settingsByKey: TopicSettingsCollection = {};
+  #onForceUpdate?: () => void;
 
   // When not-empty, fade any markers that don't match
-  _highlightMarkerMatchersByTopic: MarkerMatchersByTopic = {};
+  #highlightMarkerMatchersByTopic: MarkerMatchersByTopic = {};
 
   // When not-empty, override the color of matching markers
-  _colorOverrideMarkerMatchersByTopic: MarkerMatchersByTopic = {};
+  #colorOverrideMarkerMatchersByTopic: MarkerMatchersByTopic = {};
 
-  _hooks: ThreeDimensionalVizHooks;
+  #hooks: ThreeDimensionalVizHooks;
 
   // Decodes `velodyne_msgs/VelodyneScan` ROS messages into
   // `VelodyneScanDecoded` objects that mimic `PointCloud2` and can be rendered
   // as point clouds
-  _velodyneCloudConverter = new VelodyneCloudConverter();
+  #velodyneCloudConverter = new VelodyneCloudConverter();
 
   allNamespaces: Namespace[] = [];
   // TODO(Audrey): remove enabledNamespaces once we release topic groups
@@ -234,7 +234,7 @@ export default class SceneBuilder implements MarkerProvider {
   } = {};
 
   constructor(hooks: ThreeDimensionalVizHooks) {
-    this._hooks = hooks;
+    this.#hooks = hooks;
   }
 
   setTransforms = (transforms: Transforms, rootTransformID: string): void => {
@@ -253,7 +253,7 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   setPlayerId(playerId: string): void {
-    if (this._playerId !== playerId) {
+    if (this.#playerId !== playerId) {
       this.errors = {
         rootTransformID: "",
         topicsMissingFrameIds: new Map(),
@@ -263,11 +263,11 @@ export default class SceneBuilder implements MarkerProvider {
       };
       this._updateErrorsByTopic();
     }
-    this._playerId = playerId;
+    this.#playerId = playerId;
   }
 
   setSettingsByKey(settings: TopicSettingsCollection): void {
-    this._settingsByKey = settings;
+    this.#settingsByKey = settings;
   }
 
   // set the topics the scene builder should consume from each frame
@@ -331,17 +331,17 @@ export default class SceneBuilder implements MarkerProvider {
 
   setHighlightedMatchers(markerMatchers: Array<MarkerMatcher>): void {
     const markerMatchersByTopic = groupBy<MarkerMatcher>(markerMatchers, ({ topic }) => topic);
-    this._addTopicsToRenderForMarkerMatchers(this._highlightMarkerMatchersByTopic, markerMatchers);
-    this._highlightMarkerMatchersByTopic = markerMatchersByTopic;
+    this._addTopicsToRenderForMarkerMatchers(this.#highlightMarkerMatchersByTopic, markerMatchers);
+    this.#highlightMarkerMatchersByTopic = markerMatchersByTopic;
   }
 
   setColorOverrideMatchers(markerMatchers: Array<MarkerMatcher>): void {
     const markerMatchersByTopic = groupBy<MarkerMatcher>(markerMatchers, ({ topic }) => topic);
     this._addTopicsToRenderForMarkerMatchers(
-      this._colorOverrideMarkerMatchersByTopic,
+      this.#colorOverrideMarkerMatchersByTopic,
       markerMatchers,
     );
-    this._colorOverrideMarkerMatchersByTopic = markerMatchersByTopic;
+    this.#colorOverrideMarkerMatchersByTopic = markerMatchersByTopic;
   }
 
   _addTopicsToRenderForMarkerMatchers(
@@ -379,7 +379,7 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   setOnForceUpdate(callback: () => void): void {
-    this._onForceUpdate = callback;
+    this.#onForceUpdate = callback;
   }
 
   _addError(map: Map<string, ErrorDetails>, topic: string): ErrorDetails {
@@ -392,7 +392,7 @@ export default class SceneBuilder implements MarkerProvider {
     return values;
   }
 
-  _setTopicError = (topic: string, message: string): void => {
+  #setTopicError = (topic: string, message: string): void => {
     this.errors.topicsWithError.set(topic, message);
     this._updateErrorsByTopic();
   };
@@ -406,8 +406,8 @@ export default class SceneBuilder implements MarkerProvider {
     const errorsByTopic = getSceneErrorsByTopic(this.errors, this.transforms);
     if (!isEqual(this.errorsByTopic, errorsByTopic)) {
       this.errorsByTopic = errorsByTopic;
-      if (this._onForceUpdate) {
-        this._onForceUpdate();
+      if (this.#onForceUpdate) {
+        this.#onForceUpdate();
       }
     }
   }
@@ -418,8 +418,8 @@ export default class SceneBuilder implements MarkerProvider {
       return;
     }
     this.allNamespaces = this.allNamespaces.concat([{ topic, name }]);
-    if (this._onForceUpdate) {
-      this._onForceUpdate();
+    if (this.#onForceUpdate) {
+      this.#onForceUpdate();
     }
   }
 
@@ -432,7 +432,7 @@ export default class SceneBuilder implements MarkerProvider {
     return some(this.enabledNamespaces, (ns) => ns.topic === topic && ns.name === name);
   }
 
-  _transformMarkerPose = (topic: string, marker: BaseMarker): MutablePose | undefined => {
+  #transformMarkerPose = (topic: string, marker: BaseMarker): MutablePose | undefined => {
     const frame_id = marker.header.frame_id;
 
     if (frame_id.length === 0) {
@@ -497,7 +497,7 @@ export default class SceneBuilder implements MarkerProvider {
         break;
       case 1:
         // deprecated in ros
-        this._setTopicError(topic, "Marker.action=1 is deprecated");
+        this.#setTopicError(topic, "Marker.action=1 is deprecated");
 
         return;
       case 2:
@@ -508,12 +508,12 @@ export default class SceneBuilder implements MarkerProvider {
         this.collectors[topic]!.deleteAll();
         return;
       default:
-        this._setTopicError(topic, `Unsupported action type: ${message.action}`);
+        this.#setTopicError(topic, `Unsupported action type: ${message.action}`);
 
         return;
     }
 
-    const pose = this._transformMarkerPose(topic, message);
+    const pose = this.#transformMarkerPose(topic, message);
     if (!pose) {
       return;
     }
@@ -551,15 +551,15 @@ export default class SceneBuilder implements MarkerProvider {
     // HACK(jacob): rather than hard-coding this, we should
     //  (a) produce this visualization dynamically from a non-marker topic
     //  (b) fix translucency so it looks correct (harder)
-    const color = this._hooks.getMarkerColor(topic, message.color!);
+    const color = this.#hooks.getMarkerColor(topic, message.color!);
 
     // Allow topic settings to override marker color (see MarkerSettingsEditor.js)
-    let { overrideColor } = (this._settingsByKey[`ns:${topic}:${namespace}`] ??
-      this._settingsByKey[`t:${topic}`] ??
+    let { overrideColor } = (this.#settingsByKey[`ns:${topic}:${namespace}`] ??
+      this.#settingsByKey[`t:${topic}`] ??
       {}) as { overrideColor?: Color };
 
     // Check for matching colorOverrideMarkerMatchers for this topic
-    const colorOverrideMarkerMatchers = this._colorOverrideMarkerMatchersByTopic[topic] ?? [];
+    const colorOverrideMarkerMatchers = this.#colorOverrideMarkerMatchersByTopic[topic] ?? [];
     const matchingMatcher = colorOverrideMarkerMatchers.find(({ checks = [] }) =>
       checks.every(({ markerKeyPath = [], value }) => {
         // Get the item at the key path
@@ -629,7 +629,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.collectors[topic]!.addMarker(marker, name);
   }
 
-  _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
+  #consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
     const { frame_id } = message.header;
 
     if (frame_id.length === 0) {
@@ -660,7 +660,7 @@ export default class SceneBuilder implements MarkerProvider {
 
     // set ogrid texture & alpha based on current rviz settings
     // in the future these will be customizable via the UI
-    const [alpha, map] = this._hooks.getOccupancyGridValues(topic);
+    const [alpha, map] = this.#hooks.getOccupancyGridValues(topic);
 
     const { header, info, data } = message;
     const mappedMessage = {
@@ -700,7 +700,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.collectors[topic]!.addNonMarker(topic, mappedMessage as unknown as Interactive<unknown>);
   };
 
-  _consumeColor = (msg: MessageEvent<Color>): void => {
+  #consumeColor = (msg: MessageEvent<Color>): void => {
     const color = msg.message;
     if (color.r == undefined || color.g == undefined || color.b == undefined) {
       return;
@@ -753,7 +753,7 @@ export default class SceneBuilder implements MarkerProvider {
     // If a decay time is available, we assign a lifetime to this message
     // Do not automatically assign a 0 (zero) decay time since that translates
     // to an infinite lifetime. But do allow for 0 values based on user preferences.
-    const decayTimeInSec = this._settingsByKey[`t:${topic}`]?.decayTime as number | undefined;
+    const decayTimeInSec = this.#settingsByKey[`t:${topic}`]?.decayTime as number | undefined;
     const lifetime =
       decayTimeInSec != undefined && decayTimeInSec !== 0 ? fromSec(decayTimeInSec) : undefined;
     (this.collectors[topic] as MessageCollector).addNonMarker(
@@ -766,19 +766,19 @@ export default class SceneBuilder implements MarkerProvider {
   setCurrentTime = (currentTime: { sec: number; nsec: number }): void => {
     this.bounds.reset();
 
-    this._clock = currentTime;
+    this.#clock = currentTime;
     // set the new clock value in all existing collectors
     // including those for topics not included in this frame,
     // so each can expire markers if they need to
     for (const collector of Object.values(this.collectors)) {
-      collector.setClock(this._clock);
+      collector.setClock(this.#clock);
     }
   };
 
   // extracts renderable markers from the ros frame
   render(): void {
     this.flattenedZHeightPose =
-      this._hooks.getFlattenedPose(this.frame!) ?? this.flattenedZHeightPose;
+      this.#hooks.getFlattenedPose(this.frame!) ?? this.flattenedZHeightPose;
 
     if (this.flattenedZHeightPose?.position) {
       this.bounds.update(this.flattenedZHeightPose.position);
@@ -788,13 +788,13 @@ export default class SceneBuilder implements MarkerProvider {
         this.#consumeTopic(topic);
       } catch (error) {
         log.error(error);
-        this._setTopicError(topic, error.toString());
+        this.#setTopicError(topic, error.toString());
       }
     }
     this.topicsToRender.clear();
   }
 
-  _consumeMessage = (topic: string, datatype: string, msg: MessageEvent<unknown>): void => {
+  #consumeMessage = (topic: string, datatype: string, msg: MessageEvent<unknown>): void => {
     const { message } = msg;
     switch (datatype) {
       case "visualization_msgs/Marker":
@@ -816,7 +816,7 @@ export default class SceneBuilder implements MarkerProvider {
           buildSyntheticArrowMarker(
             msg,
             pose,
-            this._hooks.getSyntheticArrowMarkerColor,
+            this.#hooks.getSyntheticArrowMarkerColor,
           ) as Interactive<unknown>,
         );
         break;
@@ -824,12 +824,12 @@ export default class SceneBuilder implements MarkerProvider {
       case "nav_msgs/OccupancyGrid":
       case "nav_msgs/msg/OccupancyGrid":
         // flatten btn: set empty z values to be at the same level as the flattenedZHeightPose
-        this._consumeOccupancyGrid(topic, message as NavMsgs$OccupancyGrid);
+        this.#consumeOccupancyGrid(topic, message as NavMsgs$OccupancyGrid);
 
         break;
       case "nav_msgs/Path":
       case "nav_msgs/msg/Path": {
-        const topicSettings = this._settingsByKey[`t:${topic}`];
+        const topicSettings = this.#settingsByKey[`t:${topic}`];
 
         const pathStamped = message as NavMsgs$Path;
         if (pathStamped.poses.length === 0) {
@@ -852,7 +852,7 @@ export default class SceneBuilder implements MarkerProvider {
         break;
       case "velodyne_msgs/VelodyneScan":
       case "velodyne_msgs/msg/VelodyneScan": {
-        const converted = this._velodyneCloudConverter.decode(message as VelodyneScan);
+        const converted = this.#velodyneCloudConverter.decode(message as VelodyneScan);
         if (converted) {
           this.#consumeNonMarkerMessage(topic, converted, 102);
         }
@@ -864,7 +864,7 @@ export default class SceneBuilder implements MarkerProvider {
         break;
       case "std_msgs/ColorRGBA":
       case "std_msgs/msg/ColorRGBA":
-        this._consumeColor(msg as MessageEvent<Color>);
+        this.#consumeColor(msg as MessageEvent<Color>);
         break;
       case "geometry_msgs/PolygonStamped":
       case "geometry_msgs/msg/PolygonStamped": {
@@ -892,7 +892,7 @@ export default class SceneBuilder implements MarkerProvider {
       }
       default: {
         if (datatype.endsWith("/Color") || datatype.endsWith("/ColorRGBA")) {
-          this._consumeColor(msg as MessageEvent<Color>);
+          this.#consumeColor(msg as MessageEvent<Color>);
           break;
         }
       }
@@ -913,7 +913,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.errors.topicsWithBadFrameIds.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();
-    this.collectors[topic]?.setClock(this._clock ?? { sec: 0, nsec: 0 });
+    this.collectors[topic]?.setClock(this.#clock ?? { sec: 0, nsec: 0 });
     this.collectors[topic]?.flush();
 
     const datatype = this.topicsByName[topic]?.datatype;
@@ -924,11 +924,11 @@ export default class SceneBuilder implements MarkerProvider {
     // If topic has a decayTime set, markers with no lifetime will get one
     // later on, so we don't need to filter them. Note: A decayTime of zero is
     // defined as an infinite lifetime
-    const decayTime = this._settingsByKey[`t:${topic}`]?.decayTime;
+    const decayTime = this.#settingsByKey[`t:${topic}`]?.decayTime;
     const filteredMessages =
       decayTime == undefined ? filterOutSupersededMessages(messages, datatype) : messages;
     for (const message of filteredMessages) {
-      this._consumeMessage(topic, datatype, message);
+      this.#consumeMessage(topic, datatype, message);
     }
   };
 
@@ -957,7 +957,7 @@ export default class SceneBuilder implements MarkerProvider {
         // Highlight if marker matches any of this topic's highlightMarkerMatchers; dim other markers
         // Markers that are not re-processed on this frame (i.e. older markers whose lifetime has
         // not expired) do not get a new copy of interactionData, so they always need to be reset.
-        const markerMatches = (this._highlightMarkerMatchersByTopic[topic.name] ?? []).some(
+        const markerMatches = (this.#highlightMarkerMatchersByTopic[topic.name] ?? []).some(
           ({ checks = [] }) =>
             checks.every(({ markerKeyPath, value }) => {
               const markerValue = markerKeyPath ? _.get(message, markerKeyPath) : message;
@@ -968,7 +968,7 @@ export default class SceneBuilder implements MarkerProvider {
 
         // TODO(bmc): once we support more topic settings
         // flesh this out to be more marker type agnostic
-        const settings = this._settingsByKey[`t:${topic.name}`];
+        const settings = this.#settingsByKey[`t:${topic.name}`];
         if (settings) {
           (marker as { settings?: unknown }).settings = settings;
         }
@@ -1002,7 +1002,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
 
     // allow topic settings to override renderable marker command (see MarkerSettingsEditor.js)
-    const { overrideCommand } = this._settingsByKey[`t:${topic.name}`] ?? {};
+    const { overrideCommand } = this.#settingsByKey[`t:${topic.name}`] ?? {};
 
     switch (marker.type) {
       case 0:
@@ -1053,7 +1053,7 @@ export default class SceneBuilder implements MarkerProvider {
       case 110:
         return add.color(marker);
       default: {
-        this._setTopicError(
+        this.#setTopicError(
           topic.name,
           `Unsupported marker type: ${(marker as { type: number }).type}`,
         );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
@@ -26,12 +26,12 @@ type ErrorsByTopic = {
   [topicName: string]: string[];
 };
 class MockTransform {
-  _values: { id: string }[];
+  #values: { id: string }[];
   constructor({ tfs }: { tfs: { id: string }[] }) {
-    this._values = tfs;
+    this.#values = tfs;
   }
   values() {
-    return this._values;
+    return this.#values;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
@@ -136,33 +136,33 @@ export class Transform {
 }
 
 class TfStore {
-  private _storage = new Map<string, Transform>();
+  #storage = new Map<string, Transform>();
 
   get(unsanitizedKey: string): Transform {
     const key = stripLeadingSlash(unsanitizedKey);
-    let result = this._storage.get(key);
+    let result = this.#storage.get(key);
     if (result) {
       return result;
     }
     result = new Transform(key);
-    this._storage.set(key, result);
+    this.#storage.set(key, result);
     return result;
   }
 
   getMaybe(key: string): Transform | undefined {
-    return this._storage.get(stripLeadingSlash(key));
+    return this.#storage.get(stripLeadingSlash(key));
   }
 
   has(key: string): boolean {
-    return this._storage.has(stripLeadingSlash(key));
+    return this.#storage.has(stripLeadingSlash(key));
   }
 
   values(): Array<Transform> {
-    return Array.from(this._storage.values());
+    return Array.from(this.#storage.values());
   }
 
   entries(): Readonly<Map<string, Transform>> {
-    return this._storage;
+    return this.#storage;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
@@ -35,7 +35,7 @@ export class Transform {
   id: string;
   matrix: mat4 = mat4.create();
   parent?: Transform;
-  _hasValidMatrix: boolean = false;
+  #hasValidMatrix: boolean = false;
 
   constructor(id: string) {
     this.id = stripLeadingSlash(id);
@@ -47,11 +47,11 @@ export class Transform {
       quat.set(tempOrient, orientation.x, orientation.y, orientation.z, orientation.w),
       vec3.set(tempPos, position.x, position.y, position.z),
     );
-    this._hasValidMatrix = true;
+    this.#hasValidMatrix = true;
   }
 
   isValid(rootId: string): boolean {
-    return this._hasValidMatrix || this.id === rootId;
+    return this.#hasValidMatrix || this.id === rootId;
   }
 
   isChildOfTransform(unsanitizedRootId: string): boolean {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/VelodyneCloudConverter.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/VelodyneCloudConverter.ts
@@ -14,7 +14,7 @@ import { Calibration, Model, PointCloud, RawPacket, Transformer } from "@foxglov
 // objects which are an amalgamation of VelodyneScan and PointCloud2 ROS
 // messages plus marker-like SceneBuilder annotations
 export default class VelodyneCloudConverter {
-  private _transformers = new Map<Model, Transformer>();
+  #transformers = new Map<Model, Transformer>();
 
   decode(scan: VelodyneScan): VelodyneScanDecoded | undefined {
     if (scan.packets.length === 0) {
@@ -58,13 +58,13 @@ export default class VelodyneCloudConverter {
   }
 
   getTransformer(model: Model): Transformer {
-    let transformer = this._transformers.get(model);
+    let transformer = this.#transformers.get(model);
     if (transformer != undefined) {
       return transformer;
     }
 
     transformer = new Transformer(new Calibration(model));
-    this._transformers.set(model, transformer);
+    this.#transformers.set(model, transformer);
     return transformer;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/VertexBufferCache.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/VertexBufferCache.ts
@@ -17,32 +17,32 @@ import { MemoizedVertexBuffer, VertexBuffer } from "./types";
 // We keep track of both the current and the previous frames to tell
 // which vertex buffer are not used anymore and need to be deleted.
 export default class VertexBufferCache {
-  _current = new Map<Float32Array, MemoizedVertexBuffer>();
-  _previous = new Map<Float32Array, MemoizedVertexBuffer>();
+  #current = new Map<Float32Array, MemoizedVertexBuffer>();
+  #previous = new Map<Float32Array, MemoizedVertexBuffer>();
 
   // Call this method before rendering to initialize
   // the cache for the current frame.
   onPreRender(): void {
-    this._previous = this._current;
-    this._current = new Map<Float32Array, MemoizedVertexBuffer>();
+    this.#previous = this.#current;
+    this.#current = new Map<Float32Array, MemoizedVertexBuffer>();
   }
 
   // Get a vertex buffer from the cache.
   get(key: VertexBuffer): MemoizedVertexBuffer | undefined {
     const { buffer } = key;
-    let existing = this._current.get(buffer);
+    let existing = this.#current.get(buffer);
     if (existing) {
       // The vertex buffer exists in the current frame
       return existing;
     }
-    existing = this._previous.get(buffer);
+    existing = this.#previous.get(buffer);
     if (existing) {
       // The vertex buffer was not used in the current frame yet
       // but there is valid cached instance in the previous frame.
       // Move the cached value to the current frame to prevent it
       // from being deleted when executing onPostRender().
       this.set(key, existing);
-      this._previous.delete(buffer);
+      this.#previous.delete(buffer);
       return existing;
     }
     // The vertex buffer has not being cached neither in the current
@@ -52,7 +52,7 @@ export default class VertexBufferCache {
 
   // Set a cached value for a vertex buffer
   set(key: VertexBuffer, value: MemoizedVertexBuffer): void {
-    const existing = this._current.get(key.buffer);
+    const existing = this.#current.get(key.buffer);
     if (existing) {
       if (existing === value) {
         // Nothing to do
@@ -61,18 +61,18 @@ export default class VertexBufferCache {
       // A vertex buffer should not change in the same frame,
       // but if it does, we need override the existing cached value
       // and delete it's buffer.
-      this._deleteBuffer(existing);
+      this.#deleteBuffer(existing);
     }
-    this._current.set(key.buffer, value);
+    this.#current.set(key.buffer, value);
   }
 
   // Call this function after rendering a frame to delete unused buffers
   onPostRender(): void {
-    this._previous.forEach(this._deleteBuffer);
-    this._previous.clear();
+    this.#previous.forEach(this.#deleteBuffer);
+    this.#previous.clear();
   }
 
-  _deleteBuffer = (cached: MemoizedVertexBuffer): void => {
+  #deleteBuffer = (cached: MemoizedVertexBuffer): void => {
     const { buffer } = cached;
     // Destroy GPU buffer
     buffer?.destroy();

--- a/packages/studio-base/src/panels/URDFViewer/Renderer.ts
+++ b/packages/studio-base/src/panels/URDFViewer/Renderer.ts
@@ -24,64 +24,64 @@ function cloneModel(robot: URDFRobot): URDFRobot {
 }
 
 export class Renderer extends EventEmitter<EventTypes> {
-  private scene = new THREE.Scene();
-  private world = new THREE.Object3D();
-  private camera = new THREE.PerspectiveCamera();
-  private renderer?: THREE.WebGLRenderer;
-  private ambientLight: THREE.HemisphereLight;
-  private dirLight: THREE.DirectionalLight;
-  private model?: URDFRobot;
-  private opacity: number = 1;
-  private jointValues: Record<string, number> = {};
+  #scene = new THREE.Scene();
+  #world = new THREE.Object3D();
+  #camera = new THREE.PerspectiveCamera();
+  #renderer?: THREE.WebGLRenderer;
+  #ambientLight: THREE.HemisphereLight;
+  #dirLight: THREE.DirectionalLight;
+  #model?: URDFRobot;
+  #opacity: number = 1;
+  #jointValues: Record<string, number> = {};
 
   constructor() {
     super();
-    this.scene.add(this.world);
-    this.world.rotation.set(-Math.PI / 2, 0, 0);
+    this.#scene.add(this.#world);
+    this.#world.rotation.set(-Math.PI / 2, 0, 0);
 
-    this.ambientLight = new THREE.HemisphereLight("#666666", "#000");
-    this.ambientLight.groundColor.lerp(this.ambientLight.color, 0.5);
-    this.ambientLight.intensity = 0.8;
-    this.ambientLight.position.set(0, 1, 0);
-    this.scene.add(this.ambientLight);
+    this.#ambientLight = new THREE.HemisphereLight("#666666", "#000");
+    this.#ambientLight.groundColor.lerp(this.#ambientLight.color, 0.5);
+    this.#ambientLight.intensity = 0.8;
+    this.#ambientLight.position.set(0, 1, 0);
+    this.#scene.add(this.#ambientLight);
 
-    this.dirLight = new THREE.DirectionalLight(0xffffff);
-    this.scene.add(this.dirLight);
-    this.scene.add(this.dirLight.target);
+    this.#dirLight = new THREE.DirectionalLight(0xffffff);
+    this.#scene.add(this.#dirLight);
+    this.#scene.add(this.#dirLight.target);
   }
 
   setCanvas(canvas: HTMLCanvasElement): void {
-    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
-    this.renderer.setClearColor(0xffffff);
-    this.renderer.setClearAlpha(0.5);
-    this.renderer.outputEncoding = THREE.sRGBEncoding;
+    this.#renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.#renderer.setClearColor(0xffffff);
+    this.#renderer.setClearAlpha(0.5);
+    this.#renderer.outputEncoding = THREE.sRGBEncoding;
   }
 
   setSize(width: number, height: number): void {
-    this.camera.aspect = width / height;
-    this.camera.updateProjectionMatrix();
-    this.renderer?.setSize(width, height);
+    this.#camera.aspect = width / height;
+    this.#camera.updateProjectionMatrix();
+    this.#renderer?.setSize(width, height);
   }
 
   setModel(model?: URDFRobot): void {
-    if (this.model) {
-      this.model.traverse((obj) => (obj as { dispose?(): void }).dispose?.());
-      this.world.remove(this.model);
+    if (this.#model) {
+      this.#model.traverse((obj) => (obj as { dispose?(): void }).dispose?.());
+      this.#world.remove(this.#model);
     }
 
     // Clone models so they can be displayed in multiple URDF panels at once without interfering.
-    this.model = model ? cloneModel(model) : undefined;
-    if (this.model) {
-      this.world.add(this.model);
+    this.#model = model ? cloneModel(model) : undefined;
+    if (this.#model) {
+      this.#world.add(this.#model);
     }
     // Re-apply customized values to new model
-    this.setOpacity(this.opacity);
-    this.setJointValues(this.jointValues);
+    this.setOpacity(this.#opacity);
+    this.setJointValues(this.#jointValues);
   }
 
   setOpacity(opacity: number): void {
-    this.opacity = opacity;
-    this.model?.traverse((obj) => {
+    this.#opacity = opacity;
+    this.#model?.traverse((obj) => {
       if (obj instanceof THREE.Mesh) {
         if (Array.isArray(obj.material)) {
           for (const material of obj.material) {
@@ -100,7 +100,7 @@ export class Renderer extends EventEmitter<EventTypes> {
 
   /** Translate a Worldview CameraState to the three.js coordinate system */
   setCameraState(cameraState: CameraState): void {
-    this.camera.position
+    this.#camera.position
       .setFromSpherical(
         new THREE.Spherical(cameraState.distance, cameraState.phi, -cameraState.thetaOffset),
       )
@@ -111,25 +111,25 @@ export class Renderer extends EventEmitter<EventTypes> {
           -cameraState.targetOffset[1],
         ),
       );
-    this.camera.quaternion.setFromEuler(
+    this.#camera.quaternion.setFromEuler(
       new THREE.Euler(cameraState.phi - Math.PI / 2, -cameraState.thetaOffset, 0, "ZYX"),
     );
-    this.camera.updateProjectionMatrix();
+    this.#camera.updateProjectionMatrix();
   }
 
   render(): void {
     // The light should follow the viewer's position
-    this.dirLight.position.copy(this.camera.position);
+    this.#dirLight.position.copy(this.#camera.position);
 
-    this.renderer?.render(this.scene, this.camera);
+    this.#renderer?.render(this.#scene, this.#camera);
   }
 
   setJointValues(values: Record<string, number>): void {
-    this.jointValues = values;
-    this.model?.setJointValues(values);
+    this.#jointValues = values;
+    this.#model?.setJointValues(values);
   }
 
   dispose(): void {
-    this.scene.traverse((obj) => obj !== this.scene && (obj as { dispose?(): void }).dispose?.());
+    this.#scene.traverse((obj) => obj !== this.#scene && (obj as { dispose?(): void }).dispose?.());
   }
 }

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
@@ -190,7 +190,7 @@ const getFormattedKeyValues = createSelector(
 
 // component to display a single diagnostic status
 class DiagnosticStatus extends React.Component<Props, unknown> {
-  _tableRef = React.createRef<HTMLTableElement>();
+  #tableRef = React.createRef<HTMLTableElement>();
 
   static defaultProps = {
     splitFraction: 0.5,
@@ -212,27 +212,26 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     }
   }
 
-  _resizeMouseDown = (event: React.MouseEvent<Element>): void => {
+  #resizeMouseDown = (event: React.MouseEvent<Element>): void => {
     event.preventDefault();
-    window.addEventListener("mousemove", this._resizeMouseMove);
-    window.addEventListener("mouseup", this._resizeMouseUp);
+    window.addEventListener("mousemove", this.#resizeMouseMove);
+    window.addEventListener("mouseup", this.#resizeMouseUp);
   };
 
-  _resizeMouseUp = (): void => {
-    window.removeEventListener("mousemove", this._resizeMouseMove);
+  #resizeMouseUp = (): void => {
+    window.removeEventListener("mousemove", this.#resizeMouseMove);
   };
 
-  _resizeMouseMove = (event: MouseEvent): void => {
+  #resizeMouseMove = (event: MouseEvent): void => {
     const {
-      _tableRef,
       props: { onChangeSplitFraction },
     } = this;
 
-    if (!_tableRef.current) {
+    if (!this.#tableRef.current) {
       return;
     }
 
-    const { left, right } = _tableRef.current.getBoundingClientRect();
+    const { left, right } = this.#tableRef.current.getBoundingClientRect();
     const splitFraction = clamp(
       (event.clientX - left) / (right - left),
       MIN_SPLIT_FRACTION,
@@ -242,8 +241,8 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
   };
 
   override componentWillUnmount(): void {
-    window.removeEventListener("mousemove", this._resizeMouseMove);
-    window.removeEventListener("mouseup", this._resizeMouseUp);
+    window.removeEventListener("mousemove", this.#resizeMouseMove);
+    window.removeEventListener("mouseup", this.#resizeMouseUp);
   }
 
   _renderKeyValueCell(
@@ -262,7 +261,7 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     );
   }
 
-  _renderKeyValueSections = (): React.ReactNode => {
+  #renderKeyValueSections = (): React.ReactNode => {
     const { info, topicToRender, openSiblingPanel, collapsedSections } = this.props;
     const formattedKeyVals: FormattedKeyValue[] = getFormattedKeyValues(info.status);
     let inCollapsedSection = false;
@@ -332,12 +331,12 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     });
   };
 
-  _getSectionsCollapsedForCurrentName = (): { name: string; section: string }[] => {
+  #getSectionsCollapsedForCurrentName = (): { name: string; section: string }[] => {
     const { collapsedSections, info } = this.props;
     return collapsedSections.filter(({ name }) => name === info.status.name);
   };
 
-  _getSectionsThatCanBeCollapsed = (): FormattedKeyValue[] => {
+  #getSectionsThatCanBeCollapsed = (): FormattedKeyValue[] => {
     const { info } = this.props;
     const formattedKeyVals = getFormattedKeyValues(info.status);
     return formattedKeyVals.filter(({ key, value }) => {
@@ -347,12 +346,12 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     });
   };
 
-  _toggleSections = (): void => {
+  #toggleSections = (): void => {
     const { saveConfig, collapsedSections, info } = this.props;
     const newSectionsForCurrentName =
-      this._getSectionsCollapsedForCurrentName().length > 0
+      this.#getSectionsCollapsedForCurrentName().length > 0
         ? []
-        : this._getSectionsThatCanBeCollapsed().map(({ key, value }) => ({
+        : this.#getSectionsThatCanBeCollapsed().map(({ key, value }) => ({
             name: info.status.name,
             section: `${key}${value}`,
           }));
@@ -380,10 +379,10 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
         <div
           className={classes.resizeHandle}
           style={{ left: `${100 * splitFraction}%` }}
-          onMouseDown={this._resizeMouseDown}
+          onMouseDown={this.#resizeMouseDown}
           data-test-resizehandle
         />
-        <table className={classes.table} ref={this._tableRef}>
+        <table className={classes.table} ref={this.#tableRef}>
           <tbody>
             {/* Use a dummy row to fix the column widths */}
             <tr style={{ height: 0 }}>
@@ -429,22 +428,22 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
                       <DotsHorizontalIcon />
                     </Icon>
                   </div>
-                  {this._getSectionsThatCanBeCollapsed().length > 0 && (
+                  {this.#getSectionsThatCanBeCollapsed().length > 0 && (
                     <div
                       style={{ color: "white", cursor: "pointer" }}
-                      onClick={this._toggleSections}
+                      onClick={this.#toggleSections}
                     >
                       <Icon
                         size="medium"
                         fade
                         style={{ padding: 4 }}
                         tooltip={
-                          this._getSectionsCollapsedForCurrentName().length > 0
+                          this.#getSectionsCollapsedForCurrentName().length > 0
                             ? "Expand all"
                             : "Collapse all"
                         }
                       >
-                        {this._getSectionsCollapsedForCurrentName().length > 0 ? (
+                        {this.#getSectionsCollapsedForCurrentName().length > 0 ? (
                           <ChevronUpIcon />
                         ) : (
                           <ChevronDownIcon />
@@ -455,7 +454,7 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
                 </Flex>
               </td>
             </tr>
-            {this._renderKeyValueSections()}
+            {this.#renderKeyValueSections()}
           </tbody>
         </table>
       </div>

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -18,11 +18,11 @@ type EventData = { [key: string]: string | number | boolean };
 export default class AnalyticsMetricsCollector implements PlayerMetricsCollectorInterface {
   metadata: EventData = {};
   playerType?: PlayerSourceDefinition;
-  private _analytics: IAnalytics;
+  #analytics: IAnalytics;
 
   constructor(analytics: IAnalytics) {
     log.debug("New AnalyticsMetricsCollector");
-    this._analytics = analytics;
+    this.#analytics = analytics;
   }
 
   setProperty(key: string, value: string | number | boolean): void {
@@ -30,7 +30,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
   }
 
   logEvent(event: AppEvent, data?: EventData): void {
-    void this._analytics.logEvent(event, { ...this.metadata, ...data });
+    void this.#analytics.logEvent(event, { ...this.metadata, ...data });
   }
 
   playerConstructed(): void {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -58,17 +58,17 @@ function getMessagesFromLoadedRange(messages: MessageEvent<unknown>[], requestRa
  * An in-memory cache of preloaded messages over a time range.
  */
 export default class MessageMemoryCache {
-  private minTime: Time;
-  private maxTime: Time;
-  private loadedRanges: { range: TimeRange; messages: MessageEvent<unknown>[] }[] = [];
+  #minTime: Time;
+  #maxTime: Time;
+  #loadedRanges: { range: TimeRange; messages: MessageEvent<unknown>[] }[] = [];
 
   constructor(totalRange: TimeRange) {
-    this.minTime = totalRange.start;
-    this.maxTime = totalRange.end;
+    this.#minTime = totalRange.start;
+    this.#maxTime = totalRange.end;
   }
 
   fullyLoadedRanges(): TimeRange[] {
-    return this.loadedRanges.map(({ range }) => range);
+    return this.#loadedRanges.map(({ range }) => range);
   }
 
   /**
@@ -76,10 +76,10 @@ export default class MessageMemoryCache {
    * displayed visually in the playback bar.
    */
   fullyLoadedFractionRanges(): Range[] {
-    const totalSeconds = secondsBetween(this.minTime, this.maxTime);
-    return this.loadedRanges.map(({ range }) => ({
-      start: secondsBetween(this.minTime, range.start) / totalSeconds,
-      end: secondsBetween(this.minTime, range.end) / totalSeconds,
+    const totalSeconds = secondsBetween(this.#minTime, this.#maxTime);
+    return this.#loadedRanges.map(({ range }) => ({
+      start: secondsBetween(this.#minTime, range.start) / totalSeconds,
+      end: secondsBetween(this.#minTime, range.end) / totalSeconds,
     }));
   }
 
@@ -88,10 +88,10 @@ export default class MessageMemoryCache {
    */
   fullyLoadedExtent(targetTime: Time): TimeRange | undefined {
     let lo = 0;
-    let hi = this.loadedRanges.length;
+    let hi = this.#loadedRanges.length;
     while (lo < hi) {
       const mid = Math.floor((lo + hi) / 2);
-      const midRange = this.loadedRanges[mid]!;
+      const midRange = this.#loadedRanges[mid]!;
       if (isGreaterThan(midRange.range.start, targetTime)) {
         hi = mid;
       } else if (!isGreaterThan(midRange.range.end, targetTime)) {
@@ -115,15 +115,15 @@ export default class MessageMemoryCache {
       throw new Error("Inserted range must not be empty");
     }
     if (
-      isLessThan(coveredRange.start, this.minTime) ||
-      isGreaterThan(coveredRange.end, this.maxTime)
+      isLessThan(coveredRange.start, this.#minTime) ||
+      isGreaterThan(coveredRange.end, this.#maxTime)
     ) {
       throw new Error(
         `Inserting messages in ${rangeToString(
           coveredRange,
         )} which extends outside cache range ${rangeToString({
-          start: this.minTime,
-          end: this.maxTime,
+          start: this.#minTime,
+          end: this.#maxTime,
         })}`,
       );
     }
@@ -132,10 +132,10 @@ export default class MessageMemoryCache {
     let insertionIdx;
     {
       let lo = 0;
-      let hi = this.loadedRanges.length;
+      let hi = this.#loadedRanges.length;
       while (lo < hi) {
         const mid = Math.floor((lo + hi) / 2);
-        const midRange = this.loadedRanges[mid]!;
+        const midRange = this.#loadedRanges[mid]!;
         if (!isLessThan(midRange.range.start, coveredRange.end)) {
           hi = mid;
         } else if (!isGreaterThan(midRange.range.end, coveredRange.start)) {
@@ -158,31 +158,31 @@ export default class MessageMemoryCache {
     let insertMessages;
     const mergeBefore =
       insertionIdx > 0 &&
-      areEqual(this.loadedRanges[insertionIdx - 1]!.range.end, coveredRange.start);
+      areEqual(this.#loadedRanges[insertionIdx - 1]!.range.end, coveredRange.start);
     const mergeAfter =
-      insertionIdx < this.loadedRanges.length &&
-      areEqual(this.loadedRanges[insertionIdx]!.range.start, coveredRange.end);
+      insertionIdx < this.#loadedRanges.length &&
+      areEqual(this.#loadedRanges[insertionIdx]!.range.start, coveredRange.end);
     if (mergeBefore && mergeAfter) {
       spliceIdx = insertionIdx - 1;
       deleteCount = 2;
-      insertStart = this.loadedRanges[insertionIdx - 1]!.range.start;
-      insertEnd = this.loadedRanges[insertionIdx]!.range.end;
-      insertMessages = this.loadedRanges[insertionIdx - 1]!.messages.concat(
+      insertStart = this.#loadedRanges[insertionIdx - 1]!.range.start;
+      insertEnd = this.#loadedRanges[insertionIdx]!.range.end;
+      insertMessages = this.#loadedRanges[insertionIdx - 1]!.messages.concat(
         messages,
-        this.loadedRanges[insertionIdx]!.messages,
+        this.#loadedRanges[insertionIdx]!.messages,
       );
     } else if (mergeBefore) {
       spliceIdx = insertionIdx - 1;
       deleteCount = 1;
-      insertStart = this.loadedRanges[insertionIdx - 1]!.range.start;
+      insertStart = this.#loadedRanges[insertionIdx - 1]!.range.start;
       insertEnd = coveredRange.end;
-      insertMessages = this.loadedRanges[insertionIdx - 1]!.messages.concat(messages);
+      insertMessages = this.#loadedRanges[insertionIdx - 1]!.messages.concat(messages);
     } else if (mergeAfter) {
       spliceIdx = insertionIdx;
       deleteCount = 1;
       insertStart = coveredRange.start;
-      insertEnd = this.loadedRanges[insertionIdx]!.range.end;
-      insertMessages = messages.concat(this.loadedRanges[insertionIdx]!.messages);
+      insertEnd = this.#loadedRanges[insertionIdx]!.range.end;
+      insertMessages = messages.concat(this.#loadedRanges[insertionIdx]!.messages);
     } else {
       spliceIdx = insertionIdx;
       deleteCount = 0;
@@ -190,7 +190,7 @@ export default class MessageMemoryCache {
       insertEnd = coveredRange.end;
       insertMessages = messages;
     }
-    this.loadedRanges.splice(spliceIdx, deleteCount, {
+    this.#loadedRanges.splice(spliceIdx, deleteCount, {
       range: { start: insertStart, end: insertEnd },
       messages: insertMessages,
     });
@@ -198,7 +198,7 @@ export default class MessageMemoryCache {
 
   /** Remove all messages and preloaded ranges. */
   clear(): void {
-    this.loadedRanges = [];
+    this.#loadedRanges = [];
   }
 
   /**
@@ -206,10 +206,10 @@ export default class MessageMemoryCache {
    */
   getMessages(requestRange: TimeRange): MessageEvent<unknown>[] | undefined {
     let lo = 0;
-    let hi = this.loadedRanges.length;
+    let hi = this.#loadedRanges.length;
     while (lo < hi) {
       const mid = Math.floor((lo + hi) / 2);
-      const midRange = this.loadedRanges[mid]!;
+      const midRange = this.#loadedRanges[mid]!;
       if (!isLessThan(midRange.range.start, requestRange.end)) {
         hi = mid;
       } else if (!isGreaterThan(midRange.range.end, requestRange.start)) {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -60,79 +60,79 @@ type FoxgloveDataPlatformPlayerOpts = {
 const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 
 export default class FoxgloveDataPlatformPlayer implements Player {
-  private readonly _preloadThresholdSecs = 5;
-  private readonly _preloadDurationSecs = 15;
+  readonly #preloadThresholdSecs = 5;
+  readonly #preloadDurationSecs = 15;
 
-  private _id: string = uuidv4(); // Unique ID for this player
-  private _name: string;
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
-  private _totalBytesReceived = 0;
-  private _initialized = false;
-  private _closed = false; // Whether the player has been completely closed using close()
-  private _isPlaying = false;
-  private _speed = 1;
-  private _start: Time;
-  private _end: Time;
-  private _consoleApi: ConsoleApi;
-  private _deviceId: string;
-  private _currentTime: Time;
-  private _lastSeekTime?: number;
-  private _topics: Topic[] = [];
-  private _datatypes: RosDatatypes = new Map();
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _preloadedMessages: MessageMemoryCache;
-  private _currentPreloadTask?: AbortController;
-  private _requestedTopics: string[] = [];
-  private _progress: Progress = {};
-  private _loadedMoreMessages?: Signal<void>;
-  private _nextFrame: MessageEvent<unknown>[] = [];
+  #id: string = uuidv4(); // Unique ID for this player
+  #name: string;
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
+  #totalBytesReceived = 0;
+  #initialized = false;
+  #closed = false; // Whether the player has been completely closed using close()
+  #isPlaying = false;
+  #speed = 1;
+  #start: Time;
+  #end: Time;
+  #consoleApi: ConsoleApi;
+  #deviceId: string;
+  #currentTime: Time;
+  #lastSeekTime?: number;
+  #topics: Topic[] = [];
+  #datatypes: RosDatatypes = new Map();
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #preloadedMessages: MessageMemoryCache;
+  #currentPreloadTask?: AbortController;
+  #requestedTopics: string[] = [];
+  #progress: Progress = {};
+  #loadedMoreMessages?: Signal<void>;
+  #nextFrame: MessageEvent<unknown>[] = [];
 
   // track issues within the player
-  private _problems: PlayerProblem[] = [];
-  private _problemsById = new Map<string, PlayerProblem>();
+  #problems: PlayerProblem[] = [];
+  #problemsById = new Map<string, PlayerProblem>();
 
   constructor({ params, metricsCollector, consoleApi }: FoxgloveDataPlatformPlayerOpts) {
     log.info(`initializing FoxgloveDataPlatformPlayer ${JSON.stringify(params)}`);
-    this._metricsCollector = metricsCollector;
-    this._metricsCollector.playerConstructed();
+    this.#metricsCollector = metricsCollector;
+    this.#metricsCollector.playerConstructed();
     const start = fromRFC3339String(params.start);
     const end = fromRFC3339String(params.end);
     if (!start || !end) {
       throw new Error(`Invalid start/end time: ${start}, ${end}`);
     }
-    this._start = start;
-    this._end = end;
-    this._currentTime = this._start;
-    this._deviceId = params.deviceId;
-    this._name = `${this._deviceId}, ${formatTimeRaw(this._start)} to ${formatTimeRaw(this._end)}`;
-    this._consoleApi = consoleApi;
-    this._preloadedMessages = new MessageMemoryCache({ start: this._start, end: this._end });
-    this._open().catch((error) => {
-      this._presence = PlayerPresence.ERROR;
+    this.#start = start;
+    this.#end = end;
+    this.#currentTime = this.#start;
+    this.#deviceId = params.deviceId;
+    this.#name = `${this.#deviceId}, ${formatTimeRaw(this.#start)} to ${formatTimeRaw(this.#end)}`;
+    this.#consoleApi = consoleApi;
+    this.#preloadedMessages = new MessageMemoryCache({ start: this.#start, end: this.#end });
+    this.#open().catch((error) => {
+      this.#presence = PlayerPresence.ERROR;
       this._addProblem("open-failed", { message: error.message, error, severity: "error" });
     });
   }
 
-  private _open = async (): Promise<void> => {
-    if (this._closed) {
+  #open = async (): Promise<void> => {
+    if (this.#closed) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
-    this._emitState();
+    this.#presence = PlayerPresence.INITIALIZING;
+    this.#emitState();
 
-    const rawTopics = await this._consoleApi.topics({
-      deviceId: this._deviceId,
-      start: toDate(this._start).toISOString(),
-      end: toDate(this._end).toISOString(),
+    const rawTopics = await this.#consoleApi.topics({
+      deviceId: this.#deviceId,
+      start: toDate(this.#start).toISOString(),
+      end: toDate(this.#end).toISOString(),
       includeSchemas: true,
     });
     if (rawTopics.length === 0) {
-      this._presence = PlayerPresence.ERROR;
+      this.#presence = PlayerPresence.ERROR;
       this._addProblem("no-data", {
-        message: `No data available for ${this._deviceId} between ${formatTimeRaw(
-          this._start,
-        )} and ${formatTimeRaw(this._end)}.`,
+        message: `No data available for ${this.#deviceId} between ${formatTimeRaw(
+          this.#start,
+        )} and ${formatTimeRaw(this.#end)}.`,
         severity: "error",
       });
       return;
@@ -163,12 +163,12 @@ export default class FoxgloveDataPlatformPlayer implements Player {
         }
       });
     }
-    this._topics = topics;
-    this._datatypes = datatypes;
+    this.#topics = topics;
+    this.#datatypes = datatypes;
 
-    this._presence = PlayerPresence.PRESENT;
-    this._initialized = true;
-    this._emitState();
+    this.#presence = PlayerPresence.PRESENT;
+    this.#initialized = true;
+    this.#emitState();
     this._startPreloadTaskIfNeeded();
   };
 
@@ -177,45 +177,45 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problemsById.set(id, problem);
-    this._problems = Array.from(this._problemsById.values());
+    this.#problemsById.set(id, problem);
+    this.#problems = Array.from(this.#problemsById.values());
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+  #emitState = debouncePromise(() => {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const messages = this._nextFrame;
+    const messages = this.#nextFrame;
     if (messages.length > 0) {
-      this._nextFrame = [];
+      this.#nextFrame = [];
     }
 
-    return this._listener({
-      name: this._name,
-      presence: this._presence,
-      progress: this._progress,
+    return this.#listener({
+      name: this.#name,
+      presence: this.#presence,
+      progress: this.#progress,
       capabilities: CAPABILITIES,
-      playerId: this._id,
-      problems: this._problems,
+      playerId: this.#id,
+      problems: this.#problems,
 
       activeData: {
         messages,
-        totalBytesReceived: this._totalBytesReceived,
+        totalBytesReceived: this.#totalBytesReceived,
         messageOrder: "receiveTime",
-        startTime: this._start ?? ZERO_TIME,
-        endTime: this._end ?? ZERO_TIME,
-        currentTime: this._currentTime,
-        isPlaying: this._isPlaying,
-        speed: this._speed,
-        lastSeekTime: this._lastSeekTime ?? 0,
-        topics: this._topics,
-        datatypes: this._datatypes,
+        startTime: this.#start ?? ZERO_TIME,
+        endTime: this.#end ?? ZERO_TIME,
+        currentTime: this.#currentTime,
+        isPlaying: this.#isPlaying,
+        speed: this.#speed,
+        lastSeekTime: this.#lastSeekTime ?? 0,
+        topics: this.#topics,
+        datatypes: this.#datatypes,
         publishedTopics: undefined,
         subscribedTopics: undefined,
         services: undefined,
@@ -226,31 +226,31 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   });
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
-    this._emitState();
+    this.#listener = listener;
+    this.#emitState();
   }
 
   close(): void {
-    this._closed = true;
-    this._metricsCollector.close();
-    this._currentPreloadTask?.abort();
-    this._currentPreloadTask = undefined;
-    this._totalBytesReceived = 0;
+    this.#closed = true;
+    this.#metricsCollector.close();
+    this.#currentPreloadTask?.abort();
+    this.#currentPreloadTask = undefined;
+    this.#totalBytesReceived = 0;
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
     log.debug("setSubscriptions", subscriptions);
-    this._requestedTopics = Array.from(new Set(subscriptions.map(({ topic }) => topic)));
+    this.#requestedTopics = Array.from(new Set(subscriptions.map(({ topic }) => topic)));
     this._clearPreloadedData();
     this._startPreloadTaskIfNeeded();
-    this._emitState();
+    this.#emitState();
   }
 
-  private _runPlaybackLoop = debouncePromise(async () => {
+  #runPlaybackLoop = debouncePromise(async () => {
     let lastTickEndTime: number | undefined;
     let lastReadMs: number | undefined;
-    mainLoop: while (this._isPlaying) {
-      await this._emitState.currentPromise;
+    mainLoop: while (this.#isPlaying) {
+      await this.#emitState.currentPromise;
 
       // compute how long of a time range we want to read by taking into account
       // the time since our last read and how fast we're currently playing back
@@ -260,81 +260,81 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       // Read at most 300ms worth of messages, otherwise things can get out of control if rendering
       // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
       // cause the next frame to also be unnecessarily slow by increasing the frame size.
-      let readMs = Math.min(msSinceLastTick * this._speed, 300);
+      let readMs = Math.min(msSinceLastTick * this.#speed, 300);
       if (lastReadMs != undefined) {
         readMs = lastReadMs * 0.9 + readMs * 0.1;
       }
       lastReadMs = readMs;
 
-      const lastSeekTime = this._lastSeekTime;
-      const startTime = this._currentTime;
-      const endTime = clampTime(add(startTime, fromMillis(readMs)), this._start, this._end);
+      const lastSeekTime = this.#lastSeekTime;
+      const startTime = this.#currentTime;
+      const endTime = clampTime(add(startTime, fromMillis(readMs)), this.#start, this.#end);
       this._startPreloadTaskIfNeeded();
       let messages;
       while (
-        !(messages = this._preloadedMessages.getMessages({ start: startTime, end: endTime }))
+        !(messages = this.#preloadedMessages.getMessages({ start: startTime, end: endTime }))
       ) {
         log.debug("Waiting for more messages");
         // Wait for new messages to be loaded
-        await (this._loadedMoreMessages = signal());
-        if (this._lastSeekTime !== lastSeekTime) {
+        await (this.#loadedMoreMessages = signal());
+        if (this.#lastSeekTime !== lastSeekTime) {
           lastTickEndTime = undefined;
           continue mainLoop;
         }
       }
       lastTickEndTime = performance.now();
-      this._nextFrame = messages;
-      this._currentTime = endTime;
-      this._emitState();
+      this.#nextFrame = messages;
+      this.#currentTime = endTime;
+      this.#emitState();
     }
   });
 
   private _clearPreloadedData() {
-    this._preloadedMessages.clear();
-    this._progress = {
-      fullyLoadedFractionRanges: this._preloadedMessages.fullyLoadedFractionRanges(),
+    this.#preloadedMessages.clear();
+    this.#progress = {
+      fullyLoadedFractionRanges: this.#preloadedMessages.fullyLoadedFractionRanges(),
     };
-    this._currentPreloadTask?.abort();
-    this._currentPreloadTask = undefined;
+    this.#currentPreloadTask?.abort();
+    this.#currentPreloadTask = undefined;
   }
 
   private _startPreloadTaskIfNeeded() {
-    if (!this._initialized || this._closed) {
+    if (!this.#initialized || this.#closed) {
       return;
     }
-    if (this._currentPreloadTask) {
+    if (this.#currentPreloadTask) {
       return;
     }
-    const preloadedExtent = this._preloadedMessages.fullyLoadedExtent(this._currentTime);
+    const preloadedExtent = this.#preloadedMessages.fullyLoadedExtent(this.#currentTime);
     const shouldPreload =
-      this._requestedTopics.length > 0 &&
+      this.#requestedTopics.length > 0 &&
       (!preloadedExtent ||
-        toSec(subtract(preloadedExtent.end, this._currentTime)) < this._preloadThresholdSecs);
+        toSec(subtract(preloadedExtent.end, this.#currentTime)) < this.#preloadThresholdSecs);
     if (!shouldPreload) {
       return;
     }
 
-    const startTime = clampTime(preloadedExtent?.end ?? this._currentTime, this._start, this._end);
+    const startTime = clampTime(preloadedExtent?.end ?? this.#currentTime, this.#start, this.#end);
     const proposedEndTime = clampTime(
-      add(startTime, fromSec(this._preloadDurationSecs)),
-      this._start,
-      this._end,
+      add(startTime, fromSec(this.#preloadDurationSecs)),
+      this.#start,
+      this.#end,
     );
     const endTime =
-      this._preloadedMessages.fullyLoadedExtent(proposedEndTime)?.start ?? proposedEndTime;
+      this.#preloadedMessages.fullyLoadedExtent(proposedEndTime)?.start ?? proposedEndTime;
 
     const thisTask = new AbortController();
     thisTask.signal.addEventListener("abort", () => {
       log.debug("Aborting preload task", startTime, endTime);
     });
-    this._currentPreloadTask = thisTask;
+    this.#currentPreloadTask = thisTask;
     log.debug("Starting preload task", startTime, endTime);
     (async () => {
-      const stream = streamMessages(this._consoleApi, thisTask.signal, {
-        deviceId: this._deviceId,
+      const stream = streamMessages(this.#consoleApi, thisTask.signal, {
+        deviceId: this.#deviceId,
         start: startTime,
         end: endTime,
-        topics: this._requestedTopics,
+        topics: this.#requestedTopics,
       });
 
       for await (const { messages, range } of collateMessageStream(stream, {
@@ -345,13 +345,13 @@ export default class FoxgloveDataPlatformPlayer implements Player {
           break;
         }
         log.debug("Adding preloaded chunk in", range, "with", messages.length, "messages");
-        this._preloadedMessages.insert(range, messages);
-        this._progress = {
-          fullyLoadedFractionRanges: this._preloadedMessages.fullyLoadedFractionRanges(),
+        this.#preloadedMessages.insert(range, messages);
+        this.#progress = {
+          fullyLoadedFractionRanges: this.#preloadedMessages.fullyLoadedFractionRanges(),
         };
-        this._loadedMoreMessages?.resolve();
-        this._loadedMoreMessages = undefined;
-        this._emitState();
+        this.#loadedMoreMessages?.resolve();
+        this.#loadedMoreMessages = undefined;
+        this.#emitState();
       }
     })()
       .catch((error) => {
@@ -362,12 +362,12 @@ export default class FoxgloveDataPlatformPlayer implements Player {
         this._addProblem("stream-error", { message: error.message, error, severity: "error" });
       })
       .finally(() => {
-        if (this._currentPreloadTask === thisTask) {
-          this._currentPreloadTask = undefined;
+        if (this.#currentPreloadTask === thisTask) {
+          this.#currentPreloadTask = undefined;
         }
       });
 
-    this._emitState();
+    this.#emitState();
   }
 
   setPublishers(publishers: AdvertiseOptions[]): void {
@@ -384,39 +384,39 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   }
 
   startPlayback(): void {
-    if (this._isPlaying) {
+    if (this.#isPlaying) {
       return;
     }
-    this._metricsCollector.play(this._speed);
-    this._isPlaying = true;
-    this._runPlaybackLoop();
-    this._emitState();
+    this.#metricsCollector.play(this.#speed);
+    this.#isPlaying = true;
+    this.#runPlaybackLoop();
+    this.#emitState();
   }
 
   pausePlayback(): void {
-    if (!this._isPlaying) {
+    if (!this.#isPlaying) {
       return;
     }
-    this._metricsCollector.pause();
-    this._isPlaying = false;
-    this._emitState();
+    this.#metricsCollector.pause();
+    this.#isPlaying = false;
+    this.#emitState();
   }
 
   seekPlayback(time: Time, _backfillDuration?: Time): void {
     log.debug("Seek", time);
-    this._currentTime = time;
-    this._lastSeekTime = Date.now();
-    this._nextFrame = [];
-    this._currentPreloadTask?.abort();
-    this._currentPreloadTask = undefined;
+    this.#currentTime = time;
+    this.#lastSeekTime = Date.now();
+    this.#nextFrame = [];
+    this.#currentPreloadTask?.abort();
+    this.#currentPreloadTask = undefined;
     this._startPreloadTaskIfNeeded();
-    this._emitState();
+    this.#emitState();
   }
 
   setPlaybackSpeed(speed: number): void {
-    this._speed = speed;
-    this._metricsCollector.setSpeed(speed);
-    this._emitState();
+    this.#speed = speed;
+    this.#metricsCollector.setSpeed(speed);
+    this.#emitState();
   }
 
   requestBackfill(): void {

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -53,41 +53,41 @@ const getTopicsWithHeader = memoizeWeak((topics: Topic[], datatypes: RosDatatype
 });
 
 export default class OrderedStampPlayer implements Player {
-  _player: UserNodePlayer;
-  _messageOrder: TimestampMethod;
+  #player: UserNodePlayer;
+  #messageOrder: TimestampMethod;
   // When messageOrder is "headerStamp", contains buffered, unsorted messages with receiveTime "in
   // the near future". Only messages with headers are stored.
-  _messageBuffer: MessageEvent<StampedMessage>[] = [];
+  #messageBuffer: MessageEvent<StampedMessage>[] = [];
   // Used to invalidate the cache. (Also signals subscription changes etc).
-  _lastSeekId?: number = undefined;
+  #lastSeekId?: number = undefined;
   // Our best guess of "now" in case we need to force a backfill.
-  _currentTime?: Time = undefined;
-  _topicsWithoutHeadersSinceSeek = new Set<string>();
+  #currentTime?: Time = undefined;
+  #topicsWithoutHeadersSinceSeek = new Set<string>();
 
   constructor(player: UserNodePlayer, messageOrder: TimestampMethod) {
-    this._player = player;
-    this._messageOrder = messageOrder;
+    this.#player = player;
+    this.#messageOrder = messageOrder;
   }
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     // Potentially performance-sensitive; await can be expensive
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    this._player.setListener((state: PlayerState) => {
+    this.#player.setListener((state: PlayerState) => {
       const { activeData } = state;
       if (!activeData) {
         // No new messages since last time.
         return listener(state);
       }
-      if (this._messageOrder === "receiveTime") {
+      if (this.#messageOrder === "receiveTime") {
         // Set "now" to seek to in case messageOrder changes.
-        this._currentTime = activeData.currentTime;
+        this.#currentTime = activeData.currentTime;
         return listener(state);
       }
 
-      if (activeData.lastSeekTime !== this._lastSeekId) {
-        this._messageBuffer = [];
-        this._lastSeekId = activeData.lastSeekTime;
-        this._topicsWithoutHeadersSinceSeek = new Set<string>();
+      if (activeData.lastSeekTime !== this.#lastSeekId) {
+        this.#messageBuffer = [];
+        this.#lastSeekId = activeData.lastSeekTime;
+        this.#topicsWithoutHeadersSinceSeek = new Set<string>();
       }
 
       // Only store messages with a header stamp.
@@ -101,7 +101,7 @@ export default class OrderedStampPlayer implements Player {
         topicsWithoutHeaders.add(topic);
       });
 
-      const extendedMessageBuffer = [...this._messageBuffer, ...newMessagesWithHeaders];
+      const extendedMessageBuffer = [...this.#messageBuffer, ...newMessagesWithHeaders];
       // output messages older than this threshold (ie, send all messages up until the threshold
       // time)
       const thresholdTime = {
@@ -112,12 +112,12 @@ export default class OrderedStampPlayer implements Player {
         isLessThan(message.message.header.stamp, thresholdTime),
       );
 
-      this._messageBuffer = newMessageBuffer;
+      this.#messageBuffer = newMessageBuffer;
 
       messages.sort((a, b) => compare(a.message.header.stamp, b.message.header.stamp));
 
       const currentTime = clampTime(thresholdTime, activeData.startTime, activeData.endTime);
-      this._currentTime = currentTime;
+      this.#currentTime = currentTime;
       const topicsWithHeader = getTopicsWithHeader(activeData.topics, activeData.datatypes);
 
       let problems: PlayerProblem[] | undefined = undefined;
@@ -152,19 +152,19 @@ export default class OrderedStampPlayer implements Player {
   }
 
   setSubscriptions = (subscriptions: SubscribePayload[]): void =>
-    this._player.setSubscriptions(subscriptions);
-  close = (): void => this._player.close();
-  setPublishers = (publishers: AdvertiseOptions[]): void => this._player.setPublishers(publishers);
+    this.#player.setSubscriptions(subscriptions);
+  close = (): void => this.#player.close();
+  setPublishers = (publishers: AdvertiseOptions[]): void => this.#player.setPublishers(publishers);
   setParameter = (key: string, value: ParameterValue): void =>
-    this._player.setParameter(key, value);
-  publish = (request: PublishPayload): void => this._player.publish(request);
-  startPlayback = (): void => this._player.startPlayback();
-  pausePlayback = (): void => this._player.pausePlayback();
-  setPlaybackSpeed = (speed: number): void => this._player.setPlaybackSpeed(speed);
+    this.#player.setParameter(key, value);
+  publish = (request: PublishPayload): void => this.#player.publish(request);
+  startPlayback = (): void => this.#player.startPlayback();
+  pausePlayback = (): void => this.#player.pausePlayback();
+  setPlaybackSpeed = (speed: number): void => this.#player.setPlaybackSpeed(speed);
   seekPlayback = (time: Time, backfillDuration?: Time): void => {
     // Add a second to the backfill duration requested downstream, to give us extra data to reorder.
-    if (this._messageOrder === "receiveTime") {
-      return this._player.seekPlayback(time, backfillDuration);
+    if (this.#messageOrder === "receiveTime") {
+      return this.#player.seekPlayback(time, backfillDuration);
     }
     if (backfillDuration) {
       throw new Error("BackfillDuration not supported by OrderedStampPlayer.");
@@ -173,11 +173,11 @@ export default class OrderedStampPlayer implements Player {
     // messages with receive times between 10s and 11s.
     // Add backfilling for our translation buffer.
     const seekLocation = add(time, { sec: BUFFER_DURATION_SECS, nsec: 0 });
-    this._player.seekPlayback(seekLocation, { sec: BUFFER_DURATION_SECS, nsec: 0 });
+    this.#player.seekPlayback(seekLocation, { sec: BUFFER_DURATION_SECS, nsec: 0 });
   };
   requestBackfill(): void {
-    if (!this._currentTime || this._messageOrder === "receiveTime") {
-      return this._player.requestBackfill();
+    if (!this.#currentTime || this.#messageOrder === "receiveTime") {
+      return this.#player.requestBackfill();
     }
 
     // If we are sorting messages by header stamps, let seekPlayback
@@ -187,25 +187,25 @@ export default class OrderedStampPlayer implements Player {
     // does not have easy access to that state without tracking it itself.
     // This shouldn't matter in practice because the next emit() will
     // populate the panels regardless of requestBackfill() getting called.
-    this.seekPlayback(this._currentTime);
+    this.seekPlayback(this.#currentTime);
   }
   async setUserNodes(nodes: UserNodes): Promise<void> {
-    return await this._player.setUserNodes(nodes);
+    return await this.#player.setUserNodes(nodes);
   }
   setGlobalVariables(globalVariables: GlobalVariables): void {
-    this._player.setGlobalVariables(globalVariables);
+    this.#player.setGlobalVariables(globalVariables);
     // So that downstream players can re-send messages that depend on global
     // variable state.
     this.requestBackfill();
   }
   setMessageOrder(order: TimestampMethod): void {
-    if (this._messageOrder !== order) {
-      this._messageOrder = order;
+    if (this.#messageOrder !== order) {
+      this.#messageOrder = order;
       // Seek to invalidate the cache. Don't just requestBackfill(), because it needs to work while
       // we're playing too.
-      if (this._currentTime) {
+      if (this.#currentTime) {
         // Cache invalidation will be handled inside the seek/playback logic.
-        this.seekPlayback(this._currentTime);
+        this.seekPlayback(this.#currentTime);
       }
     }
   }

--- a/packages/studio-base/src/players/PlayerProblemManager.ts
+++ b/packages/studio-base/src/players/PlayerProblemManager.ts
@@ -10,41 +10,41 @@ import { PlayerProblem } from "@foxglove/studio-base/players/types";
  * needs to re-process player problems.
  */
 export default class PlayerProblemManager {
-  private _problemsById = new Map<string, PlayerProblem>();
-  private _problems?: PlayerProblem[];
+  #problemsById = new Map<string, PlayerProblem>();
+  #problems?: PlayerProblem[];
 
   /**
    * Returns the current set of problems. Subsequent calls will return the same object as long as
    * problems have not been added/removed.
    */
   problems(): PlayerProblem[] {
-    return (this._problems ??= Array.from(this._problemsById.values()));
+    return (this.#problems ??= Array.from(this.#problemsById.values()));
   }
 
   addProblem(id: string, problem: PlayerProblem): void {
-    this._problemsById.set(id, problem);
-    this._problems = undefined;
+    this.#problemsById.set(id, problem);
+    this.#problems = undefined;
   }
 
   removeProblem(id: string): boolean {
-    const changed = this._problemsById.delete(id);
+    const changed = this.#problemsById.delete(id);
     if (changed) {
-      this._problems = undefined;
+      this.#problems = undefined;
     }
     return changed;
   }
 
   removeProblems(predicate: (id: string, problem: PlayerProblem) => boolean): boolean {
     let changed = false;
-    for (const [id, problem] of this._problemsById) {
+    for (const [id, problem] of this.#problemsById) {
       if (predicate(id, problem)) {
-        if (this._problemsById.delete(id)) {
+        if (this.#problemsById.delete(id)) {
           changed = true;
         }
       }
     }
     if (changed) {
-      this._problems = undefined;
+      this.#problems = undefined;
     }
     return changed;
   }

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -49,27 +49,27 @@ const playerOptions: RandomAccessPlayerOptions = {
 type PlayerStateWithoutPlayerId = Omit<PlayerState, "playerId">;
 
 class MessageStore {
-  _messages: PlayerStateWithoutPlayerId[] = [];
+  #messages: PlayerStateWithoutPlayerId[] = [];
   done: Promise<PlayerStateWithoutPlayerId[]>;
-  _expected: number;
-  _resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
+  #expected: number;
+  #resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
     // no-op
   };
   constructor(expected: number) {
-    this._expected = expected;
+    this.#expected = expected;
     this.done = new Promise((resolve) => {
-      this._resolve = resolve;
+      this.#resolve = resolve;
     });
   }
 
   add = async (message: PlayerState): Promise<void> => {
-    this._messages.push(omit(message, ["playerId"]));
-    if (this._messages.length === this._expected) {
-      this._resolve(this._messages);
+    this.#messages.push(omit(message, ["playerId"]));
+    if (this.#messages.length === this.#expected) {
+      this.#resolve(this.#messages);
     }
-    if (this._messages.length > this._expected) {
+    if (this.#messages.length > this.#expected) {
       const error = new Error(
-        `Expected: ${this._expected} messages, received: ${this._messages.length}`,
+        `Expected: ${this.#expected} messages, received: ${this.#messages.length}`,
       );
       this.done = Promise.reject(error);
       throw error;
@@ -77,10 +77,10 @@ class MessageStore {
   };
 
   reset = (expected: number): void => {
-    this._expected = expected;
-    this._messages = [];
+    this.#expected = expected;
+    this.#messages = [];
     this.done = new Promise((resolve) => {
-      this._resolve = resolve;
+      this.#resolve = resolve;
     });
   };
 }
@@ -1353,11 +1353,11 @@ describe("RandomAccessPlayer", () => {
 
   describe("metrics collecting", () => {
     class TestMetricsCollector implements PlayerMetricsCollectorInterface {
-      _initialized: number = 0;
-      _played: number = 0;
-      _paused: number = 0;
-      _seeked: number = 0;
-      _speed: number[] = [];
+      #initialized: number = 0;
+      #played: number = 0;
+      #paused: number = 0;
+      #seeked: number = 0;
+      #speed: number[] = [];
 
       setProperty(_key: string, _value: string | number | boolean): void {
         // no-op
@@ -1366,19 +1366,19 @@ describe("RandomAccessPlayer", () => {
         // no-op
       }
       initialized(): void {
-        this._initialized++;
+        this.#initialized++;
       }
       play(_speed: number): void {
-        this._played++;
+        this.#played++;
       }
       seek(_time: Time): void {
-        this._seeked++;
+        this.#seeked++;
       }
       setSpeed(speed: number): void {
-        this._speed.push(speed);
+        this.#speed.push(speed);
       }
       pause(): void {
-        this._paused++;
+        this.#paused++;
       }
       setSubscriptions(): void {
         // no-op
@@ -1403,11 +1403,11 @@ describe("RandomAccessPlayer", () => {
       }
       stats() {
         return {
-          initialized: this._initialized,
-          played: this._played,
-          paused: this._paused,
-          seeked: this._seeked,
-          speed: this._speed,
+          initialized: this.#initialized,
+          played: this.#played,
+          paused: this.#paused,
+          seeked: this.#seeked,
+          speed: this.#speed,
         };
       }
       recordTimeToFirstMsgs(): void {

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -94,8 +94,8 @@ export type RandomAccessPlayerOptions = {
 
 // A `Player` that wraps around a tree of `RandomAccessDataProviders`.
 export default class RandomAccessPlayer implements Player {
-  private _label?: string;
-  private _filePath?: string;
+  #label?: string;
+  #filePath?: string;
   _provider: RandomAccessDataProvider;
   _isPlaying: boolean = false;
   _wasPlayingBeforeTabSwitch = false;
@@ -148,8 +148,8 @@ export default class RandomAccessPlayer implements Player {
     providerDescriptor: RandomAccessDataProviderDescriptor,
     { metricsCollector, seekToTime }: RandomAccessPlayerOptions,
   ) {
-    this._label = providerDescriptor.label;
-    this._filePath = providerDescriptor.filePath;
+    this.#label = providerDescriptor.label;
+    this.#filePath = providerDescriptor.filePath;
     if (process.env.NODE_ENV === "test" && providerDescriptor.name === "TestProvider") {
       this._provider = providerDescriptor.args.provider;
     } else {
@@ -266,8 +266,8 @@ export default class RandomAccessPlayer implements Player {
 
     if (this._hasError) {
       return this._listener({
-        name: this._label,
-        filePath: this._filePath,
+        name: this.#label,
+        filePath: this.#filePath,
         presence: PlayerPresence.ERROR,
         progress: {},
         capabilities: [],
@@ -313,8 +313,8 @@ export default class RandomAccessPlayer implements Player {
     }
 
     const data: PlayerState = {
-      name: this._label,
-      filePath: this._filePath,
+      name: this.#label,
+      filePath: this.#filePath,
       presence: this._reconnecting
         ? PlayerPresence.RECONNECTING
         : this._initializing

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -96,53 +96,53 @@ export type RandomAccessPlayerOptions = {
 export default class RandomAccessPlayer implements Player {
   #label?: string;
   #filePath?: string;
-  _provider: RandomAccessDataProvider;
-  _isPlaying: boolean = false;
-  _wasPlayingBeforeTabSwitch = false;
-  _listener?: (arg0: PlayerState) => Promise<void>;
-  _speed: number = 0.2;
-  _start: Time = { sec: 0, nsec: 0 };
-  _end: Time = { sec: 0, nsec: 0 };
+  #provider: RandomAccessDataProvider;
+  #isPlaying: boolean = false;
+  #wasPlayingBeforeTabSwitch = false;
+  #listener?: (arg0: PlayerState) => Promise<void>;
+  #speed: number = 0.2;
+  #start: Time = { sec: 0, nsec: 0 };
+  #end: Time = { sec: 0, nsec: 0 };
   // next read start time indicates where to start reading for the next tick
   // after a tick read, it is set to 1nsec past the end of the read operation (preparing for the next tick)
-  _nextReadStartTime: Time = { sec: 0, nsec: 0 };
-  _lastTickMillis?: number;
+  #nextReadStartTime: Time = { sec: 0, nsec: 0 };
+  #lastTickMillis?: number;
   // The last time a "seek" was started. This is used to cancel async operations, such as seeks or ticks, when a seek
   // happens while they are ocurring.
-  _lastSeekStartTime: number = Date.now();
+  #lastSeekStartTime: number = Date.now();
   // This is the "lastSeekTime" emitted in the playerState. It is not the same as the _lastSeekStartTime because we can
   // start a seek and not end up emitting it, or emit something else while we are requesting messages for the seek. The
   // RandomAccessDataProvider's `progressCallback` can cause an emit at any time, for example.
   // We only want to set the "lastSeekTime" exactly when we emit the messages coming from the seek.
-  _lastSeekEmitTime: number = this._lastSeekStartTime;
-  _cancelSeekBackfill: boolean = false;
-  _parsedSubscribedTopics: Set<string> = new Set();
-  _providerTopics: Topic[] = [];
-  _providerConnections: Connection[] = [];
-  _providerDatatypes: RosDatatypes = new Map();
-  _metricsCollector: PlayerMetricsCollectorInterface;
-  _initializing: boolean = true;
-  _initialized: boolean = false;
-  _reconnecting: boolean = false;
-  _progress: Progress = Object.freeze({});
-  _id: string = uuidv4();
-  _messages: MessageEvent<unknown>[] = [];
-  _receivedBytes: number = 0;
-  _messageOrder: TimestampMethod = "receiveTime";
-  _hasError = false;
-  _closed = false;
-  _seekToTime: SeekToTimeSpec;
-  _lastRangeMillis?: number;
-  _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
+  #lastSeekEmitTime: number = this.#lastSeekStartTime;
+  #cancelSeekBackfill: boolean = false;
+  #parsedSubscribedTopics: Set<string> = new Set();
+  #providerTopics: Topic[] = [];
+  #providerConnections: Connection[] = [];
+  #providerDatatypes: RosDatatypes = new Map();
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #initializing: boolean = true;
+  #initialized: boolean = false;
+  #reconnecting: boolean = false;
+  #progress: Progress = Object.freeze({});
+  #id: string = uuidv4();
+  #messages: MessageEvent<unknown>[] = [];
+  #receivedBytes: number = 0;
+  #messageOrder: TimestampMethod = "receiveTime";
+  #hasError = false;
+  #closed = false;
+  #seekToTime: SeekToTimeSpec;
+  #lastRangeMillis?: number;
+  #parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
-  _currentTime?: Time;
+  #currentTime?: Time;
 
   // The problem store holds problems based on keys (which may be hard-coded problem types or topics)
   // The overall player may be healthy, but individual topics may have warnings or errors.
   // These are set/cleared in the store to track the current set of problems
-  _problems = new Map<string, PlayerProblem>();
+  #problems = new Map<string, PlayerProblem>();
 
   constructor(
     providerDescriptor: RandomAccessDataProviderDescriptor,
@@ -151,64 +151,64 @@ export default class RandomAccessPlayer implements Player {
     this.#label = providerDescriptor.label;
     this.#filePath = providerDescriptor.filePath;
     if (process.env.NODE_ENV === "test" && providerDescriptor.name === "TestProvider") {
-      this._provider = providerDescriptor.args.provider;
+      this.#provider = providerDescriptor.args.provider;
     } else {
-      this._provider = rootGetDataProvider(providerDescriptor);
+      this.#provider = rootGetDataProvider(providerDescriptor);
     }
-    this._metricsCollector = metricsCollector ?? new NoopMetricsCollector();
-    this._seekToTime = seekToTime;
-    this._metricsCollector.playerConstructed();
+    this.#metricsCollector = metricsCollector ?? new NoopMetricsCollector();
+    this.#seekToTime = seekToTime;
+    this.#metricsCollector.playerConstructed();
   }
 
   private _setError(message: string, error?: Error): void {
-    this._hasError = true;
-    this._problems.set("global-error", {
+    this.#hasError = true;
+    this.#problems.set("global-error", {
       severity: "error",
       message,
       error,
     });
-    this._isPlaying = false;
-    if (!this._initializing) {
-      void this._provider.close();
+    this.#isPlaying = false;
+    if (!this.#initializing) {
+      void this.#provider.close();
     }
-    this._emitState();
+    this.#emitState();
   }
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
-    this._emitState();
+    this.#listener = listener;
+    this.#emitState();
 
-    this._provider
+    this.#provider
       .initialize({
         progressCallback: (progress: Progress) => {
-          this._progress = progress;
+          this.#progress = progress;
           // Don't emit progress when we are playing, because we will emit whenever we get new messages anyways and
           // emitting unnecessarily will reduce playback performance.
-          if (!this._isPlaying) {
-            this._emitState();
+          if (!this.#isPlaying) {
+            this.#emitState();
           }
         },
         reportMetadataCallback: (metadata: RandomAccessDataProviderMetadata) => {
           switch (metadata.type) {
             case "updateReconnecting":
-              this._reconnecting = metadata.reconnecting;
+              this.#reconnecting = metadata.reconnecting;
 
-              this._emitState();
+              this.#emitState();
 
               break;
             case "average_throughput":
-              this._metricsCollector.recordDataProviderPerformance(metadata);
+              this.#metricsCollector.recordDataProviderPerformance(metadata);
 
               break;
             case "initializationPerformance":
-              this._metricsCollector.recordDataProviderInitializePerformance(metadata);
+              this.#metricsCollector.recordDataProviderInitializePerformance(metadata);
 
               break;
             case "received_bytes":
-              this._receivedBytes += metadata.bytes;
+              this.#receivedBytes += metadata.bytes;
               break;
             case "data_provider_stall":
-              this._metricsCollector.recordDataProviderStall(metadata);
+              this.#metricsCollector.recordDataProviderStall(metadata);
 
               break;
             default:
@@ -227,27 +227,27 @@ export default class RandomAccessPlayer implements Player {
           return;
         }
 
-        const initialTime = getSeekTimeFromSpec(this._seekToTime, start, end);
+        const initialTime = getSeekTimeFromSpec(this.#seekToTime, start, end);
 
-        this._start = start;
-        this._nextReadStartTime = initialTime;
-        this._end = end;
-        this._providerTopics = topics;
-        this._providerConnections = connections;
-        this._providerDatatypes = parsedMessageDefinitions.datatypes;
-        this._parsedMessageDefinitionsByTopic =
+        this.#start = start;
+        this.#nextReadStartTime = initialTime;
+        this.#end = end;
+        this.#providerTopics = topics;
+        this.#providerConnections = connections;
+        this.#providerDatatypes = parsedMessageDefinitions.datatypes;
+        this.#parsedMessageDefinitionsByTopic =
           parsedMessageDefinitions.parsedMessageDefinitionsByTopic;
-        this._initializing = false;
+        this.#initializing = false;
         this._reportInitialized();
 
         // Wait a bit until panels have had the chance to subscribe to topics before we start
         // playback.
         setTimeout(() => {
-          if (this._closed) {
+          if (this.#closed) {
             return;
           }
           // Only do the initial seek if we haven't started playing already.
-          if (!this._isPlaying && areEqual(this._nextReadStartTime, initialTime)) {
+          if (!this.#isPlaying && areEqual(this.#nextReadStartTime, initialTime)) {
             this.seekPlayback(initialTime);
           }
         }, SEEK_START_DELAY_MS);
@@ -259,42 +259,42 @@ export default class RandomAccessPlayer implements Player {
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  _emitState = debouncePromise(() => {
-    if (!this._listener) {
+  #emitState = debouncePromise(() => {
+    if (!this.#listener) {
       return Promise.resolve();
     }
 
-    if (this._hasError) {
-      return this._listener({
+    if (this.#hasError) {
+      return this.#listener({
         name: this.#label,
         filePath: this.#filePath,
         presence: PlayerPresence.ERROR,
         progress: {},
         capabilities: [],
-        playerId: this._id,
+        playerId: this.#id,
         activeData: undefined,
-        problems: Array.from(this._problems.values()),
+        problems: Array.from(this.#problems.values()),
       });
     }
 
-    const messages = this._messages;
-    this._messages = [];
+    const messages = this.#messages;
+    this.#messages = [];
     if (messages.length > 0) {
       // If we're outputting any messages, we need to cancel any in-progress backfills. Otherwise
       // we'd be "traveling back in time".
-      this._cancelSeekBackfill = true;
+      this.#cancelSeekBackfill = true;
     }
 
     // _nextReadStartTime points to the start of the _next_ range we want to read
     // for our player state, we want to have currentTime represent the last time of the range we read
     // It would be weird to provide a currentTime outside the bounds of what we read
-    let lastEnd = this._nextReadStartTime;
+    let lastEnd = this.#nextReadStartTime;
     if (lastEnd.sec > 0 || lastEnd.nsec > 0) {
       lastEnd = add(lastEnd, { sec: 0, nsec: -1 });
     }
 
     const publishedTopics = new Map<string, Set<string>>();
-    for (const conn of this._providerConnections) {
+    for (const conn of this.#providerConnections) {
       let publishers = publishedTopics.get(conn.topic);
       if (publishers == undefined) {
         publishers = new Set<string>();
@@ -307,47 +307,47 @@ export default class RandomAccessPlayer implements Player {
     // lastEnd is not stable due to the above TimeUtil.add which returns a new lastEnd value on ever call
     // Here we check if lastEnd is the same as the currentTime we've already set and avoid assigning
     // a new reference value to current time if the underlying time value is unchanged
-    const clampedLastEnd = clampTime(lastEnd, this._start, this._end);
-    if (!this._currentTime || compare(this._currentTime, clampedLastEnd) !== 0) {
-      this._currentTime = clampedLastEnd;
+    const clampedLastEnd = clampTime(lastEnd, this.#start, this.#end);
+    if (!this.#currentTime || compare(this.#currentTime, clampedLastEnd) !== 0) {
+      this.#currentTime = clampedLastEnd;
     }
 
     const data: PlayerState = {
       name: this.#label,
       filePath: this.#filePath,
-      presence: this._reconnecting
+      presence: this.#reconnecting
         ? PlayerPresence.RECONNECTING
-        : this._initializing
+        : this.#initializing
         ? PlayerPresence.INITIALIZING
         : PlayerPresence.PRESENT,
-      progress: this._progress,
+      progress: this.#progress,
       capabilities,
-      playerId: this._id,
-      problems: this._problems.size > 0 ? Array.from(this._problems.values()) : undefined,
-      activeData: this._initializing
+      playerId: this.#id,
+      problems: this.#problems.size > 0 ? Array.from(this.#problems.values()) : undefined,
+      activeData: this.#initializing
         ? undefined
         : {
             messages,
-            totalBytesReceived: this._receivedBytes,
-            messageOrder: this._messageOrder,
-            currentTime: this._currentTime,
-            startTime: this._start,
-            endTime: this._end,
-            isPlaying: this._isPlaying,
-            speed: this._speed,
-            lastSeekTime: this._lastSeekEmitTime,
-            topics: this._providerTopics,
-            datatypes: this._providerDatatypes,
+            totalBytesReceived: this.#receivedBytes,
+            messageOrder: this.#messageOrder,
+            currentTime: this.#currentTime,
+            startTime: this.#start,
+            endTime: this.#end,
+            isPlaying: this.#isPlaying,
+            speed: this.#speed,
+            lastSeekTime: this.#lastSeekEmitTime,
+            topics: this.#providerTopics,
+            datatypes: this.#providerDatatypes,
             publishedTopics,
-            parsedMessageDefinitionsByTopic: this._parsedMessageDefinitionsByTopic,
+            parsedMessageDefinitionsByTopic: this.#parsedMessageDefinitionsByTopic,
           },
     };
 
-    return this._listener(data);
+    return this.#listener(data);
   });
 
   async _tick(): Promise<void> {
-    if (this._initializing || !this._isPlaying || this._hasError) {
+    if (this.#initializing || !this.#isPlaying || this.#hasError) {
       return;
     }
 
@@ -355,59 +355,59 @@ export default class RandomAccessPlayer implements Player {
     // the time since our last read and how fast we're currently playing back
     const tickTime = performance.now();
     const durationMillis =
-      this._lastTickMillis != undefined && this._lastTickMillis !== 0
-        ? tickTime - this._lastTickMillis
+      this.#lastTickMillis != undefined && this.#lastTickMillis !== 0
+        ? tickTime - this.#lastTickMillis
         : 20;
-    this._lastTickMillis = tickTime;
+    this.#lastTickMillis = tickTime;
 
     // Read at most 300ms worth of messages, otherwise things can get out of control if rendering
     // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
     // cause the next frame to also be unnecessarily slow by increasing the frame size.
-    let rangeMillis = Math.min(durationMillis * this._speed, 300);
-    if (this._lastRangeMillis != undefined) {
-      rangeMillis = this._lastRangeMillis * 0.9 + rangeMillis * 0.1;
+    let rangeMillis = Math.min(durationMillis * this.#speed, 300);
+    if (this.#lastRangeMillis != undefined) {
+      rangeMillis = this.#lastRangeMillis * 0.9 + rangeMillis * 0.1;
     }
-    this._lastRangeMillis = rangeMillis;
+    this.#lastRangeMillis = rangeMillis;
 
     // read is past end of bag, no more to read
-    if (compare(this._nextReadStartTime, this._end) > 0) {
+    if (compare(this.#nextReadStartTime, this.#end) > 0) {
       return;
     }
 
-    const seekTime = this._lastSeekStartTime;
-    const start: Time = clampTime(this._nextReadStartTime, this._start, this._end);
+    const seekTime = this.#lastSeekStartTime;
+    const start: Time = clampTime(this.#nextReadStartTime, this.#start, this.#end);
     const end: Time = clampTime(
-      add(this._nextReadStartTime, fromMillis(rangeMillis)),
-      this._start,
-      this._end,
+      add(this.#nextReadStartTime, fromMillis(rangeMillis)),
+      this.#start,
+      this.#end,
     );
 
     const { parsedMessages: messages } = await this._getMessages(start, end);
-    await this._emitState.currentPromise;
+    await this.#emitState.currentPromise;
 
     // if we seeked while reading then do not emit messages
     // just start reading again from the new seek position
-    if (this._lastSeekStartTime !== seekTime) {
+    if (this.#lastSeekStartTime !== seekTime) {
       return;
     }
 
     // our read finished and we didn't seed during the read, prepare for the next tick
     // we need to do this after checking for seek changes since seek time may have changed
-    this._nextReadStartTime = add(end, { sec: 0, nsec: 1 });
+    this.#nextReadStartTime = add(end, { sec: 0, nsec: 1 });
 
     // if we paused while reading then do not emit messages
     // and exit the read loop
-    if (!this._isPlaying) {
+    if (!this.#isPlaying) {
       return;
     }
 
-    this._messages = this._messages.concat(messages);
-    this._emitState();
+    this.#messages = this.#messages.concat(messages);
+    this.#emitState();
   }
 
-  _read = debouncePromise(async () => {
+  #read = debouncePromise(async () => {
     try {
-      while (this._isPlaying && !this._hasError) {
+      while (this.#isPlaying && !this.#hasError) {
         const start = Date.now();
         await this._tick();
         const time = Date.now() - start;
@@ -423,26 +423,26 @@ export default class RandomAccessPlayer implements Player {
   });
 
   async _getMessages(start: Time, end: Time): Promise<{ parsedMessages: MessageEvent<unknown>[] }> {
-    const parsedTopics = getSanitizedTopics(this._parsedSubscribedTopics, this._providerTopics);
+    const parsedTopics = getSanitizedTopics(this.#parsedSubscribedTopics, this.#providerTopics);
     if (parsedTopics.length === 0) {
       return { parsedMessages: [] };
     }
     if (!this.hasCachedRange(start, end)) {
-      this._metricsCollector.recordUncachedRangeRequest();
+      this.#metricsCollector.recordUncachedRangeRequest();
     }
-    const messages = await this._provider.getMessages(start, end, {
+    const messages = await this.#provider.getMessages(start, end, {
       parsedMessages: parsedTopics,
     });
     const { parsedMessages } = messages;
     if (parsedMessages == undefined) {
-      this._problems.set("bad-messages", {
+      this.#problems.set("bad-messages", {
         severity: "error",
         message: `Bad set of messages`,
         tip: `Restart the app or contact support if the issue persists.`,
       });
       return { parsedMessages: [] };
     }
-    this._problems.delete("bad-messages");
+    this.#problems.delete("bad-messages");
 
     // It is very important that we record first emitted messages here, since
     // `_emitState` is awaited on `requestAnimationFrame`, which will not be
@@ -450,29 +450,29 @@ export default class RandomAccessPlayer implements Player {
     // Moreover, there is a disproportionally small amount of time between when we procure
     // messages here and when they are set to playerState.
     if (parsedMessages.length > 0) {
-      this._metricsCollector.recordTimeToFirstMsgs();
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
     const filterMessages = (msgs: readonly MessageEvent<unknown>[], topics: string[]) =>
       filterMap(msgs, (message) => {
-        this._problems.delete(message.topic);
+        this.#problems.delete(message.topic);
 
         if (!topics.includes(message.topic)) {
-          this._problems.set(message.topic, {
+          this.#problems.set(message.topic, {
             severity: "warn",
             message: `Unexpected topic encountered: ${message.topic}. Skipping message`,
           });
           return undefined;
         }
-        const topic = this._providerTopics.find((t) => t.name === message.topic);
+        const topic = this.#providerTopics.find((t) => t.name === message.topic);
         if (!topic) {
-          this._problems.set(message.topic, {
+          this.#problems.set(message.topic, {
             severity: "warn",
             message: `Unexpected message on topic: ${message.topic}. Skipping message`,
           });
           return undefined;
         }
         if (topic.datatype === "") {
-          this._problems.set(message.topic, {
+          this.#problems.set(message.topic, {
             severity: "warn",
             message: `Missing datatype for topic: ${message.topic}. Skipping message`,
           });
@@ -491,115 +491,115 @@ export default class RandomAccessPlayer implements Player {
   }
 
   startPlayback(): void {
-    if (this._isPlaying) {
+    if (this.#isPlaying) {
       return;
     }
-    this._metricsCollector.play(this._speed);
-    this._isPlaying = true;
-    this._emitState();
-    this._read();
+    this.#metricsCollector.play(this.#speed);
+    this.#isPlaying = true;
+    this.#emitState();
+    this.#read();
   }
 
   pausePlayback(): void {
-    if (!this._isPlaying) {
+    if (!this.#isPlaying) {
       return;
     }
-    this._metricsCollector.pause();
+    this.#metricsCollector.pause();
     // clear out last tick millis so we don't read a huge chunk when we unpause
-    this._lastTickMillis = undefined;
-    this._isPlaying = false;
-    this._emitState();
+    this.#lastTickMillis = undefined;
+    this.#isPlaying = false;
+    this.#emitState();
   }
 
   setPlaybackSpeed(speed: number): void {
-    delete this._lastRangeMillis;
-    this._speed = speed;
-    this._metricsCollector.setSpeed(speed);
-    this._emitState();
+    this.#lastRangeMillis = undefined;
+    this.#speed = speed;
+    this.#metricsCollector.setSpeed(speed);
+    this.#emitState();
   }
 
   _reportInitialized(): void {
-    if (this._initializing || this._initialized) {
+    if (this.#initializing || this.#initialized) {
       return;
     }
-    this._metricsCollector.initialized();
-    this._initialized = true;
+    this.#metricsCollector.initialized();
+    this.#initialized = true;
   }
 
   _setNextReadStartTime(time: Time): void {
-    this._metricsCollector.recordPlaybackTime(time, {
-      stillLoadingData: !this.hasCachedRange(this._start, this._end),
+    this.#metricsCollector.recordPlaybackTime(time, {
+      stillLoadingData: !this.hasCachedRange(this.#start, this.#end),
     });
-    this._nextReadStartTime = clampTime(time, this._start, this._end);
+    this.#nextReadStartTime = clampTime(time, this.#start, this.#end);
   }
 
-  _seekPlaybackInternal = debouncePromise(async (backfillDuration?: Time) => {
+  #seekPlaybackInternal = debouncePromise(async (backfillDuration?: Time) => {
     const seekTime = Date.now();
-    this._lastSeekStartTime = seekTime;
-    this._cancelSeekBackfill = false;
+    this.#lastSeekStartTime = seekTime;
+    this.#cancelSeekBackfill = false;
     // cancel any queued _emitState that might later emit messages from before we seeked
-    this._messages = [];
+    this.#messages = [];
 
     // backfill includes the current time we've seek'd to
     // playback after backfill will load messages after the seek time
-    const backfillEnd = clampTime(this._nextReadStartTime, this._start, this._end);
+    const backfillEnd = clampTime(this.#nextReadStartTime, this.#start, this.#end);
 
     // Backfill a few hundred milliseconds of data if we're paused so panels have something to show.
     // If we're playing, we'll give the panels some data soon anyway.
-    const internalBackfillDuration = { sec: 0, nsec: this._isPlaying ? 0 : SEEK_BACK_NANOSECONDS };
+    const internalBackfillDuration = { sec: 0, nsec: this.#isPlaying ? 0 : SEEK_BACK_NANOSECONDS };
     // Add on any extra time needed by the OrderedStampPlayer.
     const totalBackfillDuration = add(
       internalBackfillDuration,
       backfillDuration ?? { sec: 0, nsec: 0 },
     );
     const backfillStart = clampTime(
-      subtractTimes(this._nextReadStartTime, totalBackfillDuration),
-      this._start,
-      this._end,
+      subtractTimes(this.#nextReadStartTime, totalBackfillDuration),
+      this.#start,
+      this.#end,
     );
 
     // Only getMessages if we have some messages to get.
-    if (backfillDuration || !this._isPlaying) {
+    if (backfillDuration || !this.#isPlaying) {
       const { parsedMessages: messages } = await this._getMessages(backfillStart, backfillEnd);
       // Only emit the messages if we haven't seeked again / emitted messages since we
       // started loading them. Note that for the latter part just checking for `isPlaying`
       // is not enough because the user might have started playback and then paused again!
       // Therefore we really need something like `this._cancelSeekBackfill`.
-      if (this._lastSeekStartTime === seekTime && !this._cancelSeekBackfill) {
+      if (this.#lastSeekStartTime === seekTime && !this.#cancelSeekBackfill) {
         // similar to _tick(), we set the next start time past where we have read
         // this happens after reading and confirming that playback or other seeking hasn't happened
-        this._nextReadStartTime = add(backfillEnd, { sec: 0, nsec: 1 });
+        this.#nextReadStartTime = add(backfillEnd, { sec: 0, nsec: 1 });
 
-        this._messages = messages;
-        this._lastSeekEmitTime = seekTime;
-        this._emitState();
+        this.#messages = messages;
+        this.#lastSeekEmitTime = seekTime;
+        this.#emitState();
       }
     } else {
       // If we are playing, make sure we set this emit time so that consumers will know that we seeked.
-      this._lastSeekEmitTime = seekTime;
+      this.#lastSeekEmitTime = seekTime;
     }
   });
 
   seekPlayback(time: Time, backfillDuration?: Time): void {
     // Only seek when the provider initialization is done.
-    if (!this._initialized) {
+    if (!this.#initialized) {
       return;
     }
-    this._metricsCollector.seek(time);
+    this.#metricsCollector.seek(time);
     this._setNextReadStartTime(time);
-    this._seekPlaybackInternal(backfillDuration);
+    this.#seekPlaybackInternal(backfillDuration);
   }
 
   setSubscriptions(newSubscriptions: SubscribePayload[]): void {
-    this._parsedSubscribedTopics = new Set(newSubscriptions.map(({ topic }) => topic));
-    this._metricsCollector.setSubscriptions(newSubscriptions);
+    this.#parsedSubscribedTopics = new Set(newSubscriptions.map(({ topic }) => topic));
+    this.#metricsCollector.setSubscriptions(newSubscriptions);
   }
 
   requestBackfill(): void {
-    if (this._isPlaying || this._initializing || !this._currentTime) {
+    if (this.#isPlaying || this.#initializing || !this.#currentTime) {
       return;
     }
-    this.seekPlayback(this._currentTime);
+    this.seekPlayback(this.#currentTime);
   }
 
   setPublishers(_publishers: AdvertiseOptions[]): void {
@@ -615,21 +615,21 @@ export default class RandomAccessPlayer implements Player {
   }
 
   close(): void {
-    this._isPlaying = false;
-    this._closed = true;
-    if (!this._initializing && !this._hasError) {
-      void this._provider.close();
+    this.#isPlaying = false;
+    this.#closed = true;
+    if (!this.#initializing && !this.#hasError) {
+      void this.#provider.close();
     }
-    this._metricsCollector.close();
+    this.#metricsCollector.close();
   }
 
   // Exposed for testing.
   hasCachedRange(start: Time, end: Time): boolean {
-    const fractionStart = percentOf(this._start, this._end, start);
-    const fractionEnd = percentOf(this._start, this._end, end);
+    const fractionStart = percentOf(this.#start, this.#end, start);
+    const fractionEnd = percentOf(this.#start, this.#end, end);
     return isRangeCoveredByRanges(
       { start: fractionStart, end: fractionEnd },
-      this._progress.fullyLoadedFractionRanges ?? [],
+      this.#progress.fullyLoadedFractionRanges ?? [],
     );
   }
 

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -65,50 +65,50 @@ type Ros1PlayerOpts = {
 // Connects to `rosmaster` instance using `@foxglove/ros1`. Currently doesn't support seeking or
 // showing simulated time, so current time from Date.now() is always used instead.
 export default class Ros1Player implements Player {
-  private _url: string; // rosmaster URL.
-  private _hostname?: string; // ROS_HOSTNAME
-  private _rosNode?: RosNode; // Our ROS node when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed: boolean = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: Topic[]; // Topics as advertised by rosmaster.
-  private _providerDatatypes: RosDatatypes = new Map(); // All ROS message definitions received from subscriptions and set by publishers.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
-  private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
-  private _parameters = new Map<string, ParameterValue>(); // rosparams
-  private _start?: Time; // The time at which we started playing.
-  private _clockTime?: Time; // The most recent published `/clock` time, if available
-  private _clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _messageOrder: TimestampMethod = "receiveTime";
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
-  private _hasReceivedMessage = false;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
+  #url: string; // rosmaster URL.
+  #hostname?: string; // ROS_HOSTNAME
+  #rosNode?: RosNode; // Our ROS node when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed: boolean = false; // Whether the player has been completely closed using close().
+  #providerTopics?: Topic[]; // Topics as advertised by rosmaster.
+  #providerDatatypes: RosDatatypes = new Map(); // All ROS message definitions received from subscriptions and set by publishers.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
+  #parameters = new Map<string, ParameterValue>(); // rosparams
+  #start?: Time; // The time at which we started playing.
+  #clockTime?: Time; // The most recent published `/clock` time, if available
+  #clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #messageOrder: TimestampMethod = "receiveTime";
+  #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  #hasReceivedMessage = false;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({ url, hostname, metricsCollector }: Ros1PlayerOpts) {
     log.info(`initializing Ros1Player (url=${url})`);
-    this._metricsCollector = metricsCollector;
-    this._url = url;
-    this._hostname = hostname;
-    this._start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
-    void this._open();
+    this.#metricsCollector = metricsCollector;
+    this.#url = url;
+    this.#hostname = hostname;
+    this.#start = fromMillis(Date.now());
+    this.#metricsCollector.playerConstructed();
+    void this.#open();
   }
 
-  private _open = async (): Promise<void> => {
+  #open = async (): Promise<void> => {
     const os = OsContextSingleton;
-    if (this._closed || os == undefined) {
+    if (this.#closed || os == undefined) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this.#presence = PlayerPresence.INITIALIZING;
 
     const hostname =
-      this._hostname ??
+      this.#hostname ??
       RosNode.GetRosHostname(os.getEnvVar, os.getHostname, os.getNetworkInterfaces);
 
     const net = await Sockets.Create();
@@ -119,22 +119,22 @@ export default class Ros1Player implements Player {
     const tcpServer = await net.createServer();
     void tcpServer.listen(undefined, hostname, 10);
 
-    if (this._rosNode == undefined) {
+    if (this.#rosNode == undefined) {
       const rosNode = new RosNode({
         name: "/foxglovestudio",
         hostname,
         pid: os.pid,
-        rosMasterUri: this._url,
+        rosMasterUri: this.#url,
         httpServer: httpServer as unknown as HttpServer,
         tcpSocketCreate,
         tcpServer,
         log: rosLog,
       });
-      this._rosNode = rosNode;
+      this.#rosNode = rosNode;
 
       rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
         log.debug("paramUpdate", key, value, prevValue, callerId);
-        this._parameters = new Map(rosNode.parameters);
+        this.#parameters = new Map(rosNode.parameters);
       });
       rosNode.on("error", (error) => {
         this._addProblem(Problem.Node, {
@@ -146,9 +146,9 @@ export default class Ros1Player implements Player {
       });
     }
 
-    await this._rosNode.start();
-    await this._requestTopics();
-    this._presence = PlayerPresence.PRESENT;
+    await this.#rosNode.start();
+    await this.#requestTopics();
+    this.#presence = PlayerPresence.PRESENT;
   };
 
   private _addProblem(
@@ -156,39 +156,39 @@ export default class Ros1Player implements Player {
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problems.addProblem(id, problem);
+    this.#problems.addProblem(id, problem);
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   private _clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
-    if (this._problems.removeProblem(id)) {
+    if (this.#problems.removeProblem(id)) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
   private _clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
     if (
-      this._problems.removeProblems(
+      this.#problems.removeProblems(
         (id) =>
           id.startsWith("msgdef:") || id.startsWith("advertise:") || id.startsWith("publish:"),
       )
     ) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
-  private _requestTopics = async (): Promise<void> => {
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+  #requestTopics = async (): Promise<void> => {
+    if (this.#requestTopicsTimeout) {
+      clearTimeout(this.#requestTopicsTimeout);
     }
-    const rosNode = this._rosNode;
-    if (!rosNode || this._closed) {
+    const rosNode = this.#rosNode;
+    if (!rosNode || this.#closed) {
       return;
     }
 
@@ -198,23 +198,23 @@ export default class Ros1Player implements Player {
       // Sort them for easy comparison
       const sortedTopics: Topic[] = sortBy(topics, "name");
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
+      if (this.#providerTopics == undefined) {
+        this.#metricsCollector.initialized();
       }
 
-      if (!isEqual(sortedTopics, this._providerTopics)) {
-        this._providerTopics = sortedTopics;
+      if (!isEqual(sortedTopics, this.#providerTopics)) {
+        this.#providerTopics = sortedTopics;
       }
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+      this.setSubscriptions(this.#requestedSubscriptions);
 
       // Subscribe to all parameters
       try {
         const params = await rosNode.subscribeAllParams();
-        if (!isEqual(params, this._parameters)) {
-          this._parameters = new Map();
-          params.forEach((value, key) => this._parameters.set(key, value));
+        if (!isEqual(params, this.#parameters)) {
+          this.#parameters = new Map();
+          params.forEach((value, key) => this.#parameters.set(key, value));
         }
         this._clearProblem(Problem.Parameters, { skipEmit: true });
       } catch (error) {
@@ -223,7 +223,7 @@ export default class Ros1Player implements Player {
           {
             severity: "warn",
             message: "ROS parameter fetch failed",
-            tip: `Ensure that roscore is running and accessible at: ${this._url}`,
+            tip: `Ensure that roscore is running and accessible at: ${this.#url}`,
             error,
           },
           { skipEmit: true },
@@ -233,71 +233,71 @@ export default class Ros1Player implements Player {
       // Fetch the full graph topology
       await this._updateConnectionGraph(rosNode);
 
-      this._presence = PlayerPresence.PRESENT;
-      this._emitState();
+      this.#presence = PlayerPresence.PRESENT;
+      this.#emitState();
     } catch (error) {
-      this._presence = PlayerPresence.INITIALIZING;
+      this.#presence = PlayerPresence.INITIALIZING;
       this._addProblem(
         Problem.Connection,
         {
           severity: "error",
           message: "ROS connection failed",
-          tip: `Ensure that roscore is running and accessible at: ${this._url}`,
+          tip: `Ensure that roscore is running and accessible at: ${this.#url}`,
           error,
         },
         { skipEmit: false },
       );
     } finally {
       // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      this.#requestTopicsTimeout = setTimeout(this.#requestTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+  #emitState = debouncePromise(() => {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const providerTopics = this._providerTopics;
-    const start = this._start;
+    const providerTopics = this.#providerTopics;
+    const start = this.#start;
     if (!providerTopics || !start) {
-      return this._listener({
-        name: this._url,
-        presence: this._presence,
+      return this.#listener({
+        name: this.#url,
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
-        playerId: this._id,
-        problems: this._problems.problems(),
+        playerId: this.#id,
+        problems: this.#problems.problems(),
         activeData: undefined,
       });
     }
 
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
-    return this._listener({
-      name: this._url,
-      presence: this._presence,
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
+    return this.#listener({
+      name: this.#url,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
-      playerId: this._id,
-      problems: this._problems.problems(),
+      playerId: this.#id,
+      problems: this.#problems.problems(),
 
       activeData: {
         messages,
-        totalBytesReceived: this._rosNode?.receivedBytes() ?? 0,
-        messageOrder: this._messageOrder,
+        totalBytesReceived: this.#rosNode?.receivedBytes() ?? 0,
+        messageOrder: this.#messageOrder,
         startTime: start,
         endTime: currentTime,
         currentTime,
@@ -307,38 +307,38 @@ export default class Ros1Player implements Player {
         // that we don't accidentally hit falsy checks.
         lastSeekTime: 1,
         topics: providerTopics,
-        datatypes: this._providerDatatypes,
-        publishedTopics: this._publishedTopics,
-        subscribedTopics: this._subscribedTopics,
-        services: this._services,
-        parameters: this._parameters,
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
+        subscribedTopics: this.#subscribedTopics,
+        services: this.#services,
+        parameters: this.#parameters,
         parsedMessageDefinitionsByTopic: {},
       },
     });
   });
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
-    this._emitState();
+    this.#listener = listener;
+    this.#emitState();
   }
 
   close(): void {
-    this._closed = true;
-    if (this._rosNode) {
-      this._rosNode.shutdown();
+    this.#closed = true;
+    if (this.#rosNode) {
+      this.#rosNode.shutdown();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -346,7 +346,7 @@ export default class Ros1Player implements Player {
     this._addInternalSubscriptions(subscriptions);
 
     // See what topics we actually can subscribe to.
-    const availableTopicsByTopicName = getTopicsByTopicName(this._providerTopics ?? []);
+    const availableTopicsByTopicName = getTopicsByTopicName(this.#providerTopics ?? []);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
@@ -354,21 +354,21 @@ export default class Ros1Player implements Player {
     // Subscribe to all topics that we aren't subscribed to yet.
     for (const topicName of topicNames) {
       const availTopic = availableTopicsByTopicName[topicName];
-      if (!availTopic || this._rosNode.subscriptions.has(topicName)) {
+      if (!availTopic || this.#rosNode.subscriptions.has(topicName)) {
         continue;
       }
 
       const { datatype } = availTopic;
-      const subscription = this._rosNode.subscribe({ topic: topicName, dataType: datatype });
+      const subscription = this.#rosNode.subscribe({ topic: topicName, dataType: datatype });
 
       subscription.on("header", (_header, msgdef, _reader) => {
         // We have to create a new object instead of just updating _providerDatatypes to support
         // shallow memo
-        const newDatatypes = this._getRosDatatypes(datatype, msgdef);
-        this._providerDatatypes = new Map([...this._providerDatatypes, ...newDatatypes]);
+        const newDatatypes = this.#getRosDatatypes(datatype, msgdef);
+        this.#providerDatatypes = new Map([...this.#providerDatatypes, ...newDatatypes]);
       });
       subscription.on("message", (message, _data, _pub) =>
-        this._handleMessage(topicName, message, true),
+        this.#handleMessage(topicName, message, true),
       );
       subscription.on("error", (error) => {
         this._addProblem(`subscribe:${topicName}`, {
@@ -381,42 +381,42 @@ export default class Ros1Player implements Player {
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const topicName of this._rosNode.subscriptions.keys()) {
+    for (const topicName of this.#rosNode.subscriptions.keys()) {
       if (!topicNames.includes(topicName)) {
         {
-          this._rosNode.unsubscribe(topicName);
+          this.#rosNode.unsubscribe(topicName);
         }
       }
     }
   }
 
-  private _handleMessage = (
+  #handleMessage = (
     topic: string,
     message: unknown,
     // This is a hot path so we avoid extra object allocation from a parameters struct
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     external: boolean,
   ): void => {
-    if (this._providerTopics == undefined) {
+    if (this.#providerTopics == undefined) {
       return;
     }
 
     const receiveTime = fromMillis(Date.now());
 
-    if (external && !this._hasReceivedMessage) {
-      this._hasReceivedMessage = true;
-      this._metricsCollector.recordTimeToFirstMsgs();
+    if (external && !this.#hasReceivedMessage) {
+      this.#hasReceivedMessage = true;
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     const msg: MessageEvent<unknown> = { topic, receiveTime, message };
-    this._parsedMessages.push(msg);
+    this.#parsedMessages.push(msg);
     this._handleInternalMessage(msg);
 
-    this._emitState();
+    this.#emitState();
   };
 
   setPublishers(publishers: AdvertiseOptions[]): void {
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -427,17 +427,17 @@ export default class Ros1Player implements Player {
     this._clearPublishProblems({ skipEmit: true });
 
     // Unadvertise any topics that were previously published and no longer appear in the list
-    for (const topic of this._rosNode.publications.keys()) {
+    for (const topic of this.#rosNode.publications.keys()) {
       if (!topics.has(topic)) {
-        this._rosNode.unadvertise(topic);
+        this.#rosNode.unadvertise(topic);
       }
     }
 
     // Unadvertise any topics where the dataType changed
     for (const { topic, datatype } of validPublishers) {
-      const existingPub = this._rosNode.publications.get(topic);
+      const existingPub = this.#rosNode.publications.get(topic);
       if (existingPub != undefined && existingPub.dataType !== datatype) {
-        this._rosNode.unadvertise(topic);
+        this.#rosNode.unadvertise(topic);
       }
     }
 
@@ -445,7 +445,7 @@ export default class Ros1Player implements Player {
     for (const advertiseOptions of validPublishers) {
       const { topic, datatype: dataType, options } = advertiseOptions;
 
-      if (this._rosNode.publications.has(topic)) {
+      if (this.#rosNode.publications.has(topic)) {
         continue;
       }
 
@@ -470,7 +470,7 @@ export default class Ros1Player implements Player {
       }
 
       // Advertise this topic to ROS as being published by us
-      this._rosNode.advertise({ topic, dataType, messageDefinition: msgdef }).catch((error) =>
+      this.#rosNode.advertise({ topic, dataType, messageDefinition: msgdef }).catch((error) =>
         this._addProblem(advertiseProblemId, {
           severity: "error",
           message: `Failed to advertise "${topic}"`,
@@ -479,20 +479,20 @@ export default class Ros1Player implements Player {
       );
     }
 
-    this._emitState();
+    this.#emitState();
   }
 
   setParameter(key: string, value: ParameterValue): void {
     log.debug(`Ros1Player.setParameter(key=${key}, value=${value})`);
-    this._rosNode?.setParameter(key, value);
+    this.#rosNode?.setParameter(key, value);
   }
 
   publish({ topic, msg }: PublishPayload): void {
     const problemId = `publish:${topic}`;
 
-    if (this._rosNode != undefined) {
-      if (this._rosNode.isAdvertising(topic)) {
-        this._rosNode
+    if (this.#rosNode != undefined) {
+      if (this.#rosNode.isAdvertising(topic)) {
+        this.#rosNode
           .publish(topic, msg)
           .then(() => this._clearProblem(problemId))
           .catch((error) =>
@@ -532,10 +532,7 @@ export default class Ros1Player implements Player {
     // no-op
   }
 
-  private _getRosDatatypes = (
-    datatype: string,
-    messageDefinition: RosMsgDefinition[],
-  ): RosDatatypes => {
+  #getRosDatatypes = (datatype: string, messageDefinition: RosMsgDefinition[]): RosDatatypes => {
     const typesByName: RosDatatypes = new Map();
     for (const def of messageDefinition) {
       // The first definition usually doesn't have an explicit name so we use the datatype
@@ -567,12 +564,12 @@ export default class Ros1Player implements Player {
         return;
       }
 
-      if (this._clockTime == undefined) {
-        this._start = time;
+      if (this.#clockTime == undefined) {
+        this.#start = time;
       }
 
-      this._clockTime = time;
-      this._clockReceived = msg.receiveTime;
+      this.#clockTime = time;
+      this.#clockReceived = msg.receiveTime;
     }
   }
 
@@ -580,13 +577,13 @@ export default class Ros1Player implements Player {
     try {
       const graph = await rosNode.getSystemState();
       if (
-        !isEqual(this._publishedTopics, graph.publishers) ||
-        !isEqual(this._subscribedTopics, graph.subscribers) ||
-        !isEqual(this._services, graph.services)
+        !isEqual(this.#publishedTopics, graph.publishers) ||
+        !isEqual(this.#subscribedTopics, graph.subscribers) ||
+        !isEqual(this.#services, graph.services)
       ) {
-        this._publishedTopics = graph.publishers;
-        this._subscribedTopics = graph.subscribers;
-        this._services = graph.services;
+        this.#publishedTopics = graph.publishers;
+        this.#subscribedTopics = graph.subscribers;
+        this.#services = graph.services;
       }
       this._clearProblem(Problem.Graph, { skipEmit: true });
     } catch (error) {
@@ -596,24 +593,26 @@ export default class Ros1Player implements Player {
           severity: "warn",
           message: "Unable to update connection graph",
           tip: `The connection graph contains information about publishers and subscribers. A
-stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${this._url}.`,
+stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${
+            this.#url
+          }.`,
           error,
         },
         { skipEmit: true },
       );
-      this._publishedTopics = new Map();
-      this._subscribedTopics = new Map();
-      this._services = new Map();
+      this.#publishedTopics = new Map();
+      this.#subscribedTopics = new Map();
+      this.#services = new Map();
     }
   }
 
   private _getCurrentTime(): Time {
     const now = fromMillis(Date.now());
-    if (this._clockTime == undefined) {
+    if (this.#clockTime == undefined) {
       return now;
     }
 
-    const delta = subtractTimes(now, this._clockReceived);
-    return addTimes(this._clockTime, delta);
+    const delta = subtractTimes(now, this.#clockReceived);
+    return addTimes(this.#clockTime, delta);
   }
 }

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -51,73 +51,73 @@ type Ros2PlayerOpts = {
 
 // Connects to a ROS 2 network using RTPS over UDP, discovering peers via UDP multicast.
 export default class Ros2Player implements Player {
-  private _domainId: number; // ROS 2 DDS (RTPS) domain
-  private _rosNode?: RosNode; // Our ROS node when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: Topic[]; // Topics as advertised by peers
-  private _providerDatatypes = new Map<string, RosMsgDefinition>(); // All known ROS 2 message definitions.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #domainId: number; // ROS 2 DDS (RTPS) domain
+  #rosNode?: RosNode; // Our ROS node when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed = false; // Whether the player has been completely closed using close().
+  #providerTopics?: Topic[]; // Topics as advertised by peers
+  #providerDatatypes = new Map<string, RosMsgDefinition>(); // All known ROS 2 message definitions.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
   // private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
   // private _parameters = new Map<string, ParameterValue>(); // rosparams
-  private _start?: Time; // The time at which we started playing.
+  #start?: Time; // The time at which we started playing.
   // private _clockTime?: Time; // The most recent published `/clock` time, if available
   // private _clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _messageOrder: TimestampMethod = "receiveTime";
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
-  private _hasReceivedMessage = false;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #messageOrder: TimestampMethod = "receiveTime";
+  #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  #hasReceivedMessage = false;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({ domainId, metricsCollector }: Ros2PlayerOpts) {
     log.info(`initializing Ros2Player (domainId=${domainId})`);
-    this._domainId = domainId;
-    this._metricsCollector = metricsCollector;
-    this._start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
+    this.#domainId = domainId;
+    this.#metricsCollector = metricsCollector;
+    this.#start = fromMillis(Date.now());
+    this.#metricsCollector.playerConstructed();
 
     // The ros1ToRos2Type() hack can be removed when @foxglove/rosmsg-msgs-* packages are updated to
     // natively support ROS 2
     for (const dataType in commonDefs) {
       const msgDef = (commonDefs as Record<string, RosMsgDefinition>)[dataType]!;
-      this._providerDatatypes.set(dataType, msgDef);
-      this._providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
+      this.#providerDatatypes.set(dataType, msgDef);
+      this.#providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
     }
     for (const dataType in foxgloveDefs) {
       const msgDef = (foxgloveDefs as Record<string, RosMsgDefinition>)[dataType]!;
-      this._providerDatatypes.set(dataType, msgDef);
-      this._providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
+      this.#providerDatatypes.set(dataType, msgDef);
+      this.#providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
     }
 
-    void this._open();
+    void this.#open();
   }
 
-  private _open = async (): Promise<void> => {
+  #open = async (): Promise<void> => {
     const os = OsContextSingleton;
-    if (this._closed || os == undefined) {
+    if (this.#closed || os == undefined) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this.#presence = PlayerPresence.INITIALIZING;
 
     const net = await Sockets.Create();
     // eslint-disable-next-line @typescript-eslint/promise-function-async
     const udpSocketCreate = () => net.createUdpSocket();
 
-    if (this._rosNode == undefined) {
+    if (this.#rosNode == undefined) {
       const rosNode = new RosNode({
         name: "/foxglovestudio",
-        domainId: this._domainId,
+        domainId: this.#domainId,
         udpSocketCreate,
         getNetworkInterfaces: os.getNetworkInterfaces,
         log: rosLog,
       });
-      this._rosNode = rosNode;
+      this.#rosNode = rosNode;
 
       // rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
       //   log.debug("paramUpdate", key, value, prevValue, callerId);
@@ -125,9 +125,9 @@ export default class Ros2Player implements Player {
       // });
     }
 
-    await this._rosNode.start();
-    await this._requestTopics();
-    this._presence = PlayerPresence.PRESENT;
+    await this.#rosNode.start();
+    await this.#requestTopics();
+    this.#presence = PlayerPresence.PRESENT;
   };
 
   private _addProblem(
@@ -135,9 +135,9 @@ export default class Ros2Player implements Player {
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problems.addProblem(id, problem);
+    this.#problems.addProblem(id, problem);
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
@@ -151,23 +151,23 @@ export default class Ros2Player implements Player {
 
   private _clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
     if (
-      this._problems.removeProblems(
+      this.#problems.removeProblems(
         (id) =>
           id.startsWith("msgdef:") || id.startsWith("advertise:") || id.startsWith("publish:"),
       )
     ) {
       if (!skipEmit) {
-        this._emitState();
+        this.#emitState();
       }
     }
   }
 
-  private _requestTopics = async (): Promise<void> => {
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+  #requestTopics = async (): Promise<void> => {
+    if (this.#requestTopicsTimeout) {
+      clearTimeout(this.#requestTopicsTimeout);
     }
-    const rosNode = this._rosNode;
-    if (!rosNode || this._closed) {
+    const rosNode = this.#rosNode;
+    if (!rosNode || this.#closed) {
       return;
     }
 
@@ -177,16 +177,16 @@ export default class Ros2Player implements Player {
       // Sort them for easy comparison
       const sortedTopics: Topic[] = sortBy(topics, "name");
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
+      if (this.#providerTopics == undefined) {
+        this.#metricsCollector.initialized();
       }
 
-      if (!isEqual(sortedTopics, this._providerTopics)) {
-        this._providerTopics = sortedTopics;
+      if (!isEqual(sortedTopics, this.#providerTopics)) {
+        this.#providerTopics = sortedTopics;
       }
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+      this.setSubscriptions(this.#requestedSubscriptions);
 
       // Subscribe to all parameters
       // try {
@@ -212,10 +212,10 @@ export default class Ros2Player implements Player {
       // Fetch the full graph topology
       await this._updateConnectionGraph(rosNode);
 
-      this._presence = PlayerPresence.PRESENT;
-      this._emitState();
+      this.#presence = PlayerPresence.PRESENT;
+      this.#emitState();
     } catch (error) {
-      this._presence = PlayerPresence.INITIALIZING;
+      this.#presence = PlayerPresence.INITIALIZING;
       this._addProblem(
         Problem.Connection,
         {
@@ -228,53 +228,53 @@ export default class Ros2Player implements Player {
       );
     } finally {
       // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      this.#requestTopicsTimeout = setTimeout(this.#requestTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+  #emitState = debouncePromise(() => {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const providerTopics = this._providerTopics;
-    const start = this._start;
+    const providerTopics = this.#providerTopics;
+    const start = this.#start;
     if (!providerTopics || !start) {
-      return this._listener({
-        presence: this._presence,
+      return this.#listener({
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
-        playerId: this._id,
-        problems: this._problems.problems(),
+        playerId: this.#id,
+        problems: this.#problems.problems(),
         activeData: undefined,
       });
     }
 
     // Time is always moving forward even if we don't get messages from the server.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
-    return this._listener({
-      presence: this._presence,
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
+    return this.#listener({
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
-      playerId: this._id,
-      problems: this._problems.problems(),
+      playerId: this.#id,
+      problems: this.#problems.problems(),
 
       activeData: {
         messages,
-        totalBytesReceived: this._rosNode?.receivedBytes() ?? 0,
-        messageOrder: this._messageOrder,
+        totalBytesReceived: this.#rosNode?.receivedBytes() ?? 0,
+        messageOrder: this.#messageOrder,
         startTime: start,
         endTime: currentTime,
         currentTime,
@@ -284,9 +284,9 @@ export default class Ros2Player implements Player {
         // that we don't accidentally hit falsy checks.
         lastSeekTime: 1,
         topics: providerTopics,
-        datatypes: this._providerDatatypes,
-        publishedTopics: this._publishedTopics,
-        subscribedTopics: this._subscribedTopics,
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
+        subscribedTopics: this.#subscribedTopics,
         // services: this._services,
         // parameters: this._parameters,
         parsedMessageDefinitionsByTopic: {},
@@ -295,27 +295,27 @@ export default class Ros2Player implements Player {
   });
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
-    this._emitState();
+    this.#listener = listener;
+    this.#emitState();
   }
 
   close(): void {
-    this._closed = true;
-    if (this._rosNode) {
-      void this._rosNode.shutdown();
+    this.#closed = true;
+    if (this.#rosNode) {
+      void this.#rosNode.shutdown();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -323,7 +323,7 @@ export default class Ros2Player implements Player {
     this._addInternalSubscriptions(subscriptions);
 
     // See what topics we actually can subscribe to.
-    const availableTopicsByTopicName = getTopicsByTopicName(this._providerTopics ?? []);
+    const availableTopicsByTopicName = getTopicsByTopicName(this.#providerTopics ?? []);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
@@ -331,7 +331,7 @@ export default class Ros2Player implements Player {
     // Subscribe to all topics that we aren't subscribed to yet.
     for (const topicName of topicNames) {
       const availTopic = availableTopicsByTopicName[topicName];
-      if (!availTopic || this._rosNode.subscriptions.has(topicName)) {
+      if (!availTopic || this.#rosNode.subscriptions.has(topicName)) {
         continue;
       }
 
@@ -340,7 +340,7 @@ export default class Ros2Player implements Player {
       // Try to retrieve the ROS message definition for this topic
       let msgDefinition: RosMsgDefinition[] | undefined;
       try {
-        msgDefinition = rosDatatypesToMessageDefinition(this._providerDatatypes, dataType);
+        msgDefinition = rosDatatypesToMessageDefinition(this.#providerDatatypes, dataType);
       } catch (error) {
         this._addProblem(`msgdef:${topicName}`, {
           severity: "warn",
@@ -349,24 +349,24 @@ export default class Ros2Player implements Player {
         });
       }
 
-      const subscription = this._rosNode.subscribe({ topic: topicName, dataType, msgDefinition });
+      const subscription = this.#rosNode.subscribe({ topic: topicName, dataType, msgDefinition });
 
       subscription.on("message", (timestamp, message, _data, _pub) =>
-        this._handleMessage(topicName, timestamp, message, true),
+        this.#handleMessage(topicName, timestamp, message, true),
       );
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const topicName of this._rosNode.subscriptions.keys()) {
+    for (const topicName of this.#rosNode.subscriptions.keys()) {
       if (!topicNames.includes(topicName)) {
         {
-          this._rosNode.unsubscribe(topicName);
+          this.#rosNode.unsubscribe(topicName);
         }
       }
     }
   }
 
-  private _handleMessage = (
+  #handleMessage = (
     topic: string,
     timestamp: Time,
     message: unknown,
@@ -374,27 +374,27 @@ export default class Ros2Player implements Player {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     external: boolean,
   ): void => {
-    if (this._providerTopics == undefined) {
+    if (this.#providerTopics == undefined) {
       return;
     }
 
     // const receiveTime = fromMillis(Date.now());
     const receiveTime = timestamp;
 
-    if (external && !this._hasReceivedMessage) {
-      this._hasReceivedMessage = true;
-      this._metricsCollector.recordTimeToFirstMsgs();
+    if (external && !this.#hasReceivedMessage) {
+      this.#hasReceivedMessage = true;
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     const msg: MessageEvent<unknown> = { topic, receiveTime, message };
-    this._parsedMessages.push(msg);
+    this.#parsedMessages.push(msg);
     this._handleInternalMessage(msg);
 
-    this._emitState();
+    this.#emitState();
   };
 
   setPublishers(_publishers: AdvertiseOptions[]): void {
-    if (!this._rosNode || this._closed) {
+    if (!this.#rosNode || this.#closed) {
       return;
     }
 
@@ -451,7 +451,7 @@ export default class Ros2Player implements Player {
     //   );
     // }
 
-    this._emitState();
+    this.#emitState();
   }
 
   setParameter(_key: string, _value: ParameterValue): void {

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -107,14 +107,14 @@ class MockRosClient {
 }
 
 class MockRosTopic {
-  private _name: string = "";
+  #name: string = "";
 
   constructor({ name }: { name: string }) {
-    this._name = name;
+    this.#name = name;
   }
 
   subscribe(callback: (arg: unknown) => void) {
-    workerInstance.getMessagesByTopicName(this._name).forEach(({ message }) => callback(message));
+    workerInstance.getMessagesByTopicName(this.#name).forEach(({ message }) => callback(message));
   }
 }
 

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -46,11 +46,11 @@ class MockRosClient {
     workerInstance = this;
   }
 
-  _topics: string[] = [];
-  _types: string[] = [];
-  _typedefs_full_text: string[] = [];
-  _connectCallback?: () => void;
-  _messages: any[] = [];
+  #topics: string[] = [];
+  #types: string[] = [];
+  #typedefs_full_text: string[] = [];
+  #connectCallback?: () => void;
+  #messages: any[] = [];
 
   setup({
     topics = [],
@@ -63,17 +63,17 @@ class MockRosClient {
     typedefs?: string[];
     messages?: any[];
   }) {
-    this._topics = topics;
-    this._types = types;
-    this._typedefs_full_text = typedefs;
-    this._messages = messages;
+    this.#topics = topics;
+    this.#types = types;
+    this.#typedefs_full_text = typedefs;
+    this.#messages = messages;
 
-    this._connectCallback?.();
+    this.#connectCallback?.();
   }
 
   on(op: string, callback: () => void) {
     if (op === "connection") {
-      this._connectCallback = callback;
+      this.#connectCallback = callback;
     }
   }
 
@@ -83,14 +83,14 @@ class MockRosClient {
 
   getTopicsAndRawTypes(callback: (...args: unknown[]) => void) {
     callback({
-      topics: this._topics,
-      types: this._types,
-      typedefs_full_text: this._typedefs_full_text,
+      topics: this.#topics,
+      types: this.#types,
+      typedefs_full_text: this.#typedefs_full_text,
     });
   }
 
   getMessagesByTopicName(topicName: string): { message: unknown }[] {
-    return this._messages.filter(({ topic }) => topic === topicName);
+    return this.#messages.filter(({ topic }) => topic === topicName);
   }
 
   getNodes(callback: (nodes: string[]) => void, _errCb: (error: Error) => void) {

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -57,40 +57,40 @@ const CAPABILITIES = [PlayerCapabilities.advertise];
 // support raw ROS messages; instead we use the CBOR compression provided by roslibjs, which
 // unmarshalls into plain JS objects.
 export default class RosbridgePlayer implements Player {
-  private _url: string; // WebSocket URL.
-  private _rosClient?: roslib.Ros; // The roslibjs client when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
-  private _closed: boolean = false; // Whether the player has been completely closed using close().
-  private _providerTopics?: Topic[]; // Topics as published by the WebSocket.
-  private _providerDatatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
-  private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
-  private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
-  private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
-  private _messageReadersByDatatype: {
+  #url: string; // WebSocket URL.
+  #rosClient?: roslib.Ros; // The roslibjs client when we're connected.
+  #id: string = uuidv4(); // Unique ID for this player.
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
+  #closed: boolean = false; // Whether the player has been completely closed using close().
+  #providerTopics?: Topic[]; // Topics as published by the WebSocket.
+  #providerDatatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
+  #publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
+  #subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
+  #services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
+  #messageReadersByDatatype: {
     [datatype: string]: LazyMessageReader | ROS2MessageReader;
   } = {};
-  private _start?: Time; // The time at which we started playing.
-  private _clockTime?: Time; // The most recent published `/clock` time, if available
-  private _clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
+  #start?: Time; // The time at which we started playing.
+  #clockTime?: Time; // The most recent published `/clock` time, if available
+  #clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
   // active subscriptions
-  private _topicSubscriptions = new Map<string, roslib.Topic>();
-  private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
-  private _messageOrder: TimestampMethod = "receiveTime";
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  #topicSubscriptions = new Map<string, roslib.Topic>();
+  #requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
+  #messageOrder: TimestampMethod = "receiveTime";
+  #requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
   // active publishers for the current connection
-  private _topicPublishers = new Map<string, roslib.Topic>();
+  #topicPublishers = new Map<string, roslib.Topic>();
   // which topics we want to advertise to other nodes
-  private _advertisements: AdvertiseOptions[] = [];
-  private _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
-  private _parsedTopics: Set<string> = new Set();
-  private _receivedBytes: number = 0;
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _hasReceivedMessage = false;
-  private _presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
-  private _problems = new PlayerProblemManager();
-  private _emitTimer?: ReturnType<typeof setTimeout>;
+  #advertisements: AdvertiseOptions[] = [];
+  #parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
+  #parsedTopics: Set<string> = new Set();
+  #receivedBytes: number = 0;
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #hasReceivedMessage = false;
+  #presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
+  #problems = new PlayerProblemManager();
+  #emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({
     url,
@@ -99,34 +99,34 @@ export default class RosbridgePlayer implements Player {
     url: string;
     metricsCollector: PlayerMetricsCollectorInterface;
   }) {
-    this._presence = PlayerPresence.INITIALIZING;
-    this._metricsCollector = metricsCollector;
-    this._url = url;
-    this._start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
+    this.#presence = PlayerPresence.INITIALIZING;
+    this.#metricsCollector = metricsCollector;
+    this.#url = url;
+    this.#start = fromMillis(Date.now());
+    this.#metricsCollector.playerConstructed();
     this._open();
   }
 
   _open = (): void => {
-    if (this._closed) {
+    if (this.#closed) {
       return;
     }
-    if (this._rosClient != undefined) {
+    if (this.#rosClient != undefined) {
       throw new Error(`Attempted to open a second Rosbridge connection`);
     }
-    this._problems.removeProblem("rosbridge:connection-failed");
-    log.info(`Opening connection to ${this._url}`);
+    this.#problems.removeProblem("rosbridge:connection-failed");
+    log.info(`Opening connection to ${this.#url}`);
 
     // `workersocket` will open the actual WebSocket connection in a WebWorker.
-    const rosClient = new roslib.Ros({ url: this._url, transportLibrary: "workersocket" });
+    const rosClient = new roslib.Ros({ url: this.#url, transportLibrary: "workersocket" });
 
     rosClient.on("connection", () => {
-      if (this._closed) {
+      if (this.#closed) {
         return;
       }
-      this._presence = PlayerPresence.PRESENT;
-      this._problems.removeProblem("rosbridge:connection-failed");
-      this._rosClient = rosClient;
+      this.#presence = PlayerPresence.PRESENT;
+      this.#problems.removeProblem("rosbridge:connection-failed");
+      this.#rosClient = rosClient;
 
       this._setupPublishers();
       void this._requestTopics();
@@ -134,7 +134,7 @@ export default class RosbridgePlayer implements Player {
 
     rosClient.on("error", (err) => {
       if (err) {
-        this._problems.addProblem("rosbridge:error", {
+        this.#problems.addProblem("rosbridge:error", {
           severity: "warn",
           message: "Rosbridge error",
           error: err,
@@ -144,22 +144,22 @@ export default class RosbridgePlayer implements Player {
     });
 
     rosClient.on("close", () => {
-      this._presence = PlayerPresence.RECONNECTING;
+      this.#presence = PlayerPresence.RECONNECTING;
 
-      if (this._requestTopicsTimeout) {
-        clearTimeout(this._requestTopicsTimeout);
+      if (this.#requestTopicsTimeout) {
+        clearTimeout(this.#requestTopicsTimeout);
       }
-      for (const [topicName, topic] of this._topicSubscriptions) {
+      for (const [topicName, topic] of this.#topicSubscriptions) {
         topic.unsubscribe();
-        this._topicSubscriptions.delete(topicName);
+        this.#topicSubscriptions.delete(topicName);
       }
       rosClient.close(); // ensure the underlying worker is cleaned up
-      delete this._rosClient;
+      this.#rosClient = undefined;
 
-      this._problems.addProblem("rosbridge:connection-failed", {
+      this.#problems.addProblem("rosbridge:connection-failed", {
         severity: "error",
         message: "Connection failed",
-        tip: `Check that the rosbridge WebSocket server at ${this._url} is reachable.`,
+        tip: `Check that the rosbridge WebSocket server at ${this.#url} is reachable.`,
       });
 
       this._emitState();
@@ -171,13 +171,13 @@ export default class RosbridgePlayer implements Player {
 
   _requestTopics = async (): Promise<void> => {
     // clear problems before each topics request so we don't have stale problems from previous failed requests
-    this._problems.removeProblems((id) => id.startsWith("requestTopics:"));
+    this.#problems.removeProblems((id) => id.startsWith("requestTopics:"));
 
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+    if (this.#requestTopicsTimeout) {
+      clearTimeout(this.#requestTopicsTimeout);
     }
-    const rosClient = this._rosClient;
-    if (!rosClient || this._closed) {
+    const rosClient = this.#rosClient;
+    if (!rosClient || this.#closed) {
       return;
     }
 
@@ -198,13 +198,13 @@ export default class RosbridgePlayer implements Player {
       let rosVersion: 1 | 2;
       if (result.types.includes("rcl_interfaces/msg/Log")) {
         rosVersion = 2;
-        this._problems.removeProblem("unknownRosVersion");
+        this.#problems.removeProblem("unknownRosVersion");
       } else if (result.types.includes("rosgraph_msgs/Log")) {
         rosVersion = 1;
-        this._problems.removeProblem("unknownRosVersion");
+        this.#problems.removeProblem("unknownRosVersion");
       } else {
         rosVersion = 1;
-        this._problems.addProblem("unknownRosVersion", {
+        this.#problems.addProblem("unknownRosVersion", {
           severity: "warn",
           message: "Unable to detect ROS version, assuming ROS 1",
         });
@@ -228,17 +228,17 @@ export default class RosbridgePlayer implements Player {
           rosVersion === 1
             ? new LazyMessageReader(parsedDefinition)
             : new ROS2MessageReader(parsedDefinition);
-        this._parsedMessageDefinitionsByTopic[topicName] = parsedDefinition;
+        this.#parsedMessageDefinitionsByTopic[topicName] = parsedDefinition;
       }
 
       // Sort them for easy comparison. If nothing has changed here, bail out.
       const sortedTopics = sortBy(topics, "name");
-      if (isEqual(sortedTopics, this._providerTopics)) {
+      if (isEqual(sortedTopics, this.#providerTopics)) {
         return;
       }
 
       if (topicsMissingDatatypes.length > 0) {
-        this._problems.addProblem("requestTopics:missing-types", {
+        this.#problems.addProblem("requestTopics:missing-types", {
           severity: "warn",
           message: "Could not resolve all message types",
           tip: `Message types could not be found for these topics: ${topicsMissingDatatypes.join(
@@ -247,37 +247,37 @@ export default class RosbridgePlayer implements Player {
         });
       }
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
+      if (this.#providerTopics == undefined) {
+        this.#metricsCollector.initialized();
       }
 
-      this._providerTopics = sortedTopics;
-      this._providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
+      this.#providerTopics = sortedTopics;
+      this.#providerDatatypes = bagConnectionsToDatatypes(datatypeDescriptions, {
         ros2: rosVersion === 2,
       });
-      this._messageReadersByDatatype = messageReaders;
+      this.#messageReadersByDatatype = messageReaders;
 
       // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+      this.setSubscriptions(this.#requestedSubscriptions);
 
       // Fetch the full graph topology
       try {
         const graph = await this._getSystemState();
-        this._publishedTopics = graph.publishers;
-        this._subscribedTopics = graph.subscribers;
-        this._services = graph.services;
+        this.#publishedTopics = graph.publishers;
+        this.#subscribedTopics = graph.subscribers;
+        this.#services = graph.services;
       } catch (error) {
-        this._problems.addProblem("requestTopics:system-state", {
+        this.#problems.addProblem("requestTopics:system-state", {
           severity: "error",
           message: "Failed to fetch node details from rosbridge",
           error,
         });
-        this._publishedTopics = new Map();
-        this._subscribedTopics = new Map();
-        this._services = new Map();
+        this.#publishedTopics = new Map();
+        this.#subscribedTopics = new Map();
+        this.#services = new Map();
       }
     } catch (error) {
-      this._problems.addProblem("requestTopics:error", {
+      this.#problems.addProblem("requestTopics:error", {
         severity: "error",
         message: "Failed to fetch topics from rosbridge",
         error,
@@ -286,55 +286,54 @@ export default class RosbridgePlayer implements Player {
       this._emitState();
 
       // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      this.#requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
-    const { _providerTopics, _providerDatatypes, _start } = this;
-    if (!_providerTopics || !_providerDatatypes || !_start) {
-      return this._listener({
-        name: this._url,
-        presence: this._presence,
+    if (!this.#providerTopics || !this.#providerDatatypes || !this.#start) {
+      return this.#listener({
+        name: this.#url,
+        presence: this.#presence,
         progress: {},
         capabilities: CAPABILITIES,
-        playerId: this._id,
+        playerId: this.#id,
         activeData: undefined,
-        problems: this._problems.problems(),
+        problems: this.#problems.problems(),
       });
     }
 
     // When connected
     // Time is always moving forward even if we don't get messages from the server.
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this._emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
-    return this._listener({
-      name: this._url,
-      presence: this._presence,
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
+    return this.#listener({
+      name: this.#url,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
-      playerId: this._id,
-      problems: this._problems.problems(),
+      playerId: this.#id,
+      problems: this.#problems.problems(),
 
       activeData: {
         messages,
-        totalBytesReceived: this._receivedBytes,
-        messageOrder: this._messageOrder,
-        startTime: _start,
+        totalBytesReceived: this.#receivedBytes,
+        messageOrder: this.#messageOrder,
+        startTime: this.#start,
         endTime: currentTime,
         currentTime,
         isPlaying: true,
@@ -342,59 +341,59 @@ export default class RosbridgePlayer implements Player {
         // We don't support seeking, so we need to set this to any fixed value. Just avoid 0 so
         // that we don't accidentally hit falsy checks.
         lastSeekTime: 1,
-        topics: _providerTopics,
-        datatypes: _providerDatatypes,
-        publishedTopics: this._publishedTopics,
-        subscribedTopics: this._subscribedTopics,
-        services: this._services,
-        parsedMessageDefinitionsByTopic: this._parsedMessageDefinitionsByTopic,
+        topics: this.#providerTopics,
+        datatypes: this.#providerDatatypes,
+        publishedTopics: this.#publishedTopics,
+        subscribedTopics: this.#subscribedTopics,
+        services: this.#services,
+        parsedMessageDefinitionsByTopic: this.#parsedMessageDefinitionsByTopic,
       },
     });
   });
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
+    this.#listener = listener;
     this._emitState();
   }
 
   close(): void {
-    this._closed = true;
-    if (this._rosClient) {
-      this._rosClient.close();
+    this.#closed = true;
+    if (this.#rosClient) {
+      this.#rosClient.close();
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._hasReceivedMessage = false;
+    this.#metricsCollector.close();
+    this.#hasReceivedMessage = false;
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._requestedSubscriptions = subscriptions;
+    this.#requestedSubscriptions = subscriptions;
 
-    if (!this._rosClient || this._closed) {
+    if (!this.#rosClient || this.#closed) {
       return;
     }
 
     // Subscribe to additional topics used by Ros1Player itself
     this._addInternalSubscriptions(subscriptions);
 
-    this._parsedTopics = new Set(subscriptions.map(({ topic }) => topic));
+    this.#parsedTopics = new Set(subscriptions.map(({ topic }) => topic));
 
     // See what topics we actually can subscribe to.
-    const availableTopicsByTopicName = getTopicsByTopicName(this._providerTopics ?? []);
+    const availableTopicsByTopicName = getTopicsByTopicName(this.#providerTopics ?? []);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
 
     // Subscribe to all topics that we aren't subscribed to yet.
     for (const topicName of topicNames) {
-      if (this._topicSubscriptions.has(topicName)) {
+      if (this.#topicSubscriptions.has(topicName)) {
         continue;
       }
       const topic = new roslib.Topic({
-        ros: this._rosClient,
+        ros: this.#rosClient,
         name: topicName,
         compression: "cbor-raw",
       });
@@ -404,14 +403,14 @@ export default class RosbridgePlayer implements Player {
       }
 
       const { datatype } = availTopic;
-      const messageReader = this._messageReadersByDatatype[datatype];
+      const messageReader = this.#messageReadersByDatatype[datatype];
       if (!messageReader) {
         continue;
       }
 
       const problemId = `message:${topicName}`;
       topic.subscribe((message) => {
-        if (!this._providerTopics) {
+        if (!this.#providerTopics) {
           return;
         }
         try {
@@ -423,7 +422,7 @@ export default class RosbridgePlayer implements Player {
           if (messageReader instanceof LazyMessageReader) {
             const msgSize = messageReader.size(bytes);
             if (msgSize > bytes.byteLength) {
-              this._problems.addProblem(problemId, {
+              this.#problems.addProblem(problemId, {
                 severity: "error",
                 message: `Message buffer not large enough on ${topicName}`,
                 error: new Error(
@@ -437,23 +436,23 @@ export default class RosbridgePlayer implements Player {
 
           const innerMessage = messageReader.readMessage(bytes);
 
-          if (!this._hasReceivedMessage) {
-            this._hasReceivedMessage = true;
-            this._metricsCollector.recordTimeToFirstMsgs();
+          if (!this.#hasReceivedMessage) {
+            this.#hasReceivedMessage = true;
+            this.#metricsCollector.recordTimeToFirstMsgs();
           }
 
-          if (this._parsedTopics.has(topicName)) {
+          if (this.#parsedTopics.has(topicName)) {
             const msg: MessageEvent<unknown> = {
               topic: topicName,
               receiveTime,
               message: innerMessage,
             };
-            this._parsedMessages.push(msg);
+            this.#parsedMessages.push(msg);
             this._handleInternalMessage(msg);
           }
-          this._problems.removeProblem(problemId);
+          this.#problems.removeProblem(problemId);
         } catch (error) {
-          this._problems.addProblem(problemId, {
+          this.#problems.addProblem(problemId, {
             severity: "error",
             message: `Failed to parse message on ${topicName}`,
             error,
@@ -462,14 +461,14 @@ export default class RosbridgePlayer implements Player {
 
         this._emitState();
       });
-      this._topicSubscriptions.set(topicName, topic);
+      this.#topicSubscriptions.set(topicName, topic);
     }
 
     // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const [topicName, topic] of this._topicSubscriptions) {
+    for (const [topicName, topic] of this.#topicSubscriptions) {
       if (!topicNames.includes(topicName)) {
         topic.unsubscribe();
-        this._topicSubscriptions.delete(topicName);
+        this.#topicSubscriptions.delete(topicName);
       }
     }
   }
@@ -477,11 +476,11 @@ export default class RosbridgePlayer implements Player {
   setPublishers(publishers: AdvertiseOptions[]): void {
     // Since `setPublishers` is rarely called, we can get away with just throwing away the old
     // Roslib.Topic objects and creating new ones.
-    for (const publisher of this._topicPublishers.values()) {
+    for (const publisher of this.#topicPublishers.values()) {
       publisher.unadvertise();
     }
-    this._topicPublishers.clear();
-    this._advertisements = publishers;
+    this.#topicPublishers.clear();
+    this.#advertisements = publishers;
     this._setupPublishers();
   }
 
@@ -490,7 +489,7 @@ export default class RosbridgePlayer implements Player {
   }
 
   publish({ topic, msg }: PublishPayload): void {
-    const publisher = this._topicPublishers.get(topic);
+    const publisher = this.#topicPublishers.get(topic);
     if (!publisher) {
       throw new Error(
         `Tried to publish on a topic that is not registered as a publisher: ${topic}`,
@@ -521,19 +520,19 @@ export default class RosbridgePlayer implements Player {
 
   private _setupPublishers(): void {
     // This function will be called again once a connection is established
-    if (!this._rosClient) {
+    if (!this.#rosClient) {
       return;
     }
 
-    if (this._advertisements.length <= 0) {
+    if (this.#advertisements.length <= 0) {
       return;
     }
 
-    for (const { topic, datatype } of this._advertisements) {
-      this._topicPublishers.set(
+    for (const { topic, datatype } of this.#advertisements) {
+      this.#topicPublishers.set(
         topic,
         new roslib.Topic({
-          ros: this._rosClient,
+          ros: this.#rosClient,
           name: topic,
           messageType: datatype,
           queue_size: 0,
@@ -562,23 +561,23 @@ export default class RosbridgePlayer implements Player {
         return;
       }
 
-      if (this._clockTime == undefined) {
-        this._start = time;
+      if (this.#clockTime == undefined) {
+        this.#start = time;
       }
 
-      this._clockTime = time;
-      this._clockReceived = msg.receiveTime;
+      this.#clockTime = time;
+      this.#clockReceived = msg.receiveTime;
     }
   }
 
   private _getCurrentTime(): Time {
     const now = fromMillis(Date.now());
-    if (this._clockTime == undefined) {
+    if (this.#clockTime == undefined) {
       return now;
     }
 
-    const delta = subtractTimes(now, this._clockReceived);
-    return addTimes(this._clockTime, delta);
+    const delta = subtractTimes(now, this.#clockReceived);
+    return addTimes(this.#clockTime, delta);
   }
 
   private async _getSystemState(): Promise<RosGraph> {
@@ -598,10 +597,10 @@ export default class RosbridgePlayer implements Player {
     };
 
     return await new Promise((resolve, reject) => {
-      this._rosClient?.getNodes(async (nodes) => {
+      this.#rosClient?.getNodes(async (nodes) => {
         await Promise.all(
           nodes.map((node) => {
-            this._rosClient?.getNodeDetails(
+            this.#rosClient?.getNodeDetails(
               node,
               (subscriptions, publications, services) => {
                 publications.forEach((pub) => addEntry(output.publishers, pub, node));

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -104,10 +104,10 @@ export default class RosbridgePlayer implements Player {
     this.#url = url;
     this.#start = fromMillis(Date.now());
     this.#metricsCollector.playerConstructed();
-    this._open();
+    this.#open();
   }
 
-  _open = (): void => {
+  #open = (): void => {
     if (this.#closed) {
       return;
     }
@@ -129,7 +129,7 @@ export default class RosbridgePlayer implements Player {
       this.#rosClient = rosClient;
 
       this._setupPublishers();
-      void this._requestTopics();
+      void this.#requestTopics();
     });
 
     rosClient.on("error", (err) => {
@@ -139,7 +139,7 @@ export default class RosbridgePlayer implements Player {
           message: "Rosbridge error",
           error: err,
         });
-        this._emitState();
+        this.#emitState();
       }
     });
 
@@ -162,14 +162,14 @@ export default class RosbridgePlayer implements Player {
         tip: `Check that the rosbridge WebSocket server at ${this.#url} is reachable.`,
       });
 
-      this._emitState();
+      this.#emitState();
 
       // Try connecting again.
-      setTimeout(this._open, 3000);
+      setTimeout(this.#open, 3000);
     });
   };
 
-  _requestTopics = async (): Promise<void> => {
+  #requestTopics = async (): Promise<void> => {
     // clear problems before each topics request so we don't have stale problems from previous failed requests
     this.#problems.removeProblems((id) => id.startsWith("requestTopics:"));
 
@@ -283,16 +283,16 @@ export default class RosbridgePlayer implements Player {
         error,
       });
     } finally {
-      this._emitState();
+      this.#emitState();
 
       // Regardless of what happens, request topics again in a little bit.
-      this.#requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      this.#requestTopicsTimeout = setTimeout(this.#requestTopics, 3000);
     }
   };
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  _emitState = debouncePromise(() => {
+  #emitState = debouncePromise(() => {
     if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
@@ -315,7 +315,7 @@ export default class RosbridgePlayer implements Player {
       if (this.#emitTimer != undefined) {
         clearTimeout(this.#emitTimer);
       }
-      this.#emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
     const currentTime = this._getCurrentTime();
@@ -353,7 +353,7 @@ export default class RosbridgePlayer implements Player {
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.#listener = listener;
-    this._emitState();
+    this.#emitState();
   }
 
   close(): void {
@@ -429,7 +429,7 @@ export default class RosbridgePlayer implements Player {
                   `Cannot read ${msgSize} byte message from ${bytes.byteLength} byte buffer`,
                 ),
               });
-              this._emitState();
+              this.#emitState();
               return;
             }
           }
@@ -459,7 +459,7 @@ export default class RosbridgePlayer implements Player {
           });
         }
 
-        this._emitState();
+        this.#emitState();
       });
       this.#topicSubscriptions.set(topicName, topic);
     }

--- a/packages/studio-base/src/players/StoryPlayer.ts
+++ b/packages/studio-base/src/players/StoryPlayer.ts
@@ -38,15 +38,15 @@ const getBagDescriptor = async (url?: string) => {
 const NOOP_PROVIDER = [{ name: "noop", args: {}, children: [] }];
 
 export default class StoryPlayer implements Player {
-  _parsedSubscribedTopics: string[] = [];
-  _bags: string[] = [];
+  #parsedSubscribedTopics: string[] = [];
+  #bags: string[] = [];
   constructor(bags: string[]) {
-    this._bags = bags;
+    this.#bags = bags;
   }
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     void (async () => {
       const bagDescriptors = await Promise.all(
-        this._bags.map(async (file, i) => {
+        this.#bags.map(async (file, i) => {
           const bagDescriptor = await getBagDescriptor(file);
           return {
             name: "",
@@ -74,7 +74,7 @@ export default class StoryPlayer implements Player {
         })
         .then(async ({ topics, start, end, messageDefinitions }) => {
           const { parsedMessages = [] } = await provider.getMessages(start, end, {
-            parsedMessages: this._parsedSubscribedTopics,
+            parsedMessages: this.#parsedSubscribedTopics,
           });
 
           if (messageDefinitions.type === "raw") {
@@ -106,7 +106,7 @@ export default class StoryPlayer implements Player {
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._parsedSubscribedTopics = subscriptions.map(({ topic }) => topic);
+    this.#parsedSubscribedTopics = subscriptions.map(({ topic }) => topic);
   }
 
   close = noop;

--- a/packages/studio-base/src/players/TestProvider.ts
+++ b/packages/studio-base/src/players/TestProvider.ts
@@ -56,18 +56,18 @@ type GetMessages = (
 
 // ts-prune-ignore-next
 export default class TestProvider implements RandomAccessDataProvider {
-  _start: Time;
-  _end: Time;
-  _topics: Topic[];
-  _datatypes: RosDatatypes;
+  #start: Time;
+  #end: Time;
+  #topics: Topic[];
+  #datatypes: RosDatatypes;
   extensionPoint?: ExtensionPoint;
   closed: boolean = false;
 
   constructor({ getMessages, topics }: { getMessages?: GetMessages; topics?: Topic[] } = {}) {
-    this._start = defaultStart;
-    this._end = defaultEnd;
-    this._topics = topics ?? defaultTopics;
-    this._datatypes = datatypes;
+    this.#start = defaultStart;
+    this.#end = defaultEnd;
+    this.#topics = topics ?? defaultTopics;
+    this.#datatypes = datatypes;
     if (getMessages) {
       this.getMessages = getMessages;
     }
@@ -76,14 +76,14 @@ export default class TestProvider implements RandomAccessDataProvider {
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
     this.extensionPoint = extensionPoint;
     return {
-      start: this._start,
-      end: this._end,
-      topics: this._topics,
+      start: this.#start,
+      end: this.#end,
+      topics: this.#topics,
       connections: [],
       providesParsedMessages: true,
       messageDefinitions: {
         type: "parsed",
-        datatypes: this._datatypes,
+        datatypes: this.#datatypes,
         messageDefinitionsByTopic: {},
         parsedMessageDefinitionsByTopic: {},
       },

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -146,12 +146,12 @@ export default class UserNodePlayer implements Player {
     };
   }
 
-  _getTopics = memoizeWeak((topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [
+  #getTopics = memoizeWeak((topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [
     ...topics,
     ...nodeTopics,
   ]);
 
-  _getDatatypes = memoizeWeak(
+  #getDatatypes = memoizeWeak(
     (datatypes: RosDatatypes, nodeDatatypes: readonly RosDatatypes[]): RosDatatypes => {
       return nodeDatatypes.reduce(
         (allDatatypes, userNodeDatatypes) => new Map([...allDatatypes, ...userNodeDatatypes]),
@@ -172,7 +172,7 @@ export default class UserNodePlayer implements Player {
 
   // When updating nodes while paused, we seek to the current time
   // (i.e. invoke _getMessages with an empty array) to refresh messages
-  _getMessages = async (
+  #getMessages = async (
     parsedMessages: readonly MessageEvent<unknown>[],
     globalVariables: GlobalVariables,
     nodeRegistrations: readonly NodeRegistration[],
@@ -609,9 +609,9 @@ export default class UserNodePlayer implements Player {
         this.requestBackfill();
       }
 
-      const allDatatypes = this._getDatatypes(datatypes, this.#memoizedNodeDatatypes);
+      const allDatatypes = this.#getDatatypes(datatypes, this.#memoizedNodeDatatypes);
 
-      const { parsedMessages } = await this._getMessages(
+      const { parsedMessages } = await this.#getMessages(
         messages,
         this.#globalVariables,
         this.#nodeRegistrations,
@@ -622,7 +622,7 @@ export default class UserNodePlayer implements Player {
         activeData: {
           ...activeData,
           messages: parsedMessages,
-          topics: this._getTopics(topics, this.#memoizedNodeTopics),
+          topics: this.#getTopics(topics, this.#memoizedNodeTopics),
           datatypes: allDatatypes,
         },
       };

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -76,40 +76,40 @@ function maybePlainObject(rawVal: unknown) {
 // 1 - Do we convert them all over to the new node format / Typescript? What about imported libraries?
 // 2 - Do we keep them in the old format for a while and support both formats?
 export default class UserNodePlayer implements Player {
-  private _player: Player;
+  #player: Player;
 
-  private _nodeRegistrations: readonly NodeRegistration[] = [];
+  #nodeRegistrations: readonly NodeRegistration[] = [];
   // Datatypes and topics are derived from nodeRegistrations, but memoized so they only change when needed
-  private _memoizedNodeDatatypes: readonly RosDatatypes[] = [];
-  private _memoizedNodeTopics: readonly Topic[] = [];
+  #memoizedNodeDatatypes: readonly RosDatatypes[] = [];
+  #memoizedNodeTopics: readonly Topic[] = [];
 
-  private _subscriptions: SubscribePayload[] = [];
-  private _validTopics = new Set<string>();
-  private _userNodes: UserNodes = {};
+  #subscriptions: SubscribePayload[] = [];
+  #validTopics = new Set<string>();
+  #userNodes: UserNodes = {};
 
   // listener for state updates
-  private _listener?: (arg0: PlayerState) => Promise<void>;
+  #listener?: (arg0: PlayerState) => Promise<void>;
 
   // TODO: FUTURE - Terminate unused workers (some sort of timeout, for whole array or per rpc)
   // Not sure if there is perf issue with unused workers (may just go idle) - requires more research
-  private _unusedNodeRuntimeWorkers: Rpc[] = [];
-  private _lastPlayerStateActiveData?: PlayerStateActiveData;
-  private _setUserNodeDiagnostics: (nodeId: string, diagnostics: readonly Diagnostic[]) => void;
-  private _addUserNodeLogs: (nodeId: string, logs: UserNodeLog[]) => void;
-  private _setRosLib: (rosLib: string, datatypes: RosDatatypes) => void;
-  private _nodeTransformRpc?: Rpc;
-  private _rosLib?: string;
-  private _rosLibDatatypes?: RosDatatypes; // the datatypes we last used to generate rosLib -- regenerate if they change
-  private _globalVariables: GlobalVariables = {};
-  private _pendingResetWorkers?: Promise<void>;
+  #unusedNodeRuntimeWorkers: Rpc[] = [];
+  #lastPlayerStateActiveData?: PlayerStateActiveData;
+  #setUserNodeDiagnostics: (nodeId: string, diagnostics: readonly Diagnostic[]) => void;
+  #addUserNodeLogs: (nodeId: string, logs: UserNodeLog[]) => void;
+  #setRosLib: (rosLib: string, datatypes: RosDatatypes) => void;
+  #nodeTransformRpc?: Rpc;
+  #rosLib?: string;
+  #rosLibDatatypes?: RosDatatypes; // the datatypes we last used to generate rosLib -- regenerate if they change
+  #globalVariables: GlobalVariables = {};
+  #pendingResetWorkers?: Promise<void>;
 
   // Player state changes when the child player invokes our player state listener
   // we may also emit state changes on internal errors
-  private _playerState?: PlayerState;
+  #playerState?: PlayerState;
 
   // The store tracks problems for individual userspace nodes
   // a node may set its own problem or clear its problem
-  private _problemStore = new Map<string, PlayerProblem>();
+  #problemStore = new Map<string, PlayerProblem>();
 
   // exposed as a static to allow testing to mock/replace
   static CreateNodeTransformWorker = (): SharedWorker => {
@@ -122,25 +122,25 @@ export default class UserNodePlayer implements Player {
   };
 
   constructor(player: Player, userNodeActions: UserNodeActions) {
-    this._player = player;
-    this._player.setListener(async (state) => await this._onPlayerState(state));
+    this.#player = player;
+    this.#player.setListener(async (state) => await this._onPlayerState(state));
     const { setUserNodeDiagnostics, addUserNodeLogs, setUserNodeRosLib } = userNodeActions;
 
     // TODO(troy): can we make the below action flow better? Might be better to
     // just add an id, and the thing you want to update? Instead of passing in
     // objects?
-    this._setUserNodeDiagnostics = (nodeId: string, diagnostics: readonly Diagnostic[]) => {
+    this.#setUserNodeDiagnostics = (nodeId: string, diagnostics: readonly Diagnostic[]) => {
       setUserNodeDiagnostics(nodeId, diagnostics);
     };
-    this._addUserNodeLogs = (nodeId: string, logs: UserNodeLog[]) => {
+    this.#addUserNodeLogs = (nodeId: string, logs: UserNodeLog[]) => {
       if (logs.length > 0) {
         addUserNodeLogs(nodeId, logs);
       }
     };
 
-    this._setRosLib = (rosLib: string, datatypes: RosDatatypes) => {
-      this._rosLib = rosLib;
-      this._rosLibDatatypes = datatypes;
+    this.#setRosLib = (rosLib: string, datatypes: RosDatatypes) => {
+      this.#rosLib = rosLib;
+      this.#rosLibDatatypes = datatypes;
       // We set this for the monaco editor to refer to it.
       setUserNodeRosLib(rosLib);
     };
@@ -161,12 +161,12 @@ export default class UserNodePlayer implements Player {
   );
 
   // Basic memoization by remembering the last values passed to getMessages
-  private _lastGetMessagesInput: {
+  #lastGetMessagesInput: {
     parsedMessages: readonly MessageEvent<unknown>[];
     globalVariables: GlobalVariables;
     nodeRegistrations: readonly NodeRegistration[];
   } = { parsedMessages: [], globalVariables: {}, nodeRegistrations: [] };
-  private _lastGetMessagesResult: { parsedMessages: readonly MessageEvent<unknown>[] } = {
+  #lastGetMessagesResult: { parsedMessages: readonly MessageEvent<unknown>[] } = {
     parsedMessages: [],
   };
 
@@ -180,20 +180,20 @@ export default class UserNodePlayer implements Player {
     parsedMessages: readonly MessageEvent<unknown>[];
   }> => {
     if (
-      shallowequal(this._lastGetMessagesInput, {
+      shallowequal(this.#lastGetMessagesInput, {
         parsedMessages,
         globalVariables,
         nodeRegistrations,
       })
     ) {
-      return this._lastGetMessagesResult;
+      return this.#lastGetMessagesResult;
     }
     const parsedMessagesPromises: Promise<MessageEvent<unknown> | undefined>[] = [];
     for (const message of parsedMessages) {
       const messagePromises = [];
       for (const nodeRegistration of nodeRegistrations) {
         if (
-          this._validTopics.has(nodeRegistration.output.name) &&
+          this.#validTopics.has(nodeRegistration.output.name) &&
           nodeRegistration.inputs.includes(message.topic)
         ) {
           const messagePromise = nodeRegistration.processMessage(message, globalVariables);
@@ -213,53 +213,53 @@ export default class UserNodePlayer implements Player {
         .concat(nodeParsedMessages)
         .sort((a, b) => compare(a.receiveTime, b.receiveTime)),
     };
-    this._lastGetMessagesInput = { parsedMessages, globalVariables, nodeRegistrations };
-    this._lastGetMessagesResult = result;
+    this.#lastGetMessagesInput = { parsedMessages, globalVariables, nodeRegistrations };
+    this.#lastGetMessagesResult = result;
     return result;
   };
 
   setGlobalVariables(globalVariables: GlobalVariables): void {
-    this._globalVariables = globalVariables;
+    this.#globalVariables = globalVariables;
   }
 
   // Called when userNode state is updated.
   async setUserNodes(userNodes: UserNodes): Promise<void> {
-    this._userNodes = userNodes;
+    this.#userNodes = userNodes;
 
     // Prune the node registration cache so it doesn't grow forever.
     // We add one to the count so we don't have to recompile nodes if users undo/redo node changes.
     const maxNodeRegistrationCacheCount = Object.keys(userNodes).length + 1;
-    this._nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
+    this.#nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
 
     // This code causes us to reset workers twice because the forceSeek resets the workers too
     // TODO: Only reset workers once
     return await this._resetWorkers().then(() => {
-      this.setSubscriptions(this._subscriptions);
-      const { currentTime, isPlaying = false } = this._lastPlayerStateActiveData ?? {};
+      this.setSubscriptions(this.#subscriptions);
+      const { currentTime, isPlaying = false } = this.#lastPlayerStateActiveData ?? {};
       if (currentTime && !isPlaying) {
-        this._player.seekPlayback(currentTime);
+        this.#player.seekPlayback(currentTime);
       }
     });
   }
 
-  private _nodeRegistrationCache: {
+  #nodeRegistrationCache: {
     nodeId: string;
     userNode: UserNode;
     result: NodeRegistration;
   }[] = [];
   // Defines the inputs/outputs and worker interface of a user node.
-  private _createNodeRegistration = async (
+  #createNodeRegistration = async (
     nodeId: string,
     userNode: UserNode,
   ): Promise<NodeRegistration> => {
-    for (const cacheEntry of this._nodeRegistrationCache) {
+    for (const cacheEntry of this.#nodeRegistrationCache) {
       if (nodeId === cacheEntry.nodeId && isEqual(userNode, cacheEntry.userNode)) {
         return cacheEntry.result;
       }
     }
     // Pass all the nodes a set of basic datatypes that we know how to render.
     // These could be overwritten later by bag datatypes, but these datatype definitions should be very stable.
-    const { topics = [], datatypes = new Map() } = this._lastPlayerStateActiveData ?? {};
+    const { topics = [], datatypes = new Map() } = this.#lastPlayerStateActiveData ?? {};
     const nodeDatatypes: RosDatatypes = new Map([...basicDatatypes, ...datatypes]);
 
     const rosLib = await this._getRosLib();
@@ -283,7 +283,7 @@ export default class UserNodePlayer implements Player {
 
       // Register the node within a web worker to be executed.
       if (!rpc) {
-        rpc = this._unusedNodeRuntimeWorkers.pop();
+        rpc = this.#unusedNodeRuntimeWorkers.pop();
 
         // initialize a new worker since no unused one is available
         if (!rpc) {
@@ -292,7 +292,7 @@ export default class UserNodePlayer implements Player {
           worker.onerror = (event) => {
             log.error(event);
 
-            this._problemStore.set(problemKey, {
+            this.#problemStore.set(problemKey, {
               message: `Node playground runtime error: ${event.message}`,
               severity: "error",
             });
@@ -305,7 +305,7 @@ export default class UserNodePlayer implements Player {
           port.onmessageerror = (event) => {
             log.error(event);
 
-            this._problemStore.set(problemKey, {
+            this.#problemStore.set(problemKey, {
               severity: "error",
               message: `Node playground runtime error: ${String(event.data)}`,
             });
@@ -318,7 +318,7 @@ export default class UserNodePlayer implements Player {
           rpc.receive("error", (msg) => {
             log.error(msg);
 
-            this._problemStore.set(problemKey, {
+            this.#problemStore.set(problemKey, {
               severity: "error",
               message: `Node playground runtime error: ${msg}`,
             });
@@ -335,7 +335,7 @@ export default class UserNodePlayer implements Player {
           },
         );
         if (error != undefined) {
-          this._setUserNodeDiagnostics(nodeId, [
+          this.#setUserNodeDiagnostics(nodeId, [
             ...userNodeDiagnostics,
             {
               source: Sources.Runtime,
@@ -346,7 +346,7 @@ export default class UserNodePlayer implements Player {
           ]);
           return;
         }
-        this._addUserNodeLogs(nodeId, userNodeLogs);
+        this.#addUserNodeLogs(nodeId, userNodeLogs);
       }
 
       // To send the message over RPC we invoke maybePlainObject which calls toJSON on the message
@@ -359,13 +359,13 @@ export default class UserNodePlayer implements Player {
             receiveTime: msgEvent.receiveTime,
             message: maybePlainObject(msgEvent.message),
           },
-          globalVariables: this._globalVariables,
+          globalVariables: this.#globalVariables,
         }),
         terminateSignal,
       ]);
 
       if (!result) {
-        this._problemStore.set(problemKey, {
+        this.#problemStore.set(problemKey, {
           message: `Node playground node ${nodeId} timed out`,
           severity: "warn",
         });
@@ -384,12 +384,12 @@ export default class UserNodePlayer implements Player {
             ]
           : [];
       if (diagnostics.length > 0) {
-        this._setUserNodeDiagnostics(nodeId, diagnostics);
+        this.#setUserNodeDiagnostics(nodeId, diagnostics);
       }
-      this._addUserNodeLogs(nodeId, result.userNodeLogs);
+      this.#addUserNodeLogs(nodeId, result.userNodeLogs);
 
       if (!result.message) {
-        this._problemStore.set(problemKey, {
+        this.#problemStore.set(problemKey, {
           severity: "warn",
           message: `Node playground node ${nodeId} did not produce a message`,
         });
@@ -398,7 +398,7 @@ export default class UserNodePlayer implements Player {
 
       // At this point we've received a message successfully from the userspace node, therefore
       // we clear any previous problem from this node.
-      this._problemStore.delete(problemKey);
+      this.#problemStore.delete(problemKey);
 
       return {
         topic: outputTopic,
@@ -408,11 +408,11 @@ export default class UserNodePlayer implements Player {
     };
 
     const terminate = () => {
-      this._problemStore.delete(problemKey);
+      this.#problemStore.delete(problemKey);
 
       terminateSignal.resolve();
       if (rpc) {
-        this._unusedNodeRuntimeWorkers.push(rpc);
+        this.#unusedNodeRuntimeWorkers.push(rpc);
         rpc = undefined;
       }
     };
@@ -425,12 +425,12 @@ export default class UserNodePlayer implements Player {
       processMessage,
       terminate,
     };
-    this._nodeRegistrationCache.push({ nodeId, userNode, result });
+    this.#nodeRegistrationCache.push({ nodeId, userNode, result });
     return result;
   };
 
   private _getTransformWorker(): Rpc {
-    if (!this._nodeTransformRpc) {
+    if (!this.#nodeTransformRpc) {
       const worker = UserNodePlayer.CreateNodeTransformWorker();
 
       // The errors below persist for the lifetime of the player.
@@ -439,7 +439,7 @@ export default class UserNodePlayer implements Player {
       worker.onerror = (event) => {
         log.error(event);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `Node playground error: ${event.message}`,
         });
@@ -451,7 +451,7 @@ export default class UserNodePlayer implements Player {
       port.onmessageerror = (event) => {
         log.error(event);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `Node playground error: ${String(event.data)}`,
         });
@@ -464,7 +464,7 @@ export default class UserNodePlayer implements Player {
       rpc.receive("error", (msg) => {
         log.error(msg);
 
-        this._problemStore.set("worker-error", {
+        this.#problemStore.set("worker-error", {
           severity: "error",
           message: `Node playground error: ${msg}`,
         });
@@ -472,9 +472,9 @@ export default class UserNodePlayer implements Player {
         void this._emitState();
       });
 
-      this._nodeTransformRpc = rpc;
+      this.#nodeTransformRpc = rpc;
     }
-    return this._nodeTransformRpc;
+    return this.#nodeTransformRpc;
   }
 
   // We need to reset workers in a variety of circumstances:
@@ -485,34 +485,34 @@ export default class UserNodePlayer implements Player {
   // For the time being, resetWorkers is a catchall for these circumstances. As
   // performance bottlenecks are identified, it will be subject to change.
   async _resetWorkers(): Promise<void> {
-    if (!this._lastPlayerStateActiveData) {
+    if (!this.#lastPlayerStateActiveData) {
       return;
     }
 
     // Make sure that we only run this function once at a time, but using this instead of `debouncePromise` so that it
     // returns a promise.
-    if (this._pendingResetWorkers) {
-      await this._pendingResetWorkers;
+    if (this.#pendingResetWorkers) {
+      await this.#pendingResetWorkers;
     }
     const pending = signal();
-    this._pendingResetWorkers = pending;
+    this.#pendingResetWorkers = pending;
 
     // This early return is an optimization measure so that the
     // `nodeRegistrations` array is not re-defined, which will invalidate
     // downstream caches. (i.e. `this._getTopics`)
-    if (this._nodeRegistrations.length === 0 && Object.entries(this._userNodes).length === 0) {
+    if (this.#nodeRegistrations.length === 0 && Object.entries(this.#userNodes).length === 0) {
       pending.resolve();
-      this._pendingResetWorkers = undefined;
+      this.#pendingResetWorkers = undefined;
       return;
     }
 
-    for (const nodeRegistration of this._nodeRegistrations) {
+    for (const nodeRegistration of this.#nodeRegistrations) {
       nodeRegistration.terminate();
     }
 
     const allNodeRegistrations = await Promise.all(
-      Object.entries(this._userNodes).map(
-        async ([nodeId, userNode]) => await this._createNodeRegistration(nodeId, userNode),
+      Object.entries(this.#userNodes).map(
+        async ([nodeId, userNode]) => await this.#createNodeRegistration(nodeId, userNode),
       ),
     );
 
@@ -521,7 +521,7 @@ export default class UserNodePlayer implements Player {
       ({ nodeData, nodeId }) => {
         const hasError = hasTransformerErrors(nodeData);
         if (hasError) {
-          this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
+          this.#setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
         }
         return !hasError;
       },
@@ -534,7 +534,7 @@ export default class UserNodePlayer implements Player {
       (nodeReg) => nodeReg === nodesByOutputTopic[nodeReg.output.name]?.[0],
     );
     duplicateNodeRegistrations.forEach(({ nodeId, nodeData }) => {
-      this._setUserNodeDiagnostics(nodeId, [
+      this.#setUserNodeDiagnostics(nodeId, [
         ...nodeData.diagnostics,
         {
           severity: DiagnosticSeverity.Error,
@@ -545,31 +545,31 @@ export default class UserNodePlayer implements Player {
       ]);
     });
 
-    this._nodeRegistrations = validNodeRegistrations;
-    const nodeTopics = this._nodeRegistrations.map(({ output }) => output);
-    if (!isEqual(nodeTopics, this._memoizedNodeTopics)) {
-      this._memoizedNodeTopics = nodeTopics;
+    this.#nodeRegistrations = validNodeRegistrations;
+    const nodeTopics = this.#nodeRegistrations.map(({ output }) => output);
+    if (!isEqual(nodeTopics, this.#memoizedNodeTopics)) {
+      this.#memoizedNodeTopics = nodeTopics;
     }
-    const nodeDatatypes = this._nodeRegistrations.map(({ nodeData: { datatypes } }) => datatypes);
-    if (!isEqual(nodeDatatypes, this._memoizedNodeDatatypes)) {
-      this._memoizedNodeDatatypes = nodeDatatypes;
+    const nodeDatatypes = this.#nodeRegistrations.map(({ nodeData: { datatypes } }) => datatypes);
+    if (!isEqual(nodeDatatypes, this.#memoizedNodeDatatypes)) {
+      this.#memoizedNodeDatatypes = nodeDatatypes;
     }
 
-    this._nodeRegistrations.forEach(({ nodeId }) => this._setUserNodeDiagnostics(nodeId, []));
+    this.#nodeRegistrations.forEach(({ nodeId }) => this.#setUserNodeDiagnostics(nodeId, []));
 
-    this._pendingResetWorkers = undefined;
+    this.#pendingResetWorkers = undefined;
     pending.resolve();
   }
 
   async _getRosLib(): Promise<string> {
-    if (!this._lastPlayerStateActiveData) {
+    if (!this.#lastPlayerStateActiveData) {
       throw new Error("_getRosLib was called before `_lastPlayerStateActiveData` set");
     }
-    const { topics, datatypes } = this._lastPlayerStateActiveData;
+    const { topics, datatypes } = this.#lastPlayerStateActiveData;
 
     // If datatypes have not changed, we can reuse the existing rosLib
-    if (this._rosLib != undefined && this._rosLibDatatypes === datatypes) {
-      return this._rosLib;
+    if (this.#rosLib != undefined && this.#rosLibDatatypes === datatypes) {
+      return this.#rosLib;
     }
 
     const transformWorker = this._getTransformWorker();
@@ -577,7 +577,7 @@ export default class UserNodePlayer implements Player {
       topics,
       datatypes,
     });
-    this._setRosLib(rosLib, datatypes);
+    this.#setRosLib(rosLib, datatypes);
 
     return rosLib;
   }
@@ -587,7 +587,7 @@ export default class UserNodePlayer implements Player {
     try {
       const { activeData } = playerState;
       if (!activeData) {
-        this._playerState = playerState;
+        this.#playerState = playerState;
         await this._emitState();
         return;
       }
@@ -595,26 +595,26 @@ export default class UserNodePlayer implements Player {
       const { messages, topics, datatypes } = activeData;
 
       // Reset node state after seeking
-      if (activeData.lastSeekTime !== this._lastPlayerStateActiveData?.lastSeekTime) {
+      if (activeData.lastSeekTime !== this.#lastPlayerStateActiveData?.lastSeekTime) {
         await this._resetWorkers();
       }
 
       // If we do not have active player data from a previous call, then our
       // player just spun up, meaning we should re-run our user nodes in case
       // they have inputs that now exist in the current player context.
-      if (!this._lastPlayerStateActiveData) {
-        this._lastPlayerStateActiveData = activeData;
+      if (!this.#lastPlayerStateActiveData) {
+        this.#lastPlayerStateActiveData = activeData;
         await this._resetWorkers();
-        this.setSubscriptions(this._subscriptions);
+        this.setSubscriptions(this.#subscriptions);
         this.requestBackfill();
       }
 
-      const allDatatypes = this._getDatatypes(datatypes, this._memoizedNodeDatatypes);
+      const allDatatypes = this._getDatatypes(datatypes, this.#memoizedNodeDatatypes);
 
       const { parsedMessages } = await this._getMessages(
         messages,
-        this._globalVariables,
-        this._nodeRegistrations,
+        this.#globalVariables,
+        this.#nodeRegistrations,
       );
 
       const newPlayerState = {
@@ -622,57 +622,57 @@ export default class UserNodePlayer implements Player {
         activeData: {
           ...activeData,
           messages: parsedMessages,
-          topics: this._getTopics(topics, this._memoizedNodeTopics),
+          topics: this._getTopics(topics, this.#memoizedNodeTopics),
           datatypes: allDatatypes,
         },
       };
 
-      this._playerState = newPlayerState;
-      this._lastPlayerStateActiveData = playerState.activeData;
+      this.#playerState = newPlayerState;
+      this.#lastPlayerStateActiveData = playerState.activeData;
 
       // clear any previous problem we had from making a new player state
-      this._problemStore.delete("player-state-update");
+      this.#problemStore.delete("player-state-update");
     } catch (err) {
-      this._problemStore.set("player-state-update", {
+      this.#problemStore.set("player-state-update", {
         severity: "error",
         message: err.message,
         error: err,
       });
 
-      this._playerState = playerState;
+      this.#playerState = playerState;
     } finally {
       await this._emitState();
     }
   }
 
   private async _emitState() {
-    if (!this._playerState) {
+    if (!this.#playerState) {
       return;
     }
 
     // only augment child problems if we have our own problems
     // if neither child or parent have problems we do nothing
-    let problems = this._playerState.problems;
-    if (this._problemStore.size > 0) {
-      problems = (problems ?? []).concat(Array.from(this._problemStore.values()));
+    let problems = this.#playerState.problems;
+    if (this.#problemStore.size > 0) {
+      problems = (problems ?? []).concat(Array.from(this.#problemStore.values()));
     }
 
     const playerState: PlayerState = {
-      ...this._playerState,
+      ...this.#playerState,
       problems,
     };
 
-    if (this._listener) {
-      await this._listener(playerState);
+    if (this.#listener) {
+      await this.#listener(playerState);
     }
   }
 
-  setListener(listener: NonNullable<UserNodePlayer["_listener"]>): void {
-    this._listener = listener;
+  setListener(listener: NonNullable<(_: PlayerState) => Promise<void>>): void {
+    this.#listener = listener;
   }
 
   setSubscriptions(subscriptions: SubscribePayload[]): void {
-    this._subscriptions = subscriptions;
+    this.#subscriptions = subscriptions;
 
     const mappedTopics: string[] = [];
     const realTopicSubscriptions: SubscribePayload[] = [];
@@ -693,7 +693,7 @@ export default class UserNodePlayer implements Player {
       }
       mappedTopics.push(subscription.topic);
 
-      const nodeRegistration = this._nodeRegistrations.find(
+      const nodeRegistration = this.#nodeRegistrations.find(
         (info) => info.output.name === subscription.topic,
       );
       if (nodeRegistration) {
@@ -706,28 +706,28 @@ export default class UserNodePlayer implements Player {
       }
     }
 
-    this._validTopics = new Set(nodeSubscriptions.map((sub) => sub.topic));
-    this._player.setSubscriptions(realTopicSubscriptions);
+    this.#validTopics = new Set(nodeSubscriptions.map((sub) => sub.topic));
+    this.#player.setSubscriptions(realTopicSubscriptions);
   }
 
   close = (): void => {
-    for (const nodeRegistration of this._nodeRegistrations) {
+    for (const nodeRegistration of this.#nodeRegistrations) {
       nodeRegistration.terminate();
     }
-    this._player.close();
-    if (this._nodeTransformRpc) {
-      void this._nodeTransformRpc.send("close");
+    this.#player.close();
+    if (this.#nodeTransformRpc) {
+      void this.#nodeTransformRpc.send("close");
     }
   };
 
-  setPublishers = (publishers: AdvertiseOptions[]): void => this._player.setPublishers(publishers);
+  setPublishers = (publishers: AdvertiseOptions[]): void => this.#player.setPublishers(publishers);
   setParameter = (key: string, value: ParameterValue): void =>
-    this._player.setParameter(key, value);
-  publish = (request: PublishPayload): void => this._player.publish(request);
-  startPlayback = (): void => this._player.startPlayback();
-  pausePlayback = (): void => this._player.pausePlayback();
-  setPlaybackSpeed = (speed: number): void => this._player.setPlaybackSpeed(speed);
+    this.#player.setParameter(key, value);
+  publish = (request: PublishPayload): void => this.#player.publish(request);
+  startPlayback = (): void => this.#player.startPlayback();
+  pausePlayback = (): void => this.#player.pausePlayback();
+  setPlaybackSpeed = (speed: number): void => this.#player.setPlaybackSpeed(speed);
   seekPlayback = (time: Time, backfillDuration?: Time): void =>
-    this._player.seekPlayback(time, backfillDuration);
-  requestBackfill = (): void => this._player.requestBackfill();
+    this.#player.seekPlayback(time, backfillDuration);
+  requestBackfill = (): void => this.#player.requestBackfill();
 }

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -67,43 +67,43 @@ type VelodynePlayerOpts = {
 };
 
 export default class VelodynePlayer implements Player {
-  private _id: string = uuidv4(); // Unique ID for this player
-  private _port: number; // Listening UDP port
-  private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
-  private _socket?: UdpSocketRenderer;
-  private _seq = 0;
-  private _totalBytesReceived = 0;
-  private _closed: boolean = false; // Whether the player has been completely closed using close()
-  private _start: Time; // The time at which we started playing
-  private _packets: RawPacket[] = []; // Queue of packets that will form the next parsed message
-  private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
-  private _metricsCollector: PlayerMetricsCollectorInterface;
-  private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
-  private _emitTimer?: ReturnType<typeof setTimeout>;
+  #id: string = uuidv4(); // Unique ID for this player
+  #port: number; // Listening UDP port
+  #listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState()
+  #socket?: UdpSocketRenderer;
+  #seq = 0;
+  #totalBytesReceived = 0;
+  #closed: boolean = false; // Whether the player has been completely closed using close()
+  #start: Time; // The time at which we started playing
+  #packets: RawPacket[] = []; // Queue of packets that will form the next parsed message
+  #parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call
+  #metricsCollector: PlayerMetricsCollectorInterface;
+  #presence: PlayerPresence = PlayerPresence.INITIALIZING;
+  #emitTimer?: ReturnType<typeof setTimeout>;
 
   // track issues within the player
-  private _problems: PlayerProblem[] = [];
-  private _problemsById = new Map<string, PlayerProblem>();
+  #problems: PlayerProblem[] = [];
+  #problemsById = new Map<string, PlayerProblem>();
 
   constructor({ port, metricsCollector }: VelodynePlayerOpts) {
-    this._port = port ?? DEFAULT_VELODYNE_PORT;
-    log.info(`initializing VelodynePlayer on port ${this._port}`);
-    this._metricsCollector = metricsCollector;
-    this._start = fromMillis(Date.now());
-    this._metricsCollector.playerConstructed();
-    void this._open();
+    this.#port = port ?? DEFAULT_VELODYNE_PORT;
+    log.info(`initializing VelodynePlayer on port ${this.#port}`);
+    this.#metricsCollector = metricsCollector;
+    this.#start = fromMillis(Date.now());
+    this.#metricsCollector.playerConstructed();
+    void this.#open();
   }
 
-  private _open = async (): Promise<void> => {
-    if (this._closed) {
+  #open = async (): Promise<void> => {
+    if (this.#closed) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this.#presence = PlayerPresence.INITIALIZING;
 
-    if (this._socket == undefined) {
+    if (this.#socket == undefined) {
       const net = await Sockets.Create();
-      this._socket = await net.createUdpSocket();
-      this._socket.on("error", (error) => {
+      this.#socket = await net.createUdpSocket();
+      this.#socket.on("error", (error) => {
         this._addProblem(PROBLEM_SOCKET_ERROR, {
           message: "Networking error listening for Velodyne data",
           severity: "error",
@@ -111,24 +111,24 @@ export default class VelodynePlayer implements Player {
           tip: "Check that your are connected to the same local network (subnet) as the Velodyne sensor",
         });
       });
-      this._socket.on("message", this._handleMessage);
+      this.#socket.on("message", this._handleMessage);
     } else {
       try {
-        await this._socket.close();
+        await this.#socket.close();
       } catch (err) {
         log.error(`Failed to close socket: ${err}`);
       }
     }
 
     try {
-      await this._socket.bind({ address: "0.0.0.0", port: this._port });
-      log.debug(`Bound Velodyne UDP listener socket to port ${this._port}`);
+      await this.#socket.bind({ address: "0.0.0.0", port: this.#port });
+      log.debug(`Bound Velodyne UDP listener socket to port ${this.#port}`);
     } catch (error) {
       this._addProblem(PROBLEM_SOCKET_ERROR, {
         message: "Could not bind to the Velodyne UDP data port",
         severity: "error",
         error,
-        tip: `Check that port ${this._port} is not in use by another application`,
+        tip: `Check that port ${this.#port} is not in use by another application`,
       });
     }
   };
@@ -139,12 +139,12 @@ export default class VelodynePlayer implements Player {
     date.setMinutes(0, 0, 0);
     const topOfHour = fromDate(date);
 
-    this._totalBytesReceived += data.byteLength;
-    this._presence = PlayerPresence.PRESENT;
+    this.#totalBytesReceived += data.byteLength;
+    this.#presence = PlayerPresence.PRESENT;
     this._clearProblem(PROBLEM_SOCKET_ERROR, { skipEmit: true });
 
-    if (this._seq === 0) {
-      this._metricsCollector.recordTimeToFirstMsgs();
+    if (this.#seq === 0) {
+      this.#metricsCollector.recordTimeToFirstMsgs();
     }
 
     const rawPacket = new RawPacket(data);
@@ -153,18 +153,18 @@ export default class VelodynePlayer implements Player {
     const rate = packetRate(rawPacket.inferModel() ?? Model.HDL64E);
     const numPackets = Math.ceil(rate / frequency);
 
-    this._packets.push(rawPacket);
-    if (this._packets.length >= numPackets) {
+    this.#packets.push(rawPacket);
+    if (this.#packets.length >= numPackets) {
       const message = {
-        header: { seq: this._seq++, stamp: receiveTime, frame_id: rinfo.address },
-        packets: this._packets.map((raw) => rawPacketToRos(raw, topOfHour)),
+        header: { seq: this.#seq++, stamp: receiveTime, frame_id: rinfo.address },
+        packets: this.#packets.map((raw) => rawPacketToRos(raw, topOfHour)),
       };
 
       const msg: MessageEvent<unknown> = { topic: TOPIC, receiveTime, message };
-      this._parsedMessages.push(msg);
-      this._packets = [];
+      this.#parsedMessages.push(msg);
+      this.#packets = [];
 
-      this._emitState();
+      this.#emitState();
     }
   };
 
@@ -173,55 +173,55 @@ export default class VelodynePlayer implements Player {
     problem: PlayerProblem,
     { skipEmit = false }: { skipEmit?: boolean } = {},
   ): void {
-    this._problemsById.set(id, problem);
-    this._problems = Array.from(this._problemsById.values());
+    this.#problemsById.set(id, problem);
+    this.#problems = Array.from(this.#problemsById.values());
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   private _clearProblem(id: string, { skipEmit = false }: { skipEmit?: boolean } = {}): void {
-    if (!this._problemsById.delete(id)) {
+    if (!this.#problemsById.delete(id)) {
       return;
     }
-    this._problems = Array.from(this._problemsById.values());
+    this.#problems = Array.from(this.#problemsById.values());
     if (!skipEmit) {
-      this._emitState();
+      this.#emitState();
     }
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  private _emitState = debouncePromise(() => {
-    if (!this._listener || this._closed) {
+  #emitState = debouncePromise(() => {
+    if (!this.#listener || this.#closed) {
       return Promise.resolve();
     }
 
     // Time is always moving forward even if we don't get messages from the device.
     // If we are not connected, don't emit updates since we are not longer getting new data
-    if (this._presence === PlayerPresence.PRESENT) {
-      if (this._emitTimer != undefined) {
-        clearTimeout(this._emitTimer);
+    if (this.#presence === PlayerPresence.PRESENT) {
+      if (this.#emitTimer != undefined) {
+        clearTimeout(this.#emitTimer);
       }
-      this._emitTimer = setTimeout(this._emitState, 100);
+      this.#emitTimer = setTimeout(this.#emitState, 100);
     }
 
     const currentTime = fromMillis(Date.now());
-    const messages = this._parsedMessages;
-    this._parsedMessages = [];
-    return this._listener({
+    const messages = this.#parsedMessages;
+    this.#parsedMessages = [];
+    return this.#listener({
       name: "Velodyne",
-      presence: this._presence,
+      presence: this.#presence,
       progress: {},
       capabilities: CAPABILITIES,
-      playerId: this._id,
-      problems: this._problems,
+      playerId: this.#id,
+      problems: this.#problems,
 
       activeData: {
         messages,
-        totalBytesReceived: this._totalBytesReceived,
+        totalBytesReceived: this.#totalBytesReceived,
         messageOrder: "receiveTime",
-        startTime: this._start,
+        startTime: this.#start,
         endTime: currentTime,
         currentTime,
         isPlaying: true,
@@ -241,25 +241,25 @@ export default class VelodynePlayer implements Player {
   });
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
-    this._listener = listener;
-    this._emitState();
+    this.#listener = listener;
+    this.#emitState();
   }
 
   close(): void {
-    this._closed = true;
-    if (this._socket) {
-      void this._socket.dispose();
-      this._socket = undefined;
+    this.#closed = true;
+    if (this.#socket) {
+      void this.#socket.dispose();
+      this.#socket = undefined;
     }
-    if (this._emitTimer != undefined) {
-      clearTimeout(this._emitTimer);
-      this._emitTimer = undefined;
+    if (this.#emitTimer != undefined) {
+      clearTimeout(this.#emitTimer);
+      this.#emitTimer = undefined;
     }
-    this._metricsCollector.close();
-    this._totalBytesReceived = 0;
-    this._seq = 0;
-    this._packets = [];
-    this._parsedMessages = [];
+    this.#metricsCollector.close();
+    this.#totalBytesReceived = 0;
+    this.#seq = 0;
+    this.#packets = [];
+    this.#parsedMessages = [];
   }
 
   setSubscriptions(_subscriptions: SubscribePayload[]): void {}

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -111,7 +111,7 @@ export default class VelodynePlayer implements Player {
           tip: "Check that your are connected to the same local network (subnet) as the Velodyne sensor",
         });
       });
-      this.#socket.on("message", this._handleMessage);
+      this.#socket.on("message", this.#handleMessage);
     } else {
       try {
         await this.#socket.close();
@@ -133,7 +133,7 @@ export default class VelodynePlayer implements Player {
     }
   };
 
-  _handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
+  #handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
     const receiveTime = fromMillis(Date.now());
     const date = toDate(receiveTime);
     date.setMinutes(0, 0, 0);

--- a/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
@@ -60,50 +60,50 @@ export function instrumentTreeWithApiCheckerDataProvider(
 }
 
 export default class ApiCheckerDataProvider implements RandomAccessDataProvider {
-  _name: string;
-  _provider?: RandomAccessDataProvider;
-  _initializationResult?: InitializationResult;
-  _topicNames: string[] = [];
-  _closed: boolean = false;
-  _isRoot: boolean;
+  #name: string;
+  #provider?: RandomAccessDataProvider;
+  #initializationResult?: InitializationResult;
+  #topicNames: string[] = [];
+  #closed: boolean = false;
+  #isRoot: boolean;
 
   constructor(
     args: { name: string; isRoot: boolean },
     children: RandomAccessDataProviderDescriptor[],
     getDataProvider: GetDataProvider,
   ) {
-    this._name = args.name;
-    this._isRoot = args.isRoot;
+    this.#name = args.name;
+    this.#isRoot = args.isRoot;
     const child = children[0];
     if (children.length !== 1 || !child) {
       this._warn(`Required exactly 1 child, but received ${children.length}`);
       return;
     }
-    this._provider = getDataProvider(child);
+    this.#provider = getDataProvider(child);
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    if (this._initializationResult) {
+    if (this.#initializationResult) {
       this._warn("initialize was called for a second time");
     }
-    if (!this._provider) {
+    if (!this.#provider) {
       throw new Error("Provider not initialized");
     }
-    const initializationResult = await this._provider.initialize(extensionPoint);
-    this._initializationResult = initializationResult;
+    const initializationResult = await this.#provider.initialize(extensionPoint);
+    this.#initializationResult = initializationResult;
 
     if (initializationResult.topics.length === 0) {
       this._warn(
         "No topics returned at all; should have thrown error instead (with details of why this is happening)",
       );
     }
-    if (this._isRoot && initializationResult.messageDefinitions.type !== "parsed") {
+    if (this.#isRoot && initializationResult.messageDefinitions.type !== "parsed") {
       this._warn(
         `Root data provider should return parsed message definitions but instead returned raw`,
       );
     }
     for (const topic of initializationResult.topics) {
-      this._topicNames.push(topic.name);
+      this.#topicNames.push(topic.name);
       if (initializationResult.messageDefinitions.type === "raw") {
         if (
           !initializationResult.providesParsedMessages &&
@@ -131,7 +131,7 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
     end: Time,
     subscriptions: GetMessagesTopics,
   ): Promise<GetMessagesResult> {
-    if (!this._provider) {
+    if (!this.#provider) {
       throw new Error("Provider not initialized");
     }
     if (!Number.isInteger(start.sec) || !Number.isInteger(start.nsec)) {
@@ -140,7 +140,7 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
     if (!Number.isInteger(end.sec) || !Number.isInteger(end.nsec)) {
       this._warn(`end time ${JSON.stringify(end)} must only contain integers`);
     }
-    const initRes = this._initializationResult;
+    const initRes = this.#initializationResult;
     if (!initRes) {
       this._warn("getMessages was called before initialize finished");
       // Need to return, otherwise we can't refer to initRes later, and this is a really bad violation anyway.
@@ -175,17 +175,17 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
     }
     for (const messageType of MESSAGE_FORMATS) {
       for (const topic of subscriptions[messageType] ?? []) {
-        if (!this._topicNames.includes(topic)) {
+        if (!this.#topicNames.includes(topic)) {
           this._warn(
             `Requested topic (${topic}) is not in the list of topics published by "initialize" (${JSON.stringify(
-              this._topicNames,
+              this.#topicNames,
             )})`,
           );
         }
       }
     }
 
-    const providerResult = await this._provider?.getMessages(start, end, subscriptions);
+    const providerResult = await this.#provider?.getMessages(start, end, subscriptions);
 
     for (const messageType of MESSAGE_FORMATS) {
       const messages = providerResult[messageType];
@@ -230,18 +230,18 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
   }
 
   async close(): Promise<void> {
-    if (!this._initializationResult) {
+    if (!this.#initializationResult) {
       this._warn("close was called before initialize finished");
     }
-    if (this._closed) {
+    if (this.#closed) {
       this._warn("close was called twice");
     }
-    this._closed = true;
-    return await this._provider?.close();
+    this.#closed = true;
+    return await this.#provider?.close();
   }
 
   _warn(message: string): void {
-    const prefixedMessage = `ApiCheckerDataProvider(${this._name}): ${message}`;
+    const prefixedMessage = `ApiCheckerDataProvider(${this.#name}): ${message}`;
     sendNotification("Internal data provider assertion failed", prefixedMessage, "app", "warn");
 
     if (process.env.NODE_ENV !== "production") {

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -109,7 +109,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
   _bag?: Bag;
   _lastPerformanceStatsToLog?: TimedDataThroughput;
   _extensionPoint?: ExtensionPoint;
-  private bzip2?: Bzip2;
+  #bzip2?: Bzip2;
 
   constructor(options: Options, children: RandomAccessDataProviderDescriptor[]) {
     if (children.length > 0) {
@@ -122,7 +122,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     this._extensionPoint = extensionPoint;
     const { bagPath, cacheSizeInBytes } = this._options;
     await decompressLZ4.isLoaded;
-    this.bzip2 = await Bzip2.init();
+    this.#bzip2 = await Bzip2.init();
 
     try {
       if (bagPath.type === "remoteBagUrl") {
@@ -299,11 +299,11 @@ export default class BagDataProvider implements RandomAccessDataProvider {
       noParse: true,
       decompress: {
         bz2: (buffer: Uint8Array, size: number) => {
-          if (!this.bzip2) {
+          if (!this.#bzip2) {
             throw new Error("bzip2 not initialized");
           }
           try {
-            return this.bzip2.decompress(buffer, size, { small: false });
+            return this.#bzip2.decompress(buffer, size, { small: false });
           } catch (error) {
             reportMalformedError("bz2 decompression", error);
             throw error;

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -85,18 +85,18 @@ const mergeStats = (a: TimedDataThroughput, b: TimedDataThroughput): TimedDataTh
 
 // A FileReader that "spies" on data callbacks. Used to log data consumed.
 class LogMetricsReader {
-  _reader: FileReader;
-  _extensionPoint: ExtensionPoint;
+  #reader: FileReader;
+  #extensionPoint: ExtensionPoint;
   constructor(reader: FileReader, extensionPoint: ExtensionPoint) {
-    this._reader = reader;
-    this._extensionPoint = extensionPoint;
+    this.#reader = reader;
+    this.#extensionPoint = extensionPoint;
   }
   async open() {
-    return await this._reader.open();
+    return await this.#reader.open();
   }
   fetch(offset: number, length: number) {
-    const stream = this._reader.fetch(offset, length);
-    stream.on("data", getReportMetadataForChunk(this._extensionPoint));
+    const stream = this.#reader.fetch(offset, length);
+    stream.on("data", getReportMetadataForChunk(this.#extensionPoint));
     return stream;
   }
 }
@@ -105,22 +105,22 @@ class LogMetricsReader {
 // `BrowserHttpReader` for how to set up a remote server to be able to directly stream from it.
 // Returns raw messages that still need to be parsed by `ParseMessagesDataProvider`.
 export default class BagDataProvider implements RandomAccessDataProvider {
-  _options: Options;
-  _bag?: Bag;
-  _lastPerformanceStatsToLog?: TimedDataThroughput;
-  _extensionPoint?: ExtensionPoint;
+  #options: Options;
+  #bag?: Bag;
+  #lastPerformanceStatsToLog?: TimedDataThroughput;
+  #extensionPoint?: ExtensionPoint;
   #bzip2?: Bzip2;
 
   constructor(options: Options, children: RandomAccessDataProviderDescriptor[]) {
     if (children.length > 0) {
       throw new Error("BagDataProvider cannot have children");
     }
-    this._options = options;
+    this.#options = options;
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    this._extensionPoint = extensionPoint;
-    const { bagPath, cacheSizeInBytes } = this._options;
+    this.#extensionPoint = extensionPoint;
+    const { bagPath, cacheSizeInBytes } = this.#options;
     await decompressLZ4.isLoaded;
     this.#bzip2 = await Bzip2.init();
 
@@ -152,17 +152,17 @@ export default class BagDataProvider implements RandomAccessDataProvider {
           return await new Promise(() => {}); // Just never finish initializing.
         }
 
-        this._bag = new Bag(new BagReader(remoteReader));
+        this.#bag = new Bag(new BagReader(remoteReader));
 
         try {
-          await this._bag.open();
+          await this.#bag.open();
         } catch (err) {
           sendNotification("Opening remote bag failed", (err as Error).message, "user", "error");
           return await new Promise(() => {}); // Just never finish initializing.
         }
       } else {
-        this._bag = new Bag(new BagReader(new BlobReader(bagPath.file)));
-        await this._bag.open();
+        this.#bag = new Bag(new BagReader(new BlobReader(bagPath.file)));
+        await this.#bag.open();
       }
     } catch (err) {
       // Errors in this section come from invalid user data, so we don't want them to be reported as
@@ -170,13 +170,13 @@ export default class BagDataProvider implements RandomAccessDataProvider {
       throw new UserError(err);
     }
 
-    const { startTime, endTime, chunkInfos } = this._bag;
+    const { startTime, endTime, chunkInfos } = this.#bag;
     const connections: Connection[] = [];
     const emptyConnections: {
       // eslint-disable-next-line no-restricted-syntax
       [K in keyof Connection]?: Connection[K] | null;
     }[] = [];
-    for (const [connId, connection] of this._bag.connections) {
+    for (const [connId, connection] of this.#bag.connections) {
       const { messageDefinition, md5sum, topic, type, callerid } = connection;
       if (md5sum && topic && type) {
         connections.push({
@@ -243,33 +243,33 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     };
   }
 
-  _logStats = (): void => {
-    if (this._extensionPoint == undefined || this._lastPerformanceStatsToLog == undefined) {
+  #logStats = (): void => {
+    if (this.#extensionPoint == undefined || this.#lastPerformanceStatsToLog == undefined) {
       return;
     }
-    this._extensionPoint.reportMetadataCallback(this._lastPerformanceStatsToLog.data);
-    this._lastPerformanceStatsToLog = undefined;
+    this.#extensionPoint.reportMetadataCallback(this.#lastPerformanceStatsToLog.data);
+    this.#lastPerformanceStatsToLog = undefined;
   };
 
   // Logs some stats if it has been more than a second since the last call.
-  _debouncedLogStats = debounce(this._logStats, 1000, { leading: false, trailing: true });
+  #debouncedLogStats = debounce(this.#logStats, 1000, { leading: false, trailing: true });
 
   _queueStats(stats: TimedDataThroughput): void {
     if (
-      this._lastPerformanceStatsToLog != undefined &&
-      statsAreAdjacent(this._lastPerformanceStatsToLog, stats)
+      this.#lastPerformanceStatsToLog != undefined &&
+      statsAreAdjacent(this.#lastPerformanceStatsToLog, stats)
     ) {
       // The common case: The next bit of data will be next to the last one. For remote bags we'll
       // reuse the connection.
-      this._lastPerformanceStatsToLog = mergeStats(this._lastPerformanceStatsToLog, stats);
+      this.#lastPerformanceStatsToLog = mergeStats(this.#lastPerformanceStatsToLog, stats);
     } else {
       // For the initial load, or after a seek, a fresh connectionwill be made for remote bags.
       // Eagerly log any stats we know are "done".
-      this._logStats();
-      this._lastPerformanceStatsToLog = stats;
+      this.#logStats();
+      this.#lastPerformanceStatsToLog = stats;
     }
     // Kick the can down the road whether it's new or existing.
-    this._debouncedLogStats();
+    this.#debouncedLogStats();
   }
 
   async getMessages(
@@ -320,7 +320,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
       },
     };
     try {
-      await this._bag?.readMessages(options, onMessage);
+      await this.#bag?.readMessages(options, onMessage);
     } catch (error) {
       reportMalformedError("bag parsing", error);
       throw error;

--- a/packages/studio-base/src/randomAccessDataProviders/BrowserHttpReader.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BrowserHttpReader.ts
@@ -16,10 +16,10 @@ import FetchReader from "@foxglove/studio-base/util/FetchReader";
 
 // A file reader that reads from a remote HTTP URL, for usage in the browser (not for node.js).
 export default class BrowserHttpReader implements FileReader {
-  _url: string;
+  #url: string;
 
   constructor(url: string) {
-    this._url = url;
+    this.#url = url;
   }
 
   async open(): Promise<{ size: number; identifier?: string }> {
@@ -32,22 +32,22 @@ export default class BrowserHttpReader implements FileReader {
       // file size without making Content-Range a CORS header, therefore making all this a bit less
       // robust.
       const controller = new AbortController();
-      response = await fetch(this._url, { signal: controller.signal });
+      response = await fetch(this.#url, { signal: controller.signal });
       controller.abort();
     } catch (error) {
-      throw new Error(`Fetching remote file failed. <${this._url}> ${error}`);
+      throw new Error(`Fetching remote file failed. <${this.#url}> ${error}`);
     }
     if (!response.ok) {
       throw new Error(
-        `Fetching remote file failed. <${this._url}> Status code: ${response.status}.`,
+        `Fetching remote file failed. <${this.#url}> Status code: ${response.status}.`,
       );
     }
     if (response.headers.get("accept-ranges") !== "bytes") {
-      throw new Error(`Remote file does not support HTTP Range Requests. <${this._url}>`);
+      throw new Error(`Remote file does not support HTTP Range Requests. <${this.#url}>`);
     }
     const size = response.headers.get("content-length");
     if (size == undefined) {
-      throw new Error(`Remote file is missing file size. <${this._url}>`);
+      throw new Error(`Remote file is missing file size. <${this.#url}>`);
     }
     return {
       size: parseInt(size),
@@ -58,6 +58,6 @@ export default class BrowserHttpReader implements FileReader {
 
   fetch(offset: number, length: number): FileStream {
     const headers = new Headers({ range: `bytes=${offset}-${offset + (length - 1)}` });
-    return new FetchReader(this._url, { headers }) as FileStream;
+    return new FetchReader(this.#url, { headers }) as FileStream;
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
@@ -227,30 +227,30 @@ type ProcessedInitializationResult = Readonly<{
 // A RandomAccessDataProvider that combines multiple underlying RandomAccessDataProviders, optionally adding topic prefixes
 // or removing certain topics.
 export default class CombinedDataProvider implements RandomAccessDataProvider {
-  _providers: RandomAccessDataProvider[];
+  #providers: RandomAccessDataProvider[];
   // Initialization result will be undefined for providers that don't successfully initialize.
-  _initializationResultsPerProvider: (ProcessedInitializationResult | undefined)[] = [];
-  _progressPerProvider: (Progress | undefined)[];
-  _extensionPoint?: ExtensionPoint;
+  #initializationResultsPerProvider: (ProcessedInitializationResult | undefined)[] = [];
+  #progressPerProvider: (Progress | undefined)[];
+  #extensionPoint?: ExtensionPoint;
 
   constructor(
     _: unknown,
     children: RandomAccessDataProviderDescriptor[],
     getDataProvider: GetDataProvider,
   ) {
-    this._providers = children.map((descriptor) =>
+    this.#providers = children.map((descriptor) =>
       process.env.NODE_ENV === "test" && descriptor.name === "TestProvider"
         ? descriptor.args.provider
         : getDataProvider(descriptor),
     );
     // initialize progress to an empty range for each provider
-    this._progressPerProvider = children.map((__) => undefined);
+    this.#progressPerProvider = children.map((__) => undefined);
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    this._extensionPoint = extensionPoint;
+    this.#extensionPoint = extensionPoint;
 
-    const providerInitializePromises = this._providers.map(async (provider, idx) => {
+    const providerInitializePromises = this.#providers.map(async (provider, idx) => {
       return await provider.initialize({
         ...extensionPoint,
         progressCallback: (progress: Progress) => {
@@ -262,7 +262,7 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
     const results = filterMap(initializeOutcomes, (result) => {
       return result.status === "fulfilled" ? result.value : undefined;
     });
-    this._initializationResultsPerProvider = initializeOutcomes.map((outcome) => {
+    this.#initializationResultsPerProvider = initializeOutcomes.map((outcome) => {
       if (outcome.status === "fulfilled") {
         const { start, end, topics } = outcome.value;
         return { start, end, topicSet: new Set(topics.map((t) => t.name)) };
@@ -277,8 +277,8 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
     }
 
     // Any providers that didn't report progress in `initialize` are assumed fully loaded
-    this._progressPerProvider.forEach((p, i) => {
-      this._progressPerProvider[i] = p ?? fullyLoadedProgress();
+    this.#progressPerProvider.forEach((p, i) => {
+      this.#progressPerProvider[i] = p ?? fullyLoadedProgress();
     });
 
     const start = sortTimes(results.map((result) => result.start)).shift();
@@ -310,13 +310,13 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
   }
 
   async close(): Promise<void> {
-    await Promise.all(this._providers.map(async (provider) => await provider.close()));
+    await Promise.all(this.#providers.map(async (provider) => await provider.close()));
   }
 
   async getMessages(start: Time, end: Time, topics: GetMessagesTopics): Promise<GetMessagesResult> {
     const messagesPerProvider = await Promise.all(
-      this._providers.map(async (provider, index) => {
-        const initializationResult = this._initializationResultsPerProvider[index];
+      this.#providers.map(async (provider, index) => {
+        const initializationResult = this.#initializationResultsPerProvider[index];
         if (initializationResult == undefined) {
           return { parsedMessages: undefined, rosBinaryMessages: undefined };
         }
@@ -373,10 +373,10 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
   }
 
   _updateProgressForChild(providerIdx: number, progress: Progress): void {
-    this._progressPerProvider[providerIdx] = progress;
+    this.#progressPerProvider[providerIdx] = progress;
     // Assume empty for unreported progress
-    const cleanProgresses = this._progressPerProvider.map((p) => p ?? emptyProgress());
+    const cleanProgresses = this.#progressPerProvider.map((p) => p ?? emptyProgress());
     const intersected = intersectProgress(cleanProgresses);
-    this._extensionPoint?.progressCallback(intersected);
+    this.#extensionPoint?.progressCallback(intersected);
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -237,34 +237,34 @@ export function getPrefetchStartPoint(uncachedRanges: Range[], cursorPosition: n
 // unparsed ROS messages. The messages are evicted from this in-memory cache based on some constants
 // defined at the top of this file.
 export default class MemoryCacheDataProvider implements RandomAccessDataProvider {
-  _id: string;
-  _provider: RandomAccessDataProvider;
-  _extensionPoint?: ExtensionPoint;
+  #id: string;
+  #provider: RandomAccessDataProvider;
+  #extensionPoint?: ExtensionPoint;
 
   // The actual blocks that contain the messages. Blocks have a set "width" in terms of nanoseconds
   // since the start time of the bag. If a block has some messages for a topic, then by definition
   // it has *all* messages for that topic and timespan.
-  _blocks: (MemoryCacheBlock | undefined)[] = [];
+  #blocks: (MemoryCacheBlock | undefined)[] = [];
 
   // The start time of the bag. Used for computing from and to nanoseconds since the start.
-  _startTime: Time = { sec: 0, nsec: 0 };
+  #startTime: Time = { sec: 0, nsec: 0 };
 
   // The topics that we were most recently asked to load.
   // This is always set by the last `getMessages` call.
-  _preloadTopics: string[] = [];
+  #preloadTopics: string[] = [];
 
   // Total length of the data in nanoseconds. Used to compute progress with.
-  _totalNs: number = 0;
+  #totalNs: number = 0;
 
   // The current "connection", which represents the range that we're downloading.
-  _currentConnection?: {
+  #currentConnection?: {
     id: string;
     topics: string[];
     remainingBlockRange: Range;
   };
 
   // The read requests we've received via `getMessages`.
-  _readRequests: {
+  #readRequests: {
     // Actual range of messages, in nanoseconds since `this._startTime`.
     timeRange: Range;
     // The range of blocks.
@@ -276,23 +276,23 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   // Recently requested ranges of blocks, sorted by most recent to least recent. There should never
   // be any overlapping ranges. Ranges *are* allowed to cover blocks that haven't been downloaded
   // (yet).
-  _recentBlockRanges: Range[] = [];
+  #recentBlockRanges: Range[] = [];
 
   // The end time of the last callback that we've resolved. This is useful for preloading new data
   // around this time.
-  _lastResolvedCallbackEnd?: number;
+  #lastResolvedCallbackEnd?: number;
 
   // When we log a "block too large" error, we only want to do that once, to prevent
   // spamming errors.
-  _loggedTooLargeError: boolean = false;
+  #loggedTooLargeError: boolean = false;
 
   // If we're configured to use an unlimited cache, we try to just load as much as possible and
   // never evict anything.
-  _cacheSizeBytes: number;
-  _readAheadBlocks: number = 0;
-  _memCacheBlockSizeNs: number = 0;
+  #cacheSizeBytes: number;
+  #readAheadBlocks: number = 0;
+  #memCacheBlockSizeNs: number = 0;
 
-  _lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
+  #lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
 
   constructor(
     {
@@ -305,8 +305,8 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     children: RandomAccessDataProviderDescriptor[],
     getDataProvider: GetDataProvider,
   ) {
-    this._id = id;
-    this._cacheSizeBytes = unlimitedCache ? Infinity : DEFAULT_CACHE_SIZE_BYTES;
+    this.#id = id;
+    this.#cacheSizeBytes = unlimitedCache ? Infinity : DEFAULT_CACHE_SIZE_BYTES;
     const child = children[0];
     if (children.length !== 1 || !child) {
       throw new Error(
@@ -314,39 +314,39 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       );
     }
 
-    this._provider = getDataProvider(child);
+    this.#provider = getDataProvider(child);
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    this._extensionPoint = extensionPoint;
-    const result = await this._provider.initialize({
+    this.#extensionPoint = extensionPoint;
+    const result = await this.#provider.initialize({
       ...extensionPoint,
       progressCallback: () => {},
     });
-    this._startTime = result.start;
-    this._totalNs = Number(toNanoSec(subtractTimes(result.end, result.start))) + 1; // +1 since times are inclusive.
+    this.#startTime = result.start;
+    this.#totalNs = Number(toNanoSec(subtractTimes(result.end, result.start))) + 1; // +1 since times are inclusive.
 
-    this._memCacheBlockSizeNs = Math.ceil(
-      Math.max(MIN_MEM_CACHE_BLOCK_SIZE_NS, this._totalNs / MAX_BLOCKS),
+    this.#memCacheBlockSizeNs = Math.ceil(
+      Math.max(MIN_MEM_CACHE_BLOCK_SIZE_NS, this.#totalNs / MAX_BLOCKS),
     );
-    this._readAheadBlocks = Math.ceil(READ_AHEAD_NS / this._memCacheBlockSizeNs);
+    this.#readAheadBlocks = Math.ceil(READ_AHEAD_NS / this.#memCacheBlockSizeNs);
 
-    if (this._totalNs > Number.MAX_SAFE_INTEGER * 0.9) {
+    if (this.#totalNs > Number.MAX_SAFE_INTEGER * 0.9) {
       throw new Error("Time range is too long to be supported");
     }
 
-    const blockCount = Math.ceil(this._totalNs / this._memCacheBlockSizeNs);
-    this._blocks = Array.from({ length: blockCount });
+    const blockCount = Math.ceil(this.#totalNs / this.#memCacheBlockSizeNs);
+    this.#blocks = Array.from({ length: blockCount });
 
     const msgDefs = result.messageDefinitions;
     if (msgDefs.type === "parsed") {
       for (const [topic, msgDef] of Object.entries(msgDefs.parsedMessageDefinitionsByTopic)) {
-        this._lazyMessageReadersByTopic.set(topic, new LazyMessageReader(msgDef));
+        this.#lazyMessageReadersByTopic.set(topic, new LazyMessageReader(msgDef));
       }
     } else if (msgDefs.type === "raw") {
       for (const [topic, rawMsgDef] of Object.entries(msgDefs.messageDefinitionsByTopic)) {
         const msgDef = parseMessageDefinition(rawMsgDef);
-        this._lazyMessageReadersByTopic.set(topic, new LazyMessageReader(msgDef));
+        this.#lazyMessageReadersByTopic.set(topic, new LazyMessageReader(msgDef));
       }
     }
 
@@ -364,18 +364,18 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   ): Promise<GetMessagesResult> {
     // We might have a new set of topics.
     const topics = getNormalizedTopics(subscriptions.parsedMessages ?? []);
-    this._preloadTopics = topics; // Push a new entry to `this._readRequests`, and call `this._updateState()`.
+    this.#preloadTopics = topics; // Push a new entry to `this._readRequests`, and call `this._updateState()`.
 
     const timeRange = {
-      start: Number(toNanoSec(subtractTimes(startTime, this._startTime))),
-      end: Number(toNanoSec(subtractTimes(endTime, this._startTime))) + 1, // `Range` defines `end` as exclusive.
+      start: Number(toNanoSec(subtractTimes(startTime, this.#startTime))),
+      end: Number(toNanoSec(subtractTimes(endTime, this.#startTime))) + 1, // `Range` defines `end` as exclusive.
     };
     const blockRange = {
-      start: Math.floor(timeRange.start / this._memCacheBlockSizeNs),
-      end: Math.floor((timeRange.end - 1) / this._memCacheBlockSizeNs) + 1, // `Range` defines `end` as exclusive.
+      start: Math.floor(timeRange.start / this.#memCacheBlockSizeNs),
+      end: Math.floor((timeRange.end - 1) / this.#memCacheBlockSizeNs) + 1, // `Range` defines `end` as exclusive.
     };
     return new Promise((resolve) => {
-      this._readRequests.push({
+      this.#readRequests.push({
         timeRange,
         blockRange,
         topics,
@@ -387,23 +387,23 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   }
 
   async close(): Promise<void> {
-    delete this._currentConnection; // Make sure that the current "connection" loop stops executing.
+    this.#currentConnection = undefined; // Make sure that the current "connection" loop stops executing.
 
-    return await this._provider.close();
+    return await this.#provider.close();
   }
 
   // We're primarily interested in the topics for the first outstanding read request, and after that
   // we're interested in preloading topics (based on the *last* read request).
   _getCurrentTopics(): string[] {
-    if (this._readRequests[0]) {
-      return this._readRequests[0].topics;
+    if (this.#readRequests[0]) {
+      return this.#readRequests[0].topics;
     }
 
-    return this._preloadTopics;
+    return this.#preloadTopics;
   }
 
   _resolveFinishedReadRequests(): void {
-    this._readRequests = this._readRequests.filter(({ timeRange, blockRange, topics, resolve }) => {
+    this.#readRequests = this.#readRequests.filter(({ timeRange, blockRange, topics, resolve }) => {
       if (topics.length === 0) {
         resolve({
           parsedMessages: [],
@@ -414,7 +414,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
 
       // If any of the requested blocks are not fully downloaded yet, bail out.
       for (let blockIndex = blockRange.start; blockIndex < blockRange.end; blockIndex++) {
-        const block = this._blocks[blockIndex];
+        const block = this.#blocks[blockIndex];
 
         if (!block) {
           return true;
@@ -432,7 +432,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       const messages = [];
 
       for (let blockIndex = blockRange.start; blockIndex < blockRange.end; blockIndex++) {
-        const block = this._blocks[blockIndex];
+        const block = this.#blocks[blockIndex];
 
         if (!block) {
           throw new Error("Block should have been available, but it was not");
@@ -446,7 +446,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
           }
 
           for (const message of messagesFromBlock) {
-            const messageTime = toNanoSec(subtractTimes(message.receiveTime, this._startTime));
+            const messageTime = toNanoSec(subtractTimes(message.receiveTime, this.#startTime));
 
             if (
               timeRange.start <=
@@ -465,7 +465,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         parsedMessages: messages.sort((a, b) => compare(a.receiveTime, b.receiveTime)),
         rosBinaryMessages: undefined,
       });
-      this._lastResolvedCallbackEnd = blockRange.end;
+      this.#lastResolvedCallbackEnd = blockRange.end;
       return false;
     });
   }
@@ -476,11 +476,11 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     this._resolveFinishedReadRequests();
 
     if (
-      this._currentConnection &&
-      !isEqual(this._currentConnection.topics, this._getCurrentTopics())
+      this.#currentConnection &&
+      !isEqual(this.#currentConnection.topics, this._getCurrentTopics())
     ) {
       // If we have a different set of topics, stop the current "connection", and refresh everything.
-      delete this._currentConnection;
+      this.#currentConnection = undefined;
     }
 
     // Then see if we need to set a new connection based on the new connection and read requests state.
@@ -489,14 +489,14 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
 
   _getNewConnection(): Range | undefined {
     const connectionForReadRange = getNewConnection({
-      currentRemainingRange: this._currentConnection
-        ? this._currentConnection.remainingBlockRange
+      currentRemainingRange: this.#currentConnection
+        ? this.#currentConnection.remainingBlockRange
         : undefined,
-      readRequestRange: this._readRequests[0] ? this._readRequests[0].blockRange : undefined,
+      readRequestRange: this.#readRequests[0] ? this.#readRequests[0].blockRange : undefined,
       downloadedRanges: this._getDownloadedBlockRanges(),
-      lastResolvedCallbackEnd: this._lastResolvedCallbackEnd,
-      cacheSize: this._readAheadBlocks,
-      fileSize: this._blocks.length,
+      lastResolvedCallbackEnd: this.#lastResolvedCallbackEnd,
+      cacheSize: this.#readAheadBlocks,
+      fileSize: this.#blocks.length,
       continueDownloadingThreshold: 10, // Somewhat arbitrary number to not create new connections all the time.
     });
 
@@ -504,9 +504,9 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       return connectionForReadRange;
     }
 
-    const cacheBytesUsed = sum(filterMap(this._blocks, (block) => block?.sizeInBytes));
+    const cacheBytesUsed = sum(filterMap(this.#blocks, (block) => block?.sizeInBytes));
 
-    if (!this._currentConnection && cacheBytesUsed < this._cacheSizeBytes) {
+    if (!this.#currentConnection && cacheBytesUsed < this.#cacheSizeBytes) {
       // All read requests have been served, but we have free cache space available. Cache something
       // useful if possible.
       return this._getPrefetchRange();
@@ -519,7 +519,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   _getPrefetchRange(): Range | undefined {
     const bounds = {
       start: 0,
-      end: this._blocks.length,
+      end: this.#blocks.length,
     };
     const uncachedRanges = missingRanges(bounds, this._getDownloadedBlockRanges());
 
@@ -527,7 +527,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       return undefined; // We have loaded the whole file.
     }
 
-    const prefetchStart = getPrefetchStartPoint(uncachedRanges, this._lastResolvedCallbackEnd ?? 0);
+    const prefetchStart = getPrefetchStartPoint(uncachedRanges, this.#lastResolvedCallbackEnd ?? 0);
     // Just request a single block. We know there's at least one there, and we don't want to cause
     // blocks that are actually useful to be evicted because of our prefetching. We could consider
     // a "low priority" connection that aborts as soon as there's memory pressure.
@@ -550,7 +550,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       const connectionSuccess = await this._setConnection(newConnection).catch((err) => {
         sendNotification(
           `MemoryCacheDataProvider connection ${
-            this._currentConnection ? this._currentConnection.id : ""
+            this.#currentConnection ? this.#currentConnection.id : ""
           }`,
           err?.message ?? "<unknown error>",
           "app",
@@ -570,55 +570,55 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   // completed successfully, or whether we were interrupted by another connection.
   async _setConnection(blockRange: Range): Promise<boolean> {
     if (this._getCurrentTopics().length === 0) {
-      delete this._currentConnection;
+      this.#currentConnection = undefined;
       return true;
     }
 
     const id = uuidv4();
-    this._currentConnection = {
+    this.#currentConnection = {
       id,
       topics: this._getCurrentTopics(),
       remainingBlockRange: blockRange,
     }; // Merge the new `blockRange` into `_recentBlockRanges`, which upholds the invariant that
     // these ranges are never overlapping.
 
-    this._recentBlockRanges = mergeNewRangeIntoUnsortedNonOverlappingList(
+    this.#recentBlockRanges = mergeNewRangeIntoUnsortedNonOverlappingList(
       blockRange,
-      this._recentBlockRanges,
+      this.#recentBlockRanges,
     );
 
     const isCurrent = () => {
-      return this._currentConnection?.id === id;
+      return this.#currentConnection?.id === id;
     };
 
     // Just loop infinitely, but break if the connection is not current any more.
     for (;;) {
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       if (!isCurrent()) {
         return false;
       }
 
       const currentBlockIndex: number = currentConnection.remainingBlockRange.start;
       // Only request topics that we don't already have.
-      const topics = this._blocks[currentBlockIndex]
+      const topics = this.#blocks[currentBlockIndex]
         ? currentConnection.topics.filter(
-            (topic) => !this._blocks[currentBlockIndex]?.messagesByTopic[topic],
+            (topic) => !this.#blocks[currentBlockIndex]?.messagesByTopic[topic],
           )
         : currentConnection.topics;
       // Get messages from the underlying provider.
       const startTime = addTimes(
-        this._startTime,
-        fromNanoSec(BigInt(currentBlockIndex * this._memCacheBlockSizeNs)),
+        this.#startTime,
+        fromNanoSec(BigInt(currentBlockIndex * this.#memCacheBlockSizeNs)),
       );
       const endTime = addTimes(
-        this._startTime,
+        this.#startTime,
         fromNanoSec(
-          BigInt(Math.min(this._totalNs, (currentBlockIndex + 1) * this._memCacheBlockSizeNs) - 1),
+          BigInt(Math.min(this.#totalNs, (currentBlockIndex + 1) * this.#memCacheBlockSizeNs) - 1),
         ), // endTime is inclusive.
       );
       const messages =
         topics.length > 0
-          ? await this._provider.getMessages(startTime, endTime, {
+          ? await this.#provider.getMessages(startTime, endTime, {
               rosBinaryMessages: topics,
             })
           : {
@@ -641,7 +641,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         return false;
       }
 
-      const existingBlock = this._blocks[currentBlockIndex] ?? EMPTY_BLOCK;
+      const existingBlock = this.#blocks[currentBlockIndex] ?? EMPTY_BLOCK;
       const messagesByTopic = { ...existingBlock.messagesByTopic };
       let sizeInBytes = existingBlock.sizeInBytes;
       // Fill up the block with messages.
@@ -650,7 +650,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       }
 
       for (const rosBinaryMessage of rosBinaryMessages ?? []) {
-        const lazyReader = this._lazyMessageReadersByTopic.get(rosBinaryMessage.topic);
+        const lazyReader = this.#lazyMessageReadersByTopic.get(rosBinaryMessage.topic);
         if (!lazyReader) {
           continue;
         }
@@ -686,13 +686,13 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         });
       }
 
-      if (sizeInBytes > MAX_BLOCK_SIZE_BYTES && !this._loggedTooLargeError) {
-        this._loggedTooLargeError = true;
+      if (sizeInBytes > MAX_BLOCK_SIZE_BYTES && !this.#loggedTooLargeError) {
+        this.#loggedTooLargeError = true;
 
         sendNotification(
           "Very large block found",
           `A very large block (${Math.round(
-            this._memCacheBlockSizeNs / 1e6,
+            this.#memCacheBlockSizeNs / 1e6,
           )}ms) was found: ${Math.round(
             sizeInBytes / 1e6,
           )}MB. Too much data can cause performance problems and even crashes. Please fix this where the data is being generated.`,
@@ -701,14 +701,14 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         );
       }
 
-      this._blocks = this._blocks.slice(0, currentBlockIndex).concat(
+      this.#blocks = this.#blocks.slice(0, currentBlockIndex).concat(
         [
           {
             messagesByTopic,
             sizeInBytes,
           },
         ],
-        this._blocks.slice(currentBlockIndex + 1),
+        this.#blocks.slice(currentBlockIndex + 1),
       );
       // Now `this._recentBlockRanges` and `this._blocks` have been updated, so we can resolve
       // requests, purge the cache and report progress.
@@ -728,8 +728,8 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
       }
 
       // Otherwise, update the `remainingBlockRange`.
-      this._currentConnection = {
-        ...this._currentConnection,
+      this.#currentConnection = {
+        ...this.#currentConnection,
         remainingBlockRange: {
           start: currentBlockIndex + 1,
           end: blockRange.end,
@@ -738,7 +738,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     }
 
     // Connection successfully completed.
-    delete this._currentConnection;
+    this.#currentConnection = undefined;
     return true;
   }
 
@@ -747,7 +747,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     const topics: string[] = this._getCurrentTopics();
 
     return simplify(
-      filterMap(this._blocks, (block, blockIndex) => {
+      filterMap(this.#blocks, (block, blockIndex) => {
         if (!block) {
           return;
         }
@@ -767,7 +767,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   }
 
   _purgeOldBlocks(): void {
-    if (this._cacheSizeBytes === Infinity) {
+    if (this.#cacheSizeBytes === Infinity) {
       return;
     }
 
@@ -775,51 +775,51 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     // we're actively trying to fill it.
     // If we don't have open read requests, don't evict blocks in the read-ahead range (ahead of the
     // playback cursor) because we'll automatically try to refetch that data immediately after.
-    let badEvictionRange = this._readRequests[0]?.blockRange;
+    let badEvictionRange = this.#readRequests[0]?.blockRange;
 
-    if (!badEvictionRange && this._lastResolvedCallbackEnd != undefined) {
+    if (!badEvictionRange && this.#lastResolvedCallbackEnd != undefined) {
       badEvictionRange = {
-        start: this._lastResolvedCallbackEnd,
-        end: this._lastResolvedCallbackEnd + this._readAheadBlocks,
+        start: this.#lastResolvedCallbackEnd,
+        end: this.#lastResolvedCallbackEnd + this.#readAheadBlocks,
       };
     }
 
     // Call the getBlocksToKeep helper.
     const { blockIndexesToKeep, newRecentRanges } = getBlocksToKeep({
-      recentBlockRanges: this._recentBlockRanges,
-      blockSizesInBytes: this._blocks.map((block) => block?.sizeInBytes ?? 0),
-      maxCacheSizeInBytes: this._cacheSizeBytes,
+      recentBlockRanges: this.#recentBlockRanges,
+      blockSizesInBytes: this.#blocks.map((block) => block?.sizeInBytes ?? 0),
+      maxCacheSizeInBytes: this.#cacheSizeBytes,
       badEvictionRange,
     });
 
     // Update our state.
-    this._recentBlockRanges = newRecentRanges;
-    const newBlocks: (MemoryCacheBlock | undefined)[] = Array.from({ length: this._blocks.length });
+    this.#recentBlockRanges = newRecentRanges;
+    const newBlocks: (MemoryCacheBlock | undefined)[] = Array.from({ length: this.#blocks.length });
 
-    for (let blockIndex = 0; blockIndex < this._blocks.length; blockIndex++) {
-      if (this._blocks[blockIndex] && blockIndexesToKeep.has(blockIndex)) {
-        newBlocks[blockIndex] = this._blocks[blockIndex];
+    for (let blockIndex = 0; blockIndex < this.#blocks.length; blockIndex++) {
+      if (this.#blocks[blockIndex] && blockIndexesToKeep.has(blockIndex)) {
+        newBlocks[blockIndex] = this.#blocks[blockIndex];
       }
     }
 
-    this._blocks = newBlocks;
+    this.#blocks = newBlocks;
   }
 
   _updateProgress(): void {
-    this._extensionPoint?.progressCallback({
+    this.#extensionPoint?.progressCallback({
       fullyLoadedFractionRanges: this._getDownloadedBlockRanges().map((range) => ({
         // Convert block ranges into fractions.
-        start: range.start / this._blocks.length,
-        end: range.end / this._blocks.length,
+        start: range.start / this.#blocks.length,
+        end: range.end / this.#blocks.length,
       })),
       messageCache: {
-        blocks: this._blocks,
-        startTime: this._startTime,
+        blocks: this.#blocks,
+        startTime: this.#startTime,
       },
     });
   }
 
   setCacheSizeBytesInTests(cacheSizeBytes: number): void {
-    this._cacheSizeBytes = cacheSizeBytes;
+    this.#cacheSizeBytes = cacheSizeBytes;
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/ParseMessagesDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/ParseMessagesDataProvider.ts
@@ -30,9 +30,9 @@ import {
 // be the case when using the MemoryCacheDataProvider.
 export default class ParseMessagesDataProvider implements RandomAccessDataProvider {
   // Underlying RandomAccessDataProvider.
-  private _provider: RandomAccessDataProvider;
+  #provider: RandomAccessDataProvider;
 
-  private _datatypeNamesByTopic: {
+  #datatypeNamesByTopic: {
     [topic: string]: string;
   } = {};
 
@@ -47,11 +47,11 @@ export default class ParseMessagesDataProvider implements RandomAccessDataProvid
         `Incorrect number of children to ParseMessagesDataProvider: ${children.length}`,
       );
     }
-    this._provider = getDataProvider(child);
+    this.#provider = getDataProvider(child);
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    const result = await this._provider.initialize(extensionPoint);
+    const result = await this.#provider.initialize(extensionPoint);
     const { topics } = result;
     if (result.providesParsedMessages) {
       throw new Error(
@@ -64,7 +64,7 @@ export default class ParseMessagesDataProvider implements RandomAccessDataProvid
         : rawMessageDefinitionsToParsed(result.messageDefinitions, topics);
 
     topics.forEach(({ name, datatype }) => {
-      this._datatypeNamesByTopic[name] = datatype;
+      this.#datatypeNamesByTopic[name] = datatype;
     });
     // Initialize the readers asynchronously - we can load data without having the readers ready to parse it.
     return { ...result, providesParsedMessages: true, messageDefinitions };
@@ -74,7 +74,7 @@ export default class ParseMessagesDataProvider implements RandomAccessDataProvid
     // Kick off the request to the data provder to get the messages
     // This might trigger some background reading so we can do some other work before waiting
 
-    const { parsedMessages, rosBinaryMessages } = await this._provider.getMessages(start, end, {
+    const { parsedMessages, rosBinaryMessages } = await this.#provider.getMessages(start, end, {
       parsedMessages: topics.parsedMessages,
       rosBinaryMessages: topics.rosBinaryMessages,
     });
@@ -86,6 +86,6 @@ export default class ParseMessagesDataProvider implements RandomAccessDataProvid
   }
 
   async close(): Promise<void> {
-    return await this._provider.close();
+    return await this.#provider.close();
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/RenameDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/RenameDataProvider.ts
@@ -33,8 +33,8 @@ import {
 } from "@foxglove/studio-base/randomAccessDataProviders/types";
 
 export default class RenameDataProvider implements RandomAccessDataProvider {
-  _provider: RandomAccessDataProvider;
-  _prefix: string;
+  #provider: RandomAccessDataProvider;
+  #prefix: string;
 
   constructor(
     args: { prefix?: string },
@@ -48,12 +48,12 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
     if (args.prefix && !args.prefix.startsWith("/")) {
       throw new Error(`Prefix must have a leading forward slash: ${JSON.stringify(args.prefix)}`);
     }
-    this._provider = getDataProvider(child);
-    this._prefix = args.prefix ?? "";
+    this.#provider = getDataProvider(child);
+    this.#prefix = args.prefix ?? "";
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    const result = await this._provider.initialize({
+    const result = await this.#provider.initialize({
       ...extensionPoint,
       progressCallback: (progress: Progress) => {
         extensionPoint.progressCallback({
@@ -61,7 +61,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
           // because we might miss an important mapping!
           fullyLoadedFractionRanges: progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache
-            ? this._mapMessageCache(progress.messageCache)
+            ? this.#mapMessageCache(progress.messageCache)
             : undefined,
         });
       },
@@ -71,7 +71,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
     const convertTopicNameKey = <T>(objWithTopicNameKeys: Record<string, T>) => {
       const topicKeyResult: Record<string, T> = {};
       for (const [topicName, value] of Object.entries(objWithTopicNameKeys)) {
-        topicKeyResult[`${this._prefix}${topicName}`] = value;
+        topicKeyResult[`${this.#prefix}${topicName}`] = value;
       }
       return topicKeyResult;
     };
@@ -104,7 +104,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
       topics: filterMap(result.topics, (topic: Topic) => ({
         // Only map fields that we know are correctly mapped. Don't just splat in `...topic` here
         // because we might miss an important mapping!
-        name: `${this._prefix}${topic.name}`,
+        name: `${this.#prefix}${topic.name}`,
         originalTopic: topic.name,
         datatype: topic.datatype, // TODO(JP): We might want to map datatypes with a prefix in the future, to avoid collisions.
         numMessages: topic.numMessages,
@@ -114,13 +114,13 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
   }
 
   async close(): Promise<void> {
-    return await this._provider.close();
+    return await this.#provider.close();
   }
 
-  _mapMessage = <T>(message: MessageEvent<T>): MessageEvent<T> => ({
+  #mapMessage = <T>(message: MessageEvent<T>): MessageEvent<T> => ({
     // Only map fields that we know are correctly mapped. Don't just splat in `...message` here
     // because we might miss an important mapping!
-    topic: `${this._prefix}${message.topic}`,
+    topic: `${this.#prefix}${message.topic}`,
     receiveTime: message.receiveTime,
     message: message.message,
   });
@@ -131,41 +131,41 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
       const originalTopics = topics[type];
       if (originalTopics) {
         childTopics[type] = originalTopics.map((topic) => {
-          if (!topic.startsWith(this._prefix)) {
+          if (!topic.startsWith(this.#prefix)) {
             throw new Error(
               "RenameDataProvider#getMessages called with topic that doesn't match prefix",
             );
           }
-          return topic.slice(this._prefix.length);
+          return topic.slice(this.#prefix.length);
         });
       }
     }
-    const messages = await this._provider.getMessages(start, end, childTopics);
+    const messages = await this.#provider.getMessages(start, end, childTopics);
     const { parsedMessages, rosBinaryMessages } = messages;
 
     return {
-      parsedMessages: parsedMessages?.map(this._mapMessage),
-      rosBinaryMessages: rosBinaryMessages?.map(this._mapMessage),
+      parsedMessages: parsedMessages?.map(this.#mapMessage),
+      rosBinaryMessages: rosBinaryMessages?.map(this.#mapMessage),
     };
   }
 
-  _mapMessageCache = memoizeWeak(
+  #mapMessageCache = memoizeWeak(
     (messageCache: BlockCache): BlockCache => ({
       // Note: don't just map(this._mapBlock) because map also passes the array and defeats the
       // memoization.
-      blocks: messageCache.blocks.map((block) => this._mapBlock(block)),
+      blocks: messageCache.blocks.map((block) => this.#mapBlock(block)),
       startTime: messageCache.startTime,
     }),
   );
 
-  _mapBlock = memoizeWeak((block?: MemoryCacheBlock): MemoryCacheBlock | undefined => {
+  #mapBlock = memoizeWeak((block?: MemoryCacheBlock): MemoryCacheBlock | undefined => {
     if (!block) {
       return;
     }
 
     const messagesByTopic: Record<string, MessageEvent<unknown>[]> = {};
     for (const [topicName, topicMessages] of Object.entries(block.messagesByTopic)) {
-      messagesByTopic[`${this._prefix}${topicName}`] = topicMessages.map(this._mapMessage);
+      messagesByTopic[`${this.#prefix}${topicName}`] = topicMessages.map(this.#mapMessage);
     }
     return { messagesByTopic, sizeInBytes: block.sizeInBytes };
   });

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -30,29 +30,29 @@ type BagFolderPath = { type: "folder"; folder: FileSystemDirectoryHandle | strin
 type Options = { bagFolderPath: BagFolderPath };
 
 export default class Rosbag2DataProvider implements RandomAccessDataProvider {
-  private options_: Options;
-  private bag_?: Rosbag2;
+  #options_: Options;
+  #bag_?: Rosbag2;
 
   constructor(options: Options, children: RandomAccessDataProviderDescriptor[]) {
     if (children.length > 0) {
       throw new Error("Rosbag2DataProvider cannot have children");
     }
-    this.options_ = options;
+    this.#options_ = options;
   }
 
   async initialize(_extensionPoint: ExtensionPoint): Promise<InitializationResult> {
-    const folder = this.options_.bagFolderPath.folder;
+    const folder = this.#options_.bagFolderPath.folder;
     if (folder instanceof FileSystemDirectoryHandle) {
       const res = await fetch(new URL("sql.js/dist/sql-wasm.wasm", import.meta.url).toString());
       const sqlWasm = await (await res.blob()).arrayBuffer();
-      this.bag_ = await openFileSystemDirectoryHandle(folder, sqlWasm);
+      this.#bag_ = await openFileSystemDirectoryHandle(folder, sqlWasm);
     } else {
       throw new Error("Opening ROS2 bags via the native interface is not implemented yet");
     }
 
-    const [start, end] = await this.bag_.timeRange();
-    const topicDefs = await this.bag_.readTopics();
-    const messageCounts = await this.bag_.messageCounts();
+    const [start, end] = await this.#bag_.timeRange();
+    const topicDefs = await this.#bag_.readTopics();
+    const messageCounts = await this.#bag_.messageCounts();
 
     const problems: RandomAccessDataProviderProblem[] = [];
     const topics: Topic[] = [];
@@ -114,7 +114,7 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
     end: Time,
     subscriptions: GetMessagesTopics,
   ): Promise<GetMessagesResult> {
-    if (this.bag_ == undefined) {
+    if (this.#bag_ == undefined) {
       throw new Error(`Rosbag2DataProvider is not initialized`);
     }
 
@@ -124,7 +124,7 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
     }
 
     const parsedMessages: MessageEvent<unknown>[] = [];
-    for await (const msg of this.bag_.readMessages({ startTime: start, endTime: end, topics })) {
+    for await (const msg of this.#bag_.readMessages({ startTime: start, endTime: end, topics })) {
       parsedMessages.push({
         topic: msg.topic.name,
         receiveTime: msg.timestamp,
@@ -136,6 +136,6 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
   }
 
   async close(): Promise<void> {
-    await this.bag_?.close();
+    await this.#bag_?.close();
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/RpcDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/RpcDataProvider.ts
@@ -29,17 +29,17 @@ import { setupMainThreadRpc } from "@foxglove/studio-base/util/RpcMainThreadUtil
 // RpcDataProviderRemote, where we instantiate the rest of the RandomAccessDataProviderDescriptor tree.
 // See WorkerDataProvider for an example.
 export default class RpcDataProvider implements RandomAccessDataProvider {
-  _rpc: Rpc;
-  _childDescriptor: RandomAccessDataProviderDescriptor;
+  #rpc: Rpc;
+  #childDescriptor: RandomAccessDataProviderDescriptor;
 
   constructor(rpc: Rpc, children: RandomAccessDataProviderDescriptor[]) {
-    this._rpc = rpc;
-    setupMainThreadRpc(this._rpc);
+    this.#rpc = rpc;
+    setupMainThreadRpc(this.#rpc);
     const child = children[0];
     if (children.length !== 1 || !child) {
       throw new Error(`RpcDataProvider requires exactly 1 child, but received ${children.length}`);
     }
-    this._childDescriptor = child;
+    this.#childDescriptor = child;
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
@@ -48,7 +48,7 @@ export default class RpcDataProvider implements RandomAccessDataProvider {
     type ExtensionPointParams<K> = K extends keyof ExtensionPoint
       ? { type: K; data: Parameters<ExtensionPoint[K]>[0] }
       : never;
-    this._rpc.receive(
+    this.#rpc.receive(
       "extensionPointCallback",
       (value: ExtensionPointParams<keyof ExtensionPoint>) => {
         switch (value.type) {
@@ -68,14 +68,14 @@ export default class RpcDataProvider implements RandomAccessDataProvider {
         return undefined;
       },
     );
-    return await this._rpc.send("initialize", { childDescriptor: this._childDescriptor });
+    return await this.#rpc.send("initialize", { childDescriptor: this.#childDescriptor });
   }
 
   async getMessages(start: Time, end: Time, topics: GetMessagesTopics): Promise<GetMessagesResult> {
     if (topics.parsedMessages) {
       throw new Error("RpcDataProvider only supports rosBinaryMessages");
     }
-    const rpcRes = await this._rpc.send<{ messages: GetMessagesResult["rosBinaryMessages"] }>(
+    const rpcRes = await this.#rpc.send<{ messages: GetMessagesResult["rosBinaryMessages"] }>(
       "getMessages",
       {
         start,
@@ -90,6 +90,6 @@ export default class RpcDataProvider implements RandomAccessDataProvider {
   }
 
   async close(): Promise<void> {
-    return await this._rpc.send("close");
+    return await this.#rpc.send("close");
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerDataProvider.ts
@@ -38,9 +38,9 @@ if (process.env.NODE_ENV !== "test") {
 // Wraps the underlying RandomAccessDataProviderDescriptor tree in a Web Worker, therefore allowing
 // `getMessages` calls to get resolved in parallel to the main thread.
 export default class WorkerDataProvider implements RandomAccessDataProvider {
-  _worker?: Worker;
-  _provider?: RpcDataProvider;
-  _child?: RandomAccessDataProviderDescriptor;
+  #worker?: Worker;
+  #provider?: RpcDataProvider;
+  #child?: RandomAccessDataProviderDescriptor;
 
   constructor(_args: unknown, children: RandomAccessDataProviderDescriptor[]) {
     if (children.length !== 1) {
@@ -48,36 +48,36 @@ export default class WorkerDataProvider implements RandomAccessDataProvider {
     }
     const child = children[0];
     if (child) {
-      this._child = child;
+      this.#child = child;
     }
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
     if (preinitializedWorkers.length > 0) {
-      this._worker = preinitializedWorkers.pop();
+      this.#worker = preinitializedWorkers.pop();
     } else {
-      this._worker = WorkerDataProviderWorker();
+      this.#worker = WorkerDataProviderWorker();
     }
 
-    if (!this._worker || !this._child) {
+    if (!this.#worker || !this.#child) {
       throw new Error("WorderDataProvider failed to initialize");
     }
 
-    this._provider = new RpcDataProvider(new Rpc(this._worker), [this._child]);
-    return await this._provider.initialize(extensionPoint);
+    this.#provider = new RpcDataProvider(new Rpc(this.#worker), [this.#child]);
+    return await this.#provider.initialize(extensionPoint);
   }
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   getMessages(start: Time, end: Time, topics: GetMessagesTopics): Promise<GetMessagesResult> {
-    if (!this._provider) {
+    if (!this.#provider) {
       throw new Error("WorkerDataProvieder not initialized");
     }
-    return this._provider.getMessages(start, end, topics);
+    return this.#provider.getMessages(start, end, topics);
   }
 
   async close(): Promise<void> {
-    await this._provider?.close();
-    this._worker?.terminate();
+    await this.#provider?.close();
+    this.#worker?.terminate();
   }
 }

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -17,24 +17,24 @@ import IAnalytics, {
 const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
 
 export class AmplitudeAnalytics implements IAnalytics {
-  private _amp?: AmplitudeClient;
+  #amp?: AmplitudeClient;
 
   constructor(options: { enableTelemetry: boolean; amplitudeApiKey?: string }) {
     if (options.amplitudeApiKey) {
-      this._amp = amplitude.getInstance();
+      this.#amp = amplitude.getInstance();
 
       // Capitalize platform name
       let platform = os?.platform ?? "web";
       platform = platform.charAt(0).toUpperCase() + platform.slice(1);
 
-      this._amp.init(options.amplitudeApiKey, undefined, {
+      this.#amp.init(options.amplitudeApiKey, undefined, {
         platform,
       });
 
-      this._amp.setOptOut(!options.enableTelemetry);
+      this.#amp.setOptOut(!options.enableTelemetry);
 
       if (os) {
-        this._amp.setVersionName(os.getAppVersion());
+        this.#amp.setVersionName(os.getAppVersion());
       }
 
       void this.logEvent(AppEvent.APP_INIT);
@@ -47,10 +47,10 @@ export class AmplitudeAnalytics implements IAnalytics {
     // will appear as a new unique user. We also don't want to call regenerateDeviceId() every time
     // AnalyticsProvider is mounted for anonymous users.
     // https://help.amplitude.com/hc/en-us/articles/115003135607-Tracking-unique-users
-    this._amp?.setUserId(user?.id ?? null); // eslint-disable-line no-restricted-syntax
+    this.#amp?.setUserId(user?.id ?? null); // eslint-disable-line no-restricted-syntax
 
     // Update Sentry user, passing Amplitude deviceId
-    setSentryUser({ id: user?.id, device_id: this._amp?.options.deviceId });
+    setSentryUser({ id: user?.id, device_id: this.#amp?.options.deviceId });
   }
 
   async logEvent(event: AppEvent, data?: { [key: string]: unknown }): Promise<void> {
@@ -64,8 +64,8 @@ export class AmplitudeAnalytics implements IAnalytics {
     });
 
     await new Promise<void>((resolve) => {
-      if (this._amp) {
-        this._amp.logEvent(event, data, () => resolve());
+      if (this.#amp) {
+        this.#amp.logEvent(event, data, () => resolve());
       } else {
         resolve();
       }

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -71,15 +71,15 @@ export type ConsoleApiLayout = {
 type ApiResponse<T> = { status: number; json: T };
 
 class ConsoleApi {
-  private _baseUrl: string;
-  private _authHeader?: string;
+  #baseUrl: string;
+  #authHeader?: string;
 
   constructor(baseUrl: string) {
-    this._baseUrl = baseUrl;
+    this.#baseUrl = baseUrl;
   }
 
   setAuthHeader(header: string): void {
-    this._authHeader = header;
+    this.#authHeader = header;
   }
 
   async orgs(): Promise<Org[]> {
@@ -163,11 +163,11 @@ class ConsoleApi {
       allowedStatuses?: number[];
     } = {},
   ): Promise<ApiResponse<T>> {
-    const fullUrl = `${this._baseUrl}${url}`;
+    const fullUrl = `${this.#baseUrl}${url}`;
 
     const headers: Record<string, string> = {};
-    if (this._authHeader != undefined) {
-      headers["Authorization"] = this._authHeader;
+    if (this.#authHeader != undefined) {
+      headers["Authorization"] = this.#authHeader;
     }
     const fullConfig = { ...config, headers: { ...headers, ...config?.headers } };
 

--- a/packages/studio-base/src/services/LayoutManager/index.ts
+++ b/packages/studio-base/src/services/LayoutManager/index.ts
@@ -60,7 +60,7 @@ async function updateOrFetchLayout(
  * A wrapper around ILayoutStorage for a particular namespace.
  */
 class NamespacedLayoutStorage {
-  private migration: Promise<void>;
+  #migration: Promise<void>;
   constructor(
     private storage: ILayoutStorage,
     private namespace: string,
@@ -69,7 +69,7 @@ class NamespacedLayoutStorage {
       importFromNamespace,
     }: { migrateUnnamespacedLayouts: boolean; importFromNamespace: string | undefined },
   ) {
-    this.migration = (async function () {
+    this.#migration = (async function () {
       if (migrateUnnamespacedLayouts) {
         await storage
           .migrateUnnamespacedLayouts?.(namespace)
@@ -88,19 +88,19 @@ class NamespacedLayoutStorage {
   }
 
   async list(): Promise<readonly Layout[]> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.list(this.namespace);
   }
   async get(id: LayoutID): Promise<Layout | undefined> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.get(this.namespace, id);
   }
   async put(layout: Layout): Promise<Layout> {
-    await this.migration;
+    await this.#migration;
     return await this.storage.put(this.namespace, layout);
   }
   async delete(id: LayoutID): Promise<void> {
-    await this.migration;
+    await this.#migration;
     await this.storage.delete(this.namespace, id);
   }
 }
@@ -114,14 +114,14 @@ export default class LayoutManager implements ILayoutManager {
    * and then writing a single layout, or writing one and deleting another) from getting
    * interleaved.
    */
-  private local: MutexLocked<NamespacedLayoutStorage>;
-  private remote: IRemoteLayoutStorage | undefined;
+  #local: MutexLocked<NamespacedLayoutStorage>;
+  #remote: IRemoteLayoutStorage | undefined;
 
   readonly supportsSharing: boolean;
 
-  private emitter = new EventEmitter<LayoutManagerEventTypes>();
+  #emitter = new EventEmitter<LayoutManagerEventTypes>();
 
-  private busyCount = 0;
+  #busyCount = 0;
 
   /**
    * A decorator to emit busy events before and after an async operation so the UI can show that the
@@ -135,19 +135,19 @@ export default class LayoutManager implements ILayoutManager {
     const method = descriptor.value!;
     descriptor.value = async function (...args) {
       try {
-        this.busyCount++;
-        this.emitter.emit("busychange");
+        this.#busyCount++;
+        this.#emitter.emit("busychange");
         return await method.apply(this, args);
       } finally {
-        this.busyCount--;
-        this.emitter.emit("busychange");
+        this.#busyCount--;
+        this.#emitter.emit("busychange");
       }
     };
   }
 
   // eslint-disable-next-line no-restricted-syntax
   get isBusy(): boolean {
-    return this.busyCount > 0;
+    return this.#busyCount > 0;
   }
 
   isOnline = false;
@@ -155,7 +155,7 @@ export default class LayoutManager implements ILayoutManager {
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setOnline(online: boolean): void {
     this.isOnline = online;
-    this.emitter.emit("onlinechange");
+    this.#emitter.emit("onlinechange");
   }
 
   constructor({
@@ -165,7 +165,7 @@ export default class LayoutManager implements ILayoutManager {
     local: ILayoutStorage;
     remote: IRemoteLayoutStorage | undefined;
   }) {
-    this.local = new MutexLocked(
+    this.#local = new MutexLocked(
       new NamespacedLayoutStorage(
         local,
         remote
@@ -179,7 +179,7 @@ export default class LayoutManager implements ILayoutManager {
         },
       ),
     );
-    this.remote = remote;
+    this.#remote = remote;
     this.supportsSharing = remote != undefined;
   }
 
@@ -187,28 +187,28 @@ export default class LayoutManager implements ILayoutManager {
     name: E,
     listener: EventListener<LayoutManagerEventTypes, E>,
   ): void {
-    this.emitter.on(name, listener);
+    this.#emitter.on(name, listener);
   }
   off<E extends EventNames<LayoutManagerEventTypes>>(
     name: E,
     listener: EventListener<LayoutManagerEventTypes, E>,
   ): void {
-    this.emitter.off(name, listener);
+    this.#emitter.off(name, listener);
   }
 
   private notifyChangeListeners(event: { updatedLayout: Layout | undefined }) {
-    queueMicrotask(() => this.emitter.emit("change", event));
+    queueMicrotask(() => this.#emitter.emit("change", event));
   }
 
   async getLayouts(): Promise<readonly Layout[]> {
-    return await this.local.runExclusive(async (local) => {
+    return await this.#local.runExclusive(async (local) => {
       const layouts = await local.list();
       return layouts.filter((layout) => !layoutAppearsDeleted(layout));
     });
   }
 
   async getLayout(id: LayoutID): Promise<Layout | undefined> {
-    return await this.local.runExclusive(async (local) => {
+    return await this.#local.runExclusive(async (local) => {
       const layout = await local.get(id);
       return layout && !layoutAppearsDeleted(layout) ? layout : undefined;
     });
@@ -225,20 +225,20 @@ export default class LayoutManager implements ILayoutManager {
     permission: LayoutPermission;
   }): Promise<Layout> {
     if (layoutPermissionIsShared(permission)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot share a layout while offline");
       }
-      const newLayout = await this.remote.saveNewLayout({
+      const newLayout = await this.#remote.saveNewLayout({
         id: uuidv4() as LayoutID,
         name,
         data,
         permission,
         savedAt: new Date().toISOString() as ISO8601Timestamp,
       });
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             id: newLayout.id,
@@ -253,7 +253,7 @@ export default class LayoutManager implements ILayoutManager {
       return result;
     }
 
-    const newLayout = await this.local.runExclusive(
+    const newLayout = await this.#local.runExclusive(
       async (local) =>
         await local.put({
           id: uuidv4() as LayoutID,
@@ -261,7 +261,7 @@ export default class LayoutManager implements ILayoutManager {
           permission,
           baseline: { data, savedAt: new Date().toISOString() as ISO8601Timestamp },
           working: undefined,
-          syncInfo: this.remote ? { status: "new", lastRemoteSavedAt: undefined } : undefined,
+          syncInfo: this.#remote ? { status: "new", lastRemoteSavedAt: undefined } : undefined,
         }),
     );
     this.notifyChangeListeners({ updatedLayout: newLayout });
@@ -279,21 +279,21 @@ export default class LayoutManager implements ILayoutManager {
     data: PanelsState | undefined;
   }): Promise<Layout> {
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot update layout ${id} because it does not exist`);
     }
 
     // Renames of shared layouts go directly to the server
     if (name != undefined && layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot update a shared layout while offline");
       }
-      const updatedBaseline = await updateOrFetchLayout(this.remote, { id, name, savedAt: now });
-      const result = await this.local.runExclusive(
+      const updatedBaseline = await updateOrFetchLayout(this.#remote, { id, name, savedAt: now });
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -306,7 +306,7 @@ export default class LayoutManager implements ILayoutManager {
       this.notifyChangeListeners({ updatedLayout: result });
       return result;
     } else {
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -315,7 +315,7 @@ export default class LayoutManager implements ILayoutManager {
 
             // If the name is being changed, we will need to upload to the server
             syncInfo:
-              this.remote &&
+              this.#remote &&
               name != undefined &&
               localLayout.syncInfo &&
               localLayout.syncInfo?.status !== "new"
@@ -330,23 +330,23 @@ export default class LayoutManager implements ILayoutManager {
 
   @LayoutManager.withBusyStatus
   async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot update layout ${id} because it does not exist`);
     }
     if (layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (localLayout.syncInfo?.status !== "remotely-deleted") {
         if (!this.isOnline) {
           throw new Error("Cannot delete a shared layout while offline");
         }
-        await this.remote.deleteLayout(id);
+        await this.#remote.deleteLayout(id);
       }
     }
-    await this.local.runExclusive(async (local) => {
-      if (this.remote && !layoutIsShared(localLayout)) {
+    await this.#local.runExclusive(async (local) => {
+      if (this.#remote && !layoutIsShared(localLayout)) {
         await local.put({
           ...localLayout,
           working: {
@@ -368,24 +368,24 @@ export default class LayoutManager implements ILayoutManager {
 
   @LayoutManager.withBusyStatus
   async overwriteLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const localLayout = await this.local.runExclusive(async (local) => await local.get(id));
+    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
     if (!localLayout) {
       throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
     }
     const now = new Date().toISOString() as ISO8601Timestamp;
     if (layoutIsShared(localLayout)) {
-      if (!this.remote) {
+      if (!this.#remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");
       }
       if (!this.isOnline) {
         throw new Error("Cannot save a shared layout while offline");
       }
-      const updatedBaseline = await updateOrFetchLayout(this.remote, {
+      const updatedBaseline = await updateOrFetchLayout(this.#remote, {
         id,
         data: localLayout.working?.data ?? localLayout.baseline.data,
         savedAt: now,
       });
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -397,7 +397,7 @@ export default class LayoutManager implements ILayoutManager {
       this.notifyChangeListeners({ updatedLayout: result });
       return result;
     } else {
-      const result = await this.local.runExclusive(
+      const result = await this.#local.runExclusive(
         async (local) =>
           await local.put({
             ...localLayout,
@@ -406,7 +406,7 @@ export default class LayoutManager implements ILayoutManager {
               savedAt: now,
             },
             working: undefined,
-            syncInfo: this.remote
+            syncInfo: this.#remote
               ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
               : localLayout.syncInfo,
           }),
@@ -418,7 +418,7 @@ export default class LayoutManager implements ILayoutManager {
 
   @LayoutManager.withBusyStatus
   async revertLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const result = await this.local.runExclusive(async (local) => {
+    const result = await this.#local.runExclusive(async (local) => {
       const layout = await local.get(id);
       if (!layout) {
         throw new Error(`Cannot revert layout id ${id} because it does not exist`);
@@ -435,7 +435,7 @@ export default class LayoutManager implements ILayoutManager {
   @LayoutManager.withBusyStatus
   async makePersonalCopy({ id, name }: { id: LayoutID; name: string }): Promise<Layout> {
     const now = new Date().toISOString() as ISO8601Timestamp;
-    const result = await this.local.runExclusive(async (local) => {
+    const result = await this.#local.runExclusive(async (local) => {
       const layout = await local.get(id);
       if (!layout) {
         throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
@@ -456,7 +456,7 @@ export default class LayoutManager implements ILayoutManager {
   }
 
   /** Ensures at most one sync operation is in progress at a time */
-  private currentSync?: Promise<void>;
+  #currentSync?: Promise<void>;
 
   /**
    * Attempt to synchronize the local cache with remote storage. At minimum this incurs a fetch of
@@ -465,30 +465,30 @@ export default class LayoutManager implements ILayoutManager {
    */
   @LayoutManager.withBusyStatus
   async syncWithRemote(): Promise<void> {
-    if (this.currentSync) {
+    if (this.#currentSync) {
       log.debug("Layout sync is already in progress");
-      return await this.currentSync;
+      return await this.#currentSync;
     }
     const start = performance.now();
     try {
       log.debug("Starting layout sync");
-      this.currentSync = this.syncWithRemoteImpl();
-      await this.currentSync;
+      this.#currentSync = this.syncWithRemoteImpl();
+      await this.#currentSync;
       this.notifyChangeListeners({ updatedLayout: undefined });
     } finally {
-      this.currentSync = undefined;
+      this.#currentSync = undefined;
       log.debug(`Completed sync in ${((performance.now() - start) / 1000).toFixed(2)}s`);
     }
   }
 
   private async syncWithRemoteImpl(): Promise<void> {
-    if (!this.remote || !this.isOnline) {
+    if (!this.#remote || !this.isOnline) {
       return;
     }
 
     const [localLayouts, remoteLayouts] = await Promise.all([
-      this.local.runExclusive(async (local) => await local.list()),
-      this.remote.getLayouts(),
+      this.#local.runExclusive(async (local) => await local.list()),
+      this.#remote.getLayouts(),
     ]);
 
     const syncOperations = computeLayoutSyncOperations(localLayouts, remoteLayouts);
@@ -505,7 +505,7 @@ export default class LayoutManager implements ILayoutManager {
   private async performLocalSyncOperations(
     operations: readonly (SyncOperation & { local: true })[],
   ): Promise<void> {
-    await this.local.runExclusive(async (local) => {
+    await this.#local.runExclusive(async (local) => {
       for (const operation of operations) {
         switch (operation.type) {
           case "mark-deleted": {
@@ -560,7 +560,7 @@ export default class LayoutManager implements ILayoutManager {
   private async performRemoteSyncOperations(
     operations: readonly (SyncOperation & { local: false })[],
   ): Promise<void> {
-    const { remote } = this;
+    const remote = this.#remote;
     if (!remote) {
       return;
     }
@@ -622,7 +622,7 @@ export default class LayoutManager implements ILayoutManager {
       }),
     );
 
-    await this.local.runExclusive(async (local) => {
+    await this.#local.runExclusive(async (local) => {
       for (const cleanup of cleanups) {
         cleanup(local);
       }

--- a/packages/studio-base/src/services/MockLayoutStorage.ts
+++ b/packages/studio-base/src/services/MockLayoutStorage.ts
@@ -6,34 +6,34 @@ import { ILayoutStorage, Layout } from "@foxglove/studio-base/services/ILayoutSt
 
 // ts-prune-ignore-next
 export default class MockLayoutStorage implements ILayoutStorage {
-  private layoutsByIdByNamespace: Map<string, Map<string, Layout>>;
+  #layoutsByIdByNamespace: Map<string, Map<string, Layout>>;
 
   constructor(namespace: string, layouts: Layout[] = []) {
-    this.layoutsByIdByNamespace = new Map([
+    this.#layoutsByIdByNamespace = new Map([
       [namespace, new Map(layouts.map((layout) => [layout.id, layout]))],
     ]);
   }
 
   async list(namespace: string): Promise<readonly Layout[]> {
-    return Array.from(this.layoutsByIdByNamespace.get(namespace)?.values() ?? []);
+    return Array.from(this.#layoutsByIdByNamespace.get(namespace)?.values() ?? []);
   }
 
   async get(namespace: string, id: string): Promise<Layout | undefined> {
-    return this.layoutsByIdByNamespace.get(namespace)?.get(id);
+    return this.#layoutsByIdByNamespace.get(namespace)?.get(id);
   }
 
   async put(namespace: string, layout: Layout): Promise<Layout> {
-    let layoutsById = this.layoutsByIdByNamespace.get(namespace);
+    let layoutsById = this.#layoutsByIdByNamespace.get(namespace);
     if (!layoutsById) {
       layoutsById = new Map();
-      this.layoutsByIdByNamespace.set(namespace, layoutsById);
+      this.#layoutsByIdByNamespace.set(namespace, layoutsById);
     }
     layoutsById.set(layout.id, layout);
     return layout;
   }
 
   async delete(namespace: string, id: string): Promise<void> {
-    this.layoutsByIdByNamespace.get(namespace)?.delete(id);
+    this.#layoutsByIdByNamespace.get(namespace)?.delete(id);
   }
 
   async importLayouts(): Promise<void> {}

--- a/packages/studio-base/src/test/MemoryStorage.ts
+++ b/packages/studio-base/src/test/MemoryStorage.ts
@@ -17,24 +17,24 @@ const DEFAULT_LOCAL_STORAGE__QUOTA = 5000000;
 
 export default class MemoryStorage {
   // Use `__` to mark the fields as internal so we can filter them out in Storage when getting keys using Object.keys(storage).
-  _internal_items: Record<string, string> = {};
-  _internal_quota: number;
+  #internal_items: Record<string, string> = {};
+  #internal_quota: number;
   [key: string]: unknown;
 
   constructor(quota?: number) {
-    this._internal_quota = quota ?? DEFAULT_LOCAL_STORAGE__QUOTA;
+    this.#internal_quota = quota ?? DEFAULT_LOCAL_STORAGE__QUOTA;
   }
 
   clear(): void {
-    this._internal_items = {};
+    this.#internal_items = {};
   }
 
   getItem(key: string): string | undefined {
-    return this._internal_items[key];
+    return this.#internal_items[key];
   }
 
   _getUsedSize(): number {
-    return Object.keys(this._internal_items).reduce((memo, key) => {
+    return Object.keys(this.#internal_items).reduce((memo, key) => {
       return memo + new Blob([this.getItem(key)!]).size;
     }, 0);
   }
@@ -42,15 +42,15 @@ export default class MemoryStorage {
   setItem(key: string, value: string): void {
     const valueByteSize = new Blob([value]).size;
     const newSize = this._getUsedSize() + valueByteSize;
-    if (newSize > this._internal_quota) {
+    if (newSize > this.#internal_quota) {
       throw new Error("Exceeded storage limit");
     }
-    this._internal_items[key] = value;
+    this.#internal_items[key] = value;
     this[key] = value;
   }
 
   removeItem(key: string): void {
-    delete this._internal_items[key];
+    delete this.#internal_items[key];
     delete this[key];
   }
 }

--- a/packages/studio-base/src/test/setup.ts
+++ b/packages/studio-base/src/test/setup.ts
@@ -43,10 +43,10 @@ global.React = require("react");
 
 // Jest does not include ResizeObserver.
 class ResizeObserverMock {
-  private _callback: ResizeObserverCallback;
+  #callback: ResizeObserverCallback;
 
   constructor(callback: ResizeObserverCallback) {
-    this._callback = callback;
+    this.#callback = callback;
   }
 
   disconnect() {}
@@ -55,7 +55,7 @@ class ResizeObserverMock {
     const entry = {
       contentRect: { width: 150, height: 150 },
     };
-    this._callback([entry as ResizeObserverEntry], this);
+    this.#callback([entry as ResizeObserverEntry], this);
   }
 
   unobserve() {}

--- a/packages/studio-base/src/util/CachedFilelike.test.ts
+++ b/packages/studio-base/src/util/CachedFilelike.test.ts
@@ -18,21 +18,21 @@ import delay from "@foxglove/studio-base/util/delay";
 import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
 
 class InMemoryFileReader implements FileReader {
-  _buffer: Buffer;
+  #buffer: Buffer;
 
   constructor(bufferObj: Buffer) {
-    this._buffer = bufferObj;
+    this.#buffer = bufferObj;
   }
 
   async open() {
-    return { size: this._buffer.byteLength };
+    return { size: this.#buffer.byteLength };
   }
 
   fetch(offset: number, length: number): FileStream {
     return {
       on: (type: "data" | "error", callback: ((_: Buffer) => void) & ((_: Error) => void)) => {
         if (type === "data") {
-          setTimeout(() => callback(this._buffer.slice(offset, offset + length)));
+          setTimeout(() => callback(this.#buffer.slice(offset, offset + length)));
         }
       },
       destroy() {

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -67,21 +67,21 @@ const CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION = 1024 * 1024 * 5;
 const log = Logger.getLogger(__filename);
 
 export default class CachedFilelike implements Filelike {
-  _fileReader: FileReader;
-  _cacheSizeInBytes: number = Infinity;
-  _fileSize?: number;
-  _virtualBuffer: VirtualLRUBuffer;
-  _logFn: (arg0: string) => void = (msg) => log.info(msg);
-  _closed: boolean = false;
+  #fileReader: FileReader;
+  #cacheSizeInBytes: number = Infinity;
+  #fileSize?: number;
+  #virtualBuffer: VirtualLRUBuffer;
+  #logFn: (arg0: string) => void = (msg) => log.info(msg);
+  #closed: boolean = false;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
-  _keepReconnectingCallback?: (reconnecting: boolean) => void;
+  #keepReconnectingCallback?: (reconnecting: boolean) => void;
 
   // The current active connection, if there is one. `remainingRange.start` gets updated whenever
   // we receive new data, so it truly is the remaining range that it is going to download.
-  _currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
+  #currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
 
   // A list of read requests and associated ranges for all read requests, in order.
-  _readRequests: {
+  #readRequests: {
     range: Range;
     resolve: (_: Uint8Array) => void;
     reject: (_: Error) => void;
@@ -89,10 +89,10 @@ export default class CachedFilelike implements Filelike {
   }[] = [];
 
   // The range.end of the last read request that we resolved. Useful for reading ahead a bit.
-  _lastResolvedCallbackEnd?: number;
+  #lastResolvedCallbackEnd?: number;
 
   // The last time we've encountered an error;
-  _lastErrorTime?: number;
+  #lastErrorTime?: number;
 
   constructor(options: {
     fileReader: FileReader;
@@ -101,42 +101,42 @@ export default class CachedFilelike implements Filelike {
     // eslint-disable-next-line @foxglove/no-boolean-parameters
     keepReconnectingCallback?: (reconnecting: boolean) => void;
   }) {
-    this._fileReader = options.fileReader;
-    this._cacheSizeInBytes = options.cacheSizeInBytes ?? this._cacheSizeInBytes;
-    this._logFn = options.logFn ?? this._logFn;
-    this._keepReconnectingCallback = options.keepReconnectingCallback;
-    this._virtualBuffer = new VirtualLRUBuffer({ size: 0 });
+    this.#fileReader = options.fileReader;
+    this.#cacheSizeInBytes = options.cacheSizeInBytes ?? this.#cacheSizeInBytes;
+    this.#logFn = options.logFn ?? this.#logFn;
+    this.#keepReconnectingCallback = options.keepReconnectingCallback;
+    this.#virtualBuffer = new VirtualLRUBuffer({ size: 0 });
   }
 
   async open(): Promise<void> {
-    if (this._fileSize != undefined) {
+    if (this.#fileSize != undefined) {
       return;
     }
-    const { size } = await this._fileReader.open();
-    this._fileSize = size;
-    if (this._cacheSizeInBytes >= size) {
+    const { size } = await this.#fileReader.open();
+    this.#fileSize = size;
+    if (this.#cacheSizeInBytes >= size) {
       // If we have a cache limit that exceeds the file size, then we don't need to limit ourselves
       // to small blocks. This way `VirtualLRUBuffer#slice` will be faster since we'll almost always
       // not need to copy from multiple blocks into a new `Buffer` instance.
-      this._virtualBuffer = new VirtualLRUBuffer({ size });
+      this.#virtualBuffer = new VirtualLRUBuffer({ size });
     } else {
-      this._virtualBuffer = new VirtualLRUBuffer({
+      this.#virtualBuffer = new VirtualLRUBuffer({
         size,
         blockSize: CACHE_BLOCK_SIZE,
         // Rather create too many blocks than too few (Math.ceil), and always add one block,
         // to allow for a read range not starting or ending perfectly at a block boundary.
-        numberOfBlocks: Math.ceil(this._cacheSizeInBytes / CACHE_BLOCK_SIZE) + 2,
+        numberOfBlocks: Math.ceil(this.#cacheSizeInBytes / CACHE_BLOCK_SIZE) + 2,
       });
     }
-    this._logFn(`Opening file with size ${bytesToMiB(this._fileSize)}MiB`);
+    this.#logFn(`Opening file with size ${bytesToMiB(this.#fileSize)}MiB`);
   }
 
   // Get the file size. Requires a call to `open()` or `read()` first.
   size(): number {
-    if (this._fileSize == undefined) {
+    if (this.#fileSize == undefined) {
       throw new Error("CachedFilelike has not been opened");
     }
-    return this._fileSize;
+    return this.#fileSize;
   }
 
   // Potentially performance-sensitive; await can be expensive
@@ -147,13 +147,13 @@ export default class CachedFilelike implements Filelike {
     }
 
     const range = { start: offset, end: offset + length };
-    this._logFn(`Requested ${rangeToString(range)}`);
+    this.#logFn(`Requested ${rangeToString(range)}`);
 
     if (offset < 0 || length < 0) {
       throw new Error("CachedFilelike#read invalid input");
     }
-    if (length > this._cacheSizeInBytes) {
-      throw new Error(`Requested more data than cache size: ${length} > ${this._cacheSizeInBytes}`);
+    if (length > this.#cacheSizeInBytes) {
+      throw new Error(`Requested more data than cache size: ${length} > ${this.#cacheSizeInBytes}`);
     }
 
     // Potentially performance-sensitive; await can be expensive
@@ -166,7 +166,7 @@ export default class CachedFilelike implements Filelike {
             return;
           }
 
-          this._readRequests.push({ range, resolve, reject, requestTime: Date.now() });
+          this.#readRequests.push({ range, resolve, reject, requestTime: Date.now() });
           this._updateState();
         })
         .catch((err) => {
@@ -177,23 +177,23 @@ export default class CachedFilelike implements Filelike {
 
   // Gets called any time our connection or read requests change.
   _updateState(): void {
-    if (this._closed) {
+    if (this.#closed) {
       return;
     }
 
     // First, see if there are any read requests that we can resolve now.
-    this._readRequests = this._readRequests.filter(({ range, resolve, requestTime }) => {
-      if (!this._virtualBuffer.hasData(range.start, range.end)) {
+    this.#readRequests = this.#readRequests.filter(({ range, resolve, requestTime }) => {
+      if (!this.#virtualBuffer.hasData(range.start, range.end)) {
         return true;
       }
 
-      this._logFn(
+      this.#logFn(
         `Returned ${bytesToMiB(range.start)}-${bytesToMiB(range.end)}MiB in ${
           Date.now() - requestTime
         }ms`,
       );
-      this._lastResolvedCallbackEnd = range.end;
-      const buffer = this._virtualBuffer.slice(range.start, range.end);
+      this.#lastResolvedCallbackEnd = range.end;
+      const buffer = this.#virtualBuffer.slice(range.start, range.end);
 
       // You can set READ_DELAY=<number> on the command line when testing locally to simulate a slow connection.
       let delay = 0;
@@ -212,13 +212,13 @@ export default class CachedFilelike implements Filelike {
 
     // Then see if we need to set a new connection based on the new connection and read requests state.
     const newConnection = getNewConnection({
-      currentRemainingRange: this._currentConnection
-        ? this._currentConnection.remainingRange
+      currentRemainingRange: this.#currentConnection
+        ? this.#currentConnection.remainingRange
         : undefined,
-      readRequestRange: this._readRequests[0] ? this._readRequests[0].range : undefined,
-      downloadedRanges: this._virtualBuffer.getRangesWithData(),
-      lastResolvedCallbackEnd: this._lastResolvedCallbackEnd,
-      cacheSize: this._cacheSizeInBytes,
+      readRequestRange: this.#readRequests[0] ? this.#readRequests[0].range : undefined,
+      downloadedRanges: this.#virtualBuffer.getRangesWithData(),
+      lastResolvedCallbackEnd: this.#lastResolvedCallbackEnd,
+      cacheSize: this.#cacheSizeInBytes,
       fileSize: size,
       continueDownloadingThreshold: CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION,
     });
@@ -229,46 +229,46 @@ export default class CachedFilelike implements Filelike {
 
   // Replace the current connection with a new one, spanning a certain range.
   _setConnection(range: Range): void {
-    this._logFn(`Setting new connection @ ${rangeToString(range)}`);
+    this.#logFn(`Setting new connection @ ${rangeToString(range)}`);
 
-    if (this._currentConnection) {
+    if (this.#currentConnection) {
       // Destroy the current connection if there is one.
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       currentConnection.stream.destroy();
-      this._logFn(
+      this.#logFn(
         `Destroyed current connection @ ${rangeToString(currentConnection.remainingRange)}`,
       );
     }
 
     // Start the stream, and update the current connection state.
-    const stream = this._fileReader.fetch(range.start, range.end);
-    this._currentConnection = { stream, remainingRange: range };
+    const stream = this.#fileReader.fetch(range.start, range.end);
+    this.#currentConnection = { stream, remainingRange: range };
 
     stream.on("error", (error: Error) => {
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       if (!currentConnection || stream !== currentConnection.stream) {
         return; // Ignore errors from old streams.
       }
 
-      if (this._keepReconnectingCallback) {
+      if (this.#keepReconnectingCallback) {
         // If this callback is set, just keep retrying.
-        if (this._lastErrorTime == undefined) {
+        if (this.#lastErrorTime == undefined) {
           // And if this is the first error, let the callback know.
-          this._keepReconnectingCallback(true);
+          this.#keepReconnectingCallback(true);
         }
       } else {
         // Otherwise, if we get two errors in a short timespan (100ms) then there is probably a
         // serious error, we resolve all remaining callbacks with errors and close out.
-        const lastErrorTime = this._lastErrorTime;
+        const lastErrorTime = this.#lastErrorTime;
         if (lastErrorTime != undefined && Date.now() - lastErrorTime < 100) {
-          this._logFn(
+          this.#logFn(
             `Connection @ ${rangeToString(
               range,
             )} threw another error; closing: ${error.toString()}`,
           );
 
-          this._closed = true;
-          for (const request of this._readRequests) {
+          this.#closed = true;
+          for (const request of this.#readRequests) {
             request.reject(error);
           }
           return;
@@ -277,12 +277,12 @@ export default class CachedFilelike implements Filelike {
 
       // When we encounter an error there is usually a bad connection or timeout or so, so just
       // mark the current connection as destroyed, and try again.
-      this._logFn(
+      this.#logFn(
         `Connection @ ${rangeToString(range)} threw error; trying to continue: ${error.toString()}`,
       );
-      this._lastErrorTime = Date.now();
+      this.#lastErrorTime = Date.now();
       currentConnection.stream.destroy();
-      delete this._currentConnection;
+      this.#currentConnection = undefined;
       this._updateState();
     });
 
@@ -291,22 +291,22 @@ export default class CachedFilelike implements Filelike {
     let bytesRead = 0;
     let lastReportedBytesRead = 0;
     stream.on("data", (chunk: Buffer) => {
-      const currentConnection = this._currentConnection;
+      const currentConnection = this.#currentConnection;
       if (!currentConnection || stream !== currentConnection.stream) {
         return; // Ignore data from old streams.
       }
 
-      if (this._lastErrorTime != undefined) {
+      if (this.#lastErrorTime != undefined) {
         // If we had an error before, then that has clearly been resolved since we received some data.
-        this._lastErrorTime = undefined;
-        if (this._keepReconnectingCallback) {
+        this.#lastErrorTime = undefined;
+        if (this.#keepReconnectingCallback) {
           // And if we had a callback, let it know that the issue has been resolved.
-          this._keepReconnectingCallback(false);
+          this.#keepReconnectingCallback(false);
         }
       }
 
       // Copy the data into the VirtualLRUBuffer.
-      this._virtualBuffer.copyFrom(chunk, currentConnection.remainingRange.start);
+      this.#virtualBuffer.copyFrom(chunk, currentConnection.remainingRange.start);
       bytesRead += chunk.byteLength;
 
       // Every now and then, do some logging of the current download speed.
@@ -316,21 +316,21 @@ export default class CachedFilelike implements Filelike {
 
         const mibibytes = bytesToMiB(bytesRead);
         const speed = round(mibibytes / sec, 2);
-        this._logFn(
+        this.#logFn(
           `Connection @ ${rangeToString(
             currentConnection.remainingRange,
           )} downloading at ${speed} MiB/s`,
         );
       }
 
-      if (this._virtualBuffer.hasData(range.start, range.end)) {
+      if (this.#virtualBuffer.hasData(range.start, range.end)) {
         // If the requested range has been downloaded, we're done!
-        this._logFn(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
+        this.#logFn(`Connection @ ${rangeToString(currentConnection.remainingRange)} finished!`);
         stream.destroy();
-        delete this._currentConnection;
+        this.#currentConnection = undefined;
       } else {
         // Otherwise, update `remainingRange`.
-        this._currentConnection = {
+        this.#currentConnection = {
           stream,
           remainingRange: { start: range.start + bytesRead, end: range.end },
         };

--- a/packages/studio-base/src/util/FetchReader.ts
+++ b/packages/studio-base/src/util/FetchReader.ts
@@ -15,31 +15,31 @@ import { Readable } from "stream";
 // A node.js-style readable stream wrapper for the Streams API:
 // https://developer.mozilla.org/en-US/docs/Web/API/Streams_API
 export default class FetchReader extends Readable {
-  _response: Promise<Response>;
-  _reader?: ReadableStreamReader<Uint8Array>;
-  _controller: AbortController;
-  _aborted: boolean = false;
-  _url: string;
+  #response: Promise<Response>;
+  #reader?: ReadableStreamReader<Uint8Array>;
+  #controller: AbortController;
+  #aborted: boolean = false;
+  #url: string;
 
   constructor(url: string, options?: RequestInit) {
     super();
-    this._url = url;
-    this._controller = new AbortController();
-    this._response = fetch(url, { ...options, signal: this._controller.signal });
+    this.#url = url;
+    this.#controller = new AbortController();
+    this.#response = fetch(url, { ...options, signal: this.#controller.signal });
   }
 
   // you can only call getReader once on a response body
   // so keep a local copy of the reader and return it after the first call to get a reader
   async _getReader(): Promise<ReadableStreamReader<Uint8Array> | undefined> {
-    if (this._reader) {
-      return this._reader;
+    if (this.#reader) {
+      return this.#reader;
     }
     let data: Response;
     try {
-      data = await this._response;
+      data = await this.#response;
     } catch (err) {
       setImmediate(() => {
-        this.emit("error", new Error(`Request failed, fetch failed: ${this._url}`));
+        this.emit("error", new Error(`Request failed, fetch failed: ${this.#url}`));
       });
       return undefined;
     }
@@ -49,7 +49,7 @@ export default class FetchReader extends Readable {
         this.emit(
           "error",
           new Error(
-            `Bad response status code (${data.status}): ${this._url}. x-request-id: ${requestId}`,
+            `Bad response status code (${data.status}): ${this.#url}. x-request-id: ${requestId}`,
           ),
         );
       });
@@ -60,7 +60,7 @@ export default class FetchReader extends Readable {
       setImmediate(() => {
         this.emit(
           "error",
-          new Error(`Request succeeded, but failed to return a body: ${this._url}`),
+          new Error(`Request succeeded, but failed to return a body: ${this.#url}`),
         );
       });
       return undefined;
@@ -71,15 +71,15 @@ export default class FetchReader extends Readable {
       // When a stream is closed or errors, any reader it is locked to is released.
       // If the getReader method is called on an already locked stream, an exception will be thrown.
       // This is caused by server-side errors, but we should catch it anyway.
-      this._reader = data.body.getReader();
+      this.#reader = data.body.getReader();
     } catch (err) {
       setImmediate(() => {
-        this.emit("error", new Error(`Request succeeded, but failed to stream: ${this._url}`));
+        this.emit("error", new Error(`Request succeeded, but failed to stream: ${this.#url}`));
       });
       return undefined;
     }
 
-    return this._reader;
+    return this.#reader;
   }
 
   override _read(): void {
@@ -106,7 +106,7 @@ export default class FetchReader extends Readable {
           })
           .catch((err) => {
             // canceling the xhr request causes the promise to reject
-            if (this._aborted) {
+            if (this.#aborted) {
               // Null has a special meaning for streams
               // eslint-disable-next-line no-restricted-syntax
               this.push(null);
@@ -122,7 +122,7 @@ export default class FetchReader extends Readable {
 
   // aborts the xhr request if user calls stream.destroy()
   override _destroy(): void {
-    this._aborted = true;
-    this._controller.abort();
+    this.#aborted = true;
+    this.#controller.abort();
   }
 }

--- a/packages/studio-base/src/util/Rpc.test.ts
+++ b/packages/studio-base/src/util/Rpc.test.ts
@@ -153,18 +153,4 @@ describe("Rpc", () => {
       }),
     ).toThrow();
   });
-
-  // Regression test for memory leak.
-  it("clears out _pendingCallbacks when done", async () => {
-    const { local: mainChannel, remote: workerChannel } = createLinkedChannels();
-    const local = new Rpc(mainChannel);
-    const worker = new Rpc(workerChannel);
-    worker.receive<{ foo: string }, { bar: string }>("foo", (msg) => {
-      return { bar: msg.foo };
-    });
-    expect(Object.keys(local._pendingCallbacks).length).toEqual(0); // eslint-disable-line no-underscore-dangle
-    const result = await local.send("foo", { foo: "baz" });
-    expect(Object.keys(local._pendingCallbacks).length).toEqual(0); // eslint-disable-line no-underscore-dangle
-    expect(result).toEqual({ bar: "baz" });
-  });
 });

--- a/packages/studio-base/src/util/Rpc.ts
+++ b/packages/studio-base/src/util/Rpc.ts
@@ -67,35 +67,35 @@ export function createLinkedChannels(): { local: Channel; remote: Channel } {
 // Check out the tests for more examples.
 export default class Rpc {
   static transferables = "$$TRANSFERABLES";
-  _channel: Omit<Channel, "terminate">;
-  _messageId: number = 0;
-  _pendingCallbacks: {
+  #channel: Omit<Channel, "terminate">;
+  #messageId: number = 0;
+  #pendingCallbacks: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: number]: (arg0: any) => void;
   } = {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _receivers: Map<string, (arg0: any) => any> = new Map();
+  #receivers: Map<string, (arg0: any) => any> = new Map();
 
   constructor(channel: Omit<Channel, "terminate">) {
-    this._channel = channel;
-    if (this._channel.onmessage) {
+    this.#channel = channel;
+    if (this.#channel.onmessage) {
       throw new Error(
         "channel.onmessage is already set. Can only use one Rpc instance per channel.",
       );
     }
-    this._channel.onmessage = this._onChannelMessage;
+    this.#channel.onmessage = this.#onChannelMessage;
   }
 
-  _onChannelMessage = (ev: MessageEvent): void => {
+  #onChannelMessage = (ev: MessageEvent): void => {
     const { id, topic, data } = ev.data;
     if (topic === RESPONSE) {
-      this._pendingCallbacks[id]?.(ev.data);
-      delete this._pendingCallbacks[id];
+      this.#pendingCallbacks[id]?.(ev.data);
+      delete this.#pendingCallbacks[id];
       return;
     }
     // invoke the receive handler in a promise so if it throws synchronously we can reject
     new Promise<Record<string, Transferable[] | undefined> | undefined>((resolve) => {
-      const handler = this._receivers.get(topic);
+      const handler = this.#receivers.get(topic);
       if (!handler) {
         throw new Error(`no receiver registered for ${topic}`);
       }
@@ -104,7 +104,7 @@ export default class Rpc {
     })
       .then((result) => {
         if (!result) {
-          return this._channel.postMessage({ topic: RESPONSE, id });
+          return this.#channel.postMessage({ topic: RESPONSE, id });
         }
         const transferables = result[Rpc.transferables];
         delete result[Rpc.transferables];
@@ -113,7 +113,7 @@ export default class Rpc {
           id,
           data: result,
         };
-        this._channel.postMessage(message, transferables);
+        this.#channel.postMessage(message, transferables);
       })
       .catch((err) => {
         const message = {
@@ -126,7 +126,7 @@ export default class Rpc {
             stack: err.stack,
           },
         };
-        this._channel.postMessage(message);
+        this.#channel.postMessage(message);
       });
   };
 
@@ -138,10 +138,10 @@ export default class Rpc {
     data?: unknown,
     transfer?: (Transferable | OffscreenCanvas)[],
   ): Promise<TResult> {
-    const id = this._messageId++;
+    const id = this.#messageId++;
     const message = { topic, id, data };
     const result = new Promise<TResult>((resolve, reject) => {
-      this._pendingCallbacks[id] = (info) => {
+      this.#pendingCallbacks[id] = (info) => {
         if (info.data?.[ERROR] != undefined) {
           const error = new Error(info.data.message);
           error.name = info.data.name;
@@ -152,7 +152,7 @@ export default class Rpc {
         }
       };
     });
-    this._channel.postMessage(message, transfer);
+    this.#channel.postMessage(message, transfer);
     return await result;
   }
 
@@ -160,9 +160,9 @@ export default class Rpc {
   // only one receiver can be registered per topic and currently
   // 'deregistering' a receiver is not supported since this is not common
   receive<T, TOut>(topic: string, handler: (arg0: T) => TOut): void {
-    if (this._receivers.has(topic)) {
+    if (this.#receivers.has(topic)) {
       throw new Error(`Receiver already registered for topic: ${topic}`);
     }
-    this._receivers.set(topic, handler);
+    this.#receivers.set(topic, handler);
   }
 }

--- a/packages/studio-base/src/util/Storage.ts
+++ b/packages/studio-base/src/util/Storage.ts
@@ -32,29 +32,29 @@ export function clearBustStorageFnsMap(): void {
 
 // Small wrapper around localStorage for convenience.
 export default class Storage {
-  _backingStore: BackingStore;
+  #backingStore: BackingStore;
 
   constructor(backingStore: BackingStore = window.localStorage) {
-    this._backingStore = backingStore;
+    this.#backingStore = backingStore;
   }
 
   // The registered bustStorageFn will be called when the storage quota is reached.
   registerBustStorageFn(bustStorageFn: BustStorageFn): void {
-    const bustStorageFns = bustStorageFnsMap.get(this._backingStore) ?? [];
-    bustStorageFnsMap.set(this._backingStore, [...bustStorageFns, bustStorageFn]);
+    const bustStorageFns = bustStorageFnsMap.get(this.#backingStore) ?? [];
+    bustStorageFnsMap.set(this.#backingStore, [...bustStorageFns, bustStorageFn]);
   }
 
   clear(): void {
-    this._backingStore.clear();
+    this.#backingStore.clear();
   }
 
   keys(): string[] {
     // Filter out internal keys for MemoryStorage instances.
-    return Object.keys(this._backingStore).filter((key) => !key.startsWith("_internal_"));
+    return Object.keys(this.#backingStore).filter((key) => !key.startsWith("_internal_"));
   }
 
   getItem<T>(key: string): T | undefined {
-    const val = this._backingStore.getItem(key);
+    const val = this.#backingStore.getItem(key);
 
     // if a non-json value gets into local storage we should ignore it
     try {
@@ -70,26 +70,26 @@ export default class Storage {
   }
 
   _bustStorage(): void {
-    const bustStorageFns = bustStorageFnsMap.get(this._backingStore) ?? [];
+    const bustStorageFns = bustStorageFnsMap.get(this.#backingStore) ?? [];
     for (const bustStorageFn of bustStorageFns) {
-      bustStorageFn(this._backingStore, this.keys());
+      bustStorageFn(this.#backingStore, this.keys());
     }
   }
 
   setItem(key: string, value: unknown, bustStorageFn?: BustStorageFn): void {
     const strValue = JSON.stringify(value);
     try {
-      this._backingStore.setItem(key, strValue);
+      this.#backingStore.setItem(key, strValue);
     } catch {
       // If there is a bustStorageFn when setItem, we should call it first to bust the lower priority caches.
       if (bustStorageFn) {
-        bustStorageFn(this._backingStore, this.keys());
+        bustStorageFn(this.#backingStore, this.keys());
       } else {
         this._bustStorage();
       }
       let err;
       try {
-        this._backingStore.setItem(key, strValue);
+        this.#backingStore.setItem(key, strValue);
       } catch (e) {
         err = e;
         if (bustStorageFn) {
@@ -97,7 +97,7 @@ export default class Storage {
           this._bustStorage();
           try {
             // Try writing again.
-            this._backingStore.setItem(key, strValue);
+            this.#backingStore.setItem(key, strValue);
           } catch (e1) {
             err = e1;
           }
@@ -110,6 +110,6 @@ export default class Storage {
   }
 
   removeItem(key: string): void {
-    this._backingStore.removeItem(key);
+    this.#backingStore.removeItem(key);
   }
 }

--- a/packages/studio-base/src/util/VirtualLRUBuffer.ts
+++ b/packages/studio-base/src/util/VirtualLRUBuffer.ts
@@ -44,30 +44,30 @@ import { isRangeCoveredByRanges, Range } from "./ranges";
 
 export default class VirtualLRUBuffer {
   byteLength: number; // How many bytes does this buffer represent.
-  _blocks: Buffer[] = []; // Actual `Buffer` for each block.
+  #blocks: Buffer[] = []; // Actual `Buffer` for each block.
   // How many bytes is each block. This used to work up to 2GiB minus a byte, and now seems to crash
   // past 2GiB minus 4KiB. Default to 1GiB so we don't get caught out next time the limit drops.
-  _blockSize: number = Math.trunc(buffer.kMaxLength / 2);
-  _numberOfBlocks: number = Infinity; // How many blocks are we allowed to have at any time.
-  _lastAccessedBlockIndices: number[] = []; // Indexes of blocks, from least to most recently accessed.
-  _rangesWithData: Range[] = []; // Ranges for which we have data copied in (and have not been evicted).
+  #blockSize: number = Math.trunc(buffer.kMaxLength / 2);
+  #numberOfBlocks: number = Infinity; // How many blocks are we allowed to have at any time.
+  #lastAccessedBlockIndices: number[] = []; // Indexes of blocks, from least to most recently accessed.
+  #rangesWithData: Range[] = []; // Ranges for which we have data copied in (and have not been evicted).
 
   constructor(options: { size: number; blockSize?: number; numberOfBlocks?: number }) {
     this.byteLength = options.size;
-    this._blockSize = options.blockSize ?? this._blockSize;
-    this._numberOfBlocks = options.numberOfBlocks ?? this._numberOfBlocks;
+    this.#blockSize = options.blockSize ?? this.#blockSize;
+    this.#numberOfBlocks = options.numberOfBlocks ?? this.#numberOfBlocks;
   }
 
   // Check if the range between `start` (inclusive) and `end` (exclusive) fully contains data
   // copied in through `VirtualLRUBuffer#copyFrom`.
   hasData(start: number, end: number): boolean {
-    return isRangeCoveredByRanges({ start, end }, this._rangesWithData);
+    return isRangeCoveredByRanges({ start, end }, this.#rangesWithData);
   }
 
   // Get the minimal number of start-end pairs for which `VirtualLRUBuffer#hasData` will return true.
   // The array is sorted by `start`.
   getRangesWithData(): Range[] {
-    return this._rangesWithData;
+    return this.#rangesWithData;
   }
 
   // Copy data from the `source` buffer to the byte at `targetStart` in the VirtualLRUBuffer.
@@ -89,7 +89,7 @@ export default class VirtualLRUBuffer {
       position += remainingBytesInBlock;
     }
 
-    this._rangesWithData = simplify(unify([range], this._rangesWithData));
+    this.#rangesWithData = simplify(unify([range], this.#rangesWithData));
   }
 
   // Get a slice of data. Throws if `VirtualLRUBuffer#hasData(start, end)` is false, so be sure to check
@@ -127,40 +127,40 @@ export default class VirtualLRUBuffer {
 
   // Get a reference to a block, and mark it as most recently used. Might evict older blocks.
   _getBlock(index: number): Buffer {
-    if (!this._blocks[index]) {
+    if (!this.#blocks[index]) {
       // If a block is not allocated yet, do so.
-      let size = this._blockSize;
-      if ((index + 1) * this._blockSize > this.byteLength) {
-        size = this.byteLength % this._blockSize; // Trim the last block to match the total size.
+      let size = this.#blockSize;
+      if ((index + 1) * this.#blockSize > this.byteLength) {
+        size = this.byteLength % this.#blockSize; // Trim the last block to match the total size.
       }
       // It's okay to use `allocUnsafe` because we don't allow reading data from ranges that have
       // not explicitly be filled using `VirtualLRUBuffer#copyFrom`.
-      this._blocks[index] = buffer.Buffer.allocUnsafe(size);
+      this.#blocks[index] = buffer.Buffer.allocUnsafe(size);
     }
     // Put the current index to the end of the list, while avoiding duplicates.
-    this._lastAccessedBlockIndices = [
-      ...this._lastAccessedBlockIndices.filter((idx) => idx !== index),
+    this.#lastAccessedBlockIndices = [
+      ...this.#lastAccessedBlockIndices.filter((idx) => idx !== index),
       index,
     ];
-    if (this._lastAccessedBlockIndices.length > this._numberOfBlocks) {
+    if (this.#lastAccessedBlockIndices.length > this.#numberOfBlocks) {
       // If we have too many blocks, remove the least recently used one.
       // Note that we don't reuse blocks, since other code might still hold a reference to it
       // via the `VirtualLRUBuffer#slice` method.
       // TODO(JP): It might be worth measuring if under typical use it's faster to reuse blocks and always
       // copy to a new buffer in `VirtualLRUBuffer#slice` (less garbage collection), or if the current method
       // is better (faster slicing).
-      const deleteIndex = this._lastAccessedBlockIndices.shift();
+      const deleteIndex = this.#lastAccessedBlockIndices.shift();
       if (deleteIndex != undefined) {
-        delete this._blocks[deleteIndex];
+        delete this.#blocks[deleteIndex];
         // Remove the range that we evicted from `_rangesWithData`, since the range doesn't have data now.
-        this._rangesWithData = simplify(
-          substract(this._rangesWithData, [
-            { start: deleteIndex * this._blockSize, end: (deleteIndex + 1) * this._blockSize },
+        this.#rangesWithData = simplify(
+          substract(this.#rangesWithData, [
+            { start: deleteIndex * this.#blockSize, end: (deleteIndex + 1) * this.#blockSize },
           ]),
         );
       }
     }
-    const block = this._blocks[index];
+    const block = this.#blocks[index];
     if (!block) {
       throw new Error("invariant violation - no block at index");
     }
@@ -174,8 +174,8 @@ export default class VirtualLRUBuffer {
     if (position < 0 || position >= this.byteLength) {
       throw new Error("VirtualLRUBuffer#_calculatePosition invalid input");
     }
-    const blockIndex = Math.floor(position / this._blockSize);
-    const positionInBlock = position - blockIndex * this._blockSize;
+    const blockIndex = Math.floor(position / this.#blockSize);
+    const positionInBlock = position - blockIndex * this.#blockSize;
     const remainingBytesInBlock = this._getBlock(blockIndex).byteLength - positionInBlock;
     return { blockIndex, positionInBlock, remainingBytesInBlock };
   }

--- a/packages/studio-base/src/util/WebWorkerManager.ts
+++ b/packages/studio-base/src/util/WebWorkerManager.ts
@@ -23,40 +23,44 @@ import { setupMainThreadRpc } from "@foxglove/studio-base/util/RpcMainThreadUtil
 type WorkerListenerState<W> = { rpc: Rpc; worker: W; listenerIds: string[] };
 
 export default class WebWorkerManager<W extends Channel> {
-  _createWorker: () => W;
-  _maxWorkerCount: number;
-  _workerStates: (WorkerListenerState<W> | undefined)[];
-  _allListeners: Set<string>;
+  #createWorker: () => W;
+  #maxWorkerCount: number;
+  #workerStates: (WorkerListenerState<W> | undefined)[];
+  #allListeners: Set<string>;
 
   constructor(createWorker: () => W, maxWorkerCount: number) {
-    this._createWorker = createWorker;
-    this._maxWorkerCount = maxWorkerCount;
-    this._workerStates = new Array(maxWorkerCount);
-    this._allListeners = new Set();
+    this.#createWorker = createWorker;
+    this.#maxWorkerCount = maxWorkerCount;
+    this.#workerStates = new Array(maxWorkerCount);
+    this.#allListeners = new Set();
+  }
+
+  testing_workerCount(): number {
+    return this.#workerStates.filter(Boolean).length;
   }
 
   testing_getWorkerState(id: string): WorkerListenerState<W> | undefined {
-    return this._workerStates.find((workerState) => workerState?.listenerIds.includes(id));
+    return this.#workerStates.find((workerState) => workerState?.listenerIds.includes(id));
   }
 
   registerWorkerListener(id: string): Rpc {
-    if (this._allListeners.has(id)) {
+    if (this.#allListeners.has(id)) {
       throw new Error("cannot register the same listener id twice");
     }
-    this._allListeners.add(id);
+    this.#allListeners.add(id);
 
-    const currentWorkerCount = this._workerStates.filter(Boolean).length;
-    if (currentWorkerCount < this._maxWorkerCount) {
-      const worker = this._createWorker();
+    const currentWorkerCount = this.#workerStates.filter(Boolean).length;
+    if (currentWorkerCount < this.#maxWorkerCount) {
+      const worker = this.#createWorker();
       const rpc = new Rpc(worker);
       setupMainThreadRpc(rpc);
 
-      const emptyIndex = findIndex(this._workerStates, (x) => !x);
-      this._workerStates[emptyIndex] = { worker, rpc, listenerIds: [id] };
+      const emptyIndex = findIndex(this.#workerStates, (x) => !x);
+      this.#workerStates[emptyIndex] = { worker, rpc, listenerIds: [id] };
       return rpc;
     }
     const workerStateByListenerCount = sortBy(
-      this._workerStates.filter(Boolean),
+      this.#workerStates.filter(Boolean),
       (workerState) => workerState?.listenerIds.length,
     );
     const workerState = workerStateByListenerCount[0];
@@ -68,22 +72,22 @@ export default class WebWorkerManager<W extends Channel> {
   }
 
   unregisterWorkerListener(id: string): void {
-    if (!this._allListeners.has(id)) {
+    if (!this.#allListeners.has(id)) {
       throw new Error("Cannot find listener to unregister");
     }
-    this._allListeners.delete(id);
+    this.#allListeners.delete(id);
 
-    const workerStateIndex = findIndex(this._workerStates, (workerState) => {
+    const workerStateIndex = findIndex(this.#workerStates, (workerState) => {
       if (!workerState) {
         return false;
       }
       return workerState.listenerIds.includes(id);
     });
-    const workerState = this._workerStates[workerStateIndex];
+    const workerState = this.#workerStates[workerStateIndex];
     if (workerStateIndex >= 0 && workerState) {
       workerState.listenerIds = workerState.listenerIds.filter((_id) => _id !== id);
       if (workerState.listenerIds.length === 0) {
-        this._workerStates[workerStateIndex] = undefined;
+        this.#workerStates[workerStateIndex] = undefined;
         workerState.worker.terminate();
       }
     }

--- a/packages/studio-base/src/util/manageWebWorkers.test.ts
+++ b/packages/studio-base/src/util/manageWebWorkers.test.ts
@@ -77,8 +77,7 @@ describe("WebWorkerManager", () => {
     expect(webWorkerManager.testing_getWorkerState("3")?.listenerIds).toEqual(["3"]);
     webWorkerManager.unregisterWorkerListener("2");
     webWorkerManager.unregisterWorkerListener("3");
-    // eslint-disable-next-line no-underscore-dangle
-    expect(webWorkerManager._workerStates).toEqual([undefined, undefined]);
+    expect(webWorkerManager.testing_workerCount()).toEqual(0);
   });
 
   it("throws when registering an ID twice", () => {

--- a/packages/studio-base/src/util/parseMessageDefinitionsCache.ts
+++ b/packages/studio-base/src/util/parseMessageDefinitionsCache.ts
@@ -67,24 +67,24 @@ function maybeWriteLocalStorageCache(
 
 class ParseMessageDefinitionCache {
   // Used because we may load extraneous definitions that we need to clear.
-  _usedMd5Sums = new Set<string>();
-  _stringDefinitionsToParsedDefinitions: {
+  #usedMd5Sums = new Set<string>();
+  #stringDefinitionsToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _md5SumsToParsedDefinitions: {
+  #md5SumsToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _hashesToParsedDefinitions: {
+  #hashesToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _localStorageCacheDisabled = false;
+  #localStorageCacheDisabled = false;
 
   constructor() {
     const hashesToParsedDefinitionsEntries = storage
       .keys()
       .filter((key) => key.startsWith(STORAGE_ITEM_KEY_PREFIX))
       .map((key) => [key.substring(STORAGE_ITEM_KEY_PREFIX.length), storage.getItem(key)]);
-    this._md5SumsToParsedDefinitions = fromPairs(hashesToParsedDefinitionsEntries);
+    this.#md5SumsToParsedDefinitions = fromPairs(hashesToParsedDefinitionsEntries);
   }
 
   parseMessageDefinition(messageDefinition: string, md5Sum?: string): RosMsgDefinition[] {
@@ -98,23 +98,23 @@ class ParseMessageDefinitionCache {
 
     // If we don't have it stored, we have to parse it.
     const parsedDefinition =
-      this._stringDefinitionsToParsedDefinitions[messageDefinition] ??
+      this.#stringDefinitionsToParsedDefinitions[messageDefinition] ??
       parseMessageDefinition(messageDefinition);
-    this._stringDefinitionsToParsedDefinitions[messageDefinition] = parsedDefinition;
+    this.#stringDefinitionsToParsedDefinitions[messageDefinition] = parsedDefinition;
     if (md5Sum != undefined) {
-      this._hashesToParsedDefinitions[md5Sum] = parsedDefinition;
-      if (!this._localStorageCacheDisabled) {
-        this._md5SumsToParsedDefinitions[md5Sum] = parsedDefinition;
+      this.#hashesToParsedDefinitions[md5Sum] = parsedDefinition;
+      if (!this.#localStorageCacheDisabled) {
+        this.#md5SumsToParsedDefinitions[md5Sum] = parsedDefinition;
         try {
           maybeWriteLocalStorageCache(
             md5Sum,
             parsedDefinition,
-            Object.keys(this._md5SumsToParsedDefinitions),
-            [...this._usedMd5Sums],
+            Object.keys(this.#md5SumsToParsedDefinitions),
+            [...this.#usedMd5Sums],
           );
         } catch (e) {
           sendNotification("Unable to save message definition to localStorage", e, "user", "warn");
-          this._localStorageCacheDisabled = true;
+          this.#localStorageCacheDisabled = true;
         }
       }
     }
@@ -122,15 +122,15 @@ class ParseMessageDefinitionCache {
   }
 
   getStoredDefinition(md5Sum: string): RosMsgDefinition[] | undefined {
-    this._usedMd5Sums.add(md5Sum);
+    this.#usedMd5Sums.add(md5Sum);
 
-    if (this._hashesToParsedDefinitions[md5Sum]) {
-      return this._hashesToParsedDefinitions[md5Sum];
+    if (this.#hashesToParsedDefinitions[md5Sum]) {
+      return this.#hashesToParsedDefinitions[md5Sum];
     }
-    if (this._md5SumsToParsedDefinitions[md5Sum]) {
-      const parsedDefinition = this._md5SumsToParsedDefinitions[md5Sum];
+    if (this.#md5SumsToParsedDefinitions[md5Sum]) {
+      const parsedDefinition = this.#md5SumsToParsedDefinitions[md5Sum];
       if (parsedDefinition) {
-        this._hashesToParsedDefinitions[md5Sum] = parsedDefinition;
+        this.#hashesToParsedDefinitions[md5Sum] = parsedDefinition;
       }
       return parsedDefinition;
     }
@@ -138,10 +138,10 @@ class ParseMessageDefinitionCache {
   }
 
   getMd5sForStoredDefinitions(): string[] {
-    if (this._localStorageCacheDisabled) {
+    if (this.#localStorageCacheDisabled) {
       return [];
     }
-    return Object.keys(this._md5SumsToParsedDefinitions);
+    return Object.keys(this.#md5SumsToParsedDefinitions);
   }
 }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Convert all `_x;` and `private x;` class members to `#x;`.

Changes were made with this ts-morph script and a few manual fixes.

```ts
import { Project } from "ts-morph";
import ts from "typescript";

console.log("Creating project...");
const project = new Project({ tsConfigFilePath: "./packages/studio-base/tsconfig.json" });

for (const file of project.getSourceFiles()) {
  console.log(file.getFilePath());
  file: for (;;) {
    for (const prop of file.getDescendantsOfKind(ts.SyntaxKind.PropertyDeclaration)) {
      if (prop.hasModifier("private") && !prop.hasModifier("override")) {
        const newName = "#" + prop.getName().replace(/^_+/, "");
        console.log(`${prop.getParent().getName()}.${prop.getName()}`);
        prop.toggleModifier("private").rename(newName);
        continue file;
      } else if (prop.getName().startsWith("_")) {
        const newName = "#" + prop.getName().replace(/^_+/, "");
        console.log(`${prop.getParent().getName()}.${prop.getName()}`);
        prop.rename(newName);
        continue file;
      }
    }
    break;
  }
}

console.log("Saving...");
project.saveSync();
```