### PR TITLE
Refactor Dropdown to use FluentUI IconButtons, Dropdowns, and Menus

### DIFF
--- a/packages/studio-base/src/components/TopicToRenderMenu.tsx
+++ b/packages/studio-base/src/components/TopicToRenderMenu.tsx
@@ -114,14 +114,7 @@ export default function TopicToRenderMenu({
         },
       },
     }),
-    [
-      availableTopics,
-      onChange,
-      renderTopics,
-      theme.fonts.small.fontSize,
-      theme.palette.themePrimary,
-      topicToRender,
-    ],
+    [availableTopics, onChange, renderTopics, theme, topicToRender],
   );
 
   return (

--- a/packages/studio-base/src/components/TopicToRenderMenu.tsx
+++ b/packages/studio-base/src/components/TopicToRenderMenu.tsx
@@ -24,23 +24,25 @@ type Props = {
 };
 
 const topicButtonStyles = (theme: ITheme, { available }: { available: boolean }) => {
-  const color = available ? theme.palette.neutralPrimary : theme.semanticColors.warningBackground;
+  const rootStyle = {
+    backgroundColor: "transparent",
+    color: available ? theme.palette.neutralPrimary : theme.semanticColors.warningBackground,
+  };
 
   return {
     root: {
+      ...rootStyle,
       opacity: 0.6,
-      backgroundColor: "transparent",
       height: 16,
       padding: 0,
-      color,
     },
-    rootDisabled: { opacity: 0.4, backgroundColor: "transparent" },
-    rootExpanded: { opacity: 1, backgroundColor: "transparent" },
-    rootExpandedHovered: { opacity: 1, backgroundColor: "transparent" },
-    rootFocused: { backgroundColor: "transparent", color },
-    rootHasMenu: { backgroundColor: "transparent", color },
-    rootHovered: { opacity: 0.8, backgroundColor: "transparent", color },
-    rootPressed: { opacity: 1, backgroundColor: "transparent", color },
+    rootDisabled: { ...rootStyle, opacity: 0.4 },
+    rootExpanded: { ...rootStyle, opacity: 1 },
+    rootExpandedHovered: { ...rootStyle, opacity: 1 },
+    rootFocused: { ...rootStyle, opacity: 0.8 },
+    rootHasMenu: { ...rootStyle, opacity: 0.6 },
+    rootHovered: { ...rootStyle, opacity: 0.8 },
+    rootPressed: { ...rootStyle, opacity: 1 },
     icon: {
       fontSize: 14,
       margin: "0 1px",
@@ -51,12 +53,8 @@ const topicButtonStyles = (theme: ITheme, { available }: { available: boolean })
         width: "1em",
       },
     },
-    iconHovered: {
-      color: "currentColor",
-    },
-    menuIcon: {
-      display: "none",
-    },
+    iconHovered: { color: "currentColor" },
+    menuIcon: { display: "none" },
   } as Partial<IButtonStyles>;
 };
 

--- a/packages/studio-base/src/components/TopicToRenderMenu.tsx
+++ b/packages/studio-base/src/components/TopicToRenderMenu.tsx
@@ -1,25 +1,18 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
-import { makeStyles } from "@fluentui/react";
-import CheckIcon from "@mdi/svg/svg/check.svg";
-import DatabaseIcon from "@mdi/svg/svg/database.svg";
-import cx from "classnames";
+import {
+  IconButton,
+  IButtonStyles,
+  IContextualMenuItemStyles,
+  IContextualMenuProps,
+  ITheme,
+  useTheme,
+} from "@fluentui/react";
 import { uniq } from "lodash";
 import { useMemo } from "react";
 
-import Dropdown from "@foxglove/studio-base/components/Dropdown";
-import Icon from "@foxglove/studio-base/components/Icon";
 import { Topic } from "@foxglove/studio-base/players/types";
 
 type Props = {
@@ -30,40 +23,42 @@ type Props = {
   defaultTopicToRender: string;
 };
 
-const useStyles = makeStyles((theme) => ({
-  topic: {
-    display: "flex",
-    cursor: "pointer",
-    padding: 8,
-    height: 32,
-    color: theme.semanticColors.menuItemText,
-    ":hover": {
-      backgroundColor: theme.semanticColors.menuItemBackgroundHovered,
-    },
-  },
-  topicLabel: {
-    flex: "flex-start",
-    minWidth: 150,
-    height: 17,
-  },
-  checkIcon: {
-    flex: "flex-end",
+const topicButtonStyles = (theme: ITheme, { available }: { available: boolean }) => {
+  const color = available ? theme.palette.neutralPrimary : theme.semanticColors.warningBackground;
 
-    svg: {
-      fill: theme.semanticColors.menuIcon,
-      width: 15,
-      height: 15,
+  return {
+    root: {
+      opacity: 0.6,
+      backgroundColor: "transparent",
+      height: 16,
+      padding: 0,
+      color,
     },
-  },
-  icon: {
-    fontSize: 14,
-    margin: "0 0.2em",
-    color: theme.semanticColors.warningBackground,
-  },
-  iconActive: {
-    color: theme.palette.neutralPrimary,
-  },
-}));
+    rootDisabled: { opacity: 0.4, backgroundColor: "transparent" },
+    rootExpanded: { opacity: 1, backgroundColor: "transparent" },
+    rootExpandedHovered: { opacity: 1, backgroundColor: "transparent" },
+    rootFocused: { backgroundColor: "transparent", color },
+    rootHasMenu: { backgroundColor: "transparent", color },
+    rootHovered: { opacity: 0.8, backgroundColor: "transparent", color },
+    rootPressed: { opacity: 1, backgroundColor: "transparent", color },
+    icon: {
+      fontSize: 14,
+      margin: "0 1px",
+
+      svg: {
+        fill: "currentColor",
+        height: "1em",
+        width: "1em",
+      },
+    },
+    iconHovered: {
+      color: "currentColor",
+    },
+    menuIcon: {
+      display: "none",
+    },
+  } as Partial<IButtonStyles>;
+};
 
 export default function TopicToRenderMenu({
   onChange,
@@ -72,60 +67,75 @@ export default function TopicToRenderMenu({
   allowedDatatypes,
   defaultTopicToRender,
 }: Props): JSX.Element {
-  const styles = useStyles();
+  const theme = useTheme();
   const allowedDatatypesSet = useMemo(() => new Set(allowedDatatypes), [allowedDatatypes]);
-  const availableTopics: string[] = [];
-  for (const topic of topics) {
+
+  const availableTopics: Topic["name"][] = topics.reduce((acc, topic) => {
     if (allowedDatatypesSet.has(topic.datatype)) {
-      availableTopics.push(topic.name);
+      acc.push(topic.name);
     }
-  }
+    return acc;
+  }, [] as Topic["name"][]);
+
   // Keeps only the first occurrence of each topic.
-  const renderTopics: string[] = uniq([defaultTopicToRender, ...availableTopics, topicToRender]);
-  const parentTopicSpan = ({ topic, available }: { topic: string; available: boolean }) => {
-    return (
-      <>
-        {topic.length > 0 ? topic : <em>Default</em>}
-        {available ? "" : " (not available)"}
-      </>
-    );
-  };
+  const renderTopics: Topic["name"][] = uniq([
+    defaultTopicToRender,
+    ...availableTopics,
+    topicToRender,
+  ]);
+
+  const menuProps: IContextualMenuProps = useMemo(
+    () => ({
+      items: renderTopics.map((topic) => ({
+        canCheck: true,
+        checked: topic === topicToRender,
+        key: topic,
+        onClick: () => onChange(topic),
+        text: [
+          topic.length > 0 ? topic : "Default",
+          !availableTopics.includes(topic) && "(not available)",
+        ]
+          .filter(Boolean)
+          .join(" "),
+      })),
+      styles: {
+        subComponentStyles: {
+          menuItem: {
+            root: {
+              height: 32,
+              lineHeight: 32,
+              fontSize: theme.fonts.small.fontSize,
+            },
+            linkContent: {
+              flexDirection: "row-reverse",
+            },
+            checkmarkIcon: {
+              color: theme.palette.themePrimary,
+            },
+          } as Partial<IContextualMenuItemStyles>,
+        },
+      },
+    }),
+    [
+      availableTopics,
+      onChange,
+      renderTopics,
+      theme.fonts.small.fontSize,
+      theme.palette.themePrimary,
+      topicToRender,
+    ],
+  );
 
   return (
-    <Dropdown
-      toggleComponent={
-        <Icon
-          fade
-          tooltip={`Supported datatypes: ${allowedDatatypes.join(", ")}`}
-          tooltipProps={{ placement: "top" }}
-          dataTest={"topic-set"}
-        >
-          <DatabaseIcon
-            className={cx(styles.icon, {
-              [styles.iconActive]: topicToRender === defaultTopicToRender,
-            })}
-          />
-        </Icon>
-      }
-    >
-      {renderTopics.map((topic) => (
-        <div
-          className={styles.topic}
-          key={topic}
-          onClick={() => {
-            onChange(topic);
-          }}
-        >
-          <span className={styles.topicLabel}>
-            {parentTopicSpan({ topic, available: availableTopics.includes(topic) })}
-          </span>
-          {topicToRender === topic && (
-            <span className={styles.checkIcon}>
-              <CheckIcon />
-            </span>
-          )}
-        </div>
-      ))}
-    </Dropdown>
+    <IconButton
+      title={`Supported datatypes: ${allowedDatatypes.join(", ")}`}
+      data-test="topic-set"
+      iconProps={{ iconName: "Database" }}
+      menuIconProps={{ iconName: undefined }}
+      menuProps={menuProps}
+      styles={topicButtonStyles(theme, {
+        available: topicToRender === defaultTopicToRender,
+      })}
+    />
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Refactor dropdowns to use fluentui/react buttons, dropdowns and contextual menus and delete foxglove/components/Dropdown

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
