### PR TITLE
Fix drag overlay in Firefox

### DIFF
--- a/packages/studio-base/src/components/DocumentDropListener.tsx
+++ b/packages/studio-base/src/components/DocumentDropListener.tsx
@@ -118,7 +118,7 @@ export default function DocumentDropListener(props: Props): JSX.Element {
       }
 
       const { dataTransfer } = ev;
-      if (dataTransfer?.types[0] === "Files") {
+      if (dataTransfer?.types.includes("Files") === true) {
         ev.stopPropagation();
         ev.preventDefault();
         dataTransfer.dropEffect = "copy";


### PR DESCRIPTION
In Firefox, `dataTransfer.types` was `["application/x-moz-file", "Files"]`, so the drag overlay wouldn't appear (although the drop event worked properly). We shouldn't rely on `"Files"` being the first item in the list.