### PR TITLE
Enable Open Dialog feature by default

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -84,7 +84,7 @@ export default function Root(): ReactElement {
 
   const providers = [
     /* eslint-disable react/jsx-key */
-    <NativeStorageAppConfigurationProvider />,
+    <NativeStorageAppConfigurationProvider defaults={{ [AppSetting.OPEN_DIALOG]: true }} />,
     <ConsoleApiContext.Provider value={api} />,
     <ConsoleApiCurrentUserProvider />,
     <ConsoleApiRemoteLayoutStorageProvider />,

--- a/desktop/renderer/components/NativeStorageAppConfigurationProvider.tsx
+++ b/desktop/renderer/components/NativeStorageAppConfigurationProvider.tsx
@@ -6,22 +6,30 @@ import { PropsWithChildren } from "react";
 import { useAsync } from "react-use";
 
 import Log from "@foxglove/log";
-import { AppConfigurationContext } from "@foxglove/studio-base";
+import { AppConfigurationContext, AppConfigurationValue } from "@foxglove/studio-base";
 
 import { useNativeStorage } from "../context/NativeStorageContext";
 import NativeStorageAppConfiguration from "../services/NativeStorageAppConfiguration";
 
 const log = Log.getLogger(__filename);
 
-export default function NativeStorageAppConfigurationProvider({
-  children,
-}: PropsWithChildren<unknown>): React.ReactElement | ReactNull {
+type NativeStorageAppConfigurationProviderProps = {
+  // Default values for app configuration items which have never been set by a user
+  defaults?: {
+    [key: string]: AppConfigurationValue;
+  };
+};
+
+export default function NativeStorageAppConfigurationProvider(
+  props: PropsWithChildren<NativeStorageAppConfigurationProviderProps>,
+): React.ReactElement | ReactNull {
+  const { defaults, children } = props;
   const storage = useNativeStorage();
 
   const { value, error } = useAsync(async () => {
     log.debug("Initializing app configuration");
-    return await NativeStorageAppConfiguration.Initialize(storage);
-  }, [storage]);
+    return await NativeStorageAppConfiguration.Initialize(storage, { defaults });
+  }, [defaults, storage]);
 
   if (error) {
     throw error;

--- a/desktop/renderer/services/NativeStorageAppConfiguration.test.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.test.ts
@@ -38,6 +38,34 @@ describe("NativeStorageAppConfiguration", () => {
     expect(ctx.get).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves stored value when default is provided", async () => {
+    const ctx = makeMockContext();
+    ctx.get.mockImplementationOnce(async () => {
+      return JSON.stringify({ abc: 123 });
+    });
+
+    const config = await NativeStorageAppConfiguration.Initialize(ctx, {
+      defaults: {
+        abc: "foo",
+      },
+    });
+    expect(config.get("abc")).toEqual(123);
+  });
+
+  it("uses default value when no value is set", async () => {
+    const ctx = makeMockContext();
+    ctx.get.mockImplementationOnce(async () => {
+      return JSON.stringify({ abc: 123 });
+    });
+
+    const config = await NativeStorageAppConfiguration.Initialize(ctx, {
+      defaults: {
+        foo: "bar",
+      },
+    });
+    expect(config.get("foo")).toEqual("bar");
+  });
+
   it("serializes reads and writes", async () => {
     const ctx = makeMockContext();
 

--- a/desktop/renderer/services/NativeStorageAppConfiguration.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.ts
@@ -26,14 +26,18 @@ export default class NativeStorageAppConfiguration implements AppConfiguration {
   }
 
   // create a new OsContextAppConfiguration
-  static async Initialize(ctx: Storage): Promise<NativeStorageAppConfiguration> {
+  static async Initialize(
+    ctx: Storage,
+    options: { defaults?: { [key: string]: AppConfigurationValue } } = {},
+  ): Promise<NativeStorageAppConfiguration> {
+    const { defaults } = options;
     const value = await ctx.get(
       NativeStorageAppConfiguration.STORE_NAME,
       NativeStorageAppConfiguration.STORE_KEY,
       { encoding: "utf8" },
     );
     const currentValue = JSON.parse(value ?? "{}");
-    const config = new NativeStorageAppConfiguration(ctx, currentValue);
+    const config = new NativeStorageAppConfiguration(ctx, { ...defaults, ...currentValue });
 
     return config;
   }

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -102,7 +102,7 @@ export function Root({ loadWelcomeLayout }: { loadWelcomeLayout: boolean }): JSX
   ];
 
   return (
-    <LocalStorageAppConfigurationProvider>
+    <LocalStorageAppConfigurationProvider defaults={{ [AppSetting.OPEN_DIALOG]: true }}>
       <ColorSchemeThemeProvider>
         <GlobalCss />
         <CssBaseline>

--- a/web/src/components/LocalStorageAppConfigurationProvider.tsx
+++ b/web/src/components/LocalStorageAppConfigurationProvider.tsx
@@ -13,16 +13,25 @@ import {
 
 const KEY_PREFIX = "studio.app-configuration.";
 
+type LocalStorageAppConfigurationProviderProps = {
+  // Default values for app configuration items which have never been set by a user
+  defaults?: {
+    [key: string]: AppConfigurationValue;
+  };
+};
+
 export default function LocalStorageAppConfigurationProvider(
-  props: PropsWithChildren<unknown>,
+  props: PropsWithChildren<LocalStorageAppConfigurationProviderProps>,
 ): JSX.Element {
+  const { defaults } = props;
+
   const [ctx] = useState<AppConfiguration>(() => {
     const changeListeners = new Map<string, Set<ChangeHandler>>();
     return {
       get(key: string): AppConfigurationValue {
         const value = localStorage.getItem(KEY_PREFIX + key);
         try {
-          return value == undefined ? undefined : JSON.parse(value);
+          return value == undefined ? defaults?.[key] : JSON.parse(value);
         } catch {
           return undefined;
         }


### PR DESCRIPTION

**User-Facing Changes**

The open dialog is a new way to select data sources. Rather than a single list of different sources and types of sources (urls, files, native, etc), the open dialog presents the user with a simplified set of data source types. Different data sources have different modes of interaction for opening.

The dialog also introduces the concept of "sample data". These are pre-defined datasets and layouts for new users to learn aspects of the app while browsing sample datasets.



**Description**
This change also introduces a way to provide default values for app settings.

Fixes: #2431

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
