### PR TITLE
Chart: add main-thread fallback for browsers without OffscreenCanvas support

### DIFF
--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -53,7 +53,11 @@ type RpcUpdateEvent = {
 // >100%. For more info on this crash, see util/waitForFonts.ts.
 async function loadDefaultFont(): Promise<FontFace> {
   const fontFace = new FontFace("IBM Plex Mono", `url(${PlexMono}) format('woff2')`);
-  (self as unknown as WorkerGlobalScope).fonts.add(fontFace);
+  if (typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope) {
+    (self as unknown as WorkerGlobalScope).fonts.add(fontFace);
+  } else {
+    document.fonts.add(fontFace);
+  }
   return await fontFace.load();
 }
 
@@ -88,7 +92,7 @@ export default class ChartJsMux {
   constructor(rpc: Rpc) {
     this._rpc = rpc;
 
-    if (this._rpc instanceof Rpc) {
+    if (typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope) {
       setupWorker(this._rpc);
     }
 

--- a/web/src/VersionBanner.tsx
+++ b/web/src/VersionBanner.tsx
@@ -34,6 +34,7 @@ const StyledIconWrapper = styled.div`
   position: absolute;
   top: 10px;
   right: 10px;
+  cursor: pointer;
 `;
 
 const VersionBanner = function ({
@@ -52,8 +53,8 @@ const VersionBanner = function ({
   }
 
   const prompt = isChrome
-    ? "You're using an outdated version of Chrome."
-    : "You're using an unsupported browser.";
+    ? "You’re using an outdated version of Chrome."
+    : "You’re using an unsupported browser.";
   const fixText = isChrome ? "Update Chrome" : "Download Chrome";
 
   return (
@@ -75,7 +76,18 @@ const VersionBanner = function ({
         {isChrome ? undefined : (
           <Text styles={{ root: { color: "white", fontSize: "1.1em" } }}>
             Check out our cross-browser support progress in GitHub issue{" "}
-            <Link href="https://github.com/foxglove/studio/issues/1511">#1511</Link>.
+            <Link
+              styles={{
+                root: {
+                  color: "rgba(229, 218, 255, 0.9)",
+                  ":hover": { color: "rgba(247, 244, 255, 0.9)" },
+                },
+              }}
+              href="https://github.com/foxglove/studio/issues/1511"
+            >
+              #1511
+            </Link>
+            .
           </Text>
         )}
 
@@ -85,15 +97,15 @@ const VersionBanner = function ({
           rel="noreferrer"
           styles={{
             root: {
-              color: "rgba(255,255, 255, 0.7)",
+              color: "white",
               backgroundColor: "rgba(255,255, 255, 0.1)",
               borderRadius: "4px",
-              border: "none",
+              border: "1px solid rgba(255,255,255,0.3)",
               fontSize: "1em",
             },
             rootHovered: {
               color: "white",
-              backgroundColor: "rgba(255,255, 255, 0.4)",
+              backgroundColor: "rgba(255,255, 255, 0.3)",
             },
           }}
         >


### PR DESCRIPTION
Partially addresses https://github.com/foxglove/studio/issues/1541 (for Plot and StateTransitions panels).

Fixes https://github.com/foxglove/studio/issues/1758.

Adapted approach from the webviz code: https://github.com/cruise-automation/webviz/blob/633920b68bdcd951b79a0bc44d0a5cf2b35814d6/packages/webviz-core/src/panels/ImageView/ImageCanvas.js#L105-L109

<img width="892" alt="image" src="https://user-images.githubusercontent.com/14237/147282530-956ce48c-6c79-443a-9605-2ef83800e564.png">
