### PR TITLE
Console player: fix preload range calculation

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -373,22 +373,21 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       return;
     }
     const preloadedMessages = this._initialized.preloadedMessages;
-    const preloadedExtent = preloadedMessages.fullyLoadedExtent(this._currentTime);
+    const nextRangeToLoad = preloadedMessages.nextRangeToLoad(this._currentTime);
     const shouldPreload =
       this._requestedTopics.length > 0 &&
-      (!preloadedExtent ||
-        toSec(subtract(preloadedExtent.end, this._currentTime)) < this._preloadThresholdSecs);
+      nextRangeToLoad != undefined &&
+      toSec(subtract(nextRangeToLoad.start, this._currentTime)) < this._preloadThresholdSecs;
     if (!shouldPreload) {
       return;
     }
 
-    const startTime = clampTime(preloadedExtent?.end ?? this._currentTime, this._start, this._end);
-    const proposedEndTime = clampTime(
+    const startTime = nextRangeToLoad.start;
+    const endTime = clampTime(
       add(startTime, fromSec(this._preloadDurationSecs)),
       this._start,
-      this._end,
+      nextRangeToLoad.end,
     );
-    const endTime = preloadedMessages.fullyLoadedExtent(proposedEndTime)?.start ?? proposedEndTime;
     if (areEqual(startTime, endTime)) {
       return;
     }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The fullyLoadedExtent function was not well suited for preload calculation because it was unclear what it should return if the target time was the end of a loaded range or equal to the maxTime. This led to issues where an incorrect preload request would be made resulting in an error when adding overlapping data to the cache. Replace it with a nextRangeToLoad function which directly calculates the range we need to load.