### PR TITLE
Uncolor the follow toggle when not following

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -148,11 +148,11 @@ const FollowTFControl = memo<Props>(function FollowTFControl(props: Props) {
   const followButtonTooltipContent = useMemo(() => {
     switch (followMode) {
       case "follow":
-        return "Follow orientation";
+        return "Following position - click to follow orientation";
       case "follow-orientation":
-        return "Unfollow";
+        return "Following orientation - click to stop following";
       case "no-follow":
-        return "Follow";
+        return "Not following - click to follow position";
     }
   }, [followMode]);
 
@@ -237,7 +237,7 @@ const FollowTFControl = memo<Props>(function FollowTFControl(props: Props) {
       />
       {followButton.tooltip}
       <IconButton
-        checked={followTf != undefined}
+        checked={followMode !== "no-follow"}
         elementRef={followButton.ref}
         onClick={toggleFollowMode}
         iconProps={{


### PR DESCRIPTION

**User-Facing Changes**
The toggle follow icon is blue when following and white when not following.

The toggle icon tooltips indicate the current follow state and the click action.

**Description**
When the followMode is set to follow or follow-orientation, show the icon as blue (checked). When no-follow, show as white (unchecked).

Update the tooltips for the icon to indicate the current state and the new state after clicking.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
