### PR TITLE
Support URDFs in the 3D panel

### DIFF
--- a/packages/den/tsconfig.json
+++ b/packages/den/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./**/*"],
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "lib": ["DOM", "ES2020"]
   }
 }

--- a/packages/den/urdf/index.ts
+++ b/packages/den/urdf/index.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { XacroParser } from "xacro-parser";
+
+import { parseUrdf } from "./parser";
+import { UrdfRobot } from "./types";
+
+export * from "./types";
+
+export async function parseRobot(
+  urdfContents: string,
+  getFileContents: (url: string) => Promise<string>,
+): Promise<UrdfRobot> {
+  const xacroParser = new XacroParser();
+  xacroParser.rospackCommands = { find: (targetPkg) => `package://${targetPkg}` };
+  xacroParser.getFileContents = getFileContents;
+
+  const urdf = await xacroParser.parse(urdfContents);
+  return parseUrdf(urdf);
+}

--- a/packages/den/urdf/parser.ts
+++ b/packages/den/urdf/parser.ts
@@ -1,0 +1,399 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  Color,
+  Inertia,
+  JointType,
+  Pose,
+  UrdfCollider,
+  UrdfGeometry,
+  UrdfInertial,
+  UrdfJoint,
+  UrdfLink,
+  UrdfMaterial,
+  UrdfRobot,
+  UrdfVisual,
+  Vector3,
+} from "./types";
+
+const JOINT_TYPES = ["fixed", "continuous", "revolute", "planar", "prismatic", "floating"];
+
+export function parseUrdf(xml: XMLDocument | string): UrdfRobot {
+  const parser = new DOMParser();
+  const urdf =
+    xml instanceof XMLDocument ? xml : (parser.parseFromString(xml, "text/xml") as XMLDocument);
+
+  for (let i = 0; i < urdf.children.length; i++) {
+    const child = urdf.children[i]!;
+    if (child.nodeName === "robot") {
+      return parseRobot(child);
+    }
+  }
+
+  throw new Error(`No robot found in URDF`);
+}
+
+function parseRobot(xml: Element): UrdfRobot {
+  const name = xml.getAttribute("name") ?? undefined;
+  if (name == undefined) {
+    throw new Error("<robot> name is missing");
+  }
+  const links = new Map<string, UrdfLink>();
+  const joints = new Map<string, UrdfJoint>();
+  const materials = new Map<string, UrdfMaterial>();
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    const childName = child.getAttribute("name");
+    if (childName == undefined) {
+      continue;
+    }
+
+    switch (child.nodeName) {
+      case "link":
+        links.set(childName, parseLink(child));
+        break;
+      case "joint":
+        joints.set(childName, parseJoint(child));
+        break;
+      case "material":
+        materials.set(childName, parseMaterial(child));
+        break;
+    }
+  }
+
+  return { name, links, joints, materials };
+}
+
+function parseLink(xml: Element): UrdfLink {
+  const name = xml.getAttribute("name") ?? undefined;
+  if (name == undefined) {
+    throw new Error(`missing attribute "name" in ${xml}`);
+  }
+
+  const link: UrdfLink = { name, visuals: [], colliders: [] };
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "inertial":
+        link.inertial = parseInertial(child);
+        break;
+      case "visual":
+        link.visuals.push(parseVisual(child));
+        break;
+      case "collision":
+        link.colliders.push(parseCollision(child));
+        break;
+    }
+  }
+
+  return link;
+}
+
+function parseInertial(xml: Element): UrdfInertial {
+  let origin: Pose | undefined;
+  let mass: number | undefined;
+  let inertia: Inertia | undefined;
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "origin":
+        origin = parsePose(child);
+        break;
+      case "mass":
+        mass = parseFloatContent(child);
+        break;
+      case "inertia":
+        inertia = parseInertia(child);
+        break;
+    }
+  }
+
+  if (mass == undefined || inertia == undefined) {
+    throw new Error("<inertial> must have mass and inertia");
+  }
+
+  return { origin: origin ?? defaultPose(), mass, inertia };
+}
+
+function parseJoint(xml: Element): UrdfJoint {
+  const name = xml.getAttribute("name") ?? undefined;
+  const jointType = xml.getAttribute("type") ?? undefined;
+  let origin: Pose | undefined;
+  let parentLink: string | undefined;
+  let childLink: string | undefined;
+  let axis: Vector3 | undefined;
+  let calibration: { rising?: number; falling?: number } | undefined;
+  let dynamics: { damping: number; friction: number } | undefined;
+  let limit: { lower: number; upper: number; effort: number; velocity: number } | undefined;
+  let mimic: { joint: string; multiplier: number; offset: number } | undefined;
+  let safetyController:
+    | {
+        softLowerLimit: number;
+        softUpperLimit: number;
+        kPosition: number;
+        kVelocity: number;
+      }
+    | undefined;
+
+  if (name == undefined) {
+    throw new Error(`missing attribute "name" in ${xml}`);
+  }
+  if (!JOINT_TYPES.includes(jointType ?? "")) {
+    throw new Error(`invalid joint type "${jointType}" in ${xml}`);
+  }
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "origin":
+        origin = parsePose(child);
+        break;
+      case "parent":
+        parentLink = child.getAttribute("link") ?? undefined;
+        break;
+      case "child":
+        childLink = child.getAttribute("link") ?? undefined;
+        break;
+      case "axis":
+        axis = parseVec3Attribute(child, "xyz");
+        if (axis == undefined) {
+          throw new Error(`missing attribute "xyz" in ${child}`);
+        }
+        break;
+      case "calibration":
+        calibration = {
+          rising: parseFloatAttributeOptional(child, "rising"),
+          falling: parseFloatAttributeOptional(child, "falling"),
+        };
+        break;
+      case "dynamics":
+        dynamics = {
+          damping: parseFloatAttributeOptional(child, "damping") ?? 0,
+          friction: parseFloatAttributeOptional(child, "friction") ?? 0,
+        };
+        break;
+      case "limit":
+        limit = {
+          lower: parseFloatAttributeOptional(child, "lower") ?? 0,
+          upper: parseFloatAttributeOptional(child, "upper") ?? 0,
+          effort: parseFloatAttribute(child, "effort"),
+          velocity: parseFloatAttribute(child, "velocity"),
+        };
+        break;
+      case "mimic": {
+        const joint = child.getAttribute("joint") ?? undefined;
+        if (joint == undefined) {
+          throw new Error(`missing attribute "joint" in ${child}`);
+        }
+        mimic = {
+          joint,
+          multiplier: parseFloatAttributeOptional(child, "multiplier") ?? 1,
+          offset: parseFloatAttributeOptional(child, "offset") ?? 0,
+        };
+        break;
+      }
+      case "safety_controller":
+        safetyController = {
+          softLowerLimit: parseFloatAttributeOptional(child, "soft_lower_limit") ?? 0,
+          softUpperLimit: parseFloatAttributeOptional(child, "soft_upper_limit") ?? 0,
+          kPosition: parseFloatAttributeOptional(child, "k_position") ?? 0,
+          kVelocity: parseFloatAttribute(child, "k_velocity"),
+        };
+        break;
+    }
+  }
+
+  if (parentLink == undefined || childLink == undefined) {
+    throw new Error(`missing parent or child in ${xml}`);
+  }
+
+  return {
+    name,
+    jointType: jointType as JointType,
+    origin: origin ?? defaultPose(),
+    parent: parentLink,
+    child: childLink,
+    axis: axis ?? { x: 1, y: 0, z: 0 },
+    calibration,
+    dynamics,
+    limit,
+    mimic,
+    safetyController,
+  };
+}
+
+function parseVisual(xml: Element): UrdfVisual {
+  const name = xml.getAttribute("name") ?? undefined;
+  let origin: Pose | undefined;
+  let geometry: UrdfGeometry | undefined;
+  let material: UrdfMaterial | undefined;
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "origin":
+        origin = parsePose(child);
+        break;
+      case "geometry":
+        geometry = parseGeometry(child);
+        break;
+      case "material":
+        material = parseMaterial(child);
+        break;
+    }
+  }
+
+  if (geometry == undefined) {
+    throw new Error("<visual> must have geometry");
+  }
+
+  return { name, origin: origin ?? defaultPose(), geometry, material };
+}
+
+function parseCollision(xml: Element): UrdfCollider {
+  const name = xml.getAttribute("name") ?? undefined;
+  let origin: Pose | undefined;
+  let geometry: UrdfGeometry | undefined;
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "origin":
+        origin = parsePose(child);
+        break;
+      case "geometry":
+        geometry = parseGeometry(child);
+        break;
+    }
+  }
+
+  if (geometry == undefined) {
+    throw new Error("<collision> must have geometry");
+  }
+
+  return { name, origin: origin ?? defaultPose(), geometry };
+}
+
+function parseMaterial(xml: Element): UrdfMaterial {
+  const name = xml.getAttribute("name") ?? undefined;
+  let color: Color | undefined;
+  let texture: string | undefined;
+
+  for (let i = 0; i < xml.children.length; i++) {
+    const child = xml.children[i]!;
+    switch (child.nodeName) {
+      case "color":
+        color = parseColorAttribute(child, "rgba");
+        break;
+      case "texture":
+        texture = child.getAttribute("filename") ?? undefined;
+        break;
+    }
+  }
+
+  return { name, color, texture };
+}
+
+function parseInertia(xml: Element): Inertia {
+  const ixx = parseFloatAttribute(xml, "ixx");
+  const ixy = parseFloatAttribute(xml, "ixy");
+  const ixz = parseFloatAttribute(xml, "ixz");
+  const iyy = parseFloatAttribute(xml, "iyy");
+  const iyz = parseFloatAttribute(xml, "iyz");
+  const izz = parseFloatAttribute(xml, "izz");
+  return { ixx, ixy, ixz, iyy, iyz, izz };
+}
+
+function parseGeometry(xml: Element): UrdfGeometry {
+  if (xml.children.length < 1) {
+    throw new Error("<geometry> must contain box, cylinder, sphere, or mesh");
+  }
+
+  const child = xml.children[0]!;
+  switch (child.nodeName) {
+    case "box": {
+      const size = parseVec3Attribute(child, "size");
+      if (size == undefined) {
+        throw new Error(`missing attribute "size" in ${xml}`);
+      }
+      return { geometryType: "box", size };
+    }
+    case "cylinder": {
+      const length = parseFloatAttribute(child, "length");
+      const radius = parseFloatAttribute(child, "radius");
+      return { geometryType: "cylinder", length, radius };
+    }
+    case "sphere": {
+      const radius = parseFloatAttribute(child, "radius");
+      return { geometryType: "sphere", radius };
+    }
+    case "mesh": {
+      const filename = child.getAttribute("filename") ?? undefined;
+      const scale = parseVec3Attribute(child, "scale");
+      if (filename == undefined) {
+        throw new Error(`missing attribute "filename" in ${xml}`);
+      }
+      return { geometryType: "mesh", filename, scale };
+    }
+    default:
+      throw new Error("<geometry> must contain box, cylinder, sphere, or mesh");
+  }
+}
+
+function parsePose(xml: Element): Pose {
+  const xyz = parseVec3Attribute(xml, "xyz") ?? { x: 0, y: 0, z: 0 };
+  const rpy = parseVec3Attribute(xml, "rpy") ?? { x: 0, y: 0, z: 0 };
+  return { xyz, rpy };
+}
+
+function parseVec3Attribute(xml: Element, attribName: string): Vector3 | undefined {
+  const parts = xml.getAttribute(attribName)?.split(" ");
+  if (parts?.length !== 3) {
+    return undefined;
+  }
+
+  const [x, y, z] = parts as [string, string, string];
+  return { x: parseFloat(x), y: parseFloat(y), z: parseFloat(z) };
+}
+
+function parseColorAttribute(xml: Element, attribName: string): Color | undefined {
+  const parts = xml.getAttribute(attribName)?.split(" ");
+  if (parts?.length !== 4) {
+    return undefined;
+  }
+
+  const [r, g, b, a] = parts as [string, string, string, string];
+  return { r: parseFloat(r), g: parseFloat(g), b: parseFloat(b), a: parseFloat(a) };
+}
+
+function parseFloatAttribute(xml: Element, attribName: string): number {
+  const value = xml.getAttribute(attribName);
+  if (value == undefined) {
+    throw new Error(`missing attribute "${attribName}" in ${xml}`);
+  }
+  return parseFloat(value);
+}
+
+function parseFloatAttributeOptional(xml: Element, attribName: string): number | undefined {
+  const value = xml.getAttribute(attribName);
+  if (value == undefined) {
+    return undefined;
+  }
+  return parseFloat(value);
+}
+
+function parseFloatContent(xml: Element): number {
+  if (xml.textContent == undefined) {
+    throw new Error(`expected float value in "${xml}"`);
+  }
+  return parseFloat(xml.textContent);
+}
+
+function defaultPose(): Pose {
+  return { xyz: { x: 0, y: 0, z: 0 }, rpy: { x: 0, y: 0, z: 0 } };
+}

--- a/packages/den/urdf/types.ts
+++ b/packages/den/urdf/types.ts
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type Vector3 = { x: number; y: number; z: number };
+export type Color = { r: number; g: number; b: number; a: number };
+export type Pose = { xyz: Vector3; rpy: Vector3 };
+
+export type Inertia = {
+  ixx: number;
+  ixy: number;
+  ixz: number;
+  iyy: number;
+  iyz: number;
+  izz: number;
+};
+
+export type JointType = "fixed" | "continuous" | "revolute" | "planar" | "prismatic" | "floating";
+
+export type UrdfInertial = {
+  origin: Pose;
+  mass: number;
+  inertia: Inertia;
+};
+
+export type UrdfGeometryBox = {
+  geometryType: "box";
+  size: Vector3;
+};
+
+export type UrdfGeometryCylinder = {
+  geometryType: "cylinder";
+  radius: number;
+  length: number;
+};
+
+export type UrdfGeometrySphere = {
+  geometryType: "sphere";
+  radius: number;
+};
+
+export type UrdfGeometryMesh = {
+  geometryType: "mesh";
+  filename: string;
+  scale?: Vector3;
+};
+
+export type UrdfGeometry =
+  | UrdfGeometryBox
+  | UrdfGeometryCylinder
+  | UrdfGeometrySphere
+  | UrdfGeometryMesh;
+
+export type UrdfCollider = {
+  name?: string;
+  origin: Pose;
+  geometry: UrdfGeometry;
+};
+
+export type UrdfVisual = {
+  name?: string;
+  origin: Pose;
+  geometry: UrdfGeometry;
+  material?: UrdfMaterial;
+};
+
+export type UrdfLink = {
+  name: string;
+  inertial?: UrdfInertial;
+  visuals: UrdfVisual[];
+  colliders: UrdfCollider[];
+};
+
+export type UrdfJoint = {
+  name: string;
+  jointType: JointType;
+  origin: Pose;
+  parent: string;
+  child: string;
+  axis: Vector3;
+  calibration?: { rising?: number; falling?: number };
+  dynamics?: { damping: number; friction: number };
+  limit?: { lower: number; upper: number; effort: number; velocity: number };
+  mimic?: { joint: string; multiplier: number; offset: number };
+  safetyController?: {
+    softLowerLimit: number;
+    softUpperLimit: number;
+    kPosition: number;
+    kVelocity: number;
+  };
+};
+
+export type UrdfMaterial = {
+  name?: string;
+  color?: Color;
+  texture?: string;
+};
+
+export interface UrdfRobot {
+  name: string;
+  links: Map<string, UrdfLink>;
+  joints: Map<string, UrdfJoint>;
+  materials: Map<string, UrdfMaterial>;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor.tsx
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Color } from "@foxglove/regl-worldview";
+import ColorPicker from "@foxglove/studio-base/components/ColorPicker";
+import Flex from "@foxglove/studio-base/components/Flex";
+
+import { TopicSettingsEditorProps } from ".";
+import { SLabel, SDescription, SInput } from "./common";
+
+export type UrdfSettings = {
+  urdfUrl?: string;
+  overrideColor?: Color;
+};
+
+export const DEFAULT_GRID_COLOR: Color = { r: 36 / 255, g: 142 / 255, b: 255 / 255, a: 1 };
+
+export default function UrdfSettingsEditor(
+  props: TopicSettingsEditorProps<undefined, UrdfSettings>,
+): React.ReactElement {
+  const { settings = {}, onFieldChange } = props;
+
+  return (
+    <Flex col>
+      <SLabel>Color</SLabel>
+      <SDescription>Override the model color.</SDescription>
+      <ColorPicker
+        color={settings.overrideColor}
+        onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+      />
+
+      <SLabel>URDF Path</SLabel>
+      <SDescription>
+        package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file
+      </SDescription>
+      <SInput
+        type="text"
+        value={settings.urdfUrl ?? ""}
+        onChange={(e) => {
+          onFieldChange("urdfUrl", e.target.value);
+        }}
+      />
+    </Flex>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor.tsx
@@ -11,8 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Color } from "@foxglove/regl-worldview";
-import ColorPicker from "@foxglove/studio-base/components/ColorPicker";
 import Flex from "@foxglove/studio-base/components/Flex";
 
 import { TopicSettingsEditorProps } from ".";
@@ -20,10 +18,7 @@ import { SLabel, SDescription, SInput } from "./common";
 
 export type UrdfSettings = {
   urdfUrl?: string;
-  overrideColor?: Color;
 };
-
-export const DEFAULT_GRID_COLOR: Color = { r: 36 / 255, g: 142 / 255, b: 255 / 255, a: 1 };
 
 export default function UrdfSettingsEditor(
   props: TopicSettingsEditorProps<undefined, UrdfSettings>,
@@ -32,14 +27,7 @@ export default function UrdfSettingsEditor(
 
   return (
     <Flex col>
-      <SLabel>Color</SLabel>
-      <SDescription>Override the model color.</SDescription>
-      <ColorPicker
-        color={settings.overrideColor}
-        onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-      />
-
-      <SLabel>URDF Path</SLabel>
+      <SLabel>URDF Location</SLabel>
       <SDescription>
         package:// URL or http(s) URL pointing to a Unified Robot Description Format (URDF) XML file
       </SDescription>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.tsx
@@ -14,8 +14,9 @@
 import { ComponentType } from "react";
 
 import GridSettingsEditor from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/GridSettingsEditor";
+import UrdfSettingsEditor from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor";
 import { TopicSettingsEditorProps } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/types";
-import { FOXGLOVE_GRID_DATATYPE } from "@foxglove/studio-base/util/globalConstants";
+import { FOXGLOVE_GRID_DATATYPE, URDF_DATATYPE } from "@foxglove/studio-base/util/globalConstants";
 
 import LaserScanSettingsEditor from "./LaserScanSettingsEditor";
 import MarkerSettingsEditor from "./MarkerSettingsEditor";
@@ -31,6 +32,7 @@ export function topicSettingsEditorForDatatype(datatype: string):
   | undefined {
   const editors = new Map<string, unknown>([
     [FOXGLOVE_GRID_DATATYPE, GridSettingsEditor],
+    [URDF_DATATYPE, UrdfSettingsEditor],
     ["sensor_msgs/PointCloud2", PointCloudSettingsEditor],
     ["sensor_msgs/msg/PointCloud2", PointCloudSettingsEditor],
     ["velodyne_msgs/VelodyneScan", PointCloudSettingsEditor],

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -475,14 +475,13 @@ export default function Layout({
 
     sceneBuilder.setPlayerId(playerId);
 
+    urdfBuilder.setTransforms(transforms, rootTf);
     if (rootTf) {
-      urdfBuilder.setTransforms(transforms, rootTf);
       sceneBuilder.setTransforms(transforms, rootTf);
     }
 
     urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
     urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
-    urdfBuilder.updateTransforms(transforms);
 
     // Toggle scene builder topics based on visible topic nodes in the tree
     const topicsByTopicName = getTopicsByTopicName(topics);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -22,6 +22,7 @@ import { useShallowMemo } from "@foxglove/hooks";
 import { Worldview, CameraState, ReglClickInfo, MouseEventObject } from "@foxglove/regl-worldview";
 import { Time } from "@foxglove/rostime";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -75,7 +76,11 @@ import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDim
 import { Frame, Topic } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { Color, Marker } from "@foxglove/studio-base/types/Messages";
-import { FOXGLOVE_GRID_TOPIC, URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
+import {
+  FOXGLOVE_GRID_TOPIC,
+  ROBOT_DESCRIPTION_PARAM,
+  URDF_TOPIC,
+} from "@foxglove/studio-base/util/globalConstants";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 
 type EventName = "onDoubleClick" | "onMouseMove" | "onMouseDown" | "onMouseUp";
@@ -465,6 +470,8 @@ export default function Layout({
 
   const [rosPackagePath] = useAppConfigurationValue<string>(AppSetting.ROS_PACKAGE_PATH);
 
+  const [robotDescriptionParam] = PanelAPI.useParameter<string>(ROBOT_DESCRIPTION_PARAM);
+
   useMemo(() => {
     gridBuilder.setVisible(selectedTopicNames.includes(FOXGLOVE_GRID_TOPIC));
     gridBuilder.setSettingsByKey(settingsByKey);
@@ -480,6 +487,7 @@ export default function Layout({
       sceneBuilder.setTransforms(transforms, rootTf);
     }
 
+    urdfBuilder.setUrdfData(robotDescriptionParam, rosPackagePath);
     urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
     urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
 
@@ -511,6 +519,7 @@ export default function Layout({
     highlightMarkerMatchers,
     playerId,
     resetFrame,
+    robotDescriptionParam,
     rootTf,
     rosPackagePath,
     sceneBuilder,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -21,9 +21,11 @@ import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
 import { Worldview, CameraState, ReglClickInfo, MouseEventObject } from "@foxglove/regl-worldview";
 import { Time } from "@foxglove/rostime";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { Save3DConfig } from "@foxglove/studio-base/panels/ThreeDimensionalViz";
 import DebugStats from "@foxglove/studio-base/panels/ThreeDimensionalViz/DebugStats";
@@ -56,6 +58,7 @@ import Transforms, {
   DEFAULT_ROOT_FRAME_IDS,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Transforms";
 import TransformsBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/TransformsBuilder";
+import UrdfBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/UrdfBuilder";
 import World from "@foxglove/studio-base/panels/ThreeDimensionalViz/World";
 import {
   TF_DATATYPES,
@@ -72,7 +75,7 @@ import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDim
 import { Frame, Topic } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { Color, Marker } from "@foxglove/studio-base/types/Messages";
-import { FOXGLOVE_GRID_TOPIC } from "@foxglove/studio-base/util/globalConstants";
+import { FOXGLOVE_GRID_TOPIC, URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 
 type EventName = "onDoubleClick" | "onMouseMove" | "onMouseDown" | "onMouseUp";
@@ -255,11 +258,12 @@ export default function Layout({
   const isDrawing = useMemo(() => measureInfo.measureState !== "idle", [measureInfo.measureState]);
 
   // initialize the GridBuilder, SceneBuilder, and TransformsBuilder
-  const { gridBuilder, sceneBuilder, transformsBuilder } = useMemo(
+  const { gridBuilder, sceneBuilder, transformsBuilder, urdfBuilder } = useMemo(
     () => ({
       gridBuilder: new GridBuilder(),
       sceneBuilder: new SceneBuilder(sceneBuilderHooks),
       transformsBuilder: new TransformsBuilder(),
+      urdfBuilder: new UrdfBuilder(),
     }),
     [],
   );
@@ -286,6 +290,12 @@ export default function Layout({
             topicName: FOXGLOVE_GRID_TOPIC,
             children: [],
             description: "Draws a reference grid.",
+          },
+          {
+            name: "3D Model",
+            topicName: URDF_TOPIC,
+            children: [],
+            description: "Visualize a 3D model",
           },
           {
             name: "TF",
@@ -453,9 +463,15 @@ export default function Layout({
     return firstFrameId != undefined ? tfStore.get(firstFrameId)?.rootTransform().id : undefined;
   }, [transforms, followTf]);
 
+  const [rosPackagePath] = useAppConfigurationValue<string>(AppSetting.ROS_PACKAGE_PATH);
+
   useMemo(() => {
     gridBuilder.setVisible(selectedTopicNames.includes(FOXGLOVE_GRID_TOPIC));
     gridBuilder.setSettingsByKey(settingsByKey);
+
+    urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
+    urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
+    urdfBuilder.updateTransforms(transforms);
 
     if (resetFrame) {
       sceneBuilder.clear();
@@ -496,6 +512,7 @@ export default function Layout({
     playerId,
     resetFrame,
     rootTf,
+    rosPackagePath,
     sceneBuilder,
     selectedNamespacesByTopic,
     selectedTopicNames,
@@ -503,6 +520,7 @@ export default function Layout({
     topics,
     transforms,
     transformsBuilder,
+    urdfBuilder,
   ]);
 
   // use callbackInputsRef to prevent unnecessary callback changes
@@ -700,8 +718,8 @@ export default function Layout({
   }, [pinTopics, saveConfig, searchTextProps, toggleCameraMode]);
 
   const markerProviders = useMemo(
-    () => [gridBuilder, sceneBuilder, transformsBuilder],
-    [gridBuilder, sceneBuilder, transformsBuilder],
+    () => [gridBuilder, sceneBuilder, transformsBuilder, urdfBuilder],
+    [gridBuilder, sceneBuilder, transformsBuilder, urdfBuilder],
   );
 
   const cursorType = isDrawing ? "crosshair" : "";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -469,10 +469,6 @@ export default function Layout({
     gridBuilder.setVisible(selectedTopicNames.includes(FOXGLOVE_GRID_TOPIC));
     gridBuilder.setSettingsByKey(settingsByKey);
 
-    urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
-    urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
-    urdfBuilder.updateTransforms(transforms);
-
     if (resetFrame) {
       sceneBuilder.clear();
     }
@@ -480,8 +476,13 @@ export default function Layout({
     sceneBuilder.setPlayerId(playerId);
 
     if (rootTf) {
+      urdfBuilder.setTransforms(transforms, rootTf);
       sceneBuilder.setTransforms(transforms, rootTf);
     }
+
+    urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
+    urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
+    urdfBuilder.updateTransforms(transforms);
 
     // Toggle scene builder topics based on visible topic nodes in the tree
     const topicsByTopicName = getTopicsByTopicName(topics);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TreeNodeRow.tsx
@@ -286,11 +286,6 @@ export default function TreeNodeRow({
                   setHoveredMarkerMatchers([{ topic: topicName }]);
                 }
               }}
-              unavailableTooltip={
-                node.type === "group"
-                  ? "None of the topics in this group are currently available"
-                  : "Unavailable"
-              }
               visibleInScene={visible ?? false}
               onMouseEnter={() => setHoveredMarkerMatchers([{ topic: topicName }])}
               onMouseLeave={() => setHoveredMarkerMatchers([])}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
@@ -73,7 +73,6 @@ type Props = {
   onMouseLeave?: (arg0: React.MouseEvent) => void;
   overrideColor?: Color;
   size?: Size;
-  unavailableTooltip?: string;
   visibleInScene: boolean;
 };
 
@@ -125,7 +124,6 @@ export default function VisibilityToggle({
   onToggle,
   overrideColor,
   size,
-  unavailableTooltip,
   visibleInScene,
   onMouseEnter,
   onMouseLeave,
@@ -149,7 +147,7 @@ export default function VisibilityToggle({
     return (
       <Icon
         tooltipProps={{ placement: "top" }}
-        tooltip={unavailableTooltip ? unavailableTooltip : "Unavailable"}
+        tooltip={"Unavailable"}
         fade
         size="small"
         clickable={false}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderNamespaceNodes.tsx
@@ -18,7 +18,6 @@ import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedConte
 import { ThreeDimensionalVizContext } from "@foxglove/studio-base/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
 import { TREE_SPACING } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/constants";
 import { TopicTreeContext } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/useTopicTree";
-import { TRANSFORM_TOPIC } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 
 import NamespaceMenu from "./NamespaceMenu";
 import NodeName from "./NodeName";
@@ -69,7 +68,6 @@ function NamespaceNodeRow({
   maxNodeNameLen,
   filterText,
   topicNodeAvailable,
-  unavailableTooltip,
   topicName,
   onNamespaceOverrideColorChange,
 }: {
@@ -85,7 +83,6 @@ function NamespaceNodeRow({
   maxNodeNameLen: number;
   filterText: string;
   topicNodeAvailable: boolean;
-  unavailableTooltip: string;
   topicName: string;
   onNamespaceOverrideColorChange: OnNamespaceOverrideColorChange;
 }) {
@@ -163,7 +160,6 @@ function NamespaceNodeRow({
             onToggle={() => onToggle()}
             overrideColor={overrideColor}
             size="SMALL"
-            unavailableTooltip={unavailableTooltip}
             visibleInScene={visibleInScene ?? false}
             onMouseEnter={() => updateHoveredMarkerMatchers(true)}
             onMouseLeave={onMouseLeave}
@@ -199,9 +195,6 @@ export default function renderNamespaceNodes({
   const rightActionWidth = topicNode.available ? togglesWidth + ICON_SIZE : ICON_SIZE;
   const maxNodeNameLen = rowWidth - rightActionWidth - INNER_LEFT_MARGIN * 2;
 
-  const unavailableTooltip =
-    topicNode.topicName === TRANSFORM_TOPIC ? "Unsupported" : "Unavailable";
-
   const commonRowProps = {
     rowWidth,
     isXSWidth,
@@ -209,7 +202,6 @@ export default function renderNamespaceNodes({
     filterText,
     topicNodeAvailable: topicNode.available,
     onNamespaceOverrideColorChange,
-    unavailableTooltip,
     topicName: topicNode.topicName,
   };
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
@@ -170,7 +170,6 @@ function StyleExpressionNode(props: {
             onToggle={() => updateSettingsForGlobalVariable(name, { active: !active, color })}
             overrideColor={color}
             size="SMALL"
-            unavailableTooltip={""}
             visibleInScene={active}
             onMouseEnter={() =>
               setHoveredMarkerMatchers([{ topic, checks: [{ markerKeyPath, value }] }])

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -103,6 +103,21 @@ export function generateTreeNode(
       available: true,
       providerAvailable: true,
     };
+  } else if (topicName === "/tf") {
+    // Mark transforms as always available, since they can be created and displayed even without any
+    // messages or topics present (such as loading from a URDF)
+    const datatype = datatypesByTopic[topicName] ?? "tf2_msgs/TFMessage";
+    return {
+      type: "topic",
+      key,
+      topicName,
+      available: true,
+      providerAvailable,
+      ...(parentKey ? { parentKey } : undefined),
+      ...(name ? { name } : undefined),
+      ...(datatype ? { datatype } : undefined),
+      ...(description ? { description } : undefined),
+    };
   } else if (topicName) {
     const datatype = datatypesByTopic[topicName];
     return {
@@ -181,10 +196,6 @@ export default function useTopicTree({
   const rootTreeNode = useMemo((): TreeNode => {
     const topicNames = providerTopics.map((topic) => topic.name);
     const availableTopicsNamesSet = new Set(topicNames);
-
-    // Mark transforms as always available, since they can be created and displayed even without any
-    // messages or topics present (such as loading from a URDF)
-    availableTopicsNamesSet.add("/tf");
 
     // Precompute uncategorized topics to add to the transformedTreeConfig before generating the TreeNodes.
     const uncategorizedTopicNames = difference([...availableTopicsNamesSet], topicTreeTopics);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -22,6 +22,8 @@ import { TOPIC_DISPLAY_MODES } from "@foxglove/studio-base/panels/ThreeDimension
 import {
   FOXGLOVE_GRID_DATATYPE,
   FOXGLOVE_GRID_TOPIC,
+  URDF_TOPIC,
+  URDF_DATATYPE,
 } from "@foxglove/studio-base/util/globalConstants";
 
 import {
@@ -86,6 +88,16 @@ export function generateTreeNode(
       type: "topic",
       topicName: FOXGLOVE_GRID_TOPIC,
       datatype: FOXGLOVE_GRID_DATATYPE,
+      key,
+      name,
+      available: true,
+      providerAvailable: true,
+    };
+  } else if (key === `t:${URDF_TOPIC}`) {
+    return {
+      type: "topic",
+      topicName: URDF_TOPIC,
+      datatype: URDF_DATATYPE,
       key,
       name,
       available: true,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -182,6 +182,10 @@ export default function useTopicTree({
     const topicNames = providerTopics.map((topic) => topic.name);
     const availableTopicsNamesSet = new Set(topicNames);
 
+    // Mark transforms as always available, since they can be created and displayed even without any
+    // messages or topics present (such as loading from a URDF)
+    availableTopicsNamesSet.add("/tf");
+
     // Precompute uncategorized topics to add to the transformedTreeConfig before generating the TreeNodes.
     const uncategorizedTopicNames = difference([...availableTopicsNamesSet], topicTreeTopics);
     const datatypesByTopic = mapValues(keyBy(providerTopics, "name"), (item) => item.datatype);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -85,12 +85,7 @@ export default class UrdfBuilder implements MarkerProvider {
   }
 
   setTransforms = (transforms: Transforms, rootTransformID: string | undefined): void => {
-    // Just checking transforms === this._transforms will sometimes return false
-    // even though they are the same object. The storage comparison consistently works
-    if (
-      transforms.storage === this._transforms?.storage &&
-      rootTransformID === this._rootTransformID
-    ) {
+    if (transforms === this._transforms && rootTransformID === this._rootTransformID) {
       return;
     }
     this._transforms = transforms;
@@ -152,24 +147,22 @@ export default class UrdfBuilder implements MarkerProvider {
       return;
     }
 
-    log.debug(
-      `Rendering ${this._urdf.joints.size} joints and ${this._urdf.links.size} links from URDF`,
-    );
-
     for (const joint of this._urdf.joints.values()) {
-      const tf: TF = {
-        header: {
-          frame_id: joint.parent,
-          stamp: { sec: 0, nsec: 0 },
-          seq: 0,
-        },
-        child_frame_id: joint.child,
-        transform: {
-          translation: joint.origin.xyz,
-          rotation: eulerToQuaternion(joint.origin.rpy),
-        },
-      };
-      this._transforms.consume(tf);
+      if (!this._transforms.has(joint.child)) {
+        const tf: TF = {
+          header: {
+            frame_id: joint.parent,
+            stamp: { sec: 0, nsec: 0 },
+            seq: 0,
+          },
+          child_frame_id: joint.child,
+          transform: {
+            translation: joint.origin.xyz,
+            rotation: eulerToQuaternion(joint.origin.rpy),
+          },
+        };
+        this._transforms.consume(tf);
+      }
     }
 
     this.createMarkers(this._urdf);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -85,6 +85,9 @@ export default class UrdfBuilder implements MarkerProvider {
   }
 
   setTransforms = (transforms: Transforms, rootTransformID: string | undefined): void => {
+    if (transforms === this._transforms && rootTransformID === this._rootTransformID) {
+      return;
+    }
     this._transforms = transforms;
     this._rootTransformID = rootTransformID;
     this.update();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -18,7 +18,6 @@ import {
   UrdfGeometryCylinder,
   UrdfGeometryMesh,
   UrdfGeometrySphere,
-  UrdfJoint,
   UrdfRobot,
   UrdfVisual,
   parseRobot,
@@ -33,13 +32,17 @@ import {
   CubeMarker,
   CylinderMarker,
   MeshMarker,
+  MutablePose,
   SphereMarker,
   TF,
 } from "@foxglove/studio-base/types/Messages";
 import { MarkerProvider, MarkerCollector } from "@foxglove/studio-base/types/Scene";
+import { emptyPose } from "@foxglove/studio-base/util/Pose";
 import { URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 
 export const DEFAULT_COLOR: Color = { r: 36 / 255, g: 142 / 255, b: 255 / 255, a: 1 };
+
+const TIME_ZERO = { sec: 0, nsec: 0 };
 
 type Vector3 = { x: number; y: number; z: number };
 type Quaternion = { x: number; y: number; z: number; w: number };
@@ -54,6 +57,8 @@ export default class UrdfBuilder implements MarkerProvider {
   private _meshes: MeshMarker[] = [];
   private _visible = true;
   private _settings: UrdfSettings = {};
+  private _transforms?: Transforms;
+  private _rootTransformID?: string;
 
   constructor() {}
 
@@ -101,6 +106,11 @@ export default class UrdfBuilder implements MarkerProvider {
     this._visible = isVisible;
   }
 
+  setTransforms = (transforms: Transforms, rootTransformID: string): void => {
+    this._transforms = transforms;
+    this._rootTransformID = rootTransformID;
+  };
+
   setSettingsByKey(settings: TopicSettingsCollection, rosPackagePath: string | undefined): void {
     const newSettings = settings[`t:${URDF_TOPIC}`] ?? {};
     if (!isEqual(newSettings, this._settings)) {
@@ -144,115 +154,135 @@ export default class UrdfBuilder implements MarkerProvider {
   }
 
   createMarkers(urdf: UrdfRobot): void {
-    const childToJoint = new Map<string, UrdfJoint>();
-    for (const joint of urdf.joints.values()) {
-      childToJoint.set(joint.child, joint);
+    if (!this._transforms || !this._rootTransformID) {
+      return;
     }
 
+    const tfs = this._transforms;
+    const rootTf = this._rootTransformID;
+    const ns = `urdf-${urdf.name}`;
+
     for (const link of urdf.links.values()) {
-      const joint = childToJoint.get(link.name);
-      if (!joint) {
-        log.warn(`No joint found for link ${link.name}`);
-        continue;
-      }
+      const frame_id = link.name;
 
       let i = 0;
       for (const visual of link.visuals) {
         const id = `${link.name}-visual${i++}-${visual.geometry.geometryType}`;
+        const localPose = {
+          position: visual.origin.xyz,
+          orientation: eulerToQuaternion(visual.origin.rpy),
+        };
+        const pose = tfs.apply(emptyPose(), localPose, frame_id, rootTf);
+        if (!pose) {
+          continue;
+        }
+
         switch (visual.geometry.geometryType) {
           case "box":
-            this._boxes.push(UrdfBuilder.BuildBox(id, visual, joint));
+            this._boxes.push(UrdfBuilder.BuildBox(ns, id, visual, urdf, frame_id, pose));
             break;
           case "sphere":
-            this._spheres.push(UrdfBuilder.BuildSphere(id, visual, joint));
+            this._spheres.push(UrdfBuilder.BuildSphere(ns, id, visual, urdf, frame_id, pose));
             break;
           case "cylinder":
-            this._cylinders.push(UrdfBuilder.BuildCylinder(id, visual, joint));
+            this._cylinders.push(UrdfBuilder.BuildCylinder(ns, id, visual, urdf, frame_id, pose));
             break;
           case "mesh":
-            this._meshes.push(UrdfBuilder.BuildMesh(id, visual, joint));
+            this._meshes.push(UrdfBuilder.BuildMesh(ns, id, visual, urdf, frame_id, pose));
             break;
         }
       }
     }
   }
 
-  static BuildBox(id: string, visual: UrdfVisual, joint: UrdfJoint): CubeMarker {
+  static BuildBox(
+    ns: string,
+    id: string,
+    visual: UrdfVisual,
+    robot: UrdfRobot,
+    frame_id: string,
+    pose: MutablePose,
+  ): CubeMarker {
     const box = visual.geometry as UrdfGeometryBox;
     const marker: CubeMarker = {
       type: 1,
-      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
-      ns: "urdf-box",
+      header: { frame_id, stamp: TIME_ZERO, seq: 0 },
+      ns,
       id,
       action: 0,
-      pose: {
-        position: visual.origin.xyz,
-        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
-      },
+      pose,
       scale: box.size,
-      color: visual.material?.color ?? DEFAULT_COLOR,
-      frame_locked: false,
-      // scaleInvariant: true,
+      color: getColor(visual, robot),
+      frame_locked: true,
     };
     return marker;
   }
 
-  static BuildSphere(id: string, visual: UrdfVisual, joint: UrdfJoint): SphereMarker {
+  static BuildSphere(
+    ns: string,
+    id: string,
+    visual: UrdfVisual,
+    robot: UrdfRobot,
+    frame_id: string,
+    pose: MutablePose,
+  ): SphereMarker {
     const sphere = visual.geometry as UrdfGeometrySphere;
     const marker: SphereMarker = {
       type: 2,
-      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
-      ns: "urdf-sphere",
+      header: { frame_id, stamp: TIME_ZERO, seq: 0 },
+      ns,
       id,
       action: 0,
-      pose: {
-        position: visual.origin.xyz,
-        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
-      },
-      scale: { x: sphere.radius, y: sphere.radius, z: sphere.radius },
-      color: visual.material?.color ?? DEFAULT_COLOR,
-      frame_locked: false,
-      // scaleInvariant: true,
+      pose,
+      scale: { x: sphere.radius * 2, y: sphere.radius * 2, z: sphere.radius * 2 },
+      color: getColor(visual, robot),
+      frame_locked: true,
     };
     return marker;
   }
 
-  static BuildCylinder(id: string, visual: UrdfVisual, joint: UrdfJoint): CylinderMarker {
+  static BuildCylinder(
+    ns: string,
+    id: string,
+    visual: UrdfVisual,
+    robot: UrdfRobot,
+    frame_id: string,
+    pose: MutablePose,
+  ): CylinderMarker {
     const cylinder = visual.geometry as UrdfGeometryCylinder;
     const marker: CylinderMarker = {
       type: 3,
-      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
-      ns: "urdf-cylinder",
+      header: { frame_id, stamp: TIME_ZERO, seq: 0 },
+      ns,
       id,
       action: 0,
-      pose: {
-        position: visual.origin.xyz,
-        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
-      },
-      scale: { x: cylinder.radius, y: cylinder.length, z: cylinder.radius },
-      color: visual.material?.color ?? DEFAULT_COLOR,
-      frame_locked: false,
-      // scaleInvariant: true,
+      pose,
+      scale: { x: cylinder.radius * 2, y: cylinder.radius * 2, z: cylinder.length },
+      color: getColor(visual, robot),
+      frame_locked: true,
     };
     return marker;
   }
 
-  static BuildMesh(id: string, visual: UrdfVisual, joint: UrdfJoint): MeshMarker {
+  static BuildMesh(
+    ns: string,
+    id: string,
+    visual: UrdfVisual,
+    robot: UrdfRobot,
+    frame_id: string,
+    pose: MutablePose,
+  ): MeshMarker {
     const mesh = visual.geometry as UrdfGeometryMesh;
     const marker: MeshMarker = {
       type: 10,
-      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
-      ns: "urdf-mesh",
+      header: { frame_id, stamp: TIME_ZERO, seq: 0 },
+      ns,
       id,
       action: 0,
-      pose: {
-        position: visual.origin.xyz,
-        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
-      },
+      pose,
       scale: mesh.scale ?? { x: 1, y: 1, z: 1 },
-      color: visual.material?.color ?? DEFAULT_COLOR,
-      frame_locked: false,
-      // scaleInvariant: true,
+      color: getColor(visual, robot),
+      frame_locked: true,
       mesh_resource: mesh.filename,
       mesh_use_embedded_materials: true,
     };
@@ -305,4 +335,17 @@ function eulerToQuaternion(rpy: Vector3): Quaternion {
   const z = sy * cr * cp - cy * sr * sp;
 
   return { x, y, z, w };
+}
+
+function getColor(visual: UrdfVisual, robot: UrdfRobot): Color {
+  if (!visual.material) {
+    return DEFAULT_COLOR;
+  }
+  if (visual.material.color) {
+    return visual.material.color;
+  }
+  if (visual.material.name) {
+    return robot.materials.get(visual.material.name)?.color ?? DEFAULT_COLOR;
+  }
+  return DEFAULT_COLOR;
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -85,7 +85,12 @@ export default class UrdfBuilder implements MarkerProvider {
   }
 
   setTransforms = (transforms: Transforms, rootTransformID: string | undefined): void => {
-    if (transforms === this._transforms && rootTransformID === this._rootTransformID) {
+    // Just checking transforms === this._transforms will sometimes return false
+    // even though they are the same object. The storage comparison consistently works
+    if (
+      transforms.storage === this._transforms?.storage &&
+      rootTransformID === this._rootTransformID
+    ) {
       return;
     }
     this._transforms = transforms;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -57,6 +57,7 @@ export default class UrdfBuilder implements MarkerProvider {
   private _meshes: MeshMarker[] = [];
   private _visible = true;
   private _settings: UrdfSettings = {};
+  private _urdfData?: string;
   private _transforms?: Transforms;
   private _rootTransformID?: string;
 
@@ -93,15 +94,26 @@ export default class UrdfBuilder implements MarkerProvider {
     this.update();
   };
 
+  setUrdfData(urdfData: string | undefined, rosPackagePath: string | undefined): void {
+    if (this._urdfData !== urdfData) {
+      this._urdfData = urdfData;
+
+      // Only parse the /robot_description URDF if an override URL is not set
+      if (!this._settings.urdfUrl) {
+        this.clearMarkers();
+
+        if (urdfData) {
+          void this.parseUrdf(urdfData, rosPackagePath);
+        }
+      }
+    }
+  }
+
   setSettingsByKey(settings: TopicSettingsCollection, rosPackagePath: string | undefined): void {
     const newSettings = settings[`t:${URDF_TOPIC}`] ?? {};
     if (!isEqual(newSettings, this._settings)) {
       this._settings = newSettings;
-
-      this._boxes = [];
-      this._spheres = [];
-      this._cylinders = [];
-      this._meshes = [];
+      this.clearMarkers();
 
       if (this._settings.urdfUrl && isUrdfUrlValid(this._settings.urdfUrl)) {
         void this.fetchUrdf(this._settings.urdfUrl, rosPackagePath);
@@ -126,6 +138,10 @@ export default class UrdfBuilder implements MarkerProvider {
       throw new Error(`Did noy fetch any URDF data from "${url}"`);
     }
 
+    await this.parseUrdf(text, rosPackagePath);
+  }
+
+  async parseUrdf(text: string, rosPackagePath: string | undefined): Promise<void> {
     const fileFetcher = getFileFetch(rosPackagePath);
 
     try {
@@ -133,15 +149,12 @@ export default class UrdfBuilder implements MarkerProvider {
       this._urdf = await parseRobot(text, fileFetcher);
       this.update();
     } catch (err) {
-      throw new Error(`Failed to parse URDF from "${url}": ${err}`);
+      throw new Error(`Failed to parse ${text.length} byte URDF: ${err}`);
     }
   }
 
   private update(): void {
-    this._boxes = [];
-    this._spheres = [];
-    this._cylinders = [];
-    this._meshes = [];
+    this.clearMarkers();
 
     if (!this._urdf || !this._transforms) {
       return;
@@ -166,6 +179,13 @@ export default class UrdfBuilder implements MarkerProvider {
     }
 
     this.createMarkers(this._urdf);
+  }
+
+  private clearMarkers(): void {
+    this._boxes = [];
+    this._spheres = [];
+    this._cylinders = [];
+    this._meshes = [];
   }
 
   private createMarkers(urdf: UrdfRobot): void {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -79,36 +79,15 @@ export default class UrdfBuilder implements MarkerProvider {
     }
   };
 
-  updateTransforms(transforms: Transforms): void {
-    if (!this._urdf) {
-      return;
-    }
-
-    for (const joint of this._urdf.joints.values()) {
-      const tf: TF = {
-        header: {
-          frame_id: joint.parent,
-          stamp: { sec: 0, nsec: 0 },
-          seq: 0,
-        },
-        child_frame_id: joint.child,
-        transform: {
-          translation: joint.origin.xyz,
-          rotation: eulerToQuaternion(joint.origin.rpy),
-        },
-      };
-      transforms.consume(tf);
-    }
-  }
-
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setVisible(isVisible: boolean): void {
     this._visible = isVisible;
   }
 
-  setTransforms = (transforms: Transforms, rootTransformID: string): void => {
+  setTransforms = (transforms: Transforms, rootTransformID: string | undefined): void => {
     this._transforms = transforms;
     this._rootTransformID = rootTransformID;
+    this.update();
   };
 
   setSettingsByKey(settings: TopicSettingsCollection, rosPackagePath: string | undefined): void {
@@ -133,6 +112,7 @@ export default class UrdfBuilder implements MarkerProvider {
     let text: string;
     try {
       const fetchUrl = rewritePackageUrl(url, { rosPackagePath });
+      log.debug(`Fetching URDF from ${fetchUrl}`);
       const res = await fetch(fetchUrl);
       text = await res.text();
     } catch (err) {
@@ -146,14 +126,48 @@ export default class UrdfBuilder implements MarkerProvider {
     const fileFetcher = getFileFetch(rosPackagePath);
 
     try {
+      log.debug(`Parsing ${text.length} byte URDF`);
       this._urdf = await parseRobot(text, fileFetcher);
-      this.createMarkers(this._urdf);
+      this.update();
     } catch (err) {
       throw new Error(`Failed to parse URDF from "${url}": ${err}`);
     }
   }
 
-  createMarkers(urdf: UrdfRobot): void {
+  private update(): void {
+    this._boxes = [];
+    this._spheres = [];
+    this._cylinders = [];
+    this._meshes = [];
+
+    if (!this._urdf || !this._transforms) {
+      return;
+    }
+
+    log.debug(
+      `Rendering ${this._urdf.joints.size} joints and ${this._urdf.links.size} links from URDF`,
+    );
+
+    for (const joint of this._urdf.joints.values()) {
+      const tf: TF = {
+        header: {
+          frame_id: joint.parent,
+          stamp: { sec: 0, nsec: 0 },
+          seq: 0,
+        },
+        child_frame_id: joint.child,
+        transform: {
+          translation: joint.origin.xyz,
+          rotation: eulerToQuaternion(joint.origin.rpy),
+        },
+      };
+      this._transforms.consume(tf);
+    }
+
+    this.createMarkers(this._urdf);
+  }
+
+  private createMarkers(urdf: UrdfRobot): void {
     if (!this._transforms || !this._rootTransformID) {
       return;
     }
@@ -168,30 +182,50 @@ export default class UrdfBuilder implements MarkerProvider {
       let i = 0;
       for (const visual of link.visuals) {
         const id = `${link.name}-visual${i++}-${visual.geometry.geometryType}`;
-        const localPose = {
-          position: visual.origin.xyz,
-          orientation: eulerToQuaternion(visual.origin.rpy),
-        };
-        const pose = tfs.apply(emptyPose(), localPose, frame_id, rootTf);
-        if (!pose) {
-          continue;
-        }
+        this.addMarker(ns, id, frame_id, tfs, rootTf, visual, urdf);
+      }
 
-        switch (visual.geometry.geometryType) {
-          case "box":
-            this._boxes.push(UrdfBuilder.BuildBox(ns, id, visual, urdf, frame_id, pose));
-            break;
-          case "sphere":
-            this._spheres.push(UrdfBuilder.BuildSphere(ns, id, visual, urdf, frame_id, pose));
-            break;
-          case "cylinder":
-            this._cylinders.push(UrdfBuilder.BuildCylinder(ns, id, visual, urdf, frame_id, pose));
-            break;
-          case "mesh":
-            this._meshes.push(UrdfBuilder.BuildMesh(ns, id, visual, urdf, frame_id, pose));
-            break;
+      if (link.visuals.length === 0 && link.colliders.length > 0) {
+        // If there are no visuals, but there are colliders, render those instead
+        for (const collider of link.colliders) {
+          const id = `${link.name}-collider${i++}-${collider.geometry.geometryType}`;
+          this.addMarker(ns, id, frame_id, tfs, rootTf, collider, urdf);
         }
       }
+    }
+  }
+
+  private addMarker(
+    ns: string,
+    id: string,
+    frame_id: string,
+    tfs: Transforms,
+    rootTf: string,
+    visual: UrdfVisual,
+    robot: UrdfRobot,
+  ): void {
+    const localPose = {
+      position: visual.origin.xyz,
+      orientation: eulerToQuaternion(visual.origin.rpy),
+    };
+    const pose = tfs.apply(emptyPose(), localPose, frame_id, rootTf);
+    if (!pose) {
+      return;
+    }
+
+    switch (visual.geometry.geometryType) {
+      case "box":
+        this._boxes.push(UrdfBuilder.BuildBox(ns, id, visual, robot, frame_id, pose));
+        break;
+      case "sphere":
+        this._spheres.push(UrdfBuilder.BuildSphere(ns, id, visual, robot, frame_id, pose));
+        break;
+      case "cylinder":
+        this._cylinders.push(UrdfBuilder.BuildCylinder(ns, id, visual, robot, frame_id, pose));
+        break;
+      case "mesh":
+        this._meshes.push(UrdfBuilder.BuildMesh(ns, id, visual, robot, frame_id, pose));
+        break;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -1,0 +1,308 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { isEqual } from "lodash";
+
+import {
+  UrdfGeometryBox,
+  UrdfGeometryCylinder,
+  UrdfGeometryMesh,
+  UrdfGeometrySphere,
+  UrdfJoint,
+  UrdfRobot,
+  UrdfVisual,
+  parseRobot,
+} from "@foxglove/den/urdf";
+import Logger from "@foxglove/log";
+import { rewritePackageUrl } from "@foxglove/studio-base/context/AssetsContext";
+import { TopicSettingsCollection } from "@foxglove/studio-base/panels/ThreeDimensionalViz/SceneBuilder";
+import { UrdfSettings } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor";
+import Transforms from "@foxglove/studio-base/panels/ThreeDimensionalViz/Transforms";
+import {
+  Color,
+  CubeMarker,
+  CylinderMarker,
+  MeshMarker,
+  SphereMarker,
+  TF,
+} from "@foxglove/studio-base/types/Messages";
+import { MarkerProvider, MarkerCollector } from "@foxglove/studio-base/types/Scene";
+import { URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
+
+export const DEFAULT_COLOR: Color = { r: 36 / 255, g: 142 / 255, b: 255 / 255, a: 1 };
+
+type Vector3 = { x: number; y: number; z: number };
+type Quaternion = { x: number; y: number; z: number; w: number };
+
+const log = Logger.getLogger(__filename);
+
+export default class UrdfBuilder implements MarkerProvider {
+  private _urdf?: UrdfRobot;
+  private _boxes: CubeMarker[] = [];
+  private _spheres: SphereMarker[] = [];
+  private _cylinders: CylinderMarker[] = [];
+  private _meshes: MeshMarker[] = [];
+  private _visible = true;
+  private _settings: UrdfSettings = {};
+
+  constructor() {}
+
+  renderMarkers = (add: MarkerCollector): void => {
+    if (this._visible) {
+      for (const box of this._boxes) {
+        add.cube(box);
+      }
+      for (const sphere of this._spheres) {
+        add.sphere(sphere);
+      }
+      for (const cylinder of this._cylinders) {
+        add.cylinder(cylinder);
+      }
+      for (const mesh of this._meshes) {
+        add.mesh(mesh);
+      }
+    }
+  };
+
+  updateTransforms(transforms: Transforms): void {
+    if (!this._urdf) {
+      return;
+    }
+
+    for (const joint of this._urdf.joints.values()) {
+      const tf: TF = {
+        header: {
+          frame_id: joint.parent,
+          stamp: { sec: 0, nsec: 0 },
+          seq: 0,
+        },
+        child_frame_id: joint.child,
+        transform: {
+          translation: joint.origin.xyz,
+          rotation: eulerToQuaternion(joint.origin.rpy),
+        },
+      };
+      transforms.consume(tf);
+    }
+  }
+
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setVisible(isVisible: boolean): void {
+    this._visible = isVisible;
+  }
+
+  setSettingsByKey(settings: TopicSettingsCollection, rosPackagePath: string | undefined): void {
+    const newSettings = settings[`t:${URDF_TOPIC}`] ?? {};
+    if (!isEqual(newSettings, this._settings)) {
+      this._settings = newSettings;
+
+      this._boxes = [];
+      this._spheres = [];
+      this._cylinders = [];
+      this._meshes = [];
+
+      if (this._settings.urdfUrl && isUrdfUrlValid(this._settings.urdfUrl)) {
+        void this.fetchUrdf(this._settings.urdfUrl, rosPackagePath);
+      } else {
+        this._urdf = undefined;
+      }
+    }
+  }
+
+  async fetchUrdf(url: string, rosPackagePath: string | undefined): Promise<void> {
+    let text: string;
+    try {
+      const fetchUrl = rewritePackageUrl(url, { rosPackagePath });
+      const res = await fetch(fetchUrl);
+      text = await res.text();
+    } catch (err) {
+      throw new Error(`Failed to fetch URDF from "${url}": ${err}`);
+    }
+
+    if (!text) {
+      throw new Error(`Did noy fetch any URDF data from "${url}"`);
+    }
+
+    const fileFetcher = getFileFetch(rosPackagePath);
+
+    try {
+      this._urdf = await parseRobot(text, fileFetcher);
+      this.createMarkers(this._urdf);
+    } catch (err) {
+      throw new Error(`Failed to parse URDF from "${url}": ${err}`);
+    }
+  }
+
+  createMarkers(urdf: UrdfRobot): void {
+    const childToJoint = new Map<string, UrdfJoint>();
+    for (const joint of urdf.joints.values()) {
+      childToJoint.set(joint.child, joint);
+    }
+
+    for (const link of urdf.links.values()) {
+      const joint = childToJoint.get(link.name);
+      if (!joint) {
+        log.warn(`No joint found for link ${link.name}`);
+        continue;
+      }
+
+      let i = 0;
+      for (const visual of link.visuals) {
+        const id = `${link.name}-visual${i++}-${visual.geometry.geometryType}`;
+        switch (visual.geometry.geometryType) {
+          case "box":
+            this._boxes.push(UrdfBuilder.BuildBox(id, visual, joint));
+            break;
+          case "sphere":
+            this._spheres.push(UrdfBuilder.BuildSphere(id, visual, joint));
+            break;
+          case "cylinder":
+            this._cylinders.push(UrdfBuilder.BuildCylinder(id, visual, joint));
+            break;
+          case "mesh":
+            this._meshes.push(UrdfBuilder.BuildMesh(id, visual, joint));
+            break;
+        }
+      }
+    }
+  }
+
+  static BuildBox(id: string, visual: UrdfVisual, joint: UrdfJoint): CubeMarker {
+    const box = visual.geometry as UrdfGeometryBox;
+    const marker: CubeMarker = {
+      type: 1,
+      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
+      ns: "urdf-box",
+      id,
+      action: 0,
+      pose: {
+        position: visual.origin.xyz,
+        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
+      },
+      scale: box.size,
+      color: visual.material?.color ?? DEFAULT_COLOR,
+      frame_locked: false,
+      // scaleInvariant: true,
+    };
+    return marker;
+  }
+
+  static BuildSphere(id: string, visual: UrdfVisual, joint: UrdfJoint): SphereMarker {
+    const sphere = visual.geometry as UrdfGeometrySphere;
+    const marker: SphereMarker = {
+      type: 2,
+      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
+      ns: "urdf-sphere",
+      id,
+      action: 0,
+      pose: {
+        position: visual.origin.xyz,
+        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
+      },
+      scale: { x: sphere.radius, y: sphere.radius, z: sphere.radius },
+      color: visual.material?.color ?? DEFAULT_COLOR,
+      frame_locked: false,
+      // scaleInvariant: true,
+    };
+    return marker;
+  }
+
+  static BuildCylinder(id: string, visual: UrdfVisual, joint: UrdfJoint): CylinderMarker {
+    const cylinder = visual.geometry as UrdfGeometryCylinder;
+    const marker: CylinderMarker = {
+      type: 3,
+      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
+      ns: "urdf-cylinder",
+      id,
+      action: 0,
+      pose: {
+        position: visual.origin.xyz,
+        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
+      },
+      scale: { x: cylinder.radius, y: cylinder.length, z: cylinder.radius },
+      color: visual.material?.color ?? DEFAULT_COLOR,
+      frame_locked: false,
+      // scaleInvariant: true,
+    };
+    return marker;
+  }
+
+  static BuildMesh(id: string, visual: UrdfVisual, joint: UrdfJoint): MeshMarker {
+    const mesh = visual.geometry as UrdfGeometryMesh;
+    const marker: MeshMarker = {
+      type: 10,
+      header: { frame_id: joint.parent, stamp: { sec: 0, nsec: 0 }, seq: 0 },
+      ns: "urdf-mesh",
+      id,
+      action: 0,
+      pose: {
+        position: visual.origin.xyz,
+        orientation: { x: 0, y: 0, z: 0, w: 1 }, // Convert Euler rpy to quaternion
+      },
+      scale: mesh.scale ?? { x: 1, y: 1, z: 1 },
+      color: visual.material?.color ?? DEFAULT_COLOR,
+      frame_locked: false,
+      // scaleInvariant: true,
+      mesh_resource: mesh.filename,
+      mesh_use_embedded_materials: true,
+    };
+    return marker;
+  }
+}
+
+function isUrdfUrlValid(str: string): boolean {
+  try {
+    const url = new URL(str);
+    return (
+      (url.protocol === "package:" || url.protocol === "http:" || url.protocol === "https:") &&
+      (url.pathname.endsWith(".urdf") ||
+        url.pathname.endsWith(".xacro") ||
+        url.pathname.endsWith(".xml"))
+    );
+  } catch (e) {
+    return false;
+  }
+}
+
+function getFileFetch(rosPackagePath: string | undefined): (url: string) => Promise<string> {
+  return async (url: string) => {
+    try {
+      log.debug(`fetch(${url}) requested`);
+      const fetchUrl = rewritePackageUrl(url, { rosPackagePath });
+      const res = await fetch(fetchUrl);
+      return await res.text();
+    } catch (err) {
+      throw new Error(`Failed to fetch "${url}": ${err}`);
+    }
+  };
+}
+
+function eulerToQuaternion(rpy: Vector3): Quaternion {
+  const roll = rpy.x;
+  const pitch = rpy.y;
+  const yaw = rpy.z;
+
+  const cy = Math.cos(yaw * 0.5);
+  const sy = Math.sin(yaw * 0.5);
+  const cr = Math.cos(roll * 0.5);
+  const sr = Math.sin(roll * 0.5);
+  const cp = Math.cos(pitch * 0.5);
+  const sp = Math.sin(pitch * 0.5);
+
+  const w = cy * cr * cp + sy * sr * sp;
+  const x = cy * sr * cp - sy * cr * sp;
+  const y = cy * cr * sp + sy * sr * cp;
+  const z = sy * cr * cp - cy * sr * sp;
+
+  return { x, y, z, w };
+}

--- a/packages/studio-base/src/util/globalConstants.ts
+++ b/packages/studio-base/src/util/globalConstants.ts
@@ -20,6 +20,9 @@ export const DIAGNOSTIC_TOPIC = "/diagnostics";
 export const FOXGLOVE_GRID_TOPIC = "/foxglove/grid";
 export const FOXGLOVE_GRID_DATATYPE = "foxglove/Grid";
 
+export const URDF_TOPIC = "/robot_description";
+export const URDF_DATATYPE = "foxglove/RobotDescription";
+
 export const ROBOT_DESCRIPTION_PARAM = "/robot_description";
 
 export const COLORS = {


### PR DESCRIPTION
**User-facing changes**

A new entry is shown in the 3D panel topic picker, "3D Model". ROS URDF files are currently supported. The URDF source URL will automatically be set if the data source supports parameters (live ROS 1 and ROS 2 connections) and the `/robot_description` parameter points at a valid URDF using either a `package://` or `http(s)://` URL.

<img width="912" alt="Screen Shot 2021-11-19 at 10 01 29 AM" src="https://user-images.githubusercontent.com/195374/142677915-8871ce3d-31d1-4315-b2d0-d3c2e558cce3.png">

**Description**

ROS URDF files define links and joints, where each link can be thought of as a coordinate frame that optionally contains a visual representation of part of a robot, and each joint can be thought of as a transform defining a connection between parent and child coordinate frames, or links. When a URDF is parsed, each joint is turned into a transform internally. This is similar to receiving a single latched `/tf_static` message. During data playback, `/tf` messages can modify the initial transform poses set in the URDF to make the robot joints move.

Only a single URDF is currently supported per 3D panel. This is more of a UX limitation, where we don't currently have a flow for adding visualizations to a 3D scene other than observing incoming data during playback. Solving this is out of scope for the current PR but something that could be addressed in the future.

**TODO**

- [x] Monitor `/robot_description` parameter and set the URDF URL unless it is overridden in the "3D Model" settings
- [x] Sometimes the URDF model does not appear (even when the URDF transform axes are visible)
- [x] All of the transforms that only appear in the URDF are marked "Unavailable" in the topic picker and cannot be toggled to a hidden state, even though axes are rendered in the scene (that can't be hidden)

**Out of scope**

- Switch to a different tab then back to the current tab will lose the robot visualization and show the current frame as invalid until you change the camera to a different frame
- Support <material> color overrides for meshes (out of scope, requires changes to @foxglove/regl-worldview)
- Material support in COLLADA meshes
- xacro-parser fixes to support turtlebot
- xacro-parser fixes to support duckiebot