### PR TITLE
Fix url state for data sources using RandomAccessPlayer

### DIFF
--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -33,6 +33,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      name: file.name,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
@@ -33,6 +33,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      name: file.name,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -56,6 +56,10 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      name: url,
+      urlParams: {
+        url,
+      },
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -52,6 +52,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,
         seekToTime: getSeekToTime(),
+        name: args.file.name,
       });
     }
 

--- a/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
@@ -191,6 +191,10 @@ class SampleUdacityDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      name: "Sample: Udacity",
+      urlParams: {
+        url: DEMO_BAG_URL,
+      },
     });
   }
 }

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
@@ -33,6 +33,7 @@ class UlogLocalDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      name: file.name,
     });
   }
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -67,10 +67,8 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
       return;
     }
 
-    try {
+    if (appUrlState.ds && appUrlState.dsParams) {
       selectSource(appUrlState.ds, { type: "connection", params: appUrlState.dsParams });
-    } catch (err) {
-      log.error(err);
     }
   }, [appUrlState, selectSource]);
 

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -46,12 +46,8 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
-    if (!stableUrlState || !selectedSource) {
-      return;
-    }
-
     const url = encodeAppURLState(new URL(window.location.href), {
-      ds: selectedSource.id,
+      ds: selectedSource?.id,
       layoutId,
       time: canSeek ? currentTime : undefined,
       dsParams: stableUrlState,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -307,6 +307,9 @@ export default class RosbridgePlayer implements Player {
         playerId: this._id,
         activeData: undefined,
         problems: this._problems.problems(),
+        urlState: {
+          url: this._url,
+        },
       });
     }
 

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -7,10 +7,10 @@ import { LayoutID } from "@foxglove/studio-base/index";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 export type AppURLState = {
-  ds: string;
-  dsParams: Record<string, string>;
-  layoutId: LayoutID | undefined;
-  time: Time | undefined;
+  ds?: string;
+  dsParams?: Record<string, string>;
+  layoutId?: LayoutID;
+  time?: Time;
 };
 
 /**
@@ -34,10 +34,12 @@ export function encodeAppURLState(url: URL, urlState: AppURLState): URL {
     newURL.searchParams.set("time", toRFC3339String(urlState.time));
   }
 
-  newURL.searchParams.set("ds", urlState.ds);
-  Object.entries(urlState.dsParams).forEach(([k, v]) => {
-    newURL.searchParams.set("ds." + k, v);
-  });
+  if (urlState.ds && urlState.dsParams) {
+    newURL.searchParams.set("ds", urlState.ds);
+    Object.entries(urlState.dsParams).forEach(([k, v]) => {
+      newURL.searchParams.set("ds." + k, v);
+    });
+  }
 
   newURL.searchParams.sort();
 


### PR DESCRIPTION
**User-Facing Changes**
Url state is correctly updated when using data sources which support url state. When switching to a data source that does not support url state, the data source fields are cleared.

**Description**
A recent change to remove the RandomAccessPlayerDescriptors broke url state handling which relied on a _label member of RandomAccessPlayer.
    
This is fixed by having data source factories initialize RandomAccessPlayer with appropriate options if providing a url state is important for the specific data source.
    
Update url state handling to unset data source fields if a data source does not provide state. Data sources which do not provide url state are those which cannot be restored from url state.
    
Fixes: #2397

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
