### PR TITLE
Reflect sidebar menu in desktop app's File menu

### DIFF
--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -3,7 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 // Events that are forwarded from the main process
-export type ForwardedMenuEvent = "open-preferences" | "open-help" | "open-welcome-layout";
+export type ForwardedMenuEvent =
+  | "open-preferences"
+  | "open-layouts"
+  | "open-add-panel"
+  | "open-panel-settings"
+  | "open-variables"
+  | "open-extensions"
+  | "open-help"
+  | "open-account"
+  | "open-welcome-layout";
 
 interface NativeMenuBridge {
   // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -470,6 +470,24 @@ class StudioWindow {
       );
     }
 
+    const fileMenuItems = [
+      { label: "View Layouts", event: "open-layouts" },
+      { label: "Add Panel", event: "open-add-panel" },
+      { label: "Edit Panel Settings", event: "open-panel-settings" },
+      { label: "Set Variables", event: "open-variables" },
+      { label: "Install Extensions", event: "open-extensions" },
+      { label: "Log In", event: "open-account" },
+    ];
+
+    fileMenuItems.forEach(({ label, event }) =>
+      fileMenu.submenu?.append(
+        new MenuItem({
+          label,
+          click: () => browserWindow.webContents.send(event),
+        }),
+      ),
+    );
+
     if (!isMac) {
       fileMenu.submenu?.append(
         new MenuItem({

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -252,16 +252,51 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   useCalloutDismissalBlocker();
 
   useNativeAppMenuEvent(
-    "open-preferences",
+    "open-layouts",
     useCallback(() => {
-      setSelectedSidebarItem("preferences");
+      setSelectedSidebarItem("layouts");
     }, []),
   );
 
   useNativeAppMenuEvent(
-    "open-help",
+    "open-add-panel",
     useCallback(() => {
-      setSelectedSidebarItem("help");
+      setSelectedSidebarItem("add-panel");
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-panel-settings",
+    useCallback(() => {
+      setSelectedSidebarItem("panel-settings");
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-variables",
+    useCallback(() => {
+      setSelectedSidebarItem("variables");
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-extensions",
+    useCallback(() => {
+      setSelectedSidebarItem("extensions");
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-account",
+    useCallback(() => {
+      setSelectedSidebarItem("account");
+    }, []),
+  );
+
+  useNativeAppMenuEvent(
+    "open-preferences",
+    useCallback(() => {
+      setSelectedSidebarItem("preferences");
     }, []),
   );
 

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -4,7 +4,16 @@
 
 import { createContext, useContext } from "react";
 
-export type NativeAppMenuEvent = "open-preferences" | "open-help" | "open-welcome-layout";
+export type NativeAppMenuEvent =
+  | "open-layouts"
+  | "open-add-panel"
+  | "open-panel-settings"
+  | "open-variables"
+  | "open-extensions"
+  | "open-help"
+  | "open-account"
+  | "open-preferences"
+  | "open-welcome-layout";
 
 type Handler = () => void;
 


### PR DESCRIPTION
**User-Facing Changes**
- Add sidebar tab options in the desktop app's File menu

<img width="377" alt="Screen Shot 2021-12-01 at 1 18 11 PM" src="https://user-images.githubusercontent.com/6993359/144315541-17e0af15-8d39-4ea3-8788-5f5fa1f7cef4.png">

**Description**
- Will look better in conjunction with https://github.com/foxglove/studio/pull/2240

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
