### PR TITLE
Fix drag&drop when Open Dialog is open

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -514,6 +514,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         /* eslint-enable react/jsx-key */
       ]}
     >
+      {enableOpenDialog === true && showOpenDialog && (
+        <OpenDialog onDismiss={() => setShowOpenDialog(false)} />
+      )}
       <DocumentDropListener filesSelected={dropHandler} allowedExtensions={allowedDropExtensions}>
         <DropOverlay>
           <div className={classes.dropzone}>Drop a file here</div>
@@ -546,9 +549,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           </RemountOnValueChange>
         </Sidebar>
       </div>
-      {enableOpenDialog === true && showOpenDialog && (
-        <OpenDialog onDismiss={() => setShowOpenDialog(false)} />
-      )}
     </MultiProvider>
   );
 }

--- a/packages/studio-base/src/components/DocumentDropListener.tsx
+++ b/packages/studio-base/src/components/DocumentDropListener.tsx
@@ -11,11 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Layer } from "@fluentui/react";
 import { extname } from "path";
 import { useCallback, useLayoutEffect, useState } from "react";
 import { useToasts } from "react-toast-notifications";
-
-import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledComponents";
 
 type Props = {
   children: React.ReactNode; // Shown when dragging in a file.
@@ -146,7 +145,7 @@ export default function DocumentDropListener(props: Props): JSX.Element {
 
   return (
     <>
-      <LegacyInput // Expose a hidden input for Puppeteer to use to drop a file in.
+      <input // Expose a hidden input for Puppeteer to use to drop a file in.
         type="file"
         style={{ display: "none" }}
         onChange={(event) => {
@@ -157,7 +156,7 @@ export default function DocumentDropListener(props: Props): JSX.Element {
         data-puppeteer-file-upload
         multiple
       />
-      {hovering && props.children}
+      {hovering && <Layer>{props.children}</Layer>}
     </>
   );
 }

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -114,6 +114,9 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
       maxWidth={800}
       minWidth={800}
       modalProps={{
+        layerProps: {
+          eventBubblingEnabled: true,
+        },
         styles: {
           main: {
             minHeight: 520,


### PR DESCRIPTION

**User-Facing Changes**
None unless Open Dialog feature flag is on.

Users can drag&drop files over the open dialog to load in studio.

**Description**
Enable event bubbling in open dialog to support drag&drop while the dialog is open.

Fixes: #2417


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
