### PR TITLE
Remove other source method from Raw Message panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -12,14 +12,12 @@
 //   You may not use this file except in compliance with the License.
 
 import { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
-import { SECOND_SOURCE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 
 // ts-prune-ignore-next
 export const fixture = {
   topics: [
     { name: "/msgs/big_topic", datatype: "msgs/big_topic" },
     { name: "/foo", datatype: "std_msgs/String" },
-    { name: `${SECOND_SOURCE_PREFIX}/foo`, datatype: "std_msgs/String" },
     { name: "/baz/num", datatype: "baz/num" },
     { name: "/baz/bigint", datatype: "baz/bigint" },
     { name: "/baz/text", datatype: "baz/text" },
@@ -69,17 +67,6 @@ export const fixture = {
         message: {
           some_array: ["a", "b", "c", "d", "e", "f"],
           some_id_example_2: { some_id: 123 },
-        },
-      },
-    ],
-    [`${SECOND_SOURCE_PREFIX}/foo`]: [
-      {
-        topic: `${SECOND_SOURCE_PREFIX}/foo`,
-        receiveTime: { sec: 123, nsec: 456789011 },
-        message: {
-          some_array: ["a", "f", "n", "o", "p"],
-          some_deleted_key: "BYE",
-          some_id_example_2: { some_id: 567 },
         },
       },
     ],

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -13,12 +13,8 @@
 
 import { storiesOf } from "@storybook/react";
 
-import RawMessages, {
-  PREV_MSG_METHOD,
-  OTHER_SOURCE_METHOD,
-} from "@foxglove/studio-base/panels/RawMessages";
+import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
-import { SECOND_SOURCE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 
 import {
   fixture,
@@ -261,51 +257,6 @@ storiesOf("panels/RawMessages", module)
             diffMethod: PREV_MSG_METHOD,
             diffTopicPath: "/another/baz/enum_advanced",
             diffEnabled: false,
-            showFullMessageForDiff: true,
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("diff messages from different sources", () => {
-    return (
-      <PanelSetup fixture={fixture} style={{ width: 380 }} onMount={expandAll}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/foo",
-            diffMethod: OTHER_SOURCE_METHOD,
-            diffTopicPath: "",
-            diffEnabled: true,
-            showFullMessageForDiff: true,
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("diff messages from different sources when base topic is from second source", () => {
-    return (
-      <PanelSetup fixture={fixture} style={{ width: 380 }} onMount={expandAll}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: `${SECOND_SOURCE_PREFIX}/foo`,
-            diffMethod: OTHER_SOURCE_METHOD,
-            diffTopicPath: "",
-            diffEnabled: true,
-            showFullMessageForDiff: true,
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display empty state if second source is not available", () => {
-    return (
-      <PanelSetup fixture={fixture} style={{ width: 380 }} onMount={expandAll}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/baz/text",
-            diffMethod: OTHER_SOURCE_METHOD,
-            diffTopicPath: "/foo",
-            diffEnabled: true,
             showFullMessageForDiff: true,
           }}
         />

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -55,7 +55,7 @@ import getDiff, {
   DiffObject,
 } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 import { Topic } from "@foxglove/studio-base/players/types";
-import { useJsonTreeTheme, SECOND_SOURCE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
+import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/selectors";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -73,10 +73,9 @@ import { DATA_ARRAY_PREVIEW_LIMIT, getItemStringForDiff } from "./utils";
 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
-export const OTHER_SOURCE_METHOD = "other source";
 export type RawMessagesConfig = {
   topicPath: string;
-  diffMethod: "custom" | "previous message" | "other source";
+  diffMethod: "custom" | "previous message";
   diffTopicPath: string;
   diffEnabled: boolean;
   showFullMessageForDiff: boolean;
@@ -180,13 +179,7 @@ function RawMessages(props: Props) {
     useLatestMessageDataItem(topicPath),
   ];
 
-  const otherSourceTopic = topicName.startsWith(SECOND_SOURCE_PREFIX)
-    ? topicName.replace(SECOND_SOURCE_PREFIX, "")
-    : `${SECOND_SOURCE_PREFIX}${topicName}`;
-  const inOtherSourceDiffMode = diffEnabled && diffMethod === OTHER_SOURCE_METHOD;
-  const diffTopicObj = useLatestMessageDataItem(
-    diffEnabled ? (inOtherSourceDiffMode ? otherSourceTopic : diffTopicPath) : "",
-  );
+  const diffTopicObj = useLatestMessageDataItem(diffEnabled ? diffTopicPath : "");
 
   const inTimetickDiffMode = diffEnabled && diffMethod === PREV_MSG_METHOD;
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
@@ -354,11 +347,6 @@ function RawMessages(props: Props) {
     if (diffEnabled && diffMethod === CUSTOM_METHOD && (!baseItem || !diffItem)) {
       return (
         <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>
-      );
-    }
-    if (diffEnabled && diffMethod === OTHER_SOURCE_METHOD && (!baseItem || !diffItem)) {
-      return (
-        <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${otherSourceTopic}"`}</EmptyState>
       );
     }
     if (!baseItem) {
@@ -573,7 +561,6 @@ function RawMessages(props: Props) {
     jsonTreeTheme,
     expandedFields,
     diffTopicPath,
-    otherSourceTopic,
     saveConfig,
     onLabelClick,
     valueRenderer,
@@ -616,9 +603,6 @@ function RawMessages(props: Props) {
                   >
                     <DropdownItem value={PREV_MSG_METHOD}>
                       <span>{PREV_MSG_METHOD}</span>
-                    </DropdownItem>
-                    <DropdownItem value={OTHER_SOURCE_METHOD}>
-                      <span>{OTHER_SOURCE_METHOD}</span>
                     </DropdownItem>
                     <DropdownItem value={CUSTOM_METHOD}>
                       <span>custom</span>


### PR DESCRIPTION
**User-Facing Changes**
Users can no longer select "other source" for the diff mode in Raw Messages panel.

I've added a _docs_ label but I'm not actually sure this change needs a docs update as it may not have been documented.

**Description**
We recently removed support for loading multiple ros1 bag files as the feature was not documented and not well supported across the app. Additionally no other data source behaved in the same way as ros1 bags when loading multiple files.
    
This change removes "other source" handling from RawMessage panel since there is only one source now.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
