### PR TITLE
Fix empty state for ImagePanel

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageEmptyState.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageEmptyState.tsx
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { makeStyles } from "@fluentui/react";
+
+import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { formatTimeRaw, getTimestampForMessage } from "@foxglove/studio-base/util/time";
+
+type Props = {
+  cameraTopic: string;
+  markerTopics: string[];
+  shouldSynchronize: boolean;
+  messagesByTopic: {
+    [topic: string]: readonly MessageEvent<unknown>[];
+  };
+};
+
+const useStyles = makeStyles((theme) => ({
+  emptyStateWrapper: {
+    width: "100%",
+    height: "100%",
+    background: theme.palette.neutralLighterAlt,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+}));
+
+// Group image topics by the first component of their name
+export default function ImageEmptyState(props: Props): JSX.Element {
+  const { cameraTopic, markerTopics, shouldSynchronize, messagesByTopic } = props;
+
+  const classes = useStyles();
+  if (cameraTopic === "") {
+    return (
+      <div className={classes.emptyStateWrapper}>
+        <EmptyState>Select a topic to view images</EmptyState>
+      </div>
+    );
+  }
+  return (
+    <div className={classes.emptyStateWrapper}>
+      <EmptyState>
+        Waiting for images {markerTopics.length > 0 && "and markers"} on:
+        <div>
+          <div>
+            <code>{cameraTopic}</code>
+          </div>
+          {markerTopics.sort().map((m) => (
+            <div key={m}>
+              <code>{m}</code>
+            </div>
+          ))}
+        </div>
+        {shouldSynchronize && (
+          <>
+            <p>
+              Synchronization is enabled, so all messages with <code>header.stamp</code>s must match
+              exactly.
+            </p>
+            <ul>
+              {Object.entries(messagesByTopic).map(([topic, topicMessages]) => (
+                <li key={topic}>
+                  <code>{topic}</code>:{" "}
+                  {topicMessages.length > 0
+                    ? topicMessages
+                        .map(({ message }) => {
+                          const stamp = getTimestampForMessage(message);
+                          return stamp != undefined ? formatTimeRaw(stamp) : "[ unknown ]";
+                        })
+                        .join(", ")
+                    : "no messages"}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </EmptyState>
+    </div>
+  );
+}


### PR DESCRIPTION


**User-Facing Changes**
When the image panel enters empty state the user sees only the empty state message rather than a stale image and the empty state message.

**Description**
As an optimization, the image panel always keeps the ImageCanvas mounted even when there is no current image to display. When seeking or changing the message order, there may not be an image loaded for display, yet the image panel would erroneously show the stale image alongside the empty state message.

This change fixes the styles so the empty state covers any stale image and avoid split screen with empty state and stale image.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
