### PR TITLE
Add mcap local file data source

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -140,6 +140,7 @@
     "path-browserify": "1.0.1",
     "prettier": "2.4.1",
     "promise-queue": "2.2.5",
+    "protobufjs": "6.11.2",
     "quickhull3d": "2.0.5",
     "rc-tree": "5.2.1",
     "react": "17.0.2",

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -16,4 +16,5 @@ export enum AppSetting {
   ENABLE_LAYOUT_DEBUGGING = "enableLayoutDebugging",
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
   COLOR_SCHEME = "colorScheme",
+  MCAP_DATA_SOURCE = "sources.mcap",
 }

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -43,6 +43,11 @@ const features: Feature[] = [
     name: "Legacy Plot panel",
     description: <>Enable the Legacy Plot panel.</>,
   },
+  {
+    key: AppSetting.MCAP_DATA_SOURCE,
+    name: "Mcap Data Source",
+    description: <>Enable the Mcap data source.</>,
+  },
 ];
 if (process.env.NODE_ENV === "development") {
   features.push({

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  IDataSourceFactory,
+  DataSourceFactoryInitializeArgs,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { buildNonRos1PlayerFromDescriptor } from "@foxglove/studio-base/players/buildNonRos1Player";
+import { Player } from "@foxglove/studio-base/players/types";
+import { CoreDataProviders } from "@foxglove/studio-base/randomAccessDataProviders/constants";
+import { RandomAccessDataProviderDescriptor } from "@foxglove/studio-base/randomAccessDataProviders/types";
+
+class McapLocalDataSourceFactory implements IDataSourceFactory {
+  id = "mcap-local-file";
+  displayName = "Mcap (local)";
+  iconName: IDataSourceFactory["iconName"] = "OpenFile";
+  supportedFileTypes = [".mcap"];
+
+  initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
+    const file = args.file;
+    if (!file) {
+      return;
+    }
+
+    const descriptor: RandomAccessDataProviderDescriptor = {
+      label: file.name,
+      name: CoreDataProviders.McapDataProvider,
+      filePath: (file as { path?: string }).path, // File.path is added by Electron
+      args: { file },
+      children: [],
+    };
+
+    return buildNonRos1PlayerFromDescriptor(file.name, descriptor, {
+      metricsCollector: args.metricsCollector,
+      unlimitedMemoryCache: args.unlimitedMemoryCache,
+    });
+  }
+}
+
+export default McapLocalDataSourceFactory;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -60,3 +60,4 @@ export { default as Ros2SocketDataSourceFactory } from "./dataSources/Ros2Socket
 export { default as RosbridgeDataSourceFactory } from "./dataSources/RosbridgeDataSourceFactory";
 export { default as UlogLocalDataSourceFactory } from "./dataSources/UlogLocalDataSourceFactory";
 export { default as VelodyneDataSourceFactory } from "./dataSources/VelodyneDataSourceFactory";
+export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -75,7 +75,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       .filter(
         (topic) =>
           topic.datatype === "sensor_msgs/NavSatFix" ||
-          topic.datatype === "sensor_msgs/msg/NavSatFix",
+          topic.datatype === "sensor_msgs/msg/NavSatFix" ||
+          topic.datatype === "foxglove.LocationFix",
       )
       .map((topic) => topic.name);
   }, [topics]);
@@ -353,7 +354,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       }
 
       const hasFix = (ev: MessageEvent<NavSatFixMsg>) =>
-        ev.message.status.status !== NavSatFixStatus.STATUS_NO_FIX;
+        ev.message.status?.status !== NavSatFixStatus.STATUS_NO_FIX;
       const noFixEvents = events.filter((ev) => !hasFix(ev));
       const fixEvents = events.filter(hasFix);
 

--- a/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { isEqual } from "lodash";
-import { parse as protoParse, Type as ReflectedType } from "protobufjs";
+import protobufjs from "protobufjs";
 import decompressLZ4 from "wasm-lz4";
 
 import { ChannelInfo, McapReader, McapRecord } from "@foxglove/mcap";
@@ -53,7 +53,7 @@ export default class McapDataProvider implements RandomAccessDataProvider {
       number,
       {
         info: ChannelInfo;
-        messageDeserializer: ROS2MessageReader | LazyMessageReader | ReflectedType;
+        messageDeserializer: ROS2MessageReader | LazyMessageReader | protobufjs.Type;
       }
     >();
 
@@ -82,7 +82,7 @@ export default class McapDataProvider implements RandomAccessDataProvider {
             });
             messageDeserializer = new ROS2MessageReader(parsedDefinitions);
           } else if (record.encoding === "protobuf") {
-            const MsgRoot = protoParse(record.schema);
+            const MsgRoot = protobufjs.parse(record.schema);
             const Deserializer = MsgRoot.root.lookupType(record.schemaName);
             messageDeserializer = Deserializer;
           } else {
@@ -111,7 +111,7 @@ export default class McapDataProvider implements RandomAccessDataProvider {
             endTime = receiveTime;
           }
 
-          if (channelInfo.messageDeserializer instanceof ReflectedType) {
+          if (channelInfo.messageDeserializer instanceof protobufjs.Type) {
             const protoMsg = channelInfo.messageDeserializer.decode(new Uint8Array(record.data));
             messages.push({
               topic: channelInfo.info.topic,

--- a/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
@@ -1,0 +1,213 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { isEqual } from "lodash";
+import { parse as protoParse, Type as ReflectedType } from "protobufjs";
+import decompressLZ4 from "wasm-lz4";
+
+import { ChannelInfo, McapReader, McapRecord } from "@foxglove/mcap";
+import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
+import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
+import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
+import {
+  Time,
+  compare,
+  isLessThan,
+  isGreaterThan,
+  isTimeInRangeInclusive,
+} from "@foxglove/rostime";
+import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
+import {
+  RandomAccessDataProvider,
+  RandomAccessDataProviderDescriptor,
+  ExtensionPoint,
+  GetMessagesResult,
+  GetMessagesTopics,
+  InitializationResult,
+  Connection,
+} from "@foxglove/studio-base/randomAccessDataProviders/types";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+
+type Options = { file: File };
+
+export default class McapDataProvider implements RandomAccessDataProvider {
+  private options: Options;
+  private messagesByChannel?: Map<number, MessageEvent<unknown>[]>;
+
+  constructor(options: Options, children: RandomAccessDataProviderDescriptor[]) {
+    if (children.length > 0) {
+      throw new Error("McapBlobDataProvider cannot have children");
+    }
+    this.options = options;
+  }
+
+  async initialize(_extensionPoint: ExtensionPoint): Promise<InitializationResult> {
+    const { file } = this.options;
+    await decompressLZ4.isLoaded;
+
+    const streamReader = (file.stream() as ReadableStream<Uint8Array>).getReader();
+
+    const messagesByChannel = new Map<number, MessageEvent<unknown>[]>();
+    const channelInfoById = new Map<
+      number,
+      {
+        info: ChannelInfo;
+        messageDeserializer: ROS2MessageReader | LazyMessageReader | ReflectedType;
+      }
+    >();
+
+    let startTime: Time | undefined;
+    let endTime: Time | undefined;
+    function processRecord(record: McapRecord) {
+      switch (record.type) {
+        default:
+          break;
+
+        case "ChannelInfo": {
+          const existingInfo = channelInfoById.get(record.id);
+          if (existingInfo) {
+            if (!isEqual(existingInfo.info, record)) {
+              throw new Error(`differing channel infos for for ${record.id}`);
+            }
+            break;
+          }
+          let messageDeserializer;
+          if (record.schema === "ros1") {
+            const parsedDefinitions = parseMessageDefinition(record.schema);
+            messageDeserializer = new LazyMessageReader(parsedDefinitions);
+          } else if (record.schema === "ros2") {
+            const parsedDefinitions = parseMessageDefinition(record.schema, {
+              ros2: true,
+            });
+            messageDeserializer = new ROS2MessageReader(parsedDefinitions);
+          } else if (record.encoding === "protobuf") {
+            const MsgRoot = protoParse(record.schema);
+            const Deserializer = MsgRoot.root.lookupType(record.schemaName);
+            messageDeserializer = Deserializer;
+          } else {
+            throw new Error(`unsupported schema format ${record.schema}`);
+          }
+          channelInfoById.set(record.id, { info: record, messageDeserializer });
+          messagesByChannel.set(record.id, []);
+          break;
+        }
+
+        case "Message": {
+          const channelId = record.channelInfo.id;
+          const channelInfo = channelInfoById.get(channelId);
+          const messages = messagesByChannel.get(channelId);
+          if (!channelInfo || !messages) {
+            throw new Error(`message for channel ${channelId} with no prior channel info`);
+          }
+          const receiveTime = {
+            sec: Number(record.timestamp / 1_000_000_000n),
+            nsec: Number(record.timestamp % 1_000_000_000n),
+          };
+          if (!startTime || isLessThan(receiveTime, startTime)) {
+            startTime = receiveTime;
+          }
+          if (!endTime || isGreaterThan(receiveTime, endTime)) {
+            endTime = receiveTime;
+          }
+
+          if (channelInfo.messageDeserializer instanceof ReflectedType) {
+            const protoMsg = channelInfo.messageDeserializer.decode(new Uint8Array(record.data));
+            messages.push({
+              topic: channelInfo.info.topic,
+              receiveTime,
+              message: protoMsg.toJSON(),
+              sizeInBytes: record.data.byteLength,
+            });
+          } else {
+            messages.push({
+              topic: channelInfo.info.topic,
+              receiveTime,
+              message: channelInfo.messageDeserializer.readMessage(new Uint8Array(record.data)),
+              sizeInBytes: record.data.byteLength,
+            });
+          }
+          break;
+        }
+      }
+    }
+
+    const reader = new McapReader({
+      decompressHandlers: {
+        lz4: (buffer, decompressedSize) => decompressLZ4(buffer, Number(decompressedSize)),
+      },
+    });
+    for (let result; (result = await streamReader.read()), !result.done; ) {
+      reader.append(result.value);
+      for (let record; (record = reader.nextRecord()); ) {
+        processRecord(record);
+      }
+    }
+
+    this.messagesByChannel = messagesByChannel;
+
+    const topics: Topic[] = [];
+    const connections: Connection[] = [];
+    const datatypes: RosDatatypes = new Map([["TODO", { definitions: [] }]]);
+
+    for (const { info } of channelInfoById.values()) {
+      topics.push({
+        name: info.topic,
+        datatype: info.schemaName,
+      });
+
+      datatypes.set(info.schemaName, {
+        definitions: [],
+      });
+    }
+
+    return {
+      start: startTime ?? { sec: 0, nsec: 0 },
+      end: endTime ?? { sec: 0, nsec: 0 },
+      topics,
+      connections,
+      providesParsedMessages: true,
+      messageDefinitions: {
+        type: "parsed",
+        datatypes,
+        messageDefinitionsByTopic: {},
+        parsedMessageDefinitionsByTopic: {},
+      },
+      problems: [],
+    };
+  }
+
+  async getMessages(
+    start: Time,
+    end: Time,
+    subscriptions: GetMessagesTopics,
+  ): Promise<GetMessagesResult> {
+    if (!this.messagesByChannel) {
+      throw new Error("initialization not completed");
+    }
+    const topics = subscriptions.parsedMessages;
+    if (topics == undefined) {
+      return {};
+    }
+    const topicsSet = new Set(topics);
+
+    const parsedMessages: MessageEvent<unknown>[] = [];
+    for (const messages of this.messagesByChannel.values()) {
+      for (const message of messages) {
+        if (
+          isTimeInRangeInclusive(message.receiveTime, start, end) &&
+          topicsSet.has(message.topic)
+        ) {
+          parsedMessages.push(message);
+        }
+      }
+    }
+    parsedMessages.sort((msg1, msg2) => compare(msg1.receiveTime, msg2.receiveTime));
+
+    return { parsedMessages };
+  }
+
+  async close(): Promise<void> {
+    // no-op
+  }
+}

--- a/packages/studio-base/src/randomAccessDataProviders/constants.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/constants.ts
@@ -19,6 +19,7 @@ export const CoreDataProviders = {
   Rosbag2DataProvider: "Rosbag2DataProvider",
   RpcDataProvider: "RpcDataProvider",
   UlogDataProvider: "UlogDataProvider",
+  McapDataProvider: "McapDataProvider",
   WorkerDataProvider: "WorkerDataProvider",
 };
 export const MESSAGE_FORMATS = ["rosBinaryMessages", "parsedMessages"] as const;

--- a/packages/studio-base/src/randomAccessDataProviders/rootGetDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/rootGetDataProvider.ts
@@ -15,6 +15,7 @@ import ApiCheckerDataProvider, {
   instrumentTreeWithApiCheckerDataProvider,
 } from "@foxglove/studio-base/randomAccessDataProviders/ApiCheckerDataProvider";
 import BagDataProvider from "@foxglove/studio-base/randomAccessDataProviders/BagDataProvider";
+import McapDataProvider from "@foxglove/studio-base/randomAccessDataProviders/McapDataProvider";
 import MemoryCacheDataProvider from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import ParseMessagesDataProvider from "@foxglove/studio-base/randomAccessDataProviders/ParseMessagesDataProvider";
 import Ros1MemoryCacheDataProvider from "@foxglove/studio-base/randomAccessDataProviders/Ros1MemoryCacheDataProvider";
@@ -35,6 +36,7 @@ const getDataProviderBase = createGetDataProvider({
   Ros1MemoryCacheDataProvider,
   Rosbag2DataProvider,
   UlogDataProvider,
+  McapDataProvider,
   WorkerDataProvider,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,6 +2439,7 @@ __metadata:
     path-browserify: 1.0.1
     prettier: 2.4.1
     promise-queue: 2.2.5
+    protobufjs: 6.11.2
     quickhull3d: 2.0.5
     rc-tree: 5.2.1
     react: 17.0.2
@@ -3118,6 +3119,79 @@ __metadata:
   version: 2.10.1
   resolution: "@popperjs/core@npm:2.10.1"
   checksum: 55262eb98984a03364a844177a9d4b9ab1c6e3503eaa1ecb086c028b5b6d93985a92b5b5783008962633015fc9f0232fda3ce88f5b17930a909a633387a06505
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.1
+    "@protobufjs/inquire": ^1.1.0
+  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
   languageName: node
   linkType: hard
 
@@ -5161,6 +5235,13 @@ __metadata:
   version: 4.14.176
   resolution: "@types/lodash@npm:4.14.176"
   checksum: 9e949704dfffab60365b5cdca0477926af6eabe82c64b7be8f74b3a117bb373d58371be962c2b159dd0cf8fad49a7dcacc748564aea4ce6b6883c197a6f0bfa8
+  languageName: node
+  linkType: hard
+
+"@types/long@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@types/long@npm:4.0.1"
+  checksum: ff9653c33f5000d0f131fd98a950a0343e2e33107dd067a97ac4a3b9678e1a2e39ea44772ad920f54ef6e8f107f76bc92c2584ba905a0dc4253282a4101166d0
   languageName: node
   linkType: hard
 
@@ -15753,6 +15834,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -18412,6 +18500,30 @@ fsevents@^1.2.7:
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
   checksum: 4d4826e1713cbfa0f15124ab0ae494c91b597a3c458670c9714c36e8baddf5a6aad22842776f2f5b137f259c8533e741771445eb8df82e861eea37a6eaba03f7
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:6.11.2":
+  version: 6.11.2
+  resolution: "protobufjs@npm:6.11.2"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/long": ^4.0.1
+    "@types/node": ">=13.7.0"
+    long: ^4.0.0
+  bin:
+    pbjs: bin/pbjs
+    pbts: bin/pbts
+  checksum: 80e9d9610c3eb66f9eae4e44a1ae30381cedb721b7d5f635d781fe4c507e2c77bb7c879addcd1dda79733d3ae589d9e66fd18d42baf99b35df7382a0f9920795
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
The mcap data source adds support for loading mcap files. The data source requires the "mcap data source" feature flag to show up in the data sources list.
    
The mcap data source is highly experimental with the file format still evolving. This change supports the "ros1", "ros2", and "protobuf" schema types.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
