### PR TITLE
ROS2 fixes

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -36,7 +36,7 @@
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f",
     "@foxglove/regl-worldview": "1.0.1",
     "@foxglove/ros1": "1.3.5",
-    "@foxglove/ros2": "1.0.7",
+    "@foxglove/ros2": "1.0.8",
     "@foxglove/rosbag": "0.1.2",
     "@foxglove/rosbag2-web": "3.0.3",
     "@foxglove/rosmsg": "3.0.0",

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -91,8 +91,10 @@ export default class Ros2Player implements Player {
     }
     for (const dataType in foxgloveDefs) {
       const msgDef = (foxgloveDefs as Record<string, RosMsgDefinition>)[dataType]!;
-      this._providerDatatypes.set(dataType, msgDef);
-      this._providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
+      if (!this._providerDatatypes.has(dataType)) {
+        this._providerDatatypes.set(dataType, msgDef);
+        this._providerDatatypes.set(ros1ToRos2Type(dataType), msgDef);
+      }
     }
 
     void this._open();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,15 +2221,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ros2@npm:1.0.7":
-  version: 1.0.7
-  resolution: "@foxglove/ros2@npm:1.0.7"
+"@foxglove/ros2@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@foxglove/ros2@npm:1.0.8"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
     "@foxglove/rosmsg2-serialization": ^1.0.5
-    "@foxglove/rtps": ^1.2.3
+    "@foxglove/rtps": ^1.2.5
     eventemitter3: ^4.0.7
-  checksum: 2fb43771638bb7a9a387a11edd72d839581a1552bd1d3a166a29b0d08daf1b93994e2f70d7353c0b8f26ad60f77d8a1122d5c8045a004dd72a3fe4981308ee6b
+  checksum: 846763e1e6608d1e7f4ee6752d26adafe463abdd43cbc457de8dc7587ea499b9007f57d4517399b0db0027661d590a33ed221198dc03de38026dc1ecb12615f5
   languageName: node
   linkType: hard
 
@@ -2321,15 +2321,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rtps@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@foxglove/rtps@npm:1.2.3"
+"@foxglove/rtps@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "@foxglove/rtps@npm:1.2.5"
   dependencies:
     "@foxglove/cdr": ^2.0.0
     "@foxglove/rostime": ^1.1.0
     avl: ^1.5.2
     eventemitter3: ^4.0.7
-  checksum: c2f6b9928aa3829f85ea04e5552b9c443c8b6423265c461770050343d3e8b555b429d0c2bf26e697285750c266d65952e4459ff94f12800fc5756b43f788a973
+  checksum: 3d10b2aafe17bfa20f3421119b068e11ce72cb2b4fbb4eda07c367b7fffa9ceeff21e870a4c83e8fa28f5dccac4e45f9941571c09461a970b99b33f667f3f3b5
   languageName: node
   linkType: hard
 
@@ -2347,7 +2347,7 @@ __metadata:
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f"
     "@foxglove/regl-worldview": 1.0.1
     "@foxglove/ros1": 1.3.5
-    "@foxglove/ros2": 1.0.7
+    "@foxglove/ros2": 1.0.8
     "@foxglove/rosbag": 0.1.2
     "@foxglove/rosbag2-web": 3.0.3
     "@foxglove/rosmsg": 3.0.0


### PR DESCRIPTION
After this fix, it should be possible to run:

```
ros2 run tf2_ros static_transform_publisher 1 0 0 0 0 0 1 turtle1 turtle1_ahead
```

In ROS2 Galactic or Foxy, then open Studio and subscribe to `/tf_static` and see the published transform.

**User-Facing Changes**

- Subscribing to previously published "latched" topics in ROS2 works
- Fixes ROS2 data decoding crashes with some messages

**Description**

- Don't overwrite ROS2 msgdefs with ROS1 msgdefs
- Update @foxglove/ros2 to publish the durability parameter for subscriptions
- Update @foxglove/rtps to stop truncating the last four bytes of DATA msgs
