### PR TITLE
Improve error message for empty ROS 2 bags

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -37,7 +37,7 @@
     "@foxglove/ros1": "1.3.4",
     "@foxglove/ros2": "1.0.5",
     "@foxglove/rosbag": "0.1.2",
-    "@foxglove/rosbag2-web": "3.0.0",
+    "@foxglove/rosbag2-web": "3.0.2",
     "@foxglove/rosmsg": "3.0.0",
     "@foxglove/rosmsg-msgs-common": "1.0.4",
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -200,7 +200,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       return;
     }
 
-    if (selectedSidebarItem === "connection" && playerPresence !== PlayerPresence.NOT_PRESENT) {
+    if (selectedSidebarItem === "connection" && playerPresence === PlayerPresence.PRESENT) {
       setSelectedSidebarItem(undefined);
     }
   }, [selectedSidebarItem, playerPresence]);

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -1229,7 +1229,7 @@ describe("RandomAccessPlayer", () => {
         problems: [
           {
             error: new Error("fake initialization failure"),
-            message: "Error initializing player",
+            message: "Error initializing player: fake initialization failure",
             severity: "error",
           },
         ],

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -270,7 +270,7 @@ export default class RandomAccessPlayer implements Player {
         }, SEEK_START_DELAY_MS);
       })
       .catch((error: Error) => {
-        this._setError("Error initializing player", error);
+        this._setError(`Error initializing player: ${error.message}`, error);
       });
   }
 

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -53,6 +53,16 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
     const [start, end] = await this.bag_.timeRange();
     const topicDefs = await this.bag_.readTopics();
     const messageCounts = await this.bag_.messageCounts();
+    let hasAnyMessages = false;
+    for (const count of messageCounts.values()) {
+      if (count > 0) {
+        hasAnyMessages = true;
+        break;
+      }
+    }
+    if (!hasAnyMessages) {
+      throw new Error("Bag contains no messages");
+    }
 
     const problems: RandomAccessDataProviderProblem[] = [];
     const topics: Topic[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,13 +2214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosbag2-web@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@foxglove/rosbag2-web@npm:3.0.0"
+"@foxglove/rosbag2-web@npm:3.0.2":
+  version: 3.0.2
+  resolution: "@foxglove/rosbag2-web@npm:3.0.2"
   dependencies:
     "@foxglove/rosbag2": ^3.0.0
     sql.js: ^1.6.2
-  checksum: 4deab0dd3b1d526afe063740c1abb42d17cfcae5192f14491271d8a161969f2e045c6a6ab76f8907e5883700b8075ae4a8c9a64cf7287531ded1f30861899885
+  checksum: b7c2829f2cbc6ee9a476afdd7fba5cfcb74c981dd1eab5dc40ec949731f595fb4a0664a5b05eb6b94277701a627cf8e9d63756c5ee8b4070742c173d557a9762
   languageName: node
   linkType: hard
 
@@ -2329,7 +2329,7 @@ __metadata:
     "@foxglove/ros1": 1.3.4
     "@foxglove/ros2": 1.0.5
     "@foxglove/rosbag": 0.1.2
-    "@foxglove/rosbag2-web": 3.0.0
+    "@foxglove/rosbag2-web": 3.0.2
     "@foxglove/rosmsg": 3.0.0
     "@foxglove/rosmsg-msgs-common": 1.0.4
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3


### PR DESCRIPTION
**User-Facing Changes**
Improved error message when loading an empty ROS 2 bag.

**Description**
Fixes https://github.com/foxglove/studio/issues/2217

The new error message is "Bag contains no messages". Also keep the connection sidebar open if an error is encountered during initialization.