### PR TITLE
Fixes for Tab panels

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -348,6 +348,7 @@ export default function Panel<
     const [fullScreen, setFullscreen] = useState(false);
     const [fullScreenLocked, setFullscreenLocked] = useState(false);
     const panelCatalog = usePanelCatalog();
+    const isTopLevelPanel = mosaicWindowActions.getPath().length === 0 && tabId == undefined;
 
     const type = PanelComponent.panelType;
     const title = useMemo(
@@ -682,7 +683,8 @@ export default function Panel<
             hasSettings: PanelComponent.configSchema != undefined,
             tabId,
             supportsStrictMode: PanelComponent.supportsStrictMode ?? true,
-            connectToolbarDragHandle,
+            // disallow dragging the root panel in a layout
+            connectToolbarDragHandle: isTopLevelPanel ? undefined : connectToolbarDragHandle,
           }}
         >
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
@@ -697,8 +699,11 @@ export default function Panel<
             dataTest={`panel-mouseenter-container ${childId ?? ""}`}
             clip
             ref={(el) => {
-              connectOverlayDragPreview(el);
-              connectToolbarDragPreview(el);
+              // disallow dragging the root panel in a layout
+              if (!isTopLevelPanel) {
+                connectOverlayDragPreview(el);
+                connectToolbarDragPreview(el);
+              }
             }}
           >
             {isSelected && !fullScreen && numSelectedPanelsIfSelected > 1 && (
@@ -726,7 +731,10 @@ export default function Panel<
                 className={classes.actionsOverlay}
                 ref={(el) => {
                   quickActionsOverlayRef.current = el;
-                  connectOverlayDragSource(el);
+                  // disallow dragging the root panel in a layout
+                  if (!isTopLevelPanel) {
+                    connectOverlayDragSource(el);
+                  }
                 }}
                 data-panel-overlay
               >

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -41,12 +41,12 @@ import {
   MosaicNode,
 } from "react-mosaic-component";
 import { useMountedState } from "react-use";
+import styled from "styled-components";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import Button from "@foxglove/studio-base/components/Button";
 import ErrorBoundary, { ErrorRendererProps } from "@foxglove/studio-base/components/ErrorBoundary";
-import Flex from "@foxglove/studio-base/components/Flex";
 import Icon from "@foxglove/studio-base/components/Icon";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
@@ -74,36 +74,94 @@ import {
 } from "@foxglove/studio-base/util/layout";
 import { colors, spacing } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+const PanelRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  overflow: hidden;
+  z-index: 1;
+  background-color: ${({ theme }) => (theme.isInverted ? colors.DARK : colors.LIGHT)};
+  position: relative;
+
+  // To use css to hide/show toolbars on hover we use a global panelToolbar class
+  // because the PanelToolbar component is currently added within each panels render
+  // function rather than handling by the panel HOC
+
+  .panelToolbarHovered {
+    display: none;
+  }
+  :hover .panelToolbarHovered {
+    display: flex;
+  }
+  :after {
+    content: "";
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    border: 1px solid ${colors.ACCENT};
+    position: absolute;
+    pointer-events: none;
+    transition: opacity 0.125s ease-out;
+    z-index: 100000;
+  }
+`;
+
+const ActionsOverlay = styled.div`
+  cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100000; // highest level within panel
+  display: none;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-end;
+  font-size: 14px;
+  padding-top: 24px;
+
+  ${PanelRoot}:hover > & {
+    background-color: ${({ theme }) => theme.palette.neutralLight};
+    display: flex;
+    align-items: center;
+    align-content: center;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  // for screenshot tests
+  .hoverForScreenshot {
+    background-color: ${({ theme }) => theme.palette.neutralLight};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  div {
+    width: 100%;
+    padding: 6px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  svg {
+    margin-right: 4px;
+    width: 24px;
+    height: 24px;
+    fill: white;
+  }
+  p {
+    font-size: 12px;
+    color: ${colors.TEXT_MUTED};
+  }
+`;
+
 const useStyles = makeStyles((theme) => ({
-  root: {
-    zIndex: 1,
-    backgroundColor: theme.isInverted ? colors.DARK : colors.LIGHT,
-    position: "relative",
-
-    // // To use css to hide/show toolbars on hover we use a global panelToolbar class
-    // // because the PanelToolbar component is currently added within each panels render
-    // // function rather than handling by the panel HOC
-
-    ".panelToolbarHovered": {
-      display: "none",
-    },
-    ":hover .panelToolbarHovered": {
-      display: "flex",
-    },
-    ":after": {
-      content: '""',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      opacity: 0,
-      border: `1px solid ${colors.ACCENT}`,
-      position: "absolute",
-      pointerEvents: "none",
-      transition: "opacity 0.125s ease-out",
-      zIndex: 100000,
-    },
-  },
   perfInfo: {
     position: "absolute",
     whiteSpace: "pre-line",
@@ -122,67 +180,12 @@ const useStyles = makeStyles((theme) => ({
     left: 0,
     right: 0,
     bottom: spacing.PLAYBACK_CONTROL_HEIGHT,
-
-    ":hover [data-panel-overlay-exit]": {
-      display: "block",
-    },
   },
   rootSelected: {
     ":after": {
       // https://github.com/microsoft/fluentui/issues/20452
       opacity: "1 !important",
       transition: "opacity 0.05s ease-out !important",
-    },
-  },
-  actionsOverlay: {
-    cursor: "pointer",
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: 100000, // highest level within panel
-    display: "none",
-    flexDirection: "column",
-    justifyContent: "flex-start",
-    alignItems: "flex-end",
-    fontSize: "14px",
-    paddingTop: "24px",
-
-    ".mosaic-window:hover &": {
-      backgroundColor: theme.palette.neutralLight,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      flexWrap: "wrap",
-    },
-    // for screenshot tests
-    ".hoverForScreenshot": {
-      backgroundColor: theme.palette.neutralLight,
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      flexWrap: "wrap",
-    },
-
-    div: {
-      width: "100%",
-      padding: "6px 0",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      flexWrap: "wrap",
-    },
-
-    svg: {
-      marginRight: "4px",
-      width: "24px",
-      height: "24px",
-      fill: "white",
-    },
-    p: {
-      fontSize: "12px",
-      color: colors.TEXT_MUTED,
     },
   },
   quickActionsOverlayButton: {
@@ -208,11 +211,11 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   tabActionsOverlayButton: {
-    margin: "4px",
+    margin: "4px !important",
     flex: "none",
     fontSize: "14px",
     alignItems: "center",
-    background: `${theme.semanticColors.primaryButtonBackground} !important`,
+    background: `${colors.BLUE} !important`,
     color: `${theme.semanticColors.primaryButtonText} !important`,
     width: 145,
     height: 40,
@@ -225,33 +228,7 @@ const useStyles = makeStyles((theme) => ({
       fill: theme.semanticColors.primaryButtonText,
     },
     ":not(.disabled):hover": {
-      background: `${theme.semanticColors.primaryButtonBackgroundHovered} !important`,
-    },
-  },
-  exitFullscreen: {
-    position: "fixed !important" as unknown as "fixed", // ensure this overrides LegacyButton styles
-    top: 75,
-    right: 8,
-    zIndex: 102,
-    opacity: 1,
-    backgroundColor: colors.DARK3,
-    display: "none",
-
-    ".mosaic-window:hover &": {
-      display: "block",
-    },
-    ".hoverForScreenshot &": {
-      display: "block",
-    },
-    svg: {
-      width: 16,
-      height: 16,
-      fill: "currentColor",
-      float: "left",
-    },
-    span: {
-      float: "right",
-      paddingLeft: "3",
+      background: `${colors.BLUE1} !important`,
     },
   },
 }));
@@ -688,16 +665,14 @@ export default function Panel<
           }}
         >
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
-          <Flex
+          <PanelRoot
             onClick={onOverlayClick}
             onMouseMove={onMouseMove}
-            className={cx(classes.root, {
+            className={cx({
               [classes.rootFullScreen]: fullScreen,
               [classes.rootSelected]: isSelected,
             })}
-            col
-            dataTest={`panel-mouseenter-container ${childId ?? ""}`}
-            clip
+            data-test={`panel-mouseenter-container ${childId ?? ""}`}
             ref={(el) => {
               // disallow dragging the root panel in a layout
               if (!isTopLevelPanel) {
@@ -707,28 +682,23 @@ export default function Panel<
             }}
           >
             {isSelected && !fullScreen && numSelectedPanelsIfSelected > 1 && (
-              <div data-tab-options className={classes.actionsOverlay}>
-                <Button
-                  className={classes.tabActionsOverlayButton}
-                  style={{ backgroundColor: colors.BLUE }}
-                  onClick={groupPanels}
-                >
+              <ActionsOverlay>
+                <Button className={classes.tabActionsOverlayButton} onClick={groupPanels}>
                   <Icon size="small" style={{ marginBottom: 5 }}>
                     <BorderAllIcon />
                   </Icon>
                   Group in tab
                 </Button>
-                <Button style={{ backgroundColor: colors.BLUE }} onClick={createTabs}>
+                <Button className={classes.tabActionsOverlayButton} onClick={createTabs}>
                   <Icon size="small" style={{ marginBottom: 5 }}>
                     <ExpandAllOutlineIcon />
                   </Icon>
                   Create {numSelectedPanelsIfSelected} tabs
                 </Button>
-              </div>
+              </ActionsOverlay>
             )}
             {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullScreen && (
-              <div
-                className={classes.actionsOverlay}
+              <ActionsOverlay
                 ref={(el) => {
                   quickActionsOverlayRef.current = el;
                   // disallow dragging the root panel in a layout
@@ -736,7 +706,6 @@ export default function Panel<
                     connectOverlayDragSource(el);
                   }
                 }}
-                data-panel-overlay
               >
                 <div>
                   <div>
@@ -754,7 +723,7 @@ export default function Panel<
                     </Button>
                   </div>
                 </div>
-              </div>
+              </ActionsOverlay>
             )}
             <ErrorBoundary renderError={(errorProps) => <ErrorToolbar {...errorProps} />}>
               {PanelComponent.supportsStrictMode ?? true ? (
@@ -766,7 +735,7 @@ export default function Panel<
             {process.env.NODE_ENV !== "production" && (
               <div className={classes.perfInfo} ref={perfInfo} />
             )}
-          </Flex>
+          </PanelRoot>
         </PanelContext.Provider>
       </Profiler>
     );

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -30,7 +30,7 @@ export type PanelContextType<T> = {
   isFullscreen: boolean;
 
   hasSettings: boolean;
-  connectToolbarDragHandle: (el: Element | ReactNull) => void;
+  connectToolbarDragHandle?: (el: Element | ReactNull) => void;
   supportsStrictMode: boolean; // remove when all panels have strict mode enabled :)
 };
 // Context used for components to know which panel they are inside

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -338,7 +338,7 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
         setIsOpen={setMenuOpen}
         isUnknownPanel={isUnknownPanel}
       />
-      {!isUnknownPanel && (
+      {!isUnknownPanel && panelContext?.connectToolbarDragHandle && (
         <span ref={panelContext?.connectToolbarDragHandle} data-test="mosaic-drag-handle">
           <Icon fade tooltip="Move panel (shortcut: ` or ~)">
             <DragIcon className={cx(styles.icon, styles.dragIcon)} />

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
@@ -913,17 +913,19 @@ describe("layout reducers", () => {
   });
 
   describe("handles dragging panels", () => {
-    it("does not remove panel from single-panel layout when starting drag", () => {
-      let panels: PanelsState = {
+    it("disallows dragging from single-panel layout", () => {
+      const panels: PanelsState = {
         ...emptyLayout,
         layout: "Audio!a",
       };
-      panels = panelsReducer(panels, {
-        type: "START_DRAG",
-        payload: { sourceTabId: undefined, path: [] },
-      });
-      expect(panels.layout).toEqual("Audio!a");
+      expect(() =>
+        panelsReducer(panels, {
+          type: "START_DRAG",
+          payload: { sourceTabId: undefined, path: [] },
+        }),
+      ).toThrow("Can't drag the top-level panel of a layout");
     });
+
     it("hides panel from multi-panel layout when starting drag", () => {
       let panels: PanelsState = {
         ...emptyLayout,
@@ -1290,30 +1292,6 @@ describe("layout reducers", () => {
         tabs: [{ title: "B", layout: "Tab!c" }],
       });
       expect(configById["Tab!c"]).toEqual(tabCConfig);
-    });
-    it("handles drags in single-panel layouts", () => {
-      let panels: PanelsState = {
-        ...emptyLayout,
-        layout: "Audio!a",
-      };
-      panels = panelsReducer(panels, {
-        type: "START_DRAG",
-        payload: { sourceTabId: undefined, path: [] },
-      });
-      panels = panelsReducer(panels, {
-        type: "END_DRAG",
-        payload: {
-          originalLayout: "Audio!a",
-          originalSavedProps: {},
-          panelId: "Audio!a",
-          sourceTabId: undefined,
-          targetTabId: undefined,
-          position: "right",
-          destinationPath: [],
-          ownPath: [],
-        },
-      });
-      expect(panels.layout).toEqual("Audio!a");
     });
     it("handles drags in multi-panel layouts", () => {
       const originalLayout = {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
@@ -1189,6 +1189,53 @@ describe("layout reducers", () => {
         ],
       });
     });
+    it("handles dragging non-Tab panel from Tab to nested Tab", () => {
+      const originalLayout = "Tab!a";
+      const originalSavedProps = {
+        "Tab!a": {
+          activeTabIdx: 0,
+          tabs: [{ title: "A", layout: { first: "Plot!a", second: "Tab!b", direction: "row" } }],
+        },
+        "Tab!b": {
+          activeTabIdx: 0,
+          tabs: [{ title: "B", layout: "RawMessages!a" }],
+        },
+      };
+      let panels: PanelsState = {
+        ...emptyLayout,
+        layout: originalLayout,
+        configById: originalSavedProps,
+      };
+      panels = panelsReducer(panels, {
+        type: "START_DRAG",
+        payload: { sourceTabId: "Tab!a", path: ["first"] },
+      });
+      panels = panelsReducer(panels, {
+        type: "END_DRAG",
+        payload: {
+          originalLayout,
+          originalSavedProps,
+          panelId: "Plot!a",
+          sourceTabId: "Tab!a",
+          targetTabId: "Tab!b",
+          position: "right",
+          destinationPath: [],
+          ownPath: ["first"],
+        },
+      });
+      const { layout, configById } = panels;
+      expect(layout).toEqual("Tab!a");
+      expect(configById["Tab!a"]).toEqual({
+        activeTabIdx: 0,
+        tabs: [{ title: "A", layout: "Tab!b" }],
+      });
+      expect(configById["Tab!b"]).toEqual({
+        activeTabIdx: 0,
+        tabs: [
+          { title: "B", layout: { first: "RawMessages!a", second: "Plot!a", direction: "row" } },
+        ],
+      });
+    });
     it("handles dragging Tab panels between Tab panels", () => {
       const originalLayout = {
         first: "Tab!a",

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -613,7 +613,12 @@ const dragToTabFromTab = (
     trimConfigById: false,
   });
   newPanelsState = savePanelConfigs(newPanelsState, {
-    configs: [...fromTabConfigs, ...toTabConfigs, ...sourceTabChildConfigs],
+    configs: [
+      ...fromTabConfigs,
+      ...toTabConfigs,
+      // if the target tab is inside the source tab, make sure not to overwrite it with its old config
+      ...sourceTabChildConfigs.filter(({ id }) => id !== targetTabId),
+    ],
   });
   return newPanelsState;
 };

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -652,7 +652,7 @@ const startDrag = (
       configs: [{ id: sourceTabId, config: updateTabPanelLayout(undefined, sourceTabConfig) }],
     });
   }
-  return panelsState;
+  throw new Error("Can't drag the top-level panel of a layout");
 };
 
 const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsState => {
@@ -746,10 +746,6 @@ const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsS
       sourceTabConfig,
       sourceTabChildConfigs,
     });
-  }
-
-  if (typeof originalLayout === "string") {
-    return changePanelLayout(panelsState, { layout: originalLayout, trimConfigById: false });
   }
 
   if (position != undefined && destinationPath != undefined && !isEqual(destinationPath, ownPath)) {


### PR DESCRIPTION
**User-Facing Changes**
- Fixed panels disappearing when dragged from a tab into a nested tab.
- Fixed a crash when dragging a tab panel if it was the topmost panel in a layout.

**Description**
- Fixes https://github.com/foxglove/studio/issues/708. Root cause was `sourceTabChildConfigs` overwriting the new target tab config; fix is to filter target tab out of `sourceTabChildConfigs`.
- Disable dragging the topmost panel in a layout, to avoid a crash that would happen when dragging a top-level tab
- Change styling code so quick actions / grouping overlays are only shown on the hovered panel, rather than showing overlays on all panels within a hovered tab (fixed by updating CSS selector to use `>`)
