### PR TITLE
Stories for geometry_msgs/PolygonStamped and nav_msgs/Path

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -14,6 +14,7 @@ import {
   CubeListMarker,
   CubeMarker,
   CylinderMarker,
+  GeometryMsgs$PolygonStamped,
   LaserScan,
   LineListMarker,
   LineStripMarker,
@@ -138,6 +139,12 @@ function makeFail({
 
 const datatypes = new Map<string, RosMsgDefinition>(
   Object.entries({
+    "geometry_msgs/PolygonStamped": {
+      definitions: [
+        { name: "header", type: "std_msgs/Header", isComplex: true },
+        { name: "polygon", type: "geometry_msgs/Polygon", isComplex: true },
+      ],
+    },
     "geometry_msgs/TransformStamped": {
       definitions: [
         { name: "header", type: "std_msgs/Header", isComplex: true },
@@ -205,10 +212,22 @@ const datatypes = new Map<string, RosMsgDefinition>(
         { name: "frame_id", type: "string" },
       ],
     },
+    "geometry_msgs/Polygon": {
+      definitions: [
+        { name: "points", type: "geometry_msgs/Point32", isArray: true, isComplex: true },
+      ],
+    },
     "geometry_msgs/Transform": {
       definitions: [
         { name: "translation", type: "geometry_msgs/Vector3", isComplex: true },
         { name: "rotation", type: "geometry_msgs/Quaternion", isComplex: true },
+      ],
+    },
+    "geometry_msgs/Point32": {
+      definitions: [
+        { name: "x", type: "float32" },
+        { name: "y", type: "float32" },
+        { name: "z", type: "float32" },
       ],
     },
     "geometry_msgs/Vector3": {
@@ -823,6 +842,93 @@ export function MarkerLifetimes(): JSX.Element {
   );
 }
 
+export function GeometryMsgs_Polygon(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/polygon", datatype: "geometry_msgs/PolygonStamped" },
+    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
+  ];
+  const tf1: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+      child_frame_id: "base_link",
+      transform: {
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf2: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+      child_frame_id: "sensor",
+      transform: {
+        translation: { x: 0, y: 0, z: 1 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const polygon: MessageEvent<GeometryMsgs$PolygonStamped> = {
+    topic: "/polygon",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      polygon: {
+        points: [
+          { x: -1, y: -1, z: 0 },
+          { x: 0, y: 0, z: 2 },
+          { x: 1, y: 1, z: 0 },
+        ],
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const fixture = useDelayedFixture({
+    datatypes,
+    topics,
+    frame: {
+      "/polygon": [polygon],
+      "/tf": [tf1, tf2],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 0, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          checkedKeys: ["name:Topics", "t:/tf", "t:/polygon", `t:${FOXGLOVE_GRID_TOPIC}`],
+          expandedKeys: ["name:Topics", "t:/tf", "t:/polygon", `t:${FOXGLOVE_GRID_TOPIC}`],
+          followTf: "base_link",
+          cameraState: {
+            distance: 8.25,
+            perspective: true,
+            phi: 1,
+            targetOffset: [-0.7, 2.1, 0],
+            thetaOffset: -0.25,
+            fovy: 0.75,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 export function SensorMsgs_LaserScan(): JSX.Element {
   const topics: Topic[] = [
     { name: "/laserscan", datatype: "sensor_msgs/LaserScan" },
@@ -1307,6 +1413,7 @@ export function LargeTransform(): JSX.Element {
   );
 }
 
+GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };
 LargeTransform.parameters = { colorScheme: "dark" };
 MarkerLifetimes.parameters = { colorScheme: "dark" };
 Markers.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { vec3 } from "gl-matrix";
+import { quat, vec3 } from "gl-matrix";
 
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { fromSec, Time } from "@foxglove/rostime";
@@ -19,6 +19,7 @@ import {
   LineListMarker,
   LineStripMarker,
   MeshMarker,
+  NavMsgs$Path,
   Point,
   PointCloud2,
   PointsMarker,
@@ -929,6 +930,141 @@ export function GeometryMsgs_Polygon(): JSX.Element {
   );
 }
 
+export function NavMsgs_Path(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/baselink_path", datatype: "nav_msgs/Path" },
+    { name: "/sensor_path", datatype: "nav_msgs/Path" },
+    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
+  ];
+  const tf1: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+      child_frame_id: "base_link",
+      transform: {
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf2: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+      child_frame_id: "sensor",
+      transform: {
+        translation: { x: 0, y: 0, z: 1 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf3: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 10, nsec: 0 }, frame_id: "base_link" },
+      child_frame_id: "sensor",
+      transform: {
+        translation: { x: 0, y: 5, z: 1 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const q = (): quat => [0, 0, 0, 1];
+  const identity = q();
+  const makeOrientation = (i: number) => {
+    const o = quat.rotateZ(q(), identity, Math.PI * 2 * (i / 10));
+    return { x: o[0], y: o[1], z: o[2], w: o[3] };
+  };
+
+  const baseLinkPath: MessageEvent<NavMsgs$Path> = {
+    topic: "/baselink_path",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      poses: [...Array(10)].map((_, i) => ({
+        header: {
+          seq: 0,
+          stamp: { sec: i, nsec: 0 },
+          frame_id: i % 2 === 0 ? "base_link" : "sensor",
+        },
+        pose: { position: { x: i - 5, y: 0, z: 0 }, orientation: makeOrientation(i) },
+      })),
+    },
+    sizeInBytes: 0,
+  };
+
+  const sensorPath: MessageEvent<NavMsgs$Path> = {
+    topic: "/sensor_path",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      poses: [...Array(10)].map((_, i) => ({
+        header: { seq: 0, stamp: { sec: i, nsec: 0 }, frame_id: "sensor" },
+        pose: { position: { x: i - 5, y: 0, z: i % 2 }, orientation: makeOrientation(i) },
+      })),
+    },
+    sizeInBytes: 0,
+  };
+
+  const fixture = useDelayedFixture({
+    datatypes,
+    topics,
+    frame: {
+      "/baselink_path": [baseLinkPath],
+      "/sensor_path": [sensorPath],
+      "/tf": [tf1, tf2, tf3],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 3, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          checkedKeys: [
+            "name:Topics",
+            "t:/tf",
+            "t:/baselink_path",
+            "t:/sensor_path",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
+          expandedKeys: [
+            "name:Topics",
+            "t:/tf",
+            "t:/baselink_path",
+            "t:/sensor_path",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
+          followTf: "base_link",
+          cameraState: {
+            distance: 8.25,
+            perspective: true,
+            phi: 1,
+            targetOffset: [0, 2, 0],
+            thetaOffset: -0.25,
+            fovy: 0.75,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 export function SensorMsgs_LaserScan(): JSX.Element {
   const topics: Topic[] = [
     { name: "/laserscan", datatype: "sensor_msgs/LaserScan" },
@@ -1417,6 +1553,7 @@ GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };
 LargeTransform.parameters = { colorScheme: "dark" };
 MarkerLifetimes.parameters = { colorScheme: "dark" };
 Markers.parameters = { colorScheme: "dark" };
+NavMsgs_Path.parameters = { colorScheme: "dark" };
 SensorMsgs_LaserScan.parameters = { colorScheme: "dark" };
 SensorMsgs_PointCloud2_Intensity.parameters = { colorScheme: "dark" };
 SensorMsgs_PointCloud2_RGBA.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -1048,7 +1048,7 @@ export function NavMsgs_Path(): JSX.Element {
           ],
           followTf: "base_link",
           cameraState: {
-            distance: 8.25,
+            distance: 15,
             perspective: true,
             phi: 1,
             targetOffset: [0, 2, 0],


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

The `nav_msgs/Path` story demonstrates a bug where the per-pose header is ignored (neither coordinate frame nor interpolation is applied).

<img width="685" alt="Screen Shot 2021-12-26 at 10 38 41 AM" src="https://user-images.githubusercontent.com/195374/147417201-73ab9f6b-e02f-420e-8010-b545671c80ea.png">
<img width="849" alt="Screen Shot 2021-12-26 at 10 39 53 AM" src="https://user-images.githubusercontent.com/195374/147417202-62e0f5fb-d4b5-40c6-aed6-f16712b0a671.png">

