### PR TITLE
ImageCanvas: add main-thread fallback for browsers without OffscreenCanvas support

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -168,7 +168,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
   useLayoutEffect(() => {
     if (props.renderInMainThread !== true && !supportsOffscreenCanvas) {
       addToast(
-        "Your browser does not support rendering images in a backaground thread. Performance may be degraded.",
+        "Your browser does not support rendering images in a background thread. Performance may be degraded.",
         { appearance: "warning", autoDismiss: true },
       );
     }

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -16,6 +16,7 @@ import MagnifyIcon from "@mdi/svg/svg/magnify.svg";
 import cx from "classnames";
 import { useCallback, useLayoutEffect, useRef, MouseEvent, useState, useMemo } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { useToasts } from "react-toast-notifications";
 import { useAsync } from "react-use";
 import usePanZoom from "use-pan-and-zoom";
 import { v4 as uuidv4 } from "uuid";
@@ -158,10 +159,20 @@ const supportsOffscreenCanvas =
   typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function";
 
 export default function ImageCanvas(props: Props): JSX.Element {
+  const { addToast } = useToasts();
   const { rawMarkerData, topic, image, config, saveConfig, onStartRenderImage } = props;
-  const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
   const { mode } = config;
   const classes = useStyles();
+
+  const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
+  useLayoutEffect(() => {
+    if (props.renderInMainThread !== true && !supportsOffscreenCanvas) {
+      addToast(
+        "Your browser does not support rendering images in a backaground thread. Performance may be degraded.",
+        { appearance: "warning", autoDismiss: true },
+      );
+    }
+  }, [addToast, props.renderInMainThread]);
 
   // generic errors within the panel
   const [error, setError] = useState<Error | undefined>();

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -154,16 +154,12 @@ type RenderImage = (args: {
   options?: RenderOptions;
 }) => Promise<Dimensions | undefined>;
 
+const supportsOffscreenCanvas =
+  typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function";
+
 export default function ImageCanvas(props: Props): JSX.Element {
-  const {
-    rawMarkerData,
-    topic,
-    image,
-    config,
-    saveConfig,
-    renderInMainThread,
-    onStartRenderImage,
-  } = props;
+  const { rawMarkerData, topic, image, config, saveConfig, onStartRenderImage } = props;
+  const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
   const { mode } = config;
   const classes = useStyles();
 
@@ -201,7 +197,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
 
     const id = uuidv4();
 
-    if (renderInMainThread === true) {
+    if (renderInMainThread) {
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       const renderInMain = (args: {
@@ -299,7 +295,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
     }
 
     return () => {
-      if (renderInMainThread === true) {
+      if (renderInMainThread) {
         return;
       }
 


### PR DESCRIPTION
Partially addresses https://github.com/foxglove/studio/issues/1541

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/14237/147285065-117aa5e5-2ee9-4acf-bbac-c7be91b22c5f.png">

