### PR TITLE
Encode url state for foxglove websocket connections.

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -352,6 +352,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       capabilities: CAPABILITIES,
       playerId: this._id,
       problems: this._problems.problems(),
+      urlState: {
+        url: this._url,
+      },
 
       activeData: {
         messages,


### PR DESCRIPTION
**User-Facing Changes**
This fixes url state encoding for foxglove websocket connections.

**Description**
The URL state wasn't being set at all in the `FoxgloveWebSocketPlayer`. This fixes that.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2334 