### PR TITLE
Fix double-click file open on MacOS with no windows

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -158,7 +158,10 @@ function main() {
     if (preloaderFileInputIsReady) {
       const focusedWindow = BrowserWindow.getFocusedWindow();
       if (focusedWindow) {
-        await injectFilesToOpen(focusedWindow, filesToOpen);
+        await injectFilesToOpen(focusedWindow.webContents.debugger, filesToOpen);
+      } else {
+        // On MacOS the user may have closed all the windows so we need to open a new window
+        new StudioWindow().load();
       }
     }
   });
@@ -167,10 +170,9 @@ function main() {
   // It is important this handler is registered before any windows open because preload will call
   // this handler to get the files we were told to open on startup
   ipcMain.handle("load-pending-files", async (ev) => {
-    const browserWindow = BrowserWindow.fromId(ev.sender.id);
-    if (browserWindow) {
-      await injectFilesToOpen(browserWindow, filesToOpen);
-    }
+    log.debug("load-pending-files");
+    const debug = ev.sender.debugger;
+    await injectFilesToOpen(debug, filesToOpen);
     preloaderFileInputIsReady = true;
   });
 

--- a/packages/studio-base/src/hooks/useElectronFilesToOpen.ts
+++ b/packages/studio-base/src/hooks/useElectronFilesToOpen.ts
@@ -4,36 +4,37 @@
 
 import { useEffect, useState } from "react";
 
+import Logger from "@foxglove/log";
+
+const log = Logger.getLogger(__filename);
+
 // Hook to get any files the main thread has told us to open
 // See the comments in main thread implementation on how the files are injected into this input
 export default function useElectronFilesToOpen(): FileList | undefined {
-  const [fileList, setFileList] = useState<FileList>();
+  const [input] = useState(() =>
+    document.querySelector<HTMLInputElement>("#electron-open-file-input"),
+  );
+
+  const [fileList, setFileList] = useState<FileList | undefined>(input?.files ?? undefined);
 
   useEffect(() => {
-    const input = document.querySelector<HTMLInputElement>("#electron-open-file-input");
     if (!input) {
-      console.warn(
+      log.info(
         "#electron-open-file-input not found - native open-file support will not be available",
       );
       return;
     }
 
     const update = () => {
-      if (input.files) {
-        setFileList(input.files);
-      }
+      setFileList(input.files ?? undefined);
     };
 
     // handle any new file open requests
     input.addEventListener("change", update);
-
-    // trigger initial set list
-    update();
-
     return () => {
       input.removeEventListener("change", update);
     };
-  }, []);
+  }, [input]);
 
   return fileList;
 }


### PR DESCRIPTION


**User-Facing Changes**
A user on MacOS can close all windows then double click a bag file to open it in a new window.

**Description**
With MacOS it is possible to close all active windows but keep the application open. If this happened, our desktop app would stop handling double-click file open actions since there was no window to handle the action.

This change fixes the behavior by opening a window if there are no windows.

Fixes: #2539

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
