### PR TITLE
Surface initialization problems from RandomAccessDataProviders

### DIFF
--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -252,8 +252,8 @@ export default class RandomAccessPlayer implements Player {
         this._parsedMessageDefinitionsByTopic =
           parsedMessageDefinitions.parsedMessageDefinitionsByTopic;
         this._initializing = false;
-        problems.forEach(({ message, severity, error, tip }, i) => {
-          this._problems.set(`initialization-${i}`, { message, severity, error, tip });
+        problems.forEach((problem, i) => {
+          this._problems.set(`initialization-${i}`, problem);
         });
         this._reportInitialized();
 

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -224,6 +224,7 @@ export default class RandomAccessPlayer implements Player {
           parameters,
           messageDefinitions,
           providesParsedMessages,
+          problems,
         } = result;
         if (!providesParsedMessages) {
           this._setError("Incorrect message format");
@@ -251,6 +252,9 @@ export default class RandomAccessPlayer implements Player {
         this._parsedMessageDefinitionsByTopic =
           parsedMessageDefinitions.parsedMessageDefinitionsByTopic;
         this._initializing = false;
+        problems.forEach(({ message, severity, error, tip }, i) => {
+          this._problems.set(`initialization-${i}`, { message, severity, error, tip });
+        });
         this._reportInitialized();
 
         // Wait a bit until panels have had the chance to subscribe to topics before we start

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -65,7 +65,7 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
       const parsedMsgdef = ROS2_TO_DEFINITIONS.get(topicDef.type);
       if (parsedMsgdef == undefined) {
         problems.push({
-          severity: "warning",
+          severity: "warn",
           message: `Topic "${topicDef.name}" has unrecognized datatype "${topicDef.type}"`,
         });
         continue;

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -67,6 +67,7 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
         problems.push({
           severity: "warn",
           message: `Topic "${topicDef.name}" has unrecognized datatype "${topicDef.type}"`,
+          tip: "ROS 2 bags don't contain full message definitions, so only well-known ROS types are supported in Studio. As a workaround, you can try using a Rosbridge WebSocket connection. For more information, see: https://github.com/ros2/rosbag2/issues/782",
         });
         continue;
       }

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -51,7 +51,7 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 // RandomAccessDataProviders have a strict API which is enforced automatically in ApiCheckerDataProvider.
 
 export type RandomAccessDataProviderProblem = {
-  severity: "error" | "warning";
+  severity: "error" | "warn";
   message: string;
   error?: Error;
   tip?: string;


### PR DESCRIPTION
**User-Facing Changes**
Errors when loading certain data sources are now surfaced in the Connection sidebar.

**Description**
Providers were allowed to emit problems from the initialize() function, but they were being ignored by RandomAccessPlayer.

Also improve the error message for custom datatypes in ROS 2 bags.