### PR TITLE
Another attempt at extracting data source setup

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -8,7 +8,7 @@ import {
   App,
   ErrorBoundary,
   MultiProvider,
-  PlayerSourceDefinition,
+  DataSource,
   ThemeProvider,
   UserProfileLocalStorageProvider,
   StudioToastProvider,
@@ -17,6 +17,7 @@ import {
   ConsoleApi,
   ConsoleApiContext,
   ConsoleApiRemoteLayoutStorageProvider,
+  Ros1LocalBag,
 } from "@foxglove/studio-base";
 
 import { Desktop } from "../common/types";
@@ -31,43 +32,9 @@ const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo
 
 const desktopBridge = (global as unknown as { desktopBridge: Desktop }).desktopBridge;
 
-export default function Root(): ReactElement {
-  const playerSources: PlayerSourceDefinition[] = [
-    {
-      name: "ROS 1",
-      type: "ros1-socket",
-    },
-    {
-      name: "ROS 1 Rosbridge",
-      type: "rosbridge-websocket",
-    },
-    {
-      name: "ROS 1 Bag (local)",
-      type: "ros1-local-bagfile",
-    },
-    {
-      name: "ROS 1 Bag (remote)",
-      type: "ros1-remote-bagfile",
-    },
-    {
-      name: "ROS 2",
-      type: "ros2-socket",
-      badgeText: "beta",
-    },
-    {
-      name: "ROS 2 Rosbridge",
-      type: "rosbridge-websocket",
-    },
-    {
-      name: "ROS 2 Bag (local)",
-      type: "ros2-local-bagfile",
-    },
-    {
-      name: "Velodyne LIDAR",
-      type: "velodyne-device",
-    },
-  ];
+const dataSources: DataSource[] = [Ros1LocalBag];
 
+export default function Root(): ReactElement {
   const api = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL!), []);
 
   const providers = [
@@ -93,7 +60,7 @@ export default function Root(): ReactElement {
       <CssBaseline>
         <ErrorBoundary>
           <MultiProvider providers={providers}>
-            <App demoBagUrl={DEMO_BAG_URL} deepLinks={deepLinks} availableSources={playerSources} />
+            <App demoBagUrl={DEMO_BAG_URL} deepLinks={deepLinks} availableSources={dataSources} />
           </MultiProvider>
         </ErrorBoundary>
       </CssBaseline>

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -16,7 +16,7 @@ import AnalyticsProvider from "@foxglove/studio-base/context/AnalyticsProvider";
 import { AssetsProvider } from "@foxglove/studio-base/context/AssetsContext";
 import { HoverValueProvider } from "@foxglove/studio-base/context/HoverValueContext";
 import ModalHost from "@foxglove/studio-base/context/ModalHost";
-import { PlayerSourceDefinition } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { DataSource } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
 import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider";
 import ExtensionMarketplaceProvider from "@foxglove/studio-base/providers/ExtensionMarketplaceProvider";
@@ -31,7 +31,7 @@ type AppProps = {
    * on first launch and not subsequent launches.
    */
   loadWelcomeLayout?: boolean;
-  availableSources: PlayerSourceDefinition[];
+  availableSources: DataSource[];
   demoBagUrl?: string;
   deepLinks?: string[];
 };

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -194,12 +194,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     if (isMounted()) {
       setSelectedLayoutId(newLayout.id);
       if (props.demoBagUrl) {
-        selectSource(
-          { name: "Demo Bag", type: "ros1-remote-bagfile" },
-          {
-            url: props.demoBagUrl,
-          },
-        );
+        selectSource("ros1-remote-bagfile", {
+          url: props.demoBagUrl,
+        });
       }
     }
   }, [layoutStorage, isMounted, setSelectedLayoutId, props.demoBagUrl, selectSource]);
@@ -297,12 +294,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         } else {
           previousFiles.current = otherFiles;
         }
-        selectSource(
-          { name: "ROS 1 Bag File (local)", type: "ros1-local-bagfile" },
-          {
-            files: previousFiles.current,
-          },
-        );
+        selectSource("ros1-local-bagfile", {
+          files: previousFiles.current,
+        });
       }
     },
     [addToast, extensionLoader, loadFromFile, selectSource],
@@ -339,10 +333,8 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           return;
         }
         selectSource(
-          {
-            name: "ROS 1 Bag File (HTTP)",
-            type: "ros1-remote-bagfile",
-          },
+          "ros1-remote-bagfile",
+
           { url: bagUrl },
         );
       } else if (type === "foxglove-data-platform") {
@@ -362,13 +354,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           log.warn(`Missing or invalid timestamp(s) in ${url}`);
           return;
         }
-        selectSource(
-          {
-            name: "Foxglove Data Platform",
-            type: "foxglove-data-platform",
-          },
-          { start, end, seekTo, deviceId },
-        );
+        selectSource("foxglove-data-platform", { start, end, seekTo, deviceId });
       } else {
         log.warn(`Unknown deep link type ${url}`);
       }

--- a/packages/studio-base/src/components/NativeFileMenuPlayerSelection.tsx
+++ b/packages/studio-base/src/components/NativeFileMenuPlayerSelection.tsx
@@ -8,6 +8,8 @@ import { useNativeAppMenu } from "@foxglove/studio-base/context/NativeAppMenuCon
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 
 // NativeFileMenuPlayerSelection adds available player selection items to the apps native OS menubar
+// fixme - selecting the source now needs to display the UI element/sidebar
+// This should be done where?
 export function NativeFileMenuPlayerSelection(): ReactElement {
   const { selectSource, availableSources } = usePlayerSelection();
 
@@ -19,14 +21,14 @@ export function NativeFileMenuPlayerSelection(): ReactElement {
     }
 
     for (const item of availableSources) {
-      nativeAppMenu.addFileEntry(item.name, () => {
-        selectSource(item);
+      nativeAppMenu.addFileEntry(item.displayName, () => {
+        selectSource(item.id);
       });
     }
 
     return () => {
       for (const item of availableSources) {
-        nativeAppMenu.removeFileEntry(item.name);
+        nativeAppMenu.removeFileEntry(item.displayName);
       }
     };
   }, [availableSources, nativeAppMenu, selectSource]);

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -14,7 +14,6 @@
 import {
   PropsWithChildren,
   useCallback,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -22,376 +21,29 @@ import {
   useState,
 } from "react";
 import { useToasts } from "react-toast-notifications";
-import { useLocalStorage, useMountedState } from "react-use";
+import { useLocalStorage } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { MessagePipelineProvider } from "@foxglove/studio-base/components/MessagePipeline";
-import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
-import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
 import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PlayerSelectionContext, {
   DataSource,
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useUserNodeState } from "@foxglove/studio-base/context/UserNodeStateContext";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
-import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
 import useWarnImmediateReRender from "@foxglove/studio-base/hooks/useWarnImmediateReRender";
-import AnalyticsMetricsCollector from "@foxglove/studio-base/players/AnalyticsMetricsCollector";
 import OrderedStampPlayer from "@foxglove/studio-base/players/OrderedStampPlayer";
 import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
-import { BuildPlayerOptions } from "@foxglove/studio-base/players/buildPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import { UserNodes } from "@foxglove/studio-base/types/panels";
-import Storage from "@foxglove/studio-base/util/Storage";
 
 const log = Logger.getLogger(__filename);
 
 const DEFAULT_MESSAGE_ORDER = "receiveTime";
 const EMPTY_USER_NODES: UserNodes = Object.freeze({});
 const EMPTY_GLOBAL_VARIABLES: GlobalVariables = Object.freeze({});
-
-/*
-type FactoryOptions = {
-  source: PlayerSourceDefinition;
-  sourceOptions: Record<string, unknown>;
-  playerOptions: BuildPlayerOptions;
-  prompt: ReturnType<typeof usePrompt>;
-  consoleApi?: ConsoleApi;
-  storage: Storage;
-};
-
-type FoxgloveDataPlatformOptions = {
-  start: string;
-  end: string;
-  seek?: string;
-  deviceId: string;
-};
-
-async function localBagFileSource(options: FactoryOptions): Promise<Player | undefined> {
-  let file: File;
-
-  const restore = Boolean(options.sourceOptions.restore ?? false);
-
-  // future enhancement would be to store the fileHandle in indexeddb and try to restore
-  // fileHandles can be stored in indexeddb but not localstorage
-  if (restore) {
-    return undefined;
-  }
-
-  const { buildPlayerFromFiles } = await import("@foxglove/studio-base/players/buildPlayer");
-
-  // maybe the caller has some files they want to open
-  const files = options.sourceOptions.files;
-  if (files instanceof Array) {
-    return buildPlayerFromFiles(files, options.playerOptions);
-  }
-
-  try {
-    const [fileHandle] = await showOpenFilePicker({
-      types: [{ accept: { "application/octet-stream": [".bag"] } }],
-    });
-    file = await fileHandle.getFile();
-  } catch (error) {
-    if (error.name === "AbortError") {
-      return undefined;
-    }
-    throw error;
-  }
-
-  return buildPlayerFromFiles([file], options.playerOptions);
-}
-
-async function localRosbag2FolderSource(options: FactoryOptions): Promise<Player | undefined> {
-  let folder: FileSystemDirectoryHandle;
-
-  const restore = Boolean(options.sourceOptions.restore ?? false);
-  if (restore) {
-    return undefined;
-  }
-
-  try {
-    folder = await showDirectoryPicker();
-  } catch (error) {
-    if (error.name === "AbortError") {
-      return undefined;
-    }
-    throw error;
-  }
-
-  const { buildRosbag2PlayerFromDescriptor } = await import(
-    "@foxglove/studio-base/players/buildRosbag2Player"
-  );
-  return buildRosbag2PlayerFromDescriptor(getLocalRosbag2Descriptor(folder), options.playerOptions);
-}
-
-async function remoteBagFileSource(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // undefined url indicates the user canceled the prompt
-  let maybeUrl;
-
-  const restore = Boolean(options.sourceOptions.restore ?? false);
-  const urlOption = options.sourceOptions.url;
-
-  if (restore) {
-    maybeUrl = options.storage.getItem<string>(storageCacheKey);
-  } else if (typeof urlOption === "string") {
-    maybeUrl = urlOption;
-  } else {
-    maybeUrl = await options.prompt({
-      title: "Remote bag file",
-      placeholder: "https://example.com/file.bag",
-      transformer: (str) => {
-        const result = parseInputUrl(str, "https:", {
-          "http:": { port: 80 },
-          "https:": { port: 443 },
-          "ftp:": { port: 21 },
-        });
-        if (result == undefined) {
-          throw new AppError(
-            "Invalid bag URL. Use a http:// or https:// URL of a web hosted bag file.",
-          );
-        }
-        return result;
-      },
-    });
-  }
-
-  if (maybeUrl == undefined) {
-    return undefined;
-  }
-
-  const url = maybeUrl;
-  options.storage.setItem(storageCacheKey, url);
-
-  const { buildPlayerFromBagURLs } = await import("@foxglove/studio-base/players/buildPlayer");
-  return buildPlayerFromBagURLs([url], options.playerOptions);
-}
-
-async function foxgloveDataPlatformSource(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // load the player on-demand
-  const { default: FoxgloveDataPlatformPlayer } = await import(
-    "@foxglove/studio-base/players/FoxgloveDataPlatformPlayer"
-  );
-
-  let params: FoxgloveDataPlatformOptions | undefined;
-
-  const restore = Boolean(options.sourceOptions.restore ?? false);
-  if (restore) {
-    params = options.storage.getItem<FoxgloveDataPlatformOptions>(storageCacheKey);
-  } else if (typeof options.sourceOptions.start === "string") {
-    params = options.sourceOptions as FoxgloveDataPlatformOptions;
-    if (!params.start || !params.end || !params.deviceId) {
-      throw new Error(
-        `Missing required FoxgloveDataPlatform parameters in ${JSON.stringify(
-          options.sourceOptions,
-        )}`,
-      );
-    }
-  }
-
-  if (!params) {
-    return undefined;
-  }
-  if (!options.consoleApi) {
-    throw new Error(`${options.source.name} data source is not available without ConsoleApi`);
-  }
-
-  options.storage.setItem(storageCacheKey, params);
-  return new FoxgloveDataPlatformPlayer({
-    params,
-    consoleApi: options.consoleApi,
-    metricsCollector: options.playerOptions.metricsCollector,
-  });
-}
-
-async function rosbridgeSource(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // load the player on-demand
-  const { default: RosbridgePlayer } = await import(
-    "@foxglove/studio-base/players/RosbridgePlayer"
-  );
-
-  // undefined url indicates the user canceled the prompt
-  let maybeUrl;
-  const restore = Boolean(options.sourceOptions.restore);
-
-  if (restore) {
-    maybeUrl = options.storage.getItem<string>(storageCacheKey);
-  } else {
-    const value = options.storage.getItem<string>(storageCacheKey) ?? "ws://localhost:9090";
-    maybeUrl = await options.prompt({
-      title: "WebSocket connection",
-      placeholder: "ws://localhost:9090",
-      initialValue: value,
-      transformer: (str) => {
-        const result = parseInputUrl(str, "http:", {
-          "http:": { protocol: "ws:", port: 9090 },
-          "https:": { protocol: "wss:", port: 9090 },
-          "ws:": { port: 9090 },
-          "wss:": { port: 9090 },
-          "ros:": { protocol: "ws:", port: 9090 },
-        });
-        if (result == undefined) {
-          throw new AppError("Invalid rosbridge WebSocket URL. Use the ws:// or wss:// protocol.");
-        }
-        return result;
-      },
-    });
-  }
-
-  if (maybeUrl == undefined) {
-    return undefined;
-  }
-
-  const url = maybeUrl;
-  options.storage.setItem(storageCacheKey, url);
-  return new RosbridgePlayer({
-    url,
-    metricsCollector: options.playerOptions.metricsCollector,
-  });
-}
-
-async function ros1Source(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // load the player on-demand
-  const { default: Ros1Player } = await import("@foxglove/studio-base/players/Ros1Player");
-
-  // undefined url indicates the user canceled the prompt
-  let maybeUrl;
-  const restore = Boolean(options.sourceOptions.restore);
-
-  if (restore) {
-    maybeUrl = options.storage.getItem<string>(storageCacheKey);
-  } else {
-    const value = options.storage.getItem<string>(storageCacheKey);
-
-    const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
-    maybeUrl = await options.prompt({
-      title: "ROS 1 TCP connection",
-      placeholder: "localhost:11311",
-      initialValue: value ?? os?.getEnvVar("ROS_MASTER_URI") ?? "localhost:11311",
-      transformer: (str) => {
-        const result = parseInputUrl(str, "ros:", {
-          "http:": { port: 80 },
-          "https:": { port: 443 },
-          "ros:": { protocol: "http:", port: 11311 },
-        });
-        if (result == undefined) {
-          throw new AppError(
-            "Invalid ROS URL. See the ROS_MASTER_URI at http://wiki.ros.org/ROS/EnvironmentVariables for more info.",
-          );
-        }
-        return result;
-      },
-    });
-  }
-
-  if (maybeUrl == undefined) {
-    return undefined;
-  }
-
-  const url = maybeUrl;
-  options.storage.setItem(storageCacheKey, url);
-
-  const hostname = options.sourceOptions.rosHostname as string | undefined;
-
-  return new Ros1Player({
-    url,
-    hostname,
-    metricsCollector: options.playerOptions.metricsCollector,
-  });
-}
-
-async function ros2Source(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // undefined url indicates the user canceled the prompt
-  let maybeDomainId: string | undefined;
-  const restore = Boolean(options.sourceOptions.restore);
-
-  if (restore) {
-    maybeDomainId = options.storage.getItem<string>(storageCacheKey);
-  } else {
-    const value = options.storage.getItem<string>(storageCacheKey);
-
-    maybeDomainId = await options.prompt({
-      title: "ROS 2 DomainId",
-      placeholder: "0",
-      initialValue: value ?? "0",
-      transformer: (str) => {
-        const result = parseInt(str);
-        if (isNaN(result) || result < 0) {
-          throw new AppError("Invalid ROS 2 DomainId. Please use a non-negative integer");
-        }
-        return String(result);
-      },
-    });
-  }
-
-  if (maybeDomainId == undefined) {
-    return undefined;
-  }
-
-  const domainIdStr = maybeDomainId;
-  const domainId = parseInt(domainIdStr);
-  options.storage.setItem(storageCacheKey, maybeDomainId);
-
-  return new Ros2Player({ domainId, metricsCollector: options.playerOptions.metricsCollector });
-}
-
-async function velodyneSource(options: FactoryOptions): Promise<Player | undefined> {
-  const storageCacheKey = `studio.source.${options.source.name}`;
-
-  // load the player on-demand
-  const { default: VelodynePlayer, DEFAULT_VELODYNE_PORT } = await import(
-    "@foxglove/studio-base/players/VelodynePlayer"
-  );
-
-  // undefined port indicates the user canceled the prompt
-  let maybePort;
-  const restore = options.sourceOptions.restore;
-
-  if (restore != undefined) {
-    maybePort = options.storage.getItem<string>(storageCacheKey);
-  } else {
-    const value = options.storage.getItem<string>(storageCacheKey);
-
-    maybePort = await options.prompt({
-      title: "Velodyne LIDAR UDP port",
-      placeholder: `${DEFAULT_VELODYNE_PORT}`,
-      initialValue: value ?? `${DEFAULT_VELODYNE_PORT}`,
-      transformer: (str) => {
-        const parsed = parseInt(str);
-        if (isNaN(parsed) || parsed <= 0 || parsed > 65535) {
-          throw new AppError(
-            "Invalid port number. Please enter a valid UDP port number to listen for Velodyne packets",
-          );
-        }
-        return parsed.toString();
-      },
-    });
-  }
-
-  if (maybePort == undefined) {
-    return undefined;
-  }
-
-  const portStr = maybePort;
-  const port = parseInt(portStr);
-  options.storage.setItem(storageCacheKey, portStr);
-
-  return new VelodynePlayer({ port, metricsCollector: options.playerOptions.metricsCollector });
-}
-*/
 
 type PlayerManagerProps = {
   playerSources: DataSource[];
@@ -419,23 +71,11 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const globalVariablesRef = useRef<GlobalVariables>(globalVariables);
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
-  const isMounted = useMountedState();
 
   // We don't want to recreate the player when the message order changes, but we do want to
   // initialize it with the right order, so make a variable for its initial value we can use in the
   // dependency array below to defeat the linter.
   const [initialMessageOrder] = useState(messageOrder);
-
-  const analytics = useAnalytics();
-  const metricsCollector = useMemo(() => new AnalyticsMetricsCollector(analytics), [analytics]);
-
-  const [unlimitedMemoryCache = false] = useAppConfigurationValue<boolean>(
-    AppSetting.UNLIMITED_MEMORY_CACHE,
-  );
-  const buildPlayerOptions: BuildPlayerOptions = useShallowMemo({
-    unlimitedMemoryCache,
-    metricsCollector,
-  });
 
   const player = useMemo<OrderedStampPlayer | undefined>(() => {
     if (!basePlayer) {
@@ -458,40 +98,8 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     player?.setUserNodes(userNodes ?? EMPTY_USER_NODES);
   }, [player, userNodes]);
 
-  /*
-  // Based on a source type, prompt the user for additional input and return a function to build the
-  // requested player.
-  const lookupPlayerBuilderFactory = useCallback((definition: PlayerSourceDefinition) => {
-    switch (definition.type) {
-      case "foxglove-data-platform":
-        return foxgloveDataPlatformSource;
-      case "ros1-local-bagfile":
-        return localBagFileSource;
-      case "ros2-local-bagfile":
-        return localRosbag2FolderSource;
-      case "ros1-socket":
-        return ros1Source;
-      case "ros2-socket":
-        return ros2Source;
-      case "rosbridge-websocket":
-        return rosbridgeSource;
-      case "ros1-remote-bagfile":
-        return remoteBagFileSource;
-      case "velodyne-device":
-        return velodyneSource;
-      default:
-        return;
-    }
-  }, []);
-  */
-
-  //const prompt = usePrompt();
   const { addToast } = useToasts();
-  //const storage = useMemo(() => new Storage(), []);
-
-  //const [rosHostname] = useAppConfigurationValue<string>(AppSetting.ROS1_ROS_HOSTNAME);
-
-  const [savedSource, setSavedSource] = useLocalStorage<{
+  const [savedSource, setSavedSource, removeSavedSource] = useLocalStorage<{
     id: string;
     args?: Record<string, unknown>;
   }>("studio.playermanager.selected-source.v2");
@@ -501,6 +109,12 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   const selectSource = useCallback(
     async (sourceId: string, args?: Record<string, unknown>) => {
       log.debug(`Select Source: ${sourceId}`);
+
+      if (!sourceId) {
+        removeSavedSource();
+        setSelectedSource(undefined);
+        return;
+      }
 
       const foundSource = playerSources.find((source) => source.id === sourceId);
       if (!foundSource) {
@@ -516,46 +130,21 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         args,
       });
 
-      /*
-      try {
-        metricsCollector.setProperty("player", selectedSource.type);
-
-        const buildPlayer = lookupPlayerBuilderFactory(selectedSource);
-        if (!buildPlayer) {
-          // This can happen when upgrading from an older version of Studio that used different
-          // player names
-          addToast(`Could not create a player for ${selectedSource.name}.`, {
-            appearance: "error",
-          });
-          return;
-        }
-
-        const newBasePlayer = await buildPlayer({
-          source: selectedSource,
-          sourceOptions: { ...params, rosHostname },
-          playerOptions: buildPlayerOptions,
-          prompt,
-          consoleApi,
-          storage,
-        });
-        if (newBasePlayer && isMounted()) {
-          setBasePlayer(newBasePlayer);
-        }
-      } catch (error) {
-        setBasePlayer(undefined);
-        addToast(error.message, {
-          appearance: "error",
-        });
-      }
-      */
+      setSelectedSource(() => foundSource);
     },
-    [addToast, playerSources, setSavedSource],
+    [addToast, playerSources, removeSavedSource, setSavedSource],
   );
 
   // restore the saved source on first mount
   useLayoutEffect(() => {
     if (savedSource) {
-      void selectSource(savedSource, { restore: true });
+      const foundSource = playerSources.find((source) => source.id === savedSource.id);
+      if (!foundSource) {
+        return;
+      }
+
+      const initializedBasePlayer = foundSource.initialize(savedSource.args);
+      setBasePlayer(initializedBasePlayer);
     }
     // we only run the layout effect on first mount - never again even if the saved source changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -565,6 +154,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     selectSource,
     selectedSource,
     availableSources: playerSources,
+    setPlayer: setBasePlayer,
   };
 
   return (

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -4,61 +4,33 @@
 
 import { createContext, useContext } from "react";
 
-type SourceTypes =
-  | "foxglove-data-platform"
-  | "ros1-local-bagfile"
-  | "ros2-local-bagfile"
-  | "ros1-socket"
-  | "ros2-socket"
-  | "rosbridge-websocket"
-  | "ros1-remote-bagfile"
-  | "velodyne-device";
-
-export type PlayerSourceDefinition = {
-  name: string;
-  type: SourceTypes;
+export type DataSource = {
+  id: string;
+  displayName: string;
+  iconName?: string;
   disabledReason?: string | JSX.Element;
   badgeText?: string;
+
+  // Return the UI element for the data source
+  ui: () => JSX.Element;
 };
 
-type FileSourceParams = {
-  files?: File[];
+export type SourceSelection = {
+  id: string;
+  args?: unknown;
 };
 
-type FolderSourceParams = {
-  folder?: string;
-};
-
-type HttpSourceParams = {
-  url?: string;
-};
-
-type FoxgloveDataPlatformSourceParams = {
-  start?: string;
-  end?: string;
-  seekTo?: string;
-  deviceId?: string;
-};
-
-type SpecializedPlayerSource<T extends SourceTypes> = Omit<PlayerSourceDefinition, "type"> & {
-  type: T;
-};
-
-interface SelectSourceFunction {
-  (definition: SpecializedPlayerSource<"ros1-local-bagfile">, params?: FileSourceParams): void;
-  (definition: SpecializedPlayerSource<"ros2-local-bagfile">, params?: FolderSourceParams): void;
-  (definition: SpecializedPlayerSource<"ros1-remote-bagfile">, params?: HttpSourceParams): void;
-  (
-    definition: SpecializedPlayerSource<"foxglove-data-platform">,
-    params?: FoxgloveDataPlatformSourceParams,
-  ): void;
-  (definition: PlayerSourceDefinition, params?: never): void;
-}
-
-// PlayerSelection provides the user with a select function and the items to select
+/**
+ * PlayerSelectionContext exposes the available data sources and a function to set the current data source
+ */
 export interface PlayerSelection {
-  selectSource: SelectSourceFunction;
-  availableSources: PlayerSourceDefinition[];
+  selectSource: (sourceId: string, args?: Record<string, unknown>) => void;
+
+  /** Currently selected data source */
+  selectedSource?: DataSource;
+
+  /** List of available data sources */
+  availableSources: DataSource[];
 }
 
 const PlayerSelectionContext = createContext<PlayerSelection>({

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -4,6 +4,12 @@
 
 import { createContext, useContext } from "react";
 
+import { Player } from "@foxglove/studio-base/players/types";
+
+type Props = {
+  onPlayer: (player: Player) => void;
+};
+
 export type DataSource = {
   id: string;
   displayName: string;
@@ -12,7 +18,10 @@ export type DataSource = {
   badgeText?: string;
 
   // Return the UI element for the data source
-  ui: () => JSX.Element;
+  ui: (props: Props) => JSX.Element;
+
+  // initialize a player given some arguments
+  initialize: (args?: Record<string, unknown>) => Player | undefined;
 };
 
 export type SourceSelection = {
@@ -31,11 +40,15 @@ export interface PlayerSelection {
 
   /** List of available data sources */
   availableSources: DataSource[];
+
+  /** Set the active player */
+  setPlayer: (player: Player) => void;
 }
 
 const PlayerSelectionContext = createContext<PlayerSelection>({
   selectSource: () => {},
   availableSources: [],
+  setPlayer: () => {},
 });
 
 export function usePlayerSelection(): PlayerSelection {

--- a/packages/studio-base/src/dataSources/Ros1LocalBag.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBag.tsx
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback } from "react";
+import { useLatest } from "react-use";
+
+import Button from "@foxglove/studio-base/components/Button";
+import { buildPlayerFromFiles } from "@foxglove/studio-base/players/buildPlayer";
+import { Player } from "@foxglove/studio-base/players/types";
+
+type Props = {
+  onPlayer: (player: Player) => void;
+};
+
+function Ros1LocalBagUi(props: Props): JSX.Element {
+  const onPlayer = useLatest(props.onPlayer);
+
+  const onOpenFileClick = useCallback(async () => {
+    try {
+      const [fileHandle] = await showOpenFilePicker({
+        types: [{ accept: { "application/octet-stream": [".bag"] } }],
+      });
+      const file = await fileHandle.getFile();
+
+      const player = Ros1LocalBag.initialize({
+        file,
+      });
+
+      if (!player) {
+        return;
+      }
+
+      onPlayer.current(player);
+    } catch (error) {
+      if (error.name === "AbortError") {
+        return;
+      }
+      throw error;
+    }
+  }, [onPlayer]);
+
+  return (
+    <div>
+      <div style={{ padding: "4px" }}>Some text describing ROS1 bag stuff here</div>
+      <div style={{ padding: "4px" }}>
+        <Button onClick={onOpenFileClick}>Open File</Button>
+      </div>
+    </div>
+  );
+}
+
+class Ros1LocalBag {
+  static id = "ros1-local-bagfile";
+  static displayName = "ROS 1 Bag (local)";
+  static icon = "studio.ROS";
+
+  static initialize(args?: Record<string, unknown>): Player | undefined {
+    const file = args?.["file"] as File | undefined;
+    if (!file) {
+      return;
+    }
+
+    return buildPlayerFromFiles([file], {
+      unlimitedMemoryCache: false,
+      // metricsCollector: undefined,
+    });
+  }
+
+  static ui(props: Props): JSX.Element {
+    return Ros1LocalBagUi(props);
+  }
+}
+
+export default Ros1LocalBag;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -32,7 +32,7 @@ export { default as NativeAppMenuContext } from "./context/NativeAppMenuContext"
 export type { NativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";
 export { default as NativeWindowContext } from "./context/NativeWindowContext";
 export type { NativeWindow } from "./context/NativeWindowContext";
-export type { PlayerSourceDefinition } from "./context/PlayerSelectionContext";
+export type { DataSource } from "./context/PlayerSelectionContext";
 export { default as ThemeProvider } from "./theme/ThemeProvider";
 export { default as installDevtoolsFormatters } from "./util/installDevtoolsFormatters";
 export { default as overwriteFetch } from "./util/overwriteFetch";
@@ -51,3 +51,4 @@ export { default as GlobalCss } from "./components/GlobalCss";
 export { default as CurrentUserContext } from "./context/CurrentUserContext";
 export type { User } from "./context/CurrentUserContext";
 export { default as DeviceCodeDialog } from "./components/DeviceCodeDialog";
+export { default as Ros1LocalBag } from "./dataSources/Ros1LocalBag";

--- a/packages/studio-base/src/players/buildPlayer.ts
+++ b/packages/studio-base/src/players/buildPlayer.ts
@@ -15,7 +15,7 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
 export type BuildPlayerOptions = {
   unlimitedMemoryCache: boolean;
-  metricsCollector: PlayerMetricsCollectorInterface;
+  metricsCollector?: PlayerMetricsCollectorInterface;
 };
 
 export function buildPlayerFromDescriptor(


### PR DESCRIPTION
**User-Facing Changes**
TBD

**Description**

This PR changes how users select the data source. Rather than all data source selection and UI existing in the PlayerManager component, each type of data source presents its own UI and has its own player creation logic. The goal is to support adding new data sources at the _app_ level (web & desktop & eventually extensions) rather than having all data sources hard-coded within the codebase.

This PR changes how a data source is selected. Rather than PlayerManager driving the logic, each data source provides a UI element which is rendered within the connection sidebar. The user interacts with this UI element to configure the data source.

For example. To select a bag file - the user opens the Connection sidebar as before:

![image](https://user-images.githubusercontent.com/84792/136985455-6fe744b6-0b85-4ffa-82ee-822fafc928e9.png)

And click on the "ROS 1 Bag" connection which changes the Connection sidebar to work specifically with bag files. This state of the connection sidebar is remembered - so if the user is working with bag files they will remain on this panel when they re-open the app.

![image](https://user-images.githubusercontent.com/84792/136985500-98d78df4-17fd-4fa1-8e17-f4305ceffd54.png)

Other connection types like ROS 1 Rosbridge may require additional settings:

![image](https://user-images.githubusercontent.com/84792/136985835-54b03738-7bb5-4dcb-8980-3a8dbc36c9dd.png)

-----

Challenges/Questions

- How does this interact with the native file menu?
- Naming - there are two stages of data source selection: 1. selecting the connection type, 2. initializing the connection
- Special handling of "file" data sources so file drag&drop (in the Workspace component) invokes the correct data source
- Restoring data source connections. Today, if you connect to ROS 1 Live or Rosbridge then close the app - next time you open the app you are connected again. The data source is "restored" from the previous connection. In the new world, I store the connection type, but not sure where storing/restoring the connection itself lives yet. Some connections like ROS 1 Local Bag are not restorable - but the connection type is restorable.

Is this even the right approach? I like the idea of moving things like ROS_HOSTNAME out of app settings and into data source specific settings; though maybe that still belongs at the app settings level - just namespaced to the data source. I also like the idea of being able to tune the data source connection parameters where you establish the connection - feels natural.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
