### PR TITLE
Remove path requirement for deep link.

### DIFF
--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -61,10 +61,6 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
     throw Error("Unknown protocol.");
   }
 
-  if (!isDesktopApp() && url.pathname !== "/") {
-    throw Error("Unknown path.");
-  }
-
   const layoutId = url.searchParams.get("layoutId");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);


### PR DESCRIPTION
**User-Facing Changes**
This removes the path requirement from deep link state restoration.

**Description**
Currently we only restore state from URLs at the root path, `/`. This removes that restriction.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
This should address #2299 