### PR TITLE
Remove dead code for automatic sidebar close on connection

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -199,23 +199,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     setShowOpenDialog(isPlayerPresent ? undefined : { view: "start" });
   }, [isPlayerPresent]);
 
-  // Automatically close the connection sidebar when a connection is chosen
-  useLayoutEffect(() => {
-    // When using the open dialog feature we don't automatically do anything with the connection sidebar
-    if (enableOpenDialog === true) {
-      return;
-    }
-
-    if (userSelectSidebarItem.current) {
-      userSelectSidebarItem.current = false;
-      return;
-    }
-
-    if (selectedSidebarItem === "connection" && playerPresence === PlayerPresence.PRESENT) {
-      setSelectedSidebarItem(undefined);
-    }
-  }, [selectedSidebarItem, playerPresence, enableOpenDialog]);
-
   const { setHelpInfo } = useHelpInfo();
 
   const handleInternalLink = useCallback(


### PR DESCRIPTION


**User-Facing Changes**
None. The open dialog flow does not automatically close the data source sidebar.

**Description**
With the new open dialog flow we no longer close the data source sidebar when a data source is selected. This change removes this dead code path.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
