### PR TITLE
Avoid creating a new ConnectionSidebar component

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IconButton } from "@fluentui/react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import ConnectionList from "@foxglove/studio-base/components/ConnectionList";
+import connectionHelpContent from "@foxglove/studio-base/components/ConnectionList/index.help.md";
+import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
+
+type Props = {
+  onSelectDataSourceAction: () => void;
+};
+
+export default function DataSourceSidebar(props: Props): JSX.Element {
+  const { onSelectDataSourceAction } = props;
+  const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
+
+  return (
+    <SidebarContent
+      title="Data sources"
+      helpContent={connectionHelpContent}
+      trailingItems={[
+        enableOpenDialog === true && (
+          <IconButton
+            key="add-connection"
+            iconProps={{ iconName: "Add" }}
+            styles={{
+              icon: {
+                svg: { height: "1em", width: "1em" },
+                "> span": { display: "flex" },
+              },
+            }}
+            onClick={onSelectDataSourceAction}
+          />
+        ),
+      ].filter(Boolean)}
+    >
+      <ConnectionList />
+    </SidebarContent>
+  );
+}

--- a/packages/studio-base/src/components/DataSourceSidebar/index.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/index.tsx
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export { default as DataSourceSidebar } from "./DataSourceSidebar";


### PR DESCRIPTION


**User-Facing Changes**
The help text in the data source sidebar remains visible even when a data source is re-connecting.

**Description**
The ConnectionSidebar component is dynamic to support the enableOpenDialog feature flag. This component was created in a useMemo that had player problems as a dependency. As a result, whenever a player problem occured the entire component would be re-created and re-mounted.

This change moves the dynamic sidebar component into its on useMemo so it is created once rather than on every player problem change.

This change also moves some component logic into a new DataSourceSidebar folder to tidy up Workspace.

Fixes: #2434

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
