### PR TITLE
Fix message path input valid path detection for time and duration

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -159,6 +159,9 @@ function MessagePathPerformanceStory(props: { path: string; prioritizedDatatype?
 
 storiesOf("components/MessagePathInput", module)
   .addParameters({ colorScheme: "dark" })
+  .add("path with header fields", () => {
+    return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
+  })
   .add("autocomplete topics", () => {
     return <MessagePathInputStory path="/" />;
   })

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -188,8 +188,6 @@ function getExamplePrimitive(primitiveType: RosPrimitive) {
     case "int32":
     case "int64":
       return "0";
-    case "duration":
-    case "time":
     case "json":
       return "";
   }

--- a/packages/studio-base/src/components/MessagePathSyntax/constants.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/constants.ts
@@ -24,8 +24,6 @@ const RosPrimitives = {
   float32: undefined,
   float64: undefined,
   string: undefined,
-  time: undefined,
-  duration: undefined,
   json: undefined,
 };
 

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -64,6 +64,25 @@ export function messagePathStructures(
 
   lastDatatypes = undefined;
   const structureFor = memoize((datatype: string): MessagePathStructureItemMessage => {
+    if (datatype === "time" || datatype === "duration") {
+      return {
+        structureType: "message",
+        nextByName: {
+          sec: {
+            structureType: "primitive",
+            primitiveType: "uint32",
+            datatype: "",
+          },
+          nsec: {
+            structureType: "primitive",
+            primitiveType: "uint32",
+            datatype: "",
+          },
+        },
+        datatype,
+      };
+    }
+
     const nextByName: Record<string, MessagePathStructureItem> = {};
     const rosDatatype = datatypes.get(datatype);
     if (!rosDatatype) {
@@ -107,6 +126,7 @@ export function validTerminatingStructureItem(
     !!structureItem &&
     (!validTypes ||
       validTypes.includes(structureItem.structureType) ||
+      validTypes.includes(structureItem.datatype) ||
       (structureItem.structureType === "primitive" &&
         validTypes.includes(structureItem.primitiveType)))
   );

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -182,11 +182,6 @@ export function fillInGlobalVariablesInPath(
   };
 }
 
-const TIME_NEXT_BY_NAME: Record<string, MessagePathStructureItem> = Object.freeze({
-  sec: { structureType: "primitive", primitiveType: "int32", datatype: "time" },
-  nsec: { structureType: "primitive", primitiveType: "int32", datatype: "time" },
-});
-
 // Get a new item that has `queriedData` set to the values and paths as queried by `rosPath`.
 // Exported just for tests.
 export function getMessagePathDataItems(
@@ -252,17 +247,6 @@ export function getMessagePathDataItems(
           ? next
           : { structureType: "primitive", primitiveType: "json", datatype: "" };
       traverse(value[pathItem.name], pathIndex + 1, `${path}.${pathItem.name}`, actualNext);
-    } else if (
-      pathItem.type === "name" &&
-      structureItem.structureType === "primitive" &&
-      (structureItem.primitiveType === "time" || structureItem.primitiveType === "duration")
-    ) {
-      traverse(
-        value[pathItem.name],
-        pathIndex + 1,
-        `${path}.${pathItem.name}`,
-        TIME_NEXT_BY_NAME[pathItem.name],
-      );
     } else if (
       pathItem.type === "slice" &&
       (structureItem.structureType === "array" || structureIsJson)


### PR DESCRIPTION
**User-Facing Changes**
Writing a message path to .sec or .nsec fields within a field of type `time` or `duration` shows the path as valid.

**Description**
time and duration are considered primative types in ROS but are actually objects with two fields (sec, nsec). When specifying the sec or nsec field within a time field (i.e. header.stamp.sec) in the message path input, it would be marked as red indicating the path is invalid. This change fixes this behavior so paths accessing .sec or .nsec of time or duration fields is shown as valid.
    
The change produces a structure for time and duration with the message structure type and contains sec and nsec primitive fields. Previously the structure had time and duration primative fields with no knowledge of sec or nsec below.
    
Fixes: #1958

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
