### PR TITLE
Use fixed-height context menu for ChangePanel

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -213,11 +213,14 @@ function PanelActionsDropdown({
         subMenuProps: {
           items: [{ key: "dummy" }],
           calloutProps: {
+            // https://github.com/foxglove/studio/issues/2205
+            // https://github.com/microsoft/fluentui/issues/18839
+            // Lie to the callout and tell it the height of the content so that it keeps the top
+            // edge anchored as the user searches panels and the PanelList changes height.
+            calloutMaxHeight: 310,
+            finalHeight: 310,
             styles: {
-              // Work around Callout not repositioning when PanelList height changes:
-              // https://github.com/foxglove/studio/issues/2205
-              // https://github.com/microsoft/fluentui/issues/18839
-              calloutMain: { height: "100%" },
+              calloutMain: { overflowY: "auto !important" },
             },
           },
           onRenderMenuList: () => (


### PR DESCRIPTION


**User-Facing Changes**
Fixed a visual bug with the alignment of the "Change panel" menu.


**Description**
The original fix (https://github.com/foxglove/studio/commit/9cd1383dda4ee1f6c71f240ec87cfdf82c0cc5be) did not work in all cases. This change forces the subcontext menu height to a fixed height so it stays anchored to its top edge as the panel list changes when a user searches.

Fixes: #2205

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
