### PR TITLE
Initialize extension panels with the correct default state.

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -392,18 +392,21 @@ export default function Panel<
 
         // Otherwise, open new panel
         const newPanelPath = ownPath.concat("second");
-        void mosaicWindowActions.split({ type: panelType }).then(() => {
-          const newPanelId = getNodeAtPath(mosaicActions.getRoot(), newPanelPath) as string;
-          savePanelConfigs({
-            configs: [
-              {
-                id: newPanelId,
-                config: siblingConfigCreator(siblingDefaultConfig),
-                defaultConfig: siblingDefaultConfig,
-              },
-            ],
+        const newPanelConfig = siblingConfigCreator(siblingDefaultConfig);
+        void mosaicWindowActions
+          .split({ type: panelType, panelConfig: newPanelConfig })
+          .then(() => {
+            const newPanelId = getNodeAtPath(mosaicActions.getRoot(), newPanelPath) as string;
+            savePanelConfigs({
+              configs: [
+                {
+                  id: newPanelId,
+                  config: newPanelConfig,
+                  defaultConfig: siblingDefaultConfig,
+                },
+              ],
+            });
           });
-        });
       },
       [
         getCurrentLayoutState,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue in the extension panel API.

**Description**
This makes sure that when sibling panels are added via the extension panel API's `addPanel` function that they are initialized with the correct state.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #1914 
