### PR TITLE
Performance improvements

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -42,7 +42,7 @@
     "@foxglove/rosmsg": "3.0.0",
     "@foxglove/rosmsg-msgs-common": "1.0.4",
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",
-    "@foxglove/rosmsg-serialization": "1.2.3",
+    "@foxglove/rosmsg-serialization": "1.3.0",
     "@foxglove/rosmsg2-serialization": "1.0.5",
     "@foxglove/rostime": "1.1.1",
     "@foxglove/studio": "workspace:*",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.ts
@@ -16,7 +16,6 @@ import { ThreeDimensionalVizHooks } from "./types";
 const defaultHooks: ThreeDimensionalVizHooks = {
   getSyntheticArrowMarkerColor: () => ({ r: 0, g: 0, b: 1, a: 0.5 }),
   getOccupancyGridValues: (_topic) => [0.5, "map"],
-  getMarkerColor: (_topic, markerColor) => markerColor,
 };
 
 export default defaultHooks;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -33,7 +33,6 @@ import {
   MutablePose,
   Pose,
   StampedMessage,
-  MutablePoint,
   BaseMarker,
   PoseStamped,
   VelodyneScan,
@@ -102,7 +101,7 @@ const missingTransformMessage = (
   }
   const frameIds = [...error.frameIds].sort().join(`>, <`);
   const s = error.frameIds.size > 1 ? "s" : ""; // for plural
-  const msg = `missing transform${s} from frame${s} <${frameIds}> to frame <${renderFrameId}>`;
+  const msg = `Missing transform${s} from frame${s} <${frameIds}> to frame <${renderFrameId}>`;
   if (transforms.frames().size === 0) {
     return msg + ". No transforms found";
   }
@@ -239,7 +238,7 @@ export default class SceneBuilder implements MarkerProvider {
   // or because a prop affecting its rendering was changed
   topicsToRender: Set<string> = new Set();
 
-  // stored message arrays allowing used to re-render topics even when the latest
+  // stored message arrays allowing us to re-render topics even when the latest
   // frame does not not contain that topic
   lastSeenMessages: {
     [key: string]: MessageEvent<unknown>[];
@@ -480,13 +479,7 @@ export default class SceneBuilder implements MarkerProvider {
         return;
     }
 
-    const points = (message as unknown as { points: MutablePoint[] }).points;
-    const parsedPoints = points.map((p) => ({ x: p.x, y: p.y, z: p.z }));
-
-    // HACK(jacob): rather than hard-coding this, we should
-    //  (a) produce this visualization dynamically from a non-marker topic
-    //  (b) fix translucency so it looks correct (harder)
-    const color = this._hooks.getMarkerColor(topic, message.color!);
+    const color = message.color ?? { r: 0, g: 0, b: 0, a: 0 };
 
     // Allow topic settings to override marker color (see MarkerSettingsEditor.js)
     let { overrideColor } = (this._settingsByKey[`ns:${topic}:${namespace}`] ??
@@ -515,7 +508,7 @@ export default class SceneBuilder implements MarkerProvider {
     const interactionData: InteractionData = {
       topic,
       highlighted,
-      originalMessage: message as unknown as RosObject,
+      originalMessage: message as RosObject,
     };
     const lifetime = message.lifetime;
 
@@ -548,7 +541,7 @@ export default class SceneBuilder implements MarkerProvider {
       interactionData,
       color: overrideColor ?? color,
       colors: overrideColor ? [] : message.colors,
-      points: parsedPoints,
+      points: message.points,
       id: message.id,
       ns: message.ns,
       header: message.header,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -803,6 +803,16 @@ export default class SceneBuilder implements MarkerProvider {
       return;
     }
 
+    // SceneBuilder fully parses all of the messages it consumes, and sometimes
+    // repeatedly so via lastSeenMessages. All incoming lazy messages are
+    // converted into fully parsed messages here
+    for (let i = 0; i < messages.length; i++) {
+      const event = messages[i] as { message: { toJSON?: () => unknown } };
+      if ("toJSON" in event.message) {
+        (event.message as unknown) = event.message.toJSON!();
+      }
+    }
+
     this.errors.topicsMissingTransforms.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -803,16 +803,6 @@ export default class SceneBuilder implements MarkerProvider {
       return;
     }
 
-    // SceneBuilder fully parses all of the messages it consumes, and sometimes
-    // repeatedly so via lastSeenMessages. All incoming lazy messages are
-    // converted into fully parsed messages here
-    for (let i = 0; i < messages.length; i++) {
-      const event = messages[i] as { message: { toJSON?: () => unknown } };
-      if ("toJSON" in event.message) {
-        (event.message as unknown) = event.message.toJSON!();
-      }
-    }
-
     this.errors.topicsMissingTransforms.delete(topic);
     this.errors.topicsWithError.delete(topic);
     this.collectors[topic] ??= new MessageCollector();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/types.ts
@@ -14,7 +14,6 @@
 import { Color } from "@foxglove/studio-base/types/Messages";
 
 export type ThreeDimensionalVizHooks = Readonly<{
-  getMarkerColor: (arg0: string, arg1: Color) => Color;
   getOccupancyGridValues: (arg0: string) => [number, string]; // arg is topic, return value is [alpha, map].
   getSyntheticArrowMarkerColor: (arg0: string) => Color; // arg is topic
 }>;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -276,6 +276,7 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: box.size,
       color: getColor(visual, robot),
       frame_locked: true,
+      points: [],
     };
     return marker;
   }
@@ -299,6 +300,7 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: { x: sphere.radius * 2, y: sphere.radius * 2, z: sphere.radius * 2 },
       color: getColor(visual, robot),
       frame_locked: true,
+      points: [],
     };
     return marker;
   }
@@ -322,6 +324,7 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: { x: cylinder.radius * 2, y: cylinder.radius * 2, z: cylinder.length },
       color: getColor(visual, robot),
       frame_locked: true,
+      points: [],
     };
     return marker;
   }
@@ -345,6 +348,7 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: mesh.scale ?? { x: 1, y: 1, z: 1 },
       color: getColor(visual, robot),
       frame_locked: true,
+      points: [],
       mesh_resource: mesh.filename,
       mesh_use_embedded_materials: true,
     };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { getColorFromString } from "@fluentui/react";
-import { forwardRef, useMemo } from "react";
+import { forwardRef, useMemo, useRef } from "react";
 
 import {
   Worldview,
@@ -65,30 +65,11 @@ type Props = WorldSearchTextProps & {
   onMouseUp?: MouseHandler;
 };
 
-function getMarkers(markerProviders: MarkerProvider[], time: Time): InteractiveMarkersByType {
-  const markers: InteractiveMarkersByType = {
-    arrow: [],
-    color: [],
-    cube: [],
-    cubeList: [],
-    cylinder: [],
-    glText: [],
-    grid: [],
-    instancedLineList: [],
-    laserScan: [],
-    linedConvexHull: [],
-    lineList: [],
-    lineStrip: [],
-    mesh: [],
-    pointcloud: [],
-    points: [],
-    poseMarker: [],
-    sphere: [],
-    sphereList: [],
-    text: [],
-    triangleList: [],
-  };
-
+function getMarkers(
+  markers: InteractiveMarkersByType,
+  markerProviders: MarkerProvider[],
+  time: Time,
+): void {
   // These casts seem wrong - some type definitions around MarkerProvider or MarkerCollector are not
   // compatible with interactive markers. Ideally interactive markers would not require mutating
   // marker objects which would help avoid unsafe casting.
@@ -119,8 +100,6 @@ function getMarkers(markerProviders: MarkerProvider[], time: Time): InteractiveM
   for (const provider of markerProviders) {
     provider.renderMarkers(collector, time);
   }
-
-  return markers;
 }
 
 // Wrap the WorldMarkers in HoC(s)
@@ -149,7 +128,35 @@ function World(
   }: Props,
   ref: typeof Worldview,
 ) {
-  const markersByType = getMarkers(markerProviders, currentTime);
+  const markersRef = useRef<InteractiveMarkersByType | undefined>(undefined);
+  markersRef.current ??= {
+    arrow: [],
+    color: [],
+    cube: [],
+    cubeList: [],
+    cylinder: [],
+    glText: [],
+    grid: [],
+    instancedLineList: [],
+    laserScan: [],
+    linedConvexHull: [],
+    lineList: [],
+    lineStrip: [],
+    mesh: [],
+    pointcloud: [],
+    points: [],
+    poseMarker: [],
+    sphere: [],
+    sphereList: [],
+    text: [],
+    triangleList: [],
+  };
+  for (const key in markersRef.current) {
+    (markersRef.current as Record<string, unknown[]>)[key]!.length = 0;
+  }
+
+  getMarkers(markersRef.current, markerProviders, currentTime);
+  const markersByType = markersRef.current;
   const { text = [] } = markersByType;
   const processedMarkersByType = {
     ...markersByType,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -128,6 +128,8 @@ function World(
   }: Props,
   ref: typeof Worldview,
 ) {
+  // Building these arrays every frame is expensive, so we instantiate once and
+  // clear them each time to reduce allocations
   const markersRef = useRef<InteractiveMarkersByType | undefined>(undefined);
   markersRef.current ??= {
     arrow: [],

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.test.ts
@@ -61,7 +61,7 @@ describe("CoordinateFrame", () => {
     CoordinateFrame.Interpolate(outTime, outTf, lower, upper, fromSec(0.5));
     expect(outTime).toEqual({ sec: 0, nsec: 5e8 });
     expect(outTf.position()).toEqual([0.5, 0.5, 0.5]);
-    expect(outTf.rotation()).toEqual([0, 0, 0.7071067811865475, 0.7071067811865475]); // 90 degrees around z
+    expect(outTf.rotation()).toEqual([0, 0, 0.7071067811865476, 0.7071067811865476]); // 90 degrees around z
   });
 
   it("GetTransformMatrix", () => {
@@ -92,9 +92,9 @@ describe("CoordinateFrame", () => {
     );
     // prettier-ignore
     expect(out).toEqual([
-      2.220446049250313e-16, 0.9999999999999998,    0,                   0,
-      0.9999999999999998,    2.220446049250313e-16, 0,                   0,
-      0,                     0,                     -0.9999999999999996, 0,
+     -2.220446049250313e-16, 1.0000000000000002,    0,                   0,
+      1.0000000000000002,   -2.220446049250313e-16, 0,                   0,
+      0,                     0,                     -1.0000000000000004, 0,
       55,                    110,                   165,                 1,
     ]);
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/CoordinateFrame.ts
@@ -381,11 +381,13 @@ function copyTime(out: Time, time: Time): void {
 }
 
 function copyPose(out: MutablePose, pose: Pose): void {
-  out.position.x = pose.position.x;
-  out.position.y = pose.position.y;
-  out.position.z = pose.position.z;
-  out.orientation.x = pose.orientation.x;
-  out.orientation.y = pose.orientation.y;
-  out.orientation.z = pose.orientation.z;
-  out.orientation.w = pose.orientation.w;
+  const p = pose.position;
+  const o = pose.orientation;
+  out.position.x = p.x;
+  out.position.y = p.y;
+  out.position.z = p.z;
+  out.orientation.x = o.x;
+  out.orientation.y = o.y;
+  out.orientation.z = o.z;
+  out.orientation.w = o.w;
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.test.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import type { mat4 } from "gl-matrix";
+
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
 import { Transform } from "./Transform";
@@ -57,17 +59,20 @@ describe("Transform", () => {
   });
 
   it("setMatrix", () => {
+    const M: mat4 = [
+      0.03174603174603163, 0.9841269841269841, -0.17460317460317448, 0, -0.3492063492063492,
+      0.17460317460317454, 0.9206349206349207, 0, 0.9365079365079365, 0.0317460317460318,
+      0.3492063492063493, 0, 10, 20, 30, 1,
+    ];
+
     const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(4, 5, 6, 7));
-    tf.setMatrix([
-      -12199, 12400, -2200, 0, -4400, -10399, 11600, 0, 11800, 400, -8199, 0, 10, 20, 30, 1,
-    ]);
+    tf.setMatrix(M);
     expect(tf.position()).toEqual([10, 20, 30]);
     expect(tf.rotation()).toEqual([
-      0.26152369579692475, 0.2799390689932134, 0.6647845516193718, 0.3681753124784878,
+      0.3563483225498992, 0.44543540318737396, 0.5345224838248488, 0.6236095644623235,
     ]);
-    expect(tf.matrix()).toEqual([
-      -12199, 12400, -2200, 0, -4400, -10399, 11600, 0, 11800, 400, -8199, 0, 10, 20, 30, 1,
-    ]);
+    expect(tf.matrix()).not.toBe(M);
+    expect(tf.matrix()).toEqual(M);
 
     tf.setMatrix(mat4FromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1));
     expect(tf.position()).toEqual([0, 0, 0]);
@@ -79,8 +84,15 @@ describe("Transform", () => {
     const tf = Transform.Identity();
     tf.setPose({ position: { x: 1, y: 2, z: 3 }, orientation: { x: 4, y: 5, z: 6, w: 7 } });
     expect(tf.position()).toEqual([1, 2, 3]);
-    expect(tf.rotation()).toEqual([4, 5, 6, 7]);
-    expect(tf.matrix()).toEqual([-121, 124, -22, 0, -44, -103, 116, 0, 118, 4, -81, 0, 1, 2, 3, 1]);
+    expect(tf.rotation()).toEqual([
+      0.3563483225498992, 0.44543540318737396, 0.5345224838248488, 0.6236095644623235,
+    ]);
+    expect(tf.matrix()).toEqual([
+      0.03174603174603163, 0.9841269841269841, -0.17460317460317448, 0, -0.3492063492063492,
+      0.17460317460317454, 0.9206349206349207, 0, 0.9365079365079365, 0.0317460317460318,
+      0.3492063492063493, 0, 1, 2, 3, 1,
+    ]);
+    tf.setMatrix(tf.matrix());
   });
 
   it("toPose", () => {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.test.ts
@@ -18,44 +18,36 @@ describe("Transform", () => {
   });
 
   it("copy", () => {
-    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(4, 5, 6, 7));
+    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(0, 1, 0, 0));
     const tf2 = Transform.Identity();
     tf2.copy(tf);
     expect(tf2.position()).toEqual([1, 2, 3]);
-    expect(tf2.rotation()).toEqual([4, 5, 6, 7]);
-    expect(tf2.matrix()).toEqual([
-      -121, 124, -22, 0, -44, -103, 116, 0, 118, 4, -81, 0, 1, 2, 3, 1,
-    ]);
+    expect(tf2.rotation()).toEqual([0, 1, 0, 0]);
+    expect(tf2.matrix()).toEqual([-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, 1, 2, 3, 1]);
   });
 
   it("setPosition", () => {
-    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(4, 5, 6, 7));
+    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(1, 0, 0, 0));
     tf.setPosition(vec3FromValues(10, 20, 30));
     expect(tf.position()).toEqual([10, 20, 30]);
-    expect(tf.rotation()).toEqual([4, 5, 6, 7]);
-    expect(tf.matrix()).toEqual([
-      -121, 124, -22, 0, -44, -103, 116, 0, 118, 4, -81, 0, 10, 20, 30, 1,
-    ]);
+    expect(tf.rotation()).toEqual([1, 0, 0, 0]);
+    expect(tf.matrix()).toEqual([1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 10, 20, 30, 1]);
   });
 
   it("setRotation", () => {
-    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(4, 5, 6, 7));
-    tf.setRotation(quatFromValues(40, 50, 60, 70));
+    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(0, 0, 1, 0));
+    tf.setRotation(quatFromValues(0.5, 0.5, 0.5, 0.5));
     expect(tf.position()).toEqual([1, 2, 3]);
-    expect(tf.rotation()).toEqual([40, 50, 60, 70]);
-    expect(tf.matrix()).toEqual([
-      -12199, 12400, -2200, 0, -4400, -10399, 11600, 0, 11800, 400, -8199, 0, 1, 2, 3, 1,
-    ]);
+    expect(tf.rotation()).toEqual([0.5, 0.5, 0.5, 0.5]);
+    expect(tf.matrix()).toEqual([0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 2, 3, 1]);
   });
 
   it("setPositionRotation", () => {
-    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(4, 5, 6, 7));
-    tf.setPositionRotation(vec3FromValues(10, 20, 30), quatFromValues(40, 50, 60, 70));
+    const tf = new Transform(vec3FromValues(1, 2, 3), quatFromValues(0, 0, 0, 1));
+    tf.setPositionRotation(vec3FromValues(10, 20, 30), quatFromValues(1, 0, 0, 0));
     expect(tf.position()).toEqual([10, 20, 30]);
-    expect(tf.rotation()).toEqual([40, 50, 60, 70]);
-    expect(tf.matrix()).toEqual([
-      -12199, 12400, -2200, 0, -4400, -10399, 11600, 0, 11800, 400, -8199, 0, 10, 20, 30, 1,
-    ]);
+    expect(tf.rotation()).toEqual([1, 0, 0, 0]);
+    expect(tf.matrix()).toEqual([1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 10, 20, 30, 1]);
   });
 
   it("setMatrix", () => {
@@ -100,6 +92,11 @@ describe("Transform", () => {
     const pose = emptyPose();
     tf.toPose(pose);
     expect(pose.position).toEqual({ x: 1, y: 2, z: 3 });
-    expect(pose.orientation).toEqual({ x: 4, y: 5, z: 6, w: 7 });
+    expect(pose.orientation).toEqual({
+      x: 0.3563483225498992,
+      y: 0.44543540318737396,
+      z: 0.5345224838248488,
+      w: 0.6236095644623235,
+    });
   });
 });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
@@ -6,9 +6,14 @@ import { mat4, vec3, quat, ReadonlyMat4, ReadonlyVec3, ReadonlyQuat } from "gl-m
 
 import { MutablePose, Pose } from "@foxglove/studio-base/types/Messages";
 
-import { mat4Identity, quatIdentity, vec3Identity } from "./geometry";
+import {
+  approxEq,
+  getRotationNoScaling,
+  mat4Identity,
+  quatIdentity,
+  vec3Identity,
+} from "./geometry";
 
-const tempMat = mat4Identity();
 const tempScale = vec3Identity();
 
 /**
@@ -83,22 +88,15 @@ export class Transform {
    * Update position and rotation from a matrix
    */
   setMatrix(matrix: ReadonlyMat4): this {
+    // Ensure the matrix has no scaling
+    mat4.getScaling(tempScale, matrix);
+    if (!approxEq(tempScale[0], 1) || !approxEq(tempScale[1], 1) || !approxEq(tempScale[2], 1)) {
+      throw new Error(`setMatrix given a matrix with non-unit scale: ${mat4.str(matrix)}`);
+    }
+
     mat4.copy(this._matrix, matrix);
     mat4.getTranslation(this._position, matrix);
-
-    // Normalize the values in the matrix by the scale. This ensures that we get the correct rotation
-    // out even if the scale isn't 1 in each axis. The logic from this comes from the threejs
-    // implementation and an SO answer:
-    // - https://github.com/mrdoob/three.js/blob/master/src/math/Matrix4.js#L790-L815
-    // - https://math.stackexchange.com/a/1463487
-    mat4.getScaling(tempScale, matrix);
-    if (mat4.determinant(matrix) < 0) {
-      tempScale[0] *= -1;
-    }
-    vec3.inverse(tempScale, tempScale);
-    mat4.scale(tempMat, matrix, tempScale);
-
-    mat4.getRotation(this._rotation, tempMat);
+    getRotationNoScaling(this._rotation, matrix); // A faster mat4.getRotation when there is no scaling
     return this;
   }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/Transform.ts
@@ -29,6 +29,7 @@ export class Transform {
   constructor(position: vec3, rotation: quat) {
     this._position = position;
     this._rotation = rotation;
+    quat.normalize(this._rotation, this._rotation);
     this._matrix = mat4.fromRotationTranslation(mat4Identity(), this._rotation, this._position);
   }
 
@@ -51,7 +52,7 @@ export class Transform {
   }
 
   setRotation(rotation: ReadonlyQuat): this {
-    quat.copy(this._rotation, rotation);
+    quat.normalize(this._rotation, rotation);
     mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
     return this;
   }
@@ -63,7 +64,7 @@ export class Transform {
    */
   setPositionRotation(position: ReadonlyVec3, rotation: ReadonlyQuat): this {
     vec3.copy(this._position, position);
-    quat.copy(this._rotation, rotation);
+    quat.normalize(this._rotation, rotation);
     mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
     return this;
   }
@@ -80,6 +81,7 @@ export class Transform {
       pose.orientation.z,
       pose.orientation.w,
     );
+    quat.normalize(this._rotation, this._rotation);
     mat4.fromRotationTranslation(this._matrix, this._rotation, this._position);
     return this;
   }
@@ -91,7 +93,11 @@ export class Transform {
     // Ensure the matrix has no scaling
     mat4.getScaling(tempScale, matrix);
     if (!approxEq(tempScale[0], 1) || !approxEq(tempScale[1], 1) || !approxEq(tempScale[2], 1)) {
-      throw new Error(`setMatrix given a matrix with non-unit scale: ${mat4.str(matrix)}`);
+      throw new Error(
+        `setMatrix given a matrix with non-unit scale [${tempScale[0]}, ${tempScale[1]}, ${
+          tempScale[2]
+        }]: ${mat4.str(matrix)}`,
+      );
     }
 
     mat4.copy(this._matrix, matrix);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/TransformTree.test.ts
@@ -53,10 +53,10 @@ describe("TransformTree", () => {
     expect(output.position).toEqual({ x: 1, y: 2, z: 3 });
     // Exact equality is tested to ensure we are using 64-bit math
     expect(output.orientation).toEqual({
-      x: 0.24234604615919636,
-      y: 0.2784524934265757,
-      z: 0.6759817665372134,
-      w: 0.4836539488240748,
+      x: 0.1825741858350553,
+      y: 0.3651483716701106,
+      z: 0.5477225575051661,
+      w: 0.7302967433402215,
     });
   });
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/geometry.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/geometry.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import type { vec3, quat, mat4 } from "gl-matrix";
+import type { vec3, quat, mat4, ReadonlyMat4 } from "gl-matrix";
 
 // Helper functions for constructing geometry primitives that can be used with
 // gl-matrix. These methods are preferred over the gl-matrix equivalents since
@@ -87,4 +87,59 @@ export function mat4Clone(m: mat4): mat4 {
     m[14],
     m[15],
   ];
+}
+
+/**
+ * Test if two numbers are approximately equal.
+ */
+export function approxEq(v1: number, v2: number, epsilon = 0.00001): boolean {
+  return Math.abs(v1 - v2) <= epsilon;
+}
+
+/**
+ * Returns a quaternion representing the rotational component of a
+ * transformation matrix. The matrix must not have any scaling applied to it.
+ * @param out Quaternion to receive the rotation component
+ * @param mat Matrix to be decomposed (input)
+ * @param scaling Scaling of the matrix (input)
+ * @return out
+ */
+export function getRotationNoScaling(out: quat, mat: ReadonlyMat4): quat {
+  const m11 = mat[0];
+  const m12 = mat[1];
+  const m13 = mat[2];
+  const m21 = mat[4];
+  const m22 = mat[5];
+  const m23 = mat[6];
+  const m31 = mat[8];
+  const m32 = mat[9];
+  const m33 = mat[10];
+  const trace = m11 + m22 + m33;
+  let S = 0;
+  if (trace > 0) {
+    S = Math.sqrt(trace + 1.0) * 2;
+    out[3] = 0.25 * S;
+    out[0] = (m23 - m32) / S;
+    out[1] = (m31 - m13) / S;
+    out[2] = (m12 - m21) / S;
+  } else if (m11 > m22 && m11 > m33) {
+    S = Math.sqrt(1.0 + m11 - m22 - m33) * 2;
+    out[3] = (m23 - m32) / S;
+    out[0] = 0.25 * S;
+    out[1] = (m12 + m21) / S;
+    out[2] = (m31 + m13) / S;
+  } else if (m22 > m33) {
+    S = Math.sqrt(1.0 + m22 - m11 - m33) * 2;
+    out[3] = (m31 - m13) / S;
+    out[0] = (m12 + m21) / S;
+    out[1] = 0.25 * S;
+    out[2] = (m23 + m32) / S;
+  } else {
+    S = Math.sqrt(1.0 + m33 - m11 - m22) * 2;
+    out[3] = (m12 - m21) / S;
+    out[0] = (m31 + m13) / S;
+    out[1] = (m23 + m32) / S;
+    out[2] = 0.25 * S;
+  }
+  return out;
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/groupingUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/groupingUtils.ts
@@ -127,14 +127,10 @@ export function groupLinesIntoInstancedLineLists(
           // The next strip will deal with connecting it with its first point (see above).
           // By repeating the last point in the strip we ensure gradients look
           // correctly in the final rendered image.
-          allPoints.push(allPoints[allPoints.length - 1]!);
-          allPoints.push(INFINITE_POSITION);
-          allColors.push(INFINITE_COLOR);
-          allColors.push(INFINITE_COLOR);
-          poses.push(INFINITE_POSE);
-          poses.push(INFINITE_POSE);
-          metadataByIndex.push(INFINITE_METADATA);
-          metadataByIndex.push(INFINITE_METADATA);
+          allPoints.push(allPoints[allPoints.length - 1]!, INFINITE_POSITION);
+          allColors.push(INFINITE_COLOR, INFINITE_COLOR);
+          poses.push(INFINITE_POSE, INFINITE_POSE);
+          metadataByIndex.push(INFINITE_METADATA, INFINITE_METADATA);
         }
       } else {
         // If the marker is already a line list, just add the points to the list, validating that points

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/groupingUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/groupingUtils.ts
@@ -19,6 +19,8 @@ import {
   LineStripMarker,
   InstancedLineListMarker,
   Pose,
+  Point,
+  Color,
 } from "@foxglove/studio-base/types/Messages";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 import { COLORS, MARKER_MSG_TYPES } from "@foxglove/studio-base/util/globalConstants";
@@ -53,10 +55,10 @@ export function groupLinesIntoInstancedLineLists(
         depth?: REGL.DepthTestOptions;
       };
     const isLineStrip = baseMessage.type === MARKER_MSG_TYPES.LINE_STRIP;
-    const allColors = []; // accumulated colors
-    const allPoints = []; // accumulated positions
-    const metadataByIndex = [];
-    const poses = [];
+    const allColors: Color[] = []; // accumulated colors
+    const allPoints: Point[] = []; // accumulated positions
+    const metadataByIndex: Record<string, unknown>[] = [];
+    const poses: Pose[] = [];
 
     for (let messageIdx = 0; messageIdx < messageList.length; messageIdx++) {
       const message: (LineListMarker | LineStripMarker) & {
@@ -69,6 +71,7 @@ export function groupLinesIntoInstancedLineLists(
         // Ignore markers with no points
         continue;
       }
+      const firstPoint = points[0]!;
 
       if (isLineStrip) {
         // We want to keep corners joined between lines in the same strip. The <Lines>
@@ -85,7 +88,7 @@ export function groupLinesIntoInstancedLineLists(
           // If this is not the first strip, we need to add a line from infinity to the
           // first point that we want to render. By repeating the first point in the strip,
           // we also make sure gradients look correctly in the final rendered image.
-          allPoints.push(points[0]);
+          allPoints.push(firstPoint);
           allColors.push(INFINITE_COLOR);
           poses.push(INFINITE_POSE);
           metadataByIndex.push(INFINITE_METADATA);
@@ -100,22 +103,23 @@ export function groupLinesIntoInstancedLineLists(
         fillExtend(allColors, message.color ?? COLORS.WHITE, points.length - colors.length);
 
         // Accumulate poses for each points, if they're provided in the marker
-        if (message.poses && message.poses.length > 0) {
-          extend(poses, message.poses);
+        const messagePosesLength = message.poses?.length ?? 0;
+        if (messagePosesLength > 0) {
+          extend(poses, message.poses!);
         }
 
         // Accumulate metadata and poses
         fillExtend(metadataByIndex, message, points.length);
-        fillExtend(poses, message.pose, points.length - (message.poses ? message.poses.length : 0));
+        fillExtend(poses, message.pose, points.length - messagePosesLength);
 
         if (message.closed ?? false) {
           // If this is a closed marker, we need to add an extra point to generate a new line
           // from the last element to the first one. We also need to add the metadata and a pose
           // that correspond to that point.
-          allPoints.push(points[0]);
-          allColors.push(colors.length > 0 ? colors[0] : message.color ?? COLORS.WHITE);
+          allPoints.push(firstPoint);
+          allColors.push(colors[0] ?? message.color ?? COLORS.WHITE);
           metadataByIndex.push(message);
-          poses.push(message.poses ? message.poses[0] : message.pose);
+          poses.push(message.poses?.[0] ?? message.pose);
         }
 
         if (messageIdx < messageList.length - 1) {
@@ -123,10 +127,14 @@ export function groupLinesIntoInstancedLineLists(
           // The next strip will deal with connecting it with its first point (see above).
           // By repeating the last point in the strip we ensure gradients look
           // correctly in the final rendered image.
-          allPoints.push(...[allPoints[allPoints.length - 1], INFINITE_POSITION]);
-          allColors.push(...[INFINITE_COLOR, INFINITE_COLOR]);
-          poses.push(...[INFINITE_POSE, INFINITE_POSE]);
-          metadataByIndex.push(...[INFINITE_METADATA, INFINITE_METADATA]);
+          allPoints.push(allPoints[allPoints.length - 1]!);
+          allPoints.push(INFINITE_POSITION);
+          allColors.push(INFINITE_COLOR);
+          allColors.push(INFINITE_COLOR);
+          poses.push(INFINITE_POSE);
+          poses.push(INFINITE_POSE);
+          metadataByIndex.push(INFINITE_METADATA);
+          metadataByIndex.push(INFINITE_METADATA);
         }
       } else {
         // If the marker is already a line list, just add the points to the list, validating that points
@@ -189,13 +197,14 @@ export function groupLinesIntoInstancedLineLists(
 }
 
 function extend<T>(arr1: T[], arr2: readonly T[]) {
-  arr2.forEach((v) => arr1.push(v));
+  // perf-sensitive: faster than alternatives that use filling or spreading
+  for (let i = 0; i < arr2.length; i++) {
+    arr1.push(arr2[i]!);
+  }
 }
 
-// fillExtend and extend are a bit faster than alternatives that use filling or spreading to
-// achieve the same purpose, and groupPredictionMarkersIntoInstancedMarkers is a fairly heavy
-// function.
 function fillExtend<T>(arr: T[], value: T, n: number): void {
+  // perf-sensitive: faster than alternatives that use filling or spreading
   for (let i = 0; i < n; ++i) {
     arr.push(value);
   }

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
@@ -343,7 +343,7 @@ describe("MemoryCacheDataProvider", () => {
       inputMessages.map((item) => ({
         topic: item.topic,
         receiveTime: item.receiveTime,
-        message: {},
+        message: { _offset: 0, _view: new DataView(new ArrayBuffer(0)) },
         sizeInBytes: 0,
       })),
     );

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -121,6 +121,7 @@ export type BaseMarker = Readonly<
     colors?: Colors;
     lifetime?: Time;
     frame_locked: boolean;
+    points: Point[];
     text?: string;
     mesh_resource?: string; // TODO: required
     mesh_use_embedded_materials?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2276,12 +2276,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-serialization@npm:1.2.3, @foxglove/rosmsg-serialization@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@foxglove/rosmsg-serialization@npm:1.2.3"
+"@foxglove/rosmsg-serialization@npm:1.3.0, @foxglove/rosmsg-serialization@npm:^1.2.3":
+  version: 1.3.0
+  resolution: "@foxglove/rosmsg-serialization@npm:1.3.0"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
-  checksum: ff5c6ee80c898ef75a7046945ce5fa84de16a6444394324e9294c808e4a6613c68480427c7d66c04b7926703e4054dbd38d0a4c8e22bc08576e97e9c26396ca1
+  checksum: 7e5875a96607aa70dc51e0e9d605016c89f4dde23e275d382133dcd02496cb320ff82a2e9d1c8e6e6957cc9d3ad7ee6434e30d7b9930e2a67ba6de7785823fb4
   languageName: node
   linkType: hard
 
@@ -2344,7 +2344,7 @@ __metadata:
     "@foxglove/rosmsg": 3.0.0
     "@foxglove/rosmsg-msgs-common": 1.0.4
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3
-    "@foxglove/rosmsg-serialization": 1.2.3
+    "@foxglove/rosmsg-serialization": 1.3.0
     "@foxglove/rosmsg2-serialization": 1.0.5
     "@foxglove/rostime": 1.1.1
     "@foxglove/studio": "workspace:*"


### PR DESCRIPTION
**User-facing changes**

Better performance when rendering complex scenes, especially in the 3D panel

**Description**

- Bump @foxglove/rosmsg-serialization to get faster lazy messages
- Remove unused hook, don't copy marker points
- Convert all incoming messages in SceneBuilder from lazy to fully parsed
- Speed up transform math by only working with unscaled matrices
- Add `points` to BaseMarker definition
- Cache and recycle the data structure in getMarkers instead of allocating new arrays each frame
