### PR TITLE
Avoid showing the hover time above hover ticks when showing tooltip

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -82,9 +82,13 @@ function displayMethodSelector(state: LayoutState): TimeDisplayMethod {
 
 type Props = {
   componentId: string;
+  // When true, this will display the hover time above the hover ticks
+  displayHoverTime: boolean;
 };
 
-export default function PlaybackBarHoverTicks({ componentId }: Props): JSX.Element {
+export default function PlaybackBarHoverTicks(props: Props): JSX.Element {
+  const { componentId, displayHoverTime } = props;
+
   const startTime = useMessagePipeline(getStartTime);
   const endTime = useMessagePipeline(getEndTime);
   const hoverValue = useHoverValue({ componentId, isTimestampScale: true });
@@ -126,7 +130,7 @@ export default function PlaybackBarHoverTicks({ componentId }: Props): JSX.Eleme
     <div ref={ref} style={{ width: "100%" }}>
       {scaleBounds && (
         <HoverBar componentId={componentId} scales={scaleBounds} isTimestampScale>
-          {hoverValue != undefined && <TimeLabel>{hoverTimeDisplay}</TimeLabel>}
+          {hoverValue != undefined && displayHoverTime && <TimeLabel>{hoverTimeDisplay}</TimeLabel>}
           <TopTick />
           <BottomTick />
         </HoverBar>

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -74,17 +74,16 @@ const useStyles = makeStyles((theme) => ({
   tooltip: {
     fontFamily: fonts.SANS_SERIF,
     whiteSpace: "nowrap",
+  },
+  tooltipRow: {
+    paddingBottom: theme.spacing.s2,
 
-    "> div": {
-      paddingBottom: theme.spacing.s2,
-
-      "&:last-child": {
-        paddingBottom: 0,
-      },
+    "&:last-child": {
+      paddingBottom: 0,
     },
   },
   tooltipTitle: {
-    width: "70px",
+    width: "50px",
     textAlign: "right",
     marginRight: theme.spacing.s2,
     display: "inline-block",
@@ -158,7 +157,7 @@ export default function Scrubber(props: Props): JSX.Element {
       const tip = (
         <div className={classes.tooltip}>
           {tooltipItems.map((item) => (
-            <div key={item.title}>
+            <div key={item.title} className={classes.tooltipRow}>
               <span className={classes.tooltipTitle}>{item.title}:</span>
               <span className={classes.tooltipValue}>{item.value}</span>
             </div>
@@ -238,7 +237,10 @@ export default function Scrubber(props: Props): JSX.Element {
           renderSlider={renderSlider}
         />
       </div>
-      <PlaybackBarHoverTicks componentId={hoverComponentId} />
+      <PlaybackBarHoverTicks
+        componentId={hoverComponentId}
+        displayHoverTime={tooltipState == undefined}
+      />
     </>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
The hover ticks time is only shown when hovering over panels rather than the playback controls scrubber.

<img width="212" alt="Screen Shot 2021-11-11 at 12 53 13 PM" src="https://user-images.githubusercontent.com/84792/141368074-2e284dbb-e338-4e7c-84ed-f01421b311cf.png">


**Description**
The hover time was added in https://github.com/foxglove/studio/pull/2134. However this presents the same information as the tooltip when a user hovers on the scrubber. This change avoids showing the hover time when a user hovers on the scrubber since it is shown in the tooltip.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
