### PR TITLE
Remove "/index" from story names

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -111,7 +111,7 @@ if (propsWithDatalabels.data.datasets[0]?.datalabels) {
 const divStyle = { width: 600, height: 800, background: "black" };
 
 export default {
-  title: "components/Chart/index",
+  title: "components/Chart",
   component: ChartComponent,
   parameters: {
     chromatic: {

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -89,7 +89,7 @@ const commonProps: Props = {
 };
 
 export default {
-  title: "components/TimeBasedChart/index",
+  title: "components/TimeBasedChart",
   component: TimeBasedChart,
   parameters: {
     chromatic: {

--- a/packages/studio-base/src/panels/ImageView/index.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.stories.tsx
@@ -10,7 +10,7 @@ import ImageView from "@foxglove/studio-base/panels/ImageView";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 export default {
-  title: "panels/ImageView/index",
+  title: "panels/ImageView",
   component: ImageView,
 };
 

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -27,7 +27,7 @@ OFFSET_MESSAGE.latitude += 0.1;
 OFFSET_MESSAGE.longitude += 0.1;
 
 export default {
-  title: "panels/Map/index",
+  title: "panels/Map",
   component: MapPanel,
   parameters: { colorScheme: "dark" },
   decorators: [

--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -45,7 +45,7 @@ const getFixture = ({
   };
 };
 
-storiesOf("panels/Parameters/index", module)
+storiesOf("panels/Parameters", module)
   .add("default", () => {
     return (
       <PanelSetup fixture={getFixture({ getParameters: false, setParameters: false })}>

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
@@ -43,7 +43,7 @@ function Example({ states }: { states: UnconnectedPlaybackPerformanceProps[] }) 
   return <UnconnectedPlaybackPerformance {...state[0]!} />;
 }
 
-storiesOf("panels/PlaybackPerformance/index", module).add("simple example", () => {
+storiesOf("panels/PlaybackPerformance", module).add("simple example", () => {
   const states = [
     {
       timestamp: 1000,

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -324,7 +324,7 @@ const exampleConfig: PlotConfig = {
 };
 
 export default {
-  title: "panels/Plot/index",
+  title: "panels/Plot",
   component: Plot,
   parameters: {
     chromatic: { delay: 50 },

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -44,7 +44,7 @@ const publishConfig = (config: Partial<typeof Publish["defaultConfig"]>) => ({
   ...config,
 });
 
-storiesOf("panels/Publish/index", module)
+storiesOf("panels/Publish", module)
   .add("example can publish, advanced", () => {
     const allowPublish = true;
     return (

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -53,7 +53,7 @@ const scrollToBottom = () => {
   scrollContainer.scrollTop = scrollContainer.scrollHeight;
 };
 
-storiesOf("panels/RawMessages/index", module)
+storiesOf("panels/RawMessages", module)
   .add("folded", () => {
     return (
       <PanelSetup fixture={fixture} style={{ width: 380 }}>

--- a/packages/studio-base/src/panels/Rosout/index.stories.tsx
+++ b/packages/studio-base/src/panels/Rosout/index.stories.tsx
@@ -92,7 +92,7 @@ const fixture = {
 };
 
 export default {
-  title: "panels/Rosout/index",
+  title: "panels/Rosout",
   component: Rosout,
 };
 

--- a/packages/studio-base/src/panels/SourceInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.stories.tsx
@@ -35,7 +35,7 @@ function PanelWithData() {
   );
 }
 
-storiesOf("panels/SourceInfo/index", module)
+storiesOf("panels/SourceInfo", module)
   .addParameters({
     chromatic: {
       delay: 1750,

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -93,7 +93,7 @@ const fixture = {
 };
 
 export default {
-  title: "panels/StateTransitions/index",
+  title: "panels/StateTransitions",
   component: StateTransitions,
   parameters: {
     chromatic: {

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -72,7 +72,7 @@ const manyTabs = new Array(25)
   .fill(1)
   .map((_elem, idx) => ({ title: `Tab #${idx + 1}`, layout: undefined }));
 const DEFAULT_TIMEOUT = 200;
-storiesOf("panels/Tab/index", module)
+storiesOf("panels/Tab", module)
   .addParameters({
     chromatic: {
       delay: 1000,

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -56,7 +56,7 @@ const fixture = {
   },
 };
 
-storiesOf("panels/Table/index", module)
+storiesOf("panels/Table", module)
   .add("no topic path", () => {
     return (
       <PanelSetup fixture={{ frame: {}, topics: [] }}>

--- a/packages/studio-base/src/panels/Teleop/index.stories.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.stories.tsx
@@ -11,7 +11,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import TeleopPanel from "./index";
 
 export default {
-  title: "panels/Teleop/index",
+  title: "panels/Teleop",
   component: TeleopPanel,
   decorators: [
     (StoryComponent: Story): JSX.Element => {

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -11,7 +11,7 @@ import delay from "@foxglove/studio-base/util/delay";
 import TopicGraph, { TopicVisibility } from "./index";
 
 export default {
-  title: "panels/TopicGraph/index",
+  title: "panels/TopicGraph",
   component: TopicGraph,
 };
 

--- a/packages/studio-base/src/panels/URDFViewer/index.stories.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.stories.tsx
@@ -13,7 +13,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { JointState } from "@foxglove/studio-base/types/Messages";
 
 export default {
-  title: "panels/URDFViewer/index",
+  title: "panels/URDFViewer",
   component: URDFViewer,
 };
 

--- a/packages/studio-base/src/panels/WelcomePanel/index.stories.tsx
+++ b/packages/studio-base/src/panels/WelcomePanel/index.stories.tsx
@@ -14,7 +14,7 @@ import SubscribeContext, { SubscribeNewsletterFn } from "./SubscribeContext";
 import WelcomePanel from "./index";
 
 export default {
-  title: "panels/WelcomePanel/index",
+  title: "panels/WelcomePanel",
   component: WelcomePanel,
 };
 


### PR DESCRIPTION
**User-Facing Changes**
None, internal only

**Description**
I'm not aware of any particular reason to keep `/index` in the name of any stories. It sometimes makes Chromatic hide the actual component name and display only "index".