### PR TITLE
Update mcap data provider protobuf handling for descriptor set

### DIFF
--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -315,7 +315,6 @@ export type PointCloud2 = Readonly<
     is_bigendian: boolean;
     point_step: number; // Length of point in bytes
     row_step: number; // Length of row in bytes
-    // TODO(steel): Figure out how to make data read-only in flow.
     data: Uint8Array;
     is_dense: number;
     // this is appended by scene builder


### PR DESCRIPTION
**User-Facing Changes**
Mcap is an experimental feature. This changes the requirements for mcap files containing protobuf encoded messages.

**Description**
Assume the _schema_ field for a protobuf encoding channel info contains a base64 encoded descriptor set. The descriptor set indicates how to decode binary protobuf messages into objects.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
