### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Enable Dependabot for GitHub Actions only, to ensure they are kept up to date. This does not enable any checks for NPM dependencies, which we currently handle manually.