### PR TITLE
Detect desktop app using desktopBridge instead of userAgent

### DIFF
--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -12,17 +12,15 @@ import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent"
 import TextContent from "@foxglove/studio-base/components/TextContent";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelInfo, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const productLinks = [
   { text: "Foxglove Studio", url: "https://foxglove.dev/studio" },
   { text: "Foxglove Data Platform", url: "https://foxglove.dev/data-platform" },
 ];
 
-const userAgent = navigator.userAgent.toLowerCase();
-const isDesktopApp = userAgent.includes(" electron/");
-
 const resourceLinks = [
-  ...(isDesktopApp ? [] : [{ text: "Desktop app", url: "https://foxglove.dev/download" }]),
+  ...(isDesktopApp() ? [] : [{ text: "Desktop app", url: "https://foxglove.dev/download" }]),
   { text: "Read docs", url: "https://foxglove.dev/docs" },
   { text: "Join our community", url: "https://foxglove.dev/community" },
 ];

--- a/packages/studio-base/src/util/isDesktopApp.ts
+++ b/packages/studio-base/src/util/isDesktopApp.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export default function isDesktopApp(): boolean {
+  return Boolean((global as unknown as { desktopBridge: unknown }).desktopBridge);
+}


### PR DESCRIPTION
**User-Facing Changes**
- N/A

**Description**
- In Help sidebar tab, detect desktop app using `desktopBridge` instead of `userAgent`

Closes https://github.com/foxglove/studio/issues/2157 
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
