### PR TITLE
Update Open Dialog remote file placeholder

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Remote.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Remote.tsx
@@ -61,7 +61,7 @@ export default function Remote(props: RemoteProps): JSX.Element {
         <TextField
           label="Remote file URL"
           errorMessage={errorMessage}
-          placeholder="https://storage.googleapis.com/foxglove-public-assets/demo.bag"
+          placeholder="https://example.com/file.bag"
           onChange={(_, newValue) => {
             setCurrentUrl(newValue);
           }}


### PR DESCRIPTION

**User-Facing Changes**
Change the placeholder for open remote file to a generic url. Having a url that looks like it points to a valid file gives the illusion that clicking "Open" might open this url.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
