### PR TITLE
Ignore current seek when a new seek occurs in RandomAccessPlayer

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -15,7 +15,6 @@ import {
   PropsWithChildren,
   useCallback,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -119,10 +118,10 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
     return headerStampPlayer;
   }, [basePlayer, initialMessageOrder, userNodeActions]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     player?.setMessageOrder(messageOrder ?? DEFAULT_MESSAGE_ORDER);
   }, [player, messageOrder]);
-  useEffect(() => {
+  useLayoutEffect(() => {
     player?.setUserNodes(userNodes ?? EMPTY_USER_NODES);
   }, [player, userNodes]);
 


### PR DESCRIPTION
**User-Facing Changes**
Fixes an intermittent incorrect warning "bag went back in time" when switching layouts.

**Description**
In RandomAccessPlayer when a seek is already loading messages, new seek requests are queued (queue size of 1). Prior to this change, when a seek request arrived while an existing seek request was in-flight, the existing request would finish, emit state, and then the new request would start.
    
Prior to emitting state, the in-flight seek request would set the nextReadStartTime which would override the nextReadStartTime of the latest seek request. Even if the seek requests were for the same time, the first request would alter the next read time of the subsequent request.
    
This change updates the RandomAccessPlayer logic to detect if a seek request occured while another was in-flight and avoid emitting a state update for the now-stale seek request.
    
Fixes: #1712

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
