### PR TITLE
Remove duplicate disabledReason

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -103,7 +103,6 @@ export default function Connection(props: ConnectionProps): JSX.Element {
           tokens={{ childrenGap: theme.spacing.m }}
           styles={{ root: { overflowY: "auto" } }}
         >
-          {selectedSource?.disabledReason}
           {selectedSource?.formConfig != undefined && (
             <Stack grow verticalAlign="space-between">
               <Stack tokens={{ childrenGap: theme.spacing.m }}>


### PR DESCRIPTION

**User-Facing Changes**
The disabled reason for a connection is shown once rather than twice. Twice was a bit repetitive.

**Description**
The disabledReason should only be shown once on the Open Dialog when trying to connect to a data source type that is not supported. Twice was a bit repetitive.

Fixes: #2454

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
