### PR TITLE
Feature: add wellKnownDatatype field to topics

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -17,12 +17,11 @@ import { useLatest } from "react-use";
 import { useDebouncedCallback } from "use-debounce";
 
 import { toSec } from "@foxglove/rostime";
-import { PanelExtensionContext, MessageEvent } from "@foxglove/studio";
+import { PanelExtensionContext, MessageEvent, Topic } from "@foxglove/studio";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import FilteredPointLayer, {
   POINT_MARKER_RADIUS,
 } from "@foxglove/studio-base/panels/Map/FilteredPointLayer";
-import { Topic } from "@foxglove/studio-base/players/types";
 
 import { NavSatFixMsg, NavSatFixStatus, Point } from "./types";
 
@@ -71,13 +70,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
 
   const eligibleTopics = useMemo(() => {
-    return topics
-      .filter(
-        (topic) =>
-          topic.datatype === "sensor_msgs/NavSatFix" ||
-          topic.datatype === "sensor_msgs/msg/NavSatFix",
-      )
-      .map((topic) => topic.name);
+    return topics.filter((topic) => topic.studioDatatype === "gps").map((topic) => topic.name);
   }, [topics]);
 
   // Subscribe to eligible and enabled topics

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -194,7 +194,13 @@ export default class Ros1Player implements Player {
 
     try {
       const topicArrays = await rosNode.getPublishedTopics();
-      const topics = topicArrays.map(([name, datatype]) => ({ name, datatype }));
+      const topics = topicArrays.map(([name, datatype]) => {
+        let studioDatatype: string | undefined;
+        if (datatype === "sensor_msgs/NavSatFix") {
+          studioDatatype = "gps";
+        }
+        return { name, datatype, studioDatatype };
+      });
       // Sort them for easy comparison
       const sortedTopics: Topic[] = sortBy(topics, "name");
 

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -219,7 +219,11 @@ export default class RosbridgePlayer implements Player {
           topicsMissingDatatypes.push(topicName);
           continue;
         }
-        topics.push({ name: topicName, datatype: type });
+        let studioDatatype: string | undefined;
+        if (type === "sensor_msgs/NavSatFix" || type === "sensor_msgs/msg/NavSatFix") {
+          studioDatatype = "gps";
+        }
+        topics.push({ name: topicName, datatype: type, studioDatatype });
         datatypeDescriptions.push({ type, messageDefinition });
         const parsedDefinition = parseMessageDefinition(messageDefinition, {
           ros2: rosVersion === 2,

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -214,9 +214,7 @@ export type PlayerStateActiveData = {
 
 // Represents a ROS topic, though the actual data does not need to come from a ROS system.
 export type Topic = {
-  // Of ROS topic format, i.e. "/some/topic". We currently depend on this slashes format a bit in
-  // `<MessageHistroy>`, though we could relax this and support arbitrary strings. It's nice to have
-  // a consistent representation for topics that people recognize though.
+  // Of ROS topic format, i.e. "/some/topic".
   name: string;
   // Name of the datatype (see `type PlayerStateActiveData` for details).
   datatype: string;
@@ -226,8 +224,8 @@ export type Topic = {
   // The number of messages present on the topic. Valid only for sources with a fixed number of
   // messages, such as bags.
   numMessages?: number;
-
-  studioDatatype?: string;
+  // Name of the well known studio datatype for messages on this topic
+  wellKnownDatatype?: string;
 };
 
 type RosSingularField = number | string | boolean | RosObject; // No time -- consider it a message.

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -226,6 +226,8 @@ export type Topic = {
   // The number of messages present on the topic. Valid only for sources with a fixed number of
   // messages, such as bags.
   numMessages?: number;
+
+  studioDatatype?: string;
 };
 
 type RosSingularField = number | string | boolean | RosObject; // No time -- consider it a message.

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -671,6 +671,10 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         }
 
         const lazyMsg = lazyReader.readMessage(bytes);
+
+        // fixme - if we have a topic with a well known datatype, we need to add the
+        // wellKnownMessage field and wrap the lazyMsg
+
         messagesByTopic[rosBinaryMessage.topic]?.push({
           topic: rosBinaryMessage.topic,
           receiveTime: rosBinaryMessage.receiveTime,

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -85,7 +85,7 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
         name: topicDef.name,
         datatype: topicDef.type,
         numMessages: messageCounts.get(topicDef.name),
-        studioDatatype,
+        wellKnownDatatype: studioDatatype,
       });
       connections.push({
         messageDefinition,

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -76,10 +76,16 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
       const messageDefinition = stringify(fullParsedMessageDefinitions);
       const md5sum = Md5.init(messageDefinition);
 
+      let studioDatatype: string | undefined;
+      if (topicDef.type === "sensor_msgs/msg/NavSatFix") {
+        studioDatatype = "gps";
+      }
+
       topics.push({
         name: topicDef.name,
         datatype: topicDef.type,
         numMessages: messageCounts.get(topicDef.name),
+        studioDatatype,
       });
       connections.push({
         messageDefinition,

--- a/packages/studio-base/src/util/bagConnectionsHelper.ts
+++ b/packages/studio-base/src/util/bagConnectionsHelper.ts
@@ -64,10 +64,16 @@ export function bagConnectionsToTopics(
       console.warn("duplicate topic with differing datatype", existingTopic, connection);
       return;
     }
+    let studioDatatype: string | undefined;
+    if (connection.type === "sensor_msgs/NavSatFix") {
+      studioDatatype = "gps";
+    }
+
     topics[connection.topic] = {
       name: connection.topic,
       datatype: connection.type,
       numMessages: numMessagesByConnectionIndex[index],
+      studioDatatype,
     };
   });
   return Object.values(topics);

--- a/packages/studio-base/src/util/bagConnectionsHelper.ts
+++ b/packages/studio-base/src/util/bagConnectionsHelper.ts
@@ -73,7 +73,7 @@ export function bagConnectionsToTopics(
       name: connection.topic,
       datatype: connection.type,
       numMessages: numMessagesByConnectionIndex[index],
-      studioDatatype,
+      wellKnownDatatype: studioDatatype,
     };
   });
   return Object.values(topics);

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -14,8 +14,9 @@ declare module "@foxglove/studio" {
     name: string;
     // topic datatype
     datatype: string;
-    // If the topic data conforms to a specific studio datatype, that datatype will be set in this field.
-    studioDatatype?: string;
+    // If the topic data conforms to a specific well knwon studio datatype, that datatype will be
+    // set in this field.
+    wellKnownDatatype?: string;
   };
 
   /**
@@ -25,6 +26,7 @@ declare module "@foxglove/studio" {
     topic: string;
     receiveTime: Time;
     message: T;
+    wellKnownMessage?: unknown;
   }>;
 
   export interface LayoutActions {

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -14,6 +14,8 @@ declare module "@foxglove/studio" {
     name: string;
     // topic datatype
     datatype: string;
+    // If the topic data conforms to a specific studio datatype, that datatype will be set in this field.
+    studioDatatype?: string;
   };
 
   /**


### PR DESCRIPTION
**User-Facing Changes**
Extension authors have access to the wellKnownDatatype field for each topic.

**Description**

The well known datatype field indicates if the topic adheres to a set of known studio datatypes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
