### PR TITLE
Fix default value for FoxgloveWebsocketDataSourceFactory

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -18,7 +18,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   iconName: IDataSourceFactory["iconName"] = "Flow";
 
   formConfig = {
-    fields: [{ id: "url", label: "Websocket URL", defaultValue: "ws://localhost:9090" }],
+    fields: [{ id: "url", label: "Websocket URL", defaultValue: "ws://localhost:8765" }],
   };
 
   promptOptions(previousValue?: string): PromptOptions {


### PR DESCRIPTION
**User-Facing Changes**
None unless Open Dialog is enabled

When connecting to Foxglove Websocket, the default value suggests port 8765.

**Description**
The default value for Websocket url should use port 8765 to match our example servers.

Fixes: #2420

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
