### PR TITLE
Usability enhancements for FollowTFControl

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.stories.tsx
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { action } from "@storybook/addon-actions";
+import { Story } from "@storybook/react";
+
+import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+
+import FollowTFControl from "./FollowTFControl";
+
+export default {
+  title: "panels/ThreeDimensionalViz/FollowTFControl",
+  component: FollowTFControl,
+};
+
+export const NoTransformsNoFollow: Story = () => {
+  return (
+    <FollowTFControl
+      followMode="no-follow"
+      transforms={new TransformTree()}
+      onFollowChange={action("onFollowChange")}
+    />
+  );
+};
+
+export const NoTransforms: Story = () => {
+  return (
+    <FollowTFControl
+      followTf="some_frame"
+      followMode="no-follow"
+      transforms={new TransformTree()}
+      onFollowChange={action("onFollowChange")}
+    />
+  );
+};
+
+export const FollowNotFound: Story = () => {
+  const tree = new TransformTree();
+  tree.getOrCreateFrame("new_frame");
+
+  return (
+    <FollowTFControl
+      followTf="some_frame"
+      followMode="no-follow"
+      transforms={tree}
+      onFollowChange={action("onFollowChange")}
+    />
+  );
+};
+
+export const Following: Story = () => {
+  const tree = new TransformTree();
+  tree.getOrCreateFrame("new_frame");
+
+  return (
+    <FollowTFControl
+      followTf="new_frame"
+      followMode="follow"
+      transforms={tree}
+      onFollowChange={action("onFollowChange")}
+    />
+  );
+};

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -119,8 +119,8 @@ function BaseRenderer(props: Props): JSX.Element {
 
   const renderFrame = useMemo<CoordinateFrame>(() => {
     // If the user specified a followTf, do not fall back to any other (valid) frame
-    if (typeof followTf === "string") {
-      return transforms.frame(followTf) ?? orphanedFrame;
+    if (followTf) {
+      return transforms.frame(followTf) ?? new CoordinateFrame(followTf, undefined);
     }
 
     // Try the conventional list of transform ids
@@ -242,7 +242,7 @@ function BaseRenderer(props: Props): JSX.Element {
       config={config}
       currentTime={currentTime}
       followMode={followMode}
-      followTf={followTf}
+      followTf={renderFrame.id}
       renderFrame={renderFrame}
       fixedFrame={fixedFrame}
       resetFrame={resetFrame}


### PR DESCRIPTION

**User-Facing Changes**
Disabled state when there are no transforms:

<img width="128" alt="Screen Shot 2021-12-22 at 10 02 25 PM" src="https://user-images.githubusercontent.com/84792/147197543-2473f48d-5fa4-4180-acc3-b94fb4f36cd2.png">

The frame name of the current render frame is shown. This indicates to the user what frame the camera is following by default.
<img width="145" alt="Screen Shot 2021-12-22 at 10 02 53 PM" src="https://user-images.githubusercontent.com/84792/147197561-5fad1b28-20a7-4d25-8402-16041284d435.png">

The user can change the frame to any other valid frame.
<img width="159" alt="Screen Shot 2021-12-22 at 10 03 28 PM" src="https://user-images.githubusercontent.com/84792/147197574-6fc93b3c-a07b-49cf-8f83-294feadf336b.png">

The selected frame is persisted to panel save state. If the user opens a data source missing this frame the text appears in red.
<img width="158" alt="Screen Shot 2021-12-22 at 10 03 52 PM" src="https://user-images.githubusercontent.com/84792/147197585-13cc5676-bec6-40af-9c8c-8d1226054343.png">

The user can select a new frame if they no longer want to use the invalid frame.
<img width="179" alt="Screen Shot 2021-12-22 at 10 04 40 PM" src="https://user-images.githubusercontent.com/84792/147197602-89ac2157-02e7-4005-ad8a-afd7433aa9e8.png">


**Description**
- When there are no transforms, the control is disabled.
- If a follow frame is not found in the current transform tree, it is shown in red text in the text box.
- If a user has not manually selected a frame, the frame for the current renderFrame is shown.

Fixes: #2486

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
