### PR TITLE
fix: drag & drop initializes a source with file arg

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -219,15 +219,19 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       const supportedFileTypes = foundSource.supportedFileTypes;
       if (supportedFileTypes != undefined) {
         try {
-          const [fileHandle] = await showOpenFilePicker({
-            types: [
-              {
-                description: foundSource.displayName,
-                accept: { "application/octet-stream": supportedFileTypes },
-              },
-            ],
-          });
-          const file = await fileHandle.getFile();
+          let file = (args?.files as File[] | undefined)?.[0];
+
+          if (!file) {
+            const [fileHandle] = await showOpenFilePicker({
+              types: [
+                {
+                  description: foundSource.displayName,
+                  accept: { "application/octet-stream": supportedFileTypes },
+                },
+              ],
+            });
+            file = await fileHandle.getFile();
+          }
 
           const newPlayer = foundSource.initialize({
             file,


### PR DESCRIPTION
**User-Facing Changes**
Users can drag&drop files for any data source which supports file loading.

**Description**
The player manager failed to properly detect the files argument provided when selecting a data source via drag & drop. This was a regression introduced by https://github.com/foxglove/studio/pull/1513. This fixes the regression and also expands drag & drop support to any data source that supports files.

Removes support for "shift" drag&drop to append files. Support for this was recently removed for the ros1 bag data source and not supported for ros2 bag or ulog.
    
Fixes: #2061

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
