### PR TITLE
Open an unknown panel when a sibling panel type cannot be found

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -41,6 +41,7 @@ import {
   updateTree,
   MosaicNode,
 } from "react-mosaic-component";
+import { useToasts } from "react-toast-notifications";
 import { useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -313,6 +314,7 @@ export default function Panel<
     const classes = useStyles();
     const theme = useTheme();
     const isMounted = useMountedState();
+    const { addToast } = useToasts();
 
     const { mosaicActions } = useContext(MosaicContext);
     const { mosaicWindowActions }: { mosaicWindowActions: MosaicWindowActions } =
@@ -386,6 +388,9 @@ export default function Panel<
         }
         const siblingPanel = panelCatalog.getPanelByType(panelType);
         if (!siblingPanel) {
+          addToast(`Unknown panel type: ${panelType}`, {
+            appearance: "error",
+          });
           return;
         }
 

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -384,34 +384,20 @@ export default function Panel<
         if (!panelsState) {
           return;
         }
-        const siblingPanel = panelCatalog.getPanelByType(panelType);
-        // No panel exists for the requested panel type.
-        // Make a panel anyway to show an unknown panel placeholder to inform the user.
-        if (!siblingPanel) {
-          const ownPath = mosaicWindowActions.getPath();
-          const newPanelPath = ownPath.concat("second");
-          void mosaicWindowActions.split({ type: panelType }).then(() => {
-            const newPanelId = getNodeAtPath(mosaicActions.getRoot(), newPanelPath) as string;
-            savePanelConfigs({
-              configs: [
-                {
-                  id: newPanelId,
-                  config: {},
-                  defaultConfig: {},
-                },
-              ],
-            });
-          });
-          return;
-        }
-
-        const siblingModule = await siblingPanel.module();
-        if (!isMounted()) {
-          return;
-        }
-
-        const siblingDefaultConfig = siblingModule.default.defaultConfig;
         const ownPath = mosaicWindowActions.getPath();
+
+        let siblingDefaultConfig: PanelConfig = {};
+
+        const siblingPanelInfo = panelCatalog.getPanelByType(panelType);
+        // If we can lookup the sibling panel type, try to load the default config from the panel module
+        if (siblingPanelInfo) {
+          const siblingModule = await siblingPanelInfo.module();
+          if (!isMounted()) {
+            return;
+          }
+
+          siblingDefaultConfig = siblingModule.default.defaultConfig;
+        }
 
         // Try to find a sibling panel and update it with the `siblingConfig`
         if (updateIfExists) {

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -384,12 +384,11 @@ export default function Panel<
         if (!panelsState) {
           return;
         }
-        const ownPath = mosaicWindowActions.getPath();
 
         let siblingDefaultConfig: PanelConfig = {};
 
-        const siblingPanelInfo = panelCatalog.getPanelByType(panelType);
         // If we can lookup the sibling panel type, try to load the default config from the panel module
+        const siblingPanelInfo = panelCatalog.getPanelByType(panelType);
         if (siblingPanelInfo) {
           const siblingModule = await siblingPanelInfo.module();
           if (!isMounted()) {
@@ -398,6 +397,8 @@ export default function Panel<
 
           siblingDefaultConfig = siblingModule.default.defaultConfig;
         }
+
+        const ownPath = mosaicWindowActions.getPath();
 
         // Try to find a sibling panel and update it with the `siblingConfig`
         if (updateIfExists) {

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -41,7 +41,6 @@ import {
   updateTree,
   MosaicNode,
 } from "react-mosaic-component";
-import { useToasts } from "react-toast-notifications";
 import { useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -314,7 +313,6 @@ export default function Panel<
     const classes = useStyles();
     const theme = useTheme();
     const isMounted = useMountedState();
-    const { addToast } = useToasts();
 
     const { mosaicActions } = useContext(MosaicContext);
     const { mosaicWindowActions }: { mosaicWindowActions: MosaicWindowActions } =
@@ -387,9 +385,22 @@ export default function Panel<
           return;
         }
         const siblingPanel = panelCatalog.getPanelByType(panelType);
+        // No panel exists for the requested panel type.
+        // Make a panel anyway to show an unknown panel placeholder to inform the user.
         if (!siblingPanel) {
-          addToast(`Unknown panel type: ${panelType}`, {
-            appearance: "error",
+          const ownPath = mosaicWindowActions.getPath();
+          const newPanelPath = ownPath.concat("second");
+          void mosaicWindowActions.split({ type: panelType }).then(() => {
+            const newPanelId = getNodeAtPath(mosaicActions.getRoot(), newPanelPath) as string;
+            savePanelConfigs({
+              configs: [
+                {
+                  id: newPanelId,
+                  config: {},
+                  defaultConfig: {},
+                },
+              ],
+            });
           });
           return;
         }


### PR DESCRIPTION
**User-Facing Changes**
When the user takes an action that might open a new sibling panel, but that panel type does not exist, the newly opened sibling panel will say "Unknown panel type: ...".

**Description**
Rather than fail silently to open a panel via the openSiblingPanel api, the new panel is opened with the requested type. If there is no panel of the type in the panel catalog, the new panel falls back to the "Unknown panel type" empty state.

Fixes: #2058


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
