### PR TITLE
Toggle fullscreen state for parent panels

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
       ".mosaic-tile": {
         // make room for splitters - unfortunately this means the background color will show
         // through even if the tile has its own background color set
-        margin: 1,
+        margin: 0,
       },
       ".mosaic-window": {
         boxShadow: "none",

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -234,7 +234,9 @@ function PanelActionsDropdown({
         {
           key: "fullscreen",
           text: "Fullscreen",
-          onClick: panelContext?.enterFullscreen,
+          onClick: () => {
+            panelContext?.enterFullscreen();
+          },
           "data-test": "panel-settings-fullscreen",
           iconProps: {
             iconName: "FullScreenMaximize",
@@ -269,17 +271,7 @@ function PanelActionsDropdown({
       "data-test": "panel-settings-remove",
     });
     return items;
-  }, [
-    close,
-    isUnknownPanel,
-    openSettings,
-    panelContext?.enterFullscreen,
-    panelContext?.hasSettings,
-    panelContext?.id,
-    panelContext?.title,
-    split,
-    swap,
-  ]);
+  }, [close, isUnknownPanel, openSettings, panelContext, split, swap]);
 
   const buttonRef = useRef<HTMLDivElement>(ReactNull);
 


### PR DESCRIPTION
**User-Facing Changes**
Fullscreen toggle for panels works correctly for panels within tabs.

Removes the fullscreen option from the quick access overlay.

**Description**
When a panel within a tab enters fullscreen, it needs to tell the tab panel to enter fullscreen to properly appear on top of other panels and controls.
    
This change also removes the "fullscreen" feature from the quick access controls. There is already a fullscreen icon in the panel toolbar which is available without having to open any menus or special shortcut keys.
    
Fixes: #2248

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
