### PR TITLE
Improved error messages for XML-RPC failures in ROS1 data source

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -34,7 +34,7 @@
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f",
     "@foxglove/regl-worldview": "1.0.1",
-    "@foxglove/ros1": "1.3.4",
+    "@foxglove/ros1": "1.3.5",
     "@foxglove/ros2": "1.0.7",
     "@foxglove/rosbag": "0.1.2",
     "@foxglove/rosbag2-web": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,15 +2190,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ros1@npm:1.3.4":
-  version: 1.3.4
-  resolution: "@foxglove/ros1@npm:1.3.4"
+"@foxglove/ros1@npm:1.3.5":
+  version: 1.3.5
+  resolution: "@foxglove/ros1@npm:1.3.5"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
     "@foxglove/rosmsg-serialization": ^1.2.3
-    "@foxglove/xmlrpc": ^1.1.5
+    "@foxglove/xmlrpc": ^1.1.6
     eventemitter3: ^4.0.7
-  checksum: 6e2e2c59a03473620b17e2f33de9d0a974c6bf138959054b73cb2129e3a860ec8a7cf3206ddb81235fb16ad0d95551a695bf4bb90f96ce1fdc4e40dbd817f75b
+  checksum: fe298473eba75af994913c0686687c1733e8ec25f11ddd50ab03cf4e1370142c5fb7479593c56c34f4c0756ccdcab49036517601e919ccb954845364d8659145
   languageName: node
   linkType: hard
 
@@ -2326,7 +2326,7 @@ __metadata:
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f"
     "@foxglove/regl-worldview": 1.0.1
-    "@foxglove/ros1": 1.3.4
+    "@foxglove/ros1": 1.3.5
     "@foxglove/ros2": 1.0.7
     "@foxglove/rosbag": 0.1.2
     "@foxglove/rosbag2-web": 3.0.3
@@ -2531,15 +2531,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/xmlrpc@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "@foxglove/xmlrpc@npm:1.1.5"
+"@foxglove/xmlrpc@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@foxglove/xmlrpc@npm:1.1.6"
   dependencies:
     "@foxglove/just-fetch": ^1.2.4
     byte-base64: ^1.1.0
     sax: ^1.2.4
-    xmlbuilder2: ^2.4.1
-  checksum: 46ccc82d1f001a92913ca43703ed19436305ff282cd67d7d40d2c008b65028638fc439ccfbbf827b9d3869ffe7269ab28c5566cce32df63808df7e3cb2e7d6f1
+    xmlbuilder2: ^3.0.2
+  checksum: fb4f1aba93d53f5be3943e93cb7c323c3f9346e74abb9c38650dd470d52b04ff8d0a882e5bf6593829f8db97b61725ead3604e5cca268b27185446e14a2c2488
   languageName: node
   linkType: hard
 
@@ -3008,14 +3008,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oozcitak/dom@npm:1.15.8":
-  version: 1.15.8
-  resolution: "@oozcitak/dom@npm:1.15.8"
+"@oozcitak/dom@npm:1.15.10":
+  version: 1.15.10
+  resolution: "@oozcitak/dom@npm:1.15.10"
   dependencies:
     "@oozcitak/infra": 1.0.8
     "@oozcitak/url": 1.0.4
     "@oozcitak/util": 8.3.8
-  checksum: 01725ee17b9e1f618971f2190d57bf90a866b7af8e4e41f3f6dfb24201767a9843da4a63b4225d92bcdb0394b95a56dac67049eb6b074119fe97df83728ab04d
+  checksum: c83f5dc778b12f8e52e35fac0aa741bfac074faf3f3b60345723de46cba4c8ef0dced2839379fb93e21007f52336f875cf9ddfff6c598020b0688cb7d6f03ec7
   languageName: node
   linkType: hard
 
@@ -23970,16 +23970,16 @@ typescript@4.4.4:
   languageName: node
   linkType: hard
 
-"xmlbuilder2@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "xmlbuilder2@npm:2.4.1"
+"xmlbuilder2@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "xmlbuilder2@npm:3.0.2"
   dependencies:
-    "@oozcitak/dom": 1.15.8
+    "@oozcitak/dom": 1.15.10
     "@oozcitak/infra": 1.0.8
     "@oozcitak/util": 8.3.8
     "@types/node": "*"
     js-yaml: 3.14.0
-  checksum: 1e00a96ac49e462f4d1a3790b63554b9421363bfdef971f5d54c8b34bfd7d00cd26fffbf8ff47cad85bb826dcb9bd0ed4714f5e59607b02878717dab3ca399f4
+  checksum: dfc8aa94d5666517d74efbac0e36c0e4d86d44ed29f515846f30964ab9502124babd1bca6e0b5aa9468e8218b2dc4317b43519b8b1dd1594d33fda9e5a164d02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-facing changes**

"Failed to fetch" errors are replaced with more informative error messages when using the ROS1 native data source.

**Description**

This bumps the @foxglove/ros1 dependency to bring in better error messages for XML-RPC failures when using the ROS1 native data source. Instead of "Failed to fetch", a more informative error message shows which XML-RPC method was being attempted against which URL.
