### PR TITLE
Fix clicking Autocomplete inside ChildToggle (Image panel markers menu)

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -28,6 +28,11 @@ import textMetrics from "text-metrics";
 
 import { colors, fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+// react-autocomplete tries to auto-scroll as soon as the menu is rendered, which is not compatible
+// with fluentui's Layer because the Layer takes a couple of react render cycles before elements are
+// actually mounted.
+Object.assign(ReactAutocomplete.prototype, { maybeScrollItemIntoView: () => {} });
+
 const fontFamily = fonts.SANS_SERIF;
 const fontSize = "12px";
 let textMeasure: textMetrics.TextMeasure;

--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { makeStyles } from "@fluentui/react";
+import { Layer, makeStyles } from "@fluentui/react";
 import cx from "classnames";
 import { Fzf, FzfResultItem } from "fzf";
 import { maxBy } from "lodash";
@@ -24,7 +24,6 @@ import React, {
   useImperativeHandle,
 } from "react";
 import ReactAutocomplete from "react-autocomplete";
-import { createPortal } from "react-dom";
 import textMetrics from "text-metrics";
 
 import { colors, fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -500,7 +499,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
         );
       }}
       // @ts-expect-error renderMenuWrapper added in the fork but we don't have typings for it
-      renderMenuWrapper={(menu: React.ReactNode) => createPortal(menu, document.body)}
+      renderMenuWrapper={(menu: React.ReactNode) => <Layer>{menu}</Layer>}
       ref={autocomplete}
       wrapperStyle={{ flex: "1 1 auto", overflow: "hidden", marginLeft: 6 }}
     />

--- a/packages/studio-base/src/components/ChildToggle/index.tsx
+++ b/packages/studio-base/src/components/ChildToggle/index.tsx
@@ -157,8 +157,14 @@ export default function ChildToggle(props: Props): ReactElement {
       const node = event.target as HTMLElement;
       // if there was a click outside this container and outside children[0]
       // fire the toggle callback to close expanded section
+
+      const thisLayer = el.current?.closest(".ms-Layer");
+      const nodeLayer = node.closest(".ms-Layer");
+
       if (floatingEl.current.contains(node) || (el.current?.contains(node) ?? false)) {
         // the click was inside our bounds and shouldn't auto-close the menu
+      } else if (thisLayer !== nodeLayer) {
+        // If the clicked node is in a different fluentui Layer from this node, ignore the click.
       } else {
         // allow any nested child toggle click events to reach their dom node before removing
         // the expanded toggle portion from the dom


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue where clicking the Add Topic menu inside the Image panel's Markers menu didn't work.

**Description**
Fixes #2226 by putting the Autocomplete in a Layer, and updating ChildToggle click logic to ignore clicks in different Layers.