### PR TITLE
Convert log window toolbar to non-floating to fix jumping menu issue.

### DIFF
--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -90,7 +90,7 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
 
   return (
     <Stack verticalFill>
-      <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
+      <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
         <FilterBar
           searchTerms={searchTermsSet}
           minLogLevel={minLogLevel}

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -102,8 +102,8 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
       <Stack grow>
         <LogList
           items={filteredMessages}
-          renderRow={({ item, style, key, index, ref }) => (
-            <div ref={ref} key={key} style={index === 0 ? { ...style, paddingTop: 36 } : style}>
+          renderRow={({ item, style, key, ref }) => (
+            <div ref={ref} key={key} style={style}>
               <LogMessage msg={item.message} />
             </div>
           )}


### PR DESCRIPTION
**User-Facing Changes**
As per @defunctzombie suggestion, this makes the toolbar at the top of the log window static instead of show on hover. This seems like a simple solution to https://github.com/foxglove/studio/issues/2119

**Description**
This simply removes the `floating` attribute from the toolbar.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
https://github.com/foxglove/studio/issues/2119