### PR TITLE
Per data source seekback length, set to 0.5s for remote and 2.5s elsewhere

### DIFF
--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -56,6 +56,7 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
+      seekBackNs: BigInt(0.5e9), // 500ms
       name: url,
       urlParams: {
         url,

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -56,7 +56,9 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
-      seekBackNs: BigInt(0.5e9), // 500ms
+      // Overridden to 500ms to limit the number of blocks that need to be
+      // fetched per seek from the potentially slow remote data source
+      seekBackNs: BigInt(0.5e9),
       name: url,
       urlParams: {
         url,

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -35,12 +35,9 @@ import { getSeekToTime, SEEK_ON_START_NS } from "@foxglove/studio-base/util/time
 
 import RandomAccessPlayer, {
   RandomAccessPlayerOptions,
-  DEFAULT_SEEK_BACK_NANOSECONDS,
   SEEK_START_DELAY_MS,
 } from "./RandomAccessPlayer";
 import TestProvider from "./TestProvider";
-
-const SEEK_BACK_NANOSECONDS = Number(DEFAULT_SEEK_BACK_NANOSECONDS);
 
 // By default seek to the start of the bag, since that makes things a bit simpler to reason about.
 const playerOptions: RandomAccessPlayerOptions = {
@@ -785,7 +782,7 @@ describe("RandomAccessPlayer", () => {
       callCount++;
       switch (callCount) {
         case 1: {
-          expect(start).toEqual({ sec: 19, nsec: 1e9 + 50 - SEEK_BACK_NANOSECONDS });
+          expect(start).toEqual({ sec: 17, nsec: 0.5e9 + 50 });
           expect(end).toEqual({ sec: 20, nsec: 50 });
           expect(topics).toEqual({ parsedMessages: ["/foo/bar"] });
           const parsedMessages: MessageEvent<unknown>[] = [
@@ -887,7 +884,7 @@ describe("RandomAccessPlayer", () => {
       callCount++;
       switch (callCount) {
         case 1: {
-          expect(start).toEqual({ sec: 19, nsec: 1e9 + 50 - SEEK_BACK_NANOSECONDS });
+          expect(start).toEqual({ sec: 17, nsec: 0.5e9 + 50 });
           expect(end).toEqual({ sec: 20, nsec: 50 });
           expect(topics).toEqual({ parsedMessages: ["/foo/bar"] });
           return await new Promise((resolve) => {

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -35,10 +35,12 @@ import { getSeekToTime, SEEK_ON_START_NS } from "@foxglove/studio-base/util/time
 
 import RandomAccessPlayer, {
   RandomAccessPlayerOptions,
-  SEEK_BACK_NANOSECONDS,
+  DEFAULT_SEEK_BACK_NANOSECONDS,
   SEEK_START_DELAY_MS,
 } from "./RandomAccessPlayer";
 import TestProvider from "./TestProvider";
+
+const SEEK_BACK_NANOSECONDS = Number(DEFAULT_SEEK_BACK_NANOSECONDS);
 
 // By default seek to the start of the bag, since that makes things a bit simpler to reason about.
 const playerOptions: RandomAccessPlayerOptions = {


### PR DESCRIPTION
**User-Facing Changes**

- Seeking and scrubbing will read messages up to 2.5 seconds before the playhead, improving the display of low frequency markers and transforms

**Description**

seekBackNs is a new constructor arg for RandomAccessPlayer, defaulting to 2.5s and overridden to 0.5s for Ros1RemoteBagDataSource. This could be user-configured in the future.

https://user-images.githubusercontent.com/195374/147195786-98dc3b3e-008b-4960-a586-4570df5e7662.mov