### PR TITLE
Make panel toolbars always visible

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -87,16 +87,6 @@ const PanelRoot = styled.div<{ fullscreen: boolean; selected: boolean }>`
   right: 0;
   bottom: ${({ fullscreen }) => (fullscreen ? spacing.PLAYBACK_CONTROL_HEIGHT : 0)};
 
-  // To use css to hide/show toolbars on hover we use a global panelToolbar class
-  // because the PanelToolbar component is currently added within each panels render
-  // function rather than handling by the panel HOC
-
-  .panelToolbarHovered {
-    display: none;
-  }
-  :hover .panelToolbarHovered {
-    display: flex;
-  }
   :after {
     content: "";
     top: 0;

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -13,7 +13,6 @@
 
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { createGlobalStyle } from "styled-components";
 
 import { HideErrorSourceLocations } from "@foxglove/studio-base/components/ErrorBoundary";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
@@ -111,17 +110,10 @@ export const PanelNotFoundLight = Object.assign(PanelNotFound.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-const PanelToolbarShown = createGlobalStyle`
-  .panelToolbarHovered {
-    display: flex !important;
-  }
-`;
-
 export const PanelWithError = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <HideErrorSourceLocations.Provider value={true}>
-        <PanelToolbarShown />
         <PanelSetup
           panelCatalog={new MockPanelCatalog()}
           fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -20,7 +20,6 @@ import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import cx from "classnames";
 import { useContext, useState, useCallback, useMemo, useRef } from "react";
 import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
-import { useResizeDetector } from "react-resize-detector";
 
 import Icon from "@foxglove/studio-base/components/Icon";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
@@ -312,8 +311,6 @@ type PanelToolbarControlsProps = Pick<Props, "additionalIcons" | "floating"> & {
   menuOpen: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setMenuOpen: (_: boolean) => void;
-  showControls?: boolean;
-  showPanelName?: boolean;
   isUnknownPanel: boolean;
 };
 
@@ -323,24 +320,13 @@ const PanelToolbarControls = React.memo(function PanelToolbarControls({
   menuOpen,
   setMenuOpen,
   additionalIcons,
-  showControls = false,
-  floating = false,
   isUnknownPanel,
-  showPanelName = false,
 }: PanelToolbarControlsProps) {
   const panelContext = useContext(PanelContext);
   const styles = useStyles();
 
   return (
-    <div
-      style={showControls ? { display: "flex" } : {}}
-      className={cx(styles.iconContainer, {
-        panelToolbarHovered: !floating,
-      })}
-    >
-      {showPanelName && panelContext && (
-        <div className={styles.panelName}>{panelContext.title}</div>
-      )}
+    <div className={styles.iconContainer}>
       {additionalIcons}
       <PanelActionsDropdown
         isOpen={menuOpen}
@@ -438,15 +424,6 @@ export default React.memo<Props>(function PanelToolbar({
     exitFullscreen,
   ]);
 
-  // Use a debounce and 0 refresh rate to avoid triggering a resize observation while handling
-  // and existing resize observation.
-  // https://github.com/maslianok/react-resize-detector/issues/45
-  const { width, ref: sizeRef } = useResizeDetector({
-    handleHeight: false,
-    refreshRate: 0,
-    refreshMode: "debounce",
-  });
-
   if (hideToolbars) {
     return ReactNull;
   }
@@ -456,26 +433,21 @@ export default React.memo<Props>(function PanelToolbar({
   const showToolbar = menuOpen || !!isUnknownPanel;
 
   return (
-    <div ref={sizeRef}>
-      <div
-        className={cx(styles.panelToolbarContainer, {
-          panelToolbarHovered: floating,
-          floating,
-          hasChildren: Boolean(children),
-        })}
-        style={showToolbar ? { display: "flex", backgroundColor } : { backgroundColor }}
-      >
-        {children}
-        <PanelToolbarControls
-          showControls={showToolbar}
-          floating={floating}
-          showPanelName={(width ?? 0) > 360}
-          additionalIcons={additionalIconsWithHelp}
-          isUnknownPanel={!!isUnknownPanel}
-          menuOpen={menuOpen}
-          setMenuOpen={setMenuOpen}
-        />
-      </div>
+    <div
+      className={cx(styles.panelToolbarContainer, {
+        floating,
+        hasChildren: Boolean(children),
+      })}
+      style={showToolbar ? { display: "flex", backgroundColor } : { backgroundColor }}
+    >
+      {children}
+      <PanelToolbarControls
+        floating={floating}
+        additionalIcons={additionalIconsWithHelp}
+        isUnknownPanel={!!isUnknownPanel}
+        menuOpen={menuOpen}
+        setMenuOpen={setMenuOpen}
+      />
     </div>
   );
 });

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -640,14 +640,14 @@ function ImageView(props: Props) {
 
   const toolbar = useMemo(() => {
     return (
-      <PanelToolbar floating={cameraTopic !== ""} helpContent={helpContent}>
+      <PanelToolbar helpContent={helpContent}>
         <div className={classes.controls}>
           {imageTopicDropdown}
           {markerDropdown}
         </div>
       </PanelToolbar>
     );
-  }, [cameraTopic, classes.controls, imageTopicDropdown, markerDropdown]);
+  }, [classes.controls, imageTopicDropdown, markerDropdown]);
 
   const renderBottomBar = () => {
     const canTransformMarkers = canTransformMarkersByTopic(cameraTopic);

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -113,7 +113,7 @@ function DiagnosticStatusPanel(props: Props) {
 
   return (
     <Flex scroll scrollX col>
-      <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
+      <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
         <Autocomplete
           placeholder={selectedDisplayName ?? "Select a diagnostic"}
           items={diagnostics.sortedAutocompleteEntries}

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -7,7 +7,6 @@ import { PropsWithChildren, useMemo } from "react";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
-import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
 import PanelCatalogContext, {
   PanelCatalog,
@@ -40,7 +39,6 @@ export default function PanelCatalogProvider(
       const PanelWrapper = (panelProps: PanelProps) => {
         return (
           <>
-            <PanelToolbar floating />
             <PanelExtensionAdapter
               config={panelProps.config}
               saveConfig={panelProps.saveConfig}


### PR DESCRIPTION
**User-Facing Changes**
Panel toolbars are always visibile regardless of user mouse position.

**Description**
Elements that change their visibility state based on the mouse hover on a panel draw attention as the user moves their cursor around the app or into a panel. They also make it harder to see where to move your cursor within a panel to use the actions on the toolbar.
    
By always showing the toolbar the user knows where the control icons are. The other elements do not shift when the toolbar appears/disappears since it is always visible.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
