### PR TITLE
Open account settings button in new window

### DIFF
--- a/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.tsx
@@ -76,7 +76,7 @@ export default function AccountInfo(props: { currentUser?: User }): JSX.Element 
             </Text>
           </Stack>
         </Stack>
-        <PrimaryButton href={process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL}>
+        <PrimaryButton href={process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL} target="_blank">
           Account settings
         </PrimaryButton>
       </Stack>


### PR DESCRIPTION
**User-Facing Changes**
Insignificant

**Description**
In the web build, open a new window rather than replacing the current window when visiting account settings.