### PR TITLE
Update some custom component borderRadius to match Fluent

### DIFF
--- a/packages/studio-base/src/components/Dropdown/index.tsx
+++ b/packages/studio-base/src/components/Dropdown/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { mergeStyleSets } from "@fluentui/merge-styles";
+import { mergeStyleSets } from "@fluentui/react";
 import ChevronDownIcon from "@mdi/svg/svg/chevron-down.svg";
 import cx from "classnames";
 import { ReactNode, CSSProperties, ReactElement } from "react";

--- a/packages/studio-base/src/components/Dropdown/index.tsx
+++ b/packages/studio-base/src/components/Dropdown/index.tsx
@@ -155,7 +155,7 @@ export default class Dropdown<T> extends React.Component<Props<T>, State> {
       borderTopRightRadius: flatEdges && position !== "above" ? "0" : undefined,
       borderBottomLeftRadius: flatEdges && position === "above" ? "0" : undefined,
       borderBottomRightRadius: flatEdges && position === "above" ? "0" : undefined,
-      ...(position === "above" ? { marginBottom: 4, borderRadius: 4 } : {}),
+      ...(position === "above" ? { marginBottom: 4, borderRadius: 2 } : {}),
       ...menuStyle,
     };
     return (

--- a/packages/studio-base/src/components/Dropdown/index.tsx
+++ b/packages/studio-base/src/components/Dropdown/index.tsx
@@ -155,7 +155,7 @@ export default class Dropdown<T> extends React.Component<Props<T>, State> {
       borderTopRightRadius: flatEdges && position !== "above" ? "0" : undefined,
       borderBottomLeftRadius: flatEdges && position === "above" ? "0" : undefined,
       borderBottomRightRadius: flatEdges && position === "above" ? "0" : undefined,
-      ...(position === "above" ? { marginBottom: 4, borderRadius: 2 } : {}),
+      ...(position === "above" ? { marginBottom: 4, borderRadius: 4 } : {}),
       ...menuStyle,
     };
     return (

--- a/packages/studio-base/src/components/LegacyStyledComponents.tsx
+++ b/packages/studio-base/src/components/LegacyStyledComponents.tsx
@@ -11,7 +11,7 @@ import { fonts, spacing } from "@foxglove/studio-base/util/sharedStyleConstants"
  */
 export const LegacyButton = styled.button`
   background-color: ${({ theme }) => theme.palette.neutralLighter};
-  border-radius: 4px;
+  border-radius: 2px;
   border: none;
   color: ${({ theme }) => theme.semanticColors.buttonText};
   font: inherit;

--- a/packages/studio-base/src/components/LegacyStyledComponents.tsx
+++ b/packages/studio-base/src/components/LegacyStyledComponents.tsx
@@ -11,7 +11,7 @@ import { fonts, spacing } from "@foxglove/studio-base/util/sharedStyleConstants"
  */
 export const LegacyButton = styled.button`
   background-color: ${({ theme }) => theme.palette.neutralLighter};
-  border-radius: 2px;
+  border-radius: ${({ theme }) => theme.effects.roundedCorner2};
   border: none;
   color: ${({ theme }) => theme.semanticColors.buttonText};
   font: inherit;
@@ -63,7 +63,7 @@ export const LegacyButton = styled.button`
  */
 export const LegacyInput = styled.input`
   background-color: ${({ theme }) => theme.palette.neutralLighter};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.effects.roundedCorner2};
   border: none;
   color: ${({ theme }) => theme.semanticColors.inputText};
   font: inherit;
@@ -89,7 +89,7 @@ export const LegacyInput = styled.input`
  */
 export const LegacyTextarea = styled.textarea`
   background-color: ${({ theme }) => theme.semanticColors.inputBackground};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.effects.roundedCorner2};
   border: 2px solid ${({ theme }) => theme.semanticColors.inputBorder};
   color: ${({ theme }) => theme.semanticColors.inputText};
   font: inherit;
@@ -114,7 +114,7 @@ export const LegacyTextarea = styled.textarea`
  */
 export const LegacySelect = styled.select`
   background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.effects.roundedCorner2};
   border: none;
   color: ${({ theme }) => theme.semanticColors.inputText};
   font: inherit;

--- a/packages/studio-base/src/components/Menu/ExpandableMenu.tsx
+++ b/packages/studio-base/src/components/Menu/ExpandableMenu.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { mergeStyleSets } from "@fluentui/merge-styles";
+import { mergeStyleSets } from "@fluentui/react";
 import ChevronDownIcon from "@mdi/svg/svg/chevron-down.svg";
 import ChevronUpIcon from "@mdi/svg/svg/chevron-up.svg";
 import { ReactNode } from "react";

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
       },
       "&:not(.hasChildren) > *": {
         backgroundColor: theme.palette.neutralLighterAlt,
-        borderRadius: 4,
+        borderRadius: 2,
         boxShadow: theme.effects.elevation16,
       },
     },

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
       },
       "&:not(.hasChildren) > *": {
         backgroundColor: theme.palette.neutralLighterAlt,
-        borderRadius: 2,
+        borderRadius: theme.effects.roundedCorner2,
         boxShadow: theme.effects.elevation16,
       },
     },

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -40,7 +40,7 @@ const stylesForButtonsDisplayedOnHover = (theme: ITheme) =>
     top: 0,
     height: 25,
     width: 25,
-    borderRadius: 2,
+    borderRadius: theme.effects.roundedCorner2,
     userSelect: "none",
     background: tinycolor(theme.palette.neutralLight).setAlpha(0.75).toRgbString(),
 

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -40,7 +40,7 @@ const stylesForButtonsDisplayedOnHover = (theme: ITheme) =>
     top: 0,
     height: 25,
     width: 25,
-    borderRadius: 5,
+    borderRadius: 2,
     userSelect: "none",
     background: tinycolor(theme.palette.neutralLight).setAlpha(0.75).toRgbString(),
 


### PR DESCRIPTION
**User-Facing Changes**
More consistent styling for floating buttons and toolbars.

**Description**
The radius on these components no longer matches the radius of FluentUI components. This change updates them to match.
    
- Dropdown
- Panel Toolbar
- Plot Floating buttons
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
