### PR TITLE
Fix "Each child in a list should have a unique key prop" error

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -322,18 +322,16 @@ function PanelList(props: Props): JSX.Element {
   const displayPanelListItem = React.useCallback(
     ({ title, type, description, config, relatedConfigs }: PanelInfo) => {
       return (
-        <>
-          <DraggablePanelItem
-            key={`${type}-${title}`}
-            mosaicId={mosaicId}
-            panel={{ type, title, description, config, relatedConfigs }}
-            onDrop={onPanelMenuItemDrop}
-            onClick={() => onPanelSelect({ type, config, relatedConfigs })}
-            checked={title === selectedPanelTitle}
-            highlighted={highlightedPanel?.title === title}
-            searchQuery={searchQuery}
-          />
-        </>
+        <DraggablePanelItem
+          key={`${type}-${title}`}
+          mosaicId={mosaicId}
+          panel={{ type, title, description, config, relatedConfigs }}
+          onDrop={onPanelMenuItemDrop}
+          onClick={() => onPanelSelect({ type, config, relatedConfigs })}
+          checked={title === selectedPanelTitle}
+          highlighted={highlightedPanel?.title === title}
+          searchQuery={searchQuery}
+        />
       );
     },
     [


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
- Got rid of unnecessary fragment in PanelList to get rid of "Each child in a list should have a unique key prop" error

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
