### PR TITLE
Regression fixes for new TransformTree

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -78,7 +78,6 @@ export type ErrorDetails = { frameIds: Set<string>; namespaces: Set<string> };
 export type SceneErrors = {
   topicsMissingFrameIds: Map<string, ErrorDetails>;
   topicsMissingTransforms: Map<string, ErrorDetails>;
-  topicsWithBadFrameIds: Map<string, ErrorDetails>;
   topicsWithError: Map<string, string>;
   rootTransformID: string;
 };
@@ -205,7 +204,6 @@ export default class SceneBuilder implements MarkerProvider {
     rootTransformID: "",
     topicsMissingFrameIds: new Map(),
     topicsMissingTransforms: new Map(),
-    topicsWithBadFrameIds: new Map(),
     topicsWithError: new Map(),
   };
   errorsByTopic: {
@@ -278,7 +276,6 @@ export default class SceneBuilder implements MarkerProvider {
         rootTransformID: "",
         topicsMissingFrameIds: new Map(),
         topicsMissingTransforms: new Map(),
-        topicsWithBadFrameIds: new Map(),
         topicsWithError: new Map(),
       };
       this._updateErrorsByTopic();
@@ -384,16 +381,10 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   hasErrors(): boolean {
-    const {
-      topicsMissingFrameIds,
-      topicsMissingTransforms,
-      topicsWithBadFrameIds,
-      topicsWithError,
-    } = this.errors;
+    const { topicsMissingFrameIds, topicsMissingTransforms, topicsWithError } = this.errors;
     return (
       topicsMissingFrameIds.size !== 0 ||
       topicsMissingTransforms.size !== 0 ||
-      topicsWithBadFrameIds.size !== 0 ||
       topicsWithError.size !== 0
     );
   }
@@ -596,11 +587,6 @@ export default class SceneBuilder implements MarkerProvider {
     if (frame_id.length === 0) {
       this._addError(this.errors.topicsMissingFrameIds, topic);
       return;
-    }
-
-    if (frame_id !== this.rootTransformID) {
-      const error = this._addError(this.errors.topicsWithBadFrameIds, topic);
-      error.frameIds.add(frame_id);
     }
 
     let pose: MutablePose | undefined = emptyPose();
@@ -874,7 +860,6 @@ export default class SceneBuilder implements MarkerProvider {
 
     this.errors.topicsMissingFrameIds.delete(topic);
     this.errors.topicsMissingTransforms.delete(topic);
-    this.errors.topicsWithBadFrameIds.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();
     this.collectors[topic]?.setClock(this._clock ?? { sec: 0, nsec: 0 });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -76,7 +76,6 @@ const buildSyntheticArrowMarker = (
 export type ErrorDetails = { frameIds: Set<string>; namespaces: Set<string> };
 
 export type SceneErrors = {
-  topicsMissingFrameIds: Map<string, ErrorDetails>;
   topicsMissingTransforms: Map<string, ErrorDetails>;
   topicsWithError: Map<string, string>;
   rootTransformID: string;
@@ -126,9 +125,6 @@ export function getSceneErrorsByTopic(
   // errors related to missing frame ids and transform ids
   sceneErrors.topicsMissingTransforms.forEach((err, topic) => {
     addError(topic, missingTransformMessage(sceneErrors.rootTransformID, err, transforms));
-  });
-  sceneErrors.topicsMissingFrameIds.forEach((_err, topic) => {
-    addError(topic, "missing frame id");
   });
   return res;
 }
@@ -202,7 +198,6 @@ export default class SceneBuilder implements MarkerProvider {
   // have to keep in sync.
   errors: SceneErrors = {
     rootTransformID: "",
-    topicsMissingFrameIds: new Map(),
     topicsMissingTransforms: new Map(),
     topicsWithError: new Map(),
   };
@@ -274,7 +269,6 @@ export default class SceneBuilder implements MarkerProvider {
     if (this._playerId !== playerId) {
       this.errors = {
         rootTransformID: "",
-        topicsMissingFrameIds: new Map(),
         topicsMissingTransforms: new Map(),
         topicsWithError: new Map(),
       };
@@ -381,12 +375,8 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   hasErrors(): boolean {
-    const { topicsMissingFrameIds, topicsMissingTransforms, topicsWithError } = this.errors;
-    return (
-      topicsMissingFrameIds.size !== 0 ||
-      topicsMissingTransforms.size !== 0 ||
-      topicsWithError.size !== 0
-    );
+    const { topicsMissingTransforms, topicsWithError } = this.errors;
+    return topicsMissingTransforms.size !== 0 || topicsWithError.size !== 0;
   }
 
   setOnForceUpdate(callback: () => void): void {
@@ -583,11 +573,6 @@ export default class SceneBuilder implements MarkerProvider {
 
   private _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
     const { frame_id } = message.header;
-
-    if (frame_id.length === 0) {
-      this._addError(this.errors.topicsMissingFrameIds, topic);
-      return;
-    }
 
     let pose: MutablePose | undefined = emptyPose();
     if (this.transforms) {
@@ -858,7 +843,6 @@ export default class SceneBuilder implements MarkerProvider {
       return;
     }
 
-    this.errors.topicsMissingFrameIds.delete(topic);
     this.errors.topicsMissingTransforms.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -72,8 +72,7 @@ const buildSyntheticArrowMarker = (
   interactionData: { topic, originalMessage: message },
 });
 
-// TODO(JP): looks like we might not actually use these fields in the new topic picker?
-export type ErrorDetails = { frameIds: Set<string>; namespaces: Set<string> };
+export type ErrorDetails = { frameIds: Set<string> };
 
 export type SceneErrors = {
   topicsMissingTransforms: Map<string, ErrorDetails>;
@@ -96,12 +95,12 @@ const missingTransformMessage = (
   error: ErrorDetails,
   transforms: TransformTree,
 ): string => {
-  const frameIds = [...error.frameIds].sort().join(",");
-  const s = error.frameIds.size === 1 ? "" : "s"; // for plural
-  const msg =
-    frameIds.length > 0
-      ? `missing transforms from frame${s} <${frameIds}> to root frame <${rootTransformId}>`
-      : `missing transform <${rootTransformId}>`;
+  if (error.frameIds.size === 0) {
+    throw new Error(`Missing transform error has no frameIds`);
+  }
+  const frameIds = [...error.frameIds].sort().join(`>, <`);
+  const s = error.frameIds.size > 1 ? "s" : ""; // for plural
+  const msg = `missing transform${s} from frame${s} <${frameIds}> to frame <${rootTransformId}>`;
   if (transforms.frames().size === 0) {
     return msg + ". No transforms found";
   }
@@ -122,10 +121,10 @@ export function getSceneErrorsByTopic(
   for (const [topic, message] of sceneErrors.topicsWithError) {
     addError(topic, message);
   }
-  // errors related to missing frame ids and transform ids
-  sceneErrors.topicsMissingTransforms.forEach((err, topic) => {
-    addError(topic, missingTransformMessage(sceneErrors.rootTransformID, err, transforms));
-  });
+  // errors related to missing transforms
+  for (const [topic, error] of sceneErrors.topicsMissingTransforms) {
+    addError(topic, missingTransformMessage(sceneErrors.rootTransformID, error, transforms));
+  }
   return res;
 }
 
@@ -375,8 +374,7 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   hasErrors(): boolean {
-    const { topicsMissingTransforms, topicsWithError } = this.errors;
-    return topicsMissingTransforms.size !== 0 || topicsWithError.size !== 0;
+    return this.errors.topicsMissingTransforms.size !== 0 || this.errors.topicsWithError.size !== 0;
   }
 
   setOnForceUpdate(callback: () => void): void {
@@ -386,10 +384,9 @@ export default class SceneBuilder implements MarkerProvider {
   private _addError(map: Map<string, ErrorDetails>, topic: string): ErrorDetails {
     let values = map.get(topic);
     if (!values) {
-      values = { namespaces: new Set(), frameIds: new Set() };
+      values = { frameIds: new Set() };
       map.set(topic, values);
     }
-    this._updateErrorsByTopic();
     return values;
   }
 
@@ -572,22 +569,6 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   private _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
-    const { frame_id } = message.header;
-
-    let pose: MutablePose | undefined = emptyPose();
-    if (this.transforms) {
-      const rootFrameId = this.rootTransformID;
-      if (rootFrameId == undefined) {
-        throw new Error("missing rootTransformId");
-      }
-      pose = this.transforms.apply(pose, pose, rootFrameId, frame_id, message.header.stamp);
-    }
-    if (!pose) {
-      const error = this._addError(this.errors.topicsMissingTransforms, topic);
-      error.frameIds.add(frame_id);
-      return;
-    }
-
     const type = 101;
     const name = `${topic}/${type}`;
 
@@ -614,7 +595,7 @@ export default class SceneBuilder implements MarkerProvider {
       map,
       type,
       name,
-      pose,
+      pose: emptyPose(),
       interactionData: { topic, originalMessage: message },
     };
 
@@ -654,22 +635,6 @@ export default class SceneBuilder implements MarkerProvider {
     if (this.rootTransformID == undefined) {
       throw new Error("missing rootTransformId");
     }
-    const sourcePose = emptyPose();
-    const frameId = drawData.header.frame_id;
-    const pose = this.transforms?.apply(
-      sourcePose,
-      sourcePose,
-      this.rootTransformID,
-      frameId,
-      drawData.header.stamp,
-    );
-    if (!pose) {
-      if (!(this.transforms?.hasFrame(frameId) ?? false)) {
-        const error = this._addError(this.errors.topicsMissingTransforms, topic);
-        error.frameIds.add(drawData.header.frame_id);
-      }
-      return;
-    }
 
     // some callers of _consumeNonMarkerMessage provide LazyMessages and others provide regular objects
     const obj =
@@ -679,7 +644,7 @@ export default class SceneBuilder implements MarkerProvider {
     const mappedMessage = {
       ...obj,
       type,
-      pose,
+      pose: emptyPose(),
       interactionData: { topic, originalMessage: originalMessage ?? drawData },
     };
 
@@ -870,11 +835,17 @@ export default class SceneBuilder implements MarkerProvider {
       return;
     }
 
+    this.errors.topicsMissingTransforms.clear();
+    const missingTfFrameIds = new Set<string>();
+
     for (const topic of Object.values(this.topicsByName)) {
       const collector = this.collectors[topic.name];
       if (!collector) {
         continue;
       }
+
+      missingTfFrameIds.clear();
+
       const topicMarkers = collector.getMessages();
       for (const message of topicMarkers) {
         const marker = message as unknown as Interactive<BaseMarker & Marker>;
@@ -886,6 +857,7 @@ export default class SceneBuilder implements MarkerProvider {
 
         const pose = computeMarkerPose(marker, this.transforms, this.rootTransformID, time);
         if (!pose) {
+          missingTfFrameIds.add(marker.header.frame_id);
           continue;
         }
 
@@ -910,6 +882,18 @@ export default class SceneBuilder implements MarkerProvider {
 
         this._addMarkerToCollector(add, topic, marker, pose);
       }
+
+      if (missingTfFrameIds.size > 0) {
+        const error = this._addError(this.errors.topicsMissingTransforms, topic.name);
+        for (const frameId of missingTfFrameIds) {
+          error.frameIds.add(frameId);
+        }
+      }
+    }
+
+    const errorsByTopic = getSceneErrorsByTopic(this.errors, this.transforms);
+    if (!isEqual(this.errorsByTopic, errorsByTopic)) {
+      this.errorsByTopic = errorsByTopic;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -416,5 +416,10 @@ function updatePose(
   if (!frame || !rootFrame) {
     return false;
   }
-  return rootFrame.apply(marker.pose, marker.pose, frame, currentTime) != undefined;
+
+  // Store the original pose on the marker
+  const markerWithOrigPose = marker as Marker & { origPose?: MutablePose };
+  markerWithOrigPose.origPose ??= marker.pose;
+
+  return rootFrame.apply(marker.pose, markerWithOrigPose.origPose, frame, currentTime) != undefined;
 }

--- a/packages/studio-base/src/util/Pose.ts
+++ b/packages/studio-base/src/util/Pose.ts
@@ -17,3 +17,21 @@ import { MutablePose } from "@foxglove/studio-base/types/Messages";
 export function emptyPose(): MutablePose {
   return { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 1 } };
 }
+
+// Perform a deep copy of a pose object
+export function clonePose(pose: MutablePose): MutablePose {
+  const p = pose.position;
+  const o = pose.orientation;
+  return { position: { x: p.x, y: p.y, z: p.z }, orientation: { x: o.x, y: o.y, z: o.z, w: o.w } };
+}
+
+// Reset a pose object to the identity pose
+export function setIdentityPose(pose: MutablePose): void {
+  pose.position.x = 0;
+  pose.position.y = 0;
+  pose.position.z = 0;
+  pose.orientation.x = 0;
+  pose.orientation.y = 0;
+  pose.orientation.z = 0;
+  pose.orientation.w = 1;
+}


### PR DESCRIPTION
**User-facing changes**

None, regression fixes in between releases.

**Description**

- Don't accumulate pose transforms on URDF markers
- Avoid a repeated pose transform
- Remove unused topicsWithBadFrameIds
- Remove topicsMissingFrameIds and treat empty frame_id as valid
- Update non-marker message poses per-frame instead of once at consumption, report topic errors when any marker cannot be rendered due to transform failure
