### PR TITLE
Add TypeScript `private` keyword to existing underscore-prefixed properties and methods

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -154,9 +154,9 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   AutocompleteProps<T>,
   AutocompleteState
 > {
-  _autocomplete: RefObject<ReactAutocomplete>;
-  _ignoreFocus: boolean = false;
-  _ignoreBlur: boolean = false;
+  private _autocomplete: RefObject<ReactAutocomplete>;
+  private _ignoreFocus: boolean = false;
+  private _ignoreBlur: boolean = false;
 
   static defaultProps = {
     getItemText: defaultGetText("getItemText"),
@@ -212,7 +212,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     }
   }
 
-  _onFocus = (): void => {
+  private _onFocus = (): void => {
     if (this._ignoreFocus) {
       return;
     }
@@ -231,7 +231,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   // Wait for a mouseup event, and check in the mouseup event if anything was actually selected, or
   // if it just was a click without a drag. In the latter case, select everything. This is very
   // similar to how, say, the browser bar in Chrome behaves.
-  _onMouseDown = (_event: React.MouseEvent<HTMLInputElement>): void => {
+  private _onMouseDown = (_event: React.MouseEvent<HTMLInputElement>): void => {
     if (this.props.disableAutoSelect ?? false) {
       return;
     }
@@ -260,7 +260,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     document.addEventListener("mouseup", onMouseUp, true);
   };
 
-  _onBlur = (): void => {
+  private _onBlur = (): void => {
     if (this._ignoreBlur) {
       return;
     }
@@ -277,7 +277,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     }
   };
 
-  _onChange = (event: React.SyntheticEvent<HTMLInputElement>): void => {
+  private _onChange = (event: React.SyntheticEvent<HTMLInputElement>): void => {
     if (this.props.onChange) {
       this.props.onChange(event, (event.target as HTMLInputElement).value);
     } else {
@@ -288,7 +288,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
   // Make sure the input field gets focused again after selecting, in case we're doing multiple
   // autocompletes. We pass in `this` to `onSelect` in case the user of this component wants to call
   // `blur()`.
-  _onSelect = (value: string, item: T): void => {
+  private _onSelect = (value: string, item: T): void => {
     if (this._autocomplete.current?.refs.input) {
       (this._autocomplete.current.refs.input as HTMLInputElement).focus();
       this.setState({ focused: true, value: undefined }, () => {
@@ -299,7 +299,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
 
   // When scrolling down by even a little bit, just show all items. In most cases people won't
   // do this and instead will type more text to narrow down their autocomplete.
-  _onScroll = (event: React.MouseEvent<HTMLDivElement>): void => {
+  private _onScroll = (event: React.MouseEvent<HTMLDivElement>): void => {
     if (event.currentTarget.scrollTop > 0) {
       // Never set `showAllItems` to false here, as `<ReactAutocomplete>` may have a reference to
       // the highlighted element. We only set it back to false in `componentDidUpdate`.
@@ -307,7 +307,7 @@ export default class Autocomplete<T = unknown> extends PureComponent<
     }
   };
 
-  _onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+  private _onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === "Escape" || (event.key === "Enter" && this.props.items.length === 0)) {
       this.blur();
     }

--- a/packages/studio-base/src/components/Menu/SubMenu.tsx
+++ b/packages/studio-base/src/components/Menu/SubMenu.tsx
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export default class SubMenu extends React.Component<Props, State> {
-  _unmounted: boolean = false;
+  private _unmounted: boolean = false;
 
   override state = {
     open: false,

--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -28,7 +28,7 @@ export default class FakePlayer implements Player {
   playerId: string = "test";
   subscriptions: SubscribePayload[] = [];
   publishers: AdvertiseOptions[] | undefined;
-  _capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
+  private _capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
 
   setListener(listener: (arg0: PlayerState) => Promise<void>): void {
     this.listener = listener;

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -19,10 +19,10 @@ import { renderImage } from "./renderImage";
 import { Dimensions, RawMarkerData, RenderOptions } from "./util";
 
 class ImageCanvasWorker {
-  _idToCanvas: {
+  private _idToCanvas: {
     [key: string]: OffscreenCanvas;
   } = {};
-  _rpc: Rpc;
+  private _rpc: Rpc;
 
   constructor(rpc: Rpc) {
     setupWorker(rpc);

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -22,11 +22,9 @@ class ImageCanvasWorker {
   private _idToCanvas: {
     [key: string]: OffscreenCanvas;
   } = {};
-  private _rpc: Rpc;
 
   constructor(rpc: Rpc) {
     setupWorker(rpc);
-    this._rpc = rpc;
 
     rpc.receive("initialize", async ({ id, canvas }: { id: string; canvas: OffscreenCanvas }) => {
       this._idToCanvas[id] = canvas;

--- a/packages/studio-base/src/panels/Rosout/LogList.stories.tsx
+++ b/packages/studio-base/src/panels/Rosout/LogList.stories.tsx
@@ -48,7 +48,7 @@ type State = {
 };
 
 class Example extends Component<Props, State> {
-  _intervalId?: ReturnType<typeof setInterval>;
+  private _intervalId?: ReturnType<typeof setInterval>;
   override state = { items: generateData(MSG_BATCH_SIZE), paused: true };
 
   override componentDidMount() {
@@ -63,7 +63,7 @@ class Example extends Component<Props, State> {
     }
   }
 
-  _startTimer = () => {
+  private _startTimer = () => {
     this._intervalId = setInterval(() => {
       const newData = generateData(MSG_BATCH_SIZE);
       const items = [...this.state.items, ...newData];

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/MeasuringTool.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DrawingTools/MeasuringTool.ts
@@ -54,11 +54,11 @@ export default class MeasuringTool extends React.Component<Props> {
     });
   };
 
-  _canvasMouseDownHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
+  private _canvasMouseDownHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
     this.mouseDownCoords = [e.clientX, e.clientY];
   };
 
-  _canvasMouseUpHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
+  private _canvasMouseUpHandler = (e: MouseEvent, _clickInfo: ReglClickInfo): void => {
     const mouseUpCoords = [e.clientX, e.clientY];
     const { measureState, measurePoints, onMeasureInfoChange } = this.props;
 
@@ -77,7 +77,7 @@ export default class MeasuringTool extends React.Component<Props> {
     }
   };
 
-  _canvasMouseMoveHandler = (_e: MouseEvent, clickInfo: ReglClickInfo): void => {
+  private _canvasMouseMoveHandler = (_e: MouseEvent, clickInfo: ReglClickInfo): void => {
     const { measureState, measurePoints, onMeasureInfoChange } = this.props;
     switch (measureState) {
       case "place-start":

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
@@ -96,7 +96,7 @@ export default class MessageCollector {
     });
   }
 
-  _addItem(key: string, item: ObjectWithInteractionData, lifetime?: Time): void {
+  private _addItem(key: string, item: ObjectWithInteractionData, lifetime?: Time): void {
     const existing = this.markers.get(key);
     if (existing) {
       existing.update(item, this.clock, lifetime);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -198,23 +198,23 @@ export default class SceneBuilder implements MarkerProvider {
   collectors: {
     [key: string]: MessageCollector;
   } = {};
-  _clock?: Time;
-  _playerId?: string;
-  _settingsByKey: TopicSettingsCollection = {};
-  _onForceUpdate?: () => void;
+  private _clock?: Time;
+  private _playerId?: string;
+  private _settingsByKey: TopicSettingsCollection = {};
+  private _onForceUpdate?: () => void;
 
   // When not-empty, fade any markers that don't match
-  _highlightMarkerMatchersByTopic: MarkerMatchersByTopic = {};
+  private _highlightMarkerMatchersByTopic: MarkerMatchersByTopic = {};
 
   // When not-empty, override the color of matching markers
-  _colorOverrideMarkerMatchersByTopic: MarkerMatchersByTopic = {};
+  private _colorOverrideMarkerMatchersByTopic: MarkerMatchersByTopic = {};
 
-  _hooks: ThreeDimensionalVizHooks;
+  private _hooks: ThreeDimensionalVizHooks;
 
   // Decodes `velodyne_msgs/VelodyneScan` ROS messages into
   // `VelodyneScanDecoded` objects that mimic `PointCloud2` and can be rendered
   // as point clouds
-  _velodyneCloudConverter = new VelodyneCloudConverter();
+  private _velodyneCloudConverter = new VelodyneCloudConverter();
 
   allNamespaces: Namespace[] = [];
   // TODO(Audrey): remove enabledNamespaces once we release topic groups
@@ -344,7 +344,7 @@ export default class SceneBuilder implements MarkerProvider {
     this._colorOverrideMarkerMatchersByTopic = markerMatchersByTopic;
   }
 
-  _addTopicsToRenderForMarkerMatchers(
+  private _addTopicsToRenderForMarkerMatchers(
     previousMarkerMatchersByTopic: MarkerMatchersByTopic,
     newMarkerMatchers: Array<MarkerMatcher>,
   ): void {
@@ -357,7 +357,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
   }
 
-  _markTopicToRender(topicName: string): void {
+  private _markTopicToRender(topicName: string): void {
     if (this.topicsByName[topicName]) {
       this.topicsToRender.add(topicName);
     }
@@ -382,7 +382,7 @@ export default class SceneBuilder implements MarkerProvider {
     this._onForceUpdate = callback;
   }
 
-  _addError(map: Map<string, ErrorDetails>, topic: string): ErrorDetails {
+  private _addError(map: Map<string, ErrorDetails>, topic: string): ErrorDetails {
     let values = map.get(topic);
     if (!values) {
       values = { namespaces: new Set(), frameIds: new Set() };
@@ -392,13 +392,13 @@ export default class SceneBuilder implements MarkerProvider {
     return values;
   }
 
-  _setTopicError = (topic: string, message: string): void => {
+  private _setTopicError = (topic: string, message: string): void => {
     this.errors.topicsWithError.set(topic, message);
     this._updateErrorsByTopic();
   };
 
   // Update the field anytime the errors change in order to generate a new object to trigger TopicTree to rerender.
-  _updateErrorsByTopic(): void {
+  private _updateErrorsByTopic(): void {
     if (!this.transforms) {
       return;
     }
@@ -413,7 +413,7 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   // keep a unique set of all seen namespaces
-  _consumeNamespace(topic: string, name: string): void {
+  private _consumeNamespace(topic: string, name: string): void {
     if (some(this.allNamespaces, (ns) => ns.topic === topic && ns.name === name)) {
       return;
     }
@@ -432,7 +432,7 @@ export default class SceneBuilder implements MarkerProvider {
     return some(this.enabledNamespaces, (ns) => ns.topic === topic && ns.name === name);
   }
 
-  _transformMarkerPose = (topic: string, marker: BaseMarker): MutablePose | undefined => {
+  private _transformMarkerPose = (topic: string, marker: BaseMarker): MutablePose | undefined => {
     const frame_id = marker.header.frame_id;
 
     if (frame_id.length === 0) {
@@ -477,7 +477,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
   };
 
-  _consumeMarker(topic: string, message: BaseMarker): void {
+  private _consumeMarker(topic: string, message: BaseMarker): void {
     const namespace = message.ns;
     if (namespace.length > 0) {
       // Consume namespaces even if the message is later discarded
@@ -632,7 +632,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.collectors[topic]!.addMarker(marker, name);
   }
 
-  _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
+  private _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
     const { frame_id } = message.header;
 
     if (frame_id.length === 0) {
@@ -703,7 +703,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.collectors[topic]!.addNonMarker(topic, mappedMessage as unknown as Interactive<unknown>);
   };
 
-  _consumeColor = (msg: MessageEvent<Color>): void => {
+  private _consumeColor = (msg: MessageEvent<Color>): void => {
     const color = msg.message;
     if (color.r == undefined || color.g == undefined || color.b == undefined) {
       return;
@@ -797,7 +797,7 @@ export default class SceneBuilder implements MarkerProvider {
     this.topicsToRender.clear();
   }
 
-  _consumeMessage = (topic: string, datatype: string, msg: MessageEvent<unknown>): void => {
+  private _consumeMessage = (topic: string, datatype: string, msg: MessageEvent<unknown>): void => {
     const { message } = msg;
     switch (datatype) {
       case "visualization_msgs/Marker":

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useSceneBuilderAndTransformsData.test.tsx
@@ -26,7 +26,7 @@ type ErrorsByTopic = {
   [topicName: string]: string[];
 };
 class MockTransform {
-  _values: { id: string }[];
+  private _values: { id: string }[];
   constructor({ tfs }: { tfs: { id: string }[] }) {
     this._values = tfs;
   }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Transforms.ts
@@ -35,7 +35,7 @@ export class Transform {
   id: string;
   matrix: mat4 = mat4.create();
   parent?: Transform;
-  _hasValidMatrix: boolean = false;
+  private _hasValidMatrix: boolean = false;
 
   constructor(id: string) {
     this.id = stripLeadingSlash(id);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/VertexBufferCache.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/VertexBufferCache.ts
@@ -17,8 +17,8 @@ import { MemoizedVertexBuffer, VertexBuffer } from "./types";
 // We keep track of both the current and the previous frames to tell
 // which vertex buffer are not used anymore and need to be deleted.
 export default class VertexBufferCache {
-  _current = new Map<Float32Array, MemoizedVertexBuffer>();
-  _previous = new Map<Float32Array, MemoizedVertexBuffer>();
+  private _current = new Map<Float32Array, MemoizedVertexBuffer>();
+  private _previous = new Map<Float32Array, MemoizedVertexBuffer>();
 
   // Call this method before rendering to initialize
   // the cache for the current frame.
@@ -72,7 +72,7 @@ export default class VertexBufferCache {
     this._previous.clear();
   }
 
-  _deleteBuffer = (cached: MemoizedVertexBuffer): void => {
+  private _deleteBuffer = (cached: MemoizedVertexBuffer): void => {
     const { buffer } = cached;
     // Destroy GPU buffer
     buffer?.destroy();

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
@@ -190,13 +190,13 @@ const getFormattedKeyValues = createSelector(
 
 // component to display a single diagnostic status
 class DiagnosticStatus extends React.Component<Props, unknown> {
-  _tableRef = React.createRef<HTMLTableElement>();
+  private _tableRef = React.createRef<HTMLTableElement>();
 
   static defaultProps = {
     splitFraction: 0.5,
   };
 
-  _onClickSection(sectionObj: { name: string; section: string }): void {
+  private _onClickSection(sectionObj: { name: string; section: string }): void {
     const { collapsedSections, saveConfig } = this.props;
     const clickedSelectionIsCollapsed = collapsedSections.find(
       ({ name, section }) => name === sectionObj.name && section === sectionObj.section,
@@ -212,17 +212,17 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     }
   }
 
-  _resizeMouseDown = (event: React.MouseEvent<Element>): void => {
+  private _resizeMouseDown = (event: React.MouseEvent<Element>): void => {
     event.preventDefault();
     window.addEventListener("mousemove", this._resizeMouseMove);
     window.addEventListener("mouseup", this._resizeMouseUp);
   };
 
-  _resizeMouseUp = (): void => {
+  private _resizeMouseUp = (): void => {
     window.removeEventListener("mousemove", this._resizeMouseMove);
   };
 
-  _resizeMouseMove = (event: MouseEvent): void => {
+  private _resizeMouseMove = (event: MouseEvent): void => {
     const {
       _tableRef,
       props: { onChangeSplitFraction },
@@ -246,7 +246,7 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     window.removeEventListener("mouseup", this._resizeMouseUp);
   }
 
-  _renderKeyValueCell(
+  private _renderKeyValueCell(
     html: { __html: string } | undefined,
     str: string,
     openPlotPanelIconElem?: React.ReactNode,
@@ -262,7 +262,7 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     );
   }
 
-  _renderKeyValueSections = (): React.ReactNode => {
+  private _renderKeyValueSections = (): React.ReactNode => {
     const { info, topicToRender, openSiblingPanel, collapsedSections } = this.props;
     const formattedKeyVals: FormattedKeyValue[] = getFormattedKeyValues(info.status);
     let inCollapsedSection = false;
@@ -332,12 +332,12 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     });
   };
 
-  _getSectionsCollapsedForCurrentName = (): { name: string; section: string }[] => {
+  private _getSectionsCollapsedForCurrentName = (): { name: string; section: string }[] => {
     const { collapsedSections, info } = this.props;
     return collapsedSections.filter(({ name }) => name === info.status.name);
   };
 
-  _getSectionsThatCanBeCollapsed = (): FormattedKeyValue[] => {
+  private _getSectionsThatCanBeCollapsed = (): FormattedKeyValue[] => {
     const { info } = this.props;
     const formattedKeyVals = getFormattedKeyValues(info.status);
     return formattedKeyVals.filter(({ key, value }) => {
@@ -347,7 +347,7 @@ class DiagnosticStatus extends React.Component<Props, unknown> {
     });
   };
 
-  _toggleSections = (): void => {
+  private _toggleSections = (): void => {
     const { saveConfig, collapsedSections, info } = this.props;
     const newSectionsForCurrentName =
       this._getSectionsCollapsedForCurrentName().length > 0

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -53,16 +53,16 @@ const getTopicsWithHeader = memoizeWeak((topics: Topic[], datatypes: RosDatatype
 });
 
 export default class OrderedStampPlayer implements Player {
-  _player: UserNodePlayer;
-  _messageOrder: TimestampMethod;
+  private _player: UserNodePlayer;
+  private _messageOrder: TimestampMethod;
   // When messageOrder is "headerStamp", contains buffered, unsorted messages with receiveTime "in
   // the near future". Only messages with headers are stored.
-  _messageBuffer: MessageEvent<StampedMessage>[] = [];
+  private _messageBuffer: MessageEvent<StampedMessage>[] = [];
   // Used to invalidate the cache. (Also signals subscription changes etc).
-  _lastSeekId?: number = undefined;
+  private _lastSeekId?: number = undefined;
   // Our best guess of "now" in case we need to force a backfill.
-  _currentTime?: Time = undefined;
-  _topicsWithoutHeadersSinceSeek = new Set<string>();
+  private _currentTime?: Time = undefined;
+  private _topicsWithoutHeadersSinceSeek = new Set<string>();
 
   constructor(player: UserNodePlayer, messageOrder: TimestampMethod) {
     this._player = player;

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -62,7 +62,6 @@ export default class OrderedStampPlayer implements Player {
   private _lastSeekId?: number = undefined;
   // Our best guess of "now" in case we need to force a backfill.
   private _currentTime?: Time = undefined;
-  private _topicsWithoutHeadersSinceSeek = new Set<string>();
 
   constructor(player: UserNodePlayer, messageOrder: TimestampMethod) {
     this._player = player;
@@ -87,7 +86,6 @@ export default class OrderedStampPlayer implements Player {
       if (activeData.lastSeekTime !== this._lastSeekId) {
         this._messageBuffer = [];
         this._lastSeekId = activeData.lastSeekTime;
-        this._topicsWithoutHeadersSinceSeek = new Set<string>();
       }
 
       // Only store messages with a header stamp.

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -49,10 +49,10 @@ const playerOptions: RandomAccessPlayerOptions = {
 type PlayerStateWithoutPlayerId = Omit<PlayerState, "playerId">;
 
 class MessageStore {
-  _messages: PlayerStateWithoutPlayerId[] = [];
+  private _messages: PlayerStateWithoutPlayerId[] = [];
   done: Promise<PlayerStateWithoutPlayerId[]>;
-  _expected: number;
-  _resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
+  private _expected: number;
+  private _resolve: (arg0: PlayerStateWithoutPlayerId[]) => void = () => {
     // no-op
   };
   constructor(expected: number) {
@@ -1353,11 +1353,11 @@ describe("RandomAccessPlayer", () => {
 
   describe("metrics collecting", () => {
     class TestMetricsCollector implements PlayerMetricsCollectorInterface {
-      _initialized: number = 0;
-      _played: number = 0;
-      _paused: number = 0;
-      _seeked: number = 0;
-      _speed: number[] = [];
+      private _initialized: number = 0;
+      private _played: number = 0;
+      private _paused: number = 0;
+      private _seeked: number = 0;
+      private _speed: number[] = [];
 
       setProperty(_key: string, _value: string | number | boolean): void {
         // no-op

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -98,7 +98,6 @@ export default class RandomAccessPlayer implements Player {
   private _filePath?: string;
   private _provider: RandomAccessDataProvider;
   private _isPlaying: boolean = false;
-  private _wasPlayingBeforeTabSwitch = false;
   private _listener?: (arg0: PlayerState) => Promise<void>;
   private _speed: number = 0.2;
   private _start: Time = { sec: 0, nsec: 0 };

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -96,53 +96,53 @@ export type RandomAccessPlayerOptions = {
 export default class RandomAccessPlayer implements Player {
   private _label?: string;
   private _filePath?: string;
-  _provider: RandomAccessDataProvider;
-  _isPlaying: boolean = false;
-  _wasPlayingBeforeTabSwitch = false;
-  _listener?: (arg0: PlayerState) => Promise<void>;
-  _speed: number = 0.2;
-  _start: Time = { sec: 0, nsec: 0 };
-  _end: Time = { sec: 0, nsec: 0 };
+  private _provider: RandomAccessDataProvider;
+  private _isPlaying: boolean = false;
+  private _wasPlayingBeforeTabSwitch = false;
+  private _listener?: (arg0: PlayerState) => Promise<void>;
+  private _speed: number = 0.2;
+  private _start: Time = { sec: 0, nsec: 0 };
+  private _end: Time = { sec: 0, nsec: 0 };
   // next read start time indicates where to start reading for the next tick
   // after a tick read, it is set to 1nsec past the end of the read operation (preparing for the next tick)
-  _nextReadStartTime: Time = { sec: 0, nsec: 0 };
-  _lastTickMillis?: number;
+  private _nextReadStartTime: Time = { sec: 0, nsec: 0 };
+  private _lastTickMillis?: number;
   // The last time a "seek" was started. This is used to cancel async operations, such as seeks or ticks, when a seek
   // happens while they are ocurring.
-  _lastSeekStartTime: number = Date.now();
+  private _lastSeekStartTime: number = Date.now();
   // This is the "lastSeekTime" emitted in the playerState. It is not the same as the _lastSeekStartTime because we can
   // start a seek and not end up emitting it, or emit something else while we are requesting messages for the seek. The
   // RandomAccessDataProvider's `progressCallback` can cause an emit at any time, for example.
   // We only want to set the "lastSeekTime" exactly when we emit the messages coming from the seek.
-  _lastSeekEmitTime: number = this._lastSeekStartTime;
-  _cancelSeekBackfill: boolean = false;
-  _parsedSubscribedTopics: Set<string> = new Set();
-  _providerTopics: Topic[] = [];
-  _providerConnections: Connection[] = [];
-  _providerDatatypes: RosDatatypes = new Map();
-  _metricsCollector: PlayerMetricsCollectorInterface;
-  _initializing: boolean = true;
-  _initialized: boolean = false;
-  _reconnecting: boolean = false;
-  _progress: Progress = Object.freeze({});
-  _id: string = uuidv4();
-  _messages: MessageEvent<unknown>[] = [];
-  _receivedBytes: number = 0;
-  _messageOrder: TimestampMethod = "receiveTime";
-  _hasError = false;
-  _closed = false;
-  _seekToTime: SeekToTimeSpec;
-  _lastRangeMillis?: number;
-  _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
+  private _lastSeekEmitTime: number = this._lastSeekStartTime;
+  private _cancelSeekBackfill: boolean = false;
+  private _parsedSubscribedTopics: Set<string> = new Set();
+  private _providerTopics: Topic[] = [];
+  private _providerConnections: Connection[] = [];
+  private _providerDatatypes: RosDatatypes = new Map();
+  private _metricsCollector: PlayerMetricsCollectorInterface;
+  private _initializing: boolean = true;
+  private _initialized: boolean = false;
+  private _reconnecting: boolean = false;
+  private _progress: Progress = Object.freeze({});
+  private _id: string = uuidv4();
+  private _messages: MessageEvent<unknown>[] = [];
+  private _receivedBytes: number = 0;
+  private _messageOrder: TimestampMethod = "receiveTime";
+  private _hasError = false;
+  private _closed = false;
+  private _seekToTime: SeekToTimeSpec;
+  private _lastRangeMillis?: number;
+  private _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
-  _currentTime?: Time;
+  private _currentTime?: Time;
 
   // The problem store holds problems based on keys (which may be hard-coded problem types or topics)
   // The overall player may be healthy, but individual topics may have warnings or errors.
   // These are set/cleared in the store to track the current set of problems
-  _problems = new Map<string, PlayerProblem>();
+  private _problems = new Map<string, PlayerProblem>();
 
   constructor(
     providerDescriptor: RandomAccessDataProviderDescriptor,
@@ -259,7 +259,7 @@ export default class RandomAccessPlayer implements Player {
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  _emitState = debouncePromise(() => {
+  private _emitState = debouncePromise(() => {
     if (!this._listener) {
       return Promise.resolve();
     }
@@ -346,7 +346,7 @@ export default class RandomAccessPlayer implements Player {
     return this._listener(data);
   });
 
-  async _tick(): Promise<void> {
+  private async _tick(): Promise<void> {
     if (this._initializing || !this._isPlaying || this._hasError) {
       return;
     }
@@ -405,7 +405,7 @@ export default class RandomAccessPlayer implements Player {
     this._emitState();
   }
 
-  _read = debouncePromise(async () => {
+  private _read = debouncePromise(async () => {
     try {
       while (this._isPlaying && !this._hasError) {
         const start = Date.now();
@@ -422,7 +422,10 @@ export default class RandomAccessPlayer implements Player {
     }
   });
 
-  async _getMessages(start: Time, end: Time): Promise<{ parsedMessages: MessageEvent<unknown>[] }> {
+  private async _getMessages(
+    start: Time,
+    end: Time,
+  ): Promise<{ parsedMessages: MessageEvent<unknown>[] }> {
     const parsedTopics = getSanitizedTopics(this._parsedSubscribedTopics, this._providerTopics);
     if (parsedTopics.length === 0) {
       return { parsedMessages: [] };
@@ -518,7 +521,7 @@ export default class RandomAccessPlayer implements Player {
     this._emitState();
   }
 
-  _reportInitialized(): void {
+  private _reportInitialized(): void {
     if (this._initializing || this._initialized) {
       return;
     }
@@ -526,14 +529,14 @@ export default class RandomAccessPlayer implements Player {
     this._initialized = true;
   }
 
-  _setNextReadStartTime(time: Time): void {
+  private _setNextReadStartTime(time: Time): void {
     this._metricsCollector.recordPlaybackTime(time, {
       stillLoadingData: !this.hasCachedRange(this._start, this._end),
     });
     this._nextReadStartTime = clampTime(time, this._start, this._end);
   }
 
-  _seekPlaybackInternal = debouncePromise(async (backfillDuration?: Time) => {
+  private _seekPlaybackInternal = debouncePromise(async (backfillDuration?: Time) => {
     const seekTime = Date.now();
     this._lastSeekStartTime = seekTime;
     this._cancelSeekBackfill = false;

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -46,11 +46,11 @@ class MockRosClient {
     workerInstance = this;
   }
 
-  _topics: string[] = [];
-  _types: string[] = [];
-  _typedefs_full_text: string[] = [];
-  _connectCallback?: () => void;
-  _messages: any[] = [];
+  private _topics: string[] = [];
+  private _types: string[] = [];
+  private _typedefs_full_text: string[] = [];
+  private _connectCallback?: () => void;
+  private _messages: any[] = [];
 
   setup({
     topics = [],

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -107,7 +107,7 @@ export default class RosbridgePlayer implements Player {
     this._open();
   }
 
-  _open = (): void => {
+  private _open = (): void => {
     if (this._closed) {
       return;
     }
@@ -169,7 +169,7 @@ export default class RosbridgePlayer implements Player {
     });
   };
 
-  _requestTopics = async (): Promise<void> => {
+  private _requestTopics = async (): Promise<void> => {
     // clear problems before each topics request so we don't have stale problems from previous failed requests
     this._problems.removeProblems((id) => id.startsWith("requestTopics:"));
 
@@ -292,7 +292,7 @@ export default class RosbridgePlayer implements Player {
 
   // Potentially performance-sensitive; await can be expensive
   // eslint-disable-next-line @typescript-eslint/promise-function-async
-  _emitState = debouncePromise(() => {
+  private _emitState = debouncePromise(() => {
     if (!this._listener || this._closed) {
       return Promise.resolve();
     }

--- a/packages/studio-base/src/players/StoryPlayer.ts
+++ b/packages/studio-base/src/players/StoryPlayer.ts
@@ -38,8 +38,8 @@ const getBagDescriptor = async (url?: string) => {
 const NOOP_PROVIDER = [{ name: "noop", args: {}, children: [] }];
 
 export default class StoryPlayer implements Player {
-  _parsedSubscribedTopics: string[] = [];
-  _bags: string[] = [];
+  private _parsedSubscribedTopics: string[] = [];
+  private _bags: string[] = [];
   constructor(bags: string[]) {
     this._bags = bags;
   }

--- a/packages/studio-base/src/players/TestProvider.ts
+++ b/packages/studio-base/src/players/TestProvider.ts
@@ -56,10 +56,10 @@ type GetMessages = (
 
 // ts-prune-ignore-next
 export default class TestProvider implements RandomAccessDataProvider {
-  _start: Time;
-  _end: Time;
-  _topics: Topic[];
-  _datatypes: RosDatatypes;
+  private _start: Time;
+  private _end: Time;
+  private _topics: Topic[];
+  private _datatypes: RosDatatypes;
   extensionPoint?: ExtensionPoint;
   closed: boolean = false;
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -146,12 +146,11 @@ export default class UserNodePlayer implements Player {
     };
   }
 
-  _getTopics = memoizeWeak((topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [
-    ...topics,
-    ...nodeTopics,
-  ]);
+  private _getTopics = memoizeWeak(
+    (topics: readonly Topic[], nodeTopics: readonly Topic[]): Topic[] => [...topics, ...nodeTopics],
+  );
 
-  _getDatatypes = memoizeWeak(
+  private _getDatatypes = memoizeWeak(
     (datatypes: RosDatatypes, nodeDatatypes: readonly RosDatatypes[]): RosDatatypes => {
       return nodeDatatypes.reduce(
         (allDatatypes, userNodeDatatypes) => new Map([...allDatatypes, ...userNodeDatatypes]),
@@ -172,7 +171,7 @@ export default class UserNodePlayer implements Player {
 
   // When updating nodes while paused, we seek to the current time
   // (i.e. invoke _getMessages with an empty array) to refresh messages
-  _getMessages = async (
+  private _getMessages = async (
     parsedMessages: readonly MessageEvent<unknown>[],
     globalVariables: GlobalVariables,
     nodeRegistrations: readonly NodeRegistration[],
@@ -484,7 +483,7 @@ export default class UserNodePlayer implements Player {
   //
   // For the time being, resetWorkers is a catchall for these circumstances. As
   // performance bottlenecks are identified, it will be subject to change.
-  async _resetWorkers(): Promise<void> {
+  private async _resetWorkers(): Promise<void> {
     if (!this._lastPlayerStateActiveData) {
       return;
     }
@@ -561,7 +560,7 @@ export default class UserNodePlayer implements Player {
     pending.resolve();
   }
 
-  async _getRosLib(): Promise<string> {
+  private async _getRosLib(): Promise<string> {
     if (!this._lastPlayerStateActiveData) {
       throw new Error("_getRosLib was called before `_lastPlayerStateActiveData` set");
     }

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -133,7 +133,7 @@ export default class VelodynePlayer implements Player {
     }
   };
 
-  _handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
+  private _handleMessage = (data: Uint8Array, rinfo: UdpRemoteInfo): void => {
     const receiveTime = fromMillis(Date.now());
     const date = toDate(receiveTime);
     date.setMinutes(0, 0, 0);

--- a/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/ApiCheckerDataProvider.ts
@@ -60,12 +60,12 @@ export function instrumentTreeWithApiCheckerDataProvider(
 }
 
 export default class ApiCheckerDataProvider implements RandomAccessDataProvider {
-  _name: string;
-  _provider?: RandomAccessDataProvider;
-  _initializationResult?: InitializationResult;
-  _topicNames: string[] = [];
-  _closed: boolean = false;
-  _isRoot: boolean;
+  private _name: string;
+  private _provider?: RandomAccessDataProvider;
+  private _initializationResult?: InitializationResult;
+  private _topicNames: string[] = [];
+  private _closed: boolean = false;
+  private _isRoot: boolean;
 
   constructor(
     args: { name: string; isRoot: boolean },
@@ -240,7 +240,7 @@ export default class ApiCheckerDataProvider implements RandomAccessDataProvider 
     return await this._provider?.close();
   }
 
-  _warn(message: string): void {
+  private _warn(message: string): void {
     const prefixedMessage = `ApiCheckerDataProvider(${this._name}): ${message}`;
     sendNotification("Internal data provider assertion failed", prefixedMessage, "app", "warn");
 

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -85,8 +85,8 @@ const mergeStats = (a: TimedDataThroughput, b: TimedDataThroughput): TimedDataTh
 
 // A FileReader that "spies" on data callbacks. Used to log data consumed.
 class LogMetricsReader {
-  _reader: FileReader;
-  _extensionPoint: ExtensionPoint;
+  private _reader: FileReader;
+  private _extensionPoint: ExtensionPoint;
   constructor(reader: FileReader, extensionPoint: ExtensionPoint) {
     this._reader = reader;
     this._extensionPoint = extensionPoint;
@@ -105,10 +105,10 @@ class LogMetricsReader {
 // `BrowserHttpReader` for how to set up a remote server to be able to directly stream from it.
 // Returns raw messages that still need to be parsed by `ParseMessagesDataProvider`.
 export default class BagDataProvider implements RandomAccessDataProvider {
-  _options: Options;
-  _bag?: Bag;
-  _lastPerformanceStatsToLog?: TimedDataThroughput;
-  _extensionPoint?: ExtensionPoint;
+  private _options: Options;
+  private _bag?: Bag;
+  private _lastPerformanceStatsToLog?: TimedDataThroughput;
+  private _extensionPoint?: ExtensionPoint;
   private bzip2?: Bzip2;
 
   constructor(options: Options, children: RandomAccessDataProviderDescriptor[]) {
@@ -243,7 +243,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     };
   }
 
-  _logStats = (): void => {
+  private _logStats = (): void => {
     if (this._extensionPoint == undefined || this._lastPerformanceStatsToLog == undefined) {
       return;
     }
@@ -252,9 +252,9 @@ export default class BagDataProvider implements RandomAccessDataProvider {
   };
 
   // Logs some stats if it has been more than a second since the last call.
-  _debouncedLogStats = debounce(this._logStats, 1000, { leading: false, trailing: true });
+  private _debouncedLogStats = debounce(this._logStats, 1000, { leading: false, trailing: true });
 
-  _queueStats(stats: TimedDataThroughput): void {
+  private _queueStats(stats: TimedDataThroughput): void {
     if (
       this._lastPerformanceStatsToLog != undefined &&
       statsAreAdjacent(this._lastPerformanceStatsToLog, stats)

--- a/packages/studio-base/src/randomAccessDataProviders/BrowserHttpReader.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BrowserHttpReader.ts
@@ -16,7 +16,7 @@ import FetchReader from "@foxglove/studio-base/util/FetchReader";
 
 // A file reader that reads from a remote HTTP URL, for usage in the browser (not for node.js).
 export default class BrowserHttpReader implements FileReader {
-  _url: string;
+  private _url: string;
 
   constructor(url: string) {
     this._url = url;

--- a/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/CombinedDataProvider.ts
@@ -227,11 +227,11 @@ type ProcessedInitializationResult = Readonly<{
 // A RandomAccessDataProvider that combines multiple underlying RandomAccessDataProviders, optionally adding topic prefixes
 // or removing certain topics.
 export default class CombinedDataProvider implements RandomAccessDataProvider {
-  _providers: RandomAccessDataProvider[];
+  private _providers: RandomAccessDataProvider[];
   // Initialization result will be undefined for providers that don't successfully initialize.
-  _initializationResultsPerProvider: (ProcessedInitializationResult | undefined)[] = [];
-  _progressPerProvider: (Progress | undefined)[];
-  _extensionPoint?: ExtensionPoint;
+  private _initializationResultsPerProvider: (ProcessedInitializationResult | undefined)[] = [];
+  private _progressPerProvider: (Progress | undefined)[];
+  private _extensionPoint?: ExtensionPoint;
 
   constructor(
     _: unknown,
@@ -372,7 +372,7 @@ export default class CombinedDataProvider implements RandomAccessDataProvider {
     return mergedMessages;
   }
 
-  _updateProgressForChild(providerIdx: number, progress: Progress): void {
+  private _updateProgressForChild(providerIdx: number, progress: Progress): void {
     this._progressPerProvider[providerIdx] = progress;
     // Assume empty for unreported progress
     const cleanProgresses = this._progressPerProvider.map((p) => p ?? emptyProgress());

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.test.ts
@@ -88,7 +88,7 @@ function getProvider(
   });
   return {
     provider: new MemoryCacheDataProvider(
-      { id: "some-id", unlimitedCache },
+      { unlimitedCache },
       [{ name: CoreDataProviders.MemoryCacheDataProvider, args: {}, children: [] }],
       () => memoryDataProvider,
     ),

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -237,34 +237,34 @@ export function getPrefetchStartPoint(uncachedRanges: Range[], cursorPosition: n
 // unparsed ROS messages. The messages are evicted from this in-memory cache based on some constants
 // defined at the top of this file.
 export default class MemoryCacheDataProvider implements RandomAccessDataProvider {
-  _id: string;
-  _provider: RandomAccessDataProvider;
-  _extensionPoint?: ExtensionPoint;
+  private _id: string;
+  private _provider: RandomAccessDataProvider;
+  private _extensionPoint?: ExtensionPoint;
 
   // The actual blocks that contain the messages. Blocks have a set "width" in terms of nanoseconds
   // since the start time of the bag. If a block has some messages for a topic, then by definition
   // it has *all* messages for that topic and timespan.
-  _blocks: (MemoryCacheBlock | undefined)[] = [];
+  private _blocks: (MemoryCacheBlock | undefined)[] = [];
 
   // The start time of the bag. Used for computing from and to nanoseconds since the start.
-  _startTime: Time = { sec: 0, nsec: 0 };
+  private _startTime: Time = { sec: 0, nsec: 0 };
 
   // The topics that we were most recently asked to load.
   // This is always set by the last `getMessages` call.
-  _preloadTopics: string[] = [];
+  private _preloadTopics: string[] = [];
 
   // Total length of the data in nanoseconds. Used to compute progress with.
-  _totalNs: number = 0;
+  private _totalNs: number = 0;
 
   // The current "connection", which represents the range that we're downloading.
-  _currentConnection?: {
+  private _currentConnection?: {
     id: string;
     topics: string[];
     remainingBlockRange: Range;
   };
 
   // The read requests we've received via `getMessages`.
-  _readRequests: {
+  private _readRequests: {
     // Actual range of messages, in nanoseconds since `this._startTime`.
     timeRange: Range;
     // The range of blocks.
@@ -276,23 +276,23 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   // Recently requested ranges of blocks, sorted by most recent to least recent. There should never
   // be any overlapping ranges. Ranges *are* allowed to cover blocks that haven't been downloaded
   // (yet).
-  _recentBlockRanges: Range[] = [];
+  private _recentBlockRanges: Range[] = [];
 
   // The end time of the last callback that we've resolved. This is useful for preloading new data
   // around this time.
-  _lastResolvedCallbackEnd?: number;
+  private _lastResolvedCallbackEnd?: number;
 
   // When we log a "block too large" error, we only want to do that once, to prevent
   // spamming errors.
-  _loggedTooLargeError: boolean = false;
+  private _loggedTooLargeError: boolean = false;
 
   // If we're configured to use an unlimited cache, we try to just load as much as possible and
   // never evict anything.
-  _cacheSizeBytes: number;
-  _readAheadBlocks: number = 0;
-  _memCacheBlockSizeNs: number = 0;
+  private _cacheSizeBytes: number;
+  private _readAheadBlocks: number = 0;
+  private _memCacheBlockSizeNs: number = 0;
 
-  _lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
+  private _lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
 
   constructor(
     {
@@ -394,7 +394,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
 
   // We're primarily interested in the topics for the first outstanding read request, and after that
   // we're interested in preloading topics (based on the *last* read request).
-  _getCurrentTopics(): string[] {
+  private _getCurrentTopics(): string[] {
     if (this._readRequests[0]) {
       return this._readRequests[0].topics;
     }
@@ -402,7 +402,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     return this._preloadTopics;
   }
 
-  _resolveFinishedReadRequests(): void {
+  private _resolveFinishedReadRequests(): void {
     this._readRequests = this._readRequests.filter(({ timeRange, blockRange, topics, resolve }) => {
       if (topics.length === 0) {
         resolve({
@@ -471,7 +471,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   }
 
   // Gets called any time our "connection", read requests, or topics change.
-  _updateState(): void {
+  private _updateState(): void {
     // First, see if there are any read requests that we can resolve now.
     this._resolveFinishedReadRequests();
 
@@ -487,7 +487,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     void this._maybeRunNewConnections();
   }
 
-  _getNewConnection(): Range | undefined {
+  private _getNewConnection(): Range | undefined {
     const connectionForReadRange = getNewConnection({
       currentRemainingRange: this._currentConnection
         ? this._currentConnection.remainingBlockRange
@@ -516,7 +516,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     return undefined;
   }
 
-  _getPrefetchRange(): Range | undefined {
+  private _getPrefetchRange(): Range | undefined {
     const bounds = {
       start: 0,
       end: this._blocks.length,
@@ -537,7 +537,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     };
   }
 
-  async _maybeRunNewConnections(): Promise<void> {
+  private async _maybeRunNewConnections(): Promise<void> {
     for (;;) {
       const newConnection = this._getNewConnection();
 
@@ -568,7 +568,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
 
   // Replace the current connection with a new one, spanning a certain range of blocks. Return whether we
   // completed successfully, or whether we were interrupted by another connection.
-  async _setConnection(blockRange: Range): Promise<boolean> {
+  private async _setConnection(blockRange: Range): Promise<boolean> {
     if (this._getCurrentTopics().length === 0) {
       delete this._currentConnection;
       return true;
@@ -743,7 +743,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   }
 
   // For the relevant downloaded ranges, we look at `this._blocks` and the most relevant topics.
-  _getDownloadedBlockRanges(): Range[] {
+  private _getDownloadedBlockRanges(): Range[] {
     const topics: string[] = this._getCurrentTopics();
 
     return simplify(
@@ -766,7 +766,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     );
   }
 
-  _purgeOldBlocks(): void {
+  private _purgeOldBlocks(): void {
     if (this._cacheSizeBytes === Infinity) {
       return;
     }
@@ -805,7 +805,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
     this._blocks = newBlocks;
   }
 
-  _updateProgress(): void {
+  private _updateProgress(): void {
     this._extensionPoint?.progressCallback({
       fullyLoadedFractionRanges: this._getDownloadedBlockRanges().map((range) => ({
         // Convert block ranges into fractions.

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -237,7 +237,6 @@ export function getPrefetchStartPoint(uncachedRanges: Range[], cursorPosition: n
 // unparsed ROS messages. The messages are evicted from this in-memory cache based on some constants
 // defined at the top of this file.
 export default class MemoryCacheDataProvider implements RandomAccessDataProvider {
-  private _id: string;
   private _provider: RandomAccessDataProvider;
   private _extensionPoint?: ExtensionPoint;
 
@@ -295,17 +294,10 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   private _lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
 
   constructor(
-    {
-      id,
-      unlimitedCache = false,
-    }: {
-      id: string;
-      unlimitedCache?: boolean;
-    },
+    { unlimitedCache = false }: { unlimitedCache?: boolean },
     children: RandomAccessDataProviderDescriptor[],
     getDataProvider: GetDataProvider,
   ) {
-    this._id = id;
     this._cacheSizeBytes = unlimitedCache ? Infinity : DEFAULT_CACHE_SIZE_BYTES;
     const child = children[0];
     if (children.length !== 1 || !child) {

--- a/packages/studio-base/src/randomAccessDataProviders/RenameDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/RenameDataProvider.ts
@@ -33,8 +33,8 @@ import {
 } from "@foxglove/studio-base/randomAccessDataProviders/types";
 
 export default class RenameDataProvider implements RandomAccessDataProvider {
-  _provider: RandomAccessDataProvider;
-  _prefix: string;
+  private _provider: RandomAccessDataProvider;
+  private _prefix: string;
 
   constructor(
     args: { prefix?: string },
@@ -117,7 +117,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
     return await this._provider.close();
   }
 
-  _mapMessage = <T>(message: MessageEvent<T>): MessageEvent<T> => ({
+  private _mapMessage = <T>(message: MessageEvent<T>): MessageEvent<T> => ({
     // Only map fields that we know are correctly mapped. Don't just splat in `...message` here
     // because we might miss an important mapping!
     topic: `${this._prefix}${message.topic}`,
@@ -149,7 +149,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
     };
   }
 
-  _mapMessageCache = memoizeWeak(
+  private _mapMessageCache = memoizeWeak(
     (messageCache: BlockCache): BlockCache => ({
       // Note: don't just map(this._mapBlock) because map also passes the array and defeats the
       // memoization.
@@ -158,7 +158,7 @@ export default class RenameDataProvider implements RandomAccessDataProvider {
     }),
   );
 
-  _mapBlock = memoizeWeak((block?: MemoryCacheBlock): MemoryCacheBlock | undefined => {
+  private _mapBlock = memoizeWeak((block?: MemoryCacheBlock): MemoryCacheBlock | undefined => {
     if (!block) {
       return;
     }

--- a/packages/studio-base/src/randomAccessDataProviders/RpcDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/RpcDataProvider.ts
@@ -29,8 +29,8 @@ import { setupMainThreadRpc } from "@foxglove/studio-base/util/RpcMainThreadUtil
 // RpcDataProviderRemote, where we instantiate the rest of the RandomAccessDataProviderDescriptor tree.
 // See WorkerDataProvider for an example.
 export default class RpcDataProvider implements RandomAccessDataProvider {
-  _rpc: Rpc;
-  _childDescriptor: RandomAccessDataProviderDescriptor;
+  private _rpc: Rpc;
+  private _childDescriptor: RandomAccessDataProviderDescriptor;
 
   constructor(rpc: Rpc, children: RandomAccessDataProviderDescriptor[]) {
     this._rpc = rpc;

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerDataProvider.ts
@@ -38,9 +38,9 @@ if (process.env.NODE_ENV !== "test") {
 // Wraps the underlying RandomAccessDataProviderDescriptor tree in a Web Worker, therefore allowing
 // `getMessages` calls to get resolved in parallel to the main thread.
 export default class WorkerDataProvider implements RandomAccessDataProvider {
-  _worker?: Worker;
-  _provider?: RpcDataProvider;
-  _child?: RandomAccessDataProviderDescriptor;
+  private _worker?: Worker;
+  private _provider?: RpcDataProvider;
+  private _child?: RandomAccessDataProviderDescriptor;
 
   constructor(_args: unknown, children: RandomAccessDataProviderDescriptor[]) {
     if (children.length !== 1) {

--- a/packages/studio-base/src/test/MemoryStorage.ts
+++ b/packages/studio-base/src/test/MemoryStorage.ts
@@ -17,8 +17,8 @@ const DEFAULT_LOCAL_STORAGE__QUOTA = 5000000;
 
 export default class MemoryStorage {
   // Use `__` to mark the fields as internal so we can filter them out in Storage when getting keys using Object.keys(storage).
-  _internal_items: Record<string, string> = {};
-  _internal_quota: number;
+  private _internal_items: Record<string, string> = {};
+  private _internal_quota: number;
   [key: string]: unknown;
 
   constructor(quota?: number) {
@@ -33,7 +33,7 @@ export default class MemoryStorage {
     return this._internal_items[key];
   }
 
-  _getUsedSize(): number {
+  private _getUsedSize(): number {
     return Object.keys(this._internal_items).reduce((memo, key) => {
       return memo + new Blob([this.getItem(key)!]).size;
     }, 0);

--- a/packages/studio-base/src/util/CachedFilelike.test.ts
+++ b/packages/studio-base/src/util/CachedFilelike.test.ts
@@ -18,7 +18,7 @@ import delay from "@foxglove/studio-base/util/delay";
 import CachedFilelike, { FileReader, FileStream } from "./CachedFilelike";
 
 class InMemoryFileReader implements FileReader {
-  _buffer: Buffer;
+  private _buffer: Buffer;
 
   constructor(bufferObj: Buffer) {
     this._buffer = bufferObj;

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -67,21 +67,21 @@ const CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION = 1024 * 1024 * 5;
 const log = Logger.getLogger(__filename);
 
 export default class CachedFilelike implements Filelike {
-  _fileReader: FileReader;
-  _cacheSizeInBytes: number = Infinity;
-  _fileSize?: number;
-  _virtualBuffer: VirtualLRUBuffer;
-  _logFn: (arg0: string) => void = (msg) => log.info(msg);
-  _closed: boolean = false;
+  private _fileReader: FileReader;
+  private _cacheSizeInBytes: number = Infinity;
+  private _fileSize?: number;
+  private _virtualBuffer: VirtualLRUBuffer;
+  private _logFn: (arg0: string) => void = (msg) => log.info(msg);
+  private _closed: boolean = false;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
-  _keepReconnectingCallback?: (reconnecting: boolean) => void;
+  private _keepReconnectingCallback?: (reconnecting: boolean) => void;
 
   // The current active connection, if there is one. `remainingRange.start` gets updated whenever
   // we receive new data, so it truly is the remaining range that it is going to download.
-  _currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
+  private _currentConnection: { stream: FileStream; remainingRange: Range } | undefined;
 
   // A list of read requests and associated ranges for all read requests, in order.
-  _readRequests: {
+  private _readRequests: {
     range: Range;
     resolve: (_: Uint8Array) => void;
     reject: (_: Error) => void;
@@ -89,10 +89,10 @@ export default class CachedFilelike implements Filelike {
   }[] = [];
 
   // The range.end of the last read request that we resolved. Useful for reading ahead a bit.
-  _lastResolvedCallbackEnd?: number;
+  private _lastResolvedCallbackEnd?: number;
 
   // The last time we've encountered an error;
-  _lastErrorTime?: number;
+  private _lastErrorTime?: number;
 
   constructor(options: {
     fileReader: FileReader;
@@ -176,7 +176,7 @@ export default class CachedFilelike implements Filelike {
   }
 
   // Gets called any time our connection or read requests change.
-  _updateState(): void {
+  private _updateState(): void {
     if (this._closed) {
       return;
     }
@@ -228,7 +228,7 @@ export default class CachedFilelike implements Filelike {
   }
 
   // Replace the current connection with a new one, spanning a certain range.
-  _setConnection(range: Range): void {
+  private _setConnection(range: Range): void {
     this._logFn(`Setting new connection @ ${rangeToString(range)}`);
 
     if (this._currentConnection) {

--- a/packages/studio-base/src/util/FetchReader.ts
+++ b/packages/studio-base/src/util/FetchReader.ts
@@ -15,11 +15,11 @@ import { Readable } from "stream";
 // A node.js-style readable stream wrapper for the Streams API:
 // https://developer.mozilla.org/en-US/docs/Web/API/Streams_API
 export default class FetchReader extends Readable {
-  _response: Promise<Response>;
-  _reader?: ReadableStreamReader<Uint8Array>;
-  _controller: AbortController;
-  _aborted: boolean = false;
-  _url: string;
+  private _response: Promise<Response>;
+  private _reader?: ReadableStreamReader<Uint8Array>;
+  private _controller: AbortController;
+  private _aborted: boolean = false;
+  private _url: string;
 
   constructor(url: string, options?: RequestInit) {
     super();
@@ -30,7 +30,7 @@ export default class FetchReader extends Readable {
 
   // you can only call getReader once on a response body
   // so keep a local copy of the reader and return it after the first call to get a reader
-  async _getReader(): Promise<ReadableStreamReader<Uint8Array> | undefined> {
+  private async _getReader(): Promise<ReadableStreamReader<Uint8Array> | undefined> {
     if (this._reader) {
       return this._reader;
     }
@@ -82,7 +82,7 @@ export default class FetchReader extends Readable {
     return this._reader;
   }
 
-  override _read(): void {
+  private override _read(): void {
     this._getReader()
       .then((reader) => {
         // if no reader is returned then we've encountered an error
@@ -121,7 +121,7 @@ export default class FetchReader extends Readable {
   }
 
   // aborts the xhr request if user calls stream.destroy()
-  override _destroy(): void {
+  private override _destroy(): void {
     this._aborted = true;
     this._controller.abort();
   }

--- a/packages/studio-base/src/util/FetchReader.ts
+++ b/packages/studio-base/src/util/FetchReader.ts
@@ -82,7 +82,7 @@ export default class FetchReader extends Readable {
     return this._reader;
   }
 
-  private override _read(): void {
+  override _read(): void {
     this._getReader()
       .then((reader) => {
         // if no reader is returned then we've encountered an error
@@ -121,7 +121,7 @@ export default class FetchReader extends Readable {
   }
 
   // aborts the xhr request if user calls stream.destroy()
-  private override _destroy(): void {
+  override _destroy(): void {
     this._aborted = true;
     this._controller.abort();
   }

--- a/packages/studio-base/src/util/Rpc.test.ts
+++ b/packages/studio-base/src/util/Rpc.test.ts
@@ -153,18 +153,4 @@ describe("Rpc", () => {
       }),
     ).toThrow();
   });
-
-  // Regression test for memory leak.
-  it("clears out _pendingCallbacks when done", async () => {
-    const { local: mainChannel, remote: workerChannel } = createLinkedChannels();
-    const local = new Rpc(mainChannel);
-    const worker = new Rpc(workerChannel);
-    worker.receive<{ foo: string }, { bar: string }>("foo", (msg) => {
-      return { bar: msg.foo };
-    });
-    expect(Object.keys(local._pendingCallbacks).length).toEqual(0); // eslint-disable-line no-underscore-dangle
-    const result = await local.send("foo", { foo: "baz" });
-    expect(Object.keys(local._pendingCallbacks).length).toEqual(0); // eslint-disable-line no-underscore-dangle
-    expect(result).toEqual({ bar: "baz" });
-  });
 });

--- a/packages/studio-base/src/util/Rpc.ts
+++ b/packages/studio-base/src/util/Rpc.ts
@@ -67,14 +67,14 @@ export function createLinkedChannels(): { local: Channel; remote: Channel } {
 // Check out the tests for more examples.
 export default class Rpc {
   static transferables = "$$TRANSFERABLES";
-  _channel: Omit<Channel, "terminate">;
-  _messageId: number = 0;
-  _pendingCallbacks: {
+  private _channel: Omit<Channel, "terminate">;
+  private _messageId: number = 0;
+  private _pendingCallbacks: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: number]: (arg0: any) => void;
   } = {};
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _receivers: Map<string, (arg0: any) => any> = new Map();
+  private _receivers: Map<string, (arg0: any) => any> = new Map();
 
   constructor(channel: Omit<Channel, "terminate">) {
     this._channel = channel;
@@ -86,7 +86,7 @@ export default class Rpc {
     this._channel.onmessage = this._onChannelMessage;
   }
 
-  _onChannelMessage = (ev: MessageEvent): void => {
+  private _onChannelMessage = (ev: MessageEvent): void => {
     const { id, topic, data } = ev.data;
     if (topic === RESPONSE) {
       this._pendingCallbacks[id]?.(ev.data);

--- a/packages/studio-base/src/util/Storage.ts
+++ b/packages/studio-base/src/util/Storage.ts
@@ -32,7 +32,7 @@ export function clearBustStorageFnsMap(): void {
 
 // Small wrapper around localStorage for convenience.
 export default class Storage {
-  _backingStore: BackingStore;
+  private _backingStore: BackingStore;
 
   constructor(backingStore: BackingStore = window.localStorage) {
     this._backingStore = backingStore;
@@ -69,7 +69,7 @@ export default class Storage {
     }
   }
 
-  _bustStorage(): void {
+  private _bustStorage(): void {
     const bustStorageFns = bustStorageFnsMap.get(this._backingStore) ?? [];
     for (const bustStorageFn of bustStorageFns) {
       bustStorageFn(this._backingStore, this.keys());

--- a/packages/studio-base/src/util/VirtualLRUBuffer.ts
+++ b/packages/studio-base/src/util/VirtualLRUBuffer.ts
@@ -44,13 +44,13 @@ import { isRangeCoveredByRanges, Range } from "./ranges";
 
 export default class VirtualLRUBuffer {
   byteLength: number; // How many bytes does this buffer represent.
-  _blocks: Buffer[] = []; // Actual `Buffer` for each block.
+  private _blocks: Buffer[] = []; // Actual `Buffer` for each block.
   // How many bytes is each block. This used to work up to 2GiB minus a byte, and now seems to crash
   // past 2GiB minus 4KiB. Default to 1GiB so we don't get caught out next time the limit drops.
-  _blockSize: number = Math.trunc(buffer.kMaxLength / 2);
-  _numberOfBlocks: number = Infinity; // How many blocks are we allowed to have at any time.
-  _lastAccessedBlockIndices: number[] = []; // Indexes of blocks, from least to most recently accessed.
-  _rangesWithData: Range[] = []; // Ranges for which we have data copied in (and have not been evicted).
+  private _blockSize: number = Math.trunc(buffer.kMaxLength / 2);
+  private _numberOfBlocks: number = Infinity; // How many blocks are we allowed to have at any time.
+  private _lastAccessedBlockIndices: number[] = []; // Indexes of blocks, from least to most recently accessed.
+  private _rangesWithData: Range[] = []; // Ranges for which we have data copied in (and have not been evicted).
 
   constructor(options: { size: number; blockSize?: number; numberOfBlocks?: number }) {
     this.byteLength = options.size;
@@ -126,7 +126,7 @@ export default class VirtualLRUBuffer {
   }
 
   // Get a reference to a block, and mark it as most recently used. Might evict older blocks.
-  _getBlock(index: number): Buffer {
+  private _getBlock(index: number): Buffer {
     if (!this._blocks[index]) {
       // If a block is not allocated yet, do so.
       let size = this._blockSize;

--- a/packages/studio-base/src/util/WebWorkerManager.ts
+++ b/packages/studio-base/src/util/WebWorkerManager.ts
@@ -35,6 +35,10 @@ export default class WebWorkerManager<W extends Channel> {
     this._allListeners = new Set();
   }
 
+  testing_workerCount(): number {
+    return this._workerStates.filter(Boolean).length;
+  }
+
   testing_getWorkerState(id: string): WorkerListenerState<W> | undefined {
     return this._workerStates.find((workerState) => workerState?.listenerIds.includes(id));
   }

--- a/packages/studio-base/src/util/WebWorkerManager.ts
+++ b/packages/studio-base/src/util/WebWorkerManager.ts
@@ -23,10 +23,10 @@ import { setupMainThreadRpc } from "@foxglove/studio-base/util/RpcMainThreadUtil
 type WorkerListenerState<W> = { rpc: Rpc; worker: W; listenerIds: string[] };
 
 export default class WebWorkerManager<W extends Channel> {
-  _createWorker: () => W;
-  _maxWorkerCount: number;
-  _workerStates: (WorkerListenerState<W> | undefined)[];
-  _allListeners: Set<string>;
+  private _createWorker: () => W;
+  private _maxWorkerCount: number;
+  private _workerStates: (WorkerListenerState<W> | undefined)[];
+  private _allListeners: Set<string>;
 
   constructor(createWorker: () => W, maxWorkerCount: number) {
     this._createWorker = createWorker;

--- a/packages/studio-base/src/util/manageWebWorkers.test.ts
+++ b/packages/studio-base/src/util/manageWebWorkers.test.ts
@@ -64,9 +64,13 @@ describe("WebWorkerManager", () => {
 
   it("can add and remove multiple listeners to the same worker", () => {
     const webWorkerManager = new WebWorkerManager(() => new FakeWorker(), 2);
+    expect(webWorkerManager.testing_workerCount()).toEqual(0);
     webWorkerManager.registerWorkerListener("1");
+    expect(webWorkerManager.testing_workerCount()).toEqual(1);
     webWorkerManager.registerWorkerListener("2");
+    expect(webWorkerManager.testing_workerCount()).toEqual(2);
     webWorkerManager.registerWorkerListener("3");
+    expect(webWorkerManager.testing_workerCount()).toEqual(2);
     expect(webWorkerManager.testing_getWorkerState("1")).toEqual(
       webWorkerManager.testing_getWorkerState("3"),
     );
@@ -77,8 +81,7 @@ describe("WebWorkerManager", () => {
     expect(webWorkerManager.testing_getWorkerState("3")?.listenerIds).toEqual(["3"]);
     webWorkerManager.unregisterWorkerListener("2");
     webWorkerManager.unregisterWorkerListener("3");
-    // eslint-disable-next-line no-underscore-dangle
-    expect(webWorkerManager._workerStates).toEqual([undefined, undefined]);
+    expect(webWorkerManager.testing_workerCount()).toEqual(0);
   });
 
   it("throws when registering an ID twice", () => {

--- a/packages/studio-base/src/util/parseMessageDefinitionsCache.ts
+++ b/packages/studio-base/src/util/parseMessageDefinitionsCache.ts
@@ -67,17 +67,17 @@ function maybeWriteLocalStorageCache(
 
 class ParseMessageDefinitionCache {
   // Used because we may load extraneous definitions that we need to clear.
-  _usedMd5Sums = new Set<string>();
-  _stringDefinitionsToParsedDefinitions: {
+  private _usedMd5Sums = new Set<string>();
+  private _stringDefinitionsToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _md5SumsToParsedDefinitions: {
+  private _md5SumsToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _hashesToParsedDefinitions: {
+  private _hashesToParsedDefinitions: {
     [key: string]: RosMsgDefinition[];
   } = {};
-  _localStorageCacheDisabled = false;
+  private _localStorageCacheDisabled = false;
 
   constructor() {
     const hashesToParsedDefinitionsEntries = storage


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add `private` to existing underscore-prefixed properties and methods so that TypeScript can help ensure there is no access from outside the class.

(See also: #1930)

Changes made using this ts-morph script:

```ts
import { Node, Project } from "ts-morph";
import ts from "typescript";

function log(...args: unknown[]) {
  // eslint-disable-next-line no-restricted-syntax
  console.log(...args);
}

log("Creating project...");
const project = new Project({ tsConfigFilePath: "./packages/studio-base/tsconfig.json" });

for (const file of project.getSourceFiles()) {
  log(file.getFilePath());
  file: for (;;) {
    for (const prop of file.getDescendantsOfKind(ts.SyntaxKind.PropertyDeclaration)) {
      if (prop.getName().startsWith("_") && !prop.hasModifier("private")) {
        log(`${prop.getParent().getName()}.${prop.getName()}`);
        prop.toggleModifier("private");
        continue file;
      }
    }
    for (const prop of file.getDescendantsOfKind(ts.SyntaxKind.MethodDeclaration)) {
      const parent = prop.getParent();
      if (!Node.isObjectLiteralExpression(parent)) {
        if (prop.getName().startsWith("_") && !prop.hasModifier("private")) {
          log(`${parent.getName()}.${prop.getName()}`);
          prop.toggleModifier("private");
          continue file;
        }
      }
    }
    break;
  }
}

log("Saving...");
project.saveSync();
```