### PR TITLE
Pass ROS parameters to extension panels.

### DIFF
--- a/packages/studio-base/src/PanelAPI/useParameter.ts
+++ b/packages/studio-base/src/PanelAPI/useParameter.ts
@@ -4,8 +4,8 @@
 
 import { useCallback } from "react";
 
+import { ParameterValue } from "@foxglove/studio";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
-import { ParameterValue } from "@foxglove/studio-base/players/types";
 
 export default function useParameter<T extends ParameterValue>(
   key: string,

--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { ParameterValue } from "@foxglove/studio";
 import {
   PlayerCapabilities,
   PlayerStateActiveData,
@@ -19,7 +20,6 @@ import {
   SubscribePayload,
   AdvertiseOptions,
   PlayerPresence,
-  ParameterValue,
 } from "@foxglove/studio-base/players/types";
 
 // ts-prune-ignore-next

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -16,10 +16,10 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import { Time, isLessThan } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import {
   AdvertiseOptions,
   MessageEvent,
-  ParameterValue,
   PlayerPresence,
   PlayerState,
   PlayerStateActiveData,

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -15,7 +15,7 @@ import { debounce, flatten, groupBy } from "lodash";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import { Time } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio";
+import { MessageEvent, ParameterValue } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useContextSelector from "@foxglove/studio-base/hooks/useContextSelector";
@@ -24,7 +24,6 @@ import useSelectableContextGetter from "@foxglove/studio-base/hooks/useSelectabl
 import {
   AdvertiseOptions,
   Frame,
-  ParameterValue,
   Player,
   PlayerPresence,
   PlayerState,

--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { string } from "mathjs";
 import { ReactElement, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -56,7 +56,7 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
   useLayoutEffect(() => {
     context.watch("parameters");
     context.onRender = (renderState: RenderState, done) => {
-      if (renderState.parameters) {
+      if (renderState.parameters != undefined) {
         setParameters(renderState.parameters);
       }
       done();

--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -2,7 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelExtensionContext } from "@foxglove/studio";
+import { string } from "mathjs";
+import { ReactElement, useLayoutEffect, useState } from "react";
+import ReactDOM from "react-dom";
+
+import { PanelExtensionContext, ParameterValue, RenderState } from "@foxglove/studio";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -37,6 +41,55 @@ export const CatchRenderError = (): JSX.Element => {
         ],
         datatypes: new Map(),
         frame: {},
+        layout: "UnknownPanel!4co6n9d",
+      }}
+    >
+      <MockPanelContextProvider>
+        <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+      </MockPanelContextProvider>
+    </PanelSetup>
+  );
+};
+
+function SimplePanel({ context }: { context: PanelExtensionContext }) {
+  const [parameters, setParameters] = useState<Record<string, ParameterValue>>({});
+
+  useLayoutEffect(() => {
+    context.watch("parameters");
+    context.onRender = (renderState: RenderState, done) => {
+      if (renderState.parameters) {
+        setParameters(renderState.parameters);
+      }
+      done();
+    };
+  });
+
+  context.watch("parameters");
+  return (
+    <div>
+      <h2>Simple Panel</h2>
+      <h3>Parameters</h3>
+      <div>{JSON.stringify(parameters)}</div>
+    </div>
+  );
+}
+
+export const SimplePanelRender = (): ReactElement => {
+  function initPanel(context: PanelExtensionContext) {
+    ReactDOM.render(<SimplePanel context={context} />, context.panelElement);
+  }
+
+  return (
+    <PanelSetup
+      fixture={{
+        datatypes: new Map(),
+        frame: {},
+        activeData: {
+          parameters: new Map([
+            ["param1", "value1"],
+            ["param2", "value2"],
+          ]),
+        },
         layout: "UnknownPanel!4co6n9d",
       }}
     >

--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -61,9 +61,8 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
       }
       done();
     };
-  });
+  }, [context]);
 
-  context.watch("parameters");
   return (
     <div>
       <h2>Simple Panel</h2>

--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -51,13 +51,13 @@ export const CatchRenderError = (): JSX.Element => {
 };
 
 function SimplePanel({ context }: { context: PanelExtensionContext }) {
-  const [parameters, setParameters] = useState<Record<string, ParameterValue>>({});
+  const [parameters, setParameters] = useState<Map<string, ParameterValue>>(new Map());
 
   useLayoutEffect(() => {
     context.watch("parameters");
     context.onRender = (renderState: RenderState, done) => {
       if (renderState.parameters != undefined) {
-        setParameters(renderState.parameters);
+        setParameters(renderState.parameters ?? new Map());
       }
       done();
     };
@@ -67,7 +67,7 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
     <div>
       <h2>Simple Panel</h2>
       <h3>Parameters</h3>
-      <div>{JSON.stringify(parameters)}</div>
+      <div>{JSON.stringify(Array.from(parameters))}</div>
     </div>
   );
 }

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@fluentui/react";
-import { isEqual } from "lodash";
 import { CSSProperties, RefCallback, useCallback, useMemo, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 
@@ -172,7 +171,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
     if (watchedFieldsRef.current.has("parameters")) {
       const parameters = playerState.activeData?.parameters ?? EmptyParameters;
-      if (!isEqual(parameters, renderState.parameters)) {
+      if (parameters !== renderState.parameters) {
         shouldRender = true;
         renderState.parameters = parameters;
       }

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@fluentui/react";
+import { isEqual } from "lodash";
 import { CSSProperties, RefCallback, useCallback, useMemo, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 
@@ -29,6 +30,7 @@ import {
 } from "@foxglove/studio-base/context/HoverValueContext";
 import {
   AdvertiseOptions,
+  ParameterValue,
   PlayerCapabilities,
   PlayerState,
 } from "@foxglove/studio-base/players/types";
@@ -47,6 +49,8 @@ type PanelExtensionAdapterProps = {
   /** Help document for the panel */
   help?: string;
 };
+
+const EmptyParameters = new Map<string, ParameterValue>();
 
 const EmptyTopics: readonly Topic[] = [];
 
@@ -163,6 +167,14 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       if (renderState.currentFrame?.length !== 0 || currentFrame?.length !== 0) {
         shouldRender = true;
         renderState.currentFrame = currentFrame;
+      }
+    }
+
+    if (watchedFieldsRef.current.has("parameters")) {
+      const parameters = playerState.activeData?.parameters ?? EmptyParameters;
+      if (!isEqual(parameters, renderState.parameters)) {
+        shouldRender = true;
+        renderState.parameters = Object.fromEntries(parameters);
       }
     }
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -174,7 +174,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       const parameters = playerState.activeData?.parameters ?? EmptyParameters;
       if (!isEqual(parameters, renderState.parameters)) {
         shouldRender = true;
-        renderState.parameters = Object.fromEntries(parameters);
+        renderState.parameters = parameters;
       }
     }
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -13,6 +13,7 @@ import {
   ExtensionPanelRegistration,
   MessageEvent,
   PanelExtensionContext,
+  ParameterValue,
   RenderState,
   Topic,
 } from "@foxglove/studio";
@@ -30,7 +31,6 @@ import {
 } from "@foxglove/studio-base/context/HoverValueContext";
 import {
   AdvertiseOptions,
-  ParameterValue,
   PlayerCapabilities,
   PlayerState,
 } from "@foxglove/studio-base/players/types";

--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -4,7 +4,8 @@
 
 import { storiesOf } from "@storybook/react";
 
-import { ParameterValue, PlayerCapabilities } from "@foxglove/studio-base/players/types";
+import { ParameterValue } from "@foxglove/studio";
+import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import Parameters from "./index";

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -14,6 +14,7 @@
 import { union } from "lodash";
 import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
 
+import { ParameterValue } from "@foxglove/studio";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import { isActiveElementEditable } from "@foxglove/studio-base/components/GlobalVariablesTable";
 import { LegacyTable } from "@foxglove/studio-base/components/LegacyStyledComponents";
@@ -25,7 +26,7 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { JSONInput } from "@foxglove/studio-base/components/input/JSONInput";
 import { usePreviousValue } from "@foxglove/studio-base/hooks/usePreviousValue";
-import { ParameterValue, PlayerCapabilities } from "@foxglove/studio-base/players/types";
+import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
 
 import AnimatedRow from "./AnimatedRow";
 import ParametersPanel from "./ParametersPanel";

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -22,11 +22,11 @@ import {
   toRFC3339String,
   toSec,
 } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   AdvertiseOptions,
   MessageEvent,
-  ParameterValue,
   Player,
   PlayerMetricsCollectorInterface,
   PlayerPresence,

--- a/packages/studio-base/src/players/OrderedStampPlayer.ts
+++ b/packages/studio-base/src/players/OrderedStampPlayer.ts
@@ -14,6 +14,7 @@ import { partition } from "lodash";
 import memoizeWeak from "memoize-weak";
 
 import { Time, add, compare, isLessThan, clampTime, isTime } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
 import {
@@ -23,7 +24,6 @@ import {
   Player,
   PlayerState,
   Topic,
-  ParameterValue,
   MessageEvent,
   PlayerProblem,
 } from "@foxglove/studio-base/players/types";

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -23,6 +23,7 @@ import {
   percentOf,
   subtract as subtractTimes,
 } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import NoopMetricsCollector from "@foxglove/studio-base/players/NoopMetricsCollector";
 import {
   AdvertiseOptions,
@@ -37,7 +38,6 @@ import {
   Topic,
   ParsedMessageDefinitionsByTopic,
   PlayerPresence,
-  ParameterValue,
   PlayerProblem,
 } from "@foxglove/studio-base/players/types";
 import { rootGetDataProvider } from "@foxglove/studio-base/randomAccessDataProviders/rootGetDataProvider";

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -16,12 +16,12 @@ import {
   subtract as subtractTimes,
   toSec,
 } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import {
   AdvertiseOptions,
   MessageEvent,
-  ParameterValue,
   Player,
   PlayerCapabilities,
   PlayerMetricsCollectorInterface,

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -12,12 +12,12 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { definitions as foxgloveDefs } from "@foxglove/rosmsg-msgs-foxglove";
 import { Time, fromMillis } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import {
   AdvertiseOptions,
   MessageEvent,
-  ParameterValue,
   Player,
   PlayerMetricsCollectorInterface,
   PlayerPresence,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -27,6 +27,7 @@ import {
   subtract as subtractTimes,
   toSec,
 } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import {
   AdvertiseOptions,
@@ -40,7 +41,6 @@ import {
   ParsedMessageDefinitionsByTopic,
   PlayerPresence,
   PlayerMetricsCollectorInterface,
-  ParameterValue,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { bagConnectionsToDatatypes } from "@foxglove/studio-base/util/bagConnectionsHelper";

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -16,6 +16,7 @@ import shallowequal from "shallowequal";
 
 import Log from "@foxglove/log";
 import { Time, compare } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   Diagnostic,
@@ -37,7 +38,6 @@ import {
   PublishPayload,
   SubscribePayload,
   Topic,
-  ParameterValue,
   MessageEvent,
   PlayerProblem,
 } from "@foxglove/studio-base/players/types";

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -7,11 +7,11 @@ import { v4 as uuidv4 } from "uuid";
 import { Sockets, UdpRemoteInfo, UdpSocketRenderer } from "@foxglove/electron-socket/renderer";
 import Logger from "@foxglove/log";
 import { Time, fromMillis, add as addTimes, toDate, fromDate, fromMicros } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   AdvertiseOptions,
   MessageEvent,
-  ParameterValue,
   Player,
   PlayerMetricsCollectorInterface,
   PlayerPresence,

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -13,7 +13,7 @@
 
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
-import type { MessageEvent } from "@foxglove/studio";
+import type { MessageEvent, ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import {
@@ -35,19 +35,6 @@ export type MessageDefinitionsByTopic = {
 export type ParsedMessageDefinitionsByTopic = {
   [topic: string]: RosMsgDefinition[];
 };
-
-// Valid types for parameter data (such as rosparams)
-export type ParameterValue =
-  | undefined
-  | boolean
-  | number
-  | string
-  | Date
-  | Uint8Array
-  | ParameterValue[]
-  | ParameterStruct;
-
-export type ParameterStruct = { [key: string]: ParameterValue };
 
 // A `Player` is a class that manages playback state. It manages subscriptions,
 // current time, which topics and datatypes are available, and so on.

--- a/packages/studio-base/src/randomAccessDataProviders/UlogDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/UlogDataProvider.ts
@@ -6,10 +6,9 @@ import Logger from "@foxglove/log";
 import { RosMsgDefinition, RosMsgField } from "@foxglove/rosmsg";
 import { definitions as rosCommonDefinitions } from "@foxglove/rosmsg-msgs-common";
 import { Time, fromMicros, isTimeInRangeInclusive, toMicroSec } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio";
+import { MessageEvent, ParameterValue } from "@foxglove/studio";
 import {
   MessageDefinitionsByTopic,
-  ParameterValue,
   ParsedMessageDefinitionsByTopic,
   Topic,
 } from "@foxglove/studio-base/players/types";

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -12,13 +12,13 @@
 //   You may not use this file except in compliance with the License.
 
 import { Time } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import {
   Progress,
   Topic,
   MessageDefinitionsByTopic,
   ParsedMessageDefinitionsByTopic,
   MessageEvent,
-  ParameterValue,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -85,7 +85,7 @@ declare module "@foxglove/studio" {
     /**
      * Map of current parameter values.
      */
-    parameters?: readonly Record<string, ParameterValue>;
+    parameters?: readonly ParameterStruct;
 
     /**
      * List of available topics. This list includes subscribed and unsubscribed topics.

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 declare module "@foxglove/studio" {
+  export { ParameterValue } from "@foxglove/studio-base/players/types";
+
   export interface Time {
     sec: number;
     nsec: number;
@@ -68,6 +70,11 @@ declare module "@foxglove/studio" {
      * All available messages. Best-effort list of all available messages.
      */
     allFrames?: readonly MessageEvent<unknown>[];
+
+    /**
+     * Map of current parameter values.
+     */
+    parameters?: readonly Record<string, ParameterValue>;
 
     /**
      * List of available topics. This list includes subscribed and unsubscribed topics.

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -85,7 +85,7 @@ declare module "@foxglove/studio" {
     /**
      * Map of current parameter values.
      */
-    parameters?: readonly ParameterStruct;
+    parameters?: Map<string, ParameterValue>;
 
     /**
      * List of available topics. This list includes subscribed and unsubscribed topics.

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -3,7 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 declare module "@foxglove/studio" {
-  export { ParameterValue } from "@foxglove/studio-base/players/types";
+  // Valid types for parameter data (such as rosparams)
+  export type ParameterValue =
+    | undefined
+    | boolean
+    | number
+    | string
+    | Date
+    | Uint8Array
+    | ParameterValue[]
+    | ParameterStruct;
+
+  export type ParameterStruct = Record<string, ParameterValue>;
 
   export interface Time {
     sec: number;


### PR DESCRIPTION
**User-Facing Changes**
This allows extension panels to opt in to receiving ROS parameters as well as messages. 

**Description**
This extends the `PanelExtensionContext` and `RenderState` APIs to include ROS parameters. Extension panels can request parameter values and updates by adding `parameters` to the render state fields they want to watch:

``` context.watch("parameters");```

Parameters are passed as a `Record<string, ParameterValue>` object.

<!-- link relevant github issues -->
Partially addresses #1988 

<!-- add `docs` label if this PR requires documentation updates -->
We'll need to update the extension panel API docs to include the new `parameters` field.