### PR TITLE
Add enter/exit fullscreen icon to panel toolbar

### DIFF
--- a/packages/studio-base/src/components/MockPanelContextProvider.tsx
+++ b/packages/studio-base/src/components/MockPanelContextProvider.tsx
@@ -33,6 +33,10 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<PanelConfig> = {
   enterFullscreen: () => {
     // no-op
   },
+  exitFullscreen: () => {
+    // no-op
+  },
+  isFullscreen: false,
   hasSettings: false,
   supportsStrictMode: true,
   connectToolbarDragHandle: () => {},

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -13,7 +13,6 @@
 
 import { MessageBar, MessageBarType, Stack, useTheme, makeStyles } from "@fluentui/react";
 import BorderAllIcon from "@mdi/svg/svg/border-all.svg";
-import CloseIcon from "@mdi/svg/svg/close.svg";
 import ExpandAllOutlineIcon from "@mdi/svg/svg/expand-all-outline.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import GridLargeIcon from "@mdi/svg/svg/grid-large.svg";
@@ -229,7 +228,7 @@ const useStyles = makeStyles((theme) => ({
       background: `${theme.semanticColors.primaryButtonBackgroundHovered} !important`,
     },
   },
-  exitFullScreen: {
+  exitFullscreen: {
     position: "fixed !important" as unknown as "fixed", // ensure this overrides LegacyButton styles
     top: 75,
     right: 8,
@@ -346,8 +345,8 @@ export default function Panel<
     const [quickActionsKeyPressed, setQuickActionsKeyPressed] = useState(false);
     const [shiftKeyPressed, setShiftKeyPressed] = useState(false);
     const [cmdKeyPressed, setCmdKeyPressed] = useState(false);
-    const [fullScreen, setFullScreen] = useState(false);
-    const [fullScreenLocked, setFullScreenLocked] = useState(false);
+    const [fullScreen, setFullscreen] = useState(false);
+    const [fullScreenLocked, setFullscreenLocked] = useState(false);
     const panelCatalog = usePanelCatalog();
 
     const type = PanelComponent.panelType;
@@ -454,9 +453,9 @@ export default function Panel<
     const onOverlayClick: MouseEventHandler<HTMLDivElement> = useCallback(
       (e) => {
         if (!fullScreen && quickActionsKeyPressed) {
-          setFullScreen(true);
+          setFullscreen(true);
           if (shiftKeyPressed) {
-            setFullScreenLocked(true);
+            setFullscreenLocked(true);
           }
           return;
         }
@@ -558,7 +557,7 @@ export default function Panel<
       tabId,
     ]);
 
-    const { onMouseMove, enterFullscreen, exitFullScreen } = useMemo(
+    const { onMouseMove, enterFullscreen, exitFullscreen } = useMemo(
       () => ({
         onMouseMove: ((e) => {
           if (e.metaKey !== cmdKeyPressed) {
@@ -566,12 +565,12 @@ export default function Panel<
           }
         }) as MouseEventHandler<HTMLDivElement>,
         enterFullscreen: () => {
-          setFullScreen(true);
-          setFullScreenLocked(true);
+          setFullscreen(true);
+          setFullscreenLocked(true);
         },
-        exitFullScreen: () => {
-          setFullScreen(false);
-          setFullScreenLocked(false);
+        exitFullscreen: () => {
+          setFullscreen(false);
+          setFullscreenLocked(false);
         },
       }),
       [cmdKeyPressed],
@@ -580,9 +579,9 @@ export default function Panel<
     const onReleaseQuickActionsKey = useCallback(() => {
       setQuickActionsKeyPressed(false);
       if (fullScreen && !fullScreenLocked) {
-        exitFullScreen();
+        exitFullscreen();
       }
-    }, [exitFullScreen, fullScreen, fullScreenLocked]);
+    }, [exitFullscreen, fullScreen, fullScreenLocked]);
 
     const { keyUpHandlers, keyDownHandlers } = useMemo(
       () => ({
@@ -602,24 +601,24 @@ export default function Panel<
           "`": () => setQuickActionsKeyPressed(true),
           "~": () => setQuickActionsKeyPressed(true),
           Shift: () => setShiftKeyPressed(true),
-          Escape: () => exitFullScreen(),
+          Escape: () => exitFullscreen(),
           Meta: () => setCmdKeyPressed(true),
         },
       }),
-      [selectAllPanels, cmdKeyPressed, exitFullScreen, onReleaseQuickActionsKey],
+      [selectAllPanels, cmdKeyPressed, exitFullscreen, onReleaseQuickActionsKey],
     );
 
     /* Ensure user exits full-screen mode when leaving window, even if key is still pressed down */
     useEffect(() => {
       const listener = () => {
-        exitFullScreen();
+        exitFullscreen();
         setCmdKeyPressed(false);
         setShiftKeyPressed(false);
         onReleaseQuickActionsKey();
       };
       window.addEventListener("blur", listener);
       return () => window.removeEventListener("blur", listener);
-    }, [exitFullScreen, onReleaseQuickActionsKey]);
+    }, [exitFullscreen, onReleaseQuickActionsKey]);
 
     const otherPanelProps = useShallowMemo(otherProps);
     const childProps = useMemo(
@@ -678,6 +677,8 @@ export default function Panel<
             updatePanelConfigs,
             openSiblingPanel,
             enterFullscreen,
+            exitFullscreen,
+            isFullscreen: fullScreen,
             hasSettings: PanelComponent.configSchema != undefined,
             tabId,
             supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
@@ -746,15 +747,6 @@ export default function Panel<
                   </div>
                 </div>
               </div>
-            )}
-            {fullScreen && (
-              <Button
-                className={classes.exitFullScreen}
-                onClick={exitFullScreen}
-                data-panel-overlay-exit
-              >
-                <CloseIcon /> <span>Exit fullscreen</span>
-              </Button>
             )}
             <ErrorBoundary renderError={(errorProps) => <ErrorToolbar {...errorProps} />}>
               {PanelComponent.supportsStrictMode ?? true ? (

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -14,20 +14,20 @@
 import { SaveConfig, PanelConfig, OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
 
 export type PanelContextType<T> = {
-  // TODO(PanelAPI): private API, should not be used in panels
   type: string;
   id: string;
   title: string;
   tabId?: string;
 
-  // TODO(PanelAPI): move to usePanelConfig()
   config: PanelConfig;
   saveConfig: SaveConfig<T>;
 
-  // TODO(PanelAPI): move to usePanelActions()
   updatePanelConfigs: (panelType: string, updateConfig: (config: T) => T) => void;
   openSiblingPanel: OpenSiblingPanel;
+
   enterFullscreen: () => void;
+  exitFullscreen: () => void;
+  isFullscreen: boolean;
 
   hasSettings: boolean;
   connectToolbarDragHandle: (el: Element | ReactNull) => void;

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -59,7 +59,7 @@ class PanelToolbarWithOpenMenu extends React.PureComponent<{ hideToolbars?: bool
           if (el) {
             // wait for Dimensions
             setTimeout(() => {
-              const gearIcon = el.querySelectorAll("svg")[1];
+              const gearIcon = el.querySelector("[data-test=panel-settings] > svg");
               gearIcon?.parentElement?.click();
             }, 100);
           }

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -15,6 +15,8 @@ import { ContextualMenu, IContextualMenuItem, makeStyles } from "@fluentui/react
 import AlertIcon from "@mdi/svg/svg/alert.svg";
 import CogIcon from "@mdi/svg/svg/cog.svg";
 import DragIcon from "@mdi/svg/svg/drag.svg";
+import FullscreenExitIcon from "@mdi/svg/svg/fullscreen-exit.svg";
+import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import cx from "classnames";
 import { useContext, useState, useCallback, useMemo, useRef } from "react";
@@ -360,7 +362,12 @@ export default React.memo<Props>(function PanelToolbar({
   backgroundColor,
 }: Props) {
   const styles = useStyles();
-  const { supportsStrictMode = true } = useContext(PanelContext) ?? {};
+  const {
+    supportsStrictMode = true,
+    isFullscreen,
+    enterFullscreen,
+    exitFullscreen,
+  } = useContext(PanelContext) ?? {};
   const [menuOpen, setMenuOpen] = useState(false);
 
   const panelContext = useContext(PanelContext);
@@ -396,6 +403,16 @@ export default React.memo<Props>(function PanelToolbar({
             <HelpCircleOutlineIcon className={styles.icon} />
           </Icon>
         )}
+        {isFullscreen === false && (
+          <Icon fade tooltip="Fullscreen" onClick={enterFullscreen}>
+            <FullscreenIcon />
+          </Icon>
+        )}
+        {isFullscreen === true && (
+          <Icon fade tooltip="Exit fullscreen" onClick={exitFullscreen}>
+            <FullscreenExitIcon />
+          </Icon>
+        )}
       </>
     );
   }, [
@@ -406,6 +423,9 @@ export default React.memo<Props>(function PanelToolbar({
     panelContext?.type,
     styles.icon,
     supportsStrictMode,
+    isFullscreen,
+    enterFullscreen,
+    exitFullscreen,
   ]);
 
   // Use a debounce and 0 refresh rate to avoid triggering a resize observation while handling

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.stories.tsx
@@ -11,56 +11,20 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { storiesOf } from "@storybook/react";
+import { Story } from "@storybook/react";
 
-import { PlayerStateActiveData } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
-import { UnconnectedPlaybackPerformance, UnconnectedPlaybackPerformanceProps } from ".";
+import PlaybackPerformance from "./index";
 
-const defaultActiveData: PlayerStateActiveData = {
-  messages: [],
-  startTime: { sec: 0, nsec: 0 },
-  currentTime: { sec: 10, nsec: 0 },
-  endTime: { sec: 20, nsec: 0 },
-  isPlaying: true,
-  speed: 5.0,
-  messageOrder: "receiveTime",
-  lastSeekTime: 0,
-  topics: [],
-  datatypes: new Map(),
-  parsedMessageDefinitionsByTopic: {},
-  totalBytesReceived: 0,
+export default {
+  title: "panels/PlaybackPerformance",
 };
 
-function Example({ states }: { states: UnconnectedPlaybackPerformanceProps[] }) {
-  const [state, setState] = React.useState(states);
-  React.useEffect(() => {
-    if (state.length > 1) {
-      setState(state.slice(1));
-    }
-  }, [state]);
-  return <UnconnectedPlaybackPerformance {...state[0]!} />;
-}
-
-storiesOf("panels/PlaybackPerformance", module).add("simple example", () => {
-  const states = [
-    {
-      timestamp: 1000,
-      activeData: defaultActiveData,
-    },
-    {
-      timestamp: 1500,
-      activeData: {
-        ...defaultActiveData,
-        totalBytesReceived: 1e6,
-        currentTime: { sec: 11, nsec: 0 },
-      },
-    },
-  ];
+export const SimpleExample: Story = () => {
   return (
     <PanelSetup>
-      <Example states={states} />
+      <PlaybackPerformance />
     </PanelSetup>
   );
-});
+};


### PR DESCRIPTION


**User-Facing Changes**
Add an enter/exit fullscreen icon to the panel toolbar.

Remove the "exit fullscreen" floating button. This button covers up parts of the panel that are not otherwise covered when not in fullscreen mode.

Enter fullscreen icon:
<img width="1029" alt="Screen Shot 2021-11-16 at 10 19 00 AM" src="https://user-images.githubusercontent.com/84792/142043747-a683d90b-464a-4801-b604-23a134df84b0.png">

Exit fullscreen icon:
<img width="1029" alt="Screen Shot 2021-11-16 at 10 19 07 AM" src="https://user-images.githubusercontent.com/84792/142043778-4f2180a9-71b8-418c-afa2-33f5e3960add.png">


**Description**
We changed _something_ with the styles which cased the "Exit fullscreen" floating button to move from its prior home in the lower right corner of panels to somewhere higher up in the panel.

Prior to this change when in fullscreen:
<img width="1312" alt="Screen Shot 2021-11-16 at 10 16 55 AM" src="https://user-images.githubusercontent.com/84792/142043544-758bff66-59b2-4a9a-8c08-a19c2f4118af.png">

This covers up other panel elements. Since we already have a component that covers up other panel elements (the panel toolbar), this change leverages that component for the enter/exit fullscreen function. This also has the benefit of making fullscreen easier to find.

The existing shortcut functions remain in place.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
