### PR TITLE
Refactor pose handling for OccupancyGrid messages

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -68,6 +68,7 @@ const buildSyntheticArrowMarker = (
   header: message.header,
   type: 103,
   pose,
+  frame_locked: true,
   scale: { x: 2, y: 2, z: 0.1 },
   color: getSyntheticArrowMarkerColor(topic),
   interactionData: { topic, originalMessage: message },
@@ -591,7 +592,7 @@ export default class SceneBuilder implements MarkerProvider {
       type,
       name,
       pose: clonePose(info.origin),
-      frame_locked: true,
+      frame_locked: false,
       interactionData: { topic, originalMessage: message },
     };
 
@@ -916,7 +917,7 @@ export default class SceneBuilder implements MarkerProvider {
       case 10: // MeshMarker
       case 11: // TriangleListMarker
       case 102: // PointCloud2
-      case 103: // (unknown!)
+      case 103: // PoseStamped
       case 108: // InstanceLineListMarker
       case 110: // ColorMarker
         marker = { ...marker, pose };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -186,6 +186,12 @@ function computeMarkerPose(
   return frame.apply(emptyPose(), marker.pose, srcFrame, time);
 }
 
+function poseClone(pose: Pose): MutablePose {
+  const p = pose.position;
+  const o = pose.orientation;
+  return { position: { x: p.x, y: p.y, z: p.z }, orientation: { x: o.x, y: o.y, z: o.z, w: o.w } };
+}
+
 export default class SceneBuilder implements MarkerProvider {
   topicsByName: {
     [topicName: string]: Topic;
@@ -573,10 +579,6 @@ export default class SceneBuilder implements MarkerProvider {
     const type = 101;
     const name = `${topic}/${type}`;
 
-    // set ogrid texture & alpha based on current rviz settings
-    // in the future these will be customizable via the UI
-    const [alpha, map] = this._hooks.getOccupancyGridValues(topic);
-
     const { header, info, data } = message;
     const mappedMessage = {
       header: {
@@ -592,25 +594,16 @@ export default class SceneBuilder implements MarkerProvider {
         origin: info.origin,
       },
       data,
-      alpha,
-      map,
       type,
       name,
-      pose: emptyPose(),
+      pose: poseClone(info.origin),
+      frame_locked: true,
       interactionData: { topic, originalMessage: message },
     };
 
     // if we neeed to flatten the ogrid clone the position and change the z to match the flattenedZHeightPose
-    if (mappedMessage.info.origin.position.z === 0 && this.flattenedZHeightPose && this.flatten) {
-      const originalInfo = mappedMessage.info;
-      const originalPosition = originalInfo.origin.position;
-      mappedMessage.info = {
-        ...originalInfo,
-        origin: {
-          ...originalInfo.origin,
-          position: { ...originalPosition, z: this.flattenedZHeightPose.position.z },
-        },
-      };
+    if (mappedMessage.pose.position.z === 0 && this.flattenedZHeightPose && this.flatten) {
+      mappedMessage.pose.position.z = this.flattenedZHeightPose.position.z;
     }
     this.collectors[topic]!.addNonMarker(topic, mappedMessage as unknown as Interactive<unknown>);
   };
@@ -719,9 +712,7 @@ export default class SceneBuilder implements MarkerProvider {
       case "nav_msgs/OccupancyGrid":
       case "nav_msgs/msg/OccupancyGrid":
       case "ros.nav_msgs.OccupancyGrid":
-        // flatten btn: set empty z values to be at the same level as the flattenedZHeightPose
         this._consumeOccupancyGrid(topic, message as NavMsgs$OccupancyGrid);
-
         break;
       case "nav_msgs/Path":
       case "nav_msgs/msg/Path":
@@ -936,7 +927,9 @@ export default class SceneBuilder implements MarkerProvider {
       case 110: // ColorMarker
         marker = { ...marker, pose };
         break;
-      case 101: // OccupancyGridMessage - needs special handling
+      case 101: // OccupancyGridMessage
+        marker = { ...marker, pose };
+        break;
       case 104: // LaserScan - needs special handling
       default:
         break;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -47,7 +47,7 @@ import {
   PointCloud2,
 } from "@foxglove/studio-base/types/Messages";
 import { MarkerProvider, MarkerCollector } from "@foxglove/studio-base/types/Scene";
-import { emptyPose } from "@foxglove/studio-base/util/Pose";
+import { clonePose, emptyPose } from "@foxglove/studio-base/util/Pose";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
 
 import { ThreeDimensionalVizHooks } from "./types";
@@ -176,7 +176,7 @@ function computeMarkerPose(
   transforms: TransformTree,
   renderFrameId: string,
   currentTime: Time,
-): MutablePose | undefined {
+): Pose | undefined {
   const srcFrame = transforms.frame(marker.header.frame_id);
   const frame = transforms.frame(renderFrameId);
   if (!srcFrame || !frame) {
@@ -184,12 +184,6 @@ function computeMarkerPose(
   }
   const time = marker.frame_locked ? currentTime : marker.header.stamp;
   return frame.apply(emptyPose(), marker.pose, srcFrame, time);
-}
-
-function poseClone(pose: Pose): MutablePose {
-  const p = pose.position;
-  const o = pose.orientation;
-  return { position: { x: p.x, y: p.y, z: p.z }, orientation: { x: o.x, y: o.y, z: o.z, w: o.w } };
 }
 
 export default class SceneBuilder implements MarkerProvider {
@@ -596,7 +590,7 @@ export default class SceneBuilder implements MarkerProvider {
       data,
       type,
       name,
-      pose: poseClone(info.origin),
+      pose: clonePose(info.origin),
       frame_locked: true,
       interactionData: { topic, originalMessage: message },
     };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
@@ -6,7 +6,6 @@ import { quat, vec3 } from "gl-matrix";
 
 import { Worldview, Lines, DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
 import GridBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/GridBuilder";
-import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
 import OccupancyGrids from "./OccupancyGrids";
 
@@ -18,13 +17,12 @@ export default {
 
 function makeGrid([px, py, pz]: vec3, [ox, oy, oz, ow]: quat) {
   return {
-    pose: emptyPose(),
+    pose: { position: { x: px, y: py, z: pz }, orientation: { x: ox, y: oy, z: oz, w: ow } },
     alpha: 0.8,
     info: {
       resolution: 0.2,
       width: 10,
       height: 10,
-      origin: { position: { x: px, y: py, z: pz }, orientation: { x: ox, y: oy, z: oz, w: ow } },
     },
     data: new Int8Array(
       `

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.tsx
@@ -13,13 +13,7 @@
 
 import type REGL from "regl";
 
-import {
-  Command,
-  withPose,
-  pointToVec3,
-  defaultBlend,
-  CommonCommandProps,
-} from "@foxglove/regl-worldview";
+import { Command, withPose, defaultBlend, CommonCommandProps } from "@foxglove/regl-worldview";
 import {
   defaultMapPalette,
   TextureCache,
@@ -27,8 +21,6 @@ import {
 import { OccupancyGridMessage } from "@foxglove/studio-base/types/Messages";
 
 type Uniforms = {
-  offset: number[];
-  orientation: number[];
   width: number;
   height: number;
   resolution: number;
@@ -56,8 +48,6 @@ const occupancyGrids = (regl: REGL.Regl) => {
     precision lowp float;
 
     uniform mat4 projection, view;
-    uniform vec3 offset;
-    uniform vec4 orientation;
     uniform float width, height, resolution, alpha;
 
     attribute vec3 point;
@@ -75,11 +65,7 @@ const occupancyGrids = (regl: REGL.Regl) => {
       float planeWidth = width * resolution;
       float planeHeight = height * resolution;
 
-      // rotate the point by the ogrid orientation & scale the point by the plane vertex dimensions
-      vec3 position = rotate(point * vec3(planeWidth, planeHeight, 1.), orientation);
-
-      // move the vertex by the marker offset
-      vec3 loc = applyPose(position + offset);
+      vec3 loc = applyPose(point * vec3(planeWidth, planeHeight, 1.));
       vAlpha = alpha;
       gl_Position = projection * view * vec4(loc, 1);
     }
@@ -120,13 +106,6 @@ const occupancyGrids = (regl: REGL.Regl) => {
       // make alpha a uniform so in the future it can be controlled by topic settings
       alpha: (_context, props) => {
         return props.alpha ?? 0.5;
-      },
-      offset: (_context, props) => {
-        return pointToVec3(props.info.origin.position);
-      },
-      orientation: (_context, props) => {
-        const { x, y, z, w } = props.info.origin.orientation;
-        return [x, y, z, w];
       },
       palette: (_context: unknown, _props: OccupancyGridMessage) => {
         const palette = defaultMapPalette;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
@@ -230,8 +230,7 @@ export class CoordinateFrame {
     // perf-sensitive: function params instead of options object to avoid allocations
     if (srcFrame === this) {
       // Identity transform
-      out.position = input.position;
-      out.orientation = input.orientation;
+      copyPose(out, input);
       return out;
     } else if (srcFrame.findAncestor(this.id)) {
       // This frame is an ancestor of the source frame
@@ -388,4 +387,14 @@ function isDiffWithinDelta(timeA: Time, timeB: Time, delta: Duration): boolean {
   const diff = subtract(timeA, timeB);
   diff.sec = Math.abs(diff.sec);
   return compare(diff, delta) <= 0;
+}
+
+function copyPose(out: MutablePose, pose: Pose): void {
+  out.position.x = pose.position.x;
+  out.position.y = pose.position.y;
+  out.position.z = pose.position.z;
+  out.orientation.x = pose.orientation.x;
+  out.orientation.y = pose.orientation.y;
+  out.orientation.z = pose.orientation.z;
+  out.orientation.w = pose.orientation.w;
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
@@ -51,6 +51,11 @@ export class Transform {
     return this;
   }
 
+  /**
+   * Update position and rotation simultaneously. This is more efficient than
+   * calling setPosition and setRotation separately, since we only need to
+   * update the matrix once
+   */
   setPositionRotation(position: ReadonlyVec3, rotation: ReadonlyQuat): this {
     vec3.copy(this._position, position);
     quat.copy(this._rotation, rotation);
@@ -58,6 +63,9 @@ export class Transform {
     return this;
   }
 
+  /**
+   * Update position and rotation from a Pose object
+   */
   setPose(pose: Pose): this {
     vec3.set(this._position, pose.position.x, pose.position.y, pose.position.z);
     quat.set(
@@ -71,6 +79,9 @@ export class Transform {
     return this;
   }
 
+  /**
+   * Update position and rotation from a matrix
+   */
   setMatrix(matrix: ReadonlyMat4): this {
     mat4.copy(this._matrix, matrix);
     mat4.getTranslation(this._position, matrix);
@@ -91,6 +102,9 @@ export class Transform {
     return this;
   }
 
+  /**
+   * Copy the values in another transform into this one
+   */
   copy(other: Transform): this {
     // eslint-disable-next-line no-underscore-dangle
     vec3.copy(this._position, other._position);

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -231,7 +231,7 @@ type NavMsgs$MapMetaData = Readonly<{
 export type NavMsgs$OccupancyGrid = Readonly<{
   header: Header;
   info: NavMsgs$MapMetaData;
-  data: readonly number[];
+  data: number[] | Int8Array;
 }>;
 
 export type NavMsgs$Path = Readonly<{
@@ -243,9 +243,9 @@ export type OccupancyGridMessage = Readonly<{
   header: Header;
   name: string;
   type: 101;
-  map: "map" | "costmap";
-  alpha: number;
+  alpha?: number;
   info: NavMsgs$MapMetaData;
+  pose: MutablePose;
   data: readonly number[];
 }>;
 


### PR DESCRIPTION
**User-facing changes**

- OccupancyGrids will render in the 3D panel with the correct pose regardless of what frame you are viewing
- Transform interpolation works for `PoseStamped` visualizations in the 3D panel

**Description**

OccupancyGrid messages with a frame_id different than the currently viewed frame_id in the 3D panel were not rendering with the correct pose. This is because the OG shader was reading pose from `.info.origin` but also using applyPose, which reads the `.pose` field that is being updated per frame. This removes special transform handling for OG messages and unifies on `.pose`.

PoseStamped markers just needed `frame_locked: true`.