### PR TITLE
Add drag & drop file to recents

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -155,7 +155,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const allowedDropExtensions = useMemo(() => {
     const extensions = [".foxe", ".urdf", ".xacro"];
     for (const source of availableSources) {
-      if (source.supportedFileTypes) {
+      if (source.type === "file" && source.supportedFileTypes) {
         extensions.push(...source.supportedFileTypes);
       }
     }
@@ -328,6 +328,48 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const extensionLoader = useExtensionLoader();
 
+  const openHandle = useCallback(
+    async (handle: FileSystemFileHandle) => {
+      const file = await handle.getFile();
+      // electron extends File with a `path` field which is not available in browsers
+      const basePath = (file as { path?: string }).path ?? "";
+
+      if (file.name.endsWith(".foxe")) {
+        // Extension installation
+        try {
+          const arrayBuffer = await file.arrayBuffer();
+          const data = new Uint8Array(arrayBuffer);
+          const extension = await extensionLoader.installExtension(data);
+          addToast(`Installed extension ${extension.id}`, { appearance: "success" });
+        } catch (err) {
+          addToast(`Failed to install extension ${file.name}: ${err.message}`, {
+            appearance: "error",
+          });
+        }
+      } else {
+        try {
+          if (await loadFromFile(file, { basePath })) {
+            return;
+          }
+        } catch (err) {
+          addToast(`Failed to load ${file.name}`, {
+            appearance: "error",
+          });
+        }
+      }
+
+      // Look for a source that supports the file extensions
+      const matchedSource = availableSources.find((source) => {
+        const ext = extname(file.name);
+        return source.supportedFileTypes?.includes(ext);
+      });
+      if (matchedSource) {
+        selectSource(matchedSource.id, { type: "file", handle });
+      }
+    },
+    [addToast, availableSources, extensionLoader, loadFromFile, selectSource],
+  );
+
   const openFiles = useCallback(
     async (files: File[]) => {
       const otherFiles: File[] = [];
@@ -388,10 +430,14 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   }, [filesToOpen, openFiles]);
 
   const dropHandler = useCallback(
-    ({ files }: { files: File[] }) => {
-      void openFiles(files);
+    (event: { files?: File[]; handle?: FileSystemFileHandle }) => {
+      if (event.files) {
+        void openFiles(event.files);
+      } else if (event.handle) {
+        void openHandle(event.handle);
+      }
     },
-    [openFiles],
+    [openFiles, openHandle],
   );
 
   const workspaceActions = useMemo(
@@ -489,7 +535,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           onDismiss={() => setShowOpenDialog(undefined)}
         />
       )}
-      <DocumentDropListener filesSelected={dropHandler} allowedExtensions={allowedDropExtensions}>
+      <DocumentDropListener onDrop={dropHandler} allowedExtensions={allowedDropExtensions}>
         <DropOverlay>
           <div className={classes.dropzone}>Drop a file here</div>
         </DropOverlay>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import { useToasts } from "react-toast-notifications";
 
+import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AccountSettings from "@foxglove/studio-base/components/AccountSettingsSidebar/AccountSettings";
 import { DataSourceSidebar } from "@foxglove/studio-base/components/DataSourceSidebar";
@@ -71,6 +72,8 @@ import { useCalloutDismissalBlocker } from "@foxglove/studio-base/hooks/useCallo
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
+
+const log = Logger.getLogger(__filename);
 
 const useStyles = makeStyles({
   container: {
@@ -330,6 +333,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const openHandle = useCallback(
     async (handle: FileSystemFileHandle) => {
+      log.debug("open handle", handle);
       const file = await handle.getFile();
       // electron extends File with a `path` field which is not available in browsers
       const basePath = (file as { path?: string }).path ?? "";
@@ -373,6 +377,8 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const openFiles = useCallback(
     async (files: File[]) => {
       const otherFiles: File[] = [];
+      log.debug("open files", files);
+
       for (const file of files) {
         // electron extends File with a `path` field which is not available in browsers
         const basePath = (file as { path?: string }).path ?? "";
@@ -430,11 +436,15 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   }, [filesToOpen, openFiles]);
 
   const dropHandler = useCallback(
-    (event: { files?: File[]; handle?: FileSystemFileHandle }) => {
-      if (event.files) {
+    (event: { files?: File[]; handles?: FileSystemFileHandle[] }) => {
+      const handle = event.handles?.[0];
+      // When selecting sources with handles we can only select with a single handle since we haven't
+      // written the code to store multiple handles for recents. When there are multiple handles, we
+      // fall back to opening regular files.
+      if (handle && event.handles?.length === 1) {
+        void openHandle(handle);
+      } else if (event.files) {
         void openFiles(event.files);
-      } else if (event.handle) {
-        void openHandle(event.handle);
       }
     },
     [openFiles, openHandle],

--- a/packages/studio-base/src/components/DocumentDropListener.tsx
+++ b/packages/studio-base/src/components/DocumentDropListener.tsx
@@ -19,13 +19,13 @@ import { useToasts } from "react-toast-notifications";
 type Props = {
   children: React.ReactNode; // Shown when dragging in a file.
   allowedExtensions?: string[];
-  filesSelected?: (arg: { files: File[]; shiftPressed: boolean }) => void;
+  onDrop?: (event: { files?: File[]; handle?: FileSystemFileHandle }) => void;
 };
 
 export default function DocumentDropListener(props: Props): JSX.Element {
   const [hovering, setHovering] = useState(false);
 
-  const { filesSelected, allowedExtensions } = props;
+  const { onDrop: onDropProp, allowedExtensions } = props;
 
   const { addToast } = useToasts();
 
@@ -35,6 +35,18 @@ export default function DocumentDropListener(props: Props): JSX.Element {
 
       if (!ev.dataTransfer) {
         return;
+      }
+
+      const dataTransferItems = ev.dataTransfer.items;
+      if (dataTransferItems.length === 1) {
+        const item = dataTransferItems[0]!;
+        const fileSystemHandle = await item.getAsFileSystemHandle();
+        if (fileSystemHandle?.kind === "file") {
+          ev.preventDefault();
+          ev.stopPropagation();
+          onDropProp?.({ handle: fileSystemHandle });
+          return;
+        }
       }
 
       const allFiles: File[] = [];
@@ -106,9 +118,9 @@ export default function DocumentDropListener(props: Props): JSX.Element {
 
       ev.preventDefault();
       ev.stopPropagation();
-      filesSelected?.({ files, shiftPressed: ev.shiftKey });
+      onDropProp?.({ files });
     },
-    [addToast, filesSelected, allowedExtensions],
+    [addToast, onDropProp, allowedExtensions],
   );
 
   const onDragOver = useCallback(
@@ -150,7 +162,7 @@ export default function DocumentDropListener(props: Props): JSX.Element {
         style={{ display: "none" }}
         onChange={(event) => {
           if (event.target.files) {
-            props.filesSelected?.({ files: Array.from(event.target.files), shiftPressed: false });
+            props.onDrop?.({ files: Array.from(event.target.files) });
           }
         }}
         data-puppeteer-file-upload

--- a/packages/studio-base/src/components/DocumentDropListener.tsx
+++ b/packages/studio-base/src/components/DocumentDropListener.tsx
@@ -19,7 +19,7 @@ import { useToasts } from "react-toast-notifications";
 type Props = {
   children: React.ReactNode; // Shown when dragging in a file.
   allowedExtensions?: string[];
-  onDrop?: (event: { files?: File[]; handle?: FileSystemFileHandle }) => void;
+  onDrop?: (event: { files?: File[]; handles?: FileSystemFileHandle[] }) => void;
 };
 
 export default function DocumentDropListener(props: Props): JSX.Element {
@@ -33,40 +33,50 @@ export default function DocumentDropListener(props: Props): JSX.Element {
     async (ev: DragEvent) => {
       setHovering(false);
 
-      if (!ev.dataTransfer) {
+      if (!ev.dataTransfer || !allowedExtensions) {
         return;
       }
 
-      const dataTransferItems = ev.dataTransfer.items;
-      if (dataTransferItems.length === 1) {
-        const item = dataTransferItems[0]!;
-        const fileSystemHandle = await item.getAsFileSystemHandle();
-        if (fileSystemHandle?.kind === "file") {
-          ev.preventDefault();
-          ev.stopPropagation();
-          onDropProp?.({ handle: fileSystemHandle });
-          return;
+      let handles: FileSystemFileHandle[] | undefined = [];
+      const handlePromises: Promise<FileSystemHandle | ReactNull>[] = [];
+      const allFiles: File[] = [];
+      const directories: FileSystemDirectoryEntry[] = [];
+      const dataItems = ev.dataTransfer.items;
+      for (const item of Array.from(dataItems)) {
+        const entry = item.webkitGetAsEntry();
+
+        // Attempt to grab the filesystem handle if the feature is available.
+        // A file system handle is more versatile than File instances.
+        // Note: awaiting on the fileSystemHandle function triggered a (bug?) where all other
+        // dataTransfer items were ignored
+        if ("getAsFileSystemHandle" in item) {
+          handlePromises.push(item.getAsFileSystemHandle());
+        }
+
+        // Keep track of all File and Directory instaces
+        if (entry?.isFile === true) {
+          const file = item.getAsFile();
+          if (file) {
+            allFiles.push(file);
+          }
+        } else if (entry?.isDirectory === true) {
+          directories.push(entry as FileSystemDirectoryEntry);
         }
       }
 
-      const allFiles: File[] = [];
-      const directories: FileSystemDirectoryEntry[] = [];
-      for (const item of ev.dataTransfer.items) {
-        const entry = item.webkitGetAsEntry();
-        if (entry) {
-          if (entry.isFile) {
-            const file = item.getAsFile();
-            if (file) {
-              allFiles.push(file);
-            }
-          } else if (entry.isDirectory) {
-            directories.push(entry as FileSystemDirectoryEntry);
+      // If we had any directories, then we will not use handles and instead use File instances.
+      // A future enhancement could be to load handles from directories.
+      if (directories.length === 0) {
+        for (const promise of handlePromises) {
+          const fileSystemHandle = await promise;
+          if (fileSystemHandle?.kind === "file") {
+            handles.push(fileSystemHandle);
           }
         }
       }
 
       // Allow event to bubble for non-file based drag and drop
-      if ((allFiles.length === 0 && directories.length === 0) || !allowedExtensions) {
+      if (allFiles.length === 0 && directories.length === 0 && handles.length === 0) {
         return;
       }
 
@@ -87,38 +97,31 @@ export default function DocumentDropListener(props: Props): JSX.Element {
         }
       }
 
-      // Organize files by (supported) extension
-      const filesByType = new Map<string, File[]>();
-      for (const file of allFiles) {
-        const fileExtension = extname(file.name);
-        if (allowedExtensions.includes(fileExtension)) {
-          const filesOfType = filesByType.get(fileExtension) ?? [];
-          filesOfType.push(file);
-          filesByType.set(fileExtension, filesOfType);
-        }
+      // If we had any directories, then we will not use handles and instead use File instances.
+      // A future enhancement could be to load handles from directories.
+      if (directories.length > 0 || handles.length === 0) {
+        handles = undefined;
       }
 
+      const filteredFiles = allFiles.filter((file) =>
+        allowedExtensions.includes(extname(file.name)),
+      );
+      const filteredHandles = handles?.filter((handle) =>
+        allowedExtensions.includes(extname(handle.name)),
+      );
+
       // Check for no supported files
-      if (filesByType.size === 0) {
+      if (filteredFiles.length === 0 && filteredHandles?.length === 0) {
         addToast("The file format is unsupported.", {
           appearance: "error",
         });
         return;
       }
 
-      // Check for more than one supported file type
-      if (filesByType.size > 1) {
-        addToast("Cannot open different file types at once.", {
-          appearance: "error",
-        });
-        return;
-      }
-
-      const files: File[] = filesByType.values().next().value;
-
       ev.preventDefault();
       ev.stopPropagation();
-      onDropProp?.({ files });
+
+      onDropProp?.({ files: filteredFiles, handles: filteredHandles });
     },
     [addToast, onDropProp, allowedExtensions],
   );


### PR DESCRIPTION
**User-Facing Changes**
When a user drag&drops a single file into the app - that file will appear in the recents list.

**Description**
To add file items to recents we need a FileSystemFileHandle instance. This change updates the DocumentDropListener component drop event to have either a Files array or a FileSystemFileHandle array.

For now I limited this to a single handle instance since that is all our app recents feature support.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
