### PR TITLE
Style placeholder globally

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicTree.tsx
@@ -183,7 +183,6 @@ const useComponentStyles = (theme: ITheme) =>
           padding: `0 ${theme.spacing.l2}`,
 
           "::placeholder": {
-            opacity: 0.6,
             fontSize: theme.fonts.small.fontSize,
             lineHeight: 30,
           },

--- a/packages/studio-base/src/theme/index.ts
+++ b/packages/studio-base/src/theme/index.ts
@@ -13,6 +13,7 @@ import {
   IOverlayStyles,
   IPalette,
   ISpinnerStyles,
+  ITextFieldStyles,
   IToggleStyles,
   ITooltipStyleProps,
   ITooltipStyles,
@@ -95,6 +96,18 @@ function getPartialTheme({ inverted }: { inverted: boolean }): PartialTheme {
             },
           },
         } as Partial<IComboBoxStyles>,
+      },
+      TextField: {
+        styles: {
+          field: {
+            "::placeholder": {
+              opacity: 0.6,
+            },
+            ":focus::placeholder": {
+              opacity: 0,
+            },
+          },
+        } as Partial<ITextFieldStyles>,
       },
       Tooltip: {
         styles: ({ theme }: ITooltipStyleProps): Partial<ITooltipStyles> => ({


### PR DESCRIPTION
**User-Facing Changes**
Style placeholder text globally to be more subtle as the default appearance looks like the field is filled in.
