### PR TITLE
Add setParameter method to extension panel API.

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -297,6 +297,11 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
       seekPlayback: seekPlayback ? (stamp: number) => seekPlayback(fromSec(stamp)) : undefined,
 
+      setParameter: (name: string, value: ParameterValue) => {
+        const ctx = latestPipelineContextRef.current;
+        ctx?.setParameter(name, value);
+      },
+
       setPreviewTime: (stamp: number | undefined) => {
         if (stamp == undefined) {
           clearHoverValue("PanelExtensionAdatper");

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -135,6 +135,14 @@ declare module "@foxglove/studio" {
     saveState: (state: Partial<unknown>) => void;
 
     /**
+     * Set the value of parameter name to value.
+     *
+     * @param name The name of the parameter to set.
+     * @param value The new value of the parameter.
+     */
+    setParameter: (name: string, value: ParameterValue) => void;
+
+    /**
      * Set the active preview time. Setting the preview time to undefined clears the preview time.
      */
     setPreviewTime: (time: number | undefined) => void;


### PR DESCRIPTION
**User-Facing Changes**
This adds a new `setParameter` method to the extension panel API.

**Description**
This adds a new `setParameter` method to the extension panel API. It has a simple method signature:

```
    setParameter: (name: string, value: ParameterValue) => void;
```

**Note**: for ROS parameter names must begin with a `/` character.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #1988 