### PR TITLE
Remove box-shadow from SidebarContent

### DIFF
--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -230,9 +230,6 @@ export default function Sidebar<K extends string>({
                 <div
                   style={{
                     backgroundColor: theme.palette.neutralLighterAlt,
-                    // This box-shadow ensures the background color extends all the way to the
-                    // divider despite the default 1px margin around .mosaic-tile.
-                    boxShadow: `0 0 0 1px ${theme.palette.neutralLighterAlt}`,
                   }}
                 >
                   <SelectedComponent />


### PR DESCRIPTION
**User-Facing Changes**
A visual border appears on the right side of the sidebar icon stack between the icon stack and the remaining content.

**Description**
The box-shadow was a hack around a hack for mosaic tiles overlapping with mosaic splitters. The mosaic tile has was removed in a separate PR. This resulted in the remaining box-shadow hack hiding the border for the sidebar icon stack.
    
This change removes the box-shadow hack for SidebarContent so the sidebar icon stack border is shown again.
    
Fixes: #2313

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
