### PR TITLE
Style tweaks to connection sidebar based on feedback

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -429,15 +429,22 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           title="Data sources"
           helpContent={connectionHelpContent}
           trailingItems={[
-            <IconButton
-              key="add-connection"
-              iconProps={{ iconName: "Add" }}
-              styles={{ icon: { height: 20 } }}
-              onClick={() => {
-                setShowOpenDialog(true);
-              }}
-            />,
-          ]}
+            enableOpenDialog === true && (
+              <IconButton
+                key="add-connection"
+                iconProps={{ iconName: "Add" }}
+                styles={{
+                  icon: {
+                    svg: { height: "1em", width: "1em" },
+                    "> span": { display: "flex" },
+                  },
+                }}
+                onClick={() => {
+                  setShowOpenDialog(true);
+                }}
+              />
+            ),
+          ].filter(Boolean)}
         >
           <ConnectionList />
         </SidebarContent>
@@ -482,7 +489,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           ],
         ])
       : SIDEBAR_ITEMS;
-  }, [playerProblems, supportsAccountSettings, currentUser]);
+  }, [playerProblems, supportsAccountSettings, currentUser, enableOpenDialog]);
 
   const sidebarBottomItems: readonly SidebarItemKey[] = useMemo(() => {
     return supportsAccountSettings ? ["help", "account", "preferences"] : ["help", "preferences"];

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -432,6 +432,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
             <IconButton
               key="add-connection"
               iconProps={{ iconName: "Add" }}
+              styles={{ icon: { height: 20 } }}
               onClick={() => {
                 setShowOpenDialog(true);
               }}
@@ -481,7 +482,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           ],
         ])
       : SIDEBAR_ITEMS;
-  }, [supportsAccountSettings, playerProblems, currentUser]);
+  }, [playerProblems, supportsAccountSettings, currentUser]);
 
   const sidebarBottomItems: readonly SidebarItemKey[] = useMemo(() => {
     return supportsAccountSettings ? ["help", "account", "preferences"] : ["help", "preferences"];

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -426,7 +426,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     function Connection() {
       return (
         <SidebarContent
-          title="Data Sources"
+          title="Data sources"
           helpContent={connectionHelpContent}
           trailingItems={[
             <IconButton
@@ -443,20 +443,19 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       );
     }
 
-    const connectionItem: SidebarItem = {
-      iconName: "DataManagementSettings",
-      title: "Connection",
-      component: Connection,
-    };
-
-    if (playerProblems && playerProblems.length > 0) {
-      connectionItem.badge = {
-        count: playerProblems.length,
-      };
-    }
-
     const SIDEBAR_ITEMS = new Map<SidebarItemKey, SidebarItem>([
-      ["connection", connectionItem],
+      [
+        "connection",
+        {
+          iconName: "DataManagementSettings",
+          title: "Data sources",
+          component: Connection,
+          badge:
+            playerProblems && playerProblems.length > 0
+              ? { count: playerProblems.length }
+              : undefined,
+        },
+      ],
       ["layouts", { iconName: "FiveTileGrid", title: "Layouts", component: LayoutBrowser }],
       ["add-panel", { iconName: "RectangularClipping", title: "Add panel", component: AddPanel }],
       [

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -10,7 +10,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Link, makeStyles, Stack, Text, useTheme } from "@fluentui/react";
+import { Link, IconButton, makeStyles, Stack, Text, useTheme } from "@fluentui/react";
 import { extname } from "path";
 import {
   useState,
@@ -425,12 +425,20 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const sidebarItems = useMemo<Map<SidebarItemKey, SidebarItem>>(() => {
     function Connection() {
       return (
-        <SidebarContent title="Data Sources" helpContent={connectionHelpContent}>
-          <ConnectionList
-            onOpen={() => {
-              setShowOpenDialog(true);
-            }}
-          />
+        <SidebarContent
+          title="Data Sources"
+          helpContent={connectionHelpContent}
+          trailingItems={[
+            <IconButton
+              key="add-connection"
+              iconProps={{ iconName: "Add" }}
+              onClick={() => {
+                setShowOpenDialog(true);
+              }}
+            />,
+          ]}
+        >
+          <ConnectionList />
         </SidebarContent>
       );
     }

--- a/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
@@ -54,7 +54,7 @@ function DataSourceInfo(): JSX.Element {
     >
       <Stack horizontal verticalAlign="center">
         <Stack grow tokens={{ childrenGap: theme.spacing.s2 }}>
-          <Text styles={subheaderStyles}>Current Connection</Text>
+          <Text styles={subheaderStyles}>Current data source</Text>
           <Text styles={{ root: { color: theme.palette.neutralSecondary } }}>
             {playerName ?? "Select a data source"}
           </Text>
@@ -67,7 +67,7 @@ function DataSourceInfo(): JSX.Element {
           <Timestamp time={startTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
-            Waiting for data…
+            00:00:00
           </Text>
         )}
       </Stack>
@@ -78,7 +78,7 @@ function DataSourceInfo(): JSX.Element {
           <Timestamp time={endTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
-            Waiting for data…
+            00:00:00
           </Text>
         )}
       </Stack>
@@ -94,9 +94,7 @@ function DataSourceInfo(): JSX.Element {
             },
           }}
         >
-          {startTime && endTime
-            ? formatDuration(subtractTimes(endTime, startTime))
-            : "Waiting for data…"}
+          {startTime && endTime ? formatDuration(subtractTimes(endTime, startTime)) : "00:00:00"}
         </Text>
       </Stack>
     </Stack>

--- a/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
@@ -55,7 +55,9 @@ function DataSourceInfo(): JSX.Element {
       <Stack horizontal verticalAlign="center">
         <Stack grow tokens={{ childrenGap: theme.spacing.s2 }}>
           <Text styles={subheaderStyles}>Current Connection</Text>
-          <Text styles={{ root: { color: theme.palette.neutralSecondary } }}>{playerName}</Text>
+          <Text styles={{ root: { color: theme.palette.neutralSecondary } }}>
+            {playerName ?? "Select a data source"}
+          </Text>
         </Stack>
       </Stack>
 
@@ -64,13 +66,21 @@ function DataSourceInfo(): JSX.Element {
         {startTime ? (
           <Timestamp time={startTime} />
         ) : (
-          <Text variant="small">Waiting for data…</Text>
+          <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
+            Waiting for data…
+          </Text>
         )}
       </Stack>
 
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>End time</Text>
-        {endTime ? <Timestamp time={endTime} /> : <Text variant="small">Waiting for data…</Text>}
+        {endTime ? (
+          <Timestamp time={endTime} />
+        ) : (
+          <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
+            Waiting for data…
+          </Text>
+        )}
       </Stack>
 
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
@@ -79,7 +89,7 @@ function DataSourceInfo(): JSX.Element {
           variant="small"
           styles={{
             root: {
-              fontFamily: fonts.MONOSPACE,
+              fontFamily: startTime && endTime ? fonts.MONOSPACE : undefined,
               color: theme.palette.neutralSecondary,
             },
           }}

--- a/packages/studio-base/src/components/ConnectionList/index.tsx
+++ b/packages/studio-base/src/components/ConnectionList/index.tsx
@@ -2,15 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import {
-  ActionButton,
-  DefaultButton,
-  Icon,
-  makeStyles,
-  Stack,
-  Text,
-  useTheme,
-} from "@fluentui/react";
+import { ActionButton, Icon, makeStyles, Text, useTheme } from "@fluentui/react";
 import { useCallback, useContext, useMemo } from "react";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -55,12 +47,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-type Props = {
-  onOpen?: () => void;
-};
-
-export default function ConnectionList(props: Props): JSX.Element {
-  const { onOpen } = props;
+export default function ConnectionList(): JSX.Element {
   const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
   const { selectSource, availableSources } = usePlayerSelection();
   const confirm = useConfirm();
@@ -173,12 +160,7 @@ export default function ConnectionList(props: Props): JSX.Element {
   return (
     <>
       {sourcesListElements}
-      {enableOpenDialog === true && (
-        <Stack tokens={{ childrenGap: theme.spacing.m }}>
-          <DefaultButton onClick={onOpen}>Open new data source</DefaultButton>
-          <DataSourceInfo />
-        </Stack>
-      )}
+      {enableOpenDialog === true && <DataSourceInfo />}
       {playerProblems.length > 0 && <hr className={classes.divider} />}
       {playerProblems.map((problem, idx) => {
         const iconName = problem.severity === "error" ? "Error" : "Warning";

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -1,15 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import {
-  DefaultButton,
-  IconBase,
-  IconButton,
-  Spinner,
-  Stack,
-  Toggle,
-  useTheme,
-} from "@fluentui/react";
+import { DefaultButton, IconButton, Spinner, Stack, Toggle, useTheme } from "@fluentui/react";
 import { partition } from "lodash";
 import moment from "moment";
 import path from "path";
@@ -361,6 +353,7 @@ export default function LayoutBrowser({
 
   const createLayoutTooltip = useTooltip({ contents: "Create new layout" });
   const importLayoutTooltip = useTooltip({ contents: "Import layout" });
+  const offlineTooltip = useTooltip({ contents: "Offline" });
 
   const layoutDebug = useContext(LayoutStorageDebuggingContext);
   const supportsSignIn = useContext(ConsoleApiContext) != undefined;
@@ -379,10 +372,22 @@ export default function LayoutBrowser({
       trailingItems={[
         (layouts.loading || isBusy) && <Spinner key="spinner" />,
         !isOnline && (
-          <IconBase
-            iconName="CloudOffFilled"
-            styles={{ root: { color: theme.palette.themeLighterAlt } }}
-          />
+          <IconButton
+            key="offline"
+            checked
+            elementRef={offlineTooltip.ref}
+            iconProps={{ iconName: "CloudOffFilled" }}
+            styles={{
+              rootChecked: { backgroundColor: "transparent" },
+              rootCheckedHovered: { backgroundColor: "transparent" },
+              icon: {
+                color: theme.semanticColors.disabledBodyText,
+                svg: { fill: "currentColor", height: "1em", width: "1em" },
+              },
+            }}
+          >
+            {offlineTooltip.tooltip}
+          </IconButton>
         ),
         <IconButton
           key="add-layout"
@@ -392,8 +397,10 @@ export default function LayoutBrowser({
           ariaLabel="Create new layout"
           data-test="add-layout"
           styles={{
-            icon: { height: 20 },
-            root: { margin: `0 ${theme.spacing.s2}` },
+            icon: {
+              svg: { height: "1em", width: "1em" },
+              "> span": { display: "flex" },
+            },
           }}
         >
           {createLayoutTooltip.tooltip}
@@ -405,8 +412,10 @@ export default function LayoutBrowser({
           onClick={importLayout}
           ariaLabel="Import layout"
           styles={{
-            icon: { height: 20 },
-            root: { marginRight: theme.spacing.s1 },
+            icon: {
+              svg: { height: "1em", width: "1em" },
+              "> span": { display: "flex" },
+            },
           }}
         >
           {importLayoutTooltip.tooltip}

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -420,7 +420,7 @@ export default function LayoutBrowser({
         >
           {importLayoutTooltip.tooltip}
         </IconButton>,
-      ]}
+      ].filter(Boolean)}
     >
       {unsavedChangesPrompt}
       <Stack verticalFill>

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -2,17 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Stack, Text, useTheme, mergeStyleSets } from "@fluentui/react";
-import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
-import HelpCircleIcon from "@mdi/svg/svg/help-circle.svg";
+import { IconButton, Stack, Text, useTheme } from "@fluentui/react";
 import { useState, useMemo } from "react";
 
-import Icon from "@foxglove/studio-base/components/Icon";
 import TextContent from "@foxglove/studio-base/components/TextContent";
-
-const styles = mergeStyleSets({
-  icon: { fontSize: 14, margin: "0 0.2em" },
-});
+import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 
 export function SidebarContent({
   noPadding = false,
@@ -33,20 +27,35 @@ export function SidebarContent({
 }>): JSX.Element {
   const theme = useTheme();
   const [showHelp, setShowHelp] = useState<boolean>(false);
+  const button = useTooltip({ contents: showHelp ? "Hide help" : "Show help" });
 
   const trailingItemsWithHelp = useMemo(() => {
     if (helpContent != undefined) {
-      const IconComponent = showHelp ? HelpCircleIcon : HelpCircleOutlineIcon;
-      const tooltipText = showHelp ? "Hide help" : "Show help";
       return [
         ...(trailingItems ?? []),
-        <Icon key="icon" tooltip={tooltipText} fade onClick={() => setShowHelp(!showHelp)}>
-          <IconComponent className={styles.icon} style={{ width: "18px", height: "18px" }} />
-        </Icon>,
+        <IconButton
+          elementRef={button.ref}
+          key="help-icon"
+          iconProps={{ iconName: showHelp ? "HelpCircleFilled" : "HelpCircle" }}
+          onClick={() => setShowHelp(!showHelp)}
+          styles={{
+            icon: {
+              color: theme.semanticColors.bodySubtext,
+
+              svg: {
+                fill: "currentColor",
+                height: "1em",
+                width: "1em",
+              },
+            },
+          }}
+        >
+          {button.tooltip}
+        </IconButton>,
       ];
     }
     return trailingItems ?? [];
-  }, [showHelp, helpContent, trailingItems]);
+  }, [helpContent, trailingItems, button, showHelp, theme]);
 
   return (
     <Stack
@@ -65,7 +74,12 @@ export function SidebarContent({
         horizontal
         horizontalAlign="space-between"
         verticalAlign="center"
-        style={{ padding: theme.spacing.m }}
+        tokens={{ padding: theme.spacing.m }}
+        styles={{
+          root: {
+            minHeight: 56,
+          },
+        }}
       >
         {leadingItems && (
           <Stack horizontal verticalAlign="center">
@@ -88,14 +102,16 @@ export function SidebarContent({
         ) : undefined}
       </Stack>
       {showHelp ? (
-        <Stack style={{ margin: "0px", padding: theme.spacing.m, paddingTop: "0px" }}>
+        <Stack
+          tokens={{
+            padding: `0 ${theme.spacing.m} ${theme.spacing.m} ${theme.spacing.m}`,
+          }}
+        >
           <TextContent allowMarkdownHtml={true}>{helpContent}</TextContent>
         </Stack>
       ) : undefined}
       <Stack.Item
-        style={{
-          padding: noPadding ? undefined : `0px ${theme.spacing.m} ${theme.spacing.m}`,
-        }}
+        tokens={{ padding: noPadding ? undefined : `0px ${theme.spacing.m} ${theme.spacing.m}` }}
         grow
       >
         {children}

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -75,11 +75,7 @@ export function SidebarContent({
         horizontalAlign="space-between"
         verticalAlign="center"
         tokens={{ padding: theme.spacing.m }}
-        styles={{
-          root: {
-            minHeight: 56,
-          },
-        }}
+        styles={{ root: { minHeight: 56 } }}
       >
         {leadingItems && (
           <Stack horizontal verticalAlign="center">

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -47,6 +47,7 @@ import DatabaseIcon from "@mdi/svg/svg/database.svg";
 import DragIcon from "@mdi/svg/svg/drag.svg";
 import FitToPageIcon from "@mdi/svg/svg/fit-to-page-outline.svg";
 import HelpCircleIcon from "@mdi/svg/svg/help-circle-outline.svg";
+import HelpCircleFilledIcon from "@mdi/svg/svg/help-circle.svg";
 import LayersIcon from "@mdi/svg/svg/layers.svg";
 import SearchIcon from "@mdi/svg/svg/magnify.svg";
 import MenuDownIcon from "@mdi/svg/svg/menu-down.svg";
@@ -133,6 +134,7 @@ const icons: {
   FullScreenMaximize: <FullScreenMaximize20Regular />,
   GenericScan: <Icons.GenericScanIcon />,
   HelpCircle: <HelpCircleIcon />,
+  HelpCircleFilled: <HelpCircleFilledIcon />,
   Info: <Icons.InfoIcon />,
   Layers: <LayersIcon />,
   LocationDot: <Icons.LocationDotIcon />,

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -66,6 +66,7 @@ declare global {
     | "FullScreenMaximize"
     | "GenericScan"
     | "HelpCircle"
+    | "HelpCircleFilled"
     | "Info"
     | "Layers"
     | "LocationDot"


### PR DESCRIPTION
**User-Facing Changes**
<img width="315" alt="Screen Shot 2021-12-14 at 3 34 16 pm" src="https://user-images.githubusercontent.com/924528/145933631-32508f92-7082-401e-823f-a92cbabf837f.png">


**Description**
Use plus button instead of button

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
