### PR TITLE
Rename Websocket to Rosbridge in dialog box

### DIFF
--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -18,7 +18,7 @@ class RosbridgeDataSourceFactory implements IDataSourceFactory {
 
   promptOptions(previousValue?: string): PromptOptions {
     return {
-      title: "WebSocket connection",
+      title: "Rosbridge connection",
       placeholder: "ws://localhost:9090",
       initialValue: previousValue ?? "ws://localhost:9090",
       transformer: (str) => {


### PR DESCRIPTION
**User-Facing Changes and Description**
- Rename Websocket to Rosbridge in dialog box, for consistency

<img width="150" alt="dialog" src="https://user-images.githubusercontent.com/6993359/143078350-7cc46da4-7d00-4bcc-bb8d-5e98ca7a95c7.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
