### PR TITLE
Reorganize desktop app's menu items

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -162,18 +162,20 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
       submenu: [
         { role: "about" },
         { type: "separator" },
+
         {
           label: "Preferences…",
           accelerator: "CommandOrControl+,",
           click: () => browserWindow.webContents.send("open-preferences"),
         },
-        { type: "separator" },
         { role: "services" },
         { type: "separator" },
+
+        { type: "separator" },
+
         { role: "hide" },
         { role: "hideOthers" },
         { role: "unhide" },
-        { type: "separator" },
         { role: "quit" },
       ],
     });
@@ -209,9 +211,20 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "editMenu",
     label: "Edit",
     submenu: [
+      {
+        label: "Add Panel to Layout",
+        click: () => browserWindow.webContents.send("open-add-panel"),
+      },
+      {
+        label: "Edit Panel Settings",
+        click: () => browserWindow.webContents.send("open-panel-settings"),
+      },
+      { type: "separator" },
+
       { role: "undo" },
       { role: "redo" },
       { type: "separator" },
+
       { role: "cut" },
       { role: "copy" },
       { role: "paste" },
@@ -254,6 +267,12 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "viewMenu",
     label: "View",
     submenu: [
+      { label: "Layouts", click: () => browserWindow.webContents.send("open-layouts") },
+      { label: "Variables", click: () => browserWindow.webContents.send("open-variables") },
+      { label: "Extensions", click: () => browserWindow.webContents.send("open-extensions") },
+      { label: "Account", click: () => browserWindow.webContents.send("open-account") },
+      { type: "separator" },
+
       { role: "resetZoom" },
       { role: "zoomIn" },
       { role: "zoomOut" },
@@ -481,24 +500,6 @@ class StudioWindow {
           },
         })),
       }),
-    );
-
-    const fileMenuItems = [
-      { label: "View Layouts", event: "open-layouts" },
-      { label: "Add Panel", event: "open-add-panel" },
-      { label: "Edit Panel Settings", event: "open-panel-settings" },
-      { label: "Set Variables", event: "open-variables" },
-      { label: "Install Extensions", event: "open-extensions" },
-      { label: "Log In", event: "open-account" },
-    ];
-
-    fileMenuItems.forEach(({ label, event }) =>
-      fileMenu.submenu?.append(
-        new MenuItem({
-          label,
-          click: () => browserWindow.webContents.send(event),
-        }),
-      ),
     );
 
     if (!isMac) {


### PR DESCRIPTION
**User-Facing Changes**
- Reorganize desktop app's menu items

**Description**
- Move appropriate items out of the "File" menu and into the "Edit" and "View" menus
   ![image](https://user-images.githubusercontent.com/6993359/145297000-0551d9a1-e2ad-4852-be73-51c84d9fc93b.png)
   ![image](https://user-images.githubusercontent.com/6993359/145297316-d52115eb-5bdd-4126-bbfb-c7b2a6ce38d6.png)
   ![image](https://user-images.githubusercontent.com/6993359/145297183-27192e0b-c12a-4cd9-8702-e0b1ad55fb38.png)
- Removed separator between "Preferences" and "Services" in the main app menu
   ![image](https://user-images.githubusercontent.com/6993359/145296431-f5c0b432-418b-48d5-9831-7e5728932f8d.png)


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
