### PR TITLE
WebSocket: remember subscriptions to unadvertised topics and re-subscribe when they reappear

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -248,6 +248,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
             this._resolvedSubscriptionsById.delete(subId);
             this._resolvedSubscriptionsByTopic.delete(channel.topic);
             client.unsubscribe(subId); // TODO: batch
+            this._unresolvedSubscriptions.add(channel.topic);
           }
         }
         this._channelsById.delete(id);


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where the WebSocket connection would stop displaying data if topics disappeared and re-appeared on the server.

**Description**
Fixes https://github.com/foxglove/ws-protocol/issues/23