### PR TITLE
WebSocket: remove leading dot from Protobuf parsed datatypes

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -26,7 +26,7 @@ import debouncePromise from "@foxglove/studio-base/util/debouncePromise";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 import { Channel, ChannelId, FoxgloveClient, SubscriptionId } from "@foxglove/ws-protocol";
 
-import protobufDefinitionsToDatatypes from "./protobufDefinitionsToDatatypes";
+import protobufDefinitionsToDatatypes, { stripLeadingDot } from "./protobufDefinitionsToDatatypes";
 
 const log = Log.getLogger(__dirname);
 
@@ -63,7 +63,7 @@ function parseChannel(channel: Channel): ParsedChannel {
   return {
     channel,
     // fullName is a fully qualified name but includes a leading dot. Remove the leading dot.
-    fullSchemaName: type.fullName.replace(/^\./, ""),
+    fullSchemaName: stripLeadingDot(type.fullName),
     deserializer,
     datatypes,
   };

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/protobufDefinitionsToDatatypes.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/protobufDefinitionsToDatatypes.ts
@@ -34,6 +34,10 @@ function protobufScalarToRosPrimitive(type: string): string {
   throw new Error(`Expected protobuf scalar type, got ${type}`);
 }
 
+export function stripLeadingDot(typeName: string): string {
+  return typeName.replace(/^\./, "");
+}
+
 export default function protobufDefinitionsToDatatypes(
   datatypes: RosDatatypes,
   type: protobufjs.Type,
@@ -49,7 +53,7 @@ export default function protobufDefinitionsToDatatypes(
       }
     } else if (field.resolvedType) {
       definitions.push({
-        type: field.resolvedType.fullName,
+        type: stripLeadingDot(field.resolvedType.fullName),
         name: field.name,
         isComplex: true,
         isArray: field.repeated,
@@ -68,5 +72,5 @@ export default function protobufDefinitionsToDatatypes(
       });
     }
   }
-  datatypes.set(type.fullName, { definitions });
+  datatypes.set(stripLeadingDot(type.fullName), { definitions });
 }


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Follow up from #2247. The leading dot needs to be removed from all types in `datatypes`, not just the Topic.datatype.
Closes https://github.com/foxglove/studio/pull/2258
