### PR TITLE
Send legacy url parameters for now.

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -84,7 +84,9 @@ function AppContent(props: AppProps): JSX.Element {
 
 export default function App(props: AppProps): JSX.Element {
   const isDesktop = isDesktopApp();
-  const [globalLaunchPreference] = useAppConfigurationValue<string>(AppSetting.LAUNCH_PREFERENCE);
+  const [globalLaunchPreference = "unknown"] = useAppConfigurationValue<string>(
+    AppSetting.LAUNCH_PREFERENCE,
+  );
   const [sessionLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
 
   // Session preferences take priority over global preferences.
@@ -96,7 +98,7 @@ export default function App(props: AppProps): JSX.Element {
     const url = new URL(window.location.href);
     const hasParams = Array.from(url.searchParams.entries()).length > 0;
     // Ask the user in which environment they want to open this session.
-    if (activePreference == undefined && hasParams) {
+    if (activePreference === "unknown" && hasParams) {
       return <LaunchPreferenceScreen />;
     } else if (activePreference === "desktop" && hasParams) {
       return <LaunchingInDesktopScreen />;

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -22,9 +22,32 @@ export function LaunchingInDesktopScreen(): ReactElement {
 
   useEffect(() => {
     const desktopURL = new URL("foxglove://open");
-    cleanWebURL.searchParams.forEach((k, v) => {
+    cleanWebURL.searchParams.forEach((v, k) => {
       if (k && v) {
         desktopURL.searchParams.set(k, v);
+
+        // Temporarily send both sets of params until desktop app is updated to
+        // use new ds.* parameters.
+        switch (k) {
+          case "ds":
+            desktopURL.searchParams.set("type", v);
+            break;
+          case "ds.deviceId":
+            desktopURL.searchParams.set("deviceId", v);
+            break;
+          case "ds.end":
+            desktopURL.searchParams.set("end", v);
+            break;
+          case "ds.start":
+            desktopURL.searchParams.set("start", v);
+            break;
+          case "ds.url":
+            desktopURL.searchParams.set("url", v);
+            break;
+          case "time":
+            desktopURL.searchParams.set("seekTo", v);
+            break;
+        }
       }
     });
 


### PR DESCRIPTION
**User-Facing Changes**
This encodes both our new `ds.*` style URL parameters as well as the old URL parameters for `foxglove://` URLs so older versions of the desktop app will continue to work until they're updated.

**Description**
Encode both old and new style params in our `foxglove://` URLs for now as a transitional step.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
