### PR TITLE
rename rosBinaryMessages to encodedMessages

### DIFF
--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -85,7 +85,7 @@ class MessageStore {
   };
 }
 
-const getMessagesResult = { parsedMessages: [], rosBinaryMessages: undefined };
+const getMessagesResult = { parsedMessages: [], encodedMessages: undefined };
 
 describe("RandomAccessPlayer", () => {
   let mockDateNow: jest.SpyInstance<number, []>;

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.test.ts
@@ -118,9 +118,9 @@ describe("BagDataProvider", () => {
     await provider.initialize(dummyExtensionPoint);
     const start = { sec: 1396293887, nsec: 844783943 };
     const end = { sec: 1396293888, nsec: 60000000 };
-    const messages = await provider.getMessages(start, end, { rosBinaryMessages: ["/tf"] });
+    const messages = await provider.getMessages(start, end, { encodedMessages: ["/tf"] });
     expect(messages.parsedMessages).toBe(undefined);
-    expect(messages.rosBinaryMessages).toEqual([
+    expect(messages.encodedMessages).toEqual([
       {
         topic: "/tf",
         receiveTime: { sec: 1396293888, nsec: 56251251 },
@@ -146,13 +146,13 @@ describe("BagDataProvider", () => {
     await provider.initialize(dummyExtensionPoint);
     const start = { sec: 1490148912, nsec: 0 };
     const end = { sec: 1490148913, nsec: 0 };
-    const { parsedMessages, rosBinaryMessages } = await provider.getMessages(start, end, {
-      rosBinaryMessages: ["/tf"],
+    const { parsedMessages, encodedMessages } = await provider.getMessages(start, end, {
+      encodedMessages: ["/tf"],
     });
     expect(parsedMessages).toBe(undefined);
-    expect(rosBinaryMessages).toBeTruthy();
-    assert(rosBinaryMessages);
-    const timestamps = rosBinaryMessages.map(({ receiveTime }) => receiveTime);
+    expect(encodedMessages).toBeTruthy();
+    assert(encodedMessages);
+    const timestamps = encodedMessages.map(({ receiveTime }) => receiveTime);
     const sortedTimestamps = [...timestamps];
     sortedTimestamps.sort(compare);
     expect(timestamps).toEqual(sortedTimestamps);

--- a/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/BagDataProvider.ts
@@ -270,7 +270,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
     end: Time,
     subscriptions: GetMessagesTopics,
   ): Promise<GetMessagesResult> {
-    const topics = subscriptions.rosBinaryMessages ?? [];
+    const topics = subscriptions.encodedMessages ?? [];
     const connectionStart = fromMillis(new Date().getTime());
     let totalSizeOfMessages = 0;
     let numberOfMessages = 0;
@@ -336,7 +336,7 @@ export default class BagDataProvider implements RandomAccessDataProvider {
         totalTransferTime: subtractTimes(fromMillis(new Date().getTime()), connectionStart),
       },
     });
-    return { rosBinaryMessages: messages, parsedMessages: undefined };
+    return { encodedMessages: messages, parsedMessages: undefined };
   }
 
   async close(): Promise<void> {

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryDataProvider.ts
@@ -104,9 +104,9 @@ export default class MemoryDataProvider implements RandomAccessDataProvider {
         fullyLoadedFractionRanges: [{ start: 0, end: 0 }],
       });
     }
-    const { parsedMessages, rosBinaryMessages } = this.messages;
-    const sortedMessages = [...(parsedMessages ?? []), ...(rosBinaryMessages ?? [])].sort(
-      (m1, m2) => compare(m1.receiveTime, m2.receiveTime),
+    const { parsedMessages, encodedMessages } = this.messages;
+    const sortedMessages = [...(parsedMessages ?? []), ...(encodedMessages ?? [])].sort((m1, m2) =>
+      compare(m1.receiveTime, m2.receiveTime),
     );
 
     let messageDefinitions: MessageDefinitions;
@@ -153,11 +153,11 @@ export default class MemoryDataProvider implements RandomAccessDataProvider {
         topics.parsedMessages ?? [],
         this.messages.parsedMessages,
       ),
-      rosBinaryMessages: filterMessages(
+      encodedMessages: filterMessages(
         start,
         end,
-        topics.rosBinaryMessages ?? [],
-        this.messages.rosBinaryMessages,
+        topics.encodedMessages ?? [],
+        this.messages.encodedMessages,
       ),
     };
   }

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
@@ -81,7 +81,7 @@ function getProvider(
   { unlimitedCache = false }: { unlimitedCache?: boolean } = {},
 ) {
   const memoryDataProvider = new MemoryDataProvider({
-    messages: { parsedMessages: undefined, rosBinaryMessages: messages },
+    messages: { parsedMessages: undefined, encodedMessages: messages },
     providesParsedMessages: false,
     parsedMessageDefinitionsByTopic: {
       "/foo": [{ definitions: [] }],
@@ -152,7 +152,7 @@ describe("MemoryCacheDataProvider", () => {
       // The last block will typically be exactly one timestamp since BLOCK_SIZE_NS divides seconds.
       { sec: 102, nsec: 0 },
       { sec: 102, nsec: 0 },
-      { rosBinaryMessages: ["/foo"] },
+      { encodedMessages: ["/foo"] },
     ]);
   });
 
@@ -205,13 +205,13 @@ describe("MemoryCacheDataProvider", () => {
     expect(first(getMessagesSpy.mock.calls)).toEqual([
       { sec: 101, nsec: 0 },
       { sec: 101, nsec: 0.1e9 - 1 },
-      { rosBinaryMessages: ["/foo"] },
+      { encodedMessages: ["/foo"] },
     ]);
     // The last request is up to the requested range from below.
     expect(last(getMessagesSpy.mock.calls)).toEqual([
       { sec: 100, nsec: 0.9e9 },
       { sec: 100, nsec: 1e9 - 1 },
-      { rosBinaryMessages: ["/foo"] },
+      { encodedMessages: ["/foo"] },
     ]);
   });
 

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.ts
@@ -391,7 +391,7 @@ export default class Ros1MemoryCacheDataProvider implements RandomAccessDataProv
       if (topics.length === 0) {
         resolve({
           parsedMessages: [],
-          rosBinaryMessages: undefined,
+          encodedMessages: undefined,
         });
         return false;
       }
@@ -447,7 +447,7 @@ export default class Ros1MemoryCacheDataProvider implements RandomAccessDataProv
 
       resolve({
         parsedMessages: messages.sort((a, b) => compare(a.receiveTime, b.receiveTime)),
-        rosBinaryMessages: undefined,
+        encodedMessages: undefined,
       });
       this._lastResolvedCallbackEnd = blockRange.end;
       return false;
@@ -603,13 +603,13 @@ export default class Ros1MemoryCacheDataProvider implements RandomAccessDataProv
       const messages =
         topics.length > 0
           ? await this._provider.getMessages(startTime, endTime, {
-              rosBinaryMessages: topics,
+              encodedMessages: topics,
             })
           : {
-              rosBinaryMessages: [],
+              encodedMessages: [],
               parsedMessages: undefined,
             };
-      const { rosBinaryMessages, parsedMessages } = messages;
+      const { encodedMessages, parsedMessages } = messages;
 
       if (parsedMessages != undefined) {
         const types = (Object.keys(messages) as (keyof typeof messages)[])
@@ -633,7 +633,7 @@ export default class Ros1MemoryCacheDataProvider implements RandomAccessDataProv
         messagesByTopic[topic] = [];
       }
 
-      for (const rosBinaryMessage of rosBinaryMessages ?? []) {
+      for (const rosBinaryMessage of encodedMessages ?? []) {
         const lazyReader = this._lazyMessageReadersByTopic.get(rosBinaryMessage.topic);
         if (!lazyReader) {
           continue;

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.test.ts
@@ -37,7 +37,7 @@ const dummyExtensionPoint = {
 };
 
 // prior to updating MemoryCacheDataProvider to lazy messages, ParseMessageDataProvider expended to query its child
-// with rosBinaryMessages topics and do the parsing itself. Since MemoryCacheDataProvider uses lazy messages
+// with encodedMessages topics and do the parsing itself. Since MemoryCacheDataProvider uses lazy messages
 // this is no longer necessary behavior and ParseMessageDataProvider is a passthrough.
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip("ParseMessagesDataProvider", () => {
@@ -84,7 +84,7 @@ describe.skip("ParseMessagesDataProvider", () => {
     const messages = await provider.getMessages(start, end, {
       parsedMessages: ["/tf"],
     });
-    expect(messages.rosBinaryMessages).toBe(undefined);
+    expect(messages.encodedMessages).toBe(undefined);
     expect(messages.parsedMessages).toHaveLength(2);
     expect(
       messages.parsedMessages?.map((event) => {
@@ -139,10 +139,10 @@ describe.skip("ParseMessagesDataProvider", () => {
     const start = { sec: 1396293887, nsec: 844783943 };
     const end = { sec: 1396293888, nsec: 60000000 };
     const messages = await provider.getMessages(start, end, {
-      rosBinaryMessages: ["/tf"],
+      encodedMessages: ["/tf"],
       parsedMessages: [],
     });
-    expect(messages.rosBinaryMessages).toBe(undefined);
+    expect(messages.encodedMessages).toBe(undefined);
     expect(messages.parsedMessages).toEqual([]);
   });
 });

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.ts
@@ -59,14 +59,14 @@ export default class Ros1ParseMessagesDataProvider implements RandomAccessDataPr
     // Kick off the request to the data provder to get the messages
     // This might trigger some background reading so we can do some other work before waiting
 
-    const { parsedMessages, rosBinaryMessages } = await this._provider.getMessages(start, end, {
+    const { parsedMessages, encodedMessages } = await this._provider.getMessages(start, end, {
       parsedMessages: topics.parsedMessages,
-      rosBinaryMessages: topics.rosBinaryMessages,
+      encodedMessages: topics.encodedMessages,
     });
 
     return {
       parsedMessages,
-      rosBinaryMessages,
+      encodedMessages,
     };
   }
 

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
@@ -77,18 +77,18 @@ export default class WorkerBagDataProvider implements RandomAccessDataProvider {
     }
 
     if (topics.parsedMessages) {
-      throw new Error("WorkerDataProvider only supports rosBinaryMessages");
+      throw new Error("WorkerDataProvider only supports encodedMessages");
     }
-    const rpcRes = await this.rpc.send<{ messages: GetMessagesResult["rosBinaryMessages"] }>(
+    const rpcRes = await this.rpc.send<{ messages: GetMessagesResult["encodedMessages"] }>(
       "getMessages",
       {
         start,
         end,
-        topics: topics.rosBinaryMessages,
+        topics: topics.encodedMessages,
       },
     );
     return {
-      rosBinaryMessages: rpcRes.messages,
+      encodedMessages: rpcRes.messages,
       parsedMessages: undefined,
     };
   }

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.worker.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.worker.ts
@@ -51,11 +51,11 @@ if (inWebWorker()) {
     }: {
       start: Time;
       end: Time;
-      topics: GetMessagesTopics["rosBinaryMessages"];
+      topics: GetMessagesTopics["encodedMessages"];
     }) => {
-      const messages = await provider.getMessages(start, end, { rosBinaryMessages: topics });
-      const { parsedMessages, rosBinaryMessages } = messages;
-      const messagesToSend = rosBinaryMessages ?? [];
+      const messages = await provider.getMessages(start, end, { encodedMessages: topics });
+      const { parsedMessages, encodedMessages } = messages;
+      const messagesToSend = encodedMessages ?? [];
       if (parsedMessages != undefined) {
         throw new Error("Worker only accepts raw messages");
       }

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
@@ -75,7 +75,7 @@ export default class WorkerRosbag2DataProvider implements RandomAccessDataProvid
       throw new Error("WorkerRosbag2DataProvider not initialized");
     }
 
-    if (topics.rosBinaryMessages) {
+    if (topics.encodedMessages) {
       throw new Error("WorkerRosbag2DataProvider only supports parsed messages");
     }
 
@@ -88,7 +88,7 @@ export default class WorkerRosbag2DataProvider implements RandomAccessDataProvid
       },
     );
     return {
-      rosBinaryMessages: undefined,
+      encodedMessages: undefined,
       parsedMessages: rpcRes.messages,
     };
   }

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -48,12 +48,12 @@ export type RandomAccessDataProviderProblem = {
 
 export type GetMessagesTopics = Readonly<{
   parsedMessages?: readonly string[];
-  rosBinaryMessages?: readonly string[];
+  encodedMessages?: readonly string[];
 }>;
 
 export type GetMessagesResult = Readonly<{
   parsedMessages?: readonly MessageEvent<unknown>[];
-  rosBinaryMessages?: readonly MessageEvent<ArrayBuffer>[];
+  encodedMessages?: readonly MessageEvent<ArrayBuffer>[];
 }>;
 
 export type ParsedMessageDefinitions = Readonly<{
@@ -103,8 +103,6 @@ export type InitializationResult = {
 
   // Signals whether the messages returned from calls to getMessages are parsed into Javascript
   // objects or are returned in ROS binary format.
-  // TODO(steel/hernan): Replace topics and providesParsedMessages with a GetMessagesResult, and
-  // update the ApiCheckerDataProvider to enforce it.
   providesParsedMessages: boolean;
   messageDefinitions: MessageDefinitions;
 
@@ -156,8 +154,9 @@ export type RandomAccessDataProviderStall = Readonly<{
   bytesReceivedBeforeStall: number;
 }>;
 
-export type RandomAccessDataProviderMetadata = // Report whether or not the RandomAccessDataProvider is reconnecting to some external server. Used to show a
-  // loading indicator in the UI.
+// Report whether or not the RandomAccessDataProvider is reconnecting to some external server. Used
+// to show a loading indicator in the UI.
+export type RandomAccessDataProviderMetadata =
   | Readonly<{ type: "updateReconnecting"; reconnecting: boolean }>
   | AverageThroughput
   | InitializationPerformanceMetadata


### PR DESCRIPTION


**User-Facing Changes**
None. Internal code rename only.

**Description**
A RandomAccessDataProvider can produce any kind of encoded messages. It is up to the DataSourceFactory to create data providers in a way that the final data provider to RandomAccessPlayer produces parsed messages.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
