### PR TITLE
Add buttom padding to SidebarContent

### DIFF
--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -95,7 +95,7 @@ export function SidebarContent({
           <TextContent allowMarkdownHtml={true}>{helpContent}</TextContent>
         </Stack>
       ) : undefined}
-      <Stack.Item style={{ padding: noPadding ? undefined : `0px ${theme.spacing.m}` }} grow>
+      <Stack.Item style={{ padding: noPadding ? undefined : theme.spacing.m }} grow>
         {children}
       </Stack.Item>
     </Stack>


### PR DESCRIPTION
**User-Facing Changes**
Items at the bottom of sidebar content have padding under them. 

Example: the account sidebar "Sign out" button has padding under it rather than appearing at the very bottom edge of the sidebar.

**Description**
SidebarContent bottom padding was altered in https://github.com/foxglove/studio/pull/2213. This change sets the bottom padding to the same padding for top, right, left. This prevents items for appearing at the very bottom and creating a "cut-off" feeling.

Fixes #2340

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
