### PR TITLE
Add Gauge panel

### DIFF
--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -1,0 +1,295 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { last } from "lodash";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { MessageEvent, PanelExtensionContext, SettingsTreeAction } from "@foxglove/studio";
+import { RosPath } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+import { simpleGetMessagePathDataItems } from "@foxglove/studio-base/components/MessagePathSyntax/simpleGetMessagePathDataItems";
+
+import { settingsActionReducer, useSettingsTree } from "./settings";
+import type { Config } from "./types";
+
+type Props = {
+  context: PanelExtensionContext;
+};
+
+const defaultConfig: Config = {
+  path: "",
+  minValue: 0,
+  maxValue: 1,
+};
+
+type State = {
+  path: string;
+  parsedPath: RosPath | undefined;
+  latestMessage: MessageEvent<unknown> | undefined;
+  latestMatchingQueriedData: unknown | undefined;
+  error: Error | undefined;
+  pathParseError: string | undefined;
+};
+
+type Action =
+  | { type: "message"; message: MessageEvent<unknown> }
+  | { type: "path"; path: string }
+  | { type: "seek" };
+
+function getSingleDataItem(results: unknown[]) {
+  if (results.length <= 1) {
+    return results[0];
+  }
+  throw new Error("Message path produced multiple results");
+}
+
+function reducer(state: State, action: Action): State {
+  try {
+    switch (action.type) {
+      case "message": {
+        if (state.pathParseError != undefined) {
+          return { ...state, latestMessage: action.message, error: undefined };
+        }
+        const data = state.parsedPath
+          ? getSingleDataItem(simpleGetMessagePathDataItems(action.message, state.parsedPath))
+          : undefined;
+        return {
+          ...state,
+          latestMessage: action.message,
+          latestMatchingQueriedData: data ?? state.latestMatchingQueriedData,
+          error: undefined,
+        };
+      }
+      case "path": {
+        const newPath = parseRosPath(action.path);
+        let pathParseError: string | undefined;
+        if (
+          newPath?.messagePath.some(
+            (part) =>
+              (part.type === "filter" && typeof part.value === "object") ||
+              (part.type === "slice" &&
+                (typeof part.start === "object" || typeof part.end === "object")),
+          ) === true
+        ) {
+          pathParseError = "Message paths using variables are not currently supported";
+        }
+        let latestMatchingQueriedData: unknown | undefined;
+        let error: Error | undefined;
+        try {
+          latestMatchingQueriedData =
+            newPath && pathParseError == undefined && state.latestMessage
+              ? getSingleDataItem(simpleGetMessagePathDataItems(state.latestMessage, newPath))
+              : undefined;
+        } catch (err) {
+          error = err;
+        }
+        return {
+          ...state,
+          path: action.path,
+          parsedPath: newPath,
+          latestMatchingQueriedData,
+          error,
+          pathParseError,
+        };
+      }
+      case "seek":
+        return {
+          ...state,
+          latestMessage: undefined,
+          latestMatchingQueriedData: undefined,
+          error: undefined,
+        };
+    }
+  } catch (error) {
+    return { ...state, latestMatchingQueriedData: undefined, error };
+  }
+}
+
+export function Gauge({ context }: Props): JSX.Element {
+  // panel extensions must notify when they've completed rendering
+  // onRender will setRenderDone to a done callback which we can invoke after we've rendered
+  const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
+
+  const [config, setConfig] = useState(() => ({
+    ...defaultConfig,
+    ...(context.initialState as Partial<Config>),
+  }));
+
+  const [state, dispatch] = useReducer(
+    reducer,
+    config,
+    ({ path }): State => ({
+      path,
+      parsedPath: parseRosPath(path),
+      latestMessage: undefined,
+      latestMatchingQueriedData: undefined,
+      pathParseError: undefined,
+      error: undefined,
+    }),
+  );
+
+  useLayoutEffect(() => {
+    dispatch({ type: "path", path: config.path });
+  }, [config.path]);
+
+  useEffect(() => {
+    context.saveState(config);
+  }, [config, context]);
+
+  useEffect(() => {
+    context.onRender = (renderState, done) => {
+      setRenderDone(() => done);
+
+      if (renderState.didSeek === true) {
+        dispatch({ type: "seek" });
+      }
+
+      const message = last(renderState.currentFrame);
+      if (message != undefined && message.topic === state.parsedPath?.topicName) {
+        dispatch({ type: "message", message });
+      }
+    };
+    context.watch("currentFrame");
+    context.watch("didSeek");
+
+    return () => {
+      context.onRender = undefined;
+    };
+  }, [context, state.parsedPath?.topicName]);
+
+  const settingsActionHandler = useCallback(
+    (action: SettingsTreeAction) =>
+      setConfig((prevConfig) => settingsActionReducer(prevConfig, action)),
+    [setConfig],
+  );
+
+  const settingsTree = useSettingsTree(config, state.pathParseError, state.error?.message);
+  useEffect(() => {
+    context.updatePanelSettingsEditor({
+      actionHandler: settingsActionHandler,
+      nodes: settingsTree,
+    });
+  }, [context, settingsActionHandler, settingsTree]);
+
+  useEffect(() => {
+    if (state.parsedPath?.topicName != undefined) {
+      context.subscribe([state.parsedPath.topicName]);
+    }
+    return () => context.unsubscribeAll();
+  }, [context, state.parsedPath?.topicName]);
+
+  // Indicate render is complete - the effect runs after the dom is updated
+  useEffect(() => {
+    renderDone();
+  }, [renderDone]);
+
+  const rawValue =
+    typeof state.latestMatchingQueriedData === "number" ? state.latestMatchingQueriedData : NaN;
+
+  const { minValue, maxValue } = config;
+  const scaledValue =
+    (Math.max(minValue, Math.min(rawValue, maxValue)) - minValue) / (maxValue - minValue);
+  const outOfBounds = rawValue < minValue || rawValue > maxValue;
+
+  const padding = 0.1;
+  const centerX = 0.5 + padding;
+  const centerY = 0.5 + padding;
+  const gaugeAngle = -Math.PI / 8;
+  const radius = 0.5;
+  const innerRadius = 0.4;
+  const width = 1 + 2 * padding;
+  const height =
+    Math.max(
+      centerY - radius * Math.sin(gaugeAngle),
+      centerY - innerRadius * Math.sin(gaugeAngle),
+    ) + padding;
+  const needleThickness = 8;
+  const needleExtraLength = 0.05;
+  const [clipPathId] = useState(() => `gauge-clip-path-${uuidv4()}`);
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-around",
+        alignItems: "center",
+        overflow: "hidden",
+        padding: 8,
+      }}
+    >
+      <div style={{ width: "100%", overflow: "hidden" }}>
+        <div
+          style={{
+            position: "relative",
+            maxWidth: "100%",
+            maxHeight: "100%",
+            aspectRatio: `${width} / ${height}`,
+            margin: "0 auto",
+            transform: "scale(1)", // Work around a Safari bug: https://bugs.webkit.org/show_bug.cgi?id=231849
+          }}
+        >
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              background: `conic-gradient(from ${-Math.PI / 2 + gaugeAngle}rad at 50% ${
+                50 / height
+              }%, #f00, #ff0, #0c0 ${2 * (Math.PI / 2 - gaugeAngle)}rad, #f00)`,
+              clipPath: `url(#${clipPathId})`,
+              opacity: state.latestMatchingQueriedData == undefined ? 0.5 : 1,
+            }}
+          />
+          <div
+            style={{
+              backgroundColor: outOfBounds ? "orange" : "white",
+              width: needleThickness,
+              height: `${(100 * (radius + needleExtraLength)) / height}%`,
+              border: "2px solid black",
+              borderRadius: needleThickness / 2,
+              position: "absolute",
+              bottom: `${100 * (1 - centerY / height)}%`,
+              left: "50%",
+              transformOrigin: "bottom left",
+              margin: "0 auto",
+              transform: [
+                `scaleZ(1)`,
+                `rotate(${
+                  -Math.PI / 2 + gaugeAngle + scaledValue * 2 * (Math.PI / 2 - gaugeAngle)
+                }rad)`,
+                `translateX(${-needleThickness / 2}px)`,
+                `translateY(${needleThickness / 2}px)`,
+              ].join(" "),
+              display: Number.isFinite(scaledValue) ? "block" : "none",
+            }}
+          />
+        </div>
+        <svg style={{ position: "absolute" }}>
+          <clipPath id={clipPathId} clipPathUnits="objectBoundingBox">
+            <path
+              transform={`scale(${1 / width}, ${1 / height})`}
+              d={[
+                `M ${centerX - radius * Math.cos(gaugeAngle)},${
+                  centerY - radius * Math.sin(gaugeAngle)
+                }`,
+                `A 0.5,0.5 0 ${gaugeAngle < 0 ? 1 : 0} 1 ${
+                  centerX + radius * Math.cos(gaugeAngle)
+                },${centerY - radius * Math.sin(gaugeAngle)}`,
+                `L ${centerX + innerRadius * Math.cos(gaugeAngle)},${
+                  centerY - innerRadius * Math.sin(gaugeAngle)
+                }`,
+                `A ${innerRadius},${innerRadius} 0 ${gaugeAngle < 0 ? 1 : 0} 0 ${
+                  centerX - innerRadius * Math.cos(gaugeAngle)
+                },${centerY - innerRadius * Math.sin(gaugeAngle)}`,
+                `Z`,
+              ].join(" ")}
+            />
+          </clipPath>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio-base/src/panels/Gauge/index.help.md
+++ b/packages/studio-base/src/panels/Gauge/index.help.md
@@ -1,0 +1,3 @@
+Display a colored gauge based on arbitrary continuous data from a message path.
+
+The range is determined by minimum and maximum values which can be configured in the panel settings.

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Story, StoryContext } from "@storybook/react";
+
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import GaugePanel from "./index";
+
+export default {
+  title: "panels/Gauge",
+  component: GaugePanel,
+  decorators: [
+    (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
+      return (
+        <PanelSetup fixture={parameters.panelSetup?.fixture}>
+          <StoryComponent />
+        </PanelSetup>
+      );
+    },
+  ],
+};
+
+function makeFixture(value: number) {
+  return {
+    topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+    datatypes: new Map([
+      ["foo_msgs/Bar", { name: "Bar", definitions: [{ name: "value", type: "float32" }] }],
+    ]),
+    frame: {
+      "/data": [
+        {
+          topic: "/data",
+          receiveTime: { sec: 123, nsec: 456 },
+          message: { value },
+        },
+      ],
+    },
+  };
+}
+
+export const EmptyState = (): JSX.Element => {
+  return <GaugePanel />;
+};
+
+export const InvalidValue = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+};
+InvalidValue.parameters = { panelSetup: { fixture: makeFixture(NaN) } };
+
+export const MinValue = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+};
+MinValue.parameters = { panelSetup: { fixture: makeFixture(0) } };
+
+export const MaxValue = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+};
+MaxValue.parameters = { panelSetup: { fixture: makeFixture(1) } };
+
+export const TooLow = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+};
+TooLow.parameters = { panelSetup: { fixture: makeFixture(-1) } };
+export const TooHigh = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 0, maxValue: 1 }} />;
+};
+TooHigh.parameters = { panelSetup: { fixture: makeFixture(2) } };
+
+export const CustomRange = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
+};
+CustomRange.parameters = { panelSetup: { fixture: makeFixture(6.5) } };

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -1,0 +1,168 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Stack, getId } from "@fluentui/react";
+import { useCallback, useMemo } from "react";
+
+import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
+import { useLatestMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useLatestMessageDataItem";
+import Panel from "@foxglove/studio-base/components/Panel";
+import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { PanelConfigSchema, SaveConfig } from "@foxglove/studio-base/types/panels";
+
+type GaugeConfig = {
+  path: string;
+  minValue: number;
+  maxValue: number;
+};
+
+type Props = {
+  config: GaugeConfig;
+  saveConfig: SaveConfig<GaugeConfig>;
+};
+
+const supportedDataTypes = [
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "float32",
+  "float64",
+];
+
+function Gauge(props: Props) {
+  const {
+    config: { path, minValue, maxValue },
+    saveConfig,
+  } = props;
+  const onPathChange = useCallback(
+    (newPath: string) => saveConfig({ path: newPath }),
+    [saveConfig],
+  );
+  const clipPathId = useMemo(() => getId("gauge-clip-path"), []);
+  const queriedData = useLatestMessageDataItem(path)?.queriedData[0]?.value;
+
+  const rawValue = typeof queriedData === "number" ? queriedData : NaN;
+  const scaledValue =
+    (Math.max(minValue, Math.min(rawValue, maxValue)) - minValue) / (maxValue - minValue);
+  const outOfBounds = rawValue < minValue || rawValue > maxValue;
+
+  const padding = 0.1;
+  const centerX = 0.5 + padding;
+  const centerY = 0.5 + padding;
+  const gaugeAngle = -Math.PI / 8;
+  const radius = 0.5;
+  const innerRadius = 0.4;
+  const width = 1 + 2 * padding;
+  const height =
+    Math.max(
+      centerY - radius * Math.sin(gaugeAngle),
+      centerY - innerRadius * Math.sin(gaugeAngle),
+    ) + padding;
+  const needleThickness = 8;
+  const needleExtraLength = 0.05;
+  return (
+    <Stack verticalFill>
+      <PanelToolbar>
+        <MessagePathInput validTypes={supportedDataTypes} path={path} onChange={onPathChange} />
+      </PanelToolbar>
+      <Stack.Item
+        grow
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-around",
+          alignItems: "center",
+          overflow: "hidden",
+          padding: 8,
+        }}
+      >
+        <div style={{ width: "100%", overflow: "hidden" }}>
+          <div
+            style={{
+              position: "relative",
+              maxWidth: "100%",
+              maxHeight: "100%",
+              aspectRatio: `${width} / ${height}`,
+              margin: "0 auto",
+              transform: "scale(1)", // Work around a Safari bug: https://bugs.webkit.org/show_bug.cgi?id=231849
+            }}
+          >
+            <div
+              style={{
+                width: "100%",
+                height: "100%",
+                background: `conic-gradient(from ${-Math.PI / 2 + gaugeAngle}rad at 50% ${
+                  50 / height
+                }%, #f00, #ff0, #0c0 ${2 * (Math.PI / 2 - gaugeAngle)}rad, #f00)`,
+                clipPath: `url(#${clipPathId})`,
+                opacity: queriedData == undefined ? 0.5 : 1,
+              }}
+            />
+            <div
+              style={{
+                backgroundColor: outOfBounds ? "orange" : "white",
+                width: needleThickness,
+                height: `${(100 * (radius + needleExtraLength)) / height}%`,
+                border: "2px solid black",
+                borderRadius: needleThickness / 2,
+                position: "absolute",
+                bottom: `${100 * (1 - centerY / height)}%`,
+                left: "50%",
+                transformOrigin: "bottom left",
+                margin: "0 auto",
+                transform: [
+                  `scaleZ(1)`,
+                  `rotate(${
+                    -Math.PI / 2 + gaugeAngle + scaledValue * 2 * (Math.PI / 2 - gaugeAngle)
+                  }rad)`,
+                  `translateX(${-needleThickness / 2}px)`,
+                  `translateY(${needleThickness / 2}px)`,
+                ].join(" "),
+                display: Number.isFinite(scaledValue) ? "block" : "none",
+              }}
+            />
+          </div>
+          <svg style={{ position: "absolute" }}>
+            <clipPath id={clipPathId} clipPathUnits="objectBoundingBox">
+              <path
+                transform={`scale(${1 / width}, ${1 / height})`}
+                d={[
+                  `M ${centerX - radius * Math.cos(gaugeAngle)},${
+                    centerY - radius * Math.sin(gaugeAngle)
+                  }`,
+                  `A 0.5,0.5 0 ${gaugeAngle < 0 ? 1 : 0} 1 ${
+                    centerX + radius * Math.cos(gaugeAngle)
+                  },${centerY - radius * Math.sin(gaugeAngle)}`,
+                  `L ${centerX + innerRadius * Math.cos(gaugeAngle)},${
+                    centerY - innerRadius * Math.sin(gaugeAngle)
+                  }`,
+                  `A ${innerRadius},${innerRadius} 0 ${gaugeAngle < 0 ? 1 : 0} 0 ${
+                    centerX - innerRadius * Math.cos(gaugeAngle)
+                  },${centerY - innerRadius * Math.sin(gaugeAngle)}`,
+                  `Z`,
+                ].join(" ")}
+              />
+            </clipPath>
+          </svg>
+        </div>
+      </Stack.Item>
+    </Stack>
+  );
+}
+
+const defaultConfig: GaugeConfig = {
+  path: "",
+  minValue: 0,
+  maxValue: 1,
+};
+
+const configSchema: PanelConfigSchema<GaugeConfig> = [
+  { key: "minValue", type: "number", title: "Minimum value" },
+  { key: "maxValue", type: "number", title: "Maximum value" },
+];
+
+export default Panel(Object.assign(Gauge, { panelType: "gauge", configSchema, defaultConfig }));

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -2,167 +2,47 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Stack, getId } from "@fluentui/react";
-import { useCallback, useMemo } from "react";
+import { StrictMode } from "react";
+import ReactDOM from "react-dom";
 
-import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
-import { useLatestMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useLatestMessageDataItem";
+import { PanelExtensionContext } from "@foxglove/studio";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import { PanelConfigSchema, SaveConfig } from "@foxglove/studio-base/types/panels";
+import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
-type GaugeConfig = {
-  path: string;
-  minValue: number;
-  maxValue: number;
-};
+import { Gauge } from "./Gauge";
+import helpContent from "./index.help.md";
+import { Config } from "./types";
 
-type Props = {
-  config: GaugeConfig;
-  saveConfig: SaveConfig<GaugeConfig>;
-};
-
-const supportedDataTypes = [
-  "int8",
-  "uint8",
-  "int16",
-  "uint16",
-  "int32",
-  "uint32",
-  "float32",
-  "float64",
-];
-
-function Gauge(props: Props) {
-  const {
-    config: { path, minValue, maxValue },
-    saveConfig,
-  } = props;
-  const onPathChange = useCallback(
-    (newPath: string) => saveConfig({ path: newPath }),
-    [saveConfig],
-  );
-  const clipPathId = useMemo(() => getId("gauge-clip-path"), []);
-  const queriedData = useLatestMessageDataItem(path)?.queriedData[0]?.value;
-
-  const rawValue = typeof queriedData === "number" ? queriedData : NaN;
-  const scaledValue =
-    (Math.max(minValue, Math.min(rawValue, maxValue)) - minValue) / (maxValue - minValue);
-  const outOfBounds = rawValue < minValue || rawValue > maxValue;
-
-  const padding = 0.1;
-  const centerX = 0.5 + padding;
-  const centerY = 0.5 + padding;
-  const gaugeAngle = -Math.PI / 8;
-  const radius = 0.5;
-  const innerRadius = 0.4;
-  const width = 1 + 2 * padding;
-  const height =
-    Math.max(
-      centerY - radius * Math.sin(gaugeAngle),
-      centerY - innerRadius * Math.sin(gaugeAngle),
-    ) + padding;
-  const needleThickness = 8;
-  const needleExtraLength = 0.05;
-  return (
-    <Stack verticalFill>
-      <PanelToolbar>
-        <MessagePathInput validTypes={supportedDataTypes} path={path} onChange={onPathChange} />
-      </PanelToolbar>
-      <Stack.Item
-        grow
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-around",
-          alignItems: "center",
-          overflow: "hidden",
-          padding: 8,
-        }}
-      >
-        <div style={{ width: "100%", overflow: "hidden" }}>
-          <div
-            style={{
-              position: "relative",
-              maxWidth: "100%",
-              maxHeight: "100%",
-              aspectRatio: `${width} / ${height}`,
-              margin: "0 auto",
-              transform: "scale(1)", // Work around a Safari bug: https://bugs.webkit.org/show_bug.cgi?id=231849
-            }}
-          >
-            <div
-              style={{
-                width: "100%",
-                height: "100%",
-                background: `conic-gradient(from ${-Math.PI / 2 + gaugeAngle}rad at 50% ${
-                  50 / height
-                }%, #f00, #ff0, #0c0 ${2 * (Math.PI / 2 - gaugeAngle)}rad, #f00)`,
-                clipPath: `url(#${clipPathId})`,
-                opacity: queriedData == undefined ? 0.5 : 1,
-              }}
-            />
-            <div
-              style={{
-                backgroundColor: outOfBounds ? "orange" : "white",
-                width: needleThickness,
-                height: `${(100 * (radius + needleExtraLength)) / height}%`,
-                border: "2px solid black",
-                borderRadius: needleThickness / 2,
-                position: "absolute",
-                bottom: `${100 * (1 - centerY / height)}%`,
-                left: "50%",
-                transformOrigin: "bottom left",
-                margin: "0 auto",
-                transform: [
-                  `scaleZ(1)`,
-                  `rotate(${
-                    -Math.PI / 2 + gaugeAngle + scaledValue * 2 * (Math.PI / 2 - gaugeAngle)
-                  }rad)`,
-                  `translateX(${-needleThickness / 2}px)`,
-                  `translateY(${needleThickness / 2}px)`,
-                ].join(" "),
-                display: Number.isFinite(scaledValue) ? "block" : "none",
-              }}
-            />
-          </div>
-          <svg style={{ position: "absolute" }}>
-            <clipPath id={clipPathId} clipPathUnits="objectBoundingBox">
-              <path
-                transform={`scale(${1 / width}, ${1 / height})`}
-                d={[
-                  `M ${centerX - radius * Math.cos(gaugeAngle)},${
-                    centerY - radius * Math.sin(gaugeAngle)
-                  }`,
-                  `A 0.5,0.5 0 ${gaugeAngle < 0 ? 1 : 0} 1 ${
-                    centerX + radius * Math.cos(gaugeAngle)
-                  },${centerY - radius * Math.sin(gaugeAngle)}`,
-                  `L ${centerX + innerRadius * Math.cos(gaugeAngle)},${
-                    centerY - innerRadius * Math.sin(gaugeAngle)
-                  }`,
-                  `A ${innerRadius},${innerRadius} 0 ${gaugeAngle < 0 ? 1 : 0} 0 ${
-                    centerX - innerRadius * Math.cos(gaugeAngle)
-                  },${centerY - innerRadius * Math.sin(gaugeAngle)}`,
-                  `Z`,
-                ].join(" ")}
-              />
-            </clipPath>
-          </svg>
-        </div>
-      </Stack.Item>
-    </Stack>
+function initPanel(context: PanelExtensionContext) {
+  ReactDOM.render(
+    <StrictMode>
+      <ThemeProvider isDark>
+        <Gauge context={context} />
+      </ThemeProvider>
+    </StrictMode>,
+    context.panelElement,
   );
 }
 
-const defaultConfig: GaugeConfig = {
-  path: "",
-  minValue: 0,
-  maxValue: 1,
+type Props = {
+  config: Config;
+  saveConfig: SaveConfig<Config>;
 };
 
-const configSchema: PanelConfigSchema<GaugeConfig> = [
-  { key: "minValue", type: "number", title: "Minimum value" },
-  { key: "maxValue", type: "number", title: "Maximum value" },
-];
+function GaugePanelAdapter(props: Props) {
+  return (
+    <PanelExtensionAdapter
+      config={props.config}
+      saveConfig={props.saveConfig}
+      help={helpContent}
+      initPanel={initPanel}
+    />
+  );
+}
 
-export default Panel(Object.assign(Gauge, { panelType: "gauge", configSchema, defaultConfig }));
+GaugePanelAdapter.panelType = "Gauge";
+GaugePanelAdapter.defaultConfig = {};
+
+export default Panel(GaugePanelAdapter);

--- a/packages/studio-base/src/panels/Gauge/settings.ts
+++ b/packages/studio-base/src/panels/Gauge/settings.ts
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import produce from "immer";
+import { set } from "lodash";
+import { useMemo } from "react";
+
+import { useShallowMemo } from "@foxglove/hooks";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+
+import type { Config } from "./types";
+
+export function settingsActionReducer(prevConfig: Config, action: SettingsTreeAction): Config {
+  return produce(prevConfig, (draft) => {
+    switch (action.action) {
+      case "perform-node-action":
+        throw new Error(`Unhandled node action: ${action.payload.id}`);
+      case "update":
+        switch (action.payload.path[0]) {
+          case "general":
+            set(draft, [action.payload.path[1]!], action.payload.value);
+            break;
+          default:
+            throw new Error(`Unexpected payload.path[0]: ${action.payload.path[0]}`);
+        }
+        break;
+    }
+  });
+}
+
+const supportedDataTypes = [
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "float32",
+  "float64",
+];
+
+export function useSettingsTree(
+  config: Config,
+  pathParseError: string | undefined,
+  error: string | undefined,
+): SettingsTreeNodes {
+  const { path, minValue, maxValue } = config;
+  const generalSettings: SettingsTreeNode = useMemo(
+    () => ({
+      error,
+      fields: {
+        path: {
+          label: "Data",
+          input: "messagepath",
+          value: path,
+          error: pathParseError,
+          validTypes: supportedDataTypes,
+        },
+        minValue: {
+          label: "Minimum",
+          input: "number",
+          value: minValue,
+        },
+        maxValue: {
+          label: "Maximum",
+          input: "number",
+          value: maxValue,
+        },
+      },
+    }),
+    [error, maxValue, minValue, path, pathParseError],
+  );
+  return useShallowMemo({
+    general: generalSettings,
+  });
+}

--- a/packages/studio-base/src/panels/Gauge/thumbnail.png
+++ b/packages/studio-base/src/panels/Gauge/thumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac8e6ac602612d9bf3237bed9b587223adc94b8f674c4f8e754621e0759cb4fb
+size 9163

--- a/packages/studio-base/src/panels/Gauge/types.ts
+++ b/packages/studio-base/src/panels/Gauge/types.ts
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type Config = {
+  path: string;
+  minValue: number;
+  maxValue: number;
+};

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -6,6 +6,8 @@ import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 
 import DataSourceInfoHelp from "./DataSourceInfo/index.help.md";
 import dataSourceInfoThumbnail from "./DataSourceInfo/thumbnail.png";
+import GaugeHelp from "./Gauge/index.help.md";
+import gaugeThumbnail from "./Gauge/thumbnail.png";
 import ImageViewHelp from "./Image/index.help.md";
 import imageViewThumbnail from "./Image/thumbnail.png";
 import IndicatorHelp from "./Indicator/index.help.md";
@@ -95,6 +97,14 @@ const builtin: PanelInfo[] = [
     help: IndicatorHelp,
     thumbnail: indicatorThumbnail,
     module: async () => await import("./Indicator"),
+  },
+  {
+    title: "Gauge",
+    type: "Gauge",
+    description: "Display a colored gauge based on a continuous value.",
+    help: GaugeHelp,
+    thumbnail: gaugeThumbnail,
+    module: async () => await import("./Gauge"),
   },
   {
     title: "Teleop",


### PR DESCRIPTION
**User-Facing Changes**
Adds a Gauge panel for displaying numerical values on a colored scale.

<img width="762" alt="image" src="https://user-images.githubusercontent.com/14237/180579264-8d358eb2-01f8-4f21-9417-d65514cb0286.png">

**Description**
~Blocked on https://github.com/foxglove/studio/issues/2450~

Open questions /cc @defunctzombie @2metres @amacneil @esthersweon:
- Should we allow the user to customize the colors, and if so how? (One option would be allowing them to specify a string that gets added to the CSS `conic-gradient` directive, however this would present challenges since the colors are unfortunately interspersed with angles that we don't want the user to be able to change when customizing colors.)
- Should we allow the min/max range to also be dynamic values based on a message path, rather than fixed values in the panel settings?
- Do we want any other display styles, such as a linear range (think battery meter <img width="39" alt="image" src="https://user-images.githubusercontent.com/14237/137565423-f99a0d66-b526-40c1-bc28-4e02be314a25.png">) / [level indicator](https://developer.apple.com/design/human-interface-guidelines/macos/indicators/level-indicators/)? Or would these be better as separate panels?