### PR TITLE
Rename "ROS" time display method to "SEC" (Seconds), default new layouts to "TOD" (Time of Day)

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -26,6 +26,7 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import {
   formatDate,
   formatTime,
@@ -52,18 +53,19 @@ const PlaybackTimeDisplayMethod = ({
   isPlaying: boolean;
 }): JSX.Element => {
   const timestampInputRef = useRef<HTMLInputElement>(ReactNull);
-  const timeDisplayMethod = useCurrentLayoutSelector(
-    (state) => state.selectedLayout?.data?.playbackConfig.timeDisplayMethod ?? "ROS",
-  );
+  const timeDisplayMethod: TimeDisplayMethod = useCurrentLayoutSelector((state) => {
+    const method = state.selectedLayout?.data?.playbackConfig.timeDisplayMethod ?? "TOD";
+    return method === "TOD" ? "TOD" : "SEC";
+  });
   const { setPlaybackConfig } = useCurrentLayoutActions();
   const setTimeDisplayMethod = useCallback(
-    (newTimeDisplayMethod: "ROS" | "TOD") =>
+    (newTimeDisplayMethod: TimeDisplayMethod) =>
       setPlaybackConfig({ timeDisplayMethod: newTimeDisplayMethod }),
     [setPlaybackConfig],
   );
   const currentTimeString = useMemo(() => {
     if (currentTime) {
-      return timeDisplayMethod === "ROS"
+      return timeDisplayMethod === "SEC"
         ? formatTimeRaw(currentTime)
         : formatTime(currentTime, timezone);
     }
@@ -222,10 +224,10 @@ const PlaybackTimeDisplayMethod = ({
             },
             {
               canCheck: true,
-              key: "ROS",
-              text: "ROS time",
-              isChecked: timeDisplayMethod === "ROS",
-              onClick: () => setTimeDisplayMethod("ROS"),
+              key: "SEC",
+              text: "Seconds",
+              isChecked: timeDisplayMethod === "SEC",
+              onClick: () => setTimeDisplayMethod("SEC"),
             },
           ],
         }}

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -131,7 +131,7 @@ export default function Scrubber(props: Props): JSX.Element {
       const timeFromStart = subtractTimes(stamp, latestStartTime.current);
 
       const tooltipItems = [
-        { title: "ROS", value: formatTimeRaw(stamp) },
+        { title: "SEC", value: formatTimeRaw(stamp) },
         { title: "Time", value: formatTime(stamp) },
         { title: "Elapsed", value: `${toSec(timeFromStart).toFixed(9)} sec` },
       ];

--- a/packages/studio-base/src/layouts/welcomeLayout.ts
+++ b/packages/studio-base/src/layouts/welcomeLayout.ts
@@ -164,7 +164,7 @@ const data: PanelsState = {
   playbackConfig: {
     speed: 1,
     messageOrder: "receiveTime",
-    timeDisplayMethod: "ROS",
+    timeDisplayMethod: "TOD",
   },
 };
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -30,7 +30,7 @@ const TEST_LAYOUT: PanelsState = {
   playbackConfig: {
     speed: 0.2,
     messageOrder: "receiveTime",
-    timeDisplayMethod: "ROS",
+    timeDisplayMethod: "SEC",
   },
 };
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -70,7 +70,7 @@ import {
 export const defaultPlaybackConfig: PlaybackConfig = {
   speed: 1.0,
   messageOrder: "receiveTime",
-  timeDisplayMethod: "ROS",
+  timeDisplayMethod: "TOD",
 };
 
 function changePanelLayout(

--- a/packages/studio-base/src/types/panels.ts
+++ b/packages/studio-base/src/types/panels.ts
@@ -26,10 +26,12 @@ export type PanelConfig = {
   [key: string]: unknown;
 };
 
+export type TimeDisplayMethod = "SEC" | "TOD";
+
 export type PlaybackConfig = {
   speed: number;
   messageOrder: TimestampMethod;
-  timeDisplayMethod: "ROS" | "TOD";
+  timeDisplayMethod: TimeDisplayMethod;
 };
 
 export type UserNode = { name: string; sourceCode: string };

--- a/packages/studio-base/src/util/formatTime.test.ts
+++ b/packages/studio-base/src/util/formatTime.test.ts
@@ -132,7 +132,7 @@ describe("formatTime.getValidatedTimeAndMethodFromString", () => {
       }),
     ).toEqual({
       time: { nsec: 0, sec: 1598635994 },
-      method: "ROS",
+      method: "SEC",
     });
     expect(
       formatTime.getValidatedTimeAndMethodFromString({ ...commonArgs, text: "1:30:10.000 PM PST" }),

--- a/packages/studio-base/src/util/formatTime.ts
+++ b/packages/studio-base/src/util/formatTime.ts
@@ -15,6 +15,7 @@ import momentDurationFormatSetup from "moment-duration-format";
 import moment from "moment-timezone";
 
 import { Time, toDate, fromDate } from "@foxglove/rostime";
+import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 
 import parseFuzzyRosTime from "./parseFuzzyRosTime";
 
@@ -77,19 +78,19 @@ export const getValidatedTimeAndMethodFromString = ({
   text?: string;
   date: string;
   timezone?: string;
-}): { time?: Time; method: "ROS" | "TOD" } | undefined => {
+}): { time?: Time; method: TimeDisplayMethod } | undefined => {
   if (text == undefined || text === "") {
     return;
   }
-  const isInvalidRosTime = isNaN(+text);
+  const isInvalidRawTime = isNaN(+text);
   const isInvalidTodTime = !(todTimeRegex.test(text) && parseTimeStr(`${date} ${text}`, timezone));
 
-  if (isInvalidRosTime && isInvalidTodTime) {
+  if (isInvalidRawTime && isInvalidTodTime) {
     return;
   }
 
   return {
-    time: !isInvalidRosTime ? parseFuzzyRosTime(text) : parseTimeStr(`${date} ${text}`, timezone),
-    method: isInvalidRosTime ? "TOD" : "ROS",
+    time: !isInvalidRawTime ? parseFuzzyRosTime(text) : parseTimeStr(`${date} ${text}`, timezone),
+    method: isInvalidRawTime ? "TOD" : "SEC",
   };
 };


### PR DESCRIPTION
**User-facing changes**

The "ROS (ROS time)" text in the playback bar dropdown has been changed to "SEC (Seconds)" to provide additional clarity, especially for non-ROS users. New layouts will default to showing "TOD (Time of Day)" for improved readability in the default experience.