### PR TITLE
Allow coordinate frame reparenting

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
@@ -234,28 +234,28 @@ export class CoordinateFrame {
       out.orientation = input.orientation;
       return out;
     } else if (srcFrame.findAncestor(this.id)) {
-      // This frame is a parent of the source frame
+      // This frame is an ancestor of the source frame
       return CoordinateFrame.Apply(out, input, this, srcFrame, false, time, maxDelta)
         ? out
         : undefined;
     } else if (this.findAncestor(srcFrame.id)) {
-      // This frame is a child of the source frame
+      // This frame is a descendant of the source frame
       return CoordinateFrame.Apply(out, input, srcFrame, this, true, time, maxDelta)
         ? out
         : undefined;
     }
 
-    // Check if the two frames share a common parent
+    // Check if the two frames share a common ancestor
     let curSrcFrame: CoordinateFrame | undefined = srcFrame;
     while (curSrcFrame) {
-      const commonParent = this.findAncestor(curSrcFrame.id);
-      if (commonParent) {
-        // Common parent found. Apply transforms from the source frame to the common parent,
-        // then apply transforms from the common parent to this frame
-        if (!CoordinateFrame.Apply(out, input, commonParent, srcFrame, false, time, maxDelta)) {
+      const commonAncestor = this.findAncestor(curSrcFrame.id);
+      if (commonAncestor) {
+        // Common ancestor found. Apply transforms from the source frame to the common ancestor,
+        // then apply transforms from the common ancestor to this frame
+        if (!CoordinateFrame.Apply(out, input, commonAncestor, srcFrame, false, time, maxDelta)) {
           return undefined;
         }
-        return CoordinateFrame.Apply(out, out, commonParent, this, true, time, maxDelta)
+        return CoordinateFrame.Apply(out, out, commonAncestor, this, true, time, maxDelta)
           ? out
           : undefined;
       }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
@@ -74,13 +74,11 @@ export class CoordinateFrame {
 
   /**
    * Set the parent frame for this frame. If the parent frame is already set to
-   * a different frame, an error is thrown.
+   * a different frame, the transform history is cleared.
    */
   setParent(parent: CoordinateFrame): void {
     if (this._parent && this._parent !== parent) {
-      throw new Error(
-        `Cannot reparent frame "${this.id}" from "${this._parent.id}" to "${parent.id}"`,
-      );
+      this._transforms.clear();
     }
     this._parent = parent;
   }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.ts
@@ -24,7 +24,7 @@ export class TransformTree {
       frame.setParent(this.getOrCreateFrame(parentFrameId));
     } else if (curParentFrame.id !== parentFrameId) {
       throw new Error(
-        `Received "${frameId}"->"${parentFrameId}" transform but parent "${curParentFrame.id}" already exists`,
+        `Received <${parentFrameId}> <- <${frameId}> transform but <${curParentFrame.id}> <- <${frameId}> already exists`,
       );
     }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.ts
@@ -19,13 +19,10 @@ export class TransformTree {
   addTransform(frameId: string, parentFrameId: string, time: Time, transform: Transform): void {
     const frame = this.getOrCreateFrame(frameId);
     const curParentFrame = frame.parent();
-    if (curParentFrame == undefined) {
-      // This frame was previously unparented but now we know its parent. Update it
+    if (curParentFrame == undefined || curParentFrame.id !== parentFrameId) {
+      // This frame was previously unparented but now we know its parent, or we
+      // are reparenting this frame
       frame.setParent(this.getOrCreateFrame(parentFrameId));
-    } else if (curParentFrame.id !== parentFrameId) {
-      throw new Error(
-        `Received <${parentFrameId}> <- <${frameId}> transform but <${curParentFrame.id}> <- <${frameId}> already exists`,
-      );
     }
 
     frame.addTransform(time, transform);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -20,21 +20,36 @@ import {
 import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
+import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 type TfMessage = { transforms: TF[] };
 
-function consumeTfs(tfs: MessageEvent<TfMessage>[], transforms: TransformTree): void {
+function consumeTfs(
+  tfs: MessageEvent<TfMessage>[],
+  transforms: TransformTree,
+  topic: string,
+): void {
   for (const { message } of tfs) {
     const parsedMessage = message;
     for (const tf of parsedMessage.transforms) {
-      transforms.addTransformMessage(tf);
+      try {
+        transforms.addTransformMessage(tf);
+      } catch (e) {
+        const err = e as Error;
+        sendNotification(`Invalid transform on "${topic}"`, err.message, "user", "error");
+      }
     }
   }
 }
 
-function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree): void {
+function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree, topic: string): void {
   for (const { message } of tfs) {
-    transforms.addTransformMessage(message);
+    try {
+      transforms.addTransformMessage(message);
+    } catch (e) {
+      const err = e as Error;
+      sendNotification(`Invalid transform on ${topic}`, err.message, "user", "error");
+    }
   }
 }
 
@@ -96,10 +111,10 @@ function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): 
 
       // Process all TF topics (ex: /tf and /tf_static)
       if (TF_DATATYPES.includes(datatype)) {
-        consumeTfs(msgs as MessageEvent<TfMessage>[], transforms);
+        consumeTfs(msgs as MessageEvent<TfMessage>[], transforms, topic);
         updated = true;
       } else if (TRANSFORM_STAMPED_DATATYPES.includes(datatype)) {
-        consumeSingleTfs(msgs as MessageEvent<TF>[], transforms);
+        consumeSingleTfs(msgs as MessageEvent<TF>[], transforms, topic);
         updated = true;
       }
     }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -20,36 +20,21 @@ import {
 import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 type TfMessage = { transforms: TF[] };
 
-function consumeTfs(
-  tfs: MessageEvent<TfMessage>[],
-  transforms: TransformTree,
-  topic: string,
-): void {
+function consumeTfs(tfs: MessageEvent<TfMessage>[], transforms: TransformTree): void {
   for (const { message } of tfs) {
     const parsedMessage = message;
     for (const tf of parsedMessage.transforms) {
-      try {
-        transforms.addTransformMessage(tf);
-      } catch (e) {
-        const err = e as Error;
-        sendNotification(`Invalid transform on "${topic}"`, err.message, "user", "error");
-      }
+      transforms.addTransformMessage(tf);
     }
   }
 }
 
-function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree, topic: string): void {
+function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree): void {
   for (const { message } of tfs) {
-    try {
-      transforms.addTransformMessage(message);
-    } catch (e) {
-      const err = e as Error;
-      sendNotification(`Invalid transform on ${topic}`, err.message, "user", "error");
-    }
+    transforms.addTransformMessage(message);
   }
 }
 
@@ -111,10 +96,10 @@ function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): 
 
       // Process all TF topics (ex: /tf and /tf_static)
       if (TF_DATATYPES.includes(datatype)) {
-        consumeTfs(msgs as MessageEvent<TfMessage>[], transforms, topic);
+        consumeTfs(msgs as MessageEvent<TfMessage>[], transforms);
         updated = true;
       } else if (TRANSFORM_STAMPED_DATATYPES.includes(datatype)) {
-        consumeSingleTfs(msgs as MessageEvent<TF>[], transforms, topic);
+        consumeSingleTfs(msgs as MessageEvent<TF>[], transforms);
         updated = true;
       }
     }


### PR DESCRIPTION
**User-Facing Changes**

Receiving a /tf message that reparents an existing parent<-child frame connection to a new parent will succeed instead of showing an error.

**Description**

Reparenting an existing transform now clears the transform history and updates the parent reference.
