### PR TITLE
Set panel default config when config is empty

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -326,12 +326,15 @@ export default function Panel<
     const [savedConfig, saveConfig] = useConfigById<Config>(childId);
 
     // PanelSettings needs useConfigById to return a config
-    // If there is no saved config, we save the default config provided by the panel.
-    // This typically happens when a new panel is added and the layout does not yet have a config.
-    // Even if this effect gets run more than once, we only need to save the default config once.
+    // If there is no saved config (or it is an empty object), we save the default config provided
+    // by the panel. This typically happens when a new panel is added and the layout does not yet
+    // have a config. Even if this effect gets run more than once, we only need to save the default
+    // config once.
+    //
+    // An empty object can occur when swapping a panel
     const savedDefaultConfig = useRef(false);
     useLayoutEffect(() => {
-      if (!savedConfig && !savedDefaultConfig.current) {
+      if ((!savedConfig || Object.keys(savedConfig).length === 0) && !savedDefaultConfig.current) {
         savedDefaultConfig.current = true;
         saveConfig(defaultConfig);
       }


### PR DESCRIPTION
**User-Facing Changes**
When a user swaps a panel for another and then opens the panel settings they will see the correct defaults.

**Description**
Previously the Panel wrapper would set the default config only if the config was undefined. The config is sometimes defined but as an empty object (panel swap). In this instance the default config should also be set so the panel and panel settings receives the default values.
    
Fixes: #2133

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
