### PR TITLE
Refactor ImageMarker rendering

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -19,7 +19,7 @@ import ImageView, { Config } from "@foxglove/studio-base/panels/ImageView";
 import ImageCanvas from "@foxglove/studio-base/panels/ImageView/ImageCanvas";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
-import { CameraInfo, ImageMarker } from "@foxglove/studio-base/types/Messages";
+import { CameraInfo, ImageMarker, ImageMarkerType } from "@foxglove/studio-base/types/Messages";
 
 const cameraInfo: CameraInfo = {
   width: 400,
@@ -82,7 +82,7 @@ function useImageMessage() {
 }
 
 function marker(
-  type: ImageMarker["type"],
+  type: ImageMarkerType,
   props: Partial<ImageMarker> = {},
 ): MessageEvent<ImageMarker> {
   return {
@@ -130,8 +130,11 @@ const markers = [
     position: { x: 55, y: 20, z: 0 },
     scale: 5,
     outline_color: { r: 1, g: 0, b: 1, a: 1 },
+    fill_color: { r: 1, g: 0, b: 1, a: 1 },
+    filled: true,
   }),
   marker(1, {
+    scale: 1,
     points: [
       { x: 40, y: 20, z: 0 },
       { x: 40, y: 30, z: 0 },
@@ -140,22 +143,29 @@ const markers = [
     outline_color: { r: 0, g: 0, b: 1, a: 1 },
   }), // line strip
   marker(1, {
+    scale: 2,
     points: makeLines(0),
     outline_color: { r: 1, g: 1, b: 1, a: 1 },
   }), // line list
   marker(2, {
+    scale: 2,
     points: makeLines(50),
     outline_color: { r: 0.5, g: 0.5, b: 1, a: 1 },
   }), // polygon
   marker(3, {
+    scale: 2,
     points: makeLines(100),
     outline_color: { r: 0.5, g: 0.5, b: 1, a: 1 },
   }),
   marker(3, {
+    scale: 2,
     points: makeLines(150),
     outline_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    fill_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    filled: true,
   }),
   marker(3, {
+    scale: 1,
     points: [
       { x: 100, y: 20, z: 0 },
       { x: 120, y: 20, z: 0 },
@@ -163,8 +173,11 @@ const markers = [
       { x: 100, y: 30, z: 0 },
     ],
     outline_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    fill_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    filled: true,
   }),
   marker(3, {
+    scale: 1,
     points: [
       { x: 100, y: 20, z: 0 },
       { x: 120, y: 20, z: 0 },
@@ -174,6 +187,7 @@ const markers = [
     outline_color: { r: 0, g: 0, b: 0, a: 1 },
   }),
   marker(3, {
+    scale: 1,
     points: [
       { x: 150, y: 20, z: 0 },
       { x: 170, y: 20, z: 0 },
@@ -181,8 +195,11 @@ const markers = [
       { x: 150, y: 30, z: 0 },
     ],
     outline_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    fill_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
+    filled: true,
   }), // points
   marker(4, {
+    scale: 4,
     points: range(50).map((i) => ({ x: 20 + 5 * i, y: 130 + 10 * Math.sin(i / 2), z: 0 })),
     fill_color: { r: 1, g: 0, b: 0, a: 1 },
   }),
@@ -206,6 +223,20 @@ const markers = [
       a: 1,
     })),
     fill_color: { r: 0, g: 0, b: 1, a: 1 },
+  }), // text
+  marker(5, {
+    text: { data: "Hello!" },
+    position: { x: 30, y: 100, z: 0 },
+    scale: 1,
+    outline_color: { r: 1, g: 0.5, b: 0.5, a: 1 },
+  }),
+  marker(5, {
+    text: { data: "Hello!" },
+    position: { x: 130, y: 100, z: 0 },
+    scale: 1,
+    outline_color: { r: 1, g: 0.5, b: 0.5, a: 1 },
+    filled: true,
+    fill_color: { r: 50 / 255, g: 50 / 255, b: 50 / 255, a: 1 },
   }),
   marker(0, {
     position: { x: 30, y: 100, z: 0 },

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -101,8 +101,6 @@ function marker(
       fill_color: { r: 0, g: 0, b: 0, a: 0 },
       points: [],
       outline_colors: [],
-      text: { data: "" },
-      thickness: 0,
       ...props,
       type,
     },
@@ -126,17 +124,14 @@ const markers = [
   marker(0, {
     position: { x: 40, y: 20, z: 0 },
     scale: 5,
-    thickness: 2,
     outline_color: { r: 1, g: 0.5, b: 0, a: 1 },
   }),
   marker(0, {
     position: { x: 55, y: 20, z: 0 },
     scale: 5,
-    thickness: -1,
     outline_color: { r: 1, g: 0, b: 1, a: 1 },
   }),
   marker(1, {
-    thickness: 1,
     points: [
       { x: 40, y: 20, z: 0 },
       { x: 40, y: 30, z: 0 },
@@ -145,27 +140,22 @@ const markers = [
     outline_color: { r: 0, g: 0, b: 1, a: 1 },
   }), // line strip
   marker(1, {
-    thickness: 2,
     points: makeLines(0),
     outline_color: { r: 1, g: 1, b: 1, a: 1 },
   }), // line list
   marker(2, {
-    thickness: 2,
     points: makeLines(50),
     outline_color: { r: 0.5, g: 0.5, b: 1, a: 1 },
   }), // polygon
   marker(3, {
-    thickness: 2,
     points: makeLines(100),
     outline_color: { r: 0.5, g: 0.5, b: 1, a: 1 },
   }),
   marker(3, {
-    thickness: -10,
     points: makeLines(150),
     outline_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
   }),
   marker(3, {
-    thickness: -10,
     points: [
       { x: 100, y: 20, z: 0 },
       { x: 120, y: 20, z: 0 },
@@ -175,7 +165,6 @@ const markers = [
     outline_color: { r: 0.5, g: 1, b: 0.5, a: 1 },
   }),
   marker(3, {
-    thickness: 1,
     points: [
       { x: 100, y: 20, z: 0 },
       { x: 120, y: 20, z: 0 },
@@ -185,7 +174,6 @@ const markers = [
     outline_color: { r: 0, g: 0, b: 0, a: 1 },
   }),
   marker(3, {
-    thickness: -10,
     points: [
       { x: 150, y: 20, z: 0 },
       { x: 170, y: 20, z: 0 },
@@ -218,31 +206,15 @@ const markers = [
       a: 1,
     })),
     fill_color: { r: 0, g: 0, b: 1, a: 1 },
-  }), // text
-  marker(5, {
-    text: { data: "Hello!" },
-    position: { x: 30, y: 100, z: 0 },
-    scale: 1,
-    outline_color: { r: 1, g: 0.5, b: 0.5, a: 1 },
-  }),
-  marker(5, {
-    text: { data: "Hello!" },
-    position: { x: 130, y: 100, z: 0 },
-    scale: 1,
-    outline_color: { r: 1, g: 0.5, b: 0.5, a: 1 },
-    filled: true,
-    fill_color: { r: 50 / 255, g: 50 / 255, b: 50 / 255, a: 1 },
   }),
   marker(0, {
     position: { x: 30, y: 100, z: 0 },
     scale: 2,
-    thickness: -1,
     outline_color: { r: 1, g: 1, b: 0, a: 1 },
   }),
   marker(0, {
     position: { x: 130, y: 100, z: 0 },
     scale: 2,
-    thickness: -1,
     outline_color: { r: 1, g: 1, b: 0, a: 1 },
   }),
 ];

--- a/packages/studio-base/src/panels/ImageView/PinholeCameraModel.ts
+++ b/packages/studio-base/src/panels/ImageView/PinholeCameraModel.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Point, CameraInfo } from "@foxglove/studio-base/types/Messages";
+import { CameraInfo, Point2D } from "@foxglove/studio-base/types/Messages";
 
 const DISTORTION_STATE = {
   NONE: "NONE",
@@ -80,9 +80,9 @@ export default class PinholeCameraModel {
     this.K = K;
   }
 
-  unrectifyPoint({ x: rectX, y: rectY }: Point): { x: number; y: number } {
+  unrectifyPoint(point: Point2D): Point2D {
     if (this._distortionState === DISTORTION_STATE.NONE) {
-      return { x: rectX, y: rectY };
+      return point;
     }
 
     const { P, R, D, K } = this;
@@ -99,8 +99,8 @@ export default class PinholeCameraModel {
     // x <- (u - c'x) / f'x
     // y <- (v - c'y) / f'y
     // c'x, f'x, etc. (primed) come from "new camera matrix" P[0:3, 0:3].
-    const x1 = (rectX - cx - tx) / fx;
-    const y1 = (rectY - cy - ty) / fy;
+    const x1 = (point.x - cx - tx) / fx;
+    const y1 = (point.y - cy - ty) / fy;
     // [X Y W]^T <- R^-1 * [x y 1]^T
     const X = R[0]! * x1 + R[1]! * y1 + R[2]!;
     const Y = R[3]! * x1 + R[4]! * y1 + R[5]!;

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -405,13 +405,17 @@ function paintMarker(
     case ImageMarkerType.TEXT: {
       // TEXT (our own extension on visualization_msgs/Marker)
       const { x, y } = maybeUnrectifyPoint(cameraModel, marker.position);
+      const text = marker.text?.data ?? "";
+      if (!text) {
+        break;
+      }
 
       const fontSize = marker.scale * 12;
       const padding = 4 * marker.scale;
       ctx.font = `${fontSize}px sans-serif`;
       ctx.textBaseline = "bottom";
       if (marker.filled) {
-        const metrics = ctx.measureText(marker.text.data);
+        const metrics = ctx.measureText(text);
         const height =
           "fontBoundingBoxAscent" in metrics
             ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
@@ -420,7 +424,7 @@ function paintMarker(
         ctx.fillRect(x, y - height, Math.ceil(metrics.width + 2 * padding), Math.ceil(height));
       }
       ctx.fillStyle = toRGBA(marker.outline_color);
-      ctx.fillText(marker.text.data, x + padding, y);
+      ctx.fillText(text, x + padding, y);
       break;
     }
 

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -16,9 +16,10 @@ import {
   Image,
   ImageMarker,
   Color,
-  Point,
   CompressedImage,
   ImageMarkerArray,
+  ImageMarkerType,
+  Point2D,
 } from "@foxglove/studio-base/types/Messages";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
@@ -112,15 +113,8 @@ function toRGBA(color: Color) {
   return `rgba(${color.r * 255}, ${color.g * 255}, ${color.b * 255}, ${color.a})`;
 }
 
-// Note: Return type is inexact -- may contain z.
-function maybeUnrectifyPoint(
-  cameraModel: PinholeCameraModel | undefined,
-  point: Point,
-): Readonly<{ x: number; y: number }> {
-  if (cameraModel) {
-    return cameraModel.unrectifyPoint(point);
-  }
-  return point;
+function maybeUnrectifyPoint(cameraModel: PinholeCameraModel | undefined, point: Point2D): Point2D {
+  return cameraModel?.unrectifyPoint(point) ?? point;
 }
 
 // Potentially performance-sensitive; await can be expensive
@@ -312,117 +306,168 @@ function paintMarker(
   cameraModel: PinholeCameraModel | undefined,
 ) {
   switch (marker.type) {
-    case 0: {
-      // CIRCLE
-      ctx.beginPath();
-      const { x, y } = maybeUnrectifyPoint(cameraModel, marker.position);
-      ctx.arc(x, y, marker.scale, 0, 2 * Math.PI);
-      if (marker.thickness <= 0) {
-        ctx.fillStyle = toRGBA(marker.outline_color);
-        ctx.fill();
-      } else {
-        ctx.lineWidth = marker.thickness;
-        ctx.strokeStyle = toRGBA(marker.outline_color);
-        ctx.stroke();
-      }
+    case ImageMarkerType.CIRCLE: {
+      paintCircle(
+        ctx,
+        marker.position,
+        marker.scale,
+        1.0,
+        marker.outline_color,
+        marker.filled ? marker.fill_color : undefined,
+        cameraModel,
+      );
       break;
     }
 
-    // LINE_LIST
-    case 2:
+    case ImageMarkerType.LINE_LIST: {
       if (marker.points.length % 2 !== 0) {
+        sendNotification(
+          `ImageMarker LINE_LIST has an odd number of points`,
+          `LINE_LIST marker "${marker.ns}$${marker.ns ? ":" : ""}${marker.id}" has ${
+            marker.points.length
+          } point${marker.points.length !== 1 ? "s" : ""}, expected an even number`,
+          "user",
+          "error",
+        );
         break;
       }
 
-      ctx.strokeStyle = toRGBA(marker.outline_color);
-      ctx.lineWidth = marker.thickness;
+      const hasExactColors = marker.outline_colors.length === marker.points.length / 2;
 
       for (let i = 0; i < marker.points.length; i += 2) {
-        const { x: x1, y: y1 } = maybeUnrectifyPoint(cameraModel, marker.points[i] as Point);
-        const { x: x2, y: y2 } = maybeUnrectifyPoint(cameraModel, marker.points[i + 1] as Point);
-        ctx.beginPath();
-        ctx.moveTo(x1, y1);
-        ctx.lineTo(x2, y2);
-        ctx.stroke();
+        // Support the case where outline_colors is half the length of points,
+        // one color per line, and where outline_colors matches the length of
+        // points (although we only use the first color in this case). Fall back
+        // to marker.outline_color as needed
+        const outlineColor = hasExactColors
+          ? marker.outline_colors[i / 2]!
+          : marker.outline_colors.length > i
+          ? marker.outline_colors[i]!
+          : marker.outline_color;
+        paintLine(
+          ctx,
+          marker.points[i]!,
+          marker.points[i + 1]!,
+          marker.scale,
+          outlineColor,
+          cameraModel,
+        );
       }
 
       break;
+    }
 
-    // LINE_STRIP, POLYGON
-    case 1:
-    case 3: {
+    case ImageMarkerType.LINE_STRIP:
+    case ImageMarkerType.POLYGON: {
       if (marker.points.length === 0) {
         break;
       }
       ctx.beginPath();
-      const { x, y } = maybeUnrectifyPoint(cameraModel, marker.points[0] as Point);
+      const { x, y } = maybeUnrectifyPoint(cameraModel, marker.points[0]!);
       ctx.moveTo(x, y);
       for (let i = 1; i < marker.points.length; i++) {
-        const maybeUnrectifiedPoint = maybeUnrectifyPoint(cameraModel, marker.points[i] as Point);
+        const maybeUnrectifiedPoint = maybeUnrectifyPoint(cameraModel, marker.points[i]!);
         ctx.lineTo(maybeUnrectifiedPoint.x, maybeUnrectifiedPoint.y);
       }
-      if (marker.type === 3) {
+      if (marker.type === ImageMarkerType.POLYGON) {
         ctx.closePath();
+        if (marker.filled && marker.fill_color.a > 0) {
+          ctx.fillStyle = toRGBA(marker.fill_color);
+          ctx.fill();
+        }
       }
-      if (marker.thickness <= 0) {
-        ctx.fillStyle = toRGBA(marker.outline_color);
-        ctx.fill();
-      } else {
+      if (marker.outline_color.a > 0 && marker.scale > 0) {
         ctx.strokeStyle = toRGBA(marker.outline_color);
-        ctx.lineWidth = marker.thickness;
+        ctx.lineWidth = marker.scale;
         ctx.stroke();
       }
       break;
     }
 
-    case 4: {
-      // POINTS
-      if (marker.points.length === 0) {
-        break;
-      }
-
-      const size = marker.scale !== 0 ? marker.scale : 4;
-      if (marker.outline_colors.length === marker.points.length) {
-        for (let i = 0; i < marker.points.length; i++) {
-          const { x, y } = maybeUnrectifyPoint(cameraModel, marker.points[i] as Point);
-          ctx.fillStyle = toRGBA(marker.outline_colors[i] as Color);
-          ctx.beginPath();
-          ctx.arc(x, y, size, 0, 2 * Math.PI);
-          ctx.fill();
-        }
-      } else {
-        ctx.beginPath();
-        for (let i = 0; i < marker.points.length; i++) {
-          const { x, y } = maybeUnrectifyPoint(cameraModel, marker.points[i] as Point);
-          ctx.arc(x, y, size, 0, 2 * Math.PI);
-          ctx.closePath();
-        }
-        ctx.fillStyle = toRGBA(marker.fill_color);
-        ctx.fill();
+    case ImageMarkerType.POINTS: {
+      for (let i = 0; i < marker.points.length; i++) {
+        const point = marker.points[i]!;
+        // This is not a typo. ImageMarker has an array for outline_colors but
+        // not fill_colors, even though points are filled and not outlined. We
+        // only fall back to fill_color if both outline_colors[i] and
+        // outline_color are fully transparent
+        const fillColor =
+          marker.outline_colors.length > i
+            ? marker.outline_colors[i]!
+            : marker.outline_color.a > 0
+            ? marker.outline_color
+            : marker.fill_color;
+        paintCircle(ctx, point, marker.scale, marker.scale, undefined, fillColor, cameraModel);
       }
       break;
     }
 
-    case 5: {
-      // TEXT (our own extension on visualization_msgs/Marker)
-      const { x, y } = maybeUnrectifyPoint(cameraModel, marker.position);
-
-      const fontSize = marker.scale * 12;
-      const padding = 4 * marker.scale;
-      ctx.font = `${fontSize}px sans-serif`;
-      ctx.textBaseline = "bottom";
-      if (marker.filled) {
-        const metrics = ctx.measureText(marker.text.data);
-        const height = fontSize * 1.2; // Chrome doesn't yet support height in TextMetrics
-        ctx.fillStyle = toRGBA(marker.fill_color);
-        ctx.fillRect(x, y - height, Math.ceil(metrics.width + 2 * padding), Math.ceil(height));
-      }
-      ctx.fillStyle = toRGBA(marker.outline_color);
-      ctx.fillText(marker.text.data, x + padding, y);
-      break;
+    default: {
+      sendNotification(
+        `Unrecognized ImageMarker type ${marker.type}`,
+        `Marker "${marker.ns}$${marker.ns ? ":" : ""}${marker.id}" has an unrecognized type ${
+          marker.type
+        }`,
+        "user",
+        "error",
+      );
     }
+  }
+}
 
-    default:
-      console.warn("unrecognized image marker type", marker);
+function paintLine(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  pointA: Point2D,
+  pointB: Point2D,
+  thickness: number,
+  outlineColor: Color,
+  cameraModel: PinholeCameraModel | undefined,
+) {
+  if (thickness <= 0 || outlineColor.a <= 0) {
+    return;
+  }
+
+  const { x: x1, y: y1 } = maybeUnrectifyPoint(cameraModel, pointA);
+  const { x: x2, y: y2 } = maybeUnrectifyPoint(cameraModel, pointB);
+
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+
+  ctx.lineWidth = thickness;
+  ctx.strokeStyle = toRGBA(outlineColor);
+  ctx.stroke();
+}
+
+function paintCircle(
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  point: Point2D,
+  radius: number,
+  thickness: number,
+  outlineColor: Color | undefined,
+  fillColor: Color | undefined,
+  cameraModel: PinholeCameraModel | undefined,
+) {
+  // perf-sensitive: function params instead of options object to avoid allocations
+  const hasFill = fillColor != undefined && fillColor.a > 0;
+  const hasStroke = outlineColor != undefined && outlineColor.a > 0 && thickness > 0;
+
+  if (radius <= 0 || (!hasFill && !hasStroke)) {
+    return;
+  }
+
+  const { x, y } = maybeUnrectifyPoint(cameraModel, point);
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, 2 * Math.PI);
+
+  if (hasFill) {
+    ctx.fillStyle = toRGBA(fillColor);
+    ctx.fill();
+  }
+
+  if (hasStroke) {
+    ctx.lineWidth = thickness;
+    ctx.strokeStyle = toRGBA(outlineColor);
+    ctx.stroke();
   }
 }

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -402,6 +402,28 @@ function paintMarker(
       break;
     }
 
+    case ImageMarkerType.TEXT: {
+      // TEXT (our own extension on visualization_msgs/Marker)
+      const { x, y } = maybeUnrectifyPoint(cameraModel, marker.position);
+
+      const fontSize = marker.scale * 12;
+      const padding = 4 * marker.scale;
+      ctx.font = `${fontSize}px sans-serif`;
+      ctx.textBaseline = "bottom";
+      if (marker.filled) {
+        const metrics = ctx.measureText(marker.text.data);
+        const height =
+          "fontBoundingBoxAscent" in metrics
+            ? metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent
+            : fontSize * 1.2;
+        ctx.fillStyle = toRGBA(marker.fill_color);
+        ctx.fillRect(x, y - height, Math.ceil(metrics.width + 2 * padding), Math.ceil(height));
+      }
+      ctx.fillStyle = toRGBA(marker.outline_color);
+      ctx.fillText(marker.text.data, x + padding, y);
+      break;
+    }
+
     default: {
       sendNotification(
         `Unrecognized ImageMarker type ${marker.type}`,

--- a/packages/studio-base/src/panels/ImageView/util.test.ts
+++ b/packages/studio-base/src/panels/ImageView/util.test.ts
@@ -59,11 +59,7 @@ describe("ImageView", () => {
           allCameraNamespaces,
           ["visualization_msgs/ImageMarker", "vision_msgs/ImageMarker"],
         ),
-      ).toEqual([
-        "/old/some_camera_topic/marker3",
-        "/some_camera_topic/marker1",
-        "/some_camera_topic/marker2",
-      ]);
+      ).toEqual(["/some_camera_topic/marker1", "/some_camera_topic/marker2"]);
     });
   });
 

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -52,7 +52,7 @@ export function getMarkerOptions(
   for (const { name, datatype } of topics) {
     if (
       cameraNamespace &&
-      (name.startsWith(cameraNamespace) || name.startsWith(`/old${cameraNamespace}`)) &&
+      name.startsWith(cameraNamespace + "/") &&
       imageMarkerDatatypes.includes(datatype)
     ) {
       results.push(name);

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -29,6 +29,12 @@ export type MutablePoint = {
 export type Point = Readonly<MutablePoint>;
 type Points = readonly Point[];
 
+export type MutablePoint2D = {
+  x: number;
+  y: number;
+};
+export type Point2D = Readonly<MutablePoint2D>;
+
 export type Header = Readonly<{
   frame_id: string;
   stamp: Time;
@@ -373,12 +379,25 @@ export type TF = Readonly<
   }
 >;
 
+export enum ImageMarkerType {
+  CIRCLE = 0,
+  LINE_STRIP = 1,
+  LINE_LIST = 2,
+  POLYGON = 3,
+  POINTS = 4,
+}
+
+export enum ImageMarkerAction {
+  ADD = 0,
+  REMOVE = 1,
+}
+
 export type ImageMarker = Readonly<{
   header: Header;
   ns: string;
   id: number;
-  type: 0 | 1 | 2 | 3 | 4 | 5;
-  action: 0 | 1;
+  type: ImageMarkerType;
+  action: ImageMarkerAction;
   position: Point;
   scale: number;
   outline_color: Color;
@@ -387,8 +406,6 @@ export type ImageMarker = Readonly<{
   lifetime: Duration;
   points: Points;
   outline_colors: Colors;
-  text: { data: string };
-  thickness: number;
 }>;
 
 export type ImageMarkerArray = Readonly<{

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -411,7 +411,7 @@ export type ImageMarker = Readonly<{
   outline_colors: Colors;
   // `text` is not part of visualization_msgs/ImageMarker, but we include it to
   // support existing frameworks that have extended this message definition
-  text: { data: string };
+  text?: { data: string };
 }>;
 
 export type ImageMarkerArray = Readonly<{

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -385,6 +385,9 @@ export enum ImageMarkerType {
   LINE_LIST = 2,
   POLYGON = 3,
   POINTS = 4,
+  // TEXT is not part of visualization_msgs/ImageMarker, but we include it to
+  // support existing frameworks that have extended this message definition
+  TEXT = 5,
 }
 
 export enum ImageMarkerAction {
@@ -406,6 +409,9 @@ export type ImageMarker = Readonly<{
   lifetime: Duration;
   points: Points;
   outline_colors: Colors;
+  // `text` is not part of visualization_msgs/ImageMarker, but we include it to
+  // support existing frameworks that have extended this message definition
+  text: { data: string };
 }>;
 
 export type ImageMarkerArray = Readonly<{


### PR DESCRIPTION
**User-facing changes**

Several improvements to `ImageMarker` handling:
- Remove proprietary `thickness` attribute from ImageMarker
- Support outline_colors for LINE_LIST
- Support both outlines and fill colors whenever possible
- Observe the `filled` attribute

**Description**

Only a limited number of image marker use cases were previously supported. Part of the issue was a lack of reference implementation since image markers are not supported by rviz. Another issue was the webviz proprietary attribute `thickness`, which always evaluated to undefined since there is no thickness field in `visualization_msgs/ImageMarker`. There is some amount of creative intrepretation in how scale, fill_color, and outline_color(s) are used for the different marker types but overall the approach is to be as forgiving as possible since image markers are poorly documented and not rendered by any other (known) application

<img width="1396" alt="Screen Shot 2021-12-12 at 6 00 24 PM" src="https://user-images.githubusercontent.com/195374/145741089-ce245298-ab82-4f1c-8e69-5a6e71f9e6c9.png">