### PR TITLE
Remove "beta" label from Foxglove WebSocket data source

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -14,7 +14,6 @@ import { parseInputUrl } from "@foxglove/studio-base/util/url";
 export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFactory {
   id = "foxglove-websocket";
   displayName = "Foxglove WebSocket";
-  badgeText = "beta";
   iconName: IDataSourceFactory["iconName"] = "Flow";
 
   promptOptions(previousValue?: string): PromptOptions {


### PR DESCRIPTION
I swear I already removed this in #2342, but I must've not pushed that commit...