### PR TITLE
Remove ROS_HOSTNAME from app settings

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -6,7 +6,6 @@ export enum AppSetting {
   CRASH_REPORTING_ENABLED = "telemetry.crashReportingEnabled",
   MESSAGE_RATE = "messageRate",
   LAUNCH_PREFERENCE = "launchPreference",
-  ROS1_ROS_HOSTNAME = "ros1.ros_hostname",
   ROS_PACKAGE_PATH = "ros.ros_package_path",
   TELEMETRY_ENABLED = "telemetry.telemetryEnabled",
   TIME_FORMAT = "time.format",

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -19,7 +19,6 @@ import moment from "moment-timezone";
 import { useCallback, useMemo, useState } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
-import { RosNode } from "@foxglove/ros1";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import { ExperimentalFeatureSettings } from "@foxglove/studio-base/components/ExperimentalFeatureSettings";
@@ -246,30 +245,6 @@ function MessageFramerate(): React.ReactElement {
   );
 }
 
-function RosHostname(): React.ReactElement {
-  const [rosHostname, setRosHostname] = useAppConfigurationValue<string>(
-    AppSetting.ROS1_ROS_HOSTNAME,
-  );
-
-  const os = OsContextSingleton;
-  const rosHostnamePlaceholder = useMemo(
-    () =>
-      os != undefined
-        ? RosNode.GetRosHostname(os.getEnvVar, os.getHostname, os.getNetworkInterfaces)
-        : "localhost",
-    [os],
-  );
-
-  return (
-    <TextField
-      label="ROS_HOSTNAME"
-      placeholder={rosHostnamePlaceholder}
-      value={rosHostname ?? ""}
-      onChange={(_event, newValue) => void setRosHostname(newValue ? newValue : undefined)}
-    />
-  );
-}
-
 function RosPackagePath(): React.ReactElement {
   const [rosPackagePath, setRosPackagePath] = useAppConfigurationValue<string>(
     AppSetting.ROS_PACKAGE_PATH,
@@ -343,9 +318,6 @@ export default function Preferences(): React.ReactElement {
         <Stack.Item>
           <SectionHeader>ROS</SectionHeader>
           <Stack tokens={{ childrenGap: theme.spacing.s1 }}>
-            <Stack.Item>
-              <RosHostname />
-            </Stack.Item>
             <Stack.Item>
               <RosPackagePath />
             </Stack.Item>


### PR DESCRIPTION


**User-Facing Changes**
The user cannot set ROS_HOSTNAME via app settings. Since open dialog flow was enabled we were not using the ROS_HOSTNAME setting from app settings anyway so this fixes the incorrect availability of this setting at the app level.

**Description**
The ROS_HOSTNAME option is now set in the ROS1 Connection settings within the open dialog flow.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
