### PR TITLE
Enhance ability of studio to load state from external URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ $ yarn start        # launch electron
 # To launch the browser app:
 $ yarn web:serve
 
+# To launch the browser app using the dev backend server:
+$ yarn web:serve:dev
+
+# To launch the browser app using a local instance of the backend server:
+$ yarn web:serve:local
+
 # To launch the storybook:
 $ yarn storybook
 

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -10,6 +10,7 @@ import path from "path";
 import { Configuration, EnvironmentPlugin, WebpackPluginInstance } from "webpack";
 
 import type { WebpackArgv } from "@foxglove/studio-base/WebpackArgv";
+import { buildEnvironmentDefaults } from "@foxglove/studio-base/environment";
 import { makeConfig } from "@foxglove/studio-base/webpack";
 
 import packageJson from "../package.json";
@@ -79,17 +80,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
     plugins: [
       ...plugins,
       ...(appWebpackConfig.plugins ?? []),
-      new EnvironmentPlugin({
-        SENTRY_DSN: process.env.SENTRY_DSN ?? null, // eslint-disable-line no-restricted-syntax
-        SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax
-        AMPLITUDE_API_KEY: process.env.AMPLITUDE_API_KEY ?? null, // eslint-disable-line no-restricted-syntax
-        SIGNUP_API_URL: "https://foxglove.dev/api/signup",
-        SLACK_INVITE_URL: "https://foxglove.dev/join-slack",
-        OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
-        FOXGLOVE_API_URL: process.env.FOXGLOVE_API_URL ?? "https://api.foxglove.dev",
-        FOXGLOVE_ACCOUNT_DASHBOARD_URL:
-          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/profile",
-      }),
+      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND)),
       new HtmlWebpackPlugin({
         templateContent: `
   <!doctype html>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "web:build:dev": "webpack --mode development --progress --config web/webpack.config.ts",
     "web:build:prod": "webpack --mode production --progress --config web/webpack.config.ts",
     "web:serve": "webpack serve --mode development --progress --config web/webpack.config.ts",
+    "web:serve:dev": "webpack serve --mode development --progress --config web/webpack.config.ts --env FOXGLOVE_BACKEND=dev",
+    "web:serve:local": "webpack serve --mode development --progress --config web/webpack.config.ts --env FOXGLOVE_BACKEND=local",
     "license-check": "ts-node ci/license-check.ts",
     "lint": "TIMING=1 eslint --report-unused-disable-directives --fix .",
     "lint:ci": "TIMING=1 eslint --report-unused-disable-directives --config .eslintrc.ci.yaml .",

--- a/packages/studio-base/WebpackArgv.ts
+++ b/packages/studio-base/WebpackArgv.ts
@@ -4,7 +4,12 @@
 
 type WebpackArgv = {
   mode?: string;
-  env?: { WEBPACK_SERVE?: boolean; WEBPACK_BUNDLE?: boolean; WEBPACK_BUILD?: boolean };
+  env?: {
+    FOXGLOVE_BACKEND?: string;
+    WEBPACK_SERVE?: boolean;
+    WEBPACK_BUNDLE?: boolean;
+    WEBPACK_BUILD?: boolean;
+  };
   host?: string;
 };
 

--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+function serverURLsForBackend(backend: string): { api: string; console: string } {
+  if (backend === "local") {
+    return {
+      api: "http://localhost:3000/api",
+      console: "http://localhost:3000",
+    };
+  }
+
+  if (backend === "dev") {
+    return {
+      api: "https://dev-api.foxglove.dev",
+      console: "https://console-dev.foxglove.dev",
+    };
+  }
+
+  return {
+    api: process.env.FOXGLOVE_API_URL ?? "https://api.foxglove.dev",
+    console: process.env.FOXGLOVE_CONSOLE_URL ?? "https://console.foxglove.dev",
+  };
+}
+
+export function buildEnvironmentDefaults(
+  backend: string = "production",
+  // eslint-disable-next-line no-restricted-syntax
+): Record<string, string | null> {
+  const serverURLs = serverURLsForBackend(backend);
+  return {
+    AMPLITUDE_API_KEY: process.env.AMPLITUDE_API_KEY ?? null, // eslint-disable-line no-restricted-syntax
+    FOXGLOVE_API_URL: serverURLs.api,
+    FOXGLOVE_ACCOUNT_DASHBOARD_URL:
+      process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? serverURLs.console + "/dashboard",
+    FOXGLOVE_CONSOLE_URL: serverURLs.console,
+    OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
+    SENTRY_DSN: process.env.SENTRY_DSN ?? null, // eslint-disable-line no-restricted-syntax
+    SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax
+    SIGNUP_API_URL: "https://foxglove.dev/api/signup",
+    SLACK_INVITE_URL: "https://foxglove.dev/join-slack",
+  };
+}

--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -12,7 +12,7 @@ function serverURLsForBackend(backend: string): { api: string; console: string }
 
   if (backend === "dev") {
     return {
-      api: "https://dev-api.foxglove.dev",
+      api: "https://api-dev.foxglove.dev",
       console: "https://console-dev.foxglove.dev",
     };
   }

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -5,6 +5,7 @@
 export enum AppSetting {
   CRASH_REPORTING_ENABLED = "telemetry.crashReportingEnabled",
   MESSAGE_RATE = "messageRate",
+  LAUNCH_PREFERENCE = "launchPreference",
   ROS1_ROS_HOSTNAME = "ros1.ros_hostname",
   ROS_PACKAGE_PATH = "ros.ros_package_path",
   TELEMETRY_ENABLED = "telemetry.telemetryEnabled",

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -45,6 +45,7 @@ import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import { UserNodes } from "@foxglove/studio-base/types/panels";
 import Storage from "@foxglove/studio-base/util/Storage";
+import { windowHasValidURLState } from "@foxglove/studio-base/util/appURLState";
 
 const log = Logger.getLogger(__filename);
 
@@ -276,8 +277,13 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     ],
   );
 
-  // restore the saved source on first mount
+  // Restore the saved source on first mount unless our url specifies a source.
   useLayoutEffect(() => {
+    // The URL encodes a valid session state. Defer to the URL state.
+    if (windowHasValidURLState()) {
+      return;
+    }
+
     if (savedSource) {
       const foundSource = playerSources.find((source) => source.id === savedSource.id);
       if (!foundSource) {

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -297,6 +297,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         unlimitedMemoryCache,
       });
       setBasePlayer(initializedBasePlayer);
+      setSelectedSource(() => foundSource);
     }
     // we only run the layout effect on first mount - never again even if the saved source changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -27,6 +27,7 @@ import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import fuzzyFilter from "@foxglove/studio-base/util/fuzzyFilter";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const MESSAGE_RATES = [1, 3, 5, 10, 15, 20, 30, 60];
 
@@ -188,6 +189,37 @@ function TimeFormat(): React.ReactElement {
   );
 }
 
+function LaunchDefault(): React.ReactElement {
+  const [preference = "unknown", setPreference] = useAppConfigurationValue<string | undefined>(
+    AppSetting.LAUNCH_PREFERENCE,
+  );
+
+  const entries: Array<{ key: string; text: string }> = [
+    { key: "unknown", text: "Ask each time" },
+    { key: "web", text: "Web app" },
+    { key: "desktop", text: "Desktop app" },
+  ];
+
+  return (
+    <VirtualizedComboBox
+      label="Open links in:"
+      options={entries}
+      autoComplete="on"
+      openOnKeyboardFocus
+      selectedKey={preference}
+      onChange={(_event, option) => {
+        if (option) {
+          void setPreference(String(option.key));
+        }
+      }}
+      calloutProps={{
+        directionalHint: DirectionalHint.bottomLeftEdge,
+        directionalHintFixed: true,
+      }}
+    />
+  );
+}
+
 function MessageFramerate(): React.ReactElement {
   const [messageRate, setMessageRate] = useAppConfigurationValue<number>(AppSetting.MESSAGE_RATE);
   const entries = useMemo(
@@ -302,6 +334,11 @@ export default function Preferences(): React.ReactElement {
             <Stack.Item>
               <MessageFramerate />
             </Stack.Item>
+            {!isDesktopApp() && (
+              <Stack.Item>
+                <LaunchDefault />
+              </Stack.Item>
+            )}
           </Stack>
         </Stack.Item>
         <Stack.Item>

--- a/packages/studio-base/src/components/URLStateSyncAdapter.tsx
+++ b/packages/studio-base/src/components/URLStateSyncAdapter.tsx
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
+import { useStateToURLSynchronization } from "@foxglove/studio-base/hooks/useStateToURLSynchronization";
+
+// This is in a simple subcomponent so it doesn't trigger rerenders of an entire expensive
+// component like Workspace while it's listening for time values.
+export function URLStateSyncAdapter({ deepLinks }: { deepLinks: string[] }): ReactNull {
+  useInitialDeepLinkState(deepLinks);
+  useStateToURLSynchronization();
+
+  return ReactNull;
+}

--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
@@ -9,7 +9,7 @@ import {
 import FoxgloveDataPlatformPlayer from "@foxglove/studio-base/players/FoxgloveDataPlatformPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 
-type FoxgloveDataPlatformOptions = {
+export type FoxgloveDataPlatformOptions = {
   start: string;
   end: string;
   seek?: string;

--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
@@ -9,7 +9,7 @@ import {
 import FoxgloveDataPlatformPlayer from "@foxglove/studio-base/players/FoxgloveDataPlatformPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 
-export type FoxgloveDataPlatformOptions = {
+type FoxgloveDataPlatformOptions = {
   start: string;
   end: string;
   seek?: string;

--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -12,7 +12,7 @@ import { Player } from "@foxglove/studio-base/players/types";
 import { parseInputUrl } from "@foxglove/studio-base/util/url";
 
 class RosbridgeDataSourceFactory implements IDataSourceFactory {
-  id = "rosbridge-websockete";
+  id = "rosbridge-websocket";
   displayName = "Rosbridge (ROS 1 & 2)";
   iconName: IDataSourceFactory["iconName"] = "Flow";
 

--- a/packages/studio-base/src/hooks/index.ts
+++ b/packages/studio-base/src/hooks/index.ts
@@ -2,4 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+// These are exported from here to avoid circular imports via studio-base/index.
+
+export { useAppConfigurationValue } from "./useAppConfigurationValue";
 export { useAppTimeFormat } from "./useAppTimeFormat";

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -68,24 +68,22 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
 
     try {
-      if (appUrlState.type === "foxglove-data-platform") {
-        selectSource(appUrlState.type, appUrlState.options);
-      } else if (
-        appUrlState.type === "ros1" ||
-        appUrlState.type === "ros2" ||
-        appUrlState.type === "ros1-remote-bagfile" ||
-        appUrlState.type === "rosbridge-websocket"
-      ) {
-        selectSource(appUrlState.type, appUrlState);
-      }
-
-      if (appUrlState.layoutId != undefined) {
-        setSelectedLayoutId(appUrlState.layoutId);
-      }
+      selectSource(appUrlState.ds, appUrlState.dsParams);
     } catch (err) {
       log.error(err);
     }
-  }, [appUrlState, selectSource, setSelectedLayoutId]);
+  }, [appUrlState, selectSource]);
+
+  // Select layout from deeplink URL if present.
+  useEffect(() => {
+    if (appUrlState == undefined) {
+      return;
+    }
+
+    if (appUrlState.layoutId != undefined) {
+      setSelectedLayoutId(appUrlState.layoutId);
+    }
+  }, [appUrlState, setSelectedLayoutId]);
 
   // Sync to url time once our source has loaded and playback control is available.
   // seekPlayback will be undefined until the new source has loaded.

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useEffect, useMemo } from "react";
+
+import Log from "@foxglove/log";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
+import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
+const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
+
+const log = Log.getLogger(__filename);
+
+/**
+ * Restores our session state from any deep link we were passed on startup.
+ */
+export function useInitialDeepLinkState(deepLinks: string[]): void {
+  const urlState = useMessagePipeline(selectUrlState);
+  const stableUrlState = useDeepMemo(urlState);
+  const { selectSource } = usePlayerSelection();
+  const { setSelectedLayoutId } = useCurrentLayoutActions();
+  const [launchPreference, setLaunchPreference] = useSessionStorageValue(
+    AppSetting.LAUNCH_PREFERENCE,
+  );
+  const seekPlayback = useMessagePipeline(selectSeek);
+  const appUrlState = useMemo(() => {
+    const firstLink = deepLinks[0];
+    if (firstLink) {
+      try {
+        return parseAppURLState(new URL(firstLink));
+      } catch (error) {
+        log.error(error);
+        return undefined;
+      }
+    } else {
+      return undefined;
+    }
+  }, [deepLinks]);
+
+  // Set a sessionStorage preference for web if we have a stable URL state.
+  // This allows us to avoid asking for the preference immediately on
+  // launch of an empty session and makes refreshes do the right thing.
+  useEffect(() => {
+    if (isDesktopApp()) {
+      return;
+    }
+
+    if (stableUrlState && !launchPreference) {
+      setLaunchPreference("web");
+    }
+  }, [launchPreference, setLaunchPreference, stableUrlState]);
+
+  // Load app state from deeplink url if present.
+  useEffect(() => {
+    if (appUrlState == undefined) {
+      return;
+    }
+
+    try {
+      if (appUrlState.type === "foxglove-data-platform") {
+        selectSource(appUrlState.type, appUrlState.options);
+      } else if (
+        appUrlState.type === "ros1" ||
+        appUrlState.type === "ros2" ||
+        appUrlState.type === "ros1-remote-bagfile" ||
+        appUrlState.type === "rosbridge-websocket"
+      ) {
+        selectSource(appUrlState.type, appUrlState);
+      }
+
+      if (appUrlState.layoutId != undefined) {
+        setSelectedLayoutId(appUrlState.layoutId);
+      }
+    } catch (err) {
+      log.error(err);
+    }
+  }, [appUrlState, selectSource, setSelectedLayoutId]);
+
+  // Sync to url time once our source has loaded and playback control is available.
+  // seekPlayback will be undefined until the new source has loaded.
+  useEffect(() => {
+    if (appUrlState?.time == undefined || !seekPlayback) {
+      return;
+    }
+
+    seekPlayback(appUrlState.time);
+  }, [appUrlState, seekPlayback]);
+}

--- a/packages/studio-base/src/hooks/useSessionStorageValue.ts
+++ b/packages/studio-base/src/hooks/useSessionStorageValue.ts
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * This provides a convenience wrapper around sessionStorage and triggers
+ * a react state change when values change.
+ *
+ * TODO: We should probably refactor LocalStorageAppConfigurationProvider to
+ * handle localStorage & sessionStorage and replace this.
+ *
+ * @param key sessionStorage key to manage.
+ * @returns [value, setValue] tuple for that key.
+ */
+export function useSessionStorageValue(
+  key: string,
+): [value: string | undefined, setValue: (newValue: string | undefined) => void] {
+  const [value, updateValue] = useState<string | undefined>(
+    sessionStorage.getItem(key) ?? undefined,
+  );
+
+  const setValue = useCallback(
+    (newValue: string | undefined) => {
+      // Hack a manual event for now. Unfortunately the browser only fires "storage"
+      // events when triggered outside our current tab.
+      if (newValue) {
+        sessionStorage.setItem(key, newValue);
+        window.dispatchEvent(
+          new StorageEvent("storage", { key, newValue, storageArea: sessionStorage }),
+        );
+      } else {
+        sessionStorage.removeItem(key);
+        window.dispatchEvent(
+          new StorageEvent("storage", { key, newValue: undefined, storageArea: sessionStorage }),
+        );
+      }
+    },
+    [key],
+  );
+
+  const changeListener = useCallback(
+    (event: StorageEvent) => {
+      if (event.key === key) {
+        updateValue(event.newValue ?? undefined);
+      }
+    },
+    [key],
+  );
+
+  useEffect(() => {
+    window.addEventListener("storage", changeListener);
+    return () => window.removeEventListener("storage", changeListener);
+  }, [changeListener]);
+
+  return [value ?? undefined, setValue];
+}

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -10,6 +10,7 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
@@ -20,6 +21,7 @@ const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState
 const debouncedURLUpdate = debounce(
   (url: URL) => window.history.replaceState(undefined, "", url.href),
   500,
+  { leading: true },
 );
 
 /**
@@ -30,6 +32,7 @@ export function useStateToURLSynchronization(): void {
   const urlState = useMessagePipeline(selectUrlState);
   const layoutId = useCurrentLayoutSelector((layout) => layout.selectedLayout?.id);
   const stableUrlState = useDeepMemo(urlState);
+  const { selectedSource } = usePlayerSelection();
 
   useEffect(() => {
     // Electron has its own concept of what the app URL is. If we want to do anything
@@ -39,17 +42,18 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
-    if (!stableUrlState) {
+    if (!stableUrlState || !selectedSource) {
       return;
     }
 
     const url = encodeAppURLState(new URL(window.location.href), {
+      ds: selectedSource.id,
       layoutId,
       time: currentTime,
-      ...stableUrlState,
+      dsParams: stableUrlState,
     });
 
     // Debounce updates to avoid spamming changes to the address bar.
     debouncedURLUpdate(url);
-  }, [currentTime, layoutId, stableUrlState]);
+  }, [currentTime, layoutId, selectedSource, stableUrlState]);
 }

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { debounce } from "lodash";
+import { useEffect } from "react";
+
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
+import { encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
+const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
+
+const debouncedURLUpdate = debounce(
+  (url: URL) => window.history.replaceState(undefined, "", url.href),
+  500,
+);
+
+/**
+ * Syncs our current player, layout and other state with the URL in the address bar.
+ */
+export function useStateToURLSynchronization(): void {
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const urlState = useMessagePipeline(selectUrlState);
+  const layoutId = useCurrentLayoutSelector((layout) => layout.selectedLayout?.id);
+  const stableUrlState = useDeepMemo(urlState);
+
+  useEffect(() => {
+    // Electron has its own concept of what the app URL is. If we want to do anything
+    // here for desktop we'll need to find some other method of encoding the state
+    // like perhaps the URL hash.
+    if (isDesktopApp()) {
+      return;
+    }
+
+    if (!stableUrlState) {
+      return;
+    }
+
+    const url = encodeAppURLState(new URL(window.location.href), {
+      layoutId,
+      time: currentTime,
+      ...stableUrlState,
+    });
+
+    // Debounce updates to avoid spamming changes to the address bar.
+    debouncedURLUpdate(url);
+  }, [currentTime, layoutId, stableUrlState]);
+}

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -261,12 +261,9 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       playerId: this._id,
       problems: this._problems,
       urlState: {
-        type: "foxglove-data-platform",
-        options: {
-          start: toRFC3339String(this._start ?? ZERO_TIME),
-          end: toRFC3339String(this._end ?? ZERO_TIME),
-          deviceId: this._deviceId,
-        },
+        start: toRFC3339String(this._start ?? ZERO_TIME),
+        end: toRFC3339String(this._end ?? ZERO_TIME),
+        deviceId: this._deviceId,
       },
 
       activeData: {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -260,6 +260,14 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       capabilities: CAPABILITIES,
       playerId: this._id,
       problems: this._problems,
+      urlState: {
+        type: "foxglove-data-platform",
+        options: {
+          start: toRFC3339String(this._start ?? ZERO_TIME),
+          end: toRFC3339String(this._end ?? ZERO_TIME),
+          deviceId: this._deviceId,
+        },
+      },
 
       activeData: {
         messages,

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -360,6 +360,12 @@ export default class RandomAccessPlayer implements Player {
             publishedTopics,
             parsedMessageDefinitionsByTopic: this._parsedMessageDefinitionsByTopic,
           },
+      urlState: this._label
+        ? {
+            type: "ros1-remote-bagfile",
+            url: this._label,
+          }
+        : undefined,
     };
 
     return this._listener(data);

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -362,7 +362,6 @@ export default class RandomAccessPlayer implements Player {
           },
       urlState: this._label
         ? {
-            type: "ros1-remote-bagfile",
             url: this._label,
           }
         : undefined,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -330,7 +330,6 @@ export default class RosbridgePlayer implements Player {
       playerId: this._id,
       problems: this._problems.problems(),
       urlState: {
-        type: "rosbridge-websocket",
         url: this._url,
       },
 

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -329,6 +329,10 @@ export default class RosbridgePlayer implements Player {
       capabilities: CAPABILITIES,
       playerId: this._id,
       problems: this._problems.problems(),
+      urlState: {
+        type: "rosbridge-websocket",
+        url: this._url,
+      },
 
       activeData: {
         messages,

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -14,6 +14,7 @@
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
+import { FoxgloveDataPlatformOptions } from "@foxglove/studio-base/dataSources/FoxgloveDataPlatformDataSourceFactory";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import {
@@ -94,6 +95,13 @@ export type PlayerProblem = {
   tip?: string;
 };
 
+export type PlayerURLState =
+  | { type: "foxglove-data-platform"; options: FoxgloveDataPlatformOptions }
+  | { type: "ros1"; url: string }
+  | { type: "ros2"; url: string }
+  | { type: "rosbridge-websocket"; url: string }
+  | { type: "ros1-remote-bagfile"; url: string };
+
 export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.
   presence: PlayerPresence;
@@ -124,6 +132,9 @@ export type PlayerState = {
   // The actual data to render panels with. Can be empty during initialization, until all this data
   // is known. See `type PlayerStateActiveData` for more details.
   activeData?: PlayerStateActiveData;
+
+  /** State to serialize into the active URL. */
+  urlState?: PlayerURLState;
 };
 
 export type PlayerStateActiveData = {

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -14,7 +14,6 @@
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
-import { FoxgloveDataPlatformOptions } from "@foxglove/studio-base/dataSources/FoxgloveDataPlatformDataSourceFactory";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import {
@@ -95,12 +94,7 @@ export type PlayerProblem = {
   tip?: string;
 };
 
-export type PlayerURLState =
-  | { type: "foxglove-data-platform"; options: FoxgloveDataPlatformOptions }
-  | { type: "ros1"; url: string }
-  | { type: "ros2"; url: string }
-  | { type: "rosbridge-websocket"; url: string }
-  | { type: "ros1-remote-bagfile"; url: string };
+export type PlayerURLState = Record<string, string>;
 
 export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -38,6 +38,7 @@ import { LayoutID } from "@foxglove/studio-base/services/ConsoleApi";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutManagerEventTypes } from "@foxglove/studio-base/services/ILayoutManager";
 import { PanelConfig, UserNodes, PlaybackConfig } from "@foxglove/studio-base/types/panels";
+import { windowHasValidURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 const log = Logger.getLogger(__filename);
@@ -224,8 +225,13 @@ export default function CurrentLayoutProvider({
     return () => layoutManager.off("change", listener);
   }, [layoutManager, setLayoutState]);
 
-  // Load initial state by re-selecting the last selected layout from the UserProfile
+  // Load initial state by re-selecting the last selected layout from the UserProfile.
+  // Don't restore the layout if there's one specified in the app state url.
   useAsync(async () => {
+    if (windowHasValidURLState()) {
+      return;
+    }
+
     const { currentLayoutId } = await getUserProfile();
     await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
   }, [getUserProfile, setSelectedLayoutId]);

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.stories.tsx
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ReactElement } from "react";
+
+import { LaunchPreferenceScreen } from "@foxglove/studio-base/screens/LaunchPreferenceScreen";
+
+export default {
+  title: "LaunchPreferenceScreen",
+  component: LaunchPreferenceScreen,
+};
+
+export const LaunchPreferenceScreenRender = (): ReactElement => {
+  return <LaunchPreferenceScreen />;
+};

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  CompoundButton,
+  Checkbox,
+  Stack,
+  Text,
+  useTheme,
+  makeStyles,
+  IButtonStyles,
+} from "@fluentui/react";
+import { ReactElement, useState } from "react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    border: `1px solid ${theme.semanticColors.bodyDivider}`,
+    borderRadius: theme.effects.roundedCorner4,
+    marginBottom: theme.spacing.l2,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: theme.spacing.m,
+  },
+}));
+
+const buttonStyles = {
+  root: { flex: "0 1 100%" },
+  flexContainer: { alignItems: "center" },
+} as Partial<IButtonStyles>;
+
+export function LaunchPreferenceScreen(): ReactElement {
+  const theme = useTheme();
+  const classes = useStyles();
+
+  const [globalPreference, setGlobalPreference] = useAppConfigurationValue<string | undefined>(
+    AppSetting.LAUNCH_PREFERENCE,
+  );
+  const [_, setSessionPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
+  const [rememberPreference, setRememberPreference] = useState(globalPreference != undefined);
+
+  const cleanWebURL = new URL(window.location.href);
+  cleanWebURL.searchParams.delete("launch");
+
+  async function launchInWeb() {
+    if (rememberPreference) {
+      await setGlobalPreference("web");
+    } else {
+      setSessionPreference("web");
+    }
+  }
+
+  async function launchInDesktop() {
+    if (rememberPreference) {
+      await setGlobalPreference("desktop");
+    } else {
+      setSessionPreference("desktop");
+    }
+  }
+
+  async function toggleRememberPreference() {
+    if (rememberPreference) {
+      await setGlobalPreference(undefined);
+    }
+
+    setRememberPreference(!rememberPreference);
+  }
+
+  return (
+    <Stack horizontalAlign="center" verticalAlign="center" verticalFill>
+      <Stack
+        className={classes.container}
+        tokens={{
+          childrenGap: theme.spacing.l1,
+          padding: theme.spacing.l1,
+          maxWidth: 480,
+        }}
+      >
+        <Text className={classes.title} variant="xxLarge">
+          Launch Foxglove Studio
+        </Text>
+        <Stack horizontal tokens={{ childrenGap: theme.spacing.m }}>
+          <CompoundButton
+            styles={buttonStyles}
+            onClick={() => void launchInWeb()}
+            secondaryText="Requires Chrome v76+"
+          >
+            Web
+          </CompoundButton>
+          <CompoundButton
+            styles={buttonStyles}
+            onClick={() => void launchInDesktop()}
+            secondaryText="For Linux, Windows, and macOS"
+          >
+            Desktop App
+          </CompoundButton>
+        </Stack>
+        <Checkbox
+          label="Remember my preference"
+          checked={rememberPreference}
+          onChange={toggleRememberPreference}
+        />
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.stories.tsx
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ReactElement } from "react";
+
+import { LaunchingInDesktopScreen } from "@foxglove/studio-base/screens/LaunchingInDesktopScreen";
+
+export default {
+  title: "LaunchingInDesktopScreen",
+  component: LaunchingInDesktopScreen,
+};
+
+export const LaunchingInDesktopScreenRender = (): ReactElement => {
+  return <LaunchingInDesktopScreen />;
+};

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Link, Stack, Text, useTheme } from "@fluentui/react";
+import { ReactElement, useEffect } from "react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+
+export function LaunchingInDesktopScreen(): ReactElement {
+  const theme = useTheme();
+  const [, setLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
+
+  const cleanWebURL = new URL(window.location.href);
+  cleanWebURL.searchParams.delete("launch");
+
+  function openWeb() {
+    setLaunchPreference("web");
+    window.location.href = cleanWebURL.href;
+  }
+
+  useEffect(() => {
+    const desktopURL = new URL("foxglove://open");
+    cleanWebURL.searchParams.forEach((k, v) => {
+      if (k && v) {
+        desktopURL.searchParams.set(k, v);
+      }
+    });
+
+    window.location.href = desktopURL.href;
+  });
+
+  return (
+    <Stack horizontalAlign="center" verticalAlign="center" verticalFill>
+      <Stack
+        horizontalAlign="center"
+        verticalAlign="center"
+        verticalFill
+        tokens={{ childrenGap: theme.spacing.l1, maxWidth: 480 }}
+        styles={{ root: { textAlign: "center" } }}
+      >
+        <Text variant="xxLarge">Launching Foxglove Studio…</Text>
+        <Text>We’ve directed you to the desktop app.</Text>
+        <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
+          <Text>
+            You can also <Link onClick={openWeb}>open this link in your browser</Link>.
+          </Text>
+          <Text>
+            Don’t have the app installed?&nbsp;
+            <Link href="https://foxglove.dev/download">Download Foxglove Studio</Link>
+          </Text>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Time, toRFC3339String } from "@foxglove/rostime";
+import { LayoutID } from "@foxglove/studio-base/index";
+import { PlayerURLState } from "@foxglove/studio-base/players/types";
+import { encodeAppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+jest.mock("@foxglove/studio-base/util/isDesktopApp", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockIsDesktop = isDesktopApp as jest.MockedFunction<typeof isDesktopApp>;
+
+describe("app state url parser", () => {
+  // Note that the foxglove URL here is different from actual foxglove URLs because Node's URL parser
+  // interprets foxglove:// URLs differently than the browser does.
+  describe.each([
+    { isDesktop: true, urlBuilder: () => new URL("foxglove://host/open") },
+    { isDesktop: false, urlBuilder: () => new URL("https://studio.foxglove.dev/") },
+  ])("url tests", ({ isDesktop, urlBuilder }) => {
+    beforeEach(() => mockIsDesktop.mockReturnValue(isDesktop));
+    it("rejects non data state urls", () => {
+      expect(parseAppURLState(urlBuilder())).toBeUndefined();
+    });
+
+    it("parses rosbag data state urls", () => {
+      const url = urlBuilder();
+      url.searchParams.append("type", "ros1-remote-bagfile");
+      url.searchParams.append("url", "http://example.com");
+
+      expect(parseAppURLState(url)).toMatchObject({
+        type: "ros1-remote-bagfile",
+        url: "http://example.com",
+      });
+    });
+
+    it("rejects incomplete state urls", () => {
+      const url = urlBuilder();
+      url.searchParams.append("type", "foxglove-data-platform");
+      url.searchParams.append("start", toRFC3339String({ sec: new Date().getTime(), nsec: 0 }));
+
+      expect(() => parseAppURLState(url)).toThrow(Error);
+    });
+
+    it("parses data platform state urls", () => {
+      const now: Time = { sec: new Date().getTime(), nsec: 0 };
+      const url = urlBuilder();
+      url.searchParams.append("type", "foxglove-data-platform");
+      url.searchParams.append("start", toRFC3339String(now));
+      url.searchParams.append("time", toRFC3339String({ sec: now.sec + 500, nsec: 0 }));
+      url.searchParams.append("end", toRFC3339String({ sec: now.sec + 1000, nsec: 0 }));
+      url.searchParams.append("deviceId", "dummy");
+      url.searchParams.append("layoutId", "1234");
+
+      const parsed = parseAppURLState(url);
+      expect(parsed).toMatchObject({
+        layoutId: "1234",
+        time: { sec: now.sec + 500, nsec: 0 },
+        type: "foxglove-data-platform",
+      });
+    });
+  });
+});
+
+describe("app state encoding", () => {
+  const baseURL = () => new URL("http://example.com");
+
+  it("encodes rosbag urls", () => {
+    expect(
+      encodeAppURLState(baseURL(), {
+        layoutId: "123" as LayoutID,
+        time: undefined,
+        type: "ros1-remote-bagfile",
+        url: "http://foxglove.dev/test.bag",
+      }).href,
+    ).toEqual(
+      "http://example.com/?layoutId=123&type=ros1-remote-bagfile&url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag",
+    );
+  });
+
+  it("encodes url based states", () => {
+    const states: PlayerURLState[] = [
+      { type: "ros1", url: "http://example.com:11311/test.bag" },
+      { type: "ros2", url: "http://example.com:11311/test.bag" },
+      { type: "ros1-remote-bagfile", url: "http://example.com/test.bag" },
+      { type: "rosbridge-websocket", url: "ws://foxglove.dev:9090/test.bag" },
+    ];
+    states.forEach((state) => {
+      const url = "url" in state ? state.url : "";
+      expect(
+        encodeAppURLState(baseURL(), { layoutId: "123" as LayoutID, time: undefined, ...state })
+          .href,
+      ).toEqual(
+        `http://example.com/?layoutId=123&type=${state.type}&url=${encodeURIComponent(url)}`,
+      );
+    });
+  });
+});

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -4,8 +4,11 @@
 
 import { Time, toRFC3339String } from "@foxglove/rostime";
 import { LayoutID } from "@foxglove/studio-base/index";
-import { PlayerURLState } from "@foxglove/studio-base/players/types";
-import { encodeAppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import {
+  AppURLState,
+  encodeAppURLState,
+  parseAppURLState,
+} from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 jest.mock("@foxglove/studio-base/util/isDesktopApp", () => ({
@@ -29,38 +32,40 @@ describe("app state url parser", () => {
 
     it("parses rosbag data state urls", () => {
       const url = urlBuilder();
-      url.searchParams.append("type", "ros1-remote-bagfile");
-      url.searchParams.append("url", "http://example.com");
+      url.searchParams.append("ds", "ros1-remote-bagfile");
+      url.searchParams.append("ds.url", "http://example.com");
 
       expect(parseAppURLState(url)).toMatchObject({
-        type: "ros1-remote-bagfile",
-        url: "http://example.com",
+        ds: "ros1-remote-bagfile",
+        dsParams: {
+          url: "http://example.com",
+        },
       });
-    });
-
-    it("rejects incomplete state urls", () => {
-      const url = urlBuilder();
-      url.searchParams.append("type", "foxglove-data-platform");
-      url.searchParams.append("start", toRFC3339String({ sec: new Date().getTime(), nsec: 0 }));
-
-      expect(() => parseAppURLState(url)).toThrow(Error);
     });
 
     it("parses data platform state urls", () => {
       const now: Time = { sec: new Date().getTime(), nsec: 0 };
+      const time = toRFC3339String({ sec: now.sec + 500, nsec: 0 });
+      const start = toRFC3339String(now);
+      const end = toRFC3339String({ sec: now.sec + 1000, nsec: 0 });
       const url = urlBuilder();
-      url.searchParams.append("type", "foxglove-data-platform");
-      url.searchParams.append("start", toRFC3339String(now));
-      url.searchParams.append("time", toRFC3339String({ sec: now.sec + 500, nsec: 0 }));
-      url.searchParams.append("end", toRFC3339String({ sec: now.sec + 1000, nsec: 0 }));
-      url.searchParams.append("deviceId", "dummy");
+      url.searchParams.append("ds", "foxglove-data-platform");
       url.searchParams.append("layoutId", "1234");
+      url.searchParams.append("time", time);
+      url.searchParams.append("ds.deviceId", "dummy");
+      url.searchParams.append("ds.start", start);
+      url.searchParams.append("ds.end", end);
 
       const parsed = parseAppURLState(url);
       expect(parsed).toMatchObject({
         layoutId: "1234",
+        ds: "foxglove-data-platform",
         time: { sec: now.sec + 500, nsec: 0 },
-        type: "foxglove-data-platform",
+        dsParams: {
+          deviceId: "dummy",
+          start,
+          end,
+        },
       });
     });
   });
@@ -74,28 +79,42 @@ describe("app state encoding", () => {
       encodeAppURLState(baseURL(), {
         layoutId: "123" as LayoutID,
         time: undefined,
-        type: "ros1-remote-bagfile",
-        url: "http://foxglove.dev/test.bag",
+        ds: "ros1-remote-bagfile",
+        dsParams: {
+          url: "http://foxglove.dev/test.bag",
+        },
       }).href,
     ).toEqual(
-      "http://example.com/?layoutId=123&type=ros1-remote-bagfile&url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag",
+      "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123",
     );
   });
 
   it("encodes url based states", () => {
-    const states: PlayerURLState[] = [
-      { type: "ros1", url: "http://example.com:11311/test.bag" },
-      { type: "ros2", url: "http://example.com:11311/test.bag" },
-      { type: "ros1-remote-bagfile", url: "http://example.com/test.bag" },
-      { type: "rosbridge-websocket", url: "ws://foxglove.dev:9090/test.bag" },
+    const layoutId = "123" as LayoutID;
+    const time = undefined;
+    const states: Array<AppURLState> = [
+      { layoutId, time, ds: "ros1", dsParams: { url: "http://example.com:11311/test.bag" } },
+      { layoutId, time, ds: "ros2", dsParams: { url: "http://example.com:11311/test.bag" } },
+      {
+        layoutId,
+        time,
+        ds: "ros1-remote-bagfile",
+        dsParams: { url: "http://example.com/test.bag" },
+      },
+      {
+        layoutId,
+        time,
+        ds: "rosbridge-websocket",
+        dsParams: { url: "ws://foxglove.dev:9090/test.bag" },
+      },
     ];
     states.forEach((state) => {
-      const url = "url" in state ? state.url : "";
-      expect(
-        encodeAppURLState(baseURL(), { layoutId: "123" as LayoutID, time: undefined, ...state })
-          .href,
-      ).toEqual(
-        `http://example.com/?layoutId=123&type=${state.type}&url=${encodeURIComponent(url)}`,
+      const url = state.dsParams?.url;
+      const encodededURL = encodeAppURLState(baseURL(), state).href;
+      expect(encodededURL).toEqual(
+        `http://example.com/?ds=${state.ds}&ds.url=${encodeURIComponent(
+          url ?? "",
+        )}&layoutId=${layoutId}`,
       );
     });
   });

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -89,10 +89,10 @@ describe("app state encoding", () => {
     );
   });
 
-  it("encodes url based states", () => {
+  describe("url states", () => {
     const layoutId = "123" as LayoutID;
     const time = undefined;
-    const states: Array<AppURLState> = [
+    it.each<AppURLState>([
       { layoutId, time, ds: "ros1", dsParams: { url: "http://example.com:11311/test.bag" } },
       { layoutId, time, ds: "ros2", dsParams: { url: "http://example.com:11311/test.bag" } },
       {
@@ -107,8 +107,7 @@ describe("app state encoding", () => {
         ds: "rosbridge-websocket",
         dsParams: { url: "ws://foxglove.dev:9090/test.bag" },
       },
-    ];
-    states.forEach((state) => {
+    ])("encodes url state", (state) => {
       const url = state.dsParams?.url;
       const encodededURL = encodeAppURLState(baseURL(), state).href;
       expect(encodededURL).toEqual(

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -4,11 +4,11 @@
 
 import { fromRFC3339String, toRFC3339String, Time } from "@foxglove/rostime";
 import { LayoutID } from "@foxglove/studio-base/index";
-import { PlayerURLState } from "@foxglove/studio-base/players/types";
-import { assertNever } from "@foxglove/studio-base/util/assertNever";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
-export type AppURLState = PlayerURLState & {
+export type AppURLState = {
+  ds: string;
+  dsParams: Record<string, string>;
   layoutId: LayoutID | undefined;
   time: Time | undefined;
 };
@@ -17,59 +17,43 @@ export type AppURLState = PlayerURLState & {
  * Encodes app state in a URL's query params.
  *
  * @param url The base URL to encode params into.
- * @param layoutId Optinal layout ID to store in the URL.
  * @param urlState The player state to encode.
  * @returns A url with all app state stored as query pararms.
  */
 export function encodeAppURLState(url: URL, urlState: AppURLState): URL {
+  const newURL = new URL(url.href);
+
   // Clear all exisiting params first.
-  [...url.searchParams].forEach(([k, _]) => url.searchParams.delete(k));
+  [...newURL.searchParams].forEach(([k, _]) => newURL.searchParams.delete(k));
 
   if (urlState.layoutId) {
-    url.searchParams.set("layoutId", urlState.layoutId);
+    newURL.searchParams.set("layoutId", urlState.layoutId);
   }
 
-  if (urlState.type === "ros1-remote-bagfile") {
-    // We can't get full paths to local files so only set this for remote files.
-    if (urlState.url.startsWith("http")) {
-      url.searchParams.set("type", urlState.type);
-      url.searchParams.set("url", urlState.url);
-    }
-  } else if (
-    urlState.type === "ros1" ||
-    urlState.type === "ros2" ||
-    urlState.type === "rosbridge-websocket"
-  ) {
-    url.searchParams.set("type", urlState.type);
-    url.searchParams.set("url", urlState.url);
-  } else if (urlState.type === "foxglove-data-platform") {
-    url.searchParams.set("type", urlState.type);
-    Object.entries(urlState.options).forEach(([k, v]) => {
-      url.searchParams.set(k, v);
-    });
-  } else {
-    assertNever(urlState, "Unknown url state.");
+  if (urlState.time) {
+    newURL.searchParams.set("time", toRFC3339String(urlState.time));
   }
 
-  if (urlState.time != undefined) {
-    url.searchParams.set("time", toRFC3339String(urlState.time));
-  }
+  newURL.searchParams.set("ds", urlState.ds);
+  Object.entries(urlState.dsParams).forEach(([k, v]) => {
+    newURL.searchParams.set("ds." + k, v);
+  });
 
-  url.searchParams.sort();
+  newURL.searchParams.sort();
 
-  return url;
+  return newURL;
 }
 
 /**
  * Tries to parse a state url into one of the types we know how to open.
  *
  * @param url URL to try to parse.
- * @returns Parsed URL type or undefined if the url is not a foxglove URL.
+ * @returns Parsed URL type or undefined if the url is not a valid URL.
  * @throws Error if URL parsing fails.
  */
 export function parseAppURLState(url: URL): AppURLState | undefined {
-  const type = url.searchParams.get("type");
-  if (!type) {
+  const ds = url.searchParams.get("ds");
+  if (!ds) {
     return undefined;
   }
 
@@ -84,54 +68,20 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
   const layoutId = url.searchParams.get("layoutId");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
+  const dsParams: Record<string, string> = {};
+  url.searchParams.forEach((v, k) => {
+    if (k && v && k.startsWith("ds.")) {
+      const cleanKey = k.replace(/^ds./, "");
+      dsParams[cleanKey] = v;
+    }
+  });
 
-  if (
-    type === "ros1-remote-bagfile" ||
-    type === "rosbridge-websocket" ||
-    type === "ros1" ||
-    type === "ros2"
-  ) {
-    const resourceUrl = url.searchParams.get("url");
-    if (!resourceUrl) {
-      throw Error(`Missing resource url param in ${url}`);
-    } else {
-      return {
-        layoutId: layoutId ? (layoutId as LayoutID) : undefined,
-        time,
-        type,
-        url: resourceUrl,
-      };
-    }
-  } else if (type === "foxglove-data-platform") {
-    const start = url.searchParams.get("start") ?? "";
-    const end = url.searchParams.get("end") ?? "";
-    const seek = url.searchParams.get("seekTo") ?? undefined;
-    const deviceId = url.searchParams.get("deviceId");
-    if (!deviceId) {
-      throw Error(`Missing deviceId param in ${url}`);
-    }
-
-    if (
-      !fromRFC3339String(start) ||
-      !fromRFC3339String(end) ||
-      (seek && !fromRFC3339String(seek))
-    ) {
-      throw Error(`Missing or invalid timestamp(s) in ${url}`);
-    }
-    return {
-      layoutId: layoutId ? (layoutId as LayoutID) : undefined,
-      time,
-      type: "foxglove-data-platform",
-      options: {
-        start,
-        end,
-        seek,
-        deviceId,
-      },
-    };
-  } else {
-    throw Error(`Unknown deep link type ${url}`);
-  }
+  return {
+    layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+    time,
+    ds,
+    dsParams,
+  };
 }
 
 /**

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -1,0 +1,160 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fromRFC3339String, toRFC3339String, Time } from "@foxglove/rostime";
+import { LayoutID } from "@foxglove/studio-base/index";
+import { PlayerURLState } from "@foxglove/studio-base/players/types";
+import { assertNever } from "@foxglove/studio-base/util/assertNever";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+export type AppURLState = PlayerURLState & {
+  layoutId: LayoutID | undefined;
+  time: Time | undefined;
+};
+
+/**
+ * Encodes app state in a URL's query params.
+ *
+ * @param url The base URL to encode params into.
+ * @param layoutId Optinal layout ID to store in the URL.
+ * @param urlState The player state to encode.
+ * @returns A url with all app state stored as query pararms.
+ */
+export function encodeAppURLState(url: URL, urlState: AppURLState): URL {
+  // Clear all exisiting params first.
+  [...url.searchParams].forEach(([k, _]) => url.searchParams.delete(k));
+
+  if (urlState.layoutId) {
+    url.searchParams.set("layoutId", urlState.layoutId);
+  }
+
+  if (urlState.type === "ros1-remote-bagfile") {
+    // We can't get full paths to local files so only set this for remote files.
+    if (urlState.url.startsWith("http")) {
+      url.searchParams.set("type", urlState.type);
+      url.searchParams.set("url", urlState.url);
+    }
+  } else if (
+    urlState.type === "ros1" ||
+    urlState.type === "ros2" ||
+    urlState.type === "rosbridge-websocket"
+  ) {
+    url.searchParams.set("type", urlState.type);
+    url.searchParams.set("url", urlState.url);
+  } else if (urlState.type === "foxglove-data-platform") {
+    url.searchParams.set("type", urlState.type);
+    Object.entries(urlState.options).forEach(([k, v]) => {
+      url.searchParams.set(k, v);
+    });
+  } else {
+    assertNever(urlState, "Unknown url state.");
+  }
+
+  if (urlState.time != undefined) {
+    url.searchParams.set("time", toRFC3339String(urlState.time));
+  }
+
+  url.searchParams.sort();
+
+  return url;
+}
+
+/**
+ * Tries to parse a state url into one of the types we know how to open.
+ *
+ * @param url URL to try to parse.
+ * @returns Parsed URL type or undefined if the url is not a foxglove URL.
+ * @throws Error if URL parsing fails.
+ */
+export function parseAppURLState(url: URL): AppURLState | undefined {
+  const type = url.searchParams.get("type");
+  if (!type) {
+    return undefined;
+  }
+
+  if (isDesktopApp() && url.protocol !== "foxglove:") {
+    throw Error("Unknown protocol.");
+  }
+
+  if (!isDesktopApp() && url.pathname !== "/") {
+    throw Error("Unknown path.");
+  }
+
+  const layoutId = url.searchParams.get("layoutId");
+  const timeString = url.searchParams.get("time");
+  const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
+
+  if (
+    type === "ros1-remote-bagfile" ||
+    type === "rosbridge-websocket" ||
+    type === "ros1" ||
+    type === "ros2"
+  ) {
+    const resourceUrl = url.searchParams.get("url");
+    if (!resourceUrl) {
+      throw Error(`Missing resource url param in ${url}`);
+    } else {
+      return {
+        layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+        time,
+        type,
+        url: resourceUrl,
+      };
+    }
+  } else if (type === "foxglove-data-platform") {
+    const start = url.searchParams.get("start") ?? "";
+    const end = url.searchParams.get("end") ?? "";
+    const seek = url.searchParams.get("seekTo") ?? undefined;
+    const deviceId = url.searchParams.get("deviceId");
+    if (!deviceId) {
+      throw Error(`Missing deviceId param in ${url}`);
+    }
+
+    if (
+      !fromRFC3339String(start) ||
+      !fromRFC3339String(end) ||
+      (seek && !fromRFC3339String(seek))
+    ) {
+      throw Error(`Missing or invalid timestamp(s) in ${url}`);
+    }
+    return {
+      layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+      time,
+      type: "foxglove-data-platform",
+      options: {
+        start,
+        end,
+        seek,
+        deviceId,
+      },
+    };
+  } else {
+    throw Error(`Unknown deep link type ${url}`);
+  }
+}
+
+/**
+ * Tries to parse app url state from the window's current location.
+ */
+export function windowAppURLState(): AppURLState | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  try {
+    return parseAppURLState(new URL(window.location.href));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Checks to see if we have a valid state encoded in the url.
+ *
+ * @returns True if the window has a valid encoded url state.
+ */
+export function windowHasValidURLState(): boolean {
+  const urlState = windowAppURLState();
+  return urlState != undefined;
+}

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -77,6 +77,7 @@ function AppWrapper({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }) {
       loadWelcomeLayout={loadWelcomeLayout}
       demoBagUrl={DEMO_BAG_URL}
       availableSources={dataSources}
+      deepLinks={[window.location.href]}
     />
   );
 }

--- a/web/src/components/ConsoleApiCookieCurrentUserProvider.tsx
+++ b/web/src/components/ConsoleApiCookieCurrentUserProvider.tsx
@@ -46,7 +46,7 @@ export default function ConsoleApiCookieCurrentUserProvider(
   // cookies and return the user back to studio
   const signIn = useCallback(() => {
     const currentLocation = encodeURIComponent(window.location.href);
-    window.location.href = `https://console.foxglove.dev/signin?returnTo=${currentLocation}`;
+    window.location.href = `${process.env.FOXGLOVE_CONSOLE_URL}/signin?returnTo=${currentLocation}`;
   }, []);
 
   const value = useShallowMemo({ currentUser, signIn, signOut });

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -12,6 +12,7 @@ import { Configuration, EnvironmentPlugin, WebpackPluginInstance } from "webpack
 import type { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
 
 import type { WebpackArgv } from "@foxglove/studio-base/WebpackArgv";
+import { buildEnvironmentDefaults } from "@foxglove/studio-base/environment";
 import { makeConfig } from "@foxglove/studio-base/webpack";
 
 interface WebpackConfiguration extends Configuration {
@@ -101,17 +102,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     plugins: [
       ...plugins,
       ...(appWebpackConfig.plugins ?? []),
-      new EnvironmentPlugin({
-        SENTRY_DSN: process.env.SENTRY_DSN ?? null, // eslint-disable-line no-restricted-syntax
-        SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax
-        AMPLITUDE_API_KEY: process.env.AMPLITUDE_API_KEY ?? null, // eslint-disable-line no-restricted-syntax
-        SIGNUP_API_URL: "https://foxglove.dev/api/signup",
-        SLACK_INVITE_URL: "https://foxglove.dev/join-slack",
-        OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
-        FOXGLOVE_API_URL: process.env.FOXGLOVE_API_URL ?? "https://api.foxglove.dev",
-        FOXGLOVE_ACCOUNT_DASHBOARD_URL:
-          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/profile",
-      }),
+      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND)),
       new CopyPlugin({
         patterns: [{ from: "../public" }],
       }),


### PR DESCRIPTION
**User-Facing Changes**
This expands the list of parameters that can be specified in foxglove urls to bring up studio in a predefined state. It also gives the user a choice of opening a given URL in the web or desktop version of the app and to optionally remember that choice for future sessions.

**Description**
The goal here is threefold:
1. Encode the current state of the session in an always-sharable URL.
2. Reconstruct the state of the session given a URL.
3. Allow a user to select in which environment they want to open a URL.

Most of this logic is encapsulated in the `useStateLocationSynchronization` hook used in `Workspace.tsx`. It handles updating the URL as the session state changes and also restoring a session from a given URL.

Currently we support `http:` and `foxglove:` protocol URL formats. The `foxglove:` URLs are used to open the desktop app. The app state is entirely encoded in the URL search params; the host and path are not used to encode state. Datasource-specific parameters are prefixed with `ds.`.

Most URLs are a simple type/URL pair. This is the case for ros1, ros2, remote bag files and rosbridge. These take this form:

`{prefix}/?ds={type}&ds.url={url}&layoutId={layoutId}&time={time}`

Where time is an optional, RFC3339 encoded value and layoutId is an optional layoutId.

For example:

https://studio.foxglove.dev/?layoutId=7c6c0f02-b298-4ee4-9d1b-c37659a0659b&ds=ros1-remote-bagfile&ds.url=https%3A%2F%2Fstorage.googleapis.com%2Ffoxglove-public-assets%2Fdemo.bag&time=2017-03-22T02%3A26%3A20.202843111Z

Data platform URLs have several more parameters:

`{prefix}/?ds=foxglove-data-platform&ds.deviceId={deviceId}&ds.start={start}&ds.end={end}&layoutId={layoutId}&time={time}`

Where time is an optional RFC3339 time values and layoutId is an optional layoutId.

For example:

`foxglove://open/?ds=foxglove-data-platform&ds.deviceId=dev_DdVETMbZ9ikVxzdv&ds.start=2021-05-03T18%3A57%3A58.486Z&ds.end=2021-05-03T18%3A58%3A01.501Z&time=2021-05-03T18%3A57%3A59.993Z`

Some other changes were necessary to make this work:
1. Some changes to the environment config to make it possible to test signed in sessions in local dev.
2. Wrapping the `App` component for web sessions to present a web/desktop environment choice.
3. Changes to the `PlayerManager` and `CurrentLayoutProvider` to let the URL take precedence over localStorage in specifying session state.
4. Changes to the various players to include `urlState` in their `PlayerState` to pass through to the `useStateLocationSynchronization` hook.

__Note__: Because the browser doesn't give us the full path to local files it doesn't seem possible to encode their path in a bookmarkable/sharable URL.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2025 
Fixes #1911 
Fixes #1868 
Fixes #1960
