### PR TITLE
Use 1px margin for mosaic tiles next to a splitter.

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
       ".mosaic-tile": {
         // make room for splitters - unfortunately this means the background color will show
         // through even if the tile has its own background color set
-        margin: 0,
+        margin: 1,
       },
       ".mosaic-window": {
         boxShadow: "none",

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -82,9 +82,29 @@ const useStyles = makeStyles((theme) => ({
         },
       },
       ".mosaic-tile": {
+        margin: 0,
+      },
+      ".mosaic-tile:first-child": {
         // make room for splitters - unfortunately this means the background color will show
         // through even if the tile has its own background color set
-        margin: 1,
+        marginRight: 1,
+        marginBottom: 1,
+      },
+      // The last tile does not need a bottom margin
+      ".mosaic-tile:last-child": {
+        marginBottom: 0,
+      },
+      // If there is only one tile in the container there are no splitters and no margin is needed
+      ".mosaic-tile:only-child": {
+        margin: 0,
+      },
+      // tile immediately after a row splitter needs 1px margin so the splitter doesn't overlap the tile content
+      ".-row + .mosaic-tile": {
+        marginLeft: 1,
+      },
+      // tile immediately after a column splitter needs 1px margin so the splitter doesn't overlap the tile content
+      ".-column + .mosaic-tile": {
+        marginTop: 1,
       },
       ".mosaic-window": {
         boxShadow: "none",


### PR DESCRIPTION

**User-Facing Changes**
Panel elements are not obstructed when appearing within 1px of a splitter.

**Description**
react-mosaic renders tiles adjacent to each other and splitters on top of tiles. A tile without a margin is obstructed by any adjacent splitters. However, having a margin on all tiles results in unsightly gaps and borders. This change adds a margin to tiles only when there would be an adjacent splitter.
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
