### PR TITLE
Don't open panel settings after adding a new panel via the add panel sidebar.

### DIFF
--- a/packages/studio-base/src/hooks/useAddPanel.ts
+++ b/packages/studio-base/src/hooks/useAddPanel.ts
@@ -8,20 +8,17 @@ import {
   useCurrentLayoutActions,
   useSelectedPanels,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { getPanelIdForType } from "@foxglove/studio-base/util/layout";
 
 export default function useAddPanel(): (selection: PanelSelection) => void {
   const { addPanel } = useCurrentLayoutActions();
-  const { openPanelSettings } = useWorkspace();
   const { setSelectedPanelIds } = useSelectedPanels();
   return useCallback(
     ({ type, config, relatedConfigs }: PanelSelection) => {
       const id = getPanelIdForType(type);
       addPanel({ id, config, relatedConfigs });
       setSelectedPanelIds([id]);
-      openPanelSettings();
     },
-    [addPanel, setSelectedPanelIds, openPanelSettings],
+    [addPanel, setSelectedPanelIds],
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
This changes the behavior of the add panel sidebar. Instead of switching to the panel settings sidebar after adding a new panel it will keep the add panel sidebar open.

**Description**
This keeps  the add panel sidebar open after adding a new panel via a click or drag. The goal is to make it easer and more ergonomic to add a series of panels in quick succession.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
This is an attempt to address #2091 