### PR TITLE
Remove draggability from topic settings modal

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -131,14 +131,6 @@ function TopicSettingsModal({
       }}
       maxWidth={480}
       minWidth={480}
-      modalProps={{
-        isModeless: true,
-        dragOptions: {
-          moveMenuItemText: "Move",
-          closeMenuItemText: "Close",
-          menu: ContextualMenu,
-        },
-      }}
     >
       <MainEditor
         collectorMessage={sceneBuilderMessage}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ContextualMenu, DefaultButton, Dialog, DialogFooter } from "@fluentui/react";
+import { DefaultButton, Dialog, DialogFooter } from "@fluentui/react";
 import { isEmpty, omit } from "lodash";
 import React, { useCallback } from "react";
 


### PR DESCRIPTION
**User-Facing Changes**
Insignificant

**Description**
Draggable modals were causing problems with page layout when the modal went partly outside the page bounds.