### PR TITLE
Remove ds.url from SampleUdacityDataSourceFactory

### DIFF
--- a/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
@@ -192,9 +192,8 @@ class SampleUdacityDataSourceFactory implements IDataSourceFactory {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
       name: "Sample: Udacity",
-      urlParams: {
-        url: DEMO_BAG_URL,
-      },
+      // Use blank url params so the udacity data source is set in the url
+      urlParams: {},
     });
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
None unless Open Dialog flag is on.

When selecting a sample data source, the url will no longer show the data source url param since it cannot be changed for sample sources.

**Description**
The url can't be changed for the sample udacity data source, so we avoid showing it in the url state.

Fixes: #2419

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
