### PR TITLE
Change followOrientation to followMode

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.stories.tsx
@@ -11,12 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { storiesOf } from "@storybook/react";
+import { Story } from "@storybook/react";
 import { CSSProperties } from "react";
 
 import { DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import CameraInfo, {
+  CameraInfoProps,
   CAMERA_TAB_TYPE,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/CameraInfo";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -30,11 +31,10 @@ const containerStyle: CSSProperties = {
   height: "100%",
 };
 
-const DEFAULT_PROPS = {
+const DEFAULT_PROPS: CameraInfoProps = {
   cameraState: DEFAULT_CAMERA_STATE,
   targetPose: undefined,
-  expanded: true,
-  followOrientation: false,
+  followMode: "follow",
   followTf: "some_frame",
   onAlignXYAxis: () => {
     // no-op
@@ -42,21 +42,11 @@ const DEFAULT_PROPS = {
   onCameraStateChange: () => {
     // no-op
   },
-  onExpand: () => {
-    // no-op
-  },
-  saveConfig: () => {
-    // no-op
-  },
   showCrosshair: false,
-  type: CAMERA_TAB_TYPE,
-  updatePanelConfig: () => {
-    // no-op
-  },
   autoSyncCameraState: false,
 };
 
-const CameraInfoWrapper = (props: any) => (
+const CameraInfoWrapper = (props: Partial<CameraInfoProps>) => (
   <div style={containerStyle}>
     <MockPanelContextProvider>
       <CameraInfo {...DEFAULT_PROPS} defaultSelectedTab={CAMERA_TAB_TYPE} {...props} />
@@ -64,13 +54,28 @@ const CameraInfoWrapper = (props: any) => (
   </div>
 );
 
-storiesOf("panels/ThreeDimensionalViz/CameraInfo", module)
-  .add("Default", () => <CameraInfoWrapper />)
-  .add("Follow orientation", () => <CameraInfoWrapper followOrientation />)
-  .add("3D and showCrosshair", () => <CameraInfoWrapper showCrosshair />)
-  .add("2D and showCrosshair", () => (
+export default {
+  title: "panels/ThreeDimensionalViz/CameraInfo",
+  component: CameraInfo,
+};
+
+export const Default: Story = () => {
+  return <CameraInfoWrapper />;
+};
+
+export const FollowOrientation: Story = () => {
+  return <CameraInfoWrapper followMode="follow-orientation" />;
+};
+
+export const ShowCrosshair3d: Story = () => {
+  return <CameraInfoWrapper showCrosshair />;
+};
+
+export const ShowCrosshair2d: Story = () => {
+  return (
     <CameraInfoWrapper
       cameraState={{ ...DEFAULT_CAMERA_STATE, perspective: false }}
       showCrosshair
     />
-  ));
+  );
+};

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.tsx
@@ -33,7 +33,10 @@ import {
   getNewCameraStateOnFollowChange,
   TargetPose,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
-import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
+import {
+  FollowMode,
+  ThreeDimensionalVizConfig,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import clipboard from "@foxglove/studio-base/util/clipboard";
 import { point2DValidator, cameraStateValidator } from "@foxglove/studio-base/util/validators";
 
@@ -55,8 +58,8 @@ type CameraStateInfoProps = {
 };
 
 export type CameraInfoPropsWithoutCameraState = {
-  followOrientation: boolean;
-  followTf?: string | false;
+  followMode: FollowMode;
+  followTf?: string;
   isPlaying?: boolean;
   onAlignXYAxis: () => void;
   onCameraStateChange: (arg0: CameraState) => void;
@@ -65,7 +68,7 @@ export type CameraInfoPropsWithoutCameraState = {
   defaultSelectedTab?: string;
 };
 
-type CameraInfoProps = {
+export type CameraInfoProps = {
   cameraState: CameraState;
   targetPose?: TargetPose;
 } & CameraInfoPropsWithoutCameraState;
@@ -107,7 +110,7 @@ function CameraStateInfo({ cameraState, onAlignXYAxis }: CameraStateInfoProps) {
 export default function CameraInfo({
   cameraState,
   targetPose,
-  followOrientation,
+  followMode,
   followTf,
   isPlaying = false,
   onAlignXYAxis,
@@ -138,9 +141,9 @@ export default function CameraInfo({
         prevCameraState: cameraState,
         prevTargetPose: targetPose,
         prevFollowTf: followTf,
-        prevFollowOrientation: followOrientation,
+        prevFollowMode: followMode,
         newFollowTf: (config as ThreeDimensionalVizConfig).followTf,
-        newFollowOrientation: (config as ThreeDimensionalVizConfig).followOrientation,
+        newFollowMode: (config as ThreeDimensionalVizConfig).followMode,
       });
       return { ...config, cameraState: newCameraState };
     });
@@ -265,16 +268,15 @@ export default function CameraInfo({
                     </SRow>
                   )}
                 </Flex>
-                {typeof followTf === "string" && followTf.length > 0 ? (
+                {followMode === "no-follow" && <p>Not following</p>}
+                {followMode !== "no-follow" && (
                   <SRow>
                     <SLabel>Following frame:</SLabel>
                     <SValue>
                       <code>{followTf}</code>
-                      {followOrientation && " with orientation"}
+                      {followMode === "follow-orientation" && " with orientation"}
                     </SValue>
                   </SRow>
-                ) : (
-                  <p>Locked to map</p>
                 )}
               </Flex>
             )}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
@@ -53,7 +53,7 @@ function LayoutToolbar({
   autoSyncCameraState,
   cameraState,
   debug,
-  followOrientation,
+  followMode,
   followTf,
   interactionsTabType,
   isPlaying,
@@ -110,8 +110,8 @@ function LayoutToolbar({
       >
         <FollowTFControl
           transforms={transforms}
-          tfToFollow={typeof followTf === "string" && followTf.length > 0 ? followTf : undefined}
-          followOrientation={followOrientation}
+          followTf={followTf}
+          followMode={followMode}
           onFollowChange={onFollowChange}
         />
         <SearchText
@@ -159,7 +159,7 @@ function LayoutToolbar({
         <CameraInfo
           cameraState={cameraState}
           targetPose={targetPose}
-          followOrientation={followOrientation}
+          followMode={followMode}
           followTf={followTf}
           isPlaying={isPlaying}
           onAlignXYAxis={onAlignXYAxis}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -72,7 +72,10 @@ import {
   CoordinateFrame,
   TransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
-import { ThreeDimensionalVizConfig } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
+import {
+  FollowMode,
+  ThreeDimensionalVizConfig,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { Frame, Topic } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { Color, Marker } from "@foxglove/studio-base/types/Messages";
@@ -88,12 +91,11 @@ export type ClickedPosition = { clientX: number; clientY: number };
 
 export type LayoutToolbarSharedProps = {
   cameraState: CameraState;
-  followOrientation: boolean;
-  followTf?: string | false;
+  followMode: "follow" | "no-follow" | "follow-orientation";
+  followTf?: string;
   onAlignXYAxis: () => void;
   onCameraStateChange: (arg0: CameraState) => void;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  onFollowChange: (followTf?: string | false, followOrientation?: boolean) => void;
+  onFollowChange: (followTf?: string, followMode?: FollowMode) => void;
   saveConfig: Save3DConfig;
   targetPose?: TargetPose;
   transforms: TransformTree;
@@ -205,7 +207,7 @@ export default function Layout({
   renderFrame,
   fixedFrame,
   currentTime,
-  followOrientation,
+  followMode,
   followTf,
   resetFrame,
   frame,
@@ -835,7 +837,7 @@ export default function Layout({
                   interactionsTabType={interactionsTabType}
                   setInteractionsTabType={setInteractionsTabType}
                   debug={debug}
-                  followOrientation={followOrientation}
+                  followMode={followMode}
                   followTf={followTf}
                   isPlaying={isPlaying}
                   measureInfo={measureInfo}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.test.ts
@@ -23,7 +23,7 @@ describe("threeDimensionalVizUtils", () => {
   describe("getNewCameraStateOnFollowChange", () => {
     it("converts the camera state to use targetOffset instead of target when no longer following", () => {
       const prevFollowTf = "root";
-      const prevFollowOrientation = undefined;
+      const prevFollowMode = "follow";
       const prevTargetPose: TargetPose = {
         target: [1322.127197265625, -1484.3931884765625, -20.19326400756836],
         targetOrientation: [
@@ -47,9 +47,9 @@ describe("threeDimensionalVizUtils", () => {
         prevCameraState,
         prevTargetPose,
         prevFollowTf,
-        prevFollowOrientation,
-        newFollowTf: false,
-        newFollowOrientation: undefined,
+        prevFollowMode,
+        newFollowTf: prevFollowTf,
+        newFollowMode: "no-follow",
       });
       expect(newCameraState).toEqual({
         ...prevCameraState,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -35,8 +35,8 @@ export type ThreeDimensionalVizConfig = {
   enableShortDisplayNames?: boolean;
   autoTextBackgroundColor?: boolean;
   cameraState: Partial<CameraState>;
-  followTf?: string | false;
-  followOrientation?: boolean;
+  followTf?: string;
+  followMode?: "follow" | "follow-orientation" | "no-follow";
   modifiedNamespaceTopics?: string[];
   pinTopics: boolean;
   diffModeEnabled: boolean;
@@ -50,3 +50,5 @@ export type ThreeDimensionalVizConfig = {
   colorOverrideByVariable?: ColorOverrideByVariable;
   disableAutoOpenClickedObject?: boolean;
 } & PreviousThreeDimensionalVizConfig;
+
+export type FollowMode = "follow" | "follow-orientation" | "no-follow";


### PR DESCRIPTION
**User-Facing Changes**
When a user selects a follow frame, we remember their follow frame setting in the config even as they toggle through the various follow modes.

**Description**
The existing follow logic used a combination of followTf as a string | boolean and followOrientation boolean to determine the follow mode. This change makes the follow mode explicit as its own configuration value and changes followTf to store the user selected follow frame.

We will have follow-up PRs to fix follow behavior.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
