### PR TITLE
Remove getZoomDistanceFromURLParam

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
@@ -32,16 +32,6 @@ import { InstancedLineListMarker } from "@foxglove/studio-base/types/Messages";
 
 export type TargetPose = { target: Vec3; targetOrientation: Vec4 };
 
-const ZOOM_LEVEL_URL_PARAM = "zoom";
-
-function getZoomDistanceFromURLParam(): number | undefined {
-  const params = new URLSearchParams(location?.search);
-  if (params.has(ZOOM_LEVEL_URL_PARAM)) {
-    return parseFloat(params.get(ZOOM_LEVEL_URL_PARAM) as string);
-  }
-  return undefined;
-}
-
 // Get the camera target position and orientation
 function getTargetPose(
   followTf: string | false | undefined,
@@ -84,10 +74,6 @@ export function useTransformedCameraState({
     if (followMode === "follow-orientation") {
       transformedCameraState.targetOrientation = lastTargetPose.targetOrientation;
     }
-  }
-  // Read the distance from URL when World is first loaded with empty cameraState distance in savedProps
-  if (configCameraState.distance == undefined) {
-    transformedCameraState.distance = getZoomDistanceFromURLParam();
   }
 
   const mergedCameraState = mergeWith(


### PR DESCRIPTION


**User-Facing Changes**
None.

The removed functionality is unsupported and undocumented.

**Description**

This was a relic from our webviz fork. We do not support this url parameter.

Generally we avoid reading url params directly within individual components and rely on our url adapter to configure items through contexts.
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
