### PR TITLE
Internal: rename MessageAndData message field to messageEvent

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.test.tsx
@@ -865,7 +865,9 @@ describe("useDecodeMessagePathsForMessagesByTopic", () => {
     };
     expect(result.current(messagesByTopic)).toEqual({
       // Value for /topic1.value
-      "/topic1.value": [{ message, queriedData: [{ path: "/topic1.value", value: 1 }] }],
+      "/topic1.value": [
+        { messageEvent: message, queriedData: [{ path: "/topic1.value", value: 1 }] },
+      ],
       // Empty array for /topic2.value
       "/topic2.value": [],
       // No array for /topic3.value because the path is valid but the data is missing.

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -346,7 +346,10 @@ export function getMessagePathDataItems(
   return queriedData;
 }
 
-export type MessageAndData = { message: MessageEvent<unknown>; queriedData: MessagePathDataItem[] };
+export type MessageAndData = {
+  messageEvent: MessageEvent<unknown>;
+  queriedData: MessagePathDataItem[];
+};
 
 export type MessageDataItemsByPath = {
   readonly [key: string]: readonly MessageAndData[];
@@ -387,7 +390,7 @@ export function useDecodeMessagePathsForMessagesByTopic(
           // Add the item (if it exists) to the array.
           const queriedData = cachedGetMessagePathDataItems(path, message);
           if (queriedData) {
-            messagesForThisPath.push({ message, queriedData });
+            messagesForThisPath.push({ messageEvent: message, queriedData });
           }
         }
       }

--- a/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
@@ -79,13 +79,13 @@ describe("useLatestMessageDataItem", () => {
       },
     });
     expect(result.all).toEqual([
-      { message: fixtureMessages[0], queriedData: [{ path: "/topic.value", value: 0 }] },
+      { messageEvent: fixtureMessages[0], queriedData: [{ path: "/topic.value", value: 0 }] },
     ]);
 
     rerender({ path: "/topic.value", messages: [fixtureMessages[1]!, fixtureMessages[2]!] });
     expect(result.all).toEqual([
-      { message: fixtureMessages[0], queriedData: [{ path: "/topic.value", value: 0 }] },
-      { message: fixtureMessages[2], queriedData: [{ path: "/topic.value", value: 2 }] },
+      { messageEvent: fixtureMessages[0], queriedData: [{ path: "/topic.value", value: 0 }] },
+      { messageEvent: fixtureMessages[2], queriedData: [{ path: "/topic.value", value: 2 }] },
     ]);
   });
 
@@ -107,7 +107,10 @@ describe("useLatestMessageDataItem", () => {
       },
     });
     expect(result.all).toEqual([
-      { message: fixtureMessages[1], queriedData: [{ path: "/topic{value==1}.value", value: 1 }] },
+      {
+        messageEvent: fixtureMessages[1],
+        queriedData: [{ path: "/topic{value==1}.value", value: 1 }],
+      },
     ]);
   });
 
@@ -132,11 +135,11 @@ describe("useLatestMessageDataItem", () => {
     rerender({ path: "/topic{value==1}" });
     expect(result.all).toEqual([
       {
-        message: fixtureMessages[1],
+        messageEvent: fixtureMessages[1],
         queriedData: [{ path: "/topic{value==1}.value", value: 1 }],
       },
       {
-        message: fixtureMessages[1],
+        messageEvent: fixtureMessages[1],
         queriedData: [{ path: "/topic{value==1}", value: fixtureMessages[1]?.message }],
       },
     ]);

--- a/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.ts
@@ -45,7 +45,7 @@ export function useLatestMessageDataItem(path: string): MessageAndData | undefin
           return;
         }
         if (queriedData.length > 0) {
-          return { message, queriedData };
+          return { messageEvent: message, queriedData };
         }
       }
       return prevMessageAndData;
@@ -56,9 +56,9 @@ export function useLatestMessageDataItem(path: string): MessageAndData | undefin
   const restore = useCallback(
     (prevMessageAndData?: MessageAndData): MessageAndData | undefined => {
       if (prevMessageAndData) {
-        const queriedData = cachedGetMessagePathDataItems(path, prevMessageAndData.message);
+        const queriedData = cachedGetMessagePathDataItems(path, prevMessageAndData.messageEvent);
         if (queriedData && queriedData.length > 0) {
-          return { message: prevMessageAndData.message, queriedData };
+          return { messageEvent: prevMessageAndData.messageEvent, queriedData };
         }
       }
       return undefined;

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessagesByPath.test.tsx
@@ -29,7 +29,7 @@ const singleTopic = [{ name: "/some/topic", datatype: "some/datatype" }];
 
 function queriedMessage(index: 0 | 1 | 2) {
   return {
-    message: fixture.messages[index],
+    messageEvent: fixture.messages[index],
     queriedData: [{ value: fixture.messages[index].message, path: "/some/topic" }],
   };
 }
@@ -143,8 +143,8 @@ describe("useMessagesByPath", () => {
       { "/some/topic": [] },
       {
         "/some/topic": [
-          { message: fixture.messages[1], queriedData: [] },
-          { message: fixture.messages[2], queriedData: [] },
+          { messageEvent: fixture.messages[1], queriedData: [] },
+          { messageEvent: fixture.messages[2], queriedData: [] },
         ],
       },
     ]);
@@ -239,11 +239,11 @@ describe("useMessagesByPath", () => {
       {
         "/some/topic.index": [
           {
-            message: fixture.messages[0],
+            messageEvent: fixture.messages[0],
             queriedData: [{ path: "/some/topic.index", value: 0 }],
           },
           {
-            message: fixture.messages[1],
+            messageEvent: fixture.messages[1],
             queriedData: [{ path: "/some/topic.index", value: 1 }],
           },
         ],
@@ -304,7 +304,7 @@ describe("useMessagesByPath", () => {
       {
         "/some/topic.index": [
           {
-            message: fixture.messages[0],
+            messageEvent: fixture.messages[0],
             queriedData: [{ path: "/some/topic.index", value: 0 }],
           },
         ],
@@ -363,7 +363,7 @@ describe("useMessagesByPath", () => {
         {
           "/some/topic.bars[:]{index==$foo}.baz": [
             {
-              message,
+              messageEvent: message,
               queriedData: [{ path: "/some/topic.bars[:]{index==$foo}.baz", value: 10 }],
             },
           ],
@@ -371,7 +371,7 @@ describe("useMessagesByPath", () => {
         {
           "/some/topic.bars[:]{index==$foo}.baz": [
             {
-              message,
+              messageEvent: message,
               queriedData: [{ path: "/some/topic.bars[:]{index==$foo}.baz", value: 11 }],
             },
           ],

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -145,10 +145,10 @@ const getPlotDataByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath 
   Object.entries(itemsByPath).forEach(([path, items]) => {
     ret[path] = [
       items.map((messageAndData) => {
-        const headerStamp = getTimestampForMessage(messageAndData.message.message);
+        const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
         return {
           queriedData: messageAndData.queriedData,
-          receiveTime: messageAndData.message.receiveTime,
+          receiveTime: messageAndData.messageEvent.receiveTime,
           headerStamp,
         };
       }),

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -173,7 +173,7 @@ function RawMessages(props: Props) {
   const prevTickMsg = consecutiveMsgs?.[consecutiveMsgs.length - 2];
   const [prevTickObj, currTickObj] = [
     prevTickMsg && {
-      message: prevTickMsg,
+      messageEvent: prevTickMsg,
       queriedData: cachedGetMessagePathDataItems(topicPath, prevTickMsg) ?? [],
     },
     useLatestMessageDataItem(topicPath),
@@ -385,9 +385,9 @@ function RawMessages(props: Props) {
           data={data}
           diffData={diffData}
           diff={diff}
-          message={baseItem.message}
+          message={baseItem.messageEvent}
           {...(topic ? { datatype: topic.datatype } : undefined)}
-          {...(diffItem ? { diffMessage: diffItem.message } : undefined)}
+          {...(diffItem ? { diffMessage: diffItem.messageEvent } : undefined)}
         />
         {shouldDisplaySingleVal ? (
           <div className={classes.singleVal}>

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -51,9 +51,9 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
     }
 
     for (const itemByPath of messages) {
-      const headerStamp = getTimestampForMessage(itemByPath.message.message);
+      const headerStamp = getTimestampForMessage(itemByPath.messageEvent.message);
       const timestamp =
-        path.timestampMethod === "headerStamp" ? headerStamp : itemByPath.message.receiveTime;
+        path.timestampMethod === "headerStamp" ? headerStamp : itemByPath.messageEvent.receiveTime;
       if (!timestamp) {
         continue;
       }
@@ -102,7 +102,7 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
         x,
         y,
         item: {
-          receiveTime: itemByPath.message.receiveTime,
+          receiveTime: itemByPath.messageEvent.receiveTime,
           headerStamp,
         },
         path: path.value,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Having this field named message has caused me confusion since it is not the message but is actually the message event (topic, receive time, message).
    
This change aligns the field name with the content.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
