### PR TITLE
Fix CSV plot download for (u)int64 types

### DIFF
--- a/packages/studio-base/src/panels/Plot/csv.test.ts
+++ b/packages/studio-base/src/panels/Plot/csv.test.ts
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { generateCSV } from "./csv";
+
+describe("csv", () => {
+  describe("getCSVData", () => {
+    it("should generate valid csv data", () => {
+      const csv = generateCSV(
+        [
+          {
+            label: "label",
+            data: [{ receiveTime: { sec: 0, nsec: 0 }, path: "path", x: 0, y: 0, value: 0 }],
+          },
+        ],
+        "timestamp",
+      );
+      expect(csv).toEqual(
+        ["elapsed time,receive time,header.stamp,topic,value", "0,0.000000000,,label,0"].join("\n"),
+      );
+    });
+
+    it("should generate valid csv data for bigint values", () => {
+      const csv = generateCSV(
+        [
+          {
+            label: "label",
+            data: [
+              {
+                receiveTime: { sec: 0, nsec: 0 },
+                path: "path",
+                x: 0,
+                y: Number(9999999999999001),
+                value: 9999999999999001n,
+              },
+            ],
+          },
+        ],
+        "timestamp",
+      );
+      expect(csv).toEqual(
+        [
+          "elapsed time,receive time,header.stamp,topic,value",
+          "0,0.000000000,,label,9999999999999001",
+        ].join("\n"),
+      );
+    });
+  });
+});

--- a/packages/studio-base/src/panels/Plot/csv.ts
+++ b/packages/studio-base/src/panels/Plot/csv.ts
@@ -9,10 +9,10 @@ import { DataSet, Datum } from "./internalTypes";
 import { PlotXAxisVal } from "./types";
 
 function getCSVRow(label: string | undefined, data: Datum) {
-  const { x, y, receiveTime, headerStamp } = data;
+  const { x, value, receiveTime, headerStamp } = data;
   const receiveTimeFloat = formatTimeRaw(receiveTime);
   const stampTime = headerStamp ? formatTimeRaw(headerStamp) : "";
-  return [x, receiveTimeFloat, stampTime, label, y];
+  return [x, receiveTimeFloat, stampTime, label, value];
 }
 
 const getCVSColName = (xAxisVal: PlotXAxisVal): string => {
@@ -24,7 +24,7 @@ const getCVSColName = (xAxisVal: PlotXAxisVal): string => {
   }[xAxisVal];
 };
 
-function getCSVData(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
+function generateCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
   const headLine = [getCVSColName(xAxisVal), "receive time", "header.stamp", "topic", "value"];
   const combinedLines = [];
   combinedLines.push(headLine);
@@ -37,9 +37,9 @@ function getCSVData(datasets: DataSet[], xAxisVal: PlotXAxisVal): string {
 }
 
 function downloadCSV(datasets: DataSet[], xAxisVal: PlotXAxisVal): void {
-  const csvData = getCSVData(datasets, xAxisVal);
+  const csvData = generateCSV(datasets, xAxisVal);
   const blob = new Blob([csvData], { type: "text/csv;charset=utf-8;" });
   downloadFiles([{ blob, fileName: `plot_data.csv` }]);
 }
 
-export { downloadCSV };
+export { downloadCSV, generateCSV };


### PR DESCRIPTION


**User-Facing Changes**
Downloading CSV data from the plot provides the correct values for (u)int64 fields.

**Description**
When downloading data from the plot, the datum y field was used. This field is the Number conversion from the original y value. The unconverted y value is in the _value_ field. The _value_ field maintains the original bigint type. Use the _value_ field so the original data is present in the csv output.

Fixes: #2183

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
