### PR TITLE
Update actions/stale to v4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v4
         with:
           stale-issue-message: "This issue is being marked as stale because there has been no activity for 180 days. Please add a comment to keep it open."
           stale-issue-label: stale


### PR DESCRIPTION
This might make the actions bot better about removing the stale label when there have been new comments. See: https://github.com/actions/stale/pull/519