### PR TITLE
Add new flag to disable URL state synchronization.

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -41,6 +41,7 @@ type AppProps = {
   availableSources: IDataSourceFactory[];
   demoBagUrl?: string;
   deepLinks?: string[];
+  disableUrlStateSynchronization?: boolean;
 };
 
 function AppContent(props: AppProps): JSX.Element {
@@ -74,6 +75,7 @@ function AppContent(props: AppProps): JSX.Element {
               loadWelcomeLayout={props.loadWelcomeLayout}
               demoBagUrl={props.demoBagUrl}
               deepLinks={props.deepLinks}
+              disableUrlStateSynchronization={props.disableUrlStateSynchronization ?? false}
             />
           </PanelCatalogProvider>
         </Suspense>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -144,6 +144,7 @@ type WorkspaceProps = {
   loadWelcomeLayout?: boolean;
   demoBagUrl?: string;
   deepLinks?: string[];
+  disableUrlStateSynchronization?: boolean;
 };
 
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
@@ -464,7 +465,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           <div className={classes.dropzone}>Drop a file here</div>
         </DropOverlay>
       </DocumentDropListener>
-      <URLStateSyncAdapter deepLinks={props.deepLinks ?? []} />
+      {props.disableUrlStateSynchronization !== true && (
+        <URLStateSyncAdapter deepLinks={props.deepLinks ?? []} />
+      )}
       <div className={classes.container} ref={containerRef} tabIndex={0}>
         <Sidebar
           items={sidebarItems}


### PR DESCRIPTION
**User-Facing Changes**
This makes it possible to opt-put of the new URL state synchronization feature.

**Description**
This adds a new `disableUrlStateSynchronization` flag on the App component to completely disable URL state synchronization.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2356 