### PR TITLE
URDF fixes

### DIFF
--- a/packages/den/urdf/parser.ts
+++ b/packages/den/urdf/parser.ts
@@ -352,7 +352,7 @@ function parsePose(xml: Element): Pose {
 }
 
 function parseVec3Attribute(xml: Element, attribName: string): Vector3 | undefined {
-  const parts = xml.getAttribute(attribName)?.split(" ");
+  const parts = xml.getAttribute(attribName)?.trim().split(" ");
   if (parts?.length !== 3) {
     return undefined;
   }
@@ -362,7 +362,7 @@ function parseVec3Attribute(xml: Element, attribName: string): Vector3 | undefin
 }
 
 function parseColorAttribute(xml: Element, attribName: string): Color | undefined {
-  const parts = xml.getAttribute(attribName)?.split(" ");
+  const parts = xml.getAttribute(attribName)?.trim().split(" ");
   if (parts?.length !== 4) {
     return undefined;
   }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -193,6 +193,6 @@
     "uuid": "8.3.2",
     "wasm-lz4": "2.0.0",
     "webpack": "5.65.0",
-    "xacro-parser": "0.3.3"
+    "xacro-parser": "0.3.4"
   }
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -521,7 +521,7 @@ export default class SceneBuilder implements MarkerProvider {
       interactionData: InteractionData;
       color?: Color;
       colors?: readonly Color[];
-      points: Point[];
+      points?: Point[];
       id: string | number;
       ns: string;
       header: Header;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -42,7 +42,7 @@ import {
   SphereMarker,
 } from "@foxglove/studio-base/types/Messages";
 import { MarkerProvider, MarkerCollector } from "@foxglove/studio-base/types/Scene";
-import { emptyPose } from "@foxglove/studio-base/util/Pose";
+import { clonePose, emptyPose } from "@foxglove/studio-base/util/Pose";
 import { URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
@@ -426,7 +426,7 @@ function updatePose(
 
   // Store the original pose on the marker
   const markerWithOrigPose = marker as Marker & { origPose?: MutablePose };
-  markerWithOrigPose.origPose ??= marker.pose;
+  markerWithOrigPose.origPose ??= clonePose(marker.pose);
 
   return frame.apply(marker.pose, markerWithOrigPose.origPose, srcFrame, currentTime) != undefined;
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -72,20 +72,24 @@ export default class UrdfBuilder implements MarkerProvider {
   renderMarkers = (add: MarkerCollector, time: Time): void => {
     if (this._visible && this._transforms && this._renderFrameId) {
       for (const box of this._boxes) {
-        updatePose(box, this._transforms, this._renderFrameId, time);
-        add.cube(box);
+        if (updatePose(box, this._transforms, this._renderFrameId, time)) {
+          add.cube(box);
+        }
       }
       for (const sphere of this._spheres) {
-        updatePose(sphere, this._transforms, this._renderFrameId, time);
-        add.sphere(sphere);
+        if (updatePose(sphere, this._transforms, this._renderFrameId, time)) {
+          add.sphere(sphere);
+        }
       }
       for (const cylinder of this._cylinders) {
-        updatePose(cylinder, this._transforms, this._renderFrameId, time);
-        add.cylinder(cylinder);
+        if (updatePose(cylinder, this._transforms, this._renderFrameId, time)) {
+          add.cylinder(cylinder);
+        }
       }
       for (const mesh of this._meshes) {
-        updatePose(mesh, this._transforms, this._renderFrameId, time);
-        add.mesh(mesh);
+        if (updatePose(mesh, this._transforms, this._renderFrameId, time)) {
+          add.mesh(mesh);
+        }
       }
     }
   };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -42,7 +42,7 @@ import {
   SphereMarker,
 } from "@foxglove/studio-base/types/Messages";
 import { MarkerProvider, MarkerCollector } from "@foxglove/studio-base/types/Scene";
-import { clonePose, emptyPose } from "@foxglove/studio-base/util/Pose";
+import { clonePose } from "@foxglove/studio-base/util/Pose";
 import { URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
@@ -204,9 +204,8 @@ export default class UrdfBuilder implements MarkerProvider {
       return;
     }
 
-    const tfs = this._transforms;
-    const renderFrameId = this._renderFrameId;
     const ns = `urdf-${urdf.name}`;
+    log.debug(`Creating URDF markers for ${urdf.name}`);
 
     for (const link of urdf.links.values()) {
       const frame_id = link.name;
@@ -214,14 +213,14 @@ export default class UrdfBuilder implements MarkerProvider {
       let i = 0;
       for (const visual of link.visuals) {
         const id = `${link.name}-visual${i++}-${visual.geometry.geometryType}`;
-        this.addMarker(ns, id, frame_id, tfs, renderFrameId, visual, urdf);
+        this.addMarker(ns, id, frame_id, visual, urdf);
       }
 
       if (link.visuals.length === 0 && link.colliders.length > 0) {
         // If there are no visuals, but there are colliders, render those instead
         for (const collider of link.colliders) {
           const id = `${link.name}-collider${i++}-${collider.geometry.geometryType}`;
-          this.addMarker(ns, id, frame_id, tfs, renderFrameId, collider, urdf);
+          this.addMarker(ns, id, frame_id, collider, urdf);
         }
       }
     }
@@ -231,19 +230,14 @@ export default class UrdfBuilder implements MarkerProvider {
     ns: string,
     id: string,
     frame_id: string,
-    tfs: TransformTree,
-    renderFrameId: string,
     visual: UrdfVisual,
     robot: UrdfRobot,
   ): void {
-    const localPose = {
-      position: visual.origin.xyz,
+    const xyz = visual.origin.xyz;
+    const pose = {
+      position: { x: xyz.x, y: xyz.y, z: xyz.z },
       orientation: eulerToQuaternion(visual.origin.rpy),
     };
-    const pose = tfs.apply(emptyPose(), localPose, renderFrameId, frame_id, TIME_ZERO);
-    if (!pose) {
-      return;
-    }
 
     switch (visual.geometry.geometryType) {
       case "box":
@@ -280,7 +274,6 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: box.size,
       color: getColor(visual, robot),
       frame_locked: true,
-      points: [],
     };
     return marker;
   }
@@ -304,7 +297,6 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: { x: sphere.radius * 2, y: sphere.radius * 2, z: sphere.radius * 2 },
       color: getColor(visual, robot),
       frame_locked: true,
-      points: [],
     };
     return marker;
   }
@@ -328,7 +320,6 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: { x: cylinder.radius * 2, y: cylinder.radius * 2, z: cylinder.length },
       color: getColor(visual, robot),
       frame_locked: true,
-      points: [],
     };
     return marker;
   }
@@ -352,7 +343,6 @@ export default class UrdfBuilder implements MarkerProvider {
       scale: mesh.scale ?? { x: 1, y: 1, z: 1 },
       color: getColor(visual, robot),
       frame_locked: true,
-      points: [],
       mesh_resource: mesh.filename,
       mesh_use_embedded_materials: true,
     };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
@@ -98,12 +98,15 @@ function MeshMarkers({ markers, layerIndex }: MeshMarkerProps): ReactElement {
 
   for (let i = 0; i < markers.length; i++) {
     const marker = markers[i]!;
-    const { pose, mesh_resource, scale, color } = marker;
+    const { mesh_resource, color } = marker;
     if (!mesh_resource) {
       continue;
     }
     const url = rewritePackageUrl(mesh_resource, { rosPackagePath });
     const alpha = (color?.a ?? 0) > 0 ? color!.a : 1;
+
+    const newMarker = { ...marker, alpha };
+    delete newMarker.color;
 
     models.push(
       <GLTFScene
@@ -111,7 +114,7 @@ function MeshMarkers({ markers, layerIndex }: MeshMarkerProps): ReactElement {
         layerIndex={layerIndex}
         model={async () => await modelCache.load(url, reportError)}
       >
-        {{ pose, scale, alpha, interactionData: undefined }}
+        {newMarker}
       </GLTFScene>,
     );
   }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
@@ -33,8 +33,17 @@ export async function parseDaeToGlb(buffer: ArrayBuffer): Promise<GlbModel> {
       const material = (child as THREE.Mesh).material;
       const materials = Array.isArray(material) ? material : [material];
       for (const mat of materials) {
+        const lambert = mat as THREE.MeshLambertMaterial;
         // eslint-disable-next-line no-restricted-syntax
-        (mat as THREE.MeshPhongMaterial).map = null;
+        lambert.map = null;
+        // eslint-disable-next-line no-restricted-syntax
+        lambert.emissiveMap = null;
+        // eslint-disable-next-line no-restricted-syntax
+        lambert.lightMap = null;
+        // eslint-disable-next-line no-restricted-syntax
+        lambert.specularMap = null;
+        // eslint-disable-next-line no-restricted-syntax
+        (lambert as unknown as { normalMap: THREE.Texture | null }).normalMap = null;
       }
     }
   });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
@@ -2,7 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { GLTFExporter } from "three/examples/jsm/exporters/GLTFExporter";
+import type { Object3D } from "three";
+import { GLTFExporter, GLTFExporterOptions } from "three/examples/jsm/exporters/GLTFExporter";
 import { ColladaLoader } from "three/examples/jsm/loaders/ColladaLoader";
 
 import { parseGLB } from "@foxglove/regl-worldview";
@@ -11,6 +12,16 @@ import { MeshPrimitive } from "@foxglove/studio-base/panels/ThreeDimensionalViz/
 
 const UNSIGNED_INT = 5125;
 const DEFAULT_COLOR = [36 / 255, 142 / 255, 255 / 255, 1];
+
+// The type declaration for GLTFExporter.parse is not correct in THREE.js 0.135.0
+type FixedExporter = {
+  parse: (
+    input: Object3D,
+    onCompleted: (gltf: object) => void,
+    onError: (err: Error) => void,
+    options: GLTFExporterOptions,
+  ) => void;
+};
 
 export async function parseDaeToGlb(buffer: ArrayBuffer): Promise<GlbModel> {
   const loader = new ColladaLoader();
@@ -29,14 +40,15 @@ export async function parseDaeToGlb(buffer: ArrayBuffer): Promise<GlbModel> {
   });
 
   const exporter = new GLTFExporter();
-  return await new Promise((resolve) => {
-    exporter.parse(
+  return await new Promise((resolve, reject) => {
+    (exporter as FixedExporter).parse(
       collada.scene,
       async (glbBuffer) => {
         const glb = (await parseGLB(glbBuffer)) as GlbModel;
         patchGlb(glb);
         resolve(glb);
       },
+      reject,
       {
         embedImages: false,
         binary: true,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
@@ -94,7 +94,7 @@ function patchGlb(glb: GlbModel): void {
   // THREE.js uses Y-up, while we follow the ROS [REP-0103](https://www.ros.org/reps/rep-0103.html)
   // convention of Z-up
   for (const node of glb.json.nodes ?? []) {
-    node.rotation = [-Math.SQRT1_2, 0, 0, Math.SQRT1_2];
+    node.rotation = [-0.5, -0.5, -0.5, 0.5];
   }
 }
 

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -121,7 +121,7 @@ export type BaseMarker = Readonly<
     colors?: Colors;
     lifetime?: Time;
     frame_locked: boolean;
-    points: Point[];
+    points?: Point[];
     text?: string;
     mesh_resource?: string; // TODO: required
     mesh_use_embedded_materials?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,7 @@ __metadata:
     uuid: 8.3.2
     wasm-lz4: 2.0.0
     webpack: 5.65.0
-    xacro-parser: 0.3.3
+    xacro-parser: 0.3.4
   languageName: unknown
   linkType: soft
 
@@ -24514,12 +24514,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xacro-parser@npm:0.3.3":
-  version: 0.3.3
-  resolution: "xacro-parser@npm:0.3.3"
+"xacro-parser@npm:0.3.4":
+  version: 0.3.4
+  resolution: "xacro-parser@npm:0.3.4"
   dependencies:
     expr-eval: ^2.0.2
-  checksum: 555b19d371f219d7bec3931caa8f84c3b26ff34e27cd04cc9ad74bdd8c47072ffde9657f6c7a62e2a68ae06f119b896563347ef42a9aab04eac5c00c0ae35d32
+  checksum: 62c3e3cd64a5589d19b27013386c0b01344c86e4f1b6b9609c2abd3d75375c5ccf5f7f233902ef7bf4cf10739aca302d1d433a174c761f3b3a50b05c0754e1b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-facing changes**

- More .urdf/.xacro files are loaded correctly
- More COLLADA .dae files are loaded correctly

**Description**

- Bump xacro-parser to pull in "=" vs ":=" fix
- Store a copy of the pose for URDF components, not a reference
- Handle leading/trailing whitespace in URDF vector attributes
- Show marker info when clicking on URDF markers
- Only render URDF markers that have a valid transform
- Fix URDF primitives not showing up, accidental Vector3 mutation by reference
- Catch GLTFExporter errors
- Fix collada loading for materials with normal/emissive/specular/light maps
- Fix THREE.js to ROS coordinate frame conversion
- Make Marker.points optional

<img width="1164" alt="Screen Shot 2021-12-16 at 8 47 14 PM" src="https://user-images.githubusercontent.com/195374/146499910-8a1f9d61-0a14-4514-9617-3d8d78cf66ac.png">
<img width="1312" alt="Screen Shot 2021-12-16 at 7 20 33 PM" src="https://user-images.githubusercontent.com/195374/146499932-dccf7ba2-d7a1-4b32-9087-e9e63a8f4b1b.png">