### PR TITLE
Fix OpenDialog height

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -165,14 +165,14 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
             flexDirection: "column",
             padding: theme.spacing.l1,
 
-            "@media (max-height: 512px)": { overflowY: "auto" },
+            "@media (max-height: 552px)": { overflowY: "auto" },
           },
           inner: {
             flex: 1,
             display: "flex",
             flexDirection: "column",
 
-            "@media (min-height: 512px)": { overflow: "hidden" },
+            "@media (min-height: 552px)": { overflow: "hidden" },
           },
           innerContent: {
             height: "100%",
@@ -180,7 +180,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
             flexDirection: "column",
             flex: 1,
 
-            "@media (min-height: 512px)": { overflow: "hidden" },
+            "@media (min-height: 552px)": { overflow: "hidden" },
           },
         },
       }}

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -159,6 +159,8 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
         styles: {
           content: {
             overflow: "hidden",
+            // Keep a consistent height for the dialog so changing views does not change the height
+            height: 520,
             display: "flex",
             flexDirection: "column",
             padding: theme.spacing.l1,


### PR DESCRIPTION

**User-Facing Changes**
The OpenDialog does not change height when selecting different views.

**Description**
The OpenDialog height should be consistent across view changes so the back button and title remain in the same place on screen.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
