### PR TITLE
Add link to website in Foxglove Studio app

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -98,7 +98,8 @@ type SidebarItemKey =
   | "extensions"
   | "account"
   | "layouts"
-  | "preferences";
+  | "preferences"
+  | "website";
 
 function Connection() {
   return (
@@ -437,6 +438,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ["variables", { iconName: "Variable2", title: "Variables", component: Variables }],
       ["preferences", { iconName: "Settings", title: "Preferences", component: Preferences }],
       ["extensions", { iconName: "AddIn", title: "Extensions", component: ExtensionsSidebar }],
+      ["website", { iconName: "OpenInNewWindow", title: "Open website" }],
     ]);
 
     return supportsAccountSettings
@@ -455,7 +457,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   }, [supportsAccountSettings, playerProblems, currentUser]);
 
   const sidebarBottomItems: readonly SidebarItemKey[] = useMemo(() => {
-    return supportsAccountSettings ? ["account", "preferences"] : ["preferences"];
+    return supportsAccountSettings
+      ? ["website", "account", "preferences"]
+      : ["website", "preferences"];
   }, [supportsAccountSettings]);
 
   return (

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -438,7 +438,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ["variables", { iconName: "Variable2", title: "Variables", component: Variables }],
       ["preferences", { iconName: "Settings", title: "Preferences", component: Preferences }],
       ["extensions", { iconName: "AddIn", title: "Extensions", component: ExtensionsSidebar }],
-      ["website", { iconName: "OpenInNewWindow", title: "Open website" }],
+      [
+        "website",
+        { iconName: "OpenInNewWindow", title: "Open website", url: "https://foxglove.dev" },
+      ],
     ]);
 
     return supportsAccountSettings

--- a/packages/studio-base/src/components/ConnectionList/index.tsx
+++ b/packages/studio-base/src/components/ConnectionList/index.tsx
@@ -54,7 +54,7 @@ export default function ConnectionList(): JSX.Element {
     (source: IDataSourceFactory) => {
       if (source.disabledReason != undefined) {
         void confirm({
-          title: "Unsupported Connection",
+          title: "Unsupported connection",
           prompt: source.disabledReason,
           variant: "primary",
           cancel: false,

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -77,7 +77,7 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
         setIsInstalled(true);
       }
     } catch (err) {
-      addToast(`Failed to download extension ${extension.id}: ${err.message}`, {
+      addToast(`Failed to download extension ${extension.id}. ${err.message}`, {
         appearance: "error",
       });
     }

--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -41,6 +41,7 @@ export type SidebarItem = {
   title: string;
   badge?: Badge;
   component?: React.ComponentType;
+  url?: string;
 };
 
 const useStyles = makeStyles({
@@ -106,9 +107,9 @@ export default function Sidebar<K extends string>({
       if (!item) {
         throw new Error(`Missing sidebar item ${key}`);
       }
-      const { title, iconName } = item;
-      return key === "website" ? (
-        <a href="https://foxglove.dev" target="_blank" rel="noreferrer">
+      const { title, iconName, url } = item;
+      return url ? (
+        <a href={url} target="_blank" rel="noreferrer">
           <SidebarButton
             dataSidebarKey={key}
             key={key}

--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -40,7 +40,7 @@ export type SidebarItem = {
   iconName: IIconProps["iconName"];
   title: string;
   badge?: Badge;
-  component: React.ComponentType;
+  component?: React.ComponentType;
 };
 
 const useStyles = makeStyles({
@@ -107,7 +107,18 @@ export default function Sidebar<K extends string>({
         throw new Error(`Missing sidebar item ${key}`);
       }
       const { title, iconName } = item;
-      return (
+      return key === "website" ? (
+        <a href="https://foxglove.dev" target="_blank" rel="noreferrer">
+          <SidebarButton
+            dataSidebarKey={key}
+            key={key}
+            selected={selectedKey === key}
+            title={title}
+            iconProps={{ iconName }}
+            badge={item.badge}
+          />
+        </a>
+      ) : (
         <SidebarButton
           dataSidebarKey={key}
           key={key}

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -143,6 +143,7 @@ const icons: {
   NextFilled: <Next20Filled />,
   OpenFile: <Icons.OpenFileIcon />,
   OpenFolder: <Icons.OpenFolderHorizontalIcon />,
+  OpenInNewWindow: <Icons.OpenInNewWindowIcon />,
   Pause: <Pause20Regular />,
   PauseFilled: <Pause20Filled />,
   Pencil: <PencilIcon />,

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -78,6 +78,7 @@ declare global {
     | "NextFilled"
     | "OpenFile"
     | "OpenFolder"
+    | "OpenInNewWindow"
     | "Pause"
     | "PauseFilled"
     | "Pencil"

--- a/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
@@ -14,7 +14,7 @@ export default class Ros1UnavailableDataSourceFactory implements IDataSourceFact
   disabledReason = (
     <>
       <Text block as="p">
-        ROS 1 Native connections are only available in our desktop app.&nbsp;
+        Native ROS 1 connections are only available in our desktop app.&nbsp;
         <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
           Download it here.
         </Link>

--- a/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
@@ -14,7 +14,7 @@ export default class Ros2UnavailableDataSourceFactory implements IDataSourceFact
   disabledReason = (
     <>
       <Text block as="p">
-        ROS 2 Native connections are only available in our desktop app.&nbsp;
+        Native ROS 2 connections are only available in our desktop app.&nbsp;
         <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
           Download it here.
         </Link>

--- a/web/src/providers/ExtensionLoaderProvider.tsx
+++ b/web/src/providers/ExtensionLoaderProvider.tsx
@@ -58,11 +58,11 @@ export default function ExtensionLoaderProvider(props: PropsWithChildren<unknown
 }
 
 async function downloadExtension(_url: string): Promise<Uint8Array> {
-  throw new Error("Please download the desktop app to use extensions");
+  throw new Error("Download the desktop app to use extensions.");
 }
 
 async function installExtension(_foxeFileData: Uint8Array): Promise<ExtensionInfo> {
-  throw new Error("Please download the desktop app to use extensions");
+  throw new Error("Download the desktop app to use extensions.");
 }
 
 async function uninstallExtension(_id: string): Promise<boolean> {


### PR DESCRIPTION
**User-Facing Changes**
- Fixed "dead-end" issue found by ahrefs.com

   <img width="763" alt="Screen Shot 2021-11-09 at 1 38 15 AM" src="https://user-images.githubusercontent.com/6993359/140899860-b5fba8c8-f0a5-4180-82c3-11d9711f8731.png">

- Added link back to website from studio.foxglove.dev and the Foxglove Studio desktop app

  <img width="308" alt="Screen Shot 2021-11-09 at 1 43 04 AM" src="https://user-images.githubusercontent.com/6993359/140900558-3e7f1a9a-468b-4971-b51b-ca0d1c4160ba.png">
  