### PR TITLE
Render 3D panel in the selected frame instead of the root frame

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
@@ -40,7 +40,7 @@ type Props = LayoutToolbarSharedProps &
     measuringElRef: { current: MeasuringTool | ReactNull };
     onToggleCameraMode: () => void;
     onToggleDebug: () => void;
-    rootTf?: string;
+    renderFrameId?: string;
     currentTime: Time;
     selectedObject?: MouseEventObject;
     setInteractionsTabType: (arg0?: TabType) => void;
@@ -63,7 +63,7 @@ function LayoutToolbar({
   onFollowChange,
   onToggleCameraMode,
   onToggleDebug,
-  rootTf,
+  renderFrameId,
   searchInputRef,
   searchText,
   searchTextMatches,
@@ -119,7 +119,7 @@ function LayoutToolbar({
           onCameraStateChange={onCameraStateChange}
           cameraState={cameraState}
           transforms={transforms}
-          rootTf={rootTf}
+          renderFrameId={renderFrameId}
           currentTime={currentTime}
         />
         <FollowTFControl

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -634,7 +634,7 @@ export default class SceneBuilder implements MarkerProvider {
     originalMessage?: unknown,
   ): void => {
     if (this.renderFrameId == undefined) {
-      throw new Error("missing renderFrameId");
+      throw new Error("No camera frame selected");
     }
 
     // some callers of _consumeNonMarkerMessage provide LazyMessages and others provide regular objects

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -78,7 +78,7 @@ export type ErrorDetails = { frameIds: Set<string> };
 export type SceneErrors = {
   topicsMissingTransforms: Map<string, ErrorDetails>;
   topicsWithError: Map<string, string>;
-  rootTransformID: string;
+  renderFrameId: string;
 };
 
 type SelectedNamespacesByTopic = {
@@ -92,7 +92,7 @@ type MarkerMatchersByTopic = {
 };
 
 const missingTransformMessage = (
-  rootTransformId: string,
+  renderFrameId: string,
   error: ErrorDetails,
   transforms: TransformTree,
 ): string => {
@@ -101,7 +101,7 @@ const missingTransformMessage = (
   }
   const frameIds = [...error.frameIds].sort().join(`>, <`);
   const s = error.frameIds.size > 1 ? "s" : ""; // for plural
-  const msg = `missing transform${s} from frame${s} <${frameIds}> to frame <${rootTransformId}>`;
+  const msg = `missing transform${s} from frame${s} <${frameIds}> to frame <${renderFrameId}>`;
   if (transforms.frames().size === 0) {
     return msg + ". No transforms found";
   }
@@ -124,7 +124,7 @@ export function getSceneErrorsByTopic(
   }
   // errors related to missing transforms
   for (const [topic, error] of sceneErrors.topicsMissingTransforms) {
-    addError(topic, missingTransformMessage(sceneErrors.rootTransformID, error, transforms));
+    addError(topic, missingTransformMessage(sceneErrors.renderFrameId, error, transforms));
   }
   return res;
 }
@@ -174,16 +174,16 @@ export function filterOutSupersededMessages<T extends Pick<MessageEvent<unknown>
 function computeMarkerPose(
   marker: Marker,
   transforms: TransformTree,
-  rootFrameId: string,
+  renderFrameId: string,
   currentTime: Time,
 ): MutablePose | undefined {
-  const frame = transforms.frame(marker.header.frame_id);
-  const rootFrame = transforms.frame(rootFrameId);
-  if (!frame || !rootFrame) {
+  const srcFrame = transforms.frame(marker.header.frame_id);
+  const frame = transforms.frame(renderFrameId);
+  if (!srcFrame || !frame) {
     return undefined;
   }
   const time = marker.frame_locked ? currentTime : marker.header.stamp;
-  return rootFrame.apply(emptyPose(), marker.pose, frame, time);
+  return frame.apply(emptyPose(), marker.pose, srcFrame, time);
 }
 
 export default class SceneBuilder implements MarkerProvider {
@@ -192,12 +192,12 @@ export default class SceneBuilder implements MarkerProvider {
   } = {};
   markers: Marker[] = [];
   transforms?: TransformTree;
-  rootTransformID?: string;
+  renderFrameId?: string;
   frame?: Frame;
   // TODO(JP): Get rid of these two different variables `errors` and `errorsByTopic` which we
   // have to keep in sync.
   errors: SceneErrors = {
-    rootTransformID: "",
+    renderFrameId: "",
     topicsMissingTransforms: new Map(),
     topicsWithError: new Map(),
   };
@@ -248,11 +248,11 @@ export default class SceneBuilder implements MarkerProvider {
     this._hooks = hooks;
   }
 
-  setTransforms = (transforms: TransformTree, rootTransformID: string | undefined): void => {
+  setTransforms = (transforms: TransformTree, renderFrameId: string | undefined): void => {
     this.transforms = transforms;
-    this.rootTransformID = rootTransformID;
-    if (rootTransformID != undefined) {
-      this.errors.rootTransformID = rootTransformID;
+    this.renderFrameId = renderFrameId;
+    if (renderFrameId != undefined) {
+      this.errors.renderFrameId = renderFrameId;
     }
   };
 
@@ -268,7 +268,7 @@ export default class SceneBuilder implements MarkerProvider {
   setPlayerId(playerId: string): void {
     if (this._playerId !== playerId) {
       this.errors = {
-        rootTransformID: "",
+        renderFrameId: "",
         topicsMissingTransforms: new Map(),
         topicsWithError: new Map(),
       };
@@ -633,8 +633,8 @@ export default class SceneBuilder implements MarkerProvider {
     type: number,
     originalMessage?: unknown,
   ): void => {
-    if (this.rootTransformID == undefined) {
-      throw new Error("missing rootTransformId");
+    if (this.renderFrameId == undefined) {
+      throw new Error("missing renderFrameId");
     }
 
     // some callers of _consumeNonMarkerMessage provide LazyMessages and others provide regular objects
@@ -833,7 +833,7 @@ export default class SceneBuilder implements MarkerProvider {
   };
 
   renderMarkers(add: MarkerCollector, time: Time): void {
-    if (!this.transforms || !this.rootTransformID) {
+    if (!this.transforms || !this.renderFrameId) {
       return;
     }
 
@@ -857,7 +857,7 @@ export default class SceneBuilder implements MarkerProvider {
           }
         }
 
-        const pose = computeMarkerPose(marker, this.transforms, this.rootTransformID, time);
+        const pose = computeMarkerPose(marker, this.transforms, this.renderFrameId, time);
         if (!pose) {
           missingTfFrameIds.add(marker.header.frame_id);
           continue;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
@@ -217,7 +217,7 @@ describe("<SearchText />", () => {
         cameraState,
         onCameraStateChange,
         currentMatch,
-        rootTf: ROOT_FRAME_ID,
+        renderFrameId: ROOT_FRAME_ID,
         searchTextOpen: true,
         transforms,
         currentTime: { sec: 0, nsec: 0 },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -148,7 +148,7 @@ export const useSearchText = (): SearchTextProps => {
 type SearchTextComponentProps = SearchTextProps & {
   onCameraStateChange: (arg0: CameraState) => void;
   cameraState: CameraState;
-  rootTf?: string;
+  renderFrameId?: string;
   currentTime: Time;
   transforms: TransformTree;
 };
@@ -158,7 +158,7 @@ export const useSearchMatches = ({
   cameraState,
   currentMatch,
   onCameraStateChange,
-  rootTf,
+  renderFrameId,
   currentTime,
   searchTextOpen,
   transforms,
@@ -166,7 +166,7 @@ export const useSearchMatches = ({
   cameraState: CameraState;
   currentMatch?: GLTextMarker;
   onCameraStateChange: (arg0: CameraState) => void;
-  rootTf?: string;
+  renderFrameId?: string;
   currentTime: Time;
   searchTextOpen: boolean;
   transforms: TransformTree;
@@ -174,17 +174,15 @@ export const useSearchMatches = ({
   const hasCurrentMatchChanged = useDeepChangeDetector([currentMatch], { initiallyTrue: true });
 
   useEffect(() => {
-    if (!currentMatch || !searchTextOpen || !rootTf || !hasCurrentMatchChanged) {
+    if (!currentMatch || !searchTextOpen || !renderFrameId || !hasCurrentMatchChanged) {
       return;
     }
 
-    const { header, pose } = currentMatch;
-
     const output = transforms.apply(
       { position: { x: 0, y: 0, z: 0 }, orientation: { x: 0, y: 0, z: 0, w: 0 } },
-      pose,
-      rootTf,
-      header.frame_id,
+      currentMatch.pose,
+      renderFrameId,
+      currentMatch.header.frame_id,
       currentTime,
     );
     if (!output) {
@@ -209,7 +207,7 @@ export const useSearchMatches = ({
     currentTime,
     hasCurrentMatchChanged,
     onCameraStateChange,
-    rootTf,
+    renderFrameId,
     searchTextOpen,
     transforms,
   ]);
@@ -235,7 +233,7 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
   onCameraStateChange,
   cameraState,
   transforms,
-  rootTf,
+  renderFrameId,
   currentTime,
 }: SearchTextComponentProps) {
   const theme = useTheme();
@@ -264,7 +262,7 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
     cameraState,
     currentMatch,
     onCameraStateChange,
-    rootTf,
+    renderFrameId,
     currentTime,
     searchTextOpen,
     transforms,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -70,7 +70,7 @@ import {
   getUpdatedGlobalVariablesBySelectedObject,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import {
-  DEFAULT_ROOT_FRAME_IDS,
+  DEFAULT_FRAME_IDS,
   TransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
@@ -455,18 +455,14 @@ export default function Layout({
     }, [] as MarkerMatcher[]);
   }, [colorOverrideByVariable, globalVariables, linkedGlobalVariables]);
 
-  const rootTf = useMemo(() => {
-    // If the user specified a followTf we will only return the root frame from their followTf
-    if (typeof followTf === "string" && followTf.length > 0) {
-      const followFrame = transforms.frame(followTf);
-      if (followFrame) {
-        return followFrame.root().id;
-      }
-      return undefined;
+  const renderFrameId = useMemo(() => {
+    // If the user specified a followTf, do not fall back to any other frame
+    if (typeof followTf === "string") {
+      return transforms.hasFrame(followTf) ? followTf : undefined;
     }
 
-    // Try the conventional list of root frame transform ids
-    for (const frameId of DEFAULT_ROOT_FRAME_IDS) {
+    // Try the conventional list of transform ids
+    for (const frameId of DEFAULT_FRAME_IDS) {
       if (transforms.hasFrame(frameId)) {
         return frameId;
       }
@@ -489,7 +485,7 @@ export default function Layout({
       sceneBuilder.clear();
     }
 
-    urdfBuilder.setTransforms(transforms, rootTf);
+    urdfBuilder.setTransforms(transforms, renderFrameId);
     urdfBuilder.setUrdfData(robotDescriptionParam, rosPackagePath);
     urdfBuilder.setVisible(selectedTopicNames.includes(URDF_TOPIC));
     urdfBuilder.setSettingsByKey(settingsByKey, rosPackagePath);
@@ -499,7 +495,7 @@ export default function Layout({
     const selectedTopics = filterMap(selectedTopicNames, (name) => topicsByTopicName[name]);
 
     sceneBuilder.setPlayerId(playerId);
-    sceneBuilder.setTransforms(transforms, rootTf);
+    sceneBuilder.setTransforms(transforms, renderFrameId);
     sceneBuilder.setFlattenMarkers(flattenMarkers);
     sceneBuilder.setSelectedNamespacesByTopic(selectedNamespacesByTopic);
     sceneBuilder.setSettingsByKey(settingsByKey);
@@ -511,7 +507,7 @@ export default function Layout({
     sceneBuilder.render();
 
     // update the transforms and set the selected ones to render
-    transformsBuilder.setTransforms(transforms, rootTf);
+    transformsBuilder.setTransforms(transforms, renderFrameId);
     transformsBuilder.setSelectedTransforms(selectedNamespacesByTopic[TRANSFORM_TOPIC] ?? []);
   }, [
     colorOverrideMarkerMatchers,
@@ -523,7 +519,7 @@ export default function Layout({
     playerId,
     resetFrame,
     robotDescriptionParam,
-    rootTf,
+    renderFrameId,
     rosPackagePath,
     sceneBuilder,
     selectedNamespacesByTopic,
@@ -871,7 +867,7 @@ export default function Layout({
                   showCrosshair={showCrosshair}
                   targetPose={targetPose}
                   transforms={transforms}
-                  rootTf={rootTf}
+                  renderFrameId={renderFrameId}
                   currentTime={currentTime}
                   {...searchTextProps}
                 />

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -114,7 +114,6 @@ function BaseRenderer(props: Props): JSX.Element {
     followTf,
     followOrientation,
     transforms,
-    time: currentTime,
   });
 
   const onSetSubscriptions = useCallback(

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/stories/indexUtils.stories.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/stories/indexUtils.stories.ts
@@ -84,8 +84,8 @@ type Props = {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function generateMarkers(props: Props, idx: number, markerName: string) {
-  const rootTfID = "map";
-  const header = { seq: 257399, stamp: { sec: 1534827954, nsec: 262587964 }, frame_id: rootTfID };
+  const frame_id = "map";
+  const header = { seq: 257399, stamp: { sec: 1534827954, nsec: 262587964 }, frame_id };
   const pose = {
     position: { x: idx * GAP - (TOTAL * GAP) / 2 - 20, y: 0, z: 0 },
     orientation: { x: 0, y: 0, z: 0, w: 1 },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
@@ -370,27 +370,11 @@ export class CoordinateFrame {
       return false;
     }
     if (invert) {
-      // Remove the translation component, leaving only a rotation matrix
-      const x = tempMatrix[12];
-      const y = tempMatrix[13];
-      const z = tempMatrix[14];
-      tempMatrix[12] = 0;
-      tempMatrix[13] = 0;
-      tempMatrix[14] = 0;
-
-      // The transpose of a rotation matrix is its inverse
-      mat4.transpose(tempMatrix, tempMatrix);
-
-      // The negatation of the translation is its inverse
-      tempMatrix[12] = -x;
-      tempMatrix[13] = -y;
-      tempMatrix[14] = -z;
+      mat4.invert(tempMatrix, tempMatrix);
     }
 
-    tempTransform.setPose(input);
-    mat4.multiply(tempMatrix, tempMatrix, tempTransform.matrix());
-    tempTransform.setMatrix(tempMatrix);
-    tempTransform.toPose(out);
+    mat4.multiply(tempMatrix, tempMatrix, tempTransform.setPose(input).matrix());
+    tempTransform.setMatrix(tempMatrix).toPose(out);
     return true;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.test.ts
@@ -98,7 +98,7 @@ describe("TransformTree", () => {
 
     // map -> odom -> base_link
     expect(tree.apply(output, emptyPose(), "base_link", "map", TIME_ZERO)).toBeDefined();
-    expect(output.position).toEqual({ x: -9, y: -18, z: -33 });
+    expect(output.position).toEqual({ x: 9, y: 18, z: -33 });
     expect(output.orientation).toEqual({ x: 0, y: 0, z: 1, w: 0 });
 
     // base_link -> odom -> map
@@ -109,7 +109,7 @@ describe("TransformTree", () => {
 
     // map -> odom -> base_link
     expect(tree.apply(output, a, "base_link", "map", TIME_ZERO)).toBeDefined();
-    expect(output.position).toEqual({ x: -109, y: -218, z: 267 });
+    expect(output.position).toEqual({ x: -91, y: -182, z: 267 });
     expect(output.orientation).toEqual({ x: 0, y: 1, z: 0, w: 0 });
   });
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
@@ -2,9 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// REP 105 specifies a set of conventional root frame transform ids
+// REP 105 specifies a set of conventional frame ids
 // https://www.ros.org/reps/rep-0105.html
-export const DEFAULT_ROOT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
+export const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
 
 export * from "./CoordinateFrame";
 export * from "./Transform";


### PR DESCRIPTION
**User-Facing Changes**

The 3D scene world space can be set to a non-root frame. This allows rendering objects even when a transform to the root frame is missing, and fixes precision issues when a coordinate frame is far away (~1000km) from the root frame.

**Description**

Most of the work for this was done in the transform interpolation PR. This just replaces the concept of `rootTf` with `renderFrameId`, allowing any arbitrary frame to be used as the render frame.
