### PR TITLE
Add time label to playback scrubber hover ticks

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -23,6 +23,7 @@ import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 
 import { Time, isTimeInRangeInclusive } from "@foxglove/rostime";
 import {
+  LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
@@ -34,6 +35,11 @@ import {
 } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
+
+function displayMethodSelector(state: LayoutState): TimeDisplayMethod {
+  const method = state.selectedLayout?.data?.playbackConfig.timeDisplayMethod ?? "TOD";
+  return method === "TOD" ? "TOD" : "SEC";
+}
 
 const PlaybackTimeDisplayMethod = ({
   currentTime,
@@ -53,10 +59,7 @@ const PlaybackTimeDisplayMethod = ({
   isPlaying: boolean;
 }): JSX.Element => {
   const timestampInputRef = useRef<HTMLInputElement>(ReactNull);
-  const timeDisplayMethod: TimeDisplayMethod = useCurrentLayoutSelector((state) => {
-    const method = state.selectedLayout?.data?.playbackConfig.timeDisplayMethod ?? "TOD";
-    return method === "TOD" ? "TOD" : "SEC";
-  });
+  const timeDisplayMethod = useCurrentLayoutSelector(displayMethodSelector);
   const { setPlaybackConfig } = useCurrentLayoutActions();
   const setTimeDisplayMethod = useCallback(
     (newTimeDisplayMethod: TimeDisplayMethod) =>

--- a/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
@@ -13,11 +13,13 @@
 
 import { action } from "@storybook/addon-actions";
 import { Story } from "@storybook/react";
+import { useLayoutEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import AppConfigurationContext, {
   AppConfiguration,
 } from "@foxglove/studio-base/context/AppConfigurationContext";
+import { useSetHoverValue } from "@foxglove/studio-base/context/HoverValueContext";
 import {
   PlayerCapabilities,
   PlayerPresence,
@@ -129,3 +131,23 @@ export const DownloadProgressByRanges: Story = () => {
   );
 };
 DownloadProgressByRanges.parameters = { colorScheme: "both-column" };
+
+export const HoverTicks: Story = () => {
+  const player = getPlayerState();
+  const setHoverValue = useSetHoverValue();
+
+  useLayoutEffect(() => {
+    setHoverValue({
+      type: "PLAYBACK_SECONDS",
+      value: 0.5,
+      componentId: "story",
+    });
+  }, [setHoverValue]);
+
+  return (
+    <Wrapper activeData={player.activeData}>
+      <PlaybackControls />
+    </Wrapper>
+  );
+};
+HoverTicks.parameters = { colorScheme: "both-column" };

--- a/packages/studio-base/src/components/TimeBasedChart/HoverBar.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/HoverBar.tsx
@@ -50,6 +50,10 @@ export default React.memo<Props>(function HoverBar({
     const pixels = xScale.pixelMax - xScale.pixelMin;
     const range = xScale.max - xScale.min;
 
+    if (pixels === 0 || range === 0) {
+      return;
+    }
+
     const pos = (hoverValue.value - xScale.min) / (range / pixels) + xScale.pixelMin;
     // don't show hoverbar if it falls outsize our boundary
     if (pos < xScale.pixelMin || pos > xScale.pixelMax) {


### PR DESCRIPTION

**User-Facing Changes**
Hove time display above the hover ticks.

<img width="846" alt="Screen Shot 2021-11-10 at 9 02 13 AM" src="https://user-images.githubusercontent.com/84792/141158944-90914d9b-9da2-485f-a92e-eeabdf0e835b.png">
<img width="942" alt="Screen Shot 2021-11-10 at 9 02 03 AM" src="https://user-images.githubusercontent.com/84792/141158948-3800ea48-1083-4442-bb81-df1e60cb088d.png">

**Description**
When the hover time is set by panels a pair of tick marks shows up on the playback control scrubber to indicate the hover time location. This change adds a time label above the hover ticks.

The time label follows the time format selected in the playback controls.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
