### PR TITLE
WebSocket player: remove advertise capability

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -33,7 +33,7 @@ const log = Log.getLogger(__dirname);
 /** Suppress warnings about messages on unknown subscriptions if the susbscription was recently canceled. */
 const SUBSCRIPTION_WARNING_SUPPRESSION_MS = 2000;
 
-const CAPABILITIES = [PlayerCapabilities.advertise];
+const CAPABILITIES: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
 
 const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where adding a Publish panel while connected to a WebSocket data source would crash the app.

**Description**
Fixes #2386. `PlayerCapabilities.advertise` was included in the WebSocket player's capabilities but advertising is not actually supported yet.