### PR TITLE
Use a dropdown instead of a combobox for appropriate preference settings.

### DIFF
--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -5,6 +5,7 @@ import {
   Checkbox,
   ChoiceGroup,
   DirectionalHint,
+  Dropdown,
   IChoiceGroupOption,
   IComboBoxOption,
   SelectableOptionMenuItemType,
@@ -170,10 +171,9 @@ function TimeFormat(): React.ReactElement {
   ];
 
   return (
-    <VirtualizedComboBox
+    <Dropdown
       label="Timestamp format:"
       options={entries}
-      autoComplete="on"
       openOnKeyboardFocus
       selectedKey={timeFormat}
       onChange={(_event, option) => {
@@ -201,10 +201,9 @@ function LaunchDefault(): React.ReactElement {
   ];
 
   return (
-    <VirtualizedComboBox
+    <Dropdown
       label="Open links in:"
       options={entries}
-      autoComplete="on"
       openOnKeyboardFocus
       selectedKey={preference}
       onChange={(_event, option) => {


### PR DESCRIPTION
**User-Facing Changes**
This makes the `Timestamp format` and `Open links in` preference settings dropdowns instead of combo boxes.

**Description**
Since these should not accept free-form input it's more appropriate to use a constrained control like a dropdown.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2384 