### PR TITLE
WebSocket: json encoding support

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -25,7 +25,7 @@ import debouncePromise from "@foxglove/studio-base/util/debouncePromise";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 import { Channel, ChannelId, FoxgloveClient, SubscriptionId } from "@foxglove/ws-protocol";
 
-import jsonSchemaToDatatypes from "./parseJsonSchema";
+import parseJsonSchema from "./parseJsonSchema";
 import protobufDefinitionsToDatatypes, { stripLeadingDot } from "./protobufDefinitionsToDatatypes";
 
 const log = Log.getLogger(__dirname);
@@ -54,7 +54,7 @@ function parseChannel(channel: Channel): ParsedChannel {
       if (typeof schema !== "object") {
         throw new Error(`Invalid schema for channel ${channel.id}, expected JSON object`);
       }
-      const { datatypes: parsedDatatypes, postprocessValue } = jsonSchemaToDatatypes(
+      const { datatypes: parsedDatatypes, postprocessValue } = parseJsonSchema(
         schema as Record<string, unknown>,
         channel.schemaName,
       );

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import * as base64 from "@protobufjs/base64";
 import protobufjs from "protobufjs";
 import { FileDescriptorSet } from "protobufjs/ext/descriptor";
 import { v4 as uuidv4 } from "uuid";
@@ -26,6 +25,7 @@ import debouncePromise from "@foxglove/studio-base/util/debouncePromise";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 import { Channel, ChannelId, FoxgloveClient, SubscriptionId } from "@foxglove/ws-protocol";
 
+import jsonSchemaToDatatypes from "./parseJsonSchema";
 import protobufDefinitionsToDatatypes, { stripLeadingDot } from "./protobufDefinitionsToDatatypes";
 
 const log = Log.getLogger(__dirname);
@@ -45,31 +45,54 @@ type ParsedChannel = {
 };
 
 function parseChannel(channel: Channel): ParsedChannel {
-  if (channel.encoding !== "protobuf") {
-    throw new Error(`Unsupported encoding ${channel.encoding}`);
+  if (channel.encoding === "json") {
+    const schema = channel.schema.length > 0 ? JSON.parse(channel.schema) : undefined;
+    const textDecoder = new TextDecoder();
+    let datatypes: RosDatatypes = new Map();
+    let deserializer = (data: ArrayBufferView) => JSON.parse(textDecoder.decode(data));
+    if (schema != undefined) {
+      if (typeof schema !== "object") {
+        throw new Error(`Invalid schema for channel ${channel.id}, expected JSON object`);
+      }
+      const { datatypes: parsedDatatypes, postprocessValue } = jsonSchemaToDatatypes(
+        schema as Record<string, unknown>,
+        channel.schemaName,
+      );
+      datatypes = parsedDatatypes;
+      deserializer = (data) =>
+        postprocessValue(JSON.parse(textDecoder.decode(data)) as Record<string, unknown>);
+    }
+    return { channel, fullSchemaName: channel.schemaName, deserializer, datatypes };
   }
-  const decodedSchema = new Uint8Array(base64.length(channel.schema));
-  if (base64.decode(channel.schema, decodedSchema, 0) !== decodedSchema.byteLength) {
-    throw new Error(`Failed to decode base64 schema on ${channel.topic}`);
+
+  if (channel.encoding === "protobuf") {
+    const decodedSchema = new Uint8Array(protobufjs.util.base64.length(channel.schema));
+    if (
+      protobufjs.util.base64.decode(channel.schema, decodedSchema, 0) !== decodedSchema.byteLength
+    ) {
+      throw new Error(`Failed to decode base64 schema on ${channel.topic}`);
+    }
+    const root = protobufjs.Root.fromDescriptor(FileDescriptorSet.decode(decodedSchema));
+    root.resolveAll();
+    const type = root.lookupType(channel.schemaName);
+
+    const deserializer = (data: ArrayBufferView) => {
+      return type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+    };
+
+    const datatypes: RosDatatypes = new Map();
+    protobufDefinitionsToDatatypes(datatypes, type);
+
+    return {
+      channel,
+      // fullName is a fully qualified name but includes a leading dot. Remove the leading dot.
+      fullSchemaName: stripLeadingDot(type.fullName),
+      deserializer,
+      datatypes,
+    };
   }
-  const root = protobufjs.Root.fromDescriptor(FileDescriptorSet.decode(decodedSchema));
-  root.resolveAll();
-  const type = root.lookupType(channel.schemaName);
 
-  const deserializer = (data: ArrayBufferView) => {
-    return type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
-  };
-
-  const datatypes: RosDatatypes = new Map();
-  protobufDefinitionsToDatatypes(datatypes, type);
-
-  return {
-    channel,
-    // fullName is a fully qualified name but includes a leading dot. Remove the leading dot.
-    fullSchemaName: stripLeadingDot(type.fullName),
-    deserializer,
-    datatypes,
-  };
+  throw new Error(`Unsupported encoding ${channel.encoding}`);
 }
 
 export default class FoxgloveWebSocketPlayer implements Player {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.test.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.test.ts
@@ -173,7 +173,7 @@ describe("parseJsonSchema", () => {
       value: {
         bin: protobufjs.util.base64.encode(new Uint8Array([0xa1, 0xb2, 0xc3]), 0, 3),
         nested: {
-          bin2: protobufjs.util.base64.encode(new Uint8Array([0xa1, 0xb2, 0xc3]), 0, 3),
+          bin2: protobufjs.util.base64.encode(new Uint8Array([0xd4, 0xe5, 0xf6]), 0, 3),
           bar: [
             { bin3: protobufjs.util.base64.encode(new Uint8Array([0, 1, 0xfe, 0xff]), 0, 4) },
             { bin3: protobufjs.util.base64.encode(new Uint8Array([2, 3, 0xfe, 0xff]), 0, 4) },
@@ -183,7 +183,7 @@ describe("parseJsonSchema", () => {
       expectedValue: {
         bin: new Uint8Array([0xa1, 0xb2, 0xc3]),
         nested: {
-          bin2: new Uint8Array([0xa1, 0xb2, 0xc3]),
+          bin2: new Uint8Array([0xd4, 0xe5, 0xf6]),
           bar: [
             { bin3: new Uint8Array([0, 1, 0xfe, 0xff]) },
             { bin3: new Uint8Array([2, 3, 0xfe, 0xff]) },

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.test.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.test.ts
@@ -1,0 +1,202 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as protobufjs from "protobufjs";
+
+import parseJsonSchema from "./parseJsonSchema";
+
+describe("parseJsonSchema", () => {
+  it("rejects invalid schema", () => {
+    expect(() => parseJsonSchema({}, "X")).toThrow(`Expected "type": "object"`);
+    expect(() => parseJsonSchema({ type: 3 }, "X")).toThrow(`Expected "type": "object"`);
+    expect(() => parseJsonSchema({ type: "string" }, "X")).toThrow(`Expected "type": "object"`);
+    expect(() =>
+      parseJsonSchema({ type: "object", properties: { x: { type: "null" } } }, "X"),
+    ).toThrow(`Unsupported object field type for x: "null"`);
+    expect(() =>
+      parseJsonSchema(
+        { type: "object", properties: { x: { type: "string", contentEncoding: "X" } } },
+        "X",
+      ),
+    ).toThrow(`Unsupported contentEncoding "X"`);
+    expect(() =>
+      parseJsonSchema(
+        {
+          type: "object",
+          properties: {
+            x: { type: "array", items: { type: "string", contentEncoding: "base64" } },
+          },
+        },
+        "X",
+      ),
+    ).toThrow(`Unsupported contentEncoding "base64" for array item`);
+  });
+
+  it.each([
+    {
+      name: "Foo",
+      schema: { type: "object", properties: {} },
+      expectedDatatypes: new Map([["Foo", { definitions: [] }]]),
+      value: {},
+      expectedValue: {},
+    },
+
+    {
+      name: "Foo",
+      schema: {
+        type: "object",
+        properties: {
+          str: { type: "string" },
+          bin: { type: "string", contentEncoding: "base64" },
+          num: { type: "number" },
+          int: { type: "integer" },
+          bool: { type: "boolean" },
+        },
+      },
+      expectedDatatypes: new Map([
+        [
+          "Foo",
+          {
+            definitions: [
+              { name: "str", type: "string" },
+              { name: "bin", type: "uint8", isArray: true },
+              { name: "num", type: "float64" },
+              { name: "int", type: "float64" },
+              { name: "bool", type: "bool" },
+            ],
+          },
+        ],
+      ]),
+      value: {
+        str: "str",
+        bin: protobufjs.util.base64.encode(new Uint8Array([0, 1, 0xfe, 0xff]), 0, 4),
+        num: 1.5,
+        int: 1.5,
+        bool: true,
+      },
+      expectedValue: {
+        str: "str",
+        bin: new Uint8Array([0, 1, 0xfe, 0xff]),
+        num: 1.5,
+        int: 1.5,
+        bool: true,
+      },
+    },
+
+    {
+      name: "Foo",
+      schema: {
+        type: "object",
+        properties: {
+          str: { type: "array", items: { type: "string" } },
+          num: { type: "array", items: { type: "number" } },
+          int: { type: "array", items: { type: "integer" } },
+          bool: { type: "array", items: { type: "boolean" } },
+        },
+      },
+      expectedDatatypes: new Map([
+        [
+          "Foo",
+          {
+            definitions: [
+              { name: "str", type: "string", isArray: true },
+              { name: "num", type: "float64", isArray: true },
+              { name: "int", type: "float64", isArray: true },
+              { name: "bool", type: "bool", isArray: true },
+            ],
+          },
+        ],
+      ]),
+      value: { str: ["str"], num: [1.5], int: [1.5], bool: [true] },
+      expectedValue: { str: ["str"], num: [1.5], int: [1.5], bool: [true] },
+    },
+
+    {
+      name: "Foo",
+      schema: {
+        type: "object",
+        properties: {
+          bar: { type: "object", properties: { str: { type: "string" } } },
+        },
+      },
+      expectedDatatypes: new Map([
+        ["Foo", { definitions: [{ name: "bar", type: "Foo.bar", isComplex: true }] }],
+        ["Foo.bar", { definitions: [{ name: "str", type: "string" }] }],
+      ]),
+      value: { bar: { str: "str" } },
+      expectedValue: { bar: { str: "str" } },
+    },
+
+    {
+      name: "Foo",
+      schema: {
+        type: "object",
+        properties: {
+          bin: { type: "string", contentEncoding: "base64" },
+          nested: {
+            type: "object",
+            properties: {
+              bin2: { type: "string", contentEncoding: "base64" },
+              bar: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: { bin3: { type: "string", contentEncoding: "base64" } },
+                },
+              },
+            },
+          },
+        },
+      },
+      expectedDatatypes: new Map([
+        [
+          "Foo",
+          {
+            definitions: [
+              { name: "bin", type: "uint8", isArray: true },
+              { name: "nested", type: "Foo.nested", isComplex: true },
+            ],
+          },
+        ],
+        [
+          "Foo.nested",
+          {
+            definitions: [
+              { name: "bin2", type: "uint8", isArray: true },
+              { name: "bar", type: "Foo.nested.bar", isComplex: true, isArray: true },
+            ],
+          },
+        ],
+        ["Foo.nested.bar", { definitions: [{ name: "bin3", type: "uint8", isArray: true }] }],
+      ]),
+      value: {
+        bin: protobufjs.util.base64.encode(new Uint8Array([0xa1, 0xb2, 0xc3]), 0, 3),
+        nested: {
+          bin2: protobufjs.util.base64.encode(new Uint8Array([0xa1, 0xb2, 0xc3]), 0, 3),
+          bar: [
+            { bin3: protobufjs.util.base64.encode(new Uint8Array([0, 1, 0xfe, 0xff]), 0, 4) },
+            { bin3: protobufjs.util.base64.encode(new Uint8Array([2, 3, 0xfe, 0xff]), 0, 4) },
+          ],
+        },
+      },
+      expectedValue: {
+        bin: new Uint8Array([0xa1, 0xb2, 0xc3]),
+        nested: {
+          bin2: new Uint8Array([0xa1, 0xb2, 0xc3]),
+          bar: [
+            { bin3: new Uint8Array([0, 1, 0xfe, 0xff]) },
+            { bin3: new Uint8Array([2, 3, 0xfe, 0xff]) },
+          ],
+        },
+      },
+    },
+  ])(
+    "converts schema to datatypes and decodes base64",
+    ({ name, schema, expectedDatatypes, value, expectedValue }) => {
+      const { datatypes, postprocessValue } = parseJsonSchema(schema, name);
+      expect(datatypes).toEqual(expectedDatatypes);
+      expect(postprocessValue(value)).toEqual(expectedValue);
+    },
+  );
+});

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/parseJsonSchema.ts
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as protobufjs from "protobufjs";
+
+import { RosMsgField } from "@foxglove/rosmsg";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+
+export default function parseJsonSchema(
+  rootJsonSchema: Record<string, unknown>,
+  rootTypeName: string,
+): {
+  datatypes: RosDatatypes;
+
+  /**
+   * A function that should be called after parsing a value from a JSON string to do any necessary
+   * post-processing (e.g. base64 decoding)
+   */
+  postprocessValue: (value: Record<string, unknown>) => unknown;
+} {
+  const datatypes: RosDatatypes = new Map();
+
+  function addFieldsRecursive(
+    schema: Record<string, unknown>,
+    typeName: string,
+    keyPath: string[],
+  ): (value: Record<string, unknown>) => unknown {
+    let postprocessObject: (value: Record<string, unknown>) => unknown = (value) => value;
+    const fields: RosMsgField[] = [];
+    if (schema.type !== "object") {
+      throw new Error(
+        `Expected "type": "object" for schema ${typeName}, got ${JSON.stringify(schema.type)}`,
+      );
+    }
+    for (const [fieldName, fieldSchema] of Object.entries(
+      schema.properties as Record<string, Record<string, unknown>>,
+    )) {
+      switch (fieldSchema.type) {
+        case "boolean":
+          fields.push({ name: fieldName, type: "bool" });
+          break;
+        case "string":
+          switch (fieldSchema.contentEncoding) {
+            case undefined:
+              fields.push({ name: fieldName, type: "string" });
+              break;
+            case "base64": {
+              fields.push({ name: fieldName, type: "uint8", isArray: true });
+              const prevPostprocess = postprocessObject;
+              postprocessObject = (value) => {
+                const str = value[fieldName];
+                if (typeof str === "string") {
+                  const decoded = new Uint8Array(protobufjs.util.base64.length(str));
+                  if (protobufjs.util.base64.decode(str, decoded, 0) !== decoded.byteLength) {
+                    throw new Error(
+                      `Failed to decode base64 data for ${keyPath.join(".")}.${fieldName}`,
+                    );
+                  }
+                  value[fieldName] = decoded;
+                }
+                return prevPostprocess(value);
+              };
+              break;
+            }
+            default:
+              throw new Error(
+                `Unsupported contentEncoding ${JSON.stringify(fieldSchema.contentEncoding)}`,
+              );
+          }
+          break;
+        case "number":
+        case "integer":
+          fields.push({ name: fieldName, type: "float64" });
+          break;
+        case "object": {
+          const nestedTypeName = `${typeName}.${fieldName}`;
+          const postprocessNestedObject = addFieldsRecursive(
+            fieldSchema,
+            nestedTypeName,
+            keyPath.concat(fieldName),
+          );
+          const prevPostprocess = postprocessObject;
+          postprocessObject = (value) => {
+            value[fieldName] = postprocessNestedObject(value[fieldName] as Record<string, unknown>);
+            return prevPostprocess(value);
+          };
+          fields.push({ name: fieldName, type: nestedTypeName, isComplex: true });
+          break;
+        }
+        case "array": {
+          const itemSchema = fieldSchema.items as Record<string, unknown>;
+          switch (itemSchema.type) {
+            case "boolean":
+              fields.push({ name: fieldName, type: "bool", isArray: true });
+              break;
+            case "string":
+              if (itemSchema.contentEncoding != undefined) {
+                throw new Error(
+                  `Unsupported contentEncoding ${JSON.stringify(
+                    itemSchema.contentEncoding,
+                  )} for array item`,
+                );
+              }
+              fields.push({ name: fieldName, type: "string", isArray: true });
+              break;
+            case "number":
+            case "integer":
+              fields.push({ name: fieldName, type: "float64", isArray: true });
+              break;
+            case "object": {
+              const nestedTypeName = `${typeName}.${fieldName}`;
+              const postprocessArrayItem = addFieldsRecursive(
+                fieldSchema.items as Record<string, unknown>,
+                nestedTypeName,
+                keyPath.concat(fieldName),
+              );
+              const prevPostprocess = postprocessObject;
+              postprocessObject = (value) => {
+                const arr = value[fieldName];
+                if (Array.isArray(arr)) {
+                  value[fieldName] = arr.map(postprocessArrayItem);
+                }
+                return prevPostprocess(value);
+              };
+              fields.push({
+                name: fieldName,
+                type: nestedTypeName,
+                isComplex: true,
+                isArray: true,
+              });
+              break;
+            }
+            default:
+              throw new Error(`Unsupported array item type: ${JSON.stringify(itemSchema.type)}`);
+          }
+          break;
+        }
+        case "null":
+        default:
+          throw new Error(
+            `Unsupported object field type for ${fieldName}: ${JSON.stringify(fieldSchema.type)}`,
+          );
+      }
+    }
+    datatypes.set(typeName, { definitions: fields });
+    return postprocessObject;
+  }
+
+  const postprocessValue = addFieldsRecursive(rootJsonSchema, rootTypeName, []);
+  return { datatypes, postprocessValue };
+}


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
`encoding: "json"` is now supported in the WebSocket player, with the `schema` being interpreted as [JSON Schema](https://json-schema.org). Binary data is supported using `{ "type": "string", "contentEncoding": "base64" }`.

Fixes https://github.com/foxglove/studio/issues/2220