### PR TITLE
Ignore CMD modifier for 3d panel `3` hotkey

### DIFF
--- a/packages/studio-base/src/components/KeyListener.tsx
+++ b/packages/studio-base/src/components/KeyListener.tsx
@@ -12,7 +12,9 @@
 //   You may not use this file except in compliance with the License.
 
 type KeyHandlers = {
-  [key: string]: (event: KeyboardEvent) => void;
+  // Invoke handler for matcking key.
+  // By default, preventDefault() is invoked on the event. Return false to allow the default
+  [key: string]: (event: KeyboardEvent) => void | boolean | undefined;
 };
 
 type Props = {
@@ -54,8 +56,14 @@ export default class KeyListener extends React.Component<Props> {
       return;
     }
     if (typeof handlers[event.key] === "function") {
-      event.preventDefault();
-      handlers[event.key]?.(event);
+      let preventDefault = true;
+      try {
+        preventDefault = handlers[event.key]?.(event) ?? true;
+      } finally {
+        if (preventDefault) {
+          event.preventDefault();
+        }
+      }
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -690,19 +690,21 @@ export default function Layout({
     const handlers: {
       [key: string]: (e: KeyboardEvent) => void;
     } = {
-      "3": () => {
+      "3": (ev) => {
+        if (ev.metaKey || ev.ctrlKey) {
+          return false;
+        }
         toggleCameraMode();
+        return true;
       },
-      Escape: (e) => {
-        e.preventDefault();
+      Escape: () => {
         setShowTopicTree(false);
         searchTextProps.toggleSearchTextOpen(false);
         if (document.activeElement && document.activeElement === containerRef.current) {
           (document.activeElement as HTMLElement).blur();
         }
       },
-      t: (e) => {
-        e.preventDefault();
+      t: () => {
         // Unpin before enabling keyboard toggle open/close.
         if (pinTopics) {
           saveConfig({ pinTopics: false });
@@ -712,12 +714,14 @@ export default function Layout({
       },
       f: (e: KeyboardEvent) => {
         if (e.ctrlKey || e.metaKey) {
-          e.preventDefault();
           searchTextProps.toggleSearchTextOpen(true);
           if (!searchTextProps.searchInputRef.current) {
-            return;
+            return true;
           }
           searchTextProps.searchInputRef.current.select();
+          return true;
+        } else {
+          return false;
         }
       },
     };


### PR DESCRIPTION
**User-Facing Changes**
Pressing `cmd+3` in the web app - properly changes you to your third tab (in chrome) works.

**Description**
The 3d panel sets up a keyboard shortcut on the `3` key. By default the keylister captures events with modifier keys and also prevents default. This makes this keyboard shortcut capture events for `cmd+3` as well as `3`. In chrome, cmd+3 is a shortcut for switching tabs. Since the 3d panel only needs the `3` keylistener, we avoid preventing default when the meta or ctrl key is also pressed.
    
Fixes: #2371

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
