### PR TITLE
Multi-file data sources, ROS2 open file, drag and drop folders

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -38,7 +38,7 @@
     "@foxglove/ros1": "1.3.6",
     "@foxglove/ros2": "1.0.8",
     "@foxglove/rosbag": "0.1.2",
-    "@foxglove/rosbag2-web": "3.0.3",
+    "@foxglove/rosbag2-web": "3.0.4",
     "@foxglove/rosmsg": "3.0.0",
     "@foxglove/rosmsg-msgs-common": "1.0.4",
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -316,7 +316,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const extensionLoader = useExtensionLoader();
 
   const openFiles = useCallback(
-    async (files: FileList) => {
+    async (files: File[]) => {
       const otherFiles: File[] = [];
       for (const file of files) {
         // electron extends File with a `path` field which is not available in browsers
@@ -370,12 +370,12 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const filesToOpen = useElectronFilesToOpen();
   useEffect(() => {
     if (filesToOpen) {
-      void openFiles(filesToOpen);
+      void openFiles(Array.from(filesToOpen));
     }
   }, [filesToOpen, openFiles]);
 
   const dropHandler = useCallback(
-    ({ files }: { files: FileList }) => {
+    ({ files }: { files: File[] }) => {
       void openFiles(files);
     },
     [openFiles],

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -198,29 +198,11 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         return;
       }
 
-      if (foundSource.supportsOpenDirectory === true) {
-        try {
-          const folder = await showDirectoryPicker();
-          const newPlayer = foundSource.initialize({
-            folder,
-            metricsCollector,
-            unlimitedMemoryCache,
-          });
-          setBasePlayer(newPlayer);
-        } catch (error) {
-          if (error.name === "AbortError") {
-            return undefined;
-          }
-          addToast((error as Error).message, { appearance: "error" });
-        }
-
-        return;
-      }
-
       const supportedFileTypes = foundSource.supportedFileTypes;
       if (supportedFileTypes != undefined) {
         try {
-          let file = (args?.files as File[] | undefined)?.[0];
+          const fileList = (args?.files as File[] | undefined) ?? [];
+          let file = fileList[0];
 
           if (!file) {
             const [fileHandle] = await showOpenFilePicker({
@@ -234,8 +216,11 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
             file = await fileHandle.getFile();
           }
 
+          const multiFile = foundSource.supportsMultiFile === true && fileList.length > 1;
+
           const newPlayer = foundSource.initialize({
-            file,
+            file: multiFile ? undefined : file,
+            files: multiFile ? fileList : undefined,
             metricsCollector,
             unlimitedMemoryCache,
           });

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -14,6 +14,7 @@ export type DataSourceFactoryInitializeArgs = {
   rosHostname?: string;
   folder?: FileSystemDirectoryHandle;
   file?: File;
+  files?: File[];
   url?: string;
   consoleApi?: ConsoleApi;
 } & Record<string, unknown>;
@@ -30,7 +31,7 @@ export interface IDataSourceFactory {
   // file types
   supportedFileTypes?: string[];
 
-  supportsOpenDirectory?: boolean;
+  supportsMultiFile?: boolean;
 
   promptOptions?: (previousValue?: string) => PromptOptions;
 

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -13,20 +13,26 @@ import { getLocalRosbag2Descriptor } from "@foxglove/studio-base/randomAccessDat
 class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
   id = "ros2-local-bagfile";
   displayName = "ROS 2 Bag (local)";
-  iconName: IDataSourceFactory["iconName"] = "OpenFolder";
-
-  supportsOpenDirectory = true;
+  iconName: IDataSourceFactory["iconName"] = "OpenFile";
+  supportedFileTypes = [".db3"];
+  supportsMultiFile = true;
 
   initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
-    const folder = args.folder;
-    if (!folder) {
-      return;
+    if ((args.files?.length ?? 0) > 0) {
+      const files = args.files as File[];
+      return buildNonRos1PlayerFromDescriptor(files[0]!.name, getLocalRosbag2Descriptor(files), {
+        metricsCollector: args.metricsCollector,
+        unlimitedMemoryCache: args.unlimitedMemoryCache,
+      });
+    } else if (args.file) {
+      const file = args.file;
+      return buildNonRos1PlayerFromDescriptor(file.name, getLocalRosbag2Descriptor(file), {
+        metricsCollector: args.metricsCollector,
+        unlimitedMemoryCache: args.unlimitedMemoryCache,
+      });
     }
 
-    return buildNonRos1PlayerFromDescriptor(folder.name, getLocalRosbag2Descriptor(folder), {
-      metricsCollector: args.metricsCollector,
-      unlimitedMemoryCache: args.unlimitedMemoryCache,
-    });
+    return undefined;
   }
 }
 

--- a/packages/studio-base/src/randomAccessDataProviders/standardDataProviderDescriptors.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/standardDataProviderDescriptors.ts
@@ -52,14 +52,24 @@ export function getRemoteBagDescriptor(
 }
 
 export function getLocalRosbag2Descriptor(
-  folder: FileSystemDirectoryHandle,
+  files: File | File[],
 ): RandomAccessDataProviderDescriptor {
-  return {
-    label: folder.name,
-    name: CoreDataProviders.Rosbag2DataProvider,
-    args: { bagFolderPath: { type: "folder", folder } },
-    children: [],
-  };
+  if (Array.isArray(files)) {
+    return {
+      label: files[0]!.name,
+      name: CoreDataProviders.Rosbag2DataProvider,
+      args: { bagPath: { type: "files", files } },
+      children: [],
+    };
+  } else {
+    const file = files;
+    return {
+      label: file.name,
+      name: CoreDataProviders.Rosbag2DataProvider,
+      args: { bagPath: { type: "file", file } },
+      children: [],
+    };
+  }
 }
 
 export function getLocalUlogDescriptor(file: File): RandomAccessDataProviderDescriptor {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,13 +2224,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosbag2-web@npm:3.0.3":
-  version: 3.0.3
-  resolution: "@foxglove/rosbag2-web@npm:3.0.3"
+"@foxglove/rosbag2-web@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@foxglove/rosbag2-web@npm:3.0.4"
   dependencies:
     "@foxglove/rosbag2": ^3.0.1
     sql.js: ^1.6.2
-  checksum: 96a9c66f7da321a2ae2acfb20a430a9d5f1dc11235f645b29651564e97e6a425053c285049f7495a17992535c15647ef4814672d5a4dd60c1d3b7b29795422d9
+  checksum: 897717ab972f662864d021d6ecd679d09f374c6ca1da915ebc6a820ab66865db7d334a72dc6794d4e44e44eec8c5673b53861864701ed1653b7abfa07823a8b4
   languageName: node
   linkType: hard
 
@@ -2340,7 +2340,7 @@ __metadata:
     "@foxglove/ros1": 1.3.6
     "@foxglove/ros2": 1.0.8
     "@foxglove/rosbag": 0.1.2
-    "@foxglove/rosbag2-web": 3.0.3
+    "@foxglove/rosbag2-web": 3.0.4
     "@foxglove/rosmsg": 3.0.0
     "@foxglove/rosmsg-msgs-common": 1.0.4
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3


### PR DESCRIPTION
**User-Facing Changes**

- Folders can be dragged and dropped into Studio. Only the first valid file is opened for ROS1 and PX4 (for now), ROS2 supports multi-file
- Selecting "ROS 2 Bag (local)" will use the Open File dialog instead of Open Folder for consistency

**Description**

This adds the plumbing for multi-file data sources. supportsOpenDirectory has been replaced by supportsMultiFile. Dragging and dropping a folder will behave the same as dropping the contents of that folder into Studio. ROS2 bags can be opened by either dropping the folder, dropping one or more .db3 files, or browsing and opening a .db3 file
