### PR TITLE
Add arm64 architecture to windows build

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -48,7 +48,12 @@
     ]
   },
   "win": {
-    "target": ["nsis"],
+    "target": [
+      {
+        "target": "nsis",
+        "arch": ["x64", "arm64"]
+      }
+    ],
     "icon": "resources/icon/icon.png",
     "fileAssociations": [
       {


### PR DESCRIPTION


**User-Facing Changes**
Once released we will have arm64 builds for windows.

**Description**
Build arm64 binaries and x64 binaries for windows.

Fixes: #2255

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
