### PR TITLE
Update ILayoutManager to support event types for change event

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -227,15 +227,16 @@ export default function CurrentLayoutProvider({
 
   // Make sure our layout still exists after changes. If not deselect it.
   useEffect(() => {
-    async function listener() {
-      if (layoutStateRef.current?.selectedLayout?.id) {
-        const layout = await layoutManager.getLayout(layoutStateRef.current?.selectedLayout?.id);
-        if (!layout) {
-          await setSelectedLayoutId(undefined);
-          addToast("Your active layout was deleted.", { appearance: "warning" });
-        }
+    const listener: LayoutManagerEventTypes["change"] = async (event) => {
+      if (event.type !== "delete" || !layoutStateRef.current?.selectedLayout?.id) {
+        return;
       }
-    }
+
+      if (event.layoutId === layoutStateRef.current.selectedLayout.id) {
+        await setSelectedLayoutId(undefined);
+        addToast("Your active layout was deleted.", { appearance: "warning" });
+      }
+    };
 
     layoutManager.on("change", listener);
     return () => layoutManager.off("change", listener);

--- a/packages/studio-base/src/services/ILayoutManager.ts
+++ b/packages/studio-base/src/services/ILayoutManager.ts
@@ -7,12 +7,16 @@ import { EventNames, EventListener } from "eventemitter3";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { Layout, LayoutID, LayoutPermission } from "@foxglove/studio-base/services/ILayoutStorage";
 
+export type LayoutManagerChangeEvent =
+  | { type: "delete"; updatedLayout?: undefined; layoutId: LayoutID }
+  | { type: "change"; updatedLayout: Layout | undefined };
+
 export type LayoutManagerEventTypes = {
   /**
    * Called when a change has occurred to the layouts and the user interface should be updated.
    * If a particular layout was updated, its data will be passed in the event.
    */
-  change: (event: { updatedLayout: Layout | undefined }) => void;
+  change: (event: LayoutManagerChangeEvent) => void;
 
   /** Called when the layout manager starts or stops asynchronous activity.  */
   busychange: () => void;


### PR DESCRIPTION


**User-Facing Changes**
None.

**Description**
The change event instance indicates if the event is a change or delete. For delete events matching the users current layout we notify them their layout has been deleted.

Small optimization to avoid fetching a layout on all change events.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
