### PR TITLE
Fix typo for rosbridge data source factory

### DIFF
--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -12,7 +12,7 @@ import { Player } from "@foxglove/studio-base/players/types";
 import { parseInputUrl } from "@foxglove/studio-base/util/url";
 
 class RosbridgeDataSourceFactory implements IDataSourceFactory {
-  id = "rosbridge-websockete";
+  id = "rosbridge-websocket";
   displayName = "Rosbridge (ROS 1 & 2)";
   iconName: IDataSourceFactory["iconName"] = "Flow";
 


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
- Fix typo for player ID in the rosbridge data source factory (`rosbridge-websockete` --> `rosbridge-websocket`)

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
