### PR TITLE
Improve language for disabled data sources

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -58,7 +58,11 @@ export default function Connection(props: ConnectionProps): JSX.Element {
   }, [selectedSource, fieldValues, selectSource]);
 
   return (
-    <View onBack={onBack} onCancel={onCancel} onOpen={onOpen}>
+    <View
+      onBack={onBack}
+      onCancel={onCancel}
+      onOpen={selectedSource?.disabledReason == undefined ? onOpen : undefined}
+    >
       <Stack grow verticalFill horizontal tokens={{ childrenGap: theme.spacing.l2 }}>
         <Stack
           verticalFill
@@ -86,13 +90,12 @@ export default function Connection(props: ConnectionProps): JSX.Element {
           })}
         </Stack>
         <Stack grow verticalFill key={selectedSource?.id} tokens={{ childrenGap: theme.spacing.m }}>
-          {selectedSource?.disabledReason}
           {selectedSource?.formConfig != undefined && (
             <Stack grow verticalAlign="space-between">
               <Stack tokens={{ childrenGap: theme.spacing.m }}>
-                {selectedSource?.disabledReason}
                 {selectedSource?.formConfig.fields.map((field) => (
                   <TextField
+                    disabled={selectedSource?.disabledReason != undefined}
                     key={field.label}
                     label={field.label}
                     placeholder={field.placeholder}
@@ -110,6 +113,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
               </Stack>
             </Stack>
           )}
+          {selectedSource?.disabledReason}
         </Stack>
       </Stack>
     </View>

--- a/packages/studio-base/src/components/OpenDialog/View.tsx
+++ b/packages/studio-base/src/components/OpenDialog/View.tsx
@@ -8,7 +8,7 @@ import { PropsWithChildren } from "react";
 type ViewProps = {
   onBack?: () => void;
   onCancel?: () => void;
-  onOpen: () => void;
+  onOpen?: () => void;
 };
 
 export default function View(props: PropsWithChildren<ViewProps>): JSX.Element {
@@ -36,7 +36,9 @@ export default function View(props: PropsWithChildren<ViewProps>): JSX.Element {
         </ActionButton>
         <Stack horizontal tokens={{ childrenGap: theme.spacing.m }}>
           <DefaultButton onClick={onCancel}>Cancel</DefaultButton>
-          <PrimaryButton onClick={onOpen}>Open</PrimaryButton>
+          <PrimaryButton onClick={onOpen} disabled={onOpen == undefined}>
+            Open
+          </PrimaryButton>
         </Stack>
       </Stack>
     </Stack>

--- a/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
@@ -4,33 +4,24 @@
 
 import { Link, Text } from "@fluentui/react";
 
-import { IDataSourceFactory } from "@foxglove/studio-base";
+import { IDataSourceFactory, Ros1SocketDataSourceFactory } from "@foxglove/studio-base";
 
-export default class Ros1UnavailableDataSourceFactory implements IDataSourceFactory {
-  displayName = "ROS 1";
-  id = "ros1-socket";
-  type: IDataSourceFactory["type"] = "connection";
-  iconName: IDataSourceFactory["iconName"] = "studio.ROS";
-
+class Ros1UnavailableDataSourceFactory extends Ros1SocketDataSourceFactory {
   disabledReason = (
     <>
       <Text block as="p">
-        Native ROS 1 connections are only available in our desktop app.&nbsp;
+        ROS 1 connections require TCP sockets, which are not available in a web browser.{" "}
         <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
-          Download it here.
-        </Link>
-      </Text>
-      <Text
-        block
-        as="p"
-        styles={(_props, theme) => ({ root: { color: theme.semanticColors.disabledText } })}
-      >
-        Native TCP and UDP sockets are not available in a standard browser environment.
+          Download our desktop app
+        </Link>{" "}
+        to connect to a ROS 1 system.
       </Text>
     </>
   );
 
-  initialize(): ReturnType<IDataSourceFactory["initialize"]> {
+  override initialize(): ReturnType<IDataSourceFactory["initialize"]> {
     return;
   }
 }
+
+export default Ros1UnavailableDataSourceFactory;

--- a/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
@@ -4,33 +4,22 @@
 
 import { Link, Text } from "@fluentui/react";
 
-import { IDataSourceFactory } from "@foxglove/studio-base";
+import { IDataSourceFactory, Ros2SocketDataSourceFactory } from "@foxglove/studio-base";
 
-export default class Ros2UnavailableDataSourceFactory implements IDataSourceFactory {
-  displayName = "ROS 2";
-  id = "ros2-socket";
-  type: IDataSourceFactory["type"] = "connection";
-  iconName: IDataSourceFactory["iconName"] = "studio.ROS";
-
+export default class Ros2UnavailableDataSourceFactory extends Ros2SocketDataSourceFactory {
   disabledReason = (
     <>
       <Text block as="p">
-        Native ROS 2 connections are only available in our desktop app.&nbsp;
+        ROS 2 connections require UDP sockets, which are not available in a web browser.{" "}
         <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
-          Download it here.
-        </Link>
-      </Text>
-      <Text
-        block
-        as="p"
-        styles={(_props, theme) => ({ root: { color: theme.semanticColors.disabledText } })}
-      >
-        Native TCP and UDP sockets are not available in a standard browser environment.
+          Download our desktop app
+        </Link>{" "}
+        to connect to a ROS 2 system.
       </Text>
     </>
   );
 
-  initialize(): ReturnType<IDataSourceFactory["initialize"]> {
+  override initialize(): ReturnType<IDataSourceFactory["initialize"]> {
     return;
   }
 }

--- a/web/src/dataSources/VelodyneUnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/VelodyneUnavailableDataSourceFactory.tsx
@@ -4,33 +4,22 @@
 
 import { Link, Text } from "@fluentui/react";
 
-import { IDataSourceFactory } from "@foxglove/studio-base";
+import { IDataSourceFactory, VelodyneDataSourceFactory } from "@foxglove/studio-base";
 
-export default class VelodyneUnavailableDataSourceFactory implements IDataSourceFactory {
-  id = "velodyne-device";
-  displayName = "Velodyne LIDAR";
-  type: IDataSourceFactory["type"] = "connection";
-  iconName: IDataSourceFactory["iconName"] = "GenericScan";
-
+export default class VelodyneUnavailableDataSourceFactory extends VelodyneDataSourceFactory {
   disabledReason = (
     <>
       <Text block as="p">
-        Velodyne connections are only available in our desktop app.&nbsp;
+        Velodyne connections require UDP sockets, which are not available in a web browser.{" "}
         <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
-          Download it here.
-        </Link>
-      </Text>
-      <Text
-        block
-        as="p"
-        styles={(_props, theme) => ({ root: { color: theme.semanticColors.disabledText } })}
-      >
-        Native TCP and UDP sockets are not available in a standard browser environment.
+          Download our desktop app
+        </Link>{" "}
+        to connect to a Velodyne sensor.
       </Text>
     </>
   );
 
-  initialize(): ReturnType<IDataSourceFactory["initialize"]> {
+  override initialize(): ReturnType<IDataSourceFactory["initialize"]> {
     return;
   }
 }


### PR DESCRIPTION


**User-Facing Changes**
None unless Open Dialog feature flag is on.

Disabled data sources show the form fields disabled and a helpful message explaining why the data source cannot be used.

**Description**
Some data sources are not available on web. For those data sources we disable the form fields and display a message to the user explaining why the data source is not available.

Fixes: #2421

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
