### PR TITLE
Move connection options to under a submenu in desktop app menu

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -458,17 +458,18 @@ class StudioWindow {
       }),
     );
 
-    for (const sourceName of this._inputSources) {
-      fileMenu.submenu?.append(
-        new MenuItem({
-          label: `Open ${sourceName}`,
+    fileMenu.submenu?.append(
+      new MenuItem({
+        label: "Open Connection",
+        submenu: Array.from(this._inputSources).map((sourceName) => ({
+          label: sourceName,
           click: async () => {
             await simulateUserClick(browserWindow);
             browserWindow.webContents.send("menu.click-input-source", sourceName);
           },
-        }),
-      );
-    }
+        })),
+      }),
+    );
 
     if (!isMac) {
       fileMenu.submenu?.append(


### PR DESCRIPTION
**User-Facing Changes**
All connection options should be grouped under a submenu in the desktop app's `File` menu
<img width="553" alt="Screen Shot 2021-12-01 at 12 32 38 PM" src="https://user-images.githubusercontent.com/6993359/144309538-13b5b6ee-9e58-437d-99f4-c6e8e277eb77.png">

**Description**
All connection options should be grouped under a submenu in the desktop app's `File` menu


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
