### PR TITLE
Handle missing tab panel config gracefully.

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
@@ -94,6 +94,28 @@ describe("layout reducers", () => {
         tabs: [{ title: "A", layout: newAudioId }, { title: "B" }, { title: "C" }],
       });
     });
+
+    it("adds panel to uninitialized Tab layout", () => {
+      let panels: PanelsState = {
+        ...emptyLayout,
+        layout: "Tab!a",
+        configById: {
+          "Tab!a": {},
+        },
+      };
+      panels = panelsReducer(panels, {
+        type: "ADD_PANEL",
+        payload: {
+          id: "Audio!x",
+          tabId: "Tab!a",
+          config: { foo: "bar" },
+        },
+      });
+
+      const { configById } = panels;
+      const tabs = (configById["Tab!a"] as TabPanelConfig).tabs;
+      expect(tabs.length).toEqual(1);
+    });
   });
 
   describe("drops panel into a layout", () => {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -67,6 +67,8 @@ import {
   getPathFromNode,
 } from "@foxglove/studio-base/util/layout";
 
+import { isTabPanelConfig } from "../../util/layout";
+
 export const defaultPlaybackConfig: PlaybackConfig = {
   speed: 1.0,
   messageOrder: "receiveTime",
@@ -339,8 +341,10 @@ const addPanel = (
   }
   let layout: MosaicNode<string> | undefined;
   if (tabId != undefined) {
-    const tabPanelConfig = panelsState.configById[tabId] as TabPanelConfig | undefined;
-    layout = tabPanelConfig?.tabs?.[tabPanelConfig.activeTabIdx]?.layout;
+    const tabPanelConfig = panelsState.configById[tabId];
+    if (isTabPanelConfig(tabPanelConfig)) {
+      layout = tabPanelConfig.tabs[tabPanelConfig.activeTabIdx]?.layout;
+    }
   } else {
     layout = panelsState.layout;
   }

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -340,7 +340,7 @@ const addPanel = (
   let layout: MosaicNode<string> | undefined;
   if (tabId != undefined) {
     const tabPanelConfig = panelsState.configById[tabId] as TabPanelConfig | undefined;
-    layout = tabPanelConfig?.tabs[tabPanelConfig.activeTabIdx]?.layout;
+    layout = tabPanelConfig?.tabs?.[tabPanelConfig.activeTabIdx]?.layout;
   } else {
     layout = panelsState.layout;
   }

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -60,6 +60,10 @@ export function isTabPanel(panelId: string): boolean {
   return getPanelTypeFromId(panelId) === TAB_PANEL_TYPE;
 }
 
+export function isTabPanelConfig(config: PanelConfig | undefined): config is TabPanelConfig {
+  return config != undefined && "tabs" in config && "activeTabIndex" in config;
+}
+
 // Traverses `tree` to find the path to the specified `node`
 export function getPathFromNode<T extends MosaicKey>(
   node: T | undefined,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue adding a sub panel to a freshly created tab panel.

**Description**
Looks like in some cases the tab panel is configured as an empty object. We should probably find the root cause of this but it's worth adding some logic to handle it here in case there are existing layouts with this issue.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
https://github.com/foxglove/studio/issues/708