### PR TITLE
Color tweaks

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -58,6 +58,8 @@ import naturalSort from "@foxglove/studio-base/util/naturalSort";
 
 const log = Log.getLogger(__filename);
 
+const POSE_MARKER_COLOR = { r: 124 / 255, g: 107 / 255, b: 255 / 255, a: 0.5 };
+
 export type TopicSettingsCollection = {
   [topicOrNamespaceKey: string]: Record<string, unknown>;
 };
@@ -70,7 +72,7 @@ const buildSyntheticArrowMarker = ({ topic, message }: MessageEvent<PoseStamped>
   pose,
   frame_locked: true,
   scale: { x: 2, y: 2, z: 0.1 },
-  color: { r: 0, g: 0, b: 1, a: 0.5 },
+  color: POSE_MARKER_COLOR,
   interactionData: { topic, originalMessage: message },
 });
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -135,6 +135,7 @@ vec3 turboColor() {
   const vec2 kGreenVec2 = vec2(4.27729857, 2.82956604);
   const vec2 kBlueVec2 = vec2(-89.90310912, 27.34824973);
 
+  // Clamp the input between [0.0, 1.0], then scale to the range [0.01, 1.0]
   float x = clamp(getFieldValue_UNORM(), 0.0, 1.0) * 0.99 + 0.01;
   vec4 v4 = vec4(1.0, x, x * x, x * x * x);
   vec2 v2 = v4.zw * v4.z;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -135,7 +135,7 @@ vec3 turboColor() {
   const vec2 kGreenVec2 = vec2(4.27729857, 2.82956604);
   const vec2 kBlueVec2 = vec2(-89.90310912, 27.34824973);
 
-  float x = clamp(getFieldValue_UNORM(), 0.0, 1.0);
+  float x = clamp(getFieldValue_UNORM(), 0.0, 1.0) * 0.99 + 0.01;
   vec4 v4 = vec4(1.0, x, x * x, x * x * x);
   vec2 v2 = v4.zw * v4.z;
   return vec3(


### PR DESCRIPTION
**User-Facing Changes**

- Improved visibility for point clouds colored with "Turbo"
- Pose markers are rendered in the 3D panel as purple instead of blue

<img width="1231" alt="Screen Shot 2021-12-22 at 2 23 17 PM" src="https://user-images.githubusercontent.com/195374/147162150-99f69459-93e0-4499-86d8-0c1bc6d03417.png">
