### PR TITLE
Display app version in Help sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.23.0-dev",
   "description": "Integrated robotics visualization and debugging.",
   "productName": "Foxglove Studio",
-  "productDescription": "Foxglove Studio is an highly customizable and extensible visualization and display tool for robotics.",
+  "productDescription": "Foxglove Studio is a highly customizable and extensible visualization and display tool for robotics.",
   "license": "MPL-2.0",
   "private": true,
   "repository": {

--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -75,6 +75,12 @@ const useComponentStyles = (theme: ITheme) =>
           fontSize: 13,
         } as Partial<ILinkStyles>,
       },
+      footer: {
+        root: {
+          ...theme.fonts.xSmall,
+          color: theme.palette.neutralSecondaryAlt,
+        } as Partial<ITextStyles>,
+      },
     }),
     [theme],
   );
@@ -176,6 +182,7 @@ export default function HelpSidebar({
                 </Stack.Item>
               );
             })}
+            <Text styles={styles.footer}>Foxglove Studio version {FOXGLOVE_STUDIO_VERSION}</Text>
           </Stack>
         ) : (
           <Stack tokens={{ childrenGap: theme.spacing.s2 }}>

--- a/packages/studio-base/src/typings/webpack-defines.d.ts
+++ b/packages/studio-base/src/typings/webpack-defines.d.ts
@@ -4,3 +4,5 @@
 
 // Should match DefinePlugin in webpack configuration
 declare const ReactNull: ReactNull;
+
+declare const FOXGLOVE_STUDIO_VERSION: string;

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -12,6 +12,7 @@ import createStyledComponentsTransformer from "typescript-plugin-styled-componen
 import webpack, { Configuration, WebpackPluginInstance } from "webpack";
 
 import { WebpackArgv } from "./WebpackArgv";
+import packageJson from "./package.json";
 
 const styledComponentsTransformer = createStyledComponentsTransformer({
   getDisplayName: (filename, bindingName) => {
@@ -224,6 +225,7 @@ export function makeConfig(
       new webpack.DefinePlugin({
         // Should match webpack-defines.d.ts
         ReactNull: null, // eslint-disable-line no-restricted-syntax
+        FOXGLOVE_STUDIO_VERSION: JSON.stringify(packageJson.version),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({


### PR DESCRIPTION
**User-Facing Changes**
App version is now displayed in the Help sidebar.

**Description**
Fixes https://github.com/foxglove/studio/issues/2323

<img width="255" alt="image" src="https://user-images.githubusercontent.com/14237/145517453-6ffae225-f1ce-42ae-8fde-7f806223f73f.png">

(Lack of bottom padding is a separate bug: #2340)