### PR TITLE
Feature: simplify plot tooltip

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -488,7 +488,7 @@ function Chart(props: Props): JSX.Element {
       onMouseLeave={onMouseLeave}
       onMouseEnter={onMouseEnter}
       onMouseUp={onMouseUp}
-      style={{ width, height }}
+      style={{ width, height, cursor: "crosshair" }}
     />
   );
 }

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { TimeBasedChartTooltipData } from "@foxglove/studio-base/components/TimeBasedChart";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 
 import TimeBasedChartTooltipContent from "./TimeBasedChartTooltipContent";
@@ -20,28 +21,44 @@ export default {
   component: TimeBasedChartTooltipContent,
 };
 
-export function Default(): React.ReactElement {
-  const data = {
+export function SingleItem(): React.ReactElement {
+  const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
-    datasetKey: "0",
     path: "/some/topic.path",
     value: 3,
     constantName: "ACTIVE",
-    item: {
-      receiveTime: { sec: 123, nsec: 456 },
-      headerStamp: { sec: 100, nsec: 30 },
-    },
-    startTime: { sec: 95, nsec: 0 },
   };
   const { tooltip } = useTooltip({
     shown: true,
     targetPosition: { x: 200, y: 100 },
-    contents: <TimeBasedChartTooltipContent tooltip={data} />,
+    contents: <TimeBasedChartTooltipContent content={[data]} />,
   });
   return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
 }
-Default.parameters = { colorScheme: "dark" };
-export const DefaultLight = Object.assign(Default.bind(undefined), {
+SingleItem.parameters = { colorScheme: "dark" };
+
+export const SingleItemLight = Object.assign(SingleItem.bind(undefined), {
+  parameters: { colorScheme: "light" },
+});
+
+export function MultipleItems(): React.ReactElement {
+  const data: TimeBasedChartTooltipData = {
+    x: 0,
+    y: 0,
+    path: "/some/topic.path",
+    value: 3,
+    constantName: "ACTIVE",
+  };
+  const { tooltip } = useTooltip({
+    shown: true,
+    targetPosition: { x: 200, y: 100 },
+    contents: <TimeBasedChartTooltipContent content={[data, data]} />,
+  });
+  return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
+}
+MultipleItems.parameters = { colorScheme: "dark" };
+
+export const MultipleItemsLight = Object.assign(MultipleItems.bind(undefined), {
   parameters: { colorScheme: "light" },
 });

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -12,18 +12,14 @@
 //   You may not use this file except in compliance with the License.
 
 import { makeStyles } from "@fluentui/react";
-import cx from "classnames";
 import { PropsWithChildren } from "react";
 
-import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
-import { formatTime } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
-import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 import { TimeBasedChartTooltipData } from "./index";
 
 type Props = {
-  tooltip: TimeBasedChartTooltipData;
+  content: TimeBasedChartTooltipData[];
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -31,35 +27,13 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: fonts.MONOSPACE,
     fontSize: 11,
     lineHeight: "1.4",
-    maxWidth: 350,
     overflowWrap: "break-word",
   },
-  table: {
-    border: "none",
-    width: "100%",
+  multiValueItem: {
+    paddingBottom: theme.spacing.s2,
   },
-  tableCell: {
-    border: "none",
-    padding: "0 0.3em",
-    lineHeight: "1.3em",
-  },
-  tableCellHeader: {
-    color: theme.palette.neutralTertiary,
-    textAlign: "center",
-
-    ":first-child": {
-      textAlign: "left",
-    },
-  },
-  tableRow: {
-    ":first-child": {
-      "th, td": {
-        paddingBottom: 4,
-        paddingTop: 4,
-      },
-    },
-  },
-  title: {
+  path: {
+    whiteSpace: "nowrap",
     color: theme.palette.neutralTertiary,
   },
 }));
@@ -67,58 +41,50 @@ const useStyles = makeStyles((theme) => ({
 export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
-  const { tooltip } = props;
+  const { content } = props;
   const classes = useStyles();
-  const value =
-    typeof tooltip.value === "string"
-      ? tooltip.value
-      : typeof tooltip.value === "bigint"
-      ? tooltip.value.toString()
-      : JSON.stringify(tooltip.value);
-  const { receiveTime, headerStamp } = tooltip.item;
+
+  // If only one value is present we don't show the series name since it is the only series present
+  if (content.length === 1) {
+    return (
+      <div className={classes.root} data-test="TimeBasedChartTooltipContent">
+        {content.map((item, idx) => {
+          const value =
+            typeof item.value === "string"
+              ? item.value
+              : typeof item.value === "bigint"
+              ? item.value.toString()
+              : JSON.stringify(item.value);
+          return (
+            <div key={idx}>
+              {value}
+              {item.constantName != undefined ? ` (${item.constantName})` : ""}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className={classes.root} data-test="TimeBasedChartTooltipContent">
-      <div>
-        <span className={classes.title}>Value:&nbsp;</span>
-        {tooltip.constantName != undefined ? `${tooltip.constantName} (${value})` : value}
-      </div>
-      <div>
-        <span className={classes.title}>Path:&nbsp;</span>
-        {tooltip.path}
-      </div>
-      <table className={classes.table}>
-        <tbody>
-          <tr className={classes.tableRow}>
-            <th className={cx(classes.tableCell, classes.tableCellHeader)} />
-            <th className={cx(classes.tableCell, classes.tableCellHeader)}>receive time</th>
-            {headerStamp && (
-              <th className={cx(classes.tableCell, classes.tableCellHeader)}>header.stamp</th>
-            )}
-          </tr>
-          <tr className={classes.tableRow}>
-            <th className={cx(classes.tableCell, classes.tableCellHeader)}>ROS</th>
-            <td className={classes.tableCell}>{formatTimeRaw(receiveTime)}</td>
-            {headerStamp && <td className={classes.tableCell}>{formatTimeRaw(headerStamp)}</td>}
-          </tr>
-          <tr className={classes.tableRow}>
-            <th className={cx(classes.tableCell, classes.tableCellHeader)}>Time</th>
-            {<td className={classes.tableCell}>{formatTime(receiveTime)}</td>}
-            {headerStamp && <td className={classes.tableCell}>{formatTime(headerStamp)}</td>}
-          </tr>
-          <tr className={classes.tableRow}>
-            <th className={cx(classes.tableCell, classes.tableCellHeader)}>Elapsed</th>
-            <td className={classes.tableCell}>
-              {toSec(subtractTimes(receiveTime, tooltip.startTime)).toFixed(9)} sec
-            </td>
-            {headerStamp && (
-              <td className={classes.tableCell}>
-                {toSec(subtractTimes(headerStamp, tooltip.startTime)).toFixed(9)} sec
-              </td>
-            )}
-          </tr>
-        </tbody>
-      </table>
+      {content.map((item, idx) => {
+        const value =
+          typeof item.value === "string"
+            ? item.value
+            : typeof item.value === "bigint"
+            ? item.value.toString()
+            : JSON.stringify(item.value);
+        return (
+          <div key={idx} className={classes.multiValueItem}>
+            <div className={classes.path}>{item.path}</div>
+            <div>
+              {value}
+              {item.constantName != undefined ? ` (${item.constantName})` : ""}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -27,14 +27,8 @@ const dataY = 5.544444561004639;
 const tooltipData: TimeBasedChartTooltipData = {
   x: dataX,
   y: dataY,
-  item: {
-    headerStamp: undefined,
-    receiveTime: { sec: 1396293889, nsec: 214366 },
-  },
   path: "/turtle1/pose.x",
-  datasetKey: "0",
   value: 5.544444561004639,
-  startTime: { sec: 1396293889, nsec: 156763 },
 };
 
 const commonProps: Props = {

--- a/packages/studio-base/src/panels/Plot/csv.ts
+++ b/packages/studio-base/src/panels/Plot/csv.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { downloadFiles } from "@foxglove/studio-base/util/download";
+import { formatTimeRaw } from "@foxglove/studio-base/util/time";
+
+import { DataSet, Datum } from "./internalTypes";
+import { PlotXAxisVal } from "./types";
+
+function getCSVRow(label: string | undefined, data: Datum) {
+  const { x, y, receiveTime, headerStamp } = data;
+  const receiveTimeFloat = formatTimeRaw(receiveTime);
+  const stampTime = headerStamp ? formatTimeRaw(headerStamp) : "";
+  return [x, receiveTimeFloat, stampTime, label, y];
+}
+
+const getCVSColName = (xAxisVal: PlotXAxisVal): string => {
+  return {
+    timestamp: "elapsed time",
+    index: "index",
+    custom: "x value",
+    currentCustom: "x value",
+  }[xAxisVal];
+};
+
+function getCSVData(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
+  const headLine = [getCVSColName(xAxisVal), "receive time", "header.stamp", "topic", "value"];
+  const combinedLines = [];
+  combinedLines.push(headLine);
+  for (const dataset of datasets) {
+    for (const datum of dataset.data) {
+      combinedLines.push(getCSVRow(dataset.label, datum));
+    }
+  }
+  return combinedLines.join("\n");
+}
+
+function downloadCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): void {
+  const csvData = getCSVData(datasets, xAxisVal);
+  const blob = new Blob([csvData], { type: "text/csv;charset=utf-8;" });
+  downloadFiles([{ blob, fileName: `plot_data.csv` }]);
+}
+
+export { downloadCSV };

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -11,11 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ComponentProps } from "react";
+import { ChartDataset } from "chart.js";
 
 import { Time } from "@foxglove/rostime";
 import { MessagePathDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 export type BasePlotPath = {
@@ -27,12 +26,17 @@ export type PlotPath = BasePlotPath & {
   timestampMethod: TimestampMethod;
 };
 
-export type PlotChartPoint = {
+export type Datum = {
   x: number;
   y: number;
+  receiveTime: Time;
+  headerStamp?: Time;
+  path: string;
+  value: number | bigint | boolean | string;
+  constantName?: string;
 };
 
-export type DataSet = ComponentProps<typeof TimeBasedChart>["data"]["datasets"][0];
+export type DataSet = ChartDataset<"scatter", Datum[]>;
 
 export type PlotDataItem = {
   queriedData: MessagePathDataItem[];

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -101,14 +101,9 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
       const tooltip: TimeBasedChartTooltipData = {
         x,
         y,
-        item: {
-          receiveTime: itemByPath.messageEvent.receiveTime,
-          headerStamp,
-        },
         path: path.value,
         value,
         constantName,
-        startTime,
       };
       info.tooltips.unshift(tooltip);
 


### PR DESCRIPTION
**User-Facing Changes**
The tooltip for all plot panels shows only the series and series data. The tooltip can show data from multiple series. The tooltip follows the mouse y-axis so the user can move the tooltip out of the way.

The time fields are removed from the tooltip and shown above the playback control hover bar ticks as done in: https://github.com/foxglove/studio/pull/2134

| | Before | After |
| --- | --- | --- |
| Single Series | ![image](https://user-images.githubusercontent.com/84792/141349953-c9d3b5cc-4d95-4762-ac22-c70ed5227d82.png) | ![image](https://user-images.githubusercontent.com/84792/141348836-f8aa95a4-829b-4648-b8a8-ad4f01cc5ed1.png) |
| Multiple Series | ![image](https://user-images.githubusercontent.com/84792/141350054-55c22f82-4da6-4451-96dd-0b4ae347a04a.png)|![image](https://user-images.githubusercontent.com/84792/141348897-96d4c191-0209-478d-b993-a047c2c4035e.png) |
| State Transitions | ![image](https://user-images.githubusercontent.com/84792/141350114-6484e4ba-24a8-441a-bed5-195d5345eb61.png) |![image](https://user-images.githubusercontent.com/84792/141348953-3a642dcd-e41a-4972-8672-6b04aeca8160.png)
 |

**Description**
The existing tooltip would cover up a lot of the plot. This change makes the tooltip show only the hovered value.
    
Fixes: #1173
Fixes: #1344

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
