### PR TITLE
Fix Help sidebar bug where selecting the same panel twice does not work correctly

### DIFF
--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -98,7 +98,10 @@ export default function HelpSidebar({
                 key="back-arrow"
                 size="small"
                 style={{ marginRight: "5px" }}
-                onClick={() => setIsHomeView(true)}
+                onClick={() => {
+                  setIsHomeView(true);
+                  setPanelDocToDisplay("");
+                }}
               >
                 <ChevronLeftIcon />
               </Icon>,
@@ -107,16 +110,7 @@ export default function HelpSidebar({
       title={isHomeView ? "Help" : panelInfo?.title ? panelInfo.title : ""}
     >
       <Stack>
-        {!isHomeView && (
-          <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
-            {panelInfo?.help != undefined ? (
-              <TextContent allowMarkdownHtml={true}>{panelInfo?.help}</TextContent>
-            ) : (
-              "Panel does not have any documentation details."
-            )}
-          </Stack>
-        )}
-        {isHomeView && (
+        {isHomeView ? (
           <Stack tokens={{ childrenGap: theme.spacing.m }}>
             <Stack.Item>
               <Text styles={styles.subheader}>Panels</Text>
@@ -181,6 +175,14 @@ export default function HelpSidebar({
                 ))}
               </Stack>
             </Stack.Item>
+          </Stack>
+        ) : (
+          <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
+            {panelInfo?.help != undefined ? (
+              <TextContent allowMarkdownHtml={true}>{panelInfo?.help}</TextContent>
+            ) : (
+              "Panel does not have any documentation details."
+            )}
           </Stack>
         )}
       </Stack>


### PR DESCRIPTION
**User-Facing Changes**
- Fix bug where selecting a panel to display in the Help sidebar, navigating back to the main menu of the Help sidebar, and then clicking into that panel again would not work as expected

**Description**
- Code does not correctly clear the selected panel to display on navigating back to the main menu

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
