### PR TITLE
Attempt to make JS/WASM assets cacheable in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   },
   "headers": [
     {
-      "source": "/((\\w+\\.)?[0-9a-f]{20}\\.(js|js\\.map|wasm))",
+      "source": "/((?:\\w+\\.)?[0-9a-f]{20}\\.(?:js|js\\.map|wasm))",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,15 @@
 {
   "github": {
     "silent": true
-  }
+  },
+  "headers": [
+    {
+      "source": "/\\w+\\.[0-9a-f]{20}\\.js",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
+    },
+    {
+      "source": "/[0-9a-f]{20}\\.wasm",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,11 +4,7 @@
   },
   "headers": [
     {
-      "source": "/\\w+\\.[0-9a-f]{20}\\.js",
-      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
-    },
-    {
-      "source": "/[0-9a-f]{20}\\.wasm",
+      "source": "/((\\w+\\.)?[0-9a-f]{20}\\.(js|js\\.map|wasm))",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
     }
   ]


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Attempting to address #2047 — it looks like Chrome does use its cache (see screenshot below...although confusingly it sometimes shows 200s even for responses that appear to be cached), but due to Vercel's default `public, max-age=0, must-revalidate` the browser always has to revalidate its caches with the server. Since these file paths include a content hash, it should be safe to allow them to be served from cache.

<img width="960" alt="image" src="https://user-images.githubusercontent.com/14237/141008529-ec5a1121-a5dd-4546-a5e3-45b201708db9.png">
