### PR TITLE
Patch to avoid storing recents in indexeddb

### DIFF
--- a/packages/studio-base/src/util/IndexedDbRecentsStore.ts
+++ b/packages/studio-base/src/util/IndexedDbRecentsStore.ts
@@ -40,8 +40,11 @@ export class IndexedDbRecentsStore {
   }
 
   /** Save the recents into the store */
-  async set(recents: RecentRecord[]): Promise<void> {
-    await idbSet(this.key, recents, this.store);
+  async set(_recents: RecentRecord[]): Promise<void> {
+    // Avoid storing recents until we identify issues with file handles the current code tries to
+    // store File instances which incorrectly stores the entire file in indexeddb. This clears out
+    // those entries.
+    await idbSet(this.key, [], this.store);
   }
 
   static GenerateRecordId(): string {


### PR DESCRIPTION
**User-Facing Changes**
Recents are not visually exposed to users.

**Description**
Currently File instances are stored in the database which is undesireable since it will store copies of potentially large files. This change always sets recents to an empty list until we figure out the strategy for recents.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
