### PR TITLE
Add basicDatatypes to UserNodePlayer roslib

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -583,7 +583,9 @@ export default class UserNodePlayer implements Player {
     const transformWorker = this._getTransformWorker();
     const rosLib: string = await transformWorker.send("generateRosLib", {
       topics,
-      datatypes,
+      // Include basic datatypes along with any custom datatypes.
+      // Custom datatypes appear as the second array items to override any basicDatatype items
+      datatypes: new Map([...basicDatatypes, ...datatypes]),
     });
     this._setRosLib(rosLib, datatypes);
 


### PR DESCRIPTION
**User-Facing Changes**
User node authors can output messages of any basic datatype even if the datatype is not present in the datasource.

**Description**
User nodes are only able to output known datatypes. Prior to this change, known datatypes would be read from the current data source. This limited the types of messages you can output from user nodes to the datatypes in the data source.
    
This change adds the basic datatypes to the known datatypes for user nodes. This allows a user node author to output any of the basic datatypes even if not present in the data source.
    
Fixes: #1261

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
