### PR TITLE
Fix "detect timezone" displaying times in UTC until reload

### DIFF
--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -67,14 +67,14 @@ function ColorSchemeSettings(): JSX.Element {
 }
 
 function TimezoneSettings(): React.ReactElement {
-  type Option = IComboBoxOption & { data: string };
+  type Option = Omit<IComboBoxOption, "data"> & { data: string | undefined };
 
   const [timezone, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
   const detectItem = useMemo(
     () => ({
       key: "detect",
       text: `Detect from system: ${formatTimezone(moment.tz.guess())}`,
-      data: "",
+      data: undefined,
     }),
     [],
   );
@@ -101,16 +101,20 @@ function TimezoneSettings(): React.ReactElement {
   const itemsByData = useMemo(() => {
     const map = new Map<string, Option>();
     for (const item of fixedItems) {
-      map.set(item.data, item);
+      if (item.data != undefined) {
+        map.set(item.data, item);
+      }
     }
     for (const item of timezoneItems) {
-      map.set(item.data, item);
+      if (item.data != undefined) {
+        map.set(item.data, item);
+      }
     }
     return map;
   }, [fixedItems, timezoneItems]);
 
   const selectedItem = useMemo(
-    () => itemsByData.get(timezone ?? "") ?? detectItem,
+    () => (timezone != undefined && itemsByData.get(timezone)) || detectItem,
     [itemsByData, timezone, detectItem],
   );
 

--- a/web/src/components/LocalStorageAppConfigurationProvider.tsx
+++ b/web/src/components/LocalStorageAppConfigurationProvider.tsx
@@ -21,10 +21,18 @@ export default function LocalStorageAppConfigurationProvider(
     return {
       get(key: string): AppConfigurationValue {
         const value = localStorage.getItem(KEY_PREFIX + key);
-        return value == undefined ? undefined : JSON.parse(value);
+        try {
+          return value == undefined ? undefined : JSON.parse(value);
+        } catch {
+          return undefined;
+        }
       },
       async set(key: string, value: AppConfigurationValue): Promise<void> {
-        localStorage.setItem(KEY_PREFIX + key, JSON.stringify(value));
+        if (value == undefined) {
+          localStorage.removeItem(KEY_PREFIX + key);
+        } else {
+          localStorage.setItem(KEY_PREFIX + key, JSON.stringify(value));
+        }
         const listeners = changeListeners.get(key);
         if (listeners) {
           // Copy the list of listeners to protect against mutation during iteration


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where changing the timezone to "Detect from system" would temporarily display times in UTC.

**Description**
Fixes https://github.com/foxglove/studio/issues/2092

A timezone setting of `""` was being set when clicking the Detect option, which resulted in incorrect formatting. However upon initial app load the empty string is explicitly [converted to `undefined`](https://github.com/foxglove/studio/blob/e3fc661f7f2ae364d73fe71e6b17a9e9b0f8e5ba/packages/studio-base/src/hooks/useAppConfigurationValue.ts#L22-L25) which produced correct behavior. Instead of storing `""` just store undefined (i.e. delete the key when undefined is set).