### PR TITLE
Console player: automatically trim time range to available coverage; fix schema error

### DIFF
--- a/packages/mcap/scripts/validate.ts
+++ b/packages/mcap/scripts/validate.ts
@@ -64,10 +64,10 @@ async function validate(
         let parsedDefinitions;
         let messageDeserializer;
         if (record.encoding === "ros1") {
-          parsedDefinitions = parseMessageDefinition(new TextDecoder().decode(record.schema));
+          parsedDefinitions = parseMessageDefinition(record.schema);
           messageDeserializer = new ROS1LazyMessageReader(parsedDefinitions);
         } else if (record.encoding === "ros2") {
-          parsedDefinitions = parseMessageDefinition(new TextDecoder().decode(record.schema), {
+          parsedDefinitions = parseMessageDefinition(record.schema, {
             ros2: true,
           });
           messageDeserializer = new ROS2MessageReader(parsedDefinitions);

--- a/packages/mcap/src/McapReader.test.ts
+++ b/packages/mcap/src/McapReader.test.ts
@@ -223,8 +223,7 @@ describe("McapReader", () => {
           ...string("mytopic"), // topic
           ...string("utf12"), // encoding
           ...string("some data"), // schema name
-          ...string("none"), // schema format
-          ...uint32LE(0), // empty schema
+          ...string("stuff"), // schema
           ...[1, 2, 3], // channel data
         ]),
 
@@ -242,7 +241,7 @@ describe("McapReader", () => {
       topic: "mytopic",
       encoding: "utf12",
       schemaName: "some data",
-      schema: new ArrayBuffer(0),
+      schema: "stuff",
       data: new Uint8Array([1, 2, 3]).buffer,
     });
     expect(reader.nextRecord()).toEqual({ type: "Footer", indexPos: 0n, indexCrc: 0 });
@@ -255,8 +254,7 @@ describe("McapReader", () => {
       ...string("mytopic"), // topic
       ...string("utf12"), // encoding
       ...string("some data"), // schema name
-      ...string("none"), // schema format
-      ...uint32LE(0), // empty schema
+      ...string("stuff"), // schema
       ...[1, 2, 3], // channel data
     ]);
     const decompressHandlers = { xyz: () => channelInfo };
@@ -287,7 +285,7 @@ describe("McapReader", () => {
       topic: "mytopic",
       encoding: "utf12",
       schemaName: "some data",
-      schema: new ArrayBuffer(0),
+      schema: "stuff",
       data: new Uint8Array([1, 2, 3]).buffer,
     });
     expect(reader.nextRecord()).toEqual({ type: "Footer", indexPos: 0n, indexCrc: 0 });

--- a/packages/mcap/src/parse.ts
+++ b/packages/mcap/src/parse.ts
@@ -98,9 +98,8 @@ export function parseRecord(
       offset += schemaNameLen;
       const schemaLen = view.getUint32(offset, true);
       offset += 4;
-      const schema = view.buffer.slice(
-        view.byteOffset + offset,
-        view.byteOffset + offset + schemaLen,
+      const schema = new TextDecoder().decode(
+        new DataView(view.buffer, view.byteOffset + offset, schemaLen),
       );
       offset += schemaLen;
       const data = view.buffer.slice(view.byteOffset + offset, view.byteOffset + recordEndOffset);

--- a/packages/mcap/src/types.ts
+++ b/packages/mcap/src/types.ts
@@ -12,7 +12,7 @@ export type ChannelInfo = {
   topic: string;
   encoding: string;
   schemaName: string;
-  schema: ArrayBuffer;
+  schema: string;
   data: ArrayBuffer;
 };
 export type Message = {

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -55,6 +55,12 @@ type TopicResponse = {
   version: string;
 };
 
+type CoverageResponse = {
+  deviceId: string;
+  start: string;
+  end: string;
+};
+
 export type LayoutID = string & { __brand: "LayoutID" };
 export type ISO8601Timestamp = string & { __brand: "ISO8601Timestamp" };
 
@@ -233,6 +239,14 @@ class ConsoleApi {
 
   async deleteLayout(id: LayoutID): Promise<boolean> {
     return (await this.delete(`/v1/layouts/${id}`)).status === 200;
+  }
+
+  async coverage(params: {
+    deviceId: string;
+    start: string;
+    end: string;
+  }): Promise<CoverageResponse[]> {
+    return await this.get<CoverageResponse[]>("/v1/data/coverage", params);
   }
 
   async topics(params: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Make a `/coverage` request to automatically adjust the start/end time of the player.

Also fixes a bug with errors getting thrown even though there was no error due to incorrect `break`.