### PR TITLE
Internal: Add PlotDataItem to Plot/internalTypes

### DIFF
--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -7,10 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { filterMap } from "@foxglove/den/collection";
 import { isTime, Time, toSec, subtract } from "@foxglove/rostime";
-import {
-  TimeBasedChartTooltipData,
-  TooltipItem,
-} from "@foxglove/studio-base/components/TimeBasedChart";
+import { TimeBasedChartTooltipData } from "@foxglove/studio-base/components/TimeBasedChart";
 import { format } from "@foxglove/studio-base/util/formatTime";
 import { darkColor, lightColor, lineColors } from "@foxglove/studio-base/util/plotColors";
 import { formatTimeRaw, TimestampMethod } from "@foxglove/studio-base/util/time";
@@ -22,6 +19,7 @@ import {
   isReferenceLinePlotPathType,
   PlotChartPoint,
   PlotDataByPath,
+  PlotDataItem,
   PlotPath,
 } from "./internalTypes";
 import { derivative, applyToDataOrTooltips, mathFunctions } from "./transformPlotRange";
@@ -39,8 +37,8 @@ function getXForPoint(
   xAxisVal: PlotXAxisVal,
   timestamp: number,
   innerIdx: number,
-  xAxisRanges: readonly (readonly TooltipItem[])[] | undefined,
-  xItem: TooltipItem | undefined,
+  xAxisRanges: readonly (readonly PlotDataItem[])[] | undefined,
+  xItem: PlotDataItem | undefined,
   xAxisPath: BasePlotPath | undefined,
 ): number | bigint {
   if (isCustomScale(xAxisVal) && xAxisPath) {
@@ -59,13 +57,13 @@ function getXForPoint(
 }
 
 function getPointsAndTooltipsForMessagePathItem(
-  yItem: TooltipItem,
-  xItem: TooltipItem | undefined,
+  yItem: PlotDataItem,
+  xItem: PlotDataItem | undefined,
   startTime: Time,
   timestampMethod: TimestampMethod,
   xAxisVal: PlotXAxisVal,
   xAxisPath?: BasePlotPath,
-  xAxisRanges?: readonly (readonly TooltipItem[])[],
+  xAxisRanges?: readonly (readonly PlotDataItem[])[],
   datasetKey?: string,
 ): PointsAndTooltips {
   const points: PlotChartPoint[] = [];
@@ -135,11 +133,11 @@ function getDatasetAndTooltipsFromMessagePlotPath({
   invertedTheme = false,
 }: {
   path: PlotPath;
-  yAxisRanges: readonly (readonly TooltipItem[])[];
+  yAxisRanges: readonly (readonly PlotDataItem[])[];
   index: number;
   startTime: Time;
   xAxisVal: PlotXAxisVal;
-  xAxisRanges: readonly (readonly TooltipItem[])[] | undefined;
+  xAxisRanges: readonly (readonly PlotDataItem[])[] | undefined;
   xAxisPath?: BasePlotPath;
   invertedTheme?: boolean;
 }): {
@@ -159,11 +157,11 @@ function getDatasetAndTooltipsFromMessagePlotPath({
   let rangesOfTooltips: TimeBasedChartTooltipData[][] = [];
   let rangesOfPoints: PlotChartPoint[][] = [];
   for (const [rangeIdx, range] of yAxisRanges.entries()) {
-    const xRange: readonly TooltipItem[] | undefined = xAxisRanges?.[rangeIdx];
+    const xRange: readonly PlotDataItem[] | undefined = xAxisRanges?.[rangeIdx];
     const rangeTooltips = [];
     const rangePoints = [];
     for (const [outerIdx, item] of range.entries()) {
-      const xItem: TooltipItem | undefined = xRange?.[outerIdx];
+      const xItem: PlotDataItem | undefined = xRange?.[outerIdx];
       const {
         points: itemPoints,
         tooltips: itemTooltips,

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -47,7 +47,6 @@ import {
   ChartDefaultView,
   TimeBasedChartTooltipData,
   getTooltipItemForMessageHistoryItem,
-  TooltipItem,
 } from "@foxglove/studio-base/components/TimeBasedChart";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import {
@@ -62,7 +61,7 @@ import PlotChart from "./PlotChart";
 import PlotLegend from "./PlotLegend";
 import { getDatasetsAndTooltips } from "./datasets";
 import helpContent from "./index.help.md";
-import { DataSet, PlotDataByPath } from "./internalTypes";
+import { DataSet, PlotDataByPath, PlotDataItem } from "./internalTypes";
 import { PlotConfig, PlotXAxisVal } from "./types";
 
 export { plotableRosTypes } from "./types";
@@ -165,7 +164,7 @@ function getBlockItemsByPath(
   decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
   blocks: readonly MessageBlock[],
 ) {
-  const ret: Record<string, TooltipItem[][]> = {};
+  const ret: Record<string, PlotDataItem[][]> = {};
   const lastBlockIndexForPath: Record<string, number> = {};
   blocks.forEach((block, i: number) => {
     const messagePathItemsForBlock: PlotDataByPath = getMessagePathItemsForBlock(

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -13,7 +13,9 @@
 
 import { ComponentProps } from "react";
 
-import TimeBasedChart, { TooltipItem } from "@foxglove/studio-base/components/TimeBasedChart";
+import { Time } from "@foxglove/rostime";
+import { MessagePathDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 export type BasePlotPath = {
@@ -32,8 +34,14 @@ export type PlotChartPoint = {
 
 export type DataSet = ComponentProps<typeof TimeBasedChart>["data"]["datasets"][0];
 
+export type PlotDataItem = {
+  queriedData: MessagePathDataItem[];
+  receiveTime: Time;
+  headerStamp?: Time;
+};
+
 export type PlotDataByPath = {
-  [path: string]: TooltipItem[][];
+  [path: string]: PlotDataItem[][];
 };
 
 // A "reference line" plot path is a numeric value. It creates a horizontal line on the plot at the specified value.


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Rather than using TooltipItem for plot data items, use PlotDataItem. I find this naming more representative of the information. The TooltipItem is used only in the context of tooltips rather than storing the plot data.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
