### PR TITLE
Load last used layout if no layout is specified in app url.

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -38,7 +38,7 @@ import { LayoutID } from "@foxglove/studio-base/services/ConsoleApi";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutManagerEventTypes } from "@foxglove/studio-base/services/ILayoutManager";
 import { PanelConfig, UserNodes, PlaybackConfig } from "@foxglove/studio-base/types/panels";
-import { windowHasValidURLState } from "@foxglove/studio-base/util/appURLState";
+import { windowAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 const log = Logger.getLogger(__filename);
@@ -228,7 +228,7 @@ export default function CurrentLayoutProvider({
   // Load initial state by re-selecting the last selected layout from the UserProfile.
   // Don't restore the layout if there's one specified in the app state url.
   useAsync(async () => {
-    if (windowHasValidURLState()) {
+    if (windowAppURLState()?.layoutId) {
       return;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
This modifies the URL state loading logic to load the last used layout if none is specified in the URL.

**Description**
Currently we don't load the last layout if we have valid app state URL. This changes that logic to load the last layout unless a `layoutId` is present in the URL.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2321 