### PR TITLE
Use plot defaultConfig when destructuring config values

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -211,15 +211,16 @@ function selectEndTime(ctx: MessagePipelineContext) {
 
 function Plot(props: Props) {
   const { saveConfig, config } = props;
+
   const {
-    title,
+    title = defaultConfig.title,
     followingViewWidth,
-    paths: yAxisPaths,
-    minYValue,
-    maxYValue,
-    showLegend,
-    isSynced,
-    xAxisVal,
+    paths: yAxisPaths = defaultConfig.paths,
+    minYValue = defaultConfig.minYValue,
+    maxYValue = defaultConfig.maxYValue,
+    showLegend = defaultConfig.showLegend,
+    isSynced = defaultConfig.isSynced,
+    xAxisVal = defaultConfig.xAxisVal,
     xAxisPath,
   } = config;
 


### PR DESCRIPTION
The default config is only applied when a panel is added to a layout. When we add new config options to the default config, these are not applied to existing panels. Any default options with "truthy" values are thus not actually set to those values for the panel.

This change moves the default value assignment into the panel logic so it is the responsibility of the panel to provide defaults for its options.

**User-Facing Changes**


**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
