### PR TITLE
Dark theme for Quick Look previews

### DIFF
--- a/desktop/quicklook/ErrorInfo.tsx
+++ b/desktop/quicklook/ErrorInfo.tsx
@@ -6,9 +6,15 @@ import styled from "styled-components";
 
 const ErrorInfo = styled.div`
   padding: 12px;
+  border-radius: 4px;
+
   background: #ffeaea;
   border: 1px dashed #cc5f5f;
-  border-radius: 4px;
+
+  @media (prefers-color-scheme: dark) {
+    background: #673636;
+    border: 1px dashed #bb5959;
+  }
 `;
 
 export default ErrorInfo;

--- a/desktop/quicklook/FileInfoDisplay.tsx
+++ b/desktop/quicklook/FileInfoDisplay.tsx
@@ -63,12 +63,16 @@ const TopicRowWrapper = styled.tr`
   display: table-row;
   word-break: break-word;
   &:nth-child(2n) {
+    --zebra-color: rgba(0, 0, 0, 5%);
+    @media (prefers-color-scheme: dark) {
+      --zebra-color: rgba(255, 255, 255, 5%);
+    }
     > :first-child {
-      background: rgba(0, 0, 0, 5%);
+      background: var(--zebra-color);
       border-radius: 4px 0 0 4px;
     }
     > :last-child {
-      background: rgba(0, 0, 0, 5%);
+      background: var(--zebra-color);
       border-radius: 0 4px 4px 0;
     }
   }

--- a/desktop/quicklook/index.tsx
+++ b/desktop/quicklook/index.tsx
@@ -34,12 +34,21 @@ const GlobalStyle = createGlobalStyle`
     height: 100%;
     padding: 0;
     margin: 0;
+
+    @media (prefers-color-scheme: dark) {
+      background: #333;
+    }
   }
   body {
     padding: 10px;
     font-family: ui-sans-serif, -apple-system;
+    @media (prefers-color-scheme: dark) {
+      color: #fff;
+    }
   }
-  pre, code, tt {
+  pre,
+  code,
+  tt {
     font-family: ui-monospace, monospace;
   }
 `;


### PR DESCRIPTION
**User-Facing Changes**
Quick Look previews now inherit the system light/dark color scheme setting.

**Description**
<img width="300" alt="Screen Shot 2021-12-09 at 9 27 13 PM" src="https://user-images.githubusercontent.com/14237/145523032-39a76549-bad0-4741-a2cd-4c0fd0164834.png"> <img width="300" alt="Screen Shot 2021-12-09 at 9 27 11 PM" src="https://user-images.githubusercontent.com/14237/145523035-78f51ddf-3c9a-4aa3-b875-5d3f46fcf0f6.png">
<img width="300" alt="Screen Shot 2021-12-09 at 9 27 05 PM" src="https://user-images.githubusercontent.com/14237/145523037-d599f620-e10b-404f-b819-627163230b64.png"> <img width="300" alt="Screen Shot 2021-12-09 at 9 27 02 PM" src="https://user-images.githubusercontent.com/14237/145523040-f5082418-d3a8-48c2-8b9b-39d9f8a19119.png">

