### PR TITLE
Upgrade @foxglove/regl-worldview to fix Draco compression bug

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -34,7 +34,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f",
-    "@foxglove/regl-worldview": "1.0.1",
+    "@foxglove/regl-worldview": "1.0.2",
     "@foxglove/ros1": "1.3.6",
     "@foxglove/ros2": "1.0.8",
     "@foxglove/rosbag": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,9 +2176,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@foxglove/regl-worldview@npm:1.0.1"
+"@foxglove/regl-worldview@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@foxglove/regl-worldview@npm:1.0.2"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2196,7 +2196,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: 32d3bbfc3bf94f301e20522214f5e4f28ff422da2d1ce7af58ef3f3b9d24f3f50fd9650f2df03263f9c8b0a7b741f4860afe90c05050449c7850ccd8e7c88e03
+  checksum: 47d7db42dd1e6b8128c3b8ec53d34dee6a61b74714ff40535a7913fa250b640ab6edaffa7bd7796591e549ce0d80e690644e216fdc41035b86969f9b34bb638b
   languageName: node
   linkType: hard
 
@@ -2336,7 +2336,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f"
-    "@foxglove/regl-worldview": 1.0.1
+    "@foxglove/regl-worldview": 1.0.2
     "@foxglove/ros1": 1.3.6
     "@foxglove/ros2": 1.0.8
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
Fixed errors when loading certain Draco-compressed `.glb` meshes.

**Description**
Fixes https://github.com/foxglove/studio/issues/2311 for the `motional-car01.glb` model. See https://github.com/foxglove/regl-worldview/pull/7