### PR TITLE
WebSocket: Remove leading dot from Protobuf datatype name

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -60,7 +60,13 @@ function parseChannel(channel: Channel): ParsedChannel {
   const datatypes: RosDatatypes = new Map();
   protobufDefinitionsToDatatypes(datatypes, type);
 
-  return { channel, fullSchemaName: type.fullName, deserializer, datatypes };
+  return {
+    channel,
+    // fullName is a fully qualified name but includes a leading dot. Remove the leading dot.
+    fullSchemaName: type.fullName.replace(/^\./, ""),
+    deserializer,
+    datatypes,
+  };
 }
 
 export default class FoxgloveWebSocketPlayer implements Player {


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
This will be needed for the WebSocket player to take advantage of #2246.

I'm not sure if there are any caveats to doing this (like potential name conflicts). My guess is it's fine, since _all_ `fullName`s should have a leading dot, removing it should not cause any name collisions.