### PR TITLE
Remove Open Dialog from ExperimentalFeatures

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -48,11 +48,6 @@ const features: Feature[] = [
     name: "MCAP data source",
     description: <>Enable the MCAP data source.</>,
   },
-  {
-    key: AppSetting.OPEN_DIALOG,
-    name: "Open dialog",
-    description: <>Use the new open dialog for selecting data sources.</>,
-  },
 ];
 if (process.env.NODE_ENV === "development") {
   features.push({


### PR DESCRIPTION


**User-Facing Changes**
The Open Dialog feature can no longer be toggled off via the UI. It is always on.

**Description**
The Open Dialog can still be disabled by providing a default value to an AppConfigurationProvider via props.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
