### PR TITLE
Fix: Do not display help content in the Panel Settings sidebar tab

### DIFF
--- a/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+import { PanelCatalog, PanelInfo } from "@foxglove/studio-base/context/PanelCatalogContext";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import { PanelConfigSchemaEntry } from "@foxglove/studio-base/types/panels";
+
+import HelpSidebar from ".";
+
+export default {
+  title: "components/HelpSidebar",
+  component: HelpSidebar,
+};
+
+const allPanels: readonly PanelInfo[] = [
+  { title: "Some Panel", type: "Sample1", module: async () => await new Promise(() => {}) },
+  {
+    title: "Another Panel",
+    type: "Sample2",
+    module: async () => await new Promise(() => {}),
+    help: <>Another Panel&apos;s help content</>,
+  },
+];
+
+class MockPanelCatalog implements PanelCatalog {
+  async getConfigSchema(type: string): Promise<PanelConfigSchemaEntry<string>[] | undefined> {
+    const info = this.getPanelByType(type);
+    if (!info) {
+      return undefined;
+    }
+    const module = await info?.module();
+    return module.default.configSchema;
+  }
+  getPanels(): readonly PanelInfo[] {
+    return allPanels;
+  }
+  getPanelByType(type: string): PanelInfo | undefined {
+    return allPanels.find((panel) => panel.preconfigured !== true && panel.type === type);
+  }
+}
+
+export function Home(): JSX.Element {
+  return (
+    <div style={{ margin: 30, height: 400 }}>
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <PanelSetup
+            panelCatalog={new MockPanelCatalog()}
+            fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
+            omitDragAndDrop
+          >
+            <HelpSidebar />
+          </PanelSetup>
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    </div>
+  );
+}
+
+export function PanelView(): JSX.Element {
+  return (
+    <div style={{ margin: 30, height: 400 }}>
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <PanelSetup
+            panelCatalog={new MockPanelCatalog()}
+            fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
+            omitDragAndDrop
+          >
+            <HelpSidebar isHomeViewForTests={false} panelTypeForTests="Sample2" />
+          </PanelSetup>
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    </div>
+  );
+}

--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -52,16 +52,27 @@ const useComponentStyles = (theme: ITheme) =>
     [theme],
   );
 
-export default function HelpSidebar(): JSX.Element {
+export default function HelpSidebar({
+  isHomeViewForTests,
+  panelTypeForTests = "",
+}: React.PropsWithChildren<{
+  isHomeViewForTests?: boolean;
+  panelTypeForTests?: string;
+}>): JSX.Element {
   const theme = useTheme();
   const styles = useComponentStyles(theme);
-  const [isHomeView, setIsHomeView] = useState(true);
+  const [isHomeView, setIsHomeView] = useState(
+    isHomeViewForTests == undefined ? true : isHomeViewForTests,
+  );
   const { panelDocToDisplay: panelType, setPanelDocToDisplay } = useSelectedPanels();
 
   const panelCatalog = usePanelCatalog();
   const panelInfo = useMemo(
-    () => (panelType != undefined ? panelCatalog.getPanelByType(panelType) : undefined),
-    [panelCatalog, panelType],
+    () =>
+      (panelType ? panelType : panelTypeForTests) != undefined
+        ? panelCatalog.getPanelByType(panelType ? panelType : panelTypeForTests)
+        : undefined,
+    [panelCatalog, panelType, panelTypeForTests],
   );
   const sortByTitle = (a: PanelInfo, b: PanelInfo) =>
     a.title.localeCompare(b.title, undefined, { ignorePunctuation: true, sensitivity: "base" });

--- a/packages/studio-base/src/components/PanelSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.stories.tsx
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+import { PanelCatalog, PanelInfo } from "@foxglove/studio-base/context/PanelCatalogContext";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import { PanelConfigSchemaEntry } from "@foxglove/studio-base/types/panels";
+
+import PanelSettings from ".";
+
+export default {
+  title: "components/PanelSettings",
+  component: PanelSettings,
+};
+
+const panels: readonly PanelInfo[] = [
+  { title: "Sample", type: "Sample1", module: async () => await new Promise(() => {}) },
+];
+
+class MockPanelCatalog implements PanelCatalog {
+  async getConfigSchema(type: string): Promise<PanelConfigSchemaEntry<string>[] | undefined> {
+    const info = this.getPanelByType(type);
+    if (info == undefined) {
+      return undefined;
+    }
+    const module = await info?.module();
+    return module.default.configSchema;
+  }
+  getPanels(): readonly PanelInfo[] {
+    return panels;
+  }
+  getPanelByType(type: string): PanelInfo | undefined {
+    return panels.find((panel) => panel.preconfigured !== true && panel.type === type);
+  }
+}
+
+const fixture = { topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!abc" };
+const selectedPanelIds: readonly string[] = ["Sample1!abc"];
+
+export function NoPanelSelected(): JSX.Element {
+  return (
+    <div style={{ margin: 30, height: 400 }}>
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
+            <PanelSettings />
+          </PanelSetup>
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    </div>
+  );
+}
+
+export function PanelSelected(): JSX.Element {
+  return (
+    <div style={{ margin: 30, height: 400 }}>
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <PanelSetup
+            panelCatalog={new MockPanelCatalog()}
+            fixture={{ ...fixture, savedProps: { "Sample1!abc": { someKey: "someVal" } } }}
+            omitDragAndDrop
+          >
+            <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
+          </PanelSetup>
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    </div>
+  );
+}
+
+export function PanelLoading(): JSX.Element {
+  return (
+    <div style={{ margin: 30, height: 400 }}>
+      <DndProvider backend={HTML5Backend}>
+        <MockCurrentLayoutProvider>
+          <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture} omitDragAndDrop>
+            <PanelSettings selectedPanelIdsForTests={selectedPanelIds} />
+          </PanelSetup>
+        </MockCurrentLayoutProvider>
+      </DndProvider>
+    </div>
+  );
+}

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -126,7 +126,7 @@ export default function PanelSettings(): JSX.Element {
     <SidebarContent title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack tokens={{ childrenGap: theme.spacing.m }}>
-        {panelInfo?.help ?? (
+        {panelInfo?.help != undefined ? (
           <Stack.Item>
             <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>
               See docs{" "}
@@ -141,7 +141,7 @@ export default function PanelSettings(): JSX.Element {
               .
             </Text>
           </Stack.Item>
-        )}
+        ) : undefined}
         <Stack.Item>
           {schema ? (
             <StrictMode>

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -22,9 +22,18 @@ import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import SchemaEditor from "./SchemaEditor";
 
-export default function PanelSettings(): JSX.Element {
+export default function PanelSettings({
+  selectedPanelIdsForTests,
+}: React.PropsWithChildren<{
+  selectedPanelIdsForTests?: readonly string[];
+}>): JSX.Element {
   const selectedLayoutId = useCurrentLayoutSelector((state) => state.selectedLayout?.id);
-  const { selectedPanelIds, setSelectedPanelIds, setPanelDocToDisplay } = useSelectedPanels();
+  const {
+    selectedPanelIds: originalSelectedPanelIds,
+    setSelectedPanelIds,
+    setPanelDocToDisplay,
+  } = useSelectedPanels();
+  const selectedPanelIds = selectedPanelIdsForTests ?? originalSelectedPanelIds;
   const { openLayoutBrowser, openHelp } = useWorkspace();
   const selectedPanelId = useMemo(
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -135,7 +135,7 @@ export default function PanelSettings({
     <SidebarContent title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack tokens={{ childrenGap: theme.spacing.m }}>
-        {panelInfo?.help != undefined ? (
+        {panelInfo?.help != undefined && (
           <Stack.Item>
             <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>
               See docs{" "}
@@ -150,7 +150,7 @@ export default function PanelSettings({
               .
             </Text>
           </Stack.Item>
-        ) : undefined}
+        )}
         <Stack.Item>
           {schema ? (
             <StrictMode>


### PR DESCRIPTION
**User-Facing Changes**
- Fix: Do not display help content in the Panel Settings sidebar tab

Resolves https://github.com/foxglove/studio/issues/2170