### PR TITLE
Use correct casing for 'WebSocket URL' in connection dialog

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -18,7 +18,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   iconName: IDataSourceFactory["iconName"] = "Flow";
 
   formConfig = {
-    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:9090" }],
+    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:8765" }],
   };
 
   promptOptions(previousValue?: string): PromptOptions {

--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -18,7 +18,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   iconName: IDataSourceFactory["iconName"] = "Flow";
 
   formConfig = {
-    fields: [{ id: "url", label: "Websocket URL", defaultValue: "ws://localhost:9090" }],
+    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:9090" }],
   };
 
   promptOptions(previousValue?: string): PromptOptions {

--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -18,7 +18,7 @@ class RosbridgeDataSourceFactory implements IDataSourceFactory {
   iconName: IDataSourceFactory["iconName"] = "Flow";
 
   formConfig = {
-    fields: [{ id: "url", label: "Websocket URL", defaultValue: "ws://localhost:9090" }],
+    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:9090" }],
   };
 
   promptOptions(previousValue?: string): PromptOptions {


### PR DESCRIPTION
**User-Facing Changes**
- Use correct casing for 'WebSocket URL' in connection dialog
- Update Foxglove WebSocket default port to 8765

Fixes: #2420