### PR TITLE
Fix access of undefined tab config

### DIFF
--- a/packages/studio-base/src/util/layout.test.ts
+++ b/packages/studio-base/src/util/layout.test.ts
@@ -28,6 +28,7 @@ import {
   moveTabBetweenTabPanels,
   reorderTabWithinTabPanel,
   getPathFromNode,
+  getParentTabPanelByPanelId,
 } from "./layout";
 
 const tabConfig = {
@@ -618,26 +619,36 @@ describe("layout", () => {
       expect(validateTabPanelConfig(undefined)).toEqual(false);
     });
   });
-});
 
-describe("getPathFromNode", () => {
-  it("should get a node based on id", () => {
-    const tree: MosaicNode<number> = {
-      direction: "row",
-      first: 1,
-      second: {
-        direction: "column",
-        first: {
+  describe("getPathFromNode", () => {
+    it("should get a node based on id", () => {
+      const tree: MosaicNode<number> = {
+        direction: "row",
+        first: 1,
+        second: {
           direction: "column",
-          first: 2,
-          second: 3,
+          first: {
+            direction: "column",
+            first: 2,
+            second: 3,
+          },
+          second: 4,
         },
-        second: 4,
-      },
-    };
-    expect(getNodeAtPath(tree, getPathFromNode(1, tree))).toEqual(1);
-    expect(getNodeAtPath(tree, getPathFromNode(2, tree))).toEqual(2);
-    expect(getNodeAtPath(tree, getPathFromNode(3, tree))).toEqual(3);
-    expect(getNodeAtPath(tree, getPathFromNode(4, tree))).toEqual(4);
+      };
+      expect(getNodeAtPath(tree, getPathFromNode(1, tree))).toEqual(1);
+      expect(getNodeAtPath(tree, getPathFromNode(2, tree))).toEqual(2);
+      expect(getNodeAtPath(tree, getPathFromNode(3, tree))).toEqual(3);
+      expect(getNodeAtPath(tree, getPathFromNode(4, tree))).toEqual(4);
+    });
+  });
+
+  describe("getParentTabPanelByPanelId", () => {
+    it("should return parent tabs by id when there is no tab config", () => {
+      const configById = {
+        "Tab!abc": {},
+      };
+      const parentTabsByPanelId = getParentTabPanelByPanelId(configById);
+      expect(parentTabsByPanelId).toEqual({});
+    });
   });
 });

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -193,8 +193,8 @@ export const getParentTabPanelByPanelId = (
 } =>
   Object.entries(savedProps).reduce((memo: Record<string, string>, [savedPanelId, savedConfig]) => {
     if (isTabPanel(savedPanelId) && savedConfig != undefined) {
-      const tabPanelConfig = savedConfig as TabPanelConfig;
-      tabPanelConfig.tabs.forEach((tab) => {
+      const tabPanelConfig = savedConfig as Partial<TabPanelConfig>;
+      tabPanelConfig.tabs?.forEach((tab) => {
         const panelIdsInTab = getLeaves(tab.layout ?? ReactNull);
         panelIdsInTab.forEach((id) => (memo[id] = savedPanelId));
       });
@@ -202,9 +202,8 @@ export const getParentTabPanelByPanelId = (
     return memo;
   }, {});
 
-const replaceMaybeTabLayoutWithNewPanelIds =
-  (panelIdMap: PanelIdMap) =>
-  ({ id, config }: { id: string; config: Partial<TabPanelConfig> }) => {
+const replaceMaybeTabLayoutWithNewPanelIds = (panelIdMap: PanelIdMap) => {
+  return ({ id, config }: { id: string; config: Partial<TabPanelConfig> }) => {
     return config.tabs
       ? {
           id,
@@ -218,6 +217,7 @@ const replaceMaybeTabLayoutWithNewPanelIds =
         }
       : { id, config };
   };
+};
 
 export const getSaveConfigsPayloadForAddedPanel = ({
   id,


### PR DESCRIPTION


**User-Facing Changes**
The app does not crash when encountering a codepath with a tab panel config missing a tabs field.

**Description**
We can't assume that a panel will always have a valid config (some older layouts or code paths accept partial configs). This fixes access on the tabs property of a tab panel config to support the property being undefined.

Fixes: #2329

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
