### PR TITLE
Update account settings URL

### DIFF
--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -88,7 +88,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
         OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
         FOXGLOVE_API_URL: process.env.FOXGLOVE_API_URL ?? "https://api.foxglove.dev",
         FOXGLOVE_ACCOUNT_DASHBOARD_URL:
-          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/dashboard",
+          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/organization",
       }),
       new HtmlWebpackPlugin({
         templateContent: `

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -117,7 +117,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
         OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
         FOXGLOVE_API_URL: process.env.FOXGLOVE_API_URL ?? "https://api.foxglove.dev",
         FOXGLOVE_ACCOUNT_DASHBOARD_URL:
-          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/dashboard",
+          process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? "https://console.foxglove.dev/organization",
       }),
       new CopyPlugin({
         patterns: [{ from: "../public" }],


### PR DESCRIPTION
This updates the URL used for Console's "Account Settings". These now live at `/organization`.

