### PR TITLE
Support for system color scheme in desktop build

### DIFF
--- a/desktop/common/storage.ts
+++ b/desktop/common/storage.ts
@@ -3,3 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export const DATASTORES_DIR_NAME = "studio-datastores";
+
+export const SETTINGS_DATASTORE_NAME = "settings";
+export const SETTINGS_JSON_DATASTORE_KEY = "settings.json";

--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -51,6 +51,12 @@ interface Desktop {
   /** https://www.electronjs.org/docs/tutorial/represented-file */
   setRepresentedFilename(path: string | undefined): Promise<void>;
 
+  /**
+   * Notify the app that the color scheme setting has changed and the native theme may need to be
+   * updated.
+   */
+  updateNativeColorScheme(): Promise<void>;
+
   // Get an array of deep links provided on app launch
   getDeepLinks: () => string[];
 

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -34,7 +34,7 @@ const log = Logger.getLogger(__filename);
 type ClearableMenu = Menu & { clear: () => void };
 
 function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
-  const [allowCrashReporting, allowTelemetry] = getTelemetrySettings();
+  const { crashReportingEnabled, telemetryEnabled } = getTelemetrySettings();
 
   const preloadPath = path.join(app.getAppPath(), "main", "preload.js");
 
@@ -50,8 +50,8 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
       preload: preloadPath,
       nodeIntegration: false,
       additionalArguments: [
-        `--allowCrashReporting=${allowCrashReporting ? "1" : "0"}`,
-        `--allowTelemetry=${allowTelemetry ? "1" : "0"}`,
+        `--allowCrashReporting=${crashReportingEnabled ? "1" : "0"}`,
+        `--allowTelemetry=${telemetryEnabled ? "1" : "0"}`,
         ...deepLinks,
       ],
       // Disable webSecurity in development so we can make XML-RPC calls, load

--- a/desktop/main/settings.ts
+++ b/desktop/main/settings.ts
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { app } from "electron";
+import fs from "fs";
+import path from "path";
+
+import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
+
+import {
+  DATASTORES_DIR_NAME,
+  SETTINGS_DATASTORE_NAME,
+  SETTINGS_JSON_DATASTORE_KEY,
+} from "../common/storage";
+
+export function getAppSetting<T>(key: AppSetting): T | undefined {
+  const datastoreDir = path.join(
+    app.getPath("userData"),
+    DATASTORES_DIR_NAME,
+    SETTINGS_DATASTORE_NAME,
+  );
+  const settingsPath = path.join(datastoreDir, SETTINGS_JSON_DATASTORE_KEY);
+
+  try {
+    fs.mkdirSync(datastoreDir, { recursive: true });
+  } catch {
+    // Ignore directory creation errors, including dir already exists
+  }
+
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, { encoding: "utf8" }));
+    return settings[key];
+  } catch {
+    // Ignore file load or parsing errors, including settings.json not existing
+    return undefined;
+  }
+}
+
+export function setAppSetting(key: AppSetting, value: unknown): void {
+  const datastoreDir = path.join(
+    app.getPath("userData"),
+    DATASTORES_DIR_NAME,
+    SETTINGS_DATASTORE_NAME,
+  );
+  const settingsPath = path.join(datastoreDir, SETTINGS_JSON_DATASTORE_KEY);
+
+  const existingSettings = {};
+  try {
+    fs.mkdirSync(datastoreDir, { recursive: true });
+  } catch {
+    // Ignore directory creation errors, including dir already exists
+  }
+
+  fs.writeFileSync(
+    settingsPath,
+    JSON.stringify({ ...existingSettings, [key]: value }, undefined, 2),
+  );
+}

--- a/desktop/main/telemetry.ts
+++ b/desktop/main/telemetry.ts
@@ -2,35 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { app } from "electron";
-import fs from "fs";
-import path from "path";
-
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 
-import { DATASTORES_DIR_NAME } from "../common/storage";
+import { getAppSetting } from "./settings";
 
-function getTelemetrySettings(): [crashReportingEnabled: boolean, telemetryEnabled: boolean] {
-  const datastoreDir = path.join(app.getPath("userData"), DATASTORES_DIR_NAME, "settings");
-  const settingsPath = path.join(datastoreDir, "settings.json");
-  let crashReportingEnabled = true;
-  let telemetryEnabled = true;
+export function getTelemetrySettings(): {
+  crashReportingEnabled: boolean;
+  telemetryEnabled: boolean;
+} {
+  const crashReportingEnabled = getAppSetting<boolean>(AppSetting.CRASH_REPORTING_ENABLED) ?? true;
+  const telemetryEnabled = getAppSetting<boolean>(AppSetting.TELEMETRY_ENABLED) ?? true;
 
-  try {
-    fs.mkdirSync(datastoreDir, { recursive: true });
-  } catch {
-    // Ignore directory creation errors, including dir already exists
-  }
-
-  try {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, { encoding: "utf8" }));
-    crashReportingEnabled = settings[AppSetting.CRASH_REPORTING_ENABLED] ?? true;
-    telemetryEnabled = settings[AppSetting.TELEMETRY_ENABLED] ?? true;
-  } catch {
-    // Ignore file load or parsing errors, including settings.json not existing
-  }
-
-  return [crashReportingEnabled, telemetryEnabled];
+  return { crashReportingEnabled, telemetryEnabled };
 }
-
-export { getTelemetrySettings };

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -102,6 +102,9 @@ const desktopBridge: Desktop = {
   async setRepresentedFilename(path: string | undefined) {
     await ipcRenderer.invoke("setRepresentedFilename", path);
   },
+  async updateNativeColorScheme() {
+    await ipcRenderer.invoke("updateNativeColorScheme");
+  },
   getDeepLinks(): string[] {
     return window.process.argv.filter((arg) => arg.startsWith("foxglove://"));
   },

--- a/desktop/renderer/components/NativeColorSchemeAdapter.tsx
+++ b/desktop/renderer/components/NativeColorSchemeAdapter.tsx
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useLayoutEffect } from "react";
+
+import { AppSetting, useAppConfigurationValue } from "@foxglove/studio-base";
+
+import { Desktop } from "../../common/types";
+
+const desktopBridge = (global as { desktopBridge?: Desktop }).desktopBridge;
+
+/** Notify the main process when the user has changed their color scheme setting. */
+export default function NativeColorSchemeAdapter(): ReactNull {
+  const [colorScheme] = useAppConfigurationValue<string>(AppSetting.COLOR_SCHEME);
+  useLayoutEffect(() => {
+    void colorScheme;
+    desktopBridge?.updateNativeColorScheme();
+  }, [colorScheme]);
+  return ReactNull;
+}

--- a/desktop/renderer/services/NativeStorageAppConfiguration.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.ts
@@ -5,11 +5,12 @@ import { Mutex } from "async-mutex";
 
 import { AppConfiguration, AppConfigurationValue, ChangeHandler } from "@foxglove/studio-base";
 
+import { SETTINGS_DATASTORE_NAME, SETTINGS_JSON_DATASTORE_KEY } from "../../common/storage";
 import { Storage } from "../../common/types";
 
 export default class NativeStorageAppConfiguration implements AppConfiguration {
-  static STORE_NAME = "settings";
-  static STORE_KEY = "settings.json";
+  static STORE_NAME = SETTINGS_DATASTORE_NAME;
+  static STORE_KEY = SETTINGS_JSON_DATASTORE_KEY;
 
   private readonly _ctx: Storage;
   private _listeners = new Map<string, Set<ChangeHandler>>();


### PR DESCRIPTION
**User-Facing Changes**
Part of #2054 – desktop build now supports the "system" color setting.

**Description**
- The desktop app reads the colorScheme setting from settings.json at startup.
- The `desktopBridge` has a new function that the renderer can invoke when the setting is changed, to tell the desktop app to update from disk.