### PR TITLE
Remove redundant model selection from 3d panel pose editor.

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.stories.tsx
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ReactElement } from "react";
+
+import PoseSettingsEditor from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor";
+
+export default {
+  title: "panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor",
+  component: PoseSettingsEditor,
+};
+
+export function PoseSettingsEditorView(): ReactElement {
+  const message = {
+    header: {
+      frame_id: "frame",
+      stamp: { sec: 0, nsec: 0 },
+      seq: 1,
+    },
+    pose: {
+      position: { x: 0, y: 0, z: 0 },
+      orientation: { x: 0, y: 0, z: 0, w: 0 },
+    },
+  };
+
+  return (
+    <PoseSettingsEditor
+      message={message}
+      onFieldChange={() => undefined}
+      onSettingsChange={() => undefined}
+      settings={{}}
+    />
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -13,7 +13,6 @@
 
 import ColorPicker from "@foxglove/studio-base/components/ColorPicker";
 import Flex from "@foxglove/studio-base/components/Flex";
-import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledComponents";
 import { Color, PoseStamped } from "@foxglove/studio-base/types/Messages";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -93,11 +92,6 @@ export default function PoseSettingsEditor(
     }
   }, [onFieldChange, onSettingsChange, settings]);
 
-  const badModelTypeSetting = React.useMemo(
-    () => !["arrow"].includes(settings.modelType!),
-    [settings],
-  );
-
   if (!message) {
     return (
       <div style={{ color: colors.TEXT_MUTED }}>
@@ -106,34 +100,7 @@ export default function PoseSettingsEditor(
     );
   }
 
-  return (
-    <Flex col>
-      <SLabel>Rendered Car</SLabel>
-      <div
-        style={{ display: "flex", margin: "4px", flexDirection: "column" }}
-        onChange={(e) => {
-          onSettingsChange({
-            ...settings,
-            modelType: (e.target as HTMLFormElement).value,
-            alpha: undefined,
-          });
-        }}
-      >
-        {[{ value: "arrow", title: "Arrow" }].map(({ value, title }) => (
-          <div key={value} style={{ marginBottom: "4px", display: "flex" }}>
-            <LegacyInput
-              type="radio"
-              value={value}
-              checked={settings.modelType === value || (value === "arrow" && badModelTypeSetting)}
-            />
-            <label>{title}</label>
-          </div>
-        ))}
-      </div>
-
-      {settingsByCarType}
-    </Flex>
-  );
+  return <Flex col>{settingsByCarType}</Flex>;
 }
 
 PoseSettingsEditor.canEditNamespaceOverrideColor = true;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -34,59 +34,6 @@ export default function PoseSettingsEditor(
 ): JSX.Element {
   const { message, settings, onFieldChange, onSettingsChange } = props;
 
-  const settingsByCarType = React.useMemo(() => {
-    const currentShaftWidth = settings.size?.shaftWidth ?? 2;
-    const currentHeadWidth = settings.size?.headWidth ?? 2;
-    const currentHeadLength = settings.size?.headLength ?? 0.1;
-
-    return (
-      <Flex col>
-        <SLabel>Color</SLabel>
-        <ColorPicker
-          color={settings.overrideColor}
-          onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-          alphaType="alpha"
-        />
-        <SLabel>Shaft width</SLabel>
-        <SInput
-          type="number"
-          value={currentShaftWidth}
-          placeholder="2"
-          onChange={(e) =>
-            onSettingsChange({
-              ...settings,
-              size: { ...settings.size, shaftWidth: parseFloat(e.target.value) },
-            })
-          }
-        />
-        <SLabel>Head width</SLabel>
-        <SInput
-          type="number"
-          value={currentHeadWidth}
-          placeholder="2"
-          onChange={(e) =>
-            onSettingsChange({
-              ...settings,
-              size: { ...settings.size, headWidth: parseFloat(e.target.value) },
-            })
-          }
-        />
-        <SLabel>Head length</SLabel>
-        <SInput
-          type="number"
-          value={currentHeadLength}
-          placeholder="0.1"
-          onChange={(e) =>
-            onSettingsChange({
-              ...settings,
-              size: { ...settings.size, headLength: parseFloat(e.target.value) },
-            })
-          }
-        />
-      </Flex>
-    );
-  }, [onFieldChange, onSettingsChange, settings]);
-
   if (!message) {
     return (
       <div style={{ color: colors.TEXT_MUTED }}>
@@ -95,7 +42,56 @@ export default function PoseSettingsEditor(
     );
   }
 
-  return <Flex col>{settingsByCarType}</Flex>;
+  const currentShaftWidth = settings.size?.shaftWidth ?? 2;
+  const currentHeadWidth = settings.size?.headWidth ?? 2;
+  const currentHeadLength = settings.size?.headLength ?? 0.1;
+
+  return (
+    <Flex col>
+      <SLabel>Color</SLabel>
+      <ColorPicker
+        color={settings.overrideColor}
+        onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+        alphaType="alpha"
+      />
+      <SLabel>Shaft width</SLabel>
+      <SInput
+        type="number"
+        value={currentShaftWidth}
+        placeholder="2"
+        onChange={(e) =>
+          onSettingsChange({
+            ...settings,
+            size: { ...settings.size, shaftWidth: parseFloat(e.target.value) },
+          })
+        }
+      />
+      <SLabel>Head width</SLabel>
+      <SInput
+        type="number"
+        value={currentHeadWidth}
+        placeholder="2"
+        onChange={(e) =>
+          onSettingsChange({
+            ...settings,
+            size: { ...settings.size, headWidth: parseFloat(e.target.value) },
+          })
+        }
+      />
+      <SLabel>Head length</SLabel>
+      <SInput
+        type="number"
+        value={currentHeadLength}
+        placeholder="0.1"
+        onChange={(e) =>
+          onSettingsChange({
+            ...settings,
+            size: { ...settings.size, headLength: parseFloat(e.target.value) },
+          })
+        }
+      />
+    </Flex>
+  );
 }
 
 PoseSettingsEditor.canEditNamespaceOverrideColor = true;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PoseSettingsEditor.tsx
@@ -27,7 +27,6 @@ export type PoseSettings = {
     headWidth?: number;
     shaftWidth?: number;
   };
-  modelType?: "arrow";
 };
 
 export default function PoseSettingsEditor(
@@ -36,60 +35,56 @@ export default function PoseSettingsEditor(
   const { message, settings, onFieldChange, onSettingsChange } = props;
 
   const settingsByCarType = React.useMemo(() => {
-    switch (settings.modelType) {
-      case "arrow":
-      default: {
-        const currentShaftWidth = settings.size?.shaftWidth ?? 2;
-        const currentHeadWidth = settings.size?.headWidth ?? 2;
-        const currentHeadLength = settings.size?.headLength ?? 0.1;
-        return (
-          <Flex col>
-            <SLabel>Color</SLabel>
-            <ColorPicker
-              color={settings.overrideColor}
-              onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-              alphaType="alpha"
-            />
-            <SLabel>Shaft width</SLabel>
-            <SInput
-              type="number"
-              value={currentShaftWidth}
-              placeholder="2"
-              onChange={(e) =>
-                onSettingsChange({
-                  ...settings,
-                  size: { ...settings.size, shaftWidth: parseFloat(e.target.value) },
-                })
-              }
-            />
-            <SLabel>Head width</SLabel>
-            <SInput
-              type="number"
-              value={currentHeadWidth}
-              placeholder="2"
-              onChange={(e) =>
-                onSettingsChange({
-                  ...settings,
-                  size: { ...settings.size, headWidth: parseFloat(e.target.value) },
-                })
-              }
-            />
-            <SLabel>Head length</SLabel>
-            <SInput
-              type="number"
-              value={currentHeadLength}
-              placeholder="0.1"
-              onChange={(e) =>
-                onSettingsChange({
-                  ...settings,
-                  size: { ...settings.size, headLength: parseFloat(e.target.value) },
-                })
-              }
-            />
-          </Flex>
-        );
-      }
-    }
+    const currentShaftWidth = settings.size?.shaftWidth ?? 2;
+    const currentHeadWidth = settings.size?.headWidth ?? 2;
+    const currentHeadLength = settings.size?.headLength ?? 0.1;
+
+    return (
+      <Flex col>
+        <SLabel>Color</SLabel>
+        <ColorPicker
+          color={settings.overrideColor}
+          onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+          alphaType="alpha"
+        />
+        <SLabel>Shaft width</SLabel>
+        <SInput
+          type="number"
+          value={currentShaftWidth}
+          placeholder="2"
+          onChange={(e) =>
+            onSettingsChange({
+              ...settings,
+              size: { ...settings.size, shaftWidth: parseFloat(e.target.value) },
+            })
+          }
+        />
+        <SLabel>Head width</SLabel>
+        <SInput
+          type="number"
+          value={currentHeadWidth}
+          placeholder="2"
+          onChange={(e) =>
+            onSettingsChange({
+              ...settings,
+              size: { ...settings.size, headWidth: parseFloat(e.target.value) },
+            })
+          }
+        />
+        <SLabel>Head length</SLabel>
+        <SInput
+          type="number"
+          value={currentHeadLength}
+          placeholder="0.1"
+          onChange={(e) =>
+            onSettingsChange({
+              ...settings,
+              size: { ...settings.size, headLength: parseFloat(e.target.value) },
+            })
+          }
+        />
+      </Flex>
+    );
   }, [onFieldChange, onSettingsChange, settings]);
 
   if (!message) {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PoseMarkers.tsx
@@ -45,39 +45,32 @@ function PoseMarkers({ markers, layerIndex }: PoseMarkerProps): ReactElement {
   markers.forEach((marker) => {
     const { settings } = marker;
 
-    switch (settings?.modelType) {
-      case "arrow":
-      default: {
-        let newMarker = marker;
-        if (settings?.overrideColor != undefined) {
-          newMarker = { ...newMarker, color: settings.overrideColor };
-        }
-
-        if (settings?.size) {
-          newMarker = {
-            ...newMarker,
-            scale: {
-              x: settings.size.shaftWidth ?? marker.scale.x,
-              y: settings.size.headWidth ?? marker.scale.y,
-              z: settings.size.headLength ?? marker.scale.z,
-            },
-          };
-        }
-
-        const pos = pointToVec3(newMarker.pose.position);
-        const orientation = orientationToVec4(newMarker.pose.orientation);
-        const dir = vec3.transformQuat([0, 0, 0], [1, 0, 0], orientation);
-        // the total length of the arrow is 4.7, we move the tail backwards by 0.88 (prev implementation)
-        const tipPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, 3.82);
-        const tailPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, -0.88);
-        arrowMarkers.push({
-          ...newMarker,
-          points: [vec3ToPoint(tailPoint), vec3ToPoint(tipPoint)],
-        });
-
-        break;
-      }
+    let newMarker = marker;
+    if (settings?.overrideColor != undefined) {
+      newMarker = { ...newMarker, color: settings.overrideColor };
     }
+
+    if (settings?.size) {
+      newMarker = {
+        ...newMarker,
+        scale: {
+          x: settings.size.shaftWidth ?? marker.scale.x,
+          y: settings.size.headWidth ?? marker.scale.y,
+          z: settings.size.headLength ?? marker.scale.z,
+        },
+      };
+    }
+
+    const pos = pointToVec3(newMarker.pose.position);
+    const orientation = orientationToVec4(newMarker.pose.orientation);
+    const dir = vec3.transformQuat([0, 0, 0], [1, 0, 0], orientation);
+    // the total length of the arrow is 4.7, we move the tail backwards by 0.88 (prev implementation)
+    const tipPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, 3.82);
+    const tailPoint = vec3.scaleAndAdd([0, 0, 0], pos, dir, -0.88);
+    arrowMarkers.push({
+      ...newMarker,
+      points: [vec3ToPoint(tailPoint), vec3ToPoint(tipPoint)],
+    });
   });
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
This removes the extraneous model selection fields from the 3d panel pose editor dialog.

**Description**
Since we only support the arrow in this case we can remove the model selection radio & label.

<!-- link relevant github issues -->
Fixes #2184 
