### PR TITLE
Remove "TOD" / "SEC" label from playback bar, show actual time representations in dropdown

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -63,14 +63,18 @@ const PlaybackTimeDisplayMethod = ({
       setPlaybackConfig({ timeDisplayMethod: newTimeDisplayMethod }),
     [setPlaybackConfig],
   );
-  const currentTimeString = useMemo(() => {
-    if (currentTime) {
-      return timeDisplayMethod === "SEC"
-        ? formatTimeRaw(currentTime)
-        : formatTime(currentTime, timezone);
-    }
-    return undefined;
-  }, [currentTime, timeDisplayMethod, timezone]);
+  const timeRawString = useMemo(
+    () => (currentTime ? formatTimeRaw(currentTime) : undefined),
+    [currentTime],
+  );
+  const timeOfDayString = useMemo(
+    () => (currentTime ? formatTime(currentTime, timezone) : undefined),
+    [currentTime, timezone],
+  );
+  const currentTimeString = useMemo(
+    () => (timeDisplayMethod === "SEC" ? timeRawString : timeOfDayString),
+    [timeRawString, timeOfDayString, timeDisplayMethod],
+  );
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [inputText, setInputText] = useState<string | undefined>(currentTimeString ?? undefined);
   const [hasError, setHasError] = useState<boolean>(false);
@@ -84,6 +88,7 @@ const PlaybackTimeDisplayMethod = ({
         },
         field: {
           margin: 0,
+          padding: 0,
           whiteSpace: "nowrap",
           fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
           backgroundColor: "transparent",
@@ -99,6 +104,7 @@ const PlaybackTimeDisplayMethod = ({
         fieldGroup: {
           border: "none",
           backgroundColor: "transparent",
+          width: "102%",
         },
         icon: {
           height: 20,
@@ -218,14 +224,14 @@ const PlaybackTimeDisplayMethod = ({
             {
               canCheck: true,
               key: "TOD",
-              text: "Time of day (TOD)",
+              text: timeOfDayString ? timeOfDayString : "Time of Day",
               isChecked: timeDisplayMethod === "TOD",
               onClick: () => setTimeDisplayMethod("TOD"),
             },
             {
               canCheck: true,
               key: "SEC",
-              text: "Seconds",
+              text: timeRawString ? timeRawString : "Seconds",
               isChecked: timeDisplayMethod === "SEC",
               onClick: () => setTimeDisplayMethod("SEC"),
             },
@@ -235,8 +241,8 @@ const PlaybackTimeDisplayMethod = ({
           root: {
             border: "none",
             background: theme.semanticColors.buttonBackgroundHovered,
-            padding: theme.spacing.s1,
-            minWidth: "50px",
+            padding: 0,
+            minWidth: "24px",
           },
           rootHovered: {
             background: theme.semanticColors.buttonBackgroundPressed,
@@ -246,9 +252,7 @@ const PlaybackTimeDisplayMethod = ({
             fontSize: theme.fonts.tiny.fontSize,
           },
         }}
-      >
-        {timeDisplayMethod}
-      </DefaultButton>
+      ></DefaultButton>
     </Stack>
   );
 };

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -104,6 +104,8 @@ const PlaybackTimeDisplayMethod = ({
         fieldGroup: {
           border: "none",
           backgroundColor: "transparent",
+          // The flex-sizing does not correctly calculate the <input> field width for all font
+          // sizes, so we increase the width to compensate
           width: "102%",
         },
         icon: {

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -112,7 +112,6 @@ export default function PlaybackControls(): JSX.Element {
   const iconButtonStyles: IButtonStyles = {
     icon: { height: 20 },
     root: {
-      margin: 0, // Remove this when global.scss goes away
       color: theme.semanticColors.buttonText,
     },
     rootChecked: {


### PR DESCRIPTION
**User-facing changes**

The "TOD" and "SEC" (previously "ROS") labels have been removed from the playback controls. The dropdown menu items now also show the actual representative time strings instead of descriptions, unless there is no open data source.

<img width="912" alt="Screen Shot 2021-11-05 at 5 00 04 PM" src="https://user-images.githubusercontent.com/195374/140590609-8b301d0a-7940-48e0-8052-e900ebe136bb.png">
