### PR TITLE
Fix datatype column in DataSourceInfo panel

### DIFF
--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -54,6 +54,15 @@ function SourceInfo() {
     [theme],
   );
 
+  const detailListItems = useMemo<(Topic & { key: string })[]>(() => {
+    return (
+      topics?.map((topic) => ({
+        key: topic.name,
+        ...topic,
+      })) ?? []
+    );
+  }, [topics]);
+
   if (!startTime || !endTime) {
     return (
       <>
@@ -106,12 +115,7 @@ function SourceInfo() {
           disableSelectionZone
           enableUpdateAnimations={false}
           isHeaderVisible={false}
-          items={
-            topics?.map((topic) => ({
-              key: topic.name,
-              ...topic,
-            })) as Topic[]
-          }
+          items={detailListItems}
           columns={[
             {
               key: "name",
@@ -145,7 +149,7 @@ function SourceInfo() {
                   textProps={{ variant: "small" }}
                   tooltip={`Click to copy topic name ${topic.datatype} to clipboard.`}
                 >
-                  {topic.name}
+                  {topic.datatype}
                 </CopyText>
               ),
             },


### PR DESCRIPTION

**User-Facing Changes**
The datatype column displays the datatype again - yay.

**Description**
The datatype column incorrectly displayed the topic name rather than the datatype.

Fixes: #2495


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
