### PR TITLE
Fix selected panel outline disappearing when theme changes

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -130,8 +130,9 @@ const useStyles = makeStyles((theme) => ({
   },
   rootSelected: {
     ":after": {
-      opacity: 1,
-      transition: "opacity 0.05s ease-out",
+      // https://github.com/microsoft/fluentui/issues/20452
+      opacity: "1 !important",
+      transition: "opacity 0.05s ease-out !important",
     },
   },
   actionsOverlay: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Due to https://github.com/microsoft/fluentui/issues/20452, changing the theme causes the base rules (with `opacity: 0`) to be moved after the rules that are supposed to override them, so we need to manually bump up the precedence.