### PR TITLE
Add isSampleDataSource to RandomAccessPlayerOptions

### DIFF
--- a/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleUdacityDataSourceFactory.ts
@@ -9,7 +9,6 @@ import {
 import RandomAccessPlayer from "@foxglove/studio-base/players/RandomAccessPlayer";
 import Ros1MemoryCacheDataProvider from "@foxglove/studio-base/randomAccessDataProviders/Ros1MemoryCacheDataProvider";
 import WorkerBagDataProvider from "@foxglove/studio-base/randomAccessDataProviders/WorkerBagDataProvider";
-import { DEMO_BAG_URL } from "@foxglove/studio-base/util/isDemoBagUrl";
 import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
 class SampleUdacityDataSourceFactory implements IDataSourceFactory {
@@ -183,7 +182,8 @@ class SampleUdacityDataSourceFactory implements IDataSourceFactory {
   };
 
   initialize(args: DataSourceFactoryInitializeArgs): ReturnType<IDataSourceFactory["initialize"]> {
-    const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url: DEMO_BAG_URL });
+    const bagUrl = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
+    const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url: bagUrl });
     const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider, {
       unlimitedCache: args.unlimitedMemoryCache,
     });

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -35,9 +35,9 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
     this.logEvent(AppEvent.PLAYER_CONSTRUCTED);
   }
 
-  initialized(args?: { isDemoBag: boolean }): void {
+  initialized(args?: { isSampleDataSource: boolean }): void {
     this.logEvent(AppEvent.PLAYER_INITIALIZED, {
-      isDemoBag: args?.isDemoBag == undefined ? false : args.isDemoBag,
+      isSampleDataSource: args?.isSampleDataSource === true,
     });
   }
 

--- a/packages/studio-base/src/players/NoopMetricsCollector.ts
+++ b/packages/studio-base/src/players/NoopMetricsCollector.ts
@@ -23,7 +23,7 @@ export default class NoopMetricsCollector implements PlayerMetricsCollectorInter
   playerConstructed(): void {
     // no-op
   }
-  initialized(_args?: { isDemoBag: boolean }): void {
+  initialized(_args?: { isSampleDataSource: boolean }): void {
     // no-op
   }
   play(_speed: number): void {

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -1372,7 +1372,7 @@ describe("RandomAccessPlayer", () => {
       playerConstructed(): void {
         // no-op
       }
-      initialized(_args?: { isDemoBag: boolean }): void {
+      initialized(_args?: { isSampleDataSource: boolean }): void {
         this._initialized++;
       }
       play(_speed: number): void {

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -49,7 +49,6 @@ import {
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import debouncePromise from "@foxglove/studio-base/util/debouncePromise";
 import delay from "@foxglove/studio-base/util/delay";
-import isDemoBagUrl from "@foxglove/studio-base/util/isDemoBagUrl";
 import { isRangeCoveredByRanges } from "@foxglove/studio-base/util/ranges";
 import { getSanitizedTopics } from "@foxglove/studio-base/util/selectors";
 import {
@@ -82,6 +81,8 @@ export type RandomAccessPlayerOptions = {
 
   // Optional set of key/values to store with url handling
   urlParams?: Record<string, string>;
+
+  isSampleDataSource?: boolean;
 };
 
 // A `Player` that wraps around a tree of `RandomAccessDataProviders`.
@@ -129,6 +130,7 @@ export default class RandomAccessPlayer implements Player {
   private _seekToTime: SeekToTimeSpec;
   private _lastRangeMillis?: number;
   private _parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
+  private _isSampleDataSource: boolean;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
@@ -154,6 +156,7 @@ export default class RandomAccessPlayer implements Player {
     this._seekToTime = seekToTime;
     this._seekBackNs = seekBackNs;
     this._metricsCollector.playerConstructed();
+    this._isSampleDataSource = options.isSampleDataSource ?? false;
   }
 
   private _setError(message: string, error?: Error): void {
@@ -545,7 +548,7 @@ export default class RandomAccessPlayer implements Player {
     if (this._initializing || this._initialized) {
       return;
     }
-    this._metricsCollector.initialized({ isDemoBag: isDemoBagUrl(this._name ?? "") });
+    this._metricsCollector.initialized({ isSampleDataSource: this._isSampleDataSource });
     this._initialized = true;
   }
 

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -294,7 +294,7 @@ export const PlayerCapabilities = {
 export interface PlayerMetricsCollectorInterface {
   setProperty(key: string, value: string | number | boolean): void;
   playerConstructed(): void;
-  initialized(args?: { isDemoBag: boolean }): void;
+  initialized(args?: { isSampleDataSource: boolean }): void;
   play(speed: number): void;
   seek(time: Time): void;
   setSpeed(speed: number): void;

--- a/packages/studio-base/src/util/isDemoBagUrl.ts
+++ b/packages/studio-base/src/util/isDemoBagUrl.ts
@@ -1,8 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-
-export const DEMO_BAG_URL = "https://storage.googleapis.com/foxglove-public-assets/demo.bag";
-const isDemoBagUrl = (label: string): boolean => label === DEMO_BAG_URL;
-
-export default isDemoBagUrl;


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than detecting a specific url for a demo bag via isDemoBag, this change adds a new constructor option to RandomAccessPlayer for a data source factory to specify if it is for a sample data set. This option updates the metrics collector to tag sample data vs non-sample data. This will support additional sample data sets.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
