### PR TITLE
Add setting and theme-based default for 3D panel background color

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -33,7 +33,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "workspace:*",
-    "@foxglove/regl-worldview": "1.0.0",
+    "@foxglove/regl-worldview": "1.0.1",
     "@foxglove/ros1": "1.3.4",
     "@foxglove/ros2": "1.0.5",
     "@foxglove/rosbag": "0.1.2",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { mergeStyleSets } from "@fluentui/react";
+import { mergeStyleSets, useTheme } from "@fluentui/react";
 import { groupBy } from "lodash";
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
@@ -228,6 +228,8 @@ export default function Layout({
     settingsByKey,
     colorOverrideBySourceIdxByVariable,
     disableAutoOpenClickedObject = false,
+    useThemeBackgroundColor,
+    customBackgroundColor,
   },
 }: Props): React.ReactElement {
   const [filterText, setFilterText] = useState(""); // Topic tree text for filtering to see certain topics.
@@ -780,6 +782,11 @@ export default function Layout({
     refreshMode: "debounce",
   });
 
+  const theme = useTheme();
+  const canvasBackgroundColor = useThemeBackgroundColor
+    ? theme.palette.neutralLight
+    : customBackgroundColor;
+
   return (
     <ThreeDimensionalVizContext.Provider value={threeDimensionalVizContextValue}>
       <TopicTreeContext.Provider value={topicTreeData}>
@@ -848,6 +855,7 @@ export default function Layout({
           <div className={styles.world}>
             <World
               key={`${callbackInputsRef.current.autoSyncCameraState ? "synced" : "not-synced"}`}
+              canvasBackgroundColor={canvasBackgroundColor}
               autoTextBackgroundColor={autoTextBackgroundColor}
               cameraState={cameraState}
               isPlaying={isPlaying}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -784,7 +784,9 @@ export default function Layout({
 
   const theme = useTheme();
   const canvasBackgroundColor = useThemeBackgroundColor
-    ? theme.palette.neutralLight
+    ? theme.isInverted
+      ? "#000000"
+      : "#303030"
     : customBackgroundColor;
 
   return (

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -11,7 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { forwardRef } from "react";
+import { getColorFromString } from "@fluentui/react";
+import { forwardRef, useMemo } from "react";
 
 import {
   Worldview,
@@ -50,6 +51,7 @@ import { MarkerCollector, MarkerProvider } from "@foxglove/studio-base/types/Sce
 
 type Props = WorldSearchTextProps & {
   autoTextBackgroundColor: boolean;
+  canvasBackgroundColor: string;
   cameraState: CameraState;
   children?: React.ReactNode;
   isPlaying: boolean;
@@ -128,6 +130,7 @@ function World(
   {
     onClick,
     autoTextBackgroundColor,
+    canvasBackgroundColor,
     children,
     onCameraStateChange,
     diffModeEnabled,
@@ -161,8 +164,14 @@ function World(
     }),
   };
 
+  const backgroundColor = useMemo(() => {
+    const { r, g, b, a } = getColorFromString(canvasBackgroundColor) ?? { r: 0, g: 0, b: 0, a: 1 };
+    return [r / 255, g / 255, b / 255, (a ?? 100) / 100];
+  }, [canvasBackgroundColor]);
+
   return (
     <Worldview
+      backgroundColor={backgroundColor}
       cameraState={cameraState}
       enableStackedObjectEvents={!isPlaying}
       hideDebug={inScreenshotTests()}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import ThreeDimensionalViz from "./index";
+
+export default {
+  title: "panels/ThreeDimensionalViz",
+  component: ThreeDimensionalViz,
+};
+
+export function Default(): JSX.Element {
+  return (
+    <PanelSetup>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          customBackgroundColor: "#2d7566",
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+export function CustomBackgroundColor(): JSX.Element {
+  return (
+    <PanelSetup>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          useThemeBackgroundColor: false,
+          customBackgroundColor: "#2d7566",
+        }}
+      />
+    </PanelSetup>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -208,6 +208,12 @@ const configSchema: PanelConfigSchema<ThreeDimensionalVizConfig> = [
     type: "toggle",
     title: "Automatically apply dark/light background color to text",
   },
+  {
+    key: "useThemeBackgroundColor",
+    type: "toggle",
+    title: "Automatically determine background color based on the color scheme",
+  },
+  { key: "customBackgroundColor", type: "color", title: "Background color" },
 ];
 
 BaseRenderer.displayName = "ThreeDimensionalViz";
@@ -224,6 +230,8 @@ BaseRenderer.defaultConfig = {
   autoSyncCameraState: false,
   autoTextBackgroundColor: true,
   diffModeEnabled: true,
+  useThemeBackgroundColor: true,
+  customBackgroundColor: "#000000",
 } as ThreeDimensionalVizConfig;
 BaseRenderer.supportsStrictMode = false;
 BaseRenderer.configSchema = configSchema;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -17,6 +17,8 @@ import { ColorOverrideBySourceIdxByVariable } from "@foxglove/studio-base/panels
 import { TopicDisplayMode } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/types";
 
 export type ThreeDimensionalVizConfig = {
+  useThemeBackgroundColor: boolean;
+  customBackgroundColor: string;
   enableShortDisplayNames?: boolean;
   autoTextBackgroundColor?: boolean;
   cameraState: Partial<CameraState>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,9 +2173,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@foxglove/regl-worldview@npm:1.0.0"
+"@foxglove/regl-worldview@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@foxglove/regl-worldview@npm:1.0.1"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2193,7 +2193,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: 980a41e146eb7b5a3069eee15ccdadfba2ad5b45709781791c5b642419352b8109a35e0ffb3cf823904eebffbd01324973ad73a11414765c23c1ba60d1a9c97c
+  checksum: 32d3bbfc3bf94f301e20522214f5e4f28ff422da2d1ce7af58ef3f3b9d24f3f50fd9650f2df03263f9c8b0a7b741f4860afe90c05050449c7850ccd8e7c88e03
   languageName: node
   linkType: hard
 
@@ -2332,7 +2332,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "workspace:*"
-    "@foxglove/regl-worldview": 1.0.0
+    "@foxglove/regl-worldview": 1.0.1
     "@foxglove/ros1": 1.3.4
     "@foxglove/ros2": 1.0.5
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
Added a setting to the 3D panel to choose the background color. By default, the background color will be based on which color scheme is used in Studio.

Fixes https://github.com/foxglove/studio/issues/2093

<img width="925" alt="image" src="https://user-images.githubusercontent.com/14237/140802578-ea0742e5-80bf-4021-a2da-7cd9428ac503.png">
<img width="925" alt="image" src="https://user-images.githubusercontent.com/14237/140802888-3a2a2b8d-f164-4540-940e-2ae869f120ff.png">
<img width="925" alt="image" src="https://user-images.githubusercontent.com/14237/140802591-0115b9ea-6b10-4fb8-977a-8a576aa70d28.png">
