### PR TITLE
Fix LaserScan pose when rendering a different frame, use intensities[]

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -894,7 +894,7 @@ export default class SceneBuilder implements MarkerProvider {
       | OccupancyGridMessage
       | PointCloud2
       | (PoseStamped & { type: 103 })
-      | (LaserScan & { type: 104 });
+      | (LaserScan & { type: 104; pose: MutablePose });
     switch (marker.type) {
       case 1: // CubeMarker
       case 2: // SphereMarker
@@ -918,12 +918,10 @@ export default class SceneBuilder implements MarkerProvider {
       case 103: // PoseStamped
       case 108: // InstanceLineListMarker
       case 110: // ColorMarker
-        marker = { ...marker, pose };
-        break;
       case 101: // OccupancyGridMessage
+      case 104: // LaserScan
         marker = { ...marker, pose };
         break;
-      case 104: // LaserScan - needs special handling
       default:
         break;
     }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/LaserScans.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/LaserScans.tsx
@@ -48,6 +48,7 @@ const LaserScanVert = `
   attribute vec4 hitmapColor;
 
   varying vec4 vColor;
+  varying float vIntensity;
 
   void main () {
     float angle = angle_min + index * angle_increment;
@@ -60,6 +61,7 @@ const LaserScanVert = `
       gl_PointSize = 0.;
     }
     vColor = isHitmap ? hitmapColor : color;
+    vIntensity = intensity;
   }
 `;
 
@@ -91,14 +93,18 @@ const laserScan = (regl: REGL.Regl) =>
     vert: LaserScanVert,
     frag: `
   precision mediump float;
-  varying vec4 vColor;
+
   uniform bool isCircle;
+
+  varying vec4 vColor;
+  varying float vIntensity;
+
   void main () {
     if (isCircle && length(gl_PointCoord * 2.0 - 1.0) > 1.0) {
       discard;
     }
 
-    gl_FragColor = vColor;
+    gl_FragColor = vColor * vIntensity;
   }
   `,
 


### PR DESCRIPTION
**User-Facing Changes**

- Fix LaserScan pose when rendering a different frame, `intensities[]` values are now visualized

**Description**

<img width="670" alt="Screen Shot 2021-12-23 at 12 41 28 AM" src="https://user-images.githubusercontent.com/195374/147213953-3f3ecc46-d91e-482e-9385-d792f64eb0e6.png">