### PR TITLE
Workaround for Change Panel menu positioning

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -212,6 +212,14 @@ function PanelActionsDropdown({
         },
         subMenuProps: {
           items: [{ key: "dummy" }],
+          calloutProps: {
+            styles: {
+              // Work around Callout not repositioning when PanelList height changes:
+              // https://github.com/foxglove/studio/issues/2205
+              // https://github.com/microsoft/fluentui/issues/18839
+              calloutMain: { height: "100%" },
+            },
+          },
           onRenderMenuList: () => (
             <PanelList
               selectedPanelTitle={panelContext?.title}


### PR DESCRIPTION
**User-Facing Changes**
Fixed a visual bug with the alignment of the "Change panel" menu.

**Description**
Fixes #2205 by making the menu full height even when it is filtered.

The underlying problem is that fluentui's Callout doesn't reposition itself when the content size changes (https://github.com/microsoft/fluentui/issues/18839). This appears to have been addressed in https://github.com/microsoft/fluentui/pull/18887 but later reverted and the original issue is still unresolved.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/14237/144152070-d3618a3d-5a02-47ce-9520-0db207077275.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
