### PR TITLE
Improve error visibility for mesh markers; support capital .STL extension

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
@@ -10,9 +10,9 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { ReactElement, useMemo } from "react";
+import { ReactElement, useMemo, useCallback } from "react";
+import { useToasts } from "react-toast-notifications";
 
-import Logger from "@foxglove/log";
 import { CommonCommandProps, GLTFScene, parseGLB } from "@foxglove/regl-worldview";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { rewritePackageUrl } from "@foxglove/studio-base/context/AssetsContext";
@@ -22,8 +22,6 @@ import { GlbModel } from "@foxglove/studio-base/panels/ThreeDimensionalViz/utils
 import { parseDaeToGlb } from "@foxglove/studio-base/panels/ThreeDimensionalViz/utils/parseDaeToGlb";
 import { parseStlToGlb } from "@foxglove/studio-base/panels/ThreeDimensionalViz/utils/parseStlToGlb";
 import { MeshMarker } from "@foxglove/studio-base/types/Messages";
-
-const log = Logger.getLogger(__filename);
 
 type MeshMarkerProps = CommonCommandProps & {
   markers: MeshMarker[];
@@ -40,43 +38,46 @@ async function loadNotFoundModel(): Promise<GlbModel> {
 async function loadModel(url: string): Promise<GlbModel | undefined> {
   const GLB_MAGIC = 0x676c5446; // "glTF"
 
-  try {
-    const response = await fetch(url);
-    const buffer = await response.arrayBuffer();
-    if (buffer.byteLength < 4) {
-      throw new Error(`${buffer.byteLength} bytes received`);
-    }
-    const view = new DataView(buffer);
-
-    // Check if this is a glTF .glb file
-    if (GLB_MAGIC === view.getUint32(0, false)) {
-      return (await parseGLB(buffer)) as GlbModel;
-    }
-
-    // STL binary files don't have a header, so we have to rely on the file extension
-    if (url.endsWith(".stl")) {
-      return parseStlToGlb(buffer);
-    }
-
-    if (url.endsWith(".dae")) {
-      return await parseDaeToGlb(buffer);
-    }
-  } catch (err) {
-    log.error(`Failed to load model from ${url}: ${err.message}`);
+  const response = await fetch(url);
+  if (response.status !== 200) {
+    throw new Error(`Error ${response.status} loading model from ${url}`);
   }
 
-  return await loadNotFoundModel();
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength < 4) {
+    throw new Error(`${buffer.byteLength} bytes received`);
+  }
+  const view = new DataView(buffer);
+
+  // Check if this is a glTF .glb file
+  if (GLB_MAGIC === view.getUint32(0, false)) {
+    return (await parseGLB(buffer)) as GlbModel;
+  }
+
+  // STL binary files don't have a header, so we have to rely on the file extension
+  if (/\.stla$/i.test(url)) {
+    return parseStlToGlb(buffer);
+  }
+
+  if (/\.dae$/i.test(url)) {
+    return await parseDaeToGlb(buffer);
+  }
+
+  throw new Error(`Unknown mesh resource type at ${url}`);
 }
 
 class ModelCache {
   private models = new Map<string, Promise<GlbModel | undefined>>();
 
-  async load(url: string): Promise<GlbModel | undefined> {
+  async load(url: string, reportError: (_: Error) => void): Promise<GlbModel | undefined> {
     let promise = this.models.get(url);
     if (promise) {
       return await promise;
     }
-    promise = loadModel(url);
+    promise = loadModel(url).catch(async (err) => {
+      reportError(err);
+      return await loadNotFoundModel();
+    });
     this.models.set(url, promise);
     return await promise;
   }
@@ -87,6 +88,13 @@ function MeshMarkers({ markers, layerIndex }: MeshMarkerProps): ReactElement {
 
   const modelCache = useMemo(() => new ModelCache(), []);
   const [rosPackagePath] = useAppConfigurationValue<string>(AppSetting.ROS_PACKAGE_PATH);
+  const { addToast } = useToasts();
+  const reportError = useCallback(
+    (error: Error) => {
+      addToast(error.toString(), { appearance: "error", autoDismiss: true });
+    },
+    [addToast],
+  );
 
   for (let i = 0; i < markers.length; i++) {
     const marker = markers[i]!;
@@ -98,7 +106,11 @@ function MeshMarkers({ markers, layerIndex }: MeshMarkerProps): ReactElement {
     const alpha = (color?.a ?? 0) > 0 ? color!.a : 1;
 
     models.push(
-      <GLTFScene key={i} layerIndex={layerIndex} model={async () => await modelCache.load(url)}>
+      <GLTFScene
+        key={i}
+        layerIndex={layerIndex}
+        model={async () => await modelCache.load(url, reportError)}
+      >
         {{ pose, scale, alpha, interactionData: undefined }}
       </GLTFScene>,
     );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
@@ -55,7 +55,7 @@ async function loadModel(url: string): Promise<GlbModel | undefined> {
   }
 
   // STL binary files don't have a header, so we have to rely on the file extension
-  if (/\.stla$/i.test(url)) {
+  if (/\.stl$/i.test(url)) {
     return parseStlToGlb(buffer);
   }
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed loading mesh resource markers with capitalized file extensions such as `.STL`.

**Description**
Fixes https://github.com/foxglove/studio/issues/2144
- Pop up a toast notification when errors occur. This does not use the regular topic error reporting mechanism because the error occurs asynchronously.
   <img width="1214" alt="Screen Shot 2021-11-22 at 9 37 18 AM" src="https://user-images.githubusercontent.com/14237/142909548-0de74669-fc74-4dca-9b56-1dcfd2532714.png">

- Adds an error message for unrecognized file types.
- Adds an error message when fetch() returns a non-200 status code.