### PR TITLE
Move coordinate frame selection into TopicTree

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
@@ -123,7 +123,6 @@ function LayoutToolbar({
           currentTime={currentTime}
         />
         <FollowTFControl
-          transforms={transforms}
           tfToFollow={typeof followTf === "string" && followTf.length > 0 ? followTf : undefined}
           followOrientation={followOrientation}
           onFollowChange={onFollowChange}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -808,6 +808,9 @@ export default function Layout({
                 showTopicTree={showTopicTree}
                 topicDisplayMode={topicDisplayMode}
                 visibleTopicsCountByKey={visibleTopicsCountByKey}
+                transformTree={transforms}
+                tfToFollow={renderFrameId}
+                onFollowChange={onFollowChange}
               />
               {currentEditingTopic && (
                 <TopicSettingsModal


### PR DESCRIPTION
**User-Facing Changes**

<img src="https://user-images.githubusercontent.com/84792/145681232-478b748f-004d-4814-b5e9-e0ba2ae49a7e.png" width="300" />
<img src="https://user-images.githubusercontent.com/84792/145681240-97c25ca0-43dd-489d-82ec-6d8d358880ce.png" width="300" />


**Description**
The coordinate frame determines how the 3d panel resolves and renders visual elements. The existing UX has frame selection in a different part of the panel than marker selection and hidden by default. This makes it non-obvious to users what steps to take to change their coordinate frame when they select different markers to visualize.
    
This change moves the coordinate frame selection into the topic tree near marker selection. The existing frame selection widget is simplified to only the three-way toggle button for selecting the camera behavior.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
