### PR TITLE
Fix McapDataProvider ros1 and ros2 encoding detection

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
@@ -74,10 +74,10 @@ export default class McapDataProvider implements RandomAccessDataProvider {
             break;
           }
           let messageDeserializer;
-          if (record.schema === "ros1") {
+          if (record.encoding === "ros1") {
             const parsedDefinitions = parseMessageDefinition(record.schema);
             messageDeserializer = new LazyMessageReader(parsedDefinitions);
-          } else if (record.schema === "ros2") {
+          } else if (record.encoding === "ros2") {
             const parsedDefinitions = parseMessageDefinition(record.schema, {
               ros2: true,
             });


### PR DESCRIPTION
**User-Facing Changes**
None - mcap is not used publicly yet.

**Description**
MCapdDataProvider had incorrect logic for detecting ros1 and ros2 encoding. This fixes the logic.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
