### PR TITLE
Forward seek plays all messages until the seek time is reached

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -56,7 +56,7 @@ export default function PlaybackControls({
   const [repeat, setRepeat] = useState(false);
   const stopAtTime = useRef<Time | undefined>(undefined);
 
-  // See comments below in ArrowRight handler for how seeking is handled
+  // See comments below in seekForwardAction for how seeking is handled
   useMessagePipeline(
     useCallback(
       (ctx) => {

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -13,12 +13,13 @@
 
 import { Stack, IButtonStyles, useTheme, StackItem, makeStyles } from "@fluentui/react";
 import { merge } from "lodash";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { compare, Time } from "@foxglove/rostime";
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import MessageOrderControls from "@foxglove/studio-base/components/MessageOrderControls";
+import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import {
   jumpSeek,
   DIRECTION,
@@ -53,11 +54,31 @@ export default function PlaybackControls({
   const theme = useTheme();
   const styles = useStyles();
   const [repeat, setRepeat] = useState(false);
+  const stopAtTime = useRef<Time | undefined>(undefined);
+
+  // See comments below in ArrowRight handler for how seeking is handled
+  useMessagePipeline(
+    useCallback(
+      (ctx) => {
+        const currentTime = ctx.playerState.activeData?.currentTime;
+        if (stopAtTime.current && currentTime && compare(currentTime, stopAtTime.current) >= 0) {
+          stopAtTime.current = undefined;
+          pause();
+        }
+      },
+      [pause],
+    ),
+  );
 
   const resumePlay = useCallback(() => {
     const { startTime: start, endTime: end, currentTime: current } = getTimeInfo();
     // if we are at the end, we need to go back to start
     if (current && end && start && compare(current, end) >= 0) {
+      // If the resume is a result of a forward seek and we are at the end, reset the stop marker
+      // to the start.
+      if (stopAtTime.current) {
+        stopAtTime.current = start;
+      }
       seek(start);
     }
     play();
@@ -68,6 +89,7 @@ export default function PlaybackControls({
   }, []);
 
   const togglePlayPause = useCallback(() => {
+    stopAtTime.current = undefined;
     if (isPlaying) {
       pause();
     } else {
@@ -75,25 +97,50 @@ export default function PlaybackControls({
     }
   }, [pause, resumePlay, isPlaying]);
 
+  const seekForwardAction = useCallback(
+    (ev?: KeyboardEvent) => {
+      const { currentTime } = getTimeInfo();
+      if (!currentTime) {
+        return;
+      }
+
+      // We implement forward seek by playing at least up to the desired seek time rather than
+      // the "jump" seek behavior of the backwards seek.
+      //
+      // Playing forward at least up to the desired seek time will play all messages to the panels
+      // which mirrors the behavior panels would expect when playing without stepping. This behavior
+      // is important for some message types which convey state information.
+      //
+      // i.e. Skipping coordinate frame messages may result in incorrectly rendered markers or
+      // missing markers altogther.
+      stopAtTime.current = jumpSeek(DIRECTION.FORWARD, currentTime, ev);
+      resumePlay();
+    },
+    [getTimeInfo, resumePlay],
+  );
+
+  const seekBackwardAction = useCallback(
+    (ev?: KeyboardEvent) => {
+      const { currentTime } = getTimeInfo();
+      if (!currentTime) {
+        return;
+      }
+      seek(jumpSeek(DIRECTION.BACKWARD, currentTime, ev));
+    },
+    [getTimeInfo, seek],
+  );
+
   const keyDownHandlers = useMemo(
     () => ({
       " ": togglePlayPause,
       ArrowLeft: (ev: KeyboardEvent) => {
-        const { currentTime } = getTimeInfo();
-        if (!currentTime) {
-          return;
-        }
-        seek(jumpSeek(DIRECTION.BACKWARD, currentTime, ev));
+        seekBackwardAction(ev);
       },
       ArrowRight: (ev: KeyboardEvent) => {
-        const { currentTime } = getTimeInfo();
-        if (!currentTime) {
-          return;
-        }
-        seek(jumpSeek(DIRECTION.FORWARD, currentTime, ev));
+        seekForwardAction(ev);
       },
     }),
-    [getTimeInfo, seek, togglePlayPause],
+    [seekBackwardAction, seekForwardAction, togglePlayPause],
   );
 
   const iconButtonStyles: IButtonStyles = {
@@ -211,11 +258,7 @@ export default function PlaybackControls({
               <HoverableIconButton
                 iconProps={{ iconName: "Previous", iconNameActive: "PreviousFilled" }}
                 onClick={() => {
-                  const { currentTime } = getTimeInfo();
-                  if (!currentTime) {
-                    return;
-                  }
-                  seek(jumpSeek(DIRECTION.BACKWARD, currentTime));
+                  seekBackwardAction();
                 }}
                 styles={merge(seekIconButttonStyles({ left: true }), iconButtonStyles)}
               />
@@ -226,11 +269,7 @@ export default function PlaybackControls({
               <HoverableIconButton
                 iconProps={{ iconName: "Next", iconNameActive: "NextFilled" }}
                 onClick={() => {
-                  const { currentTime } = getTimeInfo();
-                  if (!currentTime) {
-                    return;
-                  }
-                  seek(jumpSeek(DIRECTION.FORWARD, currentTime));
+                  seekForwardAction();
                 }}
                 styles={merge(seekIconButttonStyles({ right: true }), iconButtonStyles)}
               />


### PR DESCRIPTION

**User-Facing Changes**
Seeking (via the keyboard shortcut or the playback control button) triggers playback to start and automatically stop when the datasource time passes the desired seek location. This allows a user to repeatedly forward seek and achieve the same result with visualization as playing the datasource. This functionality impacts panels which rely on message state (i.e. coordinate frames)  for proper visualization.

**Description**
Forward seek plays forward rather than jump seek
    
Rather than jumping forward in the datasource a fixed amount, seeking forward plays the data until at least the additional amount of time has elapsed in the datasource.
    
This allows repeated forward seeking to achieve the same playback result as playing through the datasource start to finish.
    
Fixes: #2270

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
