### PR TITLE
Add "Show on startup" checkbox to Open Dialog

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -19,4 +19,5 @@ export enum AppSetting {
   COLOR_SCHEME = "colorScheme",
   ENABLE_MCAP_DATA_SOURCE = "sources.mcap",
   OPEN_DIALOG = "ui.open-dialog",
+  SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
 }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -170,10 +170,15 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const isPlayerPresent = playerPresence !== PlayerPresence.NOT_PRESENT;
 
+  const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
+
+  const [showOpenDialogOnStartup = true] = useAppConfigurationValue<boolean>(
+    AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,
+  );
+
   const [showOpenDialog, setShowOpenDialog] = useState<
     { view: OpenDialogViews; activeDataSource?: IDataSourceFactory } | undefined
-  >(isPlayerPresent ? undefined : { view: "start" });
-  const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
+  >(isPlayerPresent || !showOpenDialogOnStartup ? undefined : { view: "start" });
 
   const [selectedSidebarItem, setSelectedSidebarItem] = useState<SidebarItemKey | undefined>(() => {
     // When using the open dialog ui - we always start with the connection sidebar open.
@@ -194,9 +199,11 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     setSelectedSidebarItem(item);
   }, []);
 
-  // When a player is activated, hide the open dialog. When a player is gone, show the open dialog.
+  // When a player is activated, hide the open dialog.
   useLayoutEffect(() => {
-    setShowOpenDialog(isPlayerPresent ? undefined : { view: "start" });
+    if (isPlayerPresent) {
+      setShowOpenDialog(undefined);
+    }
   }, [isPlayerPresent]);
 
   const { setHelpInfo } = useHelpInfo();

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -180,7 +180,6 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
           styles: {
             content: {
               overflow: "hidden",
-              height: 480,
               display: "flex",
               flexDirection: "column",
               padding: theme.spacing.l1,

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -2,10 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { CompoundButton, Stack, Text, IButtonProps, useTheme } from "@fluentui/react";
+import { CompoundButton, Stack, Text, IButtonProps, useTheme, Checkbox } from "@fluentui/react";
 import { useMemo } from "react";
 
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import TextMiddleTruncate from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/TextMiddleTruncate";
 
 import ActionList from "./ActionList";
@@ -41,6 +43,10 @@ export default function Start(props: IStartProps): JSX.Element {
   const { supportedFileExtensions = [], onSelectView } = props;
   const theme = useTheme();
   const { recentSources, selectRecent } = usePlayerSelection();
+
+  const [showOnStartup = true, setShowOnStartup] = useAppConfigurationValue<boolean>(
+    AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,
+  );
 
   const buttonStyles = useMemo(
     () => ({
@@ -147,7 +153,7 @@ export default function Start(props: IStartProps): JSX.Element {
   }, [recentSources, selectRecent, theme]);
 
   return (
-    <>
+    <Stack tokens={{ childrenGap: theme.spacing.l1 }}>
       <Stack horizontal tokens={{ childrenGap: theme.spacing.l2 }}>
         {/* Left column */}
         <Stack grow tokens={{ childrenGap: theme.spacing.m }}>
@@ -167,6 +173,13 @@ export default function Start(props: IStartProps): JSX.Element {
           <ActionList title="Help" items={HELP_ITEMS} />
         </Stack>
       </Stack>
-    </>
+      <Checkbox
+        label="Show on startup"
+        checked={showOnStartup}
+        onChange={async (_, checked) => {
+          await setShowOnStartup(checked);
+        }}
+      />
+    </Stack>
   );
 }


### PR DESCRIPTION

**User-Facing Changes**
New "Show on startup" checkbox.

<img width="873" alt="Screen Shot 2021-12-24 at 8 08 10 PM" src="https://user-images.githubusercontent.com/84792/147375357-a0c29ace-91f7-42a9-8946-aa30cd63af48.png">



**Description**
This checkbox allows the user to toggle whether the Open Dialog shows automatically on startup or requires the user to take an action to show the dialog.

Fixes: #2532

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
