### PR TITLE
Add Turbo colormap in addition to Rainbow for point clouds

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/turboColor.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/turboColor.ts
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type Vec4 = [number, number, number, number];
+type Vec3 = [number, number, number];
+type Vec2 = [number, number];
+
+function dot4(a: Vec4, b: Vec4): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
+}
+
+function dot2(a: Vec2, b: Vec2): number {
+  return a[0] * b[0] + a[1] * b[1];
+}
+
+export function turboColor(pct: number): Vec3 {
+  const kRedVec4: Vec4 = [0.13572138, 4.6153926, -42.66032258, 132.13108234];
+  const kGreenVec4: Vec4 = [0.09140261, 2.19418839, 4.84296658, -14.18503333];
+  const kBlueVec4: Vec4 = [0.1066733, 12.64194608, -60.58204836, 110.36276771];
+  const kRedVec2: Vec2 = [-152.94239396, 59.28637943];
+  const kGreenVec2: Vec2 = [4.27729857, 2.82956604];
+  const kBlueVec2: Vec2 = [-89.90310912, 27.34824973];
+
+  const x = pct;
+  const v4: Vec4 = [1.0, x, x * x, x * x * x];
+  const v2: Vec2 = [v4[2] * v4[2], v4[3] * v4[2]];
+  return [
+    255.0 * (dot4(v4, kRedVec4) + dot2(v2, kRedVec2)),
+    255.0 * (dot4(v4, kGreenVec4) + dot2(v2, kGreenVec2)),
+    255.0 * (dot4(v4, kBlueVec4) + dot2(v2, kBlueVec2)),
+  ];
+}
+
+export function turboColorString(pct: number): string {
+  const rgb = turboColor(pct);
+  return `rgb(${Math.round(rgb[0])}, ${Math.round(rgb[1])}, ${Math.round(rgb[2])})`;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker.ts
@@ -95,7 +95,11 @@ export function decodeMarker(marker: PointCloudMarker): DecodedMarker {
   // Unfortunately, we cannot do this in GPU and we need to traverse the color array to
   // fetch the required values.
   // These calculations can be ignored if we're rendering to the hitmap
-  if (colorBuffer && !isHitmap && (colorMode.mode === "gradient" || colorMode.mode === "rainbow")) {
+  if (
+    colorBuffer &&
+    !isHitmap &&
+    (colorMode.mode === "gradient" || colorMode.mode === "rainbow" || colorMode.mode === "turbo")
+  ) {
     let hasMinValue = false;
     if (colorMode.minValue != undefined) {
       hasMinValue = true;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -43,11 +43,12 @@ const COLOR_MODE_RGB = 1;
 const COLOR_MODE_BGR = -1;
 const COLOR_MODE_GRADIENT = 2;
 const COLOR_MODE_RAINBOW = 3;
+const COLOR_MODE_TURBO = 4;
 
 type Uniforms = {
   pointSize: number;
   isCircle: boolean;
-  colorMode: 2 | 3 | 1 | -1 | 0;
+  colorMode: 2 | 3 | 4 | 1 | -1 | 0;
   flatColor: [number, number, number, number];
   minGradientColor: [number, number, number, number];
   maxGradientColor: [number, number, number, number];
@@ -125,6 +126,25 @@ vec3 rainbowColor() {
   return 255.0 * ret;
 }
 
+// adapted from https://gist.github.com/mikhailov-work/0d177465a8151eb6ede1768d51d476c7
+vec3 turboColor() {
+  const vec4 kRedVec4 = vec4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
+  const vec4 kGreenVec4 = vec4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
+  const vec4 kBlueVec4 = vec4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
+  const vec2 kRedVec2 = vec2(-152.94239396, 59.28637943);
+  const vec2 kGreenVec2 = vec2(4.27729857, 2.82956604);
+  const vec2 kBlueVec2 = vec2(-89.90310912, 27.34824973);
+
+  float x = clamp(getFieldValue_UNORM(), 0.0, 1.0);
+  vec4 v4 = vec4(1.0, x, x * x, x * x * x);
+  vec2 v2 = v4.zw * v4.z;
+  return vec3(
+    255.0 * (dot(v4, kRedVec4)   + dot(v2, kRedVec2)),
+    255.0 * (dot(v4, kGreenVec4) + dot(v2, kGreenVec2)),
+    255.0 * (dot(v4, kBlueVec4)  + dot(v2, kBlueVec2))
+  );
+}
+
 void main () {
   gl_PointSize = pointSize;
   vec3 p = applyPose(position);
@@ -134,6 +154,8 @@ void main () {
     fragColor = gradientColor();
   } else if (colorMode == ${COLOR_MODE_RAINBOW}) {
     fragColor = rainbowColor();
+  } else if (colorMode == ${COLOR_MODE_TURBO}) {
+    fragColor = turboColor();
   } else {
     fragColor = flatColor.rgb;
   }
@@ -208,6 +230,8 @@ function getEffectiveColorMode(props: DecodedMarker) {
     return COLOR_MODE_GRADIENT;
   } else if (colorMode.mode === "rainbow") {
     return COLOR_MODE_RAINBOW;
+  } else if (colorMode.mode === "turbo") {
+    return COLOR_MODE_TURBO;
   }
   return is_bigendian ? COLOR_MODE_RGB : COLOR_MODE_BGR;
 }


### PR DESCRIPTION
**User-Facing Changes**

A new gradient option has been added for coloring point clouds [Turbo](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html).

Point cloud field names "intensity" or "i" are preferentially auto-selected for gradient coloring.

<img width="1282" alt="Screen Shot 2021-11-08 at 5 16 14 PM" src="https://user-images.githubusercontent.com/195374/140843821-9764cdd8-7fa5-4e4f-8934-6ae7bc7914bf.png">

<img width="1282" alt="Screen Shot 2021-11-08 at 5 35 15 PM" src="https://user-images.githubusercontent.com/195374/140845605-a67ad67b-ac18-4f5f-aba5-9bdc35bfbe86.png">