### PR TITLE
Add WorkerRosbag2DataProvider

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -38,7 +38,7 @@
     "@foxglove/ros1": "1.3.6",
     "@foxglove/ros2": "1.0.8",
     "@foxglove/rosbag": "0.1.2",
-    "@foxglove/rosbag2-web": "3.0.4",
+    "@foxglove/rosbag2-web": "4.0.1",
     "@foxglove/rosmsg": "3.0.0",
     "@foxglove/rosmsg-msgs-common": "1.0.4",
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -9,7 +9,7 @@ import {
 import RandomAccessPlayer from "@foxglove/studio-base/players/RandomAccessPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import MemoryCacheDataProvider from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
-import Rosbag2DataProvider from "@foxglove/studio-base/randomAccessDataProviders/Rosbag2DataProvider";
+import WorkerRosbag2DataProvider from "@foxglove/studio-base/randomAccessDataProviders/WorkerRosbag2DataProvider";
 import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
 class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
@@ -22,14 +22,12 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
 
   initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     if ((args.files?.length ?? 0) > 0) {
-      const rosbag2Provider = new Rosbag2DataProvider({
-        bagPath: {
-          type: "files",
-          files: args.files ?? [],
-        },
+      const bagWorkerDataProvider = new WorkerRosbag2DataProvider({
+        type: "files",
+        files: args.files ?? [],
       });
 
-      const messageCacheProvider = new MemoryCacheDataProvider(rosbag2Provider, {
+      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider, {
         unlimitedCache: args.unlimitedMemoryCache,
       });
 
@@ -38,14 +36,12 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
         seekToTime: getSeekToTime(),
       });
     } else if (args.file) {
-      const rosbag2Provider = new Rosbag2DataProvider({
-        bagPath: {
-          type: "file",
-          file: args.file,
-        },
+      const bagWorkerDataProvider = new WorkerRosbag2DataProvider({
+        type: "file",
+        file: args.file,
       });
 
-      const messageCacheProvider = new MemoryCacheDataProvider(rosbag2Provider, {
+      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider, {
         unlimitedCache: args.unlimitedMemoryCache,
       });
 

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Time } from "@foxglove/rostime";
+import { Options } from "@foxglove/studio-base/randomAccessDataProviders/Rosbag2DataProvider";
+import Rpc from "@foxglove/studio-base/util/Rpc";
+
+import {
+  RandomAccessDataProvider,
+  InitializationResult,
+  ExtensionPoint,
+  GetMessagesResult,
+  GetMessagesTopics,
+} from "./types";
+
+const WorkerDataProviderWorker = () => {
+  return new Worker(new URL("./WorkerRosbag2DataProvider.worker", import.meta.url));
+};
+
+// A Rosbag2DataProvider that runs in a web worker
+export default class WorkerRosbag2DataProvider implements RandomAccessDataProvider {
+  private worker?: Worker;
+  private rpc?: Rpc;
+  private options: Options;
+
+  constructor(options: Options) {
+    this.options = options;
+  }
+
+  async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
+    this.worker = WorkerDataProviderWorker();
+    this.rpc = new Rpc(this.worker);
+
+    const { progressCallback, reportMetadataCallback } = extensionPoint;
+
+    type ExtensionPointParams<K> = K extends keyof ExtensionPoint
+      ? { type: K; data: Parameters<ExtensionPoint[K]>[0] }
+      : never;
+    this.rpc.receive(
+      "extensionPointCallback",
+      (value: ExtensionPointParams<keyof ExtensionPoint>) => {
+        switch (value.type) {
+          case "progressCallback":
+            progressCallback(value.data);
+            break;
+          case "reportMetadataCallback":
+            reportMetadataCallback(value.data);
+            break;
+          default:
+            throw new Error(
+              `Unsupported extension point type in WorkerRosbag2DataProvider: ${
+                (value as ExtensionPointParams<keyof ExtensionPoint>).type
+              }`,
+            );
+        }
+        return undefined;
+      },
+    );
+
+    return await this.rpc.send("initialize", this.options);
+  }
+
+  async getMessages(start: Time, end: Time, topics: GetMessagesTopics): Promise<GetMessagesResult> {
+    if (!this.rpc) {
+      throw new Error("WorkerRosbag2DataProvider not initialized");
+    }
+
+    if (topics.rosBinaryMessages) {
+      throw new Error("WorkerRosbag2DataProvider only supports parsed messages");
+    }
+
+    const rpcRes = await this.rpc.send<{ messages: GetMessagesResult["parsedMessages"] }>(
+      "getMessages",
+      {
+        start,
+        end,
+        topics: topics.parsedMessages,
+      },
+    );
+    return {
+      rosBinaryMessages: undefined,
+      parsedMessages: rpcRes.messages,
+    };
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.rpc?.send("close");
+    } finally {
+      this.worker?.terminate();
+    }
+  }
+}

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.worker.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.worker.ts
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Time } from "@foxglove/rostime";
+import Rosbag2DataProvider, {
+  Options,
+} from "@foxglove/studio-base/randomAccessDataProviders/Rosbag2DataProvider";
+import {
+  RandomAccessDataProvider,
+  RandomAccessDataProviderMetadata,
+  GetMessagesTopics,
+} from "@foxglove/studio-base/randomAccessDataProviders/types";
+import Rpc, { Channel } from "@foxglove/studio-base/util/Rpc";
+import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
+import { inWebWorker } from "@foxglove/studio-base/util/workers";
+
+if (inWebWorker()) {
+  // not yet using TS Worker lib: FG-64
+  const rpc = new Rpc(global as unknown as Channel);
+
+  setupWorker(rpc);
+  let provider: RandomAccessDataProvider;
+  rpc.receive("initialize", async (options: Options) => {
+    provider = new Rosbag2DataProvider(options);
+    return await provider.initialize({
+      progressCallback: (data) => {
+        void rpc.send("extensionPointCallback", { type: "progressCallback", data });
+      },
+      reportMetadataCallback: (data: RandomAccessDataProviderMetadata) => {
+        void rpc.send("extensionPointCallback", { type: "reportMetadataCallback", data });
+      },
+    });
+  });
+  rpc.receive(
+    "getMessages",
+    async ({
+      start,
+      end,
+      topics,
+    }: {
+      start: Time;
+      end: Time;
+      topics: GetMessagesTopics["parsedMessages"];
+    }) => {
+      const messages = await provider.getMessages(start, end, { parsedMessages: topics });
+      return { messages: messages.parsedMessages };
+    },
+  );
+
+  rpc.receive("close", async () => await provider.close());
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,25 +2224,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosbag2-web@npm:3.0.4":
-  version: 3.0.4
-  resolution: "@foxglove/rosbag2-web@npm:3.0.4"
+"@foxglove/rosbag2-web@npm:4.0.1":
+  version: 4.0.1
+  resolution: "@foxglove/rosbag2-web@npm:4.0.1"
   dependencies:
-    "@foxglove/rosbag2": ^3.0.1
-    sql.js: ^1.6.2
-  checksum: 897717ab972f662864d021d6ecd679d09f374c6ca1da915ebc6a820ab66865db7d334a72dc6794d4e44e44eec8c5673b53861864701ed1653b7abfa07823a8b4
+    "@foxglove/rosbag2": ^4.0.0
+    "@foxglove/sql.js": ^0.0.3
+  checksum: 05c8d762f48df05c82dad4c76cf2f2edb0ec1a2fd8a7ede545af5b679676e171083e3d371dd2f48b97811cda9db12d24167cbb65ac1ca6b804f4360dd950564a
   languageName: node
   linkType: hard
 
-"@foxglove/rosbag2@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@foxglove/rosbag2@npm:3.0.1"
+"@foxglove/rosbag2@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@foxglove/rosbag2@npm:4.0.0"
   dependencies:
     "@foxglove/rosmsg-msgs-common": ^1.0.4
     "@foxglove/rosmsg2-serialization": ^1.0.5
     "@foxglove/rostime": ^1.1.1
     js-yaml: ^4.1.0
-  checksum: 3ce7fc4c87430cb3bc0568662ec200d1f9ee03327078d1ccfdb23942befd7e6aa5cf65d6ea267ffa8627bab8fe78f6631cff74f78860b1c757d4642583ac079b
+  checksum: 805e49a01e0b5d1ab3fde662c16bcffb4067e7085f17d590d55cd9ee7bb36677aefaa9f62a01e80dbe968f6289437535826875b9e566b820d828bbad321fc20a
   languageName: node
   linkType: hard
 
@@ -2324,6 +2324,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/sql.js@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@foxglove/sql.js@npm:0.0.3"
+  checksum: d027186b1dd10c6e3e09f74888748c01a59f93337a2b774a66facae755367ffd71f3616e1e25ab95adc4eedf74154d20c298f9a8618721051a9caa38615f82d4
+  languageName: node
+  linkType: hard
+
 "@foxglove/studio-base@workspace:*, @foxglove/studio-base@workspace:packages/studio-base":
   version: 0.0.0-use.local
   resolution: "@foxglove/studio-base@workspace:packages/studio-base"
@@ -2340,7 +2347,7 @@ __metadata:
     "@foxglove/ros1": 1.3.6
     "@foxglove/ros2": 1.0.8
     "@foxglove/rosbag": 0.1.2
-    "@foxglove/rosbag2-web": 3.0.4
+    "@foxglove/rosbag2-web": 4.0.1
     "@foxglove/rosmsg": 3.0.0
     "@foxglove/rosmsg-msgs-common": 1.0.4
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3
@@ -21637,13 +21644,6 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
-  languageName: node
-  linkType: hard
-
-"sql.js@npm:^1.6.2":
-  version: 1.6.2
-  resolution: "sql.js@npm:1.6.2"
-  checksum: 880a98527be7a62f1c25099192b0760a105ea0ac634b78293d9bd46244209f9e96329974316ad98cbdf2ba3f7c8db167588139c31d9f7dfed2a779eb05da2809
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

**User-Facing Changes**
Users are able to load and visualize rosbag2 .db3 files >2GB

**Description**
The WorkerRosbag2DataProvider reads rosbag2 .db3 files in a web worker. This leverlages @foxglove/sql.js capabilities to read arbitrary size files without loading them into memory. This capability is only present in workers.

Fixes: #1957


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
