### PR TITLE
Build docker image GitHub action

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -89,10 +89,11 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
-          images: bertaveira/foxglove
+          images: ghcr.io/$GITHUB_REPOSITORY
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
+            latest
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -106,8 +107,9 @@ jobs:
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USER }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
@@ -116,6 +118,5 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            bertaveira/foxglove:latest
-            ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -89,7 +89,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           # list of Docker images to use as base name for tags
-          images: ghcr.io/$GITHUB_REPOSITORY
+          images: ghcr.io/${{ github.repository }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
@@ -109,7 +109,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN }}
       -
         name: Build and push
         id: docker_build

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -72,3 +72,46 @@ jobs:
       - run: npm publish ./packages/studio-base
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          lfs: true
+      - run: git lfs pull
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: bertaveira/foxglove
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            bertaveira/foxglove:latest
+            ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -99,6 +99,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
       -
         name: Login to DockerHub
         uses: docker/login-action@v1
@@ -111,6 +114,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             bertaveira/foxglove:latest

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -75,6 +75,9 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       -
         name: Checkout ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
@@ -104,12 +107,12 @@ jobs:
           version: latest
           install: true
       -
-        name: Login to DockerHub
+        name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build


### PR DESCRIPTION
**Motivation**
As we saw the necessity to have an image up to date with the foxglove I decided to make it automatically build the image and push it. It has worked for us (although in gitlab not github) so I thought it would be nice to make it official and make it public so everyone can have access to an official, automatically released and up to date image. 

The idea would be to have an official foxglove account on docker hub and replace my personal one in the CI so that on every release it builds the image and tags with the version number as well as replaces the latest tag.

**Description**
What this pull does is add a new Github action job where it builds the docker image for multi-architecture and then pushes it to docker hub. Right now it is pushing ot my personal account but if this is of interest to foxglove as much as it is to me the idea would be to make it push to an official docker hub account of foxglove.

Currently it is building for 2 platforms but more could be added:
- linux/amd64 - Regular Linux x86
- linux/arm64 - The ARM version supported by ROS official docker images (ARM v8 such as Apple M1 and latest Raspberry Pi's)

The images built are tagged with the version number as well as the `:latest` tag. This way the latest is always the most recent version of foxglove studio, but everyone can also choose a specific version if they so desire.

**Tests**
To test if the action was working i did some releases on my fork in a different branch. The reason I did them on a different branch is because the release CI also commits to the branch ("Bump dev" job). Since I didn't want this pull messing with versions due to my tests, they were done in a separate branch called ` bernardo/build-docker-action` (sorry for the confusing branch names). You can check the actions and releases I made to validate that it works as well as my docker hub repository ([here](https://hub.docker.com/repository/docker/bertaveira/foxglove/general)).

To note that building both images (amd64 and arm64) takes about 1h.

**Adaptations needed**

1. Create a foxglove docker account
2. Add docker hub credentials as secret variables on github (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) and replace name of docker image in the `post-release.yml` file. I can do this last step on my branch but the account needs to be created first.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
