### PR TITLE
Combine same series hover values in timeseries tooltips

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -21,7 +21,7 @@ export default {
   component: TimeBasedChartTooltipContent,
 };
 
-export function SingleItem(): React.ReactElement {
+export function SingleItemSingleDataset(): React.ReactElement {
   const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
@@ -32,17 +32,17 @@ export function SingleItem(): React.ReactElement {
   const { tooltip } = useTooltip({
     shown: true,
     targetPosition: { x: 200, y: 100 },
-    contents: <TimeBasedChartTooltipContent content={[data]} />,
+    contents: <TimeBasedChartTooltipContent multiDataset={false} content={[data]} />,
   });
   return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
 }
-SingleItem.parameters = { colorScheme: "dark" };
+SingleItemSingleDataset.parameters = { colorScheme: "dark" };
 
-export const SingleItemLight = Object.assign(SingleItem.bind(undefined), {
+export const SingleItemSingleDatasetLight = Object.assign(SingleItemSingleDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-export function MultipleItems(): React.ReactElement {
+export function SingleItemMultiDataset(): React.ReactElement {
   const data: TimeBasedChartTooltipData = {
     x: 0,
     y: 0,
@@ -53,12 +53,60 @@ export function MultipleItems(): React.ReactElement {
   const { tooltip } = useTooltip({
     shown: true,
     targetPosition: { x: 200, y: 100 },
-    contents: <TimeBasedChartTooltipContent content={[data, data]} />,
+    contents: <TimeBasedChartTooltipContent multiDataset={true} content={[data]} />,
   });
   return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
 }
-MultipleItems.parameters = { colorScheme: "dark" };
+SingleItemMultiDataset.parameters = { colorScheme: "dark" };
 
-export const MultipleItemsLight = Object.assign(MultipleItems.bind(undefined), {
+export const SingleItemMultiDatasetLight = Object.assign(SingleItemMultiDataset.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
+
+export function MultipleItemsSingleDataset(): React.ReactElement {
+  const data: TimeBasedChartTooltipData = {
+    x: 0,
+    y: 0,
+    path: "/some/topic.path",
+    value: 3,
+    constantName: "ACTIVE",
+  };
+  const { tooltip } = useTooltip({
+    shown: true,
+    targetPosition: { x: 200, y: 100 },
+    contents: <TimeBasedChartTooltipContent multiDataset={false} content={[data, data]} />,
+  });
+  return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
+}
+MultipleItemsSingleDataset.parameters = { colorScheme: "dark" };
+
+export const MultipleItemsSingleDatasetLight = Object.assign(
+  MultipleItemsSingleDataset.bind(undefined),
+  {
+    parameters: { colorScheme: "light" },
+  },
+);
+
+export function MultipleItemsMultieDataset(): React.ReactElement {
+  const data: TimeBasedChartTooltipData = {
+    x: 0,
+    y: 0,
+    path: "/some/topic.path",
+    value: 3,
+    constantName: "ACTIVE",
+  };
+  const { tooltip } = useTooltip({
+    shown: true,
+    targetPosition: { x: 200, y: 100 },
+    contents: <TimeBasedChartTooltipContent multiDataset={true} content={[data, data]} />,
+  });
+  return <div style={{ width: "100%", height: "100%" }}>{tooltip}</div>;
+}
+MultipleItemsMultieDataset.parameters = { colorScheme: "dark" };
+
+export const MultipleItemsMultiDatasetLight = Object.assign(
+  MultipleItemsMultieDataset.bind(undefined),
+  {
+    parameters: { colorScheme: "light" },
+  },
+);

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { makeStyles } from "@fluentui/react";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useMemo } from "react";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -20,6 +20,8 @@ import { TimeBasedChartTooltipData } from "./index";
 
 type Props = {
   content: TimeBasedChartTooltipData[];
+  // Flag indicating the containing chart has multiple datasets
+  multiDataset: boolean;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -41,11 +43,29 @@ const useStyles = makeStyles((theme) => ({
 export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
-  const { content } = props;
+  const { content, multiDataset } = props;
   const classes = useStyles();
 
-  // If only one value is present we don't show the series name since it is the only series present
-  if (content.length === 1) {
+  const itemsByPath = useMemo(() => {
+    const out = new Map<string, TimeBasedChartTooltipData[]>();
+    // for single dataset plots we don't care about grouping by path - there is only one path
+    if (!multiDataset) {
+      return out;
+    }
+    // group items by path
+    for (const item of content) {
+      const existing = out.get(item.path) ?? [];
+      existing.push(item);
+      out.set(item.path, existing);
+    }
+
+    return out;
+  }, [content, multiDataset]);
+
+  // If the chart contains only one dataset, we don't need to render the dataset label - saving space
+  // We cannot detect this from the content since content is only what is actively hovered which may
+  // not include all datasets
+  if (!multiDataset) {
     return (
       <div className={classes.root} data-test="TimeBasedChartTooltipContent">
         {content.map((item, idx) => {
@@ -68,20 +88,24 @@ export default function TimeBasedChartTooltipContent(
 
   return (
     <div className={classes.root} data-test="TimeBasedChartTooltipContent">
-      {content.map((item, idx) => {
-        const value =
-          typeof item.value === "string"
-            ? item.value
-            : typeof item.value === "bigint"
-            ? item.value.toString()
-            : JSON.stringify(item.value);
+      {Array.from(itemsByPath.entries(), ([path, items], idx) => {
         return (
           <div key={idx} className={classes.multiValueItem}>
-            <div className={classes.path}>{item.path}</div>
-            <div>
-              {value}
-              {item.constantName != undefined ? ` (${item.constantName})` : ""}
-            </div>
+            <div className={classes.path}>{path}</div>
+            {items.map((item, itemIdx) => {
+              const value =
+                typeof item.value === "string"
+                  ? item.value
+                  : typeof item.value === "bigint"
+                  ? item.value.toString()
+                  : JSON.stringify(item.value);
+              return (
+                <div key={itemIdx}>
+                  {value}
+                  {item.constantName != undefined ? ` (${item.constantName})` : ""}
+                </div>
+              );
+            })}
           </div>
         );
       })}

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -783,11 +783,15 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
   useEffect(() => log.debug(`<TimeBasedChart> (datasetId=${datasetId})`), [datasetId]);
 
+  const datasetsLength = datasets.length;
   const tooltipContent = useMemo(() => {
     return activeTooltip ? (
-      <TimeBasedChartTooltipContent content={activeTooltip.data} />
+      <TimeBasedChartTooltipContent
+        multiDataset={datasetsLength > 1}
+        content={activeTooltip.data}
+      />
     ) : undefined;
-  }, [activeTooltip]);
+  }, [activeTooltip, datasetsLength]);
 
   // reset is shown if we have sync lock and there has been user interaction, or if we don't
   // have sync lock and the user has manually interacted with the plot


### PR DESCRIPTION
**User-Facing Changes**
When hovering on multiple values for a series all values are shown under a series label.

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/84792/144717479-a29f6212-5878-446a-a1c7-93cbf35f895f.png)|![image](https://user-images.githubusercontent.com/84792/144717470-ca1c67ef-09e9-4e29-9702-ce8c8ad0e438.png)|


**Description**
Depending on the zoom level, the timeseries chart tooltip may show multiple values from a series. These values would each have the series label. This change groups values from the same series under one series label. This saves some vertical space by not repeating the series label and makes it easier to see that a series has multiple values at the hover location.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
