### PR TITLE
Don't re-initialize layout storage if current user is rebuilt with same user id

### DIFF
--- a/packages/studio-base/src/providers/ConsoleApiRemoteLayoutStorageProvider.test.tsx
+++ b/packages/studio-base/src/providers/ConsoleApiRemoteLayoutStorageProvider.test.tsx
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook } from "@testing-library/react-hooks";
+import { PropsWithChildren } from "react";
+
+import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
+import CurrentUserContext, { User } from "@foxglove/studio-base/context/CurrentUserContext";
+import { useRemoteLayoutStorage } from "@foxglove/studio-base/context/RemoteLayoutStorageContext";
+import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
+
+import ConsoleApiRemoteLayoutStorageProvider from "./ConsoleApiRemoteLayoutStorageProvider";
+
+class FakeConsoleApi extends ConsoleApi {
+  constructor() {
+    super("");
+  }
+}
+
+describe("ConsoleApiRemoteLayoutStorageProvider", () => {
+  it("produces the same layout storage instance when currentUser changes, as long as currentUser.id remains the same", () => {
+    const fakeApi = new FakeConsoleApi();
+    const initialUser: User = {
+      id: "id",
+      email: "foo@example.com",
+      orgId: "org_abc",
+      orgDisplayName: "BigCo",
+      orgSlug: "bigco",
+      orgPaid: true,
+    };
+    const { result, rerender } = renderHook(() => useRemoteLayoutStorage(), {
+      initialProps: { user: initialUser },
+      wrapper: ({ children, user }: PropsWithChildren<{ user: User }>) => (
+        <ConsoleApiContext.Provider value={fakeApi}>
+          <CurrentUserContext.Provider
+            value={{ currentUser: user, signIn: () => {}, signOut: async () => {} }}
+          >
+            <ConsoleApiRemoteLayoutStorageProvider>
+              {children}
+            </ConsoleApiRemoteLayoutStorageProvider>
+          </CurrentUserContext.Provider>
+        </ConsoleApiContext.Provider>
+      ),
+    });
+
+    const initialResult = result.current;
+    rerender({ user: { ...initialUser } });
+    expect(result.current).toBe(initialResult);
+    rerender({ user: { ...initialUser, id: "id2" } });
+    expect(result.current).not.toBe(initialResult);
+  });
+});

--- a/packages/studio-base/src/providers/ConsoleApiRemoteLayoutStorageProvider.tsx
+++ b/packages/studio-base/src/providers/ConsoleApiRemoteLayoutStorageProvider.tsx
@@ -16,8 +16,8 @@ export default function ConsoleApiRemoteLayoutStorageProvider({
   const { currentUser } = useCurrentUser();
 
   const apiStorage = useMemo(
-    () => (currentUser ? new ConsoleApiRemoteLayoutStorage(currentUser.id, api) : undefined),
-    [api, currentUser],
+    () => (currentUser?.id ? new ConsoleApiRemoteLayoutStorage(currentUser.id, api) : undefined),
+    [api, currentUser?.id],
   );
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where some spurious errors would be displayed when syncing layouts after the app first opened.

**Description**
A new ConsoleApiRemoteLayoutStorage was being initialized whenever the currentUser object changed, even if the user id was the same, although it only depended on the user id.

The ConsoleApiCurrentUserProvider unfortunately triggers this behavior on every app launch because it always calls setCachedCurrentUser even if it was just validating the cached user:
https://github.com/foxglove/studio/blob/44212a8aaab9896b5ae30bf212c5eb3234034890/desktop/renderer/components/ConsoleApiCurrentUserProvider.tsx#L68

Change the useMemo dependency to be the id itself and add a unit test.

See also: #2048