### PR TITLE
components/autocomplete: wip transition from class to functional react (for #1426)

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -108,6 +108,33 @@ storiesOf("components/Autocomplete", module)
       </div>
     );
   })
+  .add(
+    "uncontrolled value light",
+    () => {
+      return (
+        <div
+          style={{ padding: 20 }}
+          ref={(el) => {
+            if (el) {
+              const input: HTMLInputElement | undefined = el.querySelector("input") as any;
+              if (input) {
+                input.focus();
+                input.value = "h";
+                TestUtils.Simulate.change(input);
+              }
+            }
+          }}
+        >
+          <Autocomplete
+            items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+            getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+            onSelect={() => {}}
+          />
+        </div>
+      );
+    },
+    { colorScheme: "light" },
+  )
   .add("uncontrolled value with selected item", () => {
     return (
       <div style={{ padding: 20 }} ref={focusInput}>

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -193,6 +193,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
 ): JSX.Element {
   // References
   const autocomplete = useRef<ReactAutocomplete>(ReactNull);
+  const ignoreBlur = useRef<boolean>(false);
 
   // Context
   const classes = useStyles();
@@ -201,7 +202,6 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   const [showAllItems, setShowAllItems] = useState<boolean>(false);
   const [stateValue, setValue] = useState<string | undefined>(undefined);
   const [focused, setFocused] = useState<boolean>(false);
-  const [stateIgnoreBlur, setIgnoreBlur] = useState<boolean>(false);
 
   const getItemText = useMemo(
     () => props.getItemText ?? defaultGetText("getItemText"),
@@ -247,11 +247,13 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   );
 
   const hasError = props.hasError ?? (autocompleteItems.length === 0 && value?.length);
+
   const open = focused && autocompleteItems.length > 0;
-  const ignoreBlur = open ? stateIgnoreBlur : false;
+  if (!open) {
+    ignoreBlur.current = false;
+  }
 
   const selectedItemValue = selectedItem != undefined ? getItemValue(selectedItem) : undefined;
-
   const setSelectionRange = useCallback((selectionStart: number, selectionEnd: number): void => {
     if (autocomplete.current?.refs.input) {
       (autocomplete.current.refs.input as HTMLInputElement).setSelectionRange(
@@ -272,7 +274,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
     if (autocomplete.current?.refs.input) {
       (autocomplete.current.refs.input as HTMLInputElement).blur();
     }
-    setIgnoreBlur(false);
+    ignoreBlur.current = false;
     setFocused(false);
     if (onBlurCallback) {
       onBlurCallback();
@@ -298,7 +300,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   );
 
   // Make sure the input field gets focused again after selecting, in case we're doing multiple
-  // autocompletes. We pass an instance of an `AutocompleteController` to `onSelect` in case
+  // autocompletes. We pass an instance of an `IAutocomplete` to `onSelect` in case
   // the user of this component wants to call `blur()`.
   const onSelect = useCallback(
     (textValue: string, { item }: FzfResultItem<T>): void => {
@@ -325,7 +327,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   }, [clearOnFocus]);
 
   const onBlur = useCallback((): void => {
-    if (ignoreBlur) {
+    if (ignoreBlur.current) {
       return;
     }
     if (
@@ -488,7 +490,10 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
           >
             {/* Have to wrap onMouseEnter and onMouseLeave in a separate <div>, as react-autocomplete
              * would override them on the root <div>. */}
-            <div onMouseEnter={() => setIgnoreBlur(true)} onMouseLeave={() => setIgnoreBlur(false)}>
+            <div
+              onMouseEnter={() => (ignoreBlur.current = true)}
+              onMouseLeave={() => (ignoreBlur.current = false)}
+            >
               {menuItemsToShow}
             </div>
           </div>

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -301,12 +301,12 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   // autocompletes. We pass an instance of an `AutocompleteController` to `onSelect` in case
   // the user of this component wants to call `blur()`.
   const onSelect = useCallback(
-    (textValue: string, item: FzfResultItem<T>): void => {
+    (textValue: string, { item }: FzfResultItem<T>): void => {
       if (autocomplete.current?.refs.input) {
         (autocomplete.current.refs.input as HTMLInputElement).focus();
         setFocused(true);
         setValue(undefined);
-        onSelectCallback(textValue, item.item, { setSelectionRange, focus, blur });
+        onSelectCallback(textValue, item, { setSelectionRange, focus, blur });
       }
     },
     [onSelectCallback, blur, focus, setSelectionRange],

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -15,7 +15,14 @@ import { makeStyles } from "@fluentui/react";
 import cx from "classnames";
 import { Fzf, FzfResultItem } from "fzf";
 import { maxBy } from "lodash";
-import React, { CSSProperties, PureComponent, RefObject, useCallback } from "react";
+import React, {
+  CSSProperties,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+  useImperativeHandle,
+} from "react";
 import ReactAutocomplete from "react-autocomplete";
 import { createPortal } from "react-dom";
 import textMetrics from "text-metrics";
@@ -97,10 +104,10 @@ const useStyles = makeStyles((theme) => ({
 // strings like in the Plot panel.
 //
 // The multiple autocompletes doesn't work super well with react-autocomplete, so we have to
-// reimplement some of its behaviour to make things work properly, such as the `_ignoreBlur`
+// reimplement some of its behaviour to make things work properly, such as the `ignoreBlur`
 // stuff. Mostly, though, we can lean on react-autocomplete to do the heavy lifting.
 //
-// For future reference, the reason `<ReactAutocomplete>` (and we) has to do `_ignoreBlur`, is that
+// For future reference, the reason `<ReactAutocomplete>` (and we) has to do `ignoreBlur`, is that
 // when you select an item from the autocomplete menu by clicking, it first triggers a `blur` event
 // on the `<input>`, before triggering a `click` event. If we wouldn't ignore that `blur` event,
 // we'd hide the menu before the `click` event even has a chance of getting fired. So the `blur`
@@ -108,35 +115,34 @@ const useStyles = makeStyles((theme) => ({
 // of a "false" focus event. (In our case we just don't bother with ignoring the `focus` event since
 // it doesn't cause any problems.)
 type AutocompleteProps<T = unknown> = {
-  classes: ReturnType<typeof useStyles>;
   items: T[];
-  getItemValue: (arg0: T) => string;
-  getItemText: (arg0: T) => string;
+  getItemValue?: (arg0: T) => string;
+  getItemText?: (arg0: T) => string;
   filterText?: string;
   value?: string;
   selectedItem?: T;
   onChange?: (event: React.SyntheticEvent<HTMLInputElement>, text: string) => void;
-  onSelect: (text: string, item: T, autocomplete: AutocompleteImpl<T>) => void;
+  onSelect: (text: string, item: T, autocomplete: IAutocomplete) => void;
   onBlur?: () => void;
   hasError?: boolean;
   autocompleteKey?: string;
   placeholder?: string;
   autoSize?: boolean;
-  sortWhenFiltering: boolean;
-  clearOnFocus: boolean; // only for uncontrolled use (when onChange is not set)
-  minWidth: number;
+  sortWhenFiltering?: boolean;
+  clearOnFocus?: boolean; // only for uncontrolled use (when onChange is not set)
+  minWidth?: number;
   menuStyle?: CSSProperties;
   inputStyle?: CSSProperties;
   disableAutoSelect?: boolean;
 };
 
-type AutocompleteState = {
-  focused: boolean;
-  showAllItems: boolean;
-  value?: string;
-};
+export interface IAutocomplete {
+  setSelectionRange(selectionStart: number, selectionEnd: number): void;
+  focus(): void;
+  blur(): void;
+}
 
-function defaultGetText(name: string) {
+function defaultGetText(name: string): (item: unknown) => string {
   return function (item: unknown) {
     if (typeof item === "string") {
       return item;
@@ -145,7 +151,7 @@ function defaultGetText(name: string) {
       typeof item === "object" &&
       typeof (item as { value?: string }).value === "string"
     ) {
-      return (item as { value?: string }).value;
+      return (item as { value: string }).value;
     }
     throw new Error(`you need to provide an implementation of ${name}`);
   };
@@ -181,336 +187,317 @@ const HighlightChars = (props: { str: string; indices: Set<number> }) => {
   return <>{nodes}</>;
 };
 
-export interface IAutocomplete {
-  setSelectionRange(selectionStart: number, selectionEnd: number): void;
-  focus(): void;
-  blur(): void;
-}
+export default React.forwardRef(function Autocomplete<T = unknown>(
+  props: AutocompleteProps<T>,
+  ref: React.ForwardedRef<IAutocomplete>,
+): JSX.Element {
+  // References
+  const autocomplete = useRef<ReactAutocomplete>(ReactNull);
 
-class AutocompleteImpl<T = unknown>
-  extends PureComponent<AutocompleteProps<T>, AutocompleteState>
-  implements IAutocomplete
-{
-  private _autocomplete: RefObject<ReactAutocomplete>;
-  private _ignoreFocus: boolean = false;
-  private _ignoreBlur: boolean = false;
+  // Context
+  const classes = useStyles();
 
-  static defaultProps = {
-    getItemText: defaultGetText("getItemText"),
-    getItemValue: defaultGetText("getItemValue"),
-    sortWhenFiltering: true,
-    clearOnFocus: false,
-    minWidth: 100,
-  };
+  // State
+  const [showAllItems, setShowAllItems] = useState<boolean>(false);
+  const [stateValue, setValue] = useState<string | undefined>(undefined);
+  const [focused, setFocused] = useState<boolean>(false);
+  const [stateIgnoreBlur, setIgnoreBlur] = useState<boolean>(false);
 
-  constructor(props: AutocompleteProps<T>) {
-    super(props);
-    this._autocomplete = React.createRef<ReactAutocomplete>();
-    this.state = { focused: false, showAllItems: false };
-  }
+  const getItemText = useMemo(
+    () => props.getItemText ?? defaultGetText("getItemText"),
+    [props.getItemText],
+  );
 
-  // When we lose the scrollbar, we can safely set `showAllItems: false` again, because all items
-  // will be in view anyway. We cannot set it to false earlier, as `<ReactAutocomplete>` may have a
-  // reference to the highlighted element, which can cause an error if we hide it.
-  override componentDidUpdate(): void {
-    if (
-      (this._autocomplete.current?.refs.menu as Element)?.scrollHeight <=
-        (this._autocomplete.current?.refs.menu as Element)?.clientHeight &&
-      this.state.showAllItems
-    ) {
-      this.setState({ showAllItems: false });
-    }
-  }
+  const getItemValue = useMemo(
+    () => props.getItemValue ?? defaultGetText("getItemValue"),
+    [props.getItemValue],
+  );
 
-  setSelectionRange(selectionStart: number, selectionEnd: number): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).setSelectionRange(
+  // Props
+  const {
+    autocompleteKey,
+    autoSize = false,
+    items,
+    placeholder,
+    selectedItem,
+    value = stateValue ?? (selectedItem ? getItemText(selectedItem) : undefined),
+    filterText = value,
+    sortWhenFiltering = true,
+    clearOnFocus = false,
+    minWidth = 100,
+    menuStyle = {},
+    inputStyle = {},
+    onChange: onChangeCallback,
+    onSelect: onSelectCallback,
+    onBlur: onBlurCallback,
+    disableAutoSelect,
+  }: AutocompleteProps<T> = props;
+
+  const autocompleteItems: FzfResultItem<T>[] = useMemo(
+    () =>
+      filterText
+        ? new Fzf(items, {
+            fuzzy: filterText.length > 2 ? "v2" : false,
+            sort: sortWhenFiltering,
+            limit: MAX_ITEMS,
+            selector: getItemText as (_: unknown) => string, // Fzf selector TS type seems to be wrong?
+          }).find(filterText)
+        : items.map((item) => itemToFzfResult(item)),
+    [filterText, getItemText, items, sortWhenFiltering],
+  );
+
+  const hasError = props.hasError ?? (autocompleteItems.length === 0 && value?.length);
+  const open = focused && autocompleteItems.length > 0;
+  const ignoreBlur = open ? stateIgnoreBlur : false;
+
+  const selectedItemValue = selectedItem != undefined ? getItemValue(selectedItem) : undefined;
+
+  const setSelectionRange = useCallback((selectionStart: number, selectionEnd: number): void => {
+    if (autocomplete.current?.refs.input) {
+      (autocomplete.current.refs.input as HTMLInputElement).setSelectionRange(
         selectionStart,
         selectionEnd,
       );
     }
-    this.setState({ focused: true });
-  }
+    setFocused(true);
+  }, []);
 
-  focus(): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).focus();
+  const focus = useCallback((): void => {
+    if (autocomplete.current?.refs.input) {
+      (autocomplete.current.refs.input as HTMLInputElement).focus();
     }
-  }
+  }, []);
 
-  blur(): void {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).blur();
+  const blur = useCallback((): void => {
+    if (autocomplete.current?.refs.input) {
+      (autocomplete.current.refs.input as HTMLInputElement).blur();
     }
-    this._ignoreBlur = false;
-    this.setState({ focused: false });
-    if (this.props.onBlur) {
-      this.props.onBlur();
+    setIgnoreBlur(false);
+    setFocused(false);
+    if (onBlurCallback) {
+      onBlurCallback();
     }
-  }
+  }, [onBlurCallback]);
 
-  private _onFocus = (): void => {
-    if (this._ignoreFocus) {
-      return;
-    }
-    const { clearOnFocus } = this.props;
+  // Give callers an opportunity to control autocomplete
+  useImperativeHandle(ref, () => ({ setSelectionRange, focus, blur }), [
+    setSelectionRange,
+    focus,
+    blur,
+  ]);
+
+  const onChange = useCallback(
+    (event: React.SyntheticEvent<HTMLInputElement>): void => {
+      if (onChangeCallback) {
+        onChangeCallback(event, (event.target as HTMLInputElement).value);
+      } else {
+        setValue((event.target as HTMLInputElement).value);
+      }
+    },
+    [onChangeCallback],
+  );
+
+  // Make sure the input field gets focused again after selecting, in case we're doing multiple
+  // autocompletes. We pass an instance of an `AutocompleteController` to `onSelect` in case
+  // the user of this component wants to call `blur()`.
+  const onSelect = useCallback(
+    (value: string, item: FzfResultItem<T>): void => {
+      if (autocomplete.current?.refs.input) {
+        (autocomplete.current.refs.input as HTMLInputElement).focus();
+        setFocused(true);
+        setValue(undefined);
+        onSelectCallback(value, item.item, { setSelectionRange, focus, blur });
+      }
+    },
+    [onSelectCallback, blur, focus, setSelectionRange],
+  );
+
+  const onFocus = useCallback((): void => {
     if (
-      this._autocomplete.current?.refs.input &&
-      document.activeElement === this._autocomplete.current.refs.input
+      autocomplete.current?.refs.input &&
+      document.activeElement === autocomplete.current.refs.input
     ) {
-      this.setState({ focused: true });
+      setFocused(true);
       if (clearOnFocus) {
-        this.setState({ value: "" });
+        setValue("");
       }
     }
-  };
+  }, [clearOnFocus]);
 
-  // Wait for a mouseup event, and check in the mouseup event if anything was actually selected, or
-  // if it just was a click without a drag. In the latter case, select everything. This is very
-  // similar to how, say, the browser bar in Chrome behaves.
-  private _onMouseDown = (_event: React.MouseEvent<HTMLInputElement>): void => {
-    if (this.props.disableAutoSelect ?? false) {
-      return;
-    }
-    if (this.state.focused) {
-      return;
-    }
-    const onMouseUp = (e: MouseEvent) => {
-      document.removeEventListener("mouseup", onMouseUp, true);
-
-      if (
-        this._autocomplete.current?.refs.input && // Make sure that the element is actually still focused.
-        document.activeElement === this._autocomplete.current.refs.input
-      ) {
-        if (
-          (this._autocomplete.current.refs.input as HTMLInputElement).selectionStart ===
-          (this._autocomplete.current.refs.input as HTMLInputElement).selectionEnd
-        ) {
-          (this._autocomplete.current.refs.input as HTMLInputElement).select();
-          e.stopPropagation();
-          e.preventDefault();
-        }
-        // Also set `state.focused` for good measure, since we know here that we're focused.
-        this.setState({ focused: true });
-      }
-    };
-    document.addEventListener("mouseup", onMouseUp, true);
-  };
-
-  private _onBlur = (): void => {
-    if (this._ignoreBlur) {
+  const onBlur = useCallback((): void => {
+    if (ignoreBlur) {
       return;
     }
     if (
-      this._autocomplete.current?.refs.input &&
-      document.activeElement === this._autocomplete.current.refs.input
+      autocomplete.current?.refs.input &&
+      document.activeElement === autocomplete.current.refs.input
     ) {
       // Bail if we actually still are focused.
       return;
     }
-    this.setState({ focused: false, value: undefined });
-    if (this.props.onBlur) {
-      this.props.onBlur();
+    setFocused(false);
+    setValue(undefined);
+    if (onBlurCallback) {
+      onBlurCallback();
     }
-  };
+  }, [onBlurCallback, ignoreBlur]);
 
-  private _onChange = (event: React.SyntheticEvent<HTMLInputElement>): void => {
-    if (this.props.onChange) {
-      this.props.onChange(event, (event.target as HTMLInputElement).value);
-    } else {
-      this.setState({ value: (event.target as HTMLInputElement).value });
-    }
-  };
+  // Wait for a mouseup event, and check in the mouseup event if anything was actually selected, or
+  // if it just was a click without a drag. In the latter case, select everything. This is very
+  // similar to how, say, the browser bar in Chrome behaves.
+  const onMouseDown = useCallback(
+    (_event: React.MouseEvent<HTMLInputElement>): void => {
+      if (disableAutoSelect ?? false) {
+        return;
+      }
+      if (focused) {
+        return;
+      }
+      const onMouseUp = (e: MouseEvent) => {
+        document.removeEventListener("mouseup", onMouseUp, true);
 
-  // Make sure the input field gets focused again after selecting, in case we're doing multiple
-  // autocompletes. We pass in `this` to `onSelect` in case the user of this component wants to call
-  // `blur()`.
-  private _onSelect = (value: string, item: FzfResultItem<T>): void => {
-    if (this._autocomplete.current?.refs.input) {
-      (this._autocomplete.current.refs.input as HTMLInputElement).focus();
-      this.setState({ focused: true, value: undefined }, () => {
-        this.props.onSelect(value, item.item, this);
-      });
-    }
-  };
+        if (
+          autocomplete.current?.refs.input && // Make sure that the element is actually still focused.
+          document.activeElement === autocomplete.current.refs.input
+        ) {
+          if (
+            (autocomplete.current.refs.input as HTMLInputElement).selectionStart ===
+            (autocomplete.current.refs.input as HTMLInputElement).selectionEnd
+          ) {
+            (autocomplete.current.refs.input as HTMLInputElement).select();
+            e.stopPropagation();
+            e.preventDefault();
+          }
+          // Also set `state.focused` for good measure, since we know here that we're focused.
+          setFocused(true);
+        }
+      };
+      document.addEventListener("mouseup", onMouseUp, true);
+    },
+    [focused, disableAutoSelect],
+  );
 
   // When scrolling down by even a little bit, just show all items. In most cases people won't
   // do this and instead will type more text to narrow down their autocomplete.
-  private _onScroll = (event: React.MouseEvent<HTMLDivElement>): void => {
+  const onScroll = useCallback((event: React.MouseEvent<HTMLDivElement>): void => {
     if (event.currentTarget.scrollTop > 0) {
       // Never set `showAllItems` to false here, as `<ReactAutocomplete>` may have a reference to
       // the highlighted element. We only set it back to false in `componentDidUpdate`.
-      this.setState({ showAllItems: true });
+      setShowAllItems(true);
     }
-  };
+  }, []);
 
-  private _onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
-    if (event.key === "Escape" || (event.key === "Enter" && this.props.items.length === 0)) {
-      this.blur();
-    }
-  };
-
-  override render(): JSX.Element {
-    const {
-      classes,
-      autocompleteKey,
-      autoSize = false,
-      getItemValue,
-      getItemText,
-      items,
-      placeholder,
-      selectedItem,
-      value = this.state.value ?? (selectedItem ? getItemText(selectedItem) : undefined),
-      filterText = value,
-      sortWhenFiltering,
-      minWidth,
-      menuStyle = {},
-      inputStyle = {},
-    } = this.props;
-    const autocompleteItems: FzfResultItem<T>[] = filterText
-      ? new Fzf(items, {
-          fuzzy: filterText.length > 2 ? "v2" : false,
-          sort: sortWhenFiltering,
-          limit: MAX_ITEMS,
-          selector: getItemText as (_: unknown) => string, // Fzf selector TS type seems to be wrong?
-        }).find(filterText)
-      : items.map((item) => itemToFzfResult(item));
-
-    const { hasError = autocompleteItems.length === 0 && value?.length } = this.props;
-
-    const open = this.state.focused && autocompleteItems.length > 0;
-    if (!open) {
-      this._ignoreBlur = false;
-    }
-
-    const selectedItemValue = selectedItem != undefined ? getItemValue(selectedItem) : undefined;
-    return (
-      <ReactAutocomplete
-        open={open}
-        items={autocompleteItems}
-        getItemValue={(item: FzfResultItem<T>) => getItemValue(item.item)}
-        renderItem={(item: FzfResultItem<T>, isHighlighted) => {
-          const itemValue = getItemValue(item.item);
-          return (
-            <div
-              key={itemValue}
-              data-highlighted={isHighlighted}
-              data-test-auto-item
-              className={cx(classes.item, {
-                [classes.itemHighlighted]: isHighlighted,
-                [classes.itemSelected]:
-                  selectedItemValue != undefined && itemValue === selectedItemValue,
-              })}
-            >
-              <HighlightChars str={getItemText(item.item)} indices={item.positions} />
-            </div>
-          );
-        }}
-        onChange={this._onChange}
-        onSelect={this._onSelect}
-        value={value ?? ""}
-        inputProps={{
-          className: cx(classes.input, {
-            [classes.inputError]: hasError,
-            [classes.inputPlaceholder]: value == undefined || value.length === 0,
-          }),
-          autoCorrect: "off",
-          autoCapitalize: "off",
-          spellCheck: "false",
-          placeholder,
-          style: {
-            ...inputStyle,
-            fontFamily,
-            fontSize,
-            width: autoSize
-              ? Math.max(
-                  measureText(value != undefined && value.length > 0 ? value : placeholder ?? ""),
-                  minWidth,
-                )
-              : "100%",
-          },
-          onFocus: this._onFocus,
-          onBlur: this._onBlur,
-          onMouseDown: this._onMouseDown,
-          onKeyDown: this._onKeyDown,
-        }}
-        renderMenu={(menuItems, _val, style) => {
-          // Hacky virtualization. Either don't show all menuItems (typical when the user is still
-          // typing in the autcomplete), or do show them all (once the user scrolls). Not the most
-          // sophisticated, but good enough!
-          const maxNumberOfItems = Math.ceil(window.innerHeight / ROW_HEIGHT + 10);
-          const menuItemsToShow =
-            this.state.showAllItems || menuItems.length <= maxNumberOfItems * 2
-              ? menuItems
-              : menuItems.slice(0, maxNumberOfItems).concat(menuItems.slice(-maxNumberOfItems));
-
-          // The longest string might not be the widest (e.g. "|||" vs "www"), but this is
-          // quite a bit faster, so we throw in a nice padding and call it good enough! :-)
-          const longestItem = maxBy(autocompleteItems, (item) => getItemText(item.item).length);
-          const width =
-            50 + (longestItem != undefined ? measureText(getItemText(longestItem.item)) : 0);
-          const maxHeight = `calc(100vh - 10px - ${style.top}px)`;
-
-          return (
-            <div
-              className={classes.root}
-              key={
-                autocompleteKey
-                /* So we scroll to the top when selecting */
-              }
-              style={
-                // If the autocomplete would fall off the screen, pin it to the right.
-                (style.left as number) + width <= window.innerWidth
-                  ? { ...menuStyle, ...style, width, maxWidth: "100%", maxHeight }
-                  : {
-                      ...menuStyle,
-                      ...style,
-                      width,
-                      maxWidth: "100%",
-                      maxHeight,
-                      left: "auto",
-                      right: 0,
-                    }
-              }
-              onScroll={this._onScroll}
-            >
-              {/* Have to wrap onMouseEnter and onMouseLeave in a separate <div>, as react-autocomplete
-               * would override them on the root <div>. */}
-              <div
-                onMouseEnter={() => (this._ignoreBlur = true)}
-                onMouseLeave={() => (this._ignoreBlur = false)}
-              >
-                {menuItemsToShow}
-              </div>
-            </div>
-          );
-        }}
-        // @ts-expect-error renderMenuWrapper added in the fork but we don't have typings for it
-        renderMenuWrapper={(menu: React.ReactNode) => createPortal(menu, document.body)}
-        ref={this._autocomplete}
-        wrapperStyle={{ flex: "1 1 auto", overflow: "hidden", marginLeft: 6 }}
-      />
-    );
-  }
-}
-
-export default React.forwardRef((props, ref) => {
-  const classes = useStyles();
-  const mapRef = useCallback(
-    (autocomplete: IAutocomplete | ReactNull) => {
-      if (typeof ref === "function") {
-        ref(autocomplete);
-      } else if (ref != undefined) {
-        ref.current = autocomplete;
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === "Escape" || (event.key === "Enter" && items.length === 0)) {
+        blur();
       }
     },
-    [ref],
+    [blur, items],
   );
-  return <AutocompleteImpl {...props} ref={mapRef} classes={classes} />;
-}) as <T>(
-  props: JSX.LibraryManagedAttributes<
-    typeof AutocompleteImpl,
-    Omit<AutocompleteProps<T>, "classes">
-  > &
-    React.RefAttributes<IAutocomplete>,
-) => React.ReactElement;
+
+  return (
+    <ReactAutocomplete
+      open={open}
+      items={autocompleteItems}
+      getItemValue={(item: FzfResultItem<T>) => getItemValue(item.item)}
+      renderItem={(item: FzfResultItem<T>, isHighlighted) => {
+        const itemValue = getItemValue(item.item);
+        return (
+          <div
+            key={itemValue}
+            data-highlighted={isHighlighted}
+            data-test-auto-item
+            className={cx(classes.item, {
+              [classes.itemHighlighted]: isHighlighted,
+              [classes.itemSelected]:
+                selectedItemValue != undefined && itemValue === selectedItemValue,
+            })}
+          >
+            <HighlightChars str={getItemText(item.item)} indices={item.positions} />
+          </div>
+        );
+      }}
+      onChange={onChange}
+      onSelect={onSelect}
+      value={value ?? ""}
+      inputProps={{
+        className: cx(classes.input, {
+          [classes.inputError]: hasError,
+          [classes.inputPlaceholder]: value == undefined || value.length === 0,
+        }),
+        autoCorrect: "off",
+        autoCapitalize: "off",
+        spellCheck: "false",
+        placeholder,
+        style: {
+          ...inputStyle,
+          fontFamily,
+          fontSize,
+          width: autoSize
+            ? Math.max(
+                measureText(value != undefined && value.length > 0 ? value : placeholder ?? ""),
+                minWidth,
+              )
+            : "100%",
+        },
+        onFocus,
+        onBlur,
+        onMouseDown,
+        onKeyDown,
+      }}
+      renderMenu={(menuItems, _val, style) => {
+        // Hacky virtualization. Either don't show all menuItems (typical when the user is still
+        // typing in the autcomplete), or do show them all (once the user scrolls). Not the most
+        // sophisticated, but good enough!
+        const maxNumberOfItems = Math.ceil(window.innerHeight / ROW_HEIGHT + 10);
+        const menuItemsToShow =
+          showAllItems || menuItems.length <= maxNumberOfItems * 2
+            ? menuItems
+            : menuItems.slice(0, maxNumberOfItems).concat(menuItems.slice(-maxNumberOfItems));
+
+        // The longest string might not be the widest (e.g. "|||" vs "www"), but this is
+        // quite a bit faster, so we throw in a nice padding and call it good enough! :-)
+        const longestItem = maxBy(autocompleteItems, (item) => getItemText(item.item).length);
+        const width =
+          50 + (longestItem != undefined ? measureText(getItemText(longestItem.item)) : 0);
+        const maxHeight = `calc(100vh - 10px - ${style.top}px)`;
+
+        return (
+          <div
+            className={classes.root}
+            key={
+              autocompleteKey
+              /* So we scroll to the top when selecting */
+            }
+            style={
+              // If the autocomplete would fall off the screen, pin it to the right.
+              (style.left as number) + width <= window.innerWidth
+                ? { ...menuStyle, ...style, width, maxWidth: "100%", maxHeight }
+                : {
+                    ...menuStyle,
+                    ...style,
+                    width,
+                    maxWidth: "100%",
+                    maxHeight,
+                    left: "auto",
+                    right: 0,
+                  }
+            }
+            onScroll={onScroll}
+          >
+            {/* Have to wrap onMouseEnter and onMouseLeave in a separate <div>, as react-autocomplete
+             * would override them on the root <div>. */}
+            <div onMouseEnter={() => setIgnoreBlur(true)} onMouseLeave={() => setIgnoreBlur(false)}>
+              {menuItemsToShow}
+            </div>
+          </div>
+        );
+      }}
+      // @ts-expect-error renderMenuWrapper added in the fork but we don't have typings for it
+      renderMenuWrapper={(menu: React.ReactNode) => createPortal(menu, document.body)}
+      ref={autocomplete}
+      wrapperStyle={{ flex: "1 1 auto", overflow: "hidden", marginLeft: 6 }}
+    />
+  );
+}) as <T>(props: AutocompleteProps<T> & React.RefAttributes<IAutocomplete>) => JSX.Element; // https://stackoverflow.com/a/58473012/23649

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -301,12 +301,12 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
   // autocompletes. We pass an instance of an `AutocompleteController` to `onSelect` in case
   // the user of this component wants to call `blur()`.
   const onSelect = useCallback(
-    (value: string, item: FzfResultItem<T>): void => {
+    (textValue: string, item: FzfResultItem<T>): void => {
       if (autocomplete.current?.refs.input) {
         (autocomplete.current.refs.input as HTMLInputElement).focus();
         setFocused(true);
         setValue(undefined);
-        onSelectCallback(value, item.item, { setSelectionRange, focus, blur });
+        onSelectCallback(textValue, item.item, { setSelectionRange, focus, blur });
       }
     },
     [onSelectCallback, blur, focus, setSelectionRange],

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -592,7 +592,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
           filterText={autocompleteFilterText}
           value={path}
           onChange={onChange}
-          onSelect={(value: string, _item: unknown, autocomplete: IAutocomplete) =>
+          onSelect={(value, _item, autocomplete) =>
             onSelect(value, autocomplete, autocompleteType, autocompleteRange)
           }
           hasError={hasError}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -13,7 +13,7 @@
 
 import { IButtonStyles, IconButton, Stack, useTheme } from "@fluentui/react";
 import { sortBy, debounce } from "lodash";
-import { memo, createRef, useCallback, useState, useMemo } from "react";
+import { memo, useCallback, useState, useMemo, useRef } from "react";
 import shallowequal from "shallowequal";
 
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
@@ -151,7 +151,7 @@ const FollowTFControl = memo<Props>((props: Props) => {
   const nodesWithoutDefaultFollowTfFrame = allNodes?.length;
   const newFollowTfFrame = allNodes?.[0]?.tf?.id;
 
-  const autocomplete = createRef<IAutocomplete>();
+  const autocomplete = useRef<IAutocomplete>(ReactNull);
 
   const getDefaultFollowTransformFrame = useCallback(() => {
     return nodesWithoutDefaultFollowTfFrame !== 0 ? newFollowTfFrame : undefined;
@@ -188,19 +188,23 @@ const FollowTFControl = memo<Props>((props: Props) => {
   ]);
 
   const onSelectFrame = useCallback(
-    (id: string, _item: unknown, autocompleteNode: IAutocomplete) => {
+    (id: string, _item: unknown) => {
       setLastSelectedFrame(id === getDefaultFollowTransformFrame() ? undefined : id);
       onFollowChange(id, followOrientation);
-      autocompleteNode.blur();
+      autocomplete.current?.blur();
     },
-    [setLastSelectedFrame, getDefaultFollowTransformFrame, onFollowChange, followOrientation],
+    [
+      setLastSelectedFrame,
+      getDefaultFollowTransformFrame,
+      onFollowChange,
+      followOrientation,
+      autocomplete,
+    ],
   );
 
   const openFrameList = useCallback(() => {
     setForceShowFrameList(true);
-    if (autocomplete.current) {
-      autocomplete.current.focus();
-    }
+    autocomplete.current?.focus();
   }, [setForceShowFrameList, autocomplete]);
 
   // slight delay to prevent the arrow from disappearing when you're trying to click it


### PR DESCRIPTION
**User-Facing Changes**

Nothing should change.

**Description**

<s>Not quite working yet, but I wanted to commit early to make sure it's going in the right direction. </s>
Refactored the Autocomplete component from a class-based React component to a hook-based functional React component.

**Todos**

- [x] Code ported over to a functional component
- [x] Get Storybook to work the same across the class and functional variants
- [x] Update `<Autocomplete>` usage across the codebase
- [x] Cleanup variables now that it's working (_onBlur => onBlur)
- [x] Make the linter happy
-  Anything else?

**Notes**

I've left some notes in comments below

**References**

This is part of https://github.com/foxglove/studio/issues/1426