### PR TITLE
Raw Messages: avoid expensive Object.keys call for large arrays

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -444,6 +444,9 @@ function RawMessages(props: Props) {
                 );
               }}
               postprocessValue={(rawVal: unknown) => {
+                if (rawVal == undefined) {
+                  return rawVal;
+                }
                 const idValue = (rawVal as Record<string, unknown>)[diffLabels.ID.labelText];
                 const addedValue = (rawVal as Record<string, unknown>)[diffLabels.ADDED.labelText];
                 const changedValue = (rawVal as Record<string, unknown>)[

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -375,7 +375,6 @@ function RawMessages(props: Props) {
           showFullMessageForDiff,
         })
       : {};
-    const diffLabelTexts = Object.values(diffLabels).map(({ labelText }) => labelText);
 
     const CheckboxComponent = showFullMessageForDiff
       ? CheckboxMarkedIcon

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -445,18 +445,24 @@ function RawMessages(props: Props) {
                 );
               }}
               postprocessValue={(rawVal: unknown) => {
-                const val = maybeDeepParse(rawVal);
+                const idValue = (rawVal as Record<string, unknown>)[diffLabels.ID.labelText];
+                const addedValue = (rawVal as Record<string, unknown>)[diffLabels.ADDED.labelText];
+                const changedValue = (rawVal as Record<string, unknown>)[
+                  diffLabels.CHANGED.labelText
+                ];
+                const deletedValue = (rawVal as Record<string, unknown>)[
+                  diffLabels.DELETED.labelText
+                ];
                 if (
-                  typeof val === "object" &&
-                  val != undefined &&
-                  Object.keys(val).length === 1 &&
-                  (diffLabelTexts as string[]).includes(Object.keys(val)[0] as string)
+                  (addedValue != undefined ? 1 : 0) +
+                    (changedValue != undefined ? 1 : 0) +
+                    (deletedValue != undefined ? 1 : 0) ===
+                    1 &&
+                  idValue == undefined
                 ) {
-                  if (Object.keys(val)[0] !== diffLabels.ID.labelText) {
-                    return Object.values(val)[0];
-                  }
+                  return addedValue ?? changedValue ?? deletedValue;
                 }
-                return val;
+                return maybeDeepParse(rawVal);
               }}
               theme={{
                 ...jsonTreeTheme,


### PR DESCRIPTION
**User-Facing Changes**
Improved performance of the Raw Messages panel when viewing large messages.

**Description**
The existing postprocessValue implementation would call Object.keys multiple times. For large objects, including TypedArrays, Object.keys can be expensive and return a large array:

```
> Object.keys(new Uint8Array(10))
[
  '0', '1', '2', '3',
  '4', '5', '6', '7',
  '8', '9'   <-- imagine a Uint8Array(1000) 😅 
]
```

This PR attempts to preserve the logic of checking the existence of diff-related keys, but does this before maybeDeepParse and without calling Object.keys.