### PR TITLE
Add sample data source

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -31,6 +31,7 @@ import {
   McapLocalDataSourceFactory,
   useAppConfigurationValue,
   AppSetting,
+  DemoOneDataSourceFactory,
 } from "@foxglove/studio-base";
 import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 
@@ -65,6 +66,7 @@ function AppWrapper() {
       new UlogLocalDataSourceFactory(),
       new VelodyneDataSourceFactory(),
       new FoxgloveDataPlatformDataSourceFactory(),
+      new DemoOneDataSourceFactory(),
     ];
 
     if (enableMcapDataSource) {

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -31,7 +31,7 @@ import {
   McapLocalDataSourceFactory,
   useAppConfigurationValue,
   AppSetting,
-  DemoOneDataSourceFactory,
+  SampleUdacityDataSourceFactory,
 } from "@foxglove/studio-base";
 import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 
@@ -66,7 +66,7 @@ function AppWrapper() {
       new UlogLocalDataSourceFactory(),
       new VelodyneDataSourceFactory(),
       new FoxgloveDataPlatformDataSourceFactory(),
-      new DemoOneDataSourceFactory(),
+      new SampleUdacityDataSourceFactory(),
     ];
 
     if (enableMcapDataSource) {

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -193,19 +193,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   // when the user wants to select a new connection we track whether the sidebar item opened
   const userSelectSidebarItem = useRef(false);
 
-  const selectSidebarItem = useCallback(
-    (item: SidebarItemKey | undefined) => {
-      userSelectSidebarItem.current = true;
-      setSelectedSidebarItem(item);
-
-      // When activating the connection sidebar and no player is present we automatically trigger
-      // the open dialog.
-      if (item === "connection" && !isPlayerPresent) {
-        setShowOpenDialog(true);
-      }
-    },
-    [isPlayerPresent],
-  );
+  const selectSidebarItem = useCallback((item: SidebarItemKey | undefined) => {
+    userSelectSidebarItem.current = true;
+    setSelectedSidebarItem(item);
+  }, []);
 
   // When a player is activated, hide the open dialog. When a player is gone, show the open dialog.
   useLayoutEffect(() => {

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -193,10 +193,24 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   // when the user wants to select a new connection we track whether the sidebar item opened
   const userSelectSidebarItem = useRef(false);
 
-  const selectSidebarItem = useCallback((item: SidebarItemKey | undefined) => {
-    userSelectSidebarItem.current = true;
-    setSelectedSidebarItem(item);
-  }, []);
+  const selectSidebarItem = useCallback(
+    (item: SidebarItemKey | undefined) => {
+      userSelectSidebarItem.current = true;
+      setSelectedSidebarItem(item);
+
+      // When activating the connection sidebar and no player is present we automatically trigger
+      // the open dialog.
+      if (item === "connection" && !isPlayerPresent) {
+        setShowOpenDialog(true);
+      }
+    },
+    [isPlayerPresent],
+  );
+
+  // When a player is activated, hide the open dialog. When a player is gone, show the open dialog.
+  useLayoutEffect(() => {
+    setShowOpenDialog(!isPlayerPresent);
+  }, [isPlayerPresent]);
 
   // Automatically close the connection sidebar when a connection is chosen
   useLayoutEffect(() => {
@@ -214,15 +228,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       setSelectedSidebarItem(undefined);
     }
   }, [selectedSidebarItem, playerPresence, enableOpenDialog]);
-
-  // When activating the connection sidebar and no player is present we automatically trigger
-  // the open dialog.
-  useLayoutEffect(() => {
-    if (selectedSidebarItem === "connection" && !isPlayerPresent) {
-      setShowOpenDialog(true);
-      return;
-    }
-  }, [isPlayerPresent, selectedSidebarItem]);
 
   const isMounted = useMountedState();
 

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -4,10 +4,7 @@
 
 import { Dialog, Stack, useTheme } from "@fluentui/react";
 import { useCallback, useMemo, useState } from "react";
-import { useMountedState } from "react-use";
 
-import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 
 import Connection from "./Connection";
@@ -24,18 +21,14 @@ type OpenDialogProps = {
 export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   const { activeView: defaultActiveView, onDismiss } = props;
   const { availableSources, selectSource } = usePlayerSelection();
-  const layoutStorage = useLayoutManager();
-  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
   const [activeView, setActiveView] = useState<OpenDialogViews>(defaultActiveView ?? "start");
   const theme = useTheme();
 
   const openFile = useOpenFile(availableSources);
 
-  const isMounted = useMountedState();
-
-  const firstDemoSource = useMemo(() => {
-    return availableSources.find((source) => source.type === "demo");
+  const firstSampleSource = useMemo(() => {
+    return availableSources.find((source) => source.type === "sample");
   }, [availableSources]);
 
   const onSelectView = useCallback(
@@ -47,28 +40,13 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
         return;
       }
 
-      if (view === "demo" && firstDemoSource && firstDemoSource.layout) {
-        layoutStorage
-          .saveNewLayout({
-            name: firstDemoSource.displayName,
-            data: firstDemoSource.layout,
-            permission: "CREATOR_WRITE",
-          })
-          .then((newLayout) => {
-            if (!isMounted()) {
-              return;
-            }
-            setSelectedLayoutId(newLayout.id);
-            selectSource(firstDemoSource.id);
-          })
-          .catch((err) => {
-            throw err;
-          });
+      if (view === "demo" && firstSampleSource) {
+        selectSource(firstSampleSource.id);
       }
 
       setActiveView(view);
     },
-    [firstDemoSource, isMounted, layoutStorage, openFile, selectSource, setSelectedLayoutId],
+    [firstSampleSource, openFile, selectSource],
   );
 
   const allExtensions = useMemo(() => {

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -4,7 +4,10 @@
 
 import { Dialog, Stack, useTheme } from "@fluentui/react";
 import { useCallback, useMemo, useState } from "react";
+import { useMountedState } from "react-use";
 
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 
 import Connection from "./Connection";
@@ -13,16 +16,27 @@ import Start from "./Start";
 import { OpenDialogViews } from "./types";
 import { useOpenFile } from "./useOpenFile";
 
-type OpenDialogProps = { activeView?: OpenDialogViews; onDismiss?: () => void };
+type OpenDialogProps = {
+  activeView?: OpenDialogViews;
+  onDismiss?: () => void;
+};
 
 export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   const { activeView: defaultActiveView, onDismiss } = props;
-  const { availableSources } = usePlayerSelection();
+  const { availableSources, selectSource } = usePlayerSelection();
+  const layoutStorage = useLayoutManager();
+  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
   const [activeView, setActiveView] = useState<OpenDialogViews>(defaultActiveView ?? "start");
   const theme = useTheme();
 
   const openFile = useOpenFile(availableSources);
+
+  const isMounted = useMountedState();
+
+  const firstDemoSource = useMemo(() => {
+    return availableSources.find((source) => source.type === "demo");
+  }, [availableSources]);
 
   const onSelectView = useCallback(
     (view: OpenDialogViews) => {
@@ -33,9 +47,28 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
         return;
       }
 
+      if (view === "demo" && firstDemoSource && firstDemoSource.layout) {
+        layoutStorage
+          .saveNewLayout({
+            name: firstDemoSource.displayName,
+            data: firstDemoSource.layout,
+            permission: "CREATOR_WRITE",
+          })
+          .then((newLayout) => {
+            if (!isMounted()) {
+              return;
+            }
+            setSelectedLayoutId(newLayout.id);
+            selectSource(firstDemoSource.id);
+          })
+          .catch((err) => {
+            throw err;
+          });
+      }
+
       setActiveView(view);
     },
-    [openFile],
+    [firstDemoSource, isMounted, layoutStorage, openFile, selectSource, setSelectedLayoutId],
   );
 
   const allExtensions = useMemo(() => {
@@ -61,11 +94,12 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
 
   const view = useMemo(() => {
     switch (activeView) {
-      case "demo":
+      case "demo": {
         return {
-          title: "Demo",
-          component: <>Demo data coming soon</>,
+          title: "",
+          component: <></>,
         };
+      }
       case "connection":
         return {
           title: "Open new connection",
@@ -88,7 +122,6 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
             />
           ),
         };
-
       default:
         return {
           title: "Open new data source",

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -64,15 +64,13 @@ export default function Start(props: IStartProps): JSX.Element {
         iconProps: { iconName: "Flow" },
         onClick: () => onSelectView("connection"),
       },
-      /*
-    {
-      id: "demo-data",
-      children: "Explore sample data",
-      secondaryText: "New to Studio? Have a play with demo data",
-      iconProps: { iconName: "BookStar" },
-      onClick: () => onSelectView("demo"),
-    },
-    */
+      {
+        id: "demo-data",
+        children: "Explore sample data",
+        secondaryText: "New to Studio? Have a play with demo data",
+        iconProps: { iconName: "BookStar" },
+        onClick: () => onSelectView("demo"),
+      },
     ],
     [onSelectView, supportedFileExtensions],
   );

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -65,9 +65,9 @@ export default function Start(props: IStartProps): JSX.Element {
         onClick: () => onSelectView("connection"),
       },
       {
-        id: "demo-data",
+        id: "sample-data",
         children: "Explore sample data",
-        secondaryText: "New to Studio? Have a play with demo data",
+        secondaryText: "New to Studio? View some sample data",
         iconProps: { iconName: "BookStar" },
         onClick: () => onSelectView("demo"),
       },

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -209,6 +209,17 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       metricsCollector.setProperty("player", sourceId);
       setSelectedSource(() => foundSource);
 
+      // Demo sources don't need args or prompts to initialize
+      if (foundSource.type === "demo") {
+        const newPlayer = foundSource.initialize({
+          consoleApi,
+          metricsCollector,
+          unlimitedMemoryCache,
+        });
+        setBasePlayer(newPlayer);
+        return;
+      }
+
       // If args is provided we try to initialize with no prompts
       if (args) {
         try {

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -21,7 +21,7 @@ import {
   useState,
 } from "react";
 import { useToasts } from "react-toast-notifications";
-import { useAsync, useLocalStorage } from "react-use";
+import { useAsync, useLocalStorage, useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
@@ -29,7 +29,11 @@ import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { MessagePipelineProvider } from "@foxglove/studio-base/components/MessagePipeline";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
-import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  useCurrentLayoutActions,
+  useCurrentLayoutSelector,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import PlayerSelectionContext, {
   DataSourceArgs,
   IDataSourceFactory,
@@ -78,6 +82,8 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const prompt = usePrompt();
 
+  const isMounted = useMountedState();
+
   // When we implement per-data-connector UI settings we will move this into the ROS 1 Socket data
   // connector. As a workaround, we read this from our app settings and provide this to
   // initialization args for all connectors.
@@ -97,6 +103,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   // When we implement per-data-connector UI settings we will move this into the foxglove data platform source.
   const consoleApi = useContext(ConsoleApiContext);
+
+  const layoutStorage = useLayoutManager();
+  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
   const messageOrder = useCurrentLayoutSelector(
     (state) => state.selectedLayout?.data?.playbackConfig.messageOrder,
@@ -209,14 +218,34 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       metricsCollector.setProperty("player", sourceId);
       setSelectedSource(() => foundSource);
 
-      // Demo sources don't need args or prompts to initialize
-      if (foundSource.type === "demo") {
+      // Sample sources don't need args or prompts to initialize
+      if (foundSource.type === "sample") {
         const newPlayer = foundSource.initialize({
           consoleApi,
           metricsCollector,
           unlimitedMemoryCache,
         });
+
         setBasePlayer(newPlayer);
+
+        if (foundSource.sampleLayout) {
+          layoutStorage
+            .saveNewLayout({
+              name: foundSource.displayName,
+              data: foundSource.sampleLayout,
+              permission: "CREATOR_WRITE",
+            })
+            .then((newLayout) => {
+              if (!isMounted()) {
+                return;
+              }
+              setSelectedLayoutId(newLayout.id);
+            })
+            .catch((err) => {
+              addToast((err as Error).message, { appearance: "error" });
+            });
+        }
+
         return;
       }
 
@@ -380,12 +409,15 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       addRecent,
       addToast,
       consoleApi,
+      isMounted,
+      layoutStorage,
       metricsCollector,
       playerSources,
       prompt,
       removeSavedSource,
       rosHostname,
       setSavedSource,
+      setSelectedLayoutId,
       unlimitedMemoryCache,
     ],
   );

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -20,7 +20,7 @@ export type DataSourceFactoryInitializeArgs = {
   consoleApi?: ConsoleApi;
 } & Record<string, unknown>;
 
-export type DataSourceFactoryType = "file" | "remote-file" | "connection" | "demo";
+export type DataSourceFactoryType = "file" | "remote-file" | "connection" | "sample";
 
 export interface IDataSourceFactory {
   id: string;
@@ -30,7 +30,8 @@ export interface IDataSourceFactory {
   disabledReason?: string | JSX.Element;
   badgeText?: string;
   hidden?: boolean;
-  layout?: PanelsState;
+
+  sampleLayout?: PanelsState;
 
   formConfig?: {
     // Initialization args are populated with keys of the _id_ field

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -4,6 +4,7 @@
 
 import { createContext, useContext } from "react";
 
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { PromptOptions } from "@foxglove/studio-base/hooks/usePrompt";
 import { Player, PlayerMetricsCollectorInterface } from "@foxglove/studio-base/players/types";
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
@@ -19,7 +20,7 @@ export type DataSourceFactoryInitializeArgs = {
   consoleApi?: ConsoleApi;
 } & Record<string, unknown>;
 
-export type DataSourceFactoryType = "file" | "remote-file" | "connection";
+export type DataSourceFactoryType = "file" | "remote-file" | "connection" | "demo";
 
 export interface IDataSourceFactory {
   id: string;
@@ -29,6 +30,7 @@ export interface IDataSourceFactory {
   disabledReason?: string | JSX.Element;
   badgeText?: string;
   hidden?: boolean;
+  layout?: PanelsState;
 
   formConfig?: {
     // Initialization args are populated with keys of the _id_ field

--- a/packages/studio-base/src/dataSources/DemoOneDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/DemoOneDataSourceFactory.ts
@@ -1,0 +1,190 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  IDataSourceFactory,
+  DataSourceFactoryInitializeArgs,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { buildPlayerFromBagURLs } from "@foxglove/studio-base/players/buildPlayer";
+import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
+
+class DemoOneDataSourceFactory implements IDataSourceFactory {
+  id = "demo-one";
+  type: IDataSourceFactory["type"] = "demo";
+  displayName = "Demo One";
+  iconName: IDataSourceFactory["iconName"] = "FileASPX";
+  hidden = true;
+
+  layout: IDataSourceFactory["layout"] = {
+    layout: {
+      first: {
+        first: {
+          first: "ImageViewPanel!4evmpi6",
+          second: {
+            direction: "column",
+            second: "3D Panel!1ltsiud",
+            first: "3D Panel!3vhcz8n",
+            splitPercentage: 65.0190114068441,
+          },
+          direction: "column",
+          splitPercentage: 23.878437047756872,
+        },
+        second: {
+          first: {
+            first: "Plot!2srxf7j",
+            second: "StateTransitions!3v5kkkn",
+            direction: "column",
+            splitPercentage: 35.91836734693877,
+          },
+          second: {
+            first: "DiagnosticSummary!2ttktu0",
+            second: "DiagnosticStatusPanel!2yh7rts",
+            direction: "column",
+            splitPercentage: 38.13953488372094,
+          },
+          direction: "column",
+          splitPercentage: 39.436619718309856,
+        },
+        direction: "row",
+        splitPercentage: 54.556650246305416,
+      },
+      second: "onboarding.welcome!31b1ehz",
+      direction: "row",
+      splitPercentage: 64.34231378763867,
+    },
+    configById: {
+      "ImageViewPanel!4evmpi6": {
+        cameraTopic: "/image_color/compressed",
+        enabledMarkerTopics: [],
+        customMarkerTopicOptions: [],
+        scale: 0.2,
+        transformMarkers: true,
+        synchronize: false,
+        mode: "fit",
+        zoomPercentage: 31.5,
+        offset: [0, 3.3599999999999994],
+      },
+      "3D Panel!3vhcz8n": {
+        checkedKeys: ["name:Topics", "t:/velodyne_points"],
+        expandedKeys: ["name:Topics", "t:/tf"],
+        followTf: "velodyne",
+        cameraState: {
+          targetOffset: [9.800968915027243, -0.39746626592445156, 0],
+          thetaOffset: 1.5747779692579127,
+          distance: 28.670626445812008,
+          perspective: true,
+          phi: 1.2421052631578948,
+          fovy: 0.7853981633974483,
+          near: 0.01,
+          far: 5000,
+          target: [0, 0, 0],
+          targetOrientation: [0, 0, 0, 1],
+        },
+        modifiedNamespaceTopics: [],
+        pinTopics: false,
+        settingsByKey: {
+          "t:/velodyne_points": {
+            colorMode: {
+              mode: "rainbow",
+              colorField: "intensity",
+            },
+            pointShape: "circle",
+            pointSize: 2,
+          },
+        },
+        autoSyncCameraState: false,
+        autoTextBackgroundColor: true,
+      },
+      "3D Panel!1ltsiud": {
+        checkedKeys: ["t:/radar/points", "name:Topics"],
+        expandedKeys: ["name:Topics"],
+        followTf: "radar",
+        cameraState: {
+          targetOffset: [67.15015727440768, -0.347169127881074, 0],
+          thetaOffset: 1.3309876595224308,
+          distance: 180.38377740872997,
+          perspective: false,
+          phi: 1.1425294663062144,
+          fovy: 0.7853981633974483,
+          near: 0.01,
+          far: 5000,
+        },
+        modifiedNamespaceTopics: [],
+        pinTopics: false,
+        settingsByKey: {
+          "t:/radar/points": {
+            pointSize: 4,
+            pointShape: "square",
+            colorMode: {
+              mode: "flat",
+              flatColor: {
+                r: 0.2196078431372549,
+                g: 1,
+                b: 0,
+                a: 1,
+              },
+            },
+          },
+        },
+        autoSyncCameraState: false,
+        autoTextBackgroundColor: true,
+      },
+      "Plot!2srxf7j": {
+        paths: [
+          {
+            value: "/radar/tracks.tracks[:]{number==$track_id}.accel",
+            enabled: true,
+            timestampMethod: "receiveTime",
+          },
+          {
+            value: "/radar/tracks.tracks[:]{number==$track_id}.rate",
+            enabled: true,
+            timestampMethod: "receiveTime",
+          },
+        ],
+        minYValue: "",
+        maxYValue: "",
+        showLegend: false,
+        xAxisVal: "timestamp",
+      },
+      "StateTransitions!3v5kkkn": {
+        paths: [
+          {
+            value: "/radar/tracks.tracks[:]{number==$track_id}.moving",
+            timestampMethod: "receiveTime",
+          },
+          {
+            value: "/radar/tracks.tracks[:]{number==$track_id}.status",
+            timestampMethod: "receiveTime",
+          },
+        ],
+      },
+      "DiagnosticStatusPanel!2yh7rts": {
+        topicToRender: "/diagnostics",
+        collapsedSections: [],
+        selectedHardwareId: "Velodyne HDL-32E",
+        splitFraction: 0.7048054919908466,
+        selectedName: "velodyne_nodelet_manager: velodyne_packets topic status",
+      },
+    },
+    globalVariables: {
+      track_id: 34,
+    },
+    userNodes: {},
+    linkedGlobalVariables: [],
+    playbackConfig: {
+      speed: 1,
+      messageOrder: "receiveTime",
+    },
+  };
+
+  initialize(args: DataSourceFactoryInitializeArgs): ReturnType<IDataSourceFactory["initialize"]> {
+    return buildPlayerFromBagURLs([DEMO_BAG_URL], {
+      unlimitedMemoryCache: args.unlimitedMemoryCache,
+      metricsCollector: args.metricsCollector,
+    });
+  }
+}
+
+export default DemoOneDataSourceFactory;

--- a/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
@@ -9,14 +9,14 @@ import {
 import { buildPlayerFromBagURLs } from "@foxglove/studio-base/players/buildPlayer";
 import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 
-class DemoOneDataSourceFactory implements IDataSourceFactory {
-  id = "demo-one";
-  type: IDataSourceFactory["type"] = "demo";
-  displayName = "Demo One";
+class SampleUdacityDataSourceFactory implements IDataSourceFactory {
+  id = "sample-udacity";
+  type: IDataSourceFactory["type"] = "sample";
+  displayName = "Sample: Udacity";
   iconName: IDataSourceFactory["iconName"] = "FileASPX";
   hidden = true;
 
-  layout: IDataSourceFactory["layout"] = {
+  sampleLayout: IDataSourceFactory["sampleLayout"] = {
     layout: {
       first: {
         first: {
@@ -187,4 +187,4 @@ class DemoOneDataSourceFactory implements IDataSourceFactory {
   }
 }
 
-export default DemoOneDataSourceFactory;
+export default SampleUdacityDataSourceFactory;

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -62,4 +62,4 @@ export { default as RosbridgeDataSourceFactory } from "./dataSources/RosbridgeDa
 export { default as UlogLocalDataSourceFactory } from "./dataSources/UlogLocalDataSourceFactory";
 export { default as VelodyneDataSourceFactory } from "./dataSources/VelodyneDataSourceFactory";
 export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";
-export { default as DemoOneDataSourceFactory } from "./dataSources/DemoOneDataSourceFactory";
+export { default as SampleUdacityDataSourceFactory } from "./dataSources/SampleUdacityDataSourceFactory";

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -62,3 +62,4 @@ export { default as RosbridgeDataSourceFactory } from "./dataSources/RosbridgeDa
 export { default as UlogLocalDataSourceFactory } from "./dataSources/UlogLocalDataSourceFactory";
 export { default as VelodyneDataSourceFactory } from "./dataSources/VelodyneDataSourceFactory";
 export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";
+export { default as DemoOneDataSourceFactory } from "./dataSources/DemoOneDataSourceFactory";

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -26,6 +26,7 @@ import {
   WeatherSunny20Regular,
   WeatherMoon20Filled,
   CircleHalfFill20Regular,
+  BookStar24Regular,
 } from "@fluentui/react-icons";
 import * as Icons from "@fluentui/react-icons-mdl2";
 import { registerIcons, unregisterIcons } from "@fluentui/style-utilities";
@@ -88,6 +89,7 @@ const icons: {
   ArrowUpDown: <ArrowUpDownIcon />,
   Blockhead: <BlockheadIcon />,
   BlockheadFilled: <BlockheadFilledIcon />,
+  BookStar: <BookStar24Regular />,
   Braces: <Braces20Regular />,
   BracesFilled: <Braces20Filled />,
   Bug: <BugIcon />,

--- a/packages/studio-base/src/typings/fluentui.d.ts
+++ b/packages/studio-base/src/typings/fluentui.d.ts
@@ -22,6 +22,7 @@ declare global {
     | "ArrowUpDown"
     | "Blockhead"
     | "BlockheadFilled"
+    | "BookStar"
     | "Braces"
     | "BracesFilled"
     | "Bug"

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -28,6 +28,7 @@ import {
   FoxgloveWebSocketDataSourceFactory,
   UlogLocalDataSourceFactory,
   McapLocalDataSourceFactory,
+  DemoOneDataSourceFactory,
 } from "@foxglove/studio-base";
 import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 
@@ -58,6 +59,7 @@ function AppWrapper({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }) {
       new UlogLocalDataSourceFactory(),
       new VelodyneUnavailableDataSourceFactory(),
       new FoxgloveDataPlatformDataSourceFactory(),
+      new DemoOneDataSourceFactory(),
     ];
 
     if (enableMcapDataSource) {

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -28,7 +28,7 @@ import {
   FoxgloveWebSocketDataSourceFactory,
   UlogLocalDataSourceFactory,
   McapLocalDataSourceFactory,
-  DemoOneDataSourceFactory,
+  SampleUdacityDataSourceFactory,
 } from "@foxglove/studio-base";
 import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 
@@ -59,7 +59,7 @@ function AppWrapper({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }) {
       new UlogLocalDataSourceFactory(),
       new VelodyneUnavailableDataSourceFactory(),
       new FoxgloveDataPlatformDataSourceFactory(),
-      new DemoOneDataSourceFactory(),
+      new SampleUdacityDataSourceFactory(),
     ];
 
     if (enableMcapDataSource) {


### PR DESCRIPTION
**User-Facing Changes**
Part of the new Open dialog experience and not enabled by default.

A new "Explore sample data" button appears on the open dialog. When clicked it loads the sample dataset and layout.

**Description**
A sample data source provides an initialization function to create a player and a layout. When selected, the player is initialized and the layout is loaded to the workspace.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
