### PR TITLE
Add padding to bottom of sidebar content.

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
@@ -13,7 +13,7 @@ type SignInPromptProps = {
 const useStyles = makeStyles((theme) => ({
   root: {
     backgroundColor: theme.palette.themeLighterAlt,
-    position: "sticky",
+    position: "absolute",
     bottom: 0,
   },
   text: {

--- a/packages/studio-base/src/components/SidebarContent.tsx
+++ b/packages/studio-base/src/components/SidebarContent.tsx
@@ -55,6 +55,7 @@ export function SidebarContent({
         root: {
           maxHeight: "100%",
           overflow: "auto",
+          paddingBottom: "16px",
         },
       }}
       tokens={{


### PR DESCRIPTION
**User-Facing Changes**
This fixes a cosmetic issue with sidebar content.

**Description**
This adds padding to the sidebar content element.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->

Fixes #2340 

<img width="367" alt="Screen Shot 2021-12-14 at 7 54 09 AM" src="https://user-images.githubusercontent.com/93935560/146022035-2bb5d78b-90a2-4825-80d9-23409a24fa4e.png">
