### PR TITLE
Remove (local) and (remote) suffix from file and remote

### DIFF
--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -15,7 +15,7 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 class McapLocalDataSourceFactory implements IDataSourceFactory {
   id = "mcap-local-file";
   type: IDataSourceFactory["type"] = "file";
-  displayName = "MCAP (local)";
+  displayName = "MCAP";
   iconName: IDataSourceFactory["iconName"] = "OpenFile";
   supportedFileTypes = [".mcap"];
 

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
@@ -15,7 +15,7 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
   id = "ros1-local-bagfile";
   type: IDataSourceFactory["type"] = "file";
-  displayName = "ROS 1 Bag (local)";
+  displayName = "ROS 1 Bag";
   iconName: IDataSourceFactory["iconName"] = "OpenFile";
   supportedFileTypes = [".bag"];
 

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -17,7 +17,7 @@ import { parseInputUrl } from "@foxglove/studio-base/util/url";
 class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
   id = "ros1-remote-bagfile";
   type: IDataSourceFactory["type"] = "remote-file";
-  displayName = "ROS 1 Bag (remote)";
+  displayName = "ROS 1 Bag";
   iconName: IDataSourceFactory["iconName"] = "FileASPX";
   supportedFileTypes = [".bag"];
 

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -15,7 +15,7 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
   id = "ros2-local-bagfile";
   type: IDataSourceFactory["type"] = "file";
-  displayName = "ROS 2 Bag (local)";
+  displayName = "ROS 2 Bag";
   iconName: IDataSourceFactory["iconName"] = "OpenFile";
   supportedFileTypes = [".db3"];
   supportsMultiFile = true;

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
@@ -15,7 +15,7 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 class UlogLocalDataSourceFactory implements IDataSourceFactory {
   id = "ulog-local-file";
   type: IDataSourceFactory["type"] = "file";
-  displayName = "PX4 ULog (local)";
+  displayName = "PX4 ULog";
   iconName: IDataSourceFactory["iconName"] = "OpenFile";
   supportedFileTypes = [".ulg", ".ulog"];
 


### PR DESCRIPTION


**User-Facing Changes**
None. Right now we no longer display these names to end users. The open dialog flow abstracts local file data sources under a single "Open file" action and remote files under a single "Open remote file" action.

**Description**
This suffix provided distinction when we had one list of data sources for the user to select. We now all the user to load any file supported by file type data sources. Similarly we allow the user to load remote files supported by any remote type data source.

The user does not select these data sources individually nor do we display them in a list.

If we do want to display them in a list - we have a _type_ field on each data source which indicates this information.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
