### PR TITLE
UI bug fix: Add back missing left padding on playback bar timestamp display

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -75,7 +75,7 @@ const PlaybackTimeDisplayMethod = ({
         },
         field: {
           margin: 0,
-          padding: 0,
+          padding: "0px 8px",
           whiteSpace: "nowrap",
           fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
           backgroundColor: "transparent",


### PR DESCRIPTION
**User-Facing Changes**
- Add back missing left (and right) padding on playback bar's timestamp display input field

**Description**
- Add back missing padding on playback bar's timestamp display input field

<!-- link relevant github issues -->
Resolves #2405 
<!-- add `docs` label if this PR requires documentation updates -->
