### PR TITLE
Keep Plot data when topics are added/removed

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -27,6 +27,7 @@ import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import {
   enumValuesByDatatypeAndField,
+  extractTypeFromStudioEnumAnnotation,
   getTopicsByTopicName,
 } from "@foxglove/studio-base/util/selectors";
 
@@ -103,7 +104,10 @@ export function useCachedGetMessagePathDataItems(
       if (type) {
         relevantDatatypes.set(datatypeName, type);
         for (const field of type.definitions) {
-          if (field.isComplex === true) {
+          if (
+            field.isComplex === true ||
+            extractTypeFromStudioEnumAnnotation(field.name) != undefined
+          ) {
             addRelevantDatatype(field.type);
           }
         }

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -71,6 +71,10 @@ export function useCachedGetMessagePathDataItems(
     [key: string]: RosPath;
   }>(unmemoizedFilledInPaths);
 
+  // Filter down topics and datatypes to only the ones we need to process the requested paths, so
+  // our result can be dependent on the relevant topics only. Without this, adding topics/datatypes
+  // dynamically would result in panels clearing out when their message reducers change as a result
+  // of the change in topics/datatypes identity from the player.
   const unmemoizedRelevantTopics = useMemo(() => {
     const topicsByName = getTopicsByTopicName(providerTopics);
     const seenNames = new Set<string>();

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -71,6 +71,47 @@ export function useCachedGetMessagePathDataItems(
     [key: string]: RosPath;
   }>(unmemoizedFilledInPaths);
 
+  const unmemoizedRelevantTopics = useMemo(() => {
+    const topicsByName = getTopicsByTopicName(providerTopics);
+    const seenNames = new Set<string>();
+    const result: Topic[] = [];
+    for (const path of memoizedPaths) {
+      const rosPath = parseRosPath(path);
+      if (rosPath) {
+        if (seenNames.has(rosPath.topicName)) {
+          continue;
+        }
+        seenNames.add(rosPath.topicName);
+        const topic = topicsByName[rosPath.topicName];
+        if (topic) {
+          result.push(topic);
+        }
+      }
+    }
+    return result;
+  }, [providerTopics, memoizedPaths]);
+  const relevantTopics = useDeepMemo(unmemoizedRelevantTopics);
+
+  const unmemoizedRelevantDatatypes = useMemo(() => {
+    const relevantDatatypes: RosDatatypes = new Map();
+    function addRelevantDatatype(datatypeName: string) {
+      const type = datatypes.get(datatypeName);
+      if (type) {
+        relevantDatatypes.set(datatypeName, type);
+        for (const field of type.definitions) {
+          if (field.isComplex === true) {
+            addRelevantDatatype(field.type);
+          }
+        }
+      }
+    }
+    for (const { datatype } of relevantTopics.values()) {
+      addRelevantDatatype(datatype);
+    }
+    return relevantDatatypes;
+  }, [datatypes, relevantTopics]);
+  const relevantDatatypes = useDeepMemo(unmemoizedRelevantDatatypes);
+
   // Cache MessagePathDataItem arrays by Message. We need to clear out this cache whenever
   // the topics or datatypes change, since that's what getMessagePathDataItems
   // depends on, outside of the message+path.
@@ -80,7 +121,7 @@ export function useCachedGetMessagePathDataItems(
       weakMap: WeakMap<MessageEvent<unknown>, MessagePathDataItem[] | undefined>;
     };
   }>({});
-  if (useChangeDetector([providerTopics, datatypes], { initiallyTrue: true })) {
+  if (useChangeDetector([relevantTopics, relevantDatatypes], { initiallyTrue: true })) {
     cachesByPath.current = {};
   }
   // When the filled in paths changed, then that means that either the path string changed, or a
@@ -113,8 +154,8 @@ export function useCachedGetMessagePathDataItems(
         const messagePathDataItems = getMessagePathDataItems(
           message,
           filledInPath,
-          providerTopics,
-          datatypes,
+          relevantTopics,
+          relevantDatatypes,
         );
         weakMap.set(message, messagePathDataItems);
         return messagePathDataItems;
@@ -122,7 +163,7 @@ export function useCachedGetMessagePathDataItems(
       const messagePathDataItems = weakMap.get(message);
       return messagePathDataItems;
     },
-    [datatypes, memoizedFilledInPaths, memoizedPaths, providerTopics],
+    [relevantDatatypes, memoizedFilledInPaths, memoizedPaths, relevantTopics],
   );
 }
 

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -105,7 +105,7 @@ export default {
 
 OnePath.parameters = { useReadySignal: true };
 export function OnePath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -120,7 +120,7 @@ export function OnePath(): JSX.Element {
 
 MultiplePaths.parameters = { useReadySignal: true };
 export function MultiplePaths(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -138,7 +138,7 @@ export function MultiplePaths(): JSX.Element {
 
 MultiplePathsWithHover.parameters = { useReadySignal: true };
 export function MultiplePathsWithHover(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup
@@ -166,7 +166,7 @@ export function MultiplePathsWithHover(): JSX.Element {
 
 LongPath.parameters = { useReadySignal: true };
 export function LongPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 100 }}>
@@ -181,7 +181,7 @@ export function LongPath(): JSX.Element {
 
 JsonPath.parameters = { useReadySignal: true };
 export function JsonPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -239,7 +239,7 @@ const messageCache: BlockCache = {
 
 Blocks.parameters = { useReadySignal: true };
 export function Blocks(): JSX.Element {
-  const readySignal = useReadySignal({ count: 2 });
+  const readySignal = useReadySignal({ count: 1 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   const blockFixture = { ...fixture, progress: { messageCache } };

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -105,7 +105,7 @@ export default {
 
 OnePath.parameters = { useReadySignal: true };
 export function OnePath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -120,7 +120,7 @@ export function OnePath(): JSX.Element {
 
 MultiplePaths.parameters = { useReadySignal: true };
 export function MultiplePaths(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -138,7 +138,7 @@ export function MultiplePaths(): JSX.Element {
 
 MultiplePathsWithHover.parameters = { useReadySignal: true };
 export function MultiplePathsWithHover(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup
@@ -166,7 +166,7 @@ export function MultiplePathsWithHover(): JSX.Element {
 
 LongPath.parameters = { useReadySignal: true };
 export function LongPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 100 }}>
@@ -181,7 +181,7 @@ export function LongPath(): JSX.Element {
 
 JsonPath.parameters = { useReadySignal: true };
 export function JsonPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -239,7 +239,7 @@ const messageCache: BlockCache = {
 
 Blocks.parameters = { useReadySignal: true };
 export function Blocks(): JSX.Element {
-  const readySignal = useReadySignal({ count: 3 });
+  const readySignal = useReadySignal({ count: 2 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   const blockFixture = { ...fixture, progress: { messageCache } };

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -51,7 +51,7 @@ const fixture = {
     Object.entries({
       "msgs/SystemState": {
         definitions: [
-          { type: "std_msgs/Header", name: "header", isArray: false },
+          { type: "std_msgs/Header", name: "header", isArray: false, isComplex: true },
           { type: "int8", name: "UNKNOWN", isConstant: true, value: -1 },
           { type: "int8", name: "OFF", isConstant: true, value: 1 },
           { type: "int8", name: "BOOTING", isConstant: true, value: 2 },
@@ -105,7 +105,7 @@ export default {
 
 OnePath.parameters = { useReadySignal: true };
 export function OnePath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -120,7 +120,7 @@ export function OnePath(): JSX.Element {
 
 MultiplePaths.parameters = { useReadySignal: true };
 export function MultiplePaths(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -138,7 +138,7 @@ export function MultiplePaths(): JSX.Element {
 
 MultiplePathsWithHover.parameters = { useReadySignal: true };
 export function MultiplePathsWithHover(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup
@@ -166,7 +166,7 @@ export function MultiplePathsWithHover(): JSX.Element {
 
 LongPath.parameters = { useReadySignal: true };
 export function LongPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ maxWidth: 100 }}>
@@ -181,7 +181,7 @@ export function LongPath(): JSX.Element {
 
 JsonPath.parameters = { useReadySignal: true };
 export function JsonPath(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
@@ -239,7 +239,7 @@ const messageCache: BlockCache = {
 
 Blocks.parameters = { useReadySignal: true };
 export function Blocks(): JSX.Element {
-  const readySignal = useReadySignal({ count: 1 });
+  const readySignal = useReadySignal({ count: 3 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   const blockFixture = { ...fixture, progress: { messageCache } };


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue where Plot panels would reset when topics were dynamically added/removed.

**Description**
Fixes https://github.com/foxglove/studio/issues/2236