### PR TITLE
Use simulated time (/clock) for receive time in Ros1Player

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -101,7 +101,7 @@ class MessageOrderTracker {
           isLessThan(messageTime, this.lastMessageTime)
         ) {
           sendNotification(
-            "Bag went back in time",
+            "Data went back in time",
             `Processed a message on ${message.topic} at ${formatFrame(
               messageTime,
             )} which is earlier than ` +


### PR DESCRIPTION
**User-facing changes**

Visualizations no longer flicker when connected to a live ROS1 source that publishes `/clock` (simulated time).

**Description**

Large disagreements between receive time and header stamps caused various data pipeline issues. Use `/clock` when available for setting receive time. This also fixes a "Bag went back in time" warning by rewriting the `receiveTime` of `/clock` messages after processing the new clock time.