### PR TITLE
Feature: add url handling to web

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -85,7 +85,27 @@ export default function Root(): ReactElement {
     /* eslint-enable react/jsx-key */
   ];
 
-  const deepLinks = useMemo(() => desktopBridge.getDeepLinks(), []);
+  const deepLinks = useMemo(() => {
+    const links = desktopBridge.getDeepLinks();
+    const firstLink = links[0];
+    if (!firstLink) {
+      return;
+    }
+
+    const url = new URL(firstLink);
+    // only support the open command
+    // Test if the pathname matches //open or //open/
+    if (!/\/\/open\/?/.test(url.pathname)) {
+      return;
+    }
+
+    return [
+      {
+        action: "open",
+        args: Object.fromEntries(url.searchParams.entries()),
+      },
+    ];
+  }, []);
 
   return (
     <ThemeProvider>

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -6,7 +6,7 @@ import { Suspense, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
-import Workspace from "@foxglove/studio-base/Workspace";
+import Workspace, { WorkspaceProps } from "@foxglove/studio-base/Workspace";
 import DocumentTitleAdapter from "@foxglove/studio-base/components/DocumentTitleAdapter";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import { NativeFileMenuPlayerSelection } from "@foxglove/studio-base/components/NativeFileMenuPlayerSelection";
@@ -33,7 +33,7 @@ type AppProps = {
   loadWelcomeLayout?: boolean;
   availableSources: PlayerSourceDefinition[];
   demoBagUrl?: string;
-  deepLinks?: string[];
+  deepLinks?: WorkspaceProps["deepLinks"];
 };
 
 export default function App(props: AppProps): JSX.Element {

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -369,6 +369,15 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           },
           { start, end, seekTo, deviceId },
         );
+      } else if (type === "rosbridge") {
+        const rosbridgeHostUrl = url.searchParams.get("url") ?? "";
+        selectSource(
+          {
+            name: "ROS 1 Rosbridge",
+            type: "rosbridge-websocket",
+          },
+          { url: rosbridgeHostUrl },
+        );
       } else {
         log.warn(`Unknown deep link type ${url}`);
       }

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -227,9 +227,12 @@ async function rosbridgeSource(options: FactoryOptions): Promise<Player | undefi
   // undefined url indicates the user canceled the prompt
   let maybeUrl;
   const restore = Boolean(options.sourceOptions.restore);
+  const urlOption = options.sourceOptions.url;
 
   if (restore) {
     maybeUrl = options.storage.getItem<string>(storageCacheKey);
+  } else if (typeof urlOption === "string") {
+    maybeUrl = urlOption;
   } else {
     const value = options.storage.getItem<string>(storageCacheKey) ?? "ws://localhost:9090";
     maybeUrl = await options.prompt({

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -33,6 +33,10 @@ type HttpSourceParams = {
   url?: string;
 };
 
+type RosbridgeSourceParams = {
+  url?: string;
+};
+
 type FoxgloveDataPlatformSourceParams = {
   start?: string;
   end?: string;
@@ -48,6 +52,10 @@ interface SelectSourceFunction {
   (definition: SpecializedPlayerSource<"ros1-local-bagfile">, params?: FileSourceParams): void;
   (definition: SpecializedPlayerSource<"ros2-local-bagfile">, params?: FolderSourceParams): void;
   (definition: SpecializedPlayerSource<"ros1-remote-bagfile">, params?: HttpSourceParams): void;
+  (
+    definition: SpecializedPlayerSource<"rosbridge-websocket">,
+    params?: RosbridgeSourceParams,
+  ): void;
   (
     definition: SpecializedPlayerSource<"foxglove-data-platform">,
     params?: FoxgloveDataPlatformSourceParams,

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -90,6 +90,17 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
 
   const api = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL!), []);
 
+  const deepLinks = useMemo(() => {
+    const url = new URL(window.location.href);
+
+    if (url.searchParams.get("action") === "open") {
+      url.searchParams.delete("action");
+      return [`foxglove://open?${url.searchParams.toString()}`];
+    }
+
+    return undefined;
+  }, []);
+
   const providers = [
     /* eslint-disable react/jsx-key */
     <LocalStorageAppConfigurationProvider />,
@@ -113,6 +124,7 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
               loadWelcomeLayout={loadWelcomeLayout}
               demoBagUrl={DEMO_BAG_URL}
               availableSources={playerSources}
+              deepLinks={deepLinks}
             />
           </MultiProvider>
         </ErrorBoundary>

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Link } from "@fluentui/react";
-import { useMemo } from "react";
+import { useMemo, ComponentProps } from "react";
 
 import {
   App,
@@ -90,12 +90,17 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
 
   const api = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL!), []);
 
-  const deepLinks = useMemo(() => {
+  type DeepLinkProp = ComponentProps<typeof App>["deepLinks"];
+  const deepLinks = useMemo<DeepLinkProp>(() => {
     const url = new URL(window.location.href);
-
     if (url.searchParams.get("action") === "open") {
       url.searchParams.delete("action");
-      return [`foxglove://open?${url.searchParams.toString()}`];
+      return [
+        {
+          action: "open",
+          args: Object.fromEntries(url.searchParams.entries()),
+        },
+      ];
     }
 
     return undefined;


### PR DESCRIPTION
**User-Facing Changes**
No UI changes. URL handling support will allow for linking to studio web with specific data source arguments.

Example url:

```
http://localhost:8080/?action=open&type=rosbridge&url=ws://localhost:9000
```

**Description**
By specifying the `open` action in url arguments, users can instruct the web version to load a particular data source on startup.
    
Fixes: #1868

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
