### PR TITLE
Add support for recent file

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -28,6 +28,9 @@ import { getTelemetrySettings } from "./telemetry";
 
 const log = Logger.getLogger(__filename);
 
+// https://github.com/electron/electron/issues/28422#issuecomment-987504138
+app.commandLine.appendSwitch("enable-experimental-web-platform-features");
+
 /**
  * Determine whether an item in argv is a file that we should try opening as a data source.
  *

--- a/packages/studio-base/src/components/OpenDialog/useOpenFile.tsx
+++ b/packages/studio-base/src/components/OpenDialog/useOpenFile.tsx
@@ -50,6 +50,6 @@ export function useOpenFile(sources: IDataSourceFactory[]): () => Promise<void> 
       throw new Error(`Cannot find source to handle ${file.name}`);
     }
 
-    selectSource(foundSource.id, { type: "file", files: [file] });
+    selectSource(foundSource.id, { type: "file", handle: fileHandle });
   }, [allExtensions, selectSource, sources]);
 }

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -69,6 +69,7 @@ type DataSourceArgsCommon = {
 type FileDataSourceArgs = DataSourceArgsCommon & {
   type: "file";
   files?: File[];
+  handle?: FileSystemFileHandle;
 };
 
 type ConnectionDataSourceArgs = DataSourceArgsCommon & {

--- a/packages/studio-base/src/util/IndexedDbRecentsStore.ts
+++ b/packages/studio-base/src/util/IndexedDbRecentsStore.ts
@@ -25,7 +25,12 @@ type RecentConnectionRecord = RecentRecordCommon & {
   extra?: Record<string, string | undefined>;
 };
 
-export type RecentRecord = RecentConnectionRecord;
+type RecentFileRecord = RecentRecordCommon & {
+  type: "file";
+  handle: FileSystemFileHandle;
+};
+
+export type RecentRecord = RecentConnectionRecord | RecentFileRecord;
 
 /**
  * IndexedDbRecentStore provides load/save operations for retrieving recent records from indexeddb
@@ -45,11 +50,8 @@ export class IndexedDbRecentsStore {
   }
 
   /** Save the recents into the store */
-  async set(_recents: RecentRecord[]): Promise<void> {
-    // Avoid storing recents until we identify issues with file handles the current code tries to
-    // store File instances which incorrectly stores the entire file in indexeddb. This clears out
-    // those entries.
-    await idbSet(this.key, [], this.store);
+  async set(recents: RecentRecord[]): Promise<void> {
+    await idbSet(this.key, recents, this.store);
   }
 
   static GenerateRecordId(): string {


### PR DESCRIPTION
**User-Facing Changes**
None. The Open Dialog is feature flagged off by default.

Within the open dialog, the list of recent sources will contain recent files when opening a single file.

**Description**
When a file is opened via the open dialog, we record an entry into recents with the FileSystemFileHandle. This entry can later be clicked to re-open the existing file.
    
On web this feature is restricted to https and may prompt the user to confirm file access before the app is able to read the file again.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
