### PR TITLE
Add workaround for fluent ui's dismiss on scroll behavior.

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -66,6 +66,7 @@ import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useWorkspace, WorkspaceContext } from "@foxglove/studio-base/context/WorkspaceContext";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
+import { useCalloutDismissalBlocker } from "@foxglove/studio-base/hooks/useCalloutDismissalBlocker";
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import welcomeLayout from "@foxglove/studio-base/layouts/welcomeLayout";
@@ -239,6 +240,8 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       containerRef.current.focus();
     }
   }, []);
+
+  useCalloutDismissalBlocker();
 
   useNativeAppMenuEvent(
     "open-preferences",

--- a/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
+++ b/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
@@ -2,7 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { on } from "@fluentui/utilities";
+import { useEffect } from "react";
+
+function blockScrollEventPropagation(event: Event) {
+  if (
+    event.target instanceof HTMLElement &&
+    event.target.classList.contains("ReactVirtualized__List")
+  ) {
+    event.stopImmediatePropagation();
+  }
+}
 
 /**
  * Installs a window level handler to get ahead of FluentUI's global
@@ -10,20 +19,11 @@ import { on } from "@fluentui/utilities";
  * scroll events from auto-scrolling windows like the log from dismissing
  * open widgets.
  *
- * This should probably be considered to be a temporary woraround.
+ * This should probably be considered to be a temporary workaround.
  */
 export function useCalloutDismissalBlocker(): void {
-  on(
-    window,
-    "scroll",
-    (e) => {
-      if (
-        e.target instanceof HTMLElement &&
-        e.target.classList.contains("ReactVirtualized__List")
-      ) {
-        e.stopImmediatePropagation();
-      }
-    },
-    true,
-  );
+  useEffect(() => {
+    window.addEventListener("scroll", blockScrollEventPropagation, { capture: true });
+    return () => window.removeEventListener("scroll", blockScrollEventPropagation);
+  }, []);
 }

--- a/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
+++ b/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
@@ -19,7 +19,17 @@ function blockScrollEventPropagation(event: Event) {
  * scroll events from auto-scrolling windows like the log from dismissing
  * open widgets.
  *
+ * This is necessary because the lists in react-virtualized generate a scroll
+ * event every time they scroll to show to rows and FluentUI installs a window
+ * level 'scroll' event handler with capture = true so it sees every scroll
+ * event anywhere in the window. And by default on any scroll event it dismisses
+ * any open widgets based around the FluentUI callout. This behavior is probably
+ * reasonable for user-initiated scrolling but it's not what we want for
+ * automatically scrolling elements.
+ *
  * This should probably be considered to be a temporary workaround.
+ *
+ * See https://codesandbox.io/s/scroll-test-3prdt
  */
 export function useCalloutDismissalBlocker(): void {
   useEffect(() => {

--- a/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
+++ b/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { on } from "@fluentui/utilities";
+
+/**
+ * Installs a window level handler to get ahead of FluentUI's global
+ * dismiss on scroll behavior for Callouts, Dropdowns etc. This prevents
+ * scroll events from auto-scrolling windows like the log from dismissing
+ * open widgets.
+ *
+ * This should probably be considered to be a temporary woraround.
+ */
+export function useCalloutDismissalBlocker(): void {
+  on(
+    window,
+    "scroll",
+    (e) => {
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.classList.contains("ReactVirtualized__List")
+      ) {
+        e.stopImmediatePropagation();
+      }
+    },
+    true,
+  );
+}

--- a/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
+++ b/packages/studio-base/src/hooks/useCalloutDismissalBlocker.ts
@@ -34,6 +34,8 @@ function blockScrollEventPropagation(event: Event) {
 export function useCalloutDismissalBlocker(): void {
   useEffect(() => {
     window.addEventListener("scroll", blockScrollEventPropagation, { capture: true });
-    return () => window.removeEventListener("scroll", blockScrollEventPropagation);
+
+    return () =>
+      window.removeEventListener("scroll", blockScrollEventPropagation, { capture: true });
   }, []);
 }


### PR DESCRIPTION
**User-Facing Changes**
This is a somewhat hacky fix for FluentUI's default dismiss on scroll behavior. 

**Description**
FluentUI by default will dismiss any open Callout based widgets like dropdowns if any element in the window scrolls. This PR installs a window-level scroll event listener ahead of Fluent to prevent that from happening if the scroll event originates in a react-virtualized list like the lists we use for the log windows.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
https://github.com/foxglove/studio/issues/2099
