### PR TITLE
Change publicPath to "auto".

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -97,7 +97,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
-      publicPath: "/",
+      publicPath: "auto",
 
       // Output filenames should include content hashes in order to cache bust when new versions are available
       filename: isDev ? "[name].js" : "[name].[contenthash].js",


### PR DESCRIPTION
This allows hosting the files from any path on the webserver as opposed to just from the root.

**User-Facing Changes**
Should be none.

**Description**

This ensures the webpack output can be hosted from any publicPath instead of just from the `/` path on the server. The magic `"auto"` string feels a bit sketchy, but it is [what the documentation states](https://webpack.js.org/guides/public-path/#automatic-publicpath).

For context, I built the files using the provided Dockerfile (thanks for providing this!) using the following;
```
cd studio
docker build -t foxglove_build_static .
docker cp $(docker create --rm foxglove_build_static):/src/ ../build/
```
I wanted to serve these files form a subpath, like `https://hostname/foxglove/` because the root of this webserver is used for other things. I didn't want to host it on another instance or port because the bags I wanted to look at  are hosted on this webserver, hosting it from the same server avoids any CORS issues.

Upon testing I discovered that specifying the bag to load in the url isn't supported yet (#1868), but thought I might as well contribute this tiny change to make additional testing easier in the future.

fyi @jasonimercer