### PR TITLE
Send data platform streaming errors to Sentry

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { captureException } from "@sentry/core";
 import { v4 as uuidv4 } from "uuid";
 
 import Logger from "@foxglove/log";
@@ -439,6 +440,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
           return;
         }
         log.error(error);
+        captureException(error);
         this._addProblem("stream-error", { message: error.message, error, severity: "error" });
       })
       .finally(() => {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Certain errors in streaming were displayed as player problems, but we should also send them to Sentry because there's nothing the user could have reasonably done to avoid or work around them.