### PR TITLE
Fix Node Playground bug with multiple nodes

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -13,6 +13,7 @@
 import { isEqual, groupBy, partition } from "lodash";
 import memoizeWeak from "memoize-weak";
 import shallowequal from "shallowequal";
+import { v4 as uuidv4 } from "uuid";
 
 import Log from "@foxglove/log";
 import { Time, compare } from "@foxglove/rostime";
@@ -118,7 +119,12 @@ export default class UserNodePlayer implements Player {
 
   // exposed as a static to allow testing to mock/replace
   static CreateNodeRuntimeWorker = (): SharedWorker => {
-    return new SharedWorker(new URL("./nodeRuntimeWorker/index", import.meta.url));
+    return new SharedWorker(new URL("./nodeRuntimeWorker/index", import.meta.url), {
+      // Although we are using SharedWorkers, each nodeRuntimeWorker uses a single global variable
+      // for the compiled `nodeCallback` function, so we need a separate worker per user node. We
+      // achieve this by passing in a unique name.
+      name: uuidv4(),
+    });
   };
 
   constructor(player: Player, userNodeActions: UserNodeActions) {


### PR DESCRIPTION
**User-Facing Changes**
Fixes a bug where Node Playground didn't work with more than one active node at a time.

**Description**
Fixes #2215 by setting a unique name for each node runtime worker. This is the approach used in upstream webviz, and it was inadvertently removed in our initial conversion effort: https://github.com/foxglove/studio/commit/9f90e799c004de6b6e675f48c2efad09020519c1#diff-a5ad522756d64137c76fcbcb0f5648a13ffd1c0d3ebed39035e67a9f0988eacfL246