### PR TITLE
Remove unnecessary "preconfigured" field in panel info

### DIFF
--- a/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
@@ -49,7 +49,7 @@ class MockPanelCatalog implements PanelCatalog {
     return allPanels;
   }
   getPanelByType(type: string): PanelInfo | undefined {
-    return allPanels.find((panel) => panel.preconfigured !== true && panel.type === type);
+    return allPanels.find((panel) => !panel.config && panel.type === type);
   }
 }
 

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -79,7 +79,7 @@ class MockPanelCatalog implements PanelCatalog {
     return allPanels;
   }
   getPanelByType(type: string): PanelInfo | undefined {
-    return allPanels.find((panel) => panel.preconfigured !== true && panel.type === type);
+    return allPanels.find((panel) => !panel.config && panel.type === type);
   }
 }
 

--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -49,14 +49,12 @@ const allPanels: PanelInfo[] = [
     type: "Sample1",
     module: async () => ({ default: MockPanel1 }),
     config: { text: "def" },
-    preconfigured: true,
   },
   {
     title: "Preconfigured Panel BBB",
     type: "Sample2",
     module: async () => ({ default: MockPanel1 }),
     config: { num: 456 },
-    preconfigured: true,
   },
 ];
 
@@ -73,7 +71,7 @@ class MockPanelCatalog implements PanelCatalog {
     return allPanels;
   }
   getPanelByType(type: string): PanelInfo | undefined {
-    return allPanels.find((panel) => panel.preconfigured !== true && panel.type === type);
+    return allPanels.find((panel) => !panel.config && panel.type === type);
   }
 }
 

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -240,8 +240,8 @@ function PanelList(props: Props): JSX.Element {
   const panelCatalog = usePanelCatalog();
   const { allRegularPanels, allPreconfiguredPanels } = useMemo(() => {
     const panels = panelCatalog.getPanels();
-    const regular = panels.filter((panel) => panel.preconfigured !== true);
-    const preconfigured = panels.filter((panel) => panel.preconfigured === true);
+    const regular = panels.filter((panel) => !panel.config);
+    const preconfigured = panels.filter((panel) => panel.config);
     const sortByTitle = (a: PanelInfo, b: PanelInfo) =>
       a.title.localeCompare(b.title, undefined, { ignorePunctuation: true, sensitivity: "base" });
 

--- a/packages/studio-base/src/components/PanelSettings/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.stories.tsx
@@ -43,7 +43,7 @@ class MockPanelCatalog implements PanelCatalog {
     return panels;
   }
   getPanelByType(type: string): PanelInfo | undefined {
-    return panels.find((panel) => panel.preconfigured !== true && panel.type === type);
+    return panels.find((panel) => !panel.config && panel.type === type);
   }
 }
 

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -63,7 +63,7 @@ class MockPanelCatalog implements PanelCatalog {
     return allPanels;
   }
   getPanelByType(type: string): PanelInfo | undefined {
-    return allPanels.find((panel) => panel.preconfigured !== true && panel.type === type);
+    return allPanels.find((panel) => !panel.config && panel.type === type);
   }
 }
 


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
- Cleanup of previously written code for yet-unreleased feature (preconfigured panels)

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
