### PR TITLE
Implement selectable image markers for image panel.

### DIFF
--- a/packages/studio-base/src/components/ExpandingToolbar.tsx
+++ b/packages/studio-base/src/components/ExpandingToolbar.tsx
@@ -11,7 +11,7 @@ import {
   useTheme,
   IButtonStyles,
 } from "@fluentui/react";
-import { ReactElement, useMemo } from "react";
+import { ReactElement, ReactNode, useMemo } from "react";
 
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -31,11 +31,7 @@ export function ToolGroup<T>({ children }: { name: T; children: React.ReactEleme
   return children;
 }
 
-export function ToolGroupFixedSizePane({
-  children,
-}: {
-  children: React.ReactElement | React.ReactElement[];
-}): JSX.Element {
+export function ToolGroupFixedSizePane({ children }: { children: ReactNode }): JSX.Element {
   const classes = useStyles();
   return <div className={classes.toolGroupFixedSizePanel}>{children}</div>;
 }

--- a/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
+++ b/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
@@ -1,0 +1,190 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { indexToIDColor } from "@foxglove/studio-base/panels/ImageView/util";
+
+/**
+ * This wraps a canvas rendering context to also render all context commands in parallel
+ * to a separate hitmap context.
+ */
+export class HitmapRenderContext {
+  private _currentMarkerIndex: number = 0;
+  private readonly _hctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | undefined;
+
+  constructor(
+    private readonly _ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    private readonly _hitmapCanvas: HTMLCanvasElement | OffscreenCanvas | undefined,
+  ) {
+    // this._hctx = this._hitmapCanvas?.getContext("2d", { alpha: false }) ?? undefined;
+    this._hctx = this._hitmapCanvas?.getContext("2d", { alpha: false }) ?? undefined;
+    if (this._hctx) {
+      this._hctx.imageSmoothingEnabled = false;
+      this._hctx.clearRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);
+    }
+  }
+
+  startMarker(): void {
+    if (this._hctx) {
+      const colorString = indexToIDColor(this._currentMarkerIndex);
+      this._hctx.fillStyle = `#${colorString}ff`;
+      this._hctx.strokeStyle = `#${colorString}ff`;
+    }
+    this._currentMarkerIndex++;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  get lineWidth(): number {
+    return this._ctx.lineWidth;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  set lineWidth(width: number) {
+    this._ctx.lineWidth = width;
+    if (this._hctx) {
+      this._hctx.lineWidth = width;
+    }
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  get fillStyle(): CanvasRenderingContext2D["fillStyle"] {
+    return this._ctx.fillStyle;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  set fillStyle(style: CanvasRenderingContext2D["fillStyle"]) {
+    this._ctx.fillStyle = style;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  get font(): string {
+    return this._ctx.font;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  set font(font: string) {
+    this._ctx.font = font;
+    if (this._hctx) {
+      this._hctx.font = font;
+    }
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  get strokeStyle(): CanvasRenderingContext2D["strokeStyle"] {
+    return this._ctx.strokeStyle;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  set strokeStyle(style: CanvasRenderingContext2D["strokeStyle"]) {
+    this._ctx.strokeStyle = style;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  get textBaseline(): CanvasRenderingContext2D["textBaseline"] {
+    return this._ctx.textBaseline;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  set textBaseline(baseline: CanvasRenderingContext2D["textBaseline"]) {
+    this._ctx.textBaseline = baseline;
+    if (this._hctx) {
+      this._hctx.textBaseline = baseline;
+    }
+  }
+
+  arc(
+    x: number,
+    y: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    counterclockwise?: boolean,
+  ): void {
+    this._ctx.arc(x, y, radius, startAngle, endAngle, counterclockwise);
+    this._hctx?.arc(x, y, radius, startAngle, endAngle, counterclockwise);
+  }
+
+  beginPath(): void {
+    this._ctx.beginPath();
+    this._hctx?.beginPath();
+  }
+
+  clearRect(x: number, y: number, w: number, h: number): void {
+    this._ctx.clearRect(x, y, w, h);
+    this._hctx?.clearRect(x, y, w, h);
+  }
+
+  closePath(): void {
+    this._ctx.closePath();
+    this._hctx?.closePath();
+  }
+
+  drawImage(image: CanvasImageSource, dx: number, dy: number): void {
+    // Don't draw into hit context.
+    this._ctx.drawImage(image, dx, dy);
+  }
+
+  fill(): void {
+    this._ctx.fill();
+    this._hctx?.fill();
+  }
+
+  fillRect(x: number, y: number, w: number, h: number): void {
+    this._ctx.fillRect(x, y, w, h);
+    this._hctx?.fillRect(x, y, w, h);
+  }
+
+  fillText(text: string, x: number, y: number): void {
+    this._ctx.fillText(text, x, y);
+    this._hctx?.fillText(text, x, y);
+  }
+
+  getTransform(): DOMMatrix {
+    return this._ctx.getTransform();
+  }
+
+  lineTo(x: number, y: number): void {
+    this._ctx.lineTo(x, y);
+    this._hctx?.lineTo(x, y);
+  }
+
+  measureText(text: string): TextMetrics {
+    return this._ctx.measureText(text);
+  }
+
+  moveTo(x: number, y: number): void {
+    this._ctx.moveTo(x, y);
+    this._hctx?.moveTo(x, y);
+  }
+
+  restore(): void {
+    this._ctx.restore();
+    this._hctx?.restore();
+  }
+
+  save(): void {
+    this._ctx.save();
+    this._hctx?.save();
+  }
+
+  scale(x: number, y: number): void {
+    this._ctx.scale(x, y);
+    this._hctx?.scale(x, y);
+  }
+
+  stroke(): void {
+    this._ctx.stroke();
+    this._hctx?.stroke();
+  }
+
+  strokeRect(x: number, y: number, w: number, h: number): void {
+    this._ctx.strokeRect(x, y, w, h);
+    this._hctx?.strokeRect(x, y, w, h);
+  }
+
+  translate(x: number, y: number): void {
+    this._ctx.translate(x, y);
+    this._hctx?.translate(x, y);
+  }
+}

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -13,10 +13,11 @@
 
 import { Story } from "@storybook/react";
 import { range, noop } from "lodash";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import ImageView, { Config } from "@foxglove/studio-base/panels/ImageView";
 import ImageCanvas from "@foxglove/studio-base/panels/ImageView/ImageCanvas";
+import { renderImage } from "@foxglove/studio-base/panels/ImageView/renderImage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { CameraInfo, ImageMarker, ImageMarkerType } from "@foxglove/studio-base/types/Messages";
@@ -295,6 +296,7 @@ function RGBStory({ encoding }: { encoding: string }) {
       rawMarkerData={noMarkersMarkerData}
       config={config}
       saveConfig={noop}
+      setActivePixelData={noop}
       onStartRenderImage={() => () => undefined}
     />
   );
@@ -337,6 +339,7 @@ function BayerStory({ encoding }: { encoding: string }) {
       rawMarkerData={noMarkersMarkerData}
       config={config}
       saveConfig={noop}
+      setActivePixelData={noop}
       onStartRenderImage={() => () => undefined}
     />
   );
@@ -373,6 +376,7 @@ function Mono16Story({
       rawMarkerData={noMarkersMarkerData}
       config={{ ...config, minValue, maxValue }}
       saveConfig={noop}
+      setActivePixelData={noop}
       onStartRenderImage={() => () => undefined}
     />
   );
@@ -437,6 +441,7 @@ export const MarkersOriginal: Story = (_args) => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         onStartRenderImage={() => readySignal}
       />
     </div>
@@ -445,6 +450,47 @@ export const MarkersOriginal: Story = (_args) => {
 
 MarkersOriginal.parameters = {
   useReadySignal: true,
+};
+
+export const MarkersWithHitmap: Story = (_args) => {
+  const imageMessage = useImageMessage();
+  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+  const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
+
+  const width = 400;
+  const height = 300;
+
+  useEffect(() => {
+    if (!canvasRef.current || !hitmapRef.current) {
+      return;
+    }
+
+    canvasRef.current.width = 2 * width;
+    canvasRef.current.height = 2 * height;
+    hitmapRef.current.width = 2 * width;
+    hitmapRef.current.height = 2 * height;
+
+    void renderImage({
+      canvas: canvasRef.current,
+      hitmapCanvas: hitmapRef.current,
+      zoomMode: "fill",
+      panZoom: { x: 0, y: 0, scale: 1 },
+      imageMessage: imageMessage?.message as any,
+      imageMessageDatatype: "sensor_msgs/Image",
+      rawMarkerData: {
+        markers,
+        cameraInfo,
+        transformMarkers: true,
+      },
+    });
+  }, [imageMessage]);
+
+  return (
+    <div style={{ backgroundColor: "white", padding: "1rem" }}>
+      <canvas ref={canvasRef} style={{ width, height }} />
+      <canvas ref={hitmapRef} style={{ width, height }} />
+    </div>
+  );
 };
 
 export const MarkersTransformed: Story = (_args) => {
@@ -463,6 +509,7 @@ export const MarkersTransformed: Story = (_args) => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         onStartRenderImage={() => readySignal}
       />
     </div>
@@ -490,6 +537,7 @@ export const MarkersImageSize: Story = (_args) => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         onStartRenderImage={() => readySignal}
       />
     </div>
@@ -516,6 +564,7 @@ export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         renderInMainThread
         onStartRenderImage={() => () => undefined}
       />
@@ -531,6 +580,7 @@ export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         renderInMainThread
         onStartRenderImage={() => () => undefined}
       />
@@ -545,6 +595,7 @@ export const MarkersWithFallbackRenderingUsingMainThread = (): JSX.Element => {
         }}
         config={config}
         saveConfig={noop}
+        setActivePixelData={noop}
         renderInMainThread
         onStartRenderImage={() => () => undefined}
       />
@@ -565,6 +616,7 @@ export const ErrorState = (): JSX.Element => {
       rawMarkerData={noMarkersMarkerData}
       config={config}
       saveConfig={noop}
+      setActivePixelData={noop}
       onStartRenderImage={() => () => undefined}
     />
   );
@@ -586,6 +638,7 @@ export const CallsOnRenderFrameWhenRenderingSucceeds = (): JSX.Element => {
           }}
           config={config}
           saveConfig={noop}
+          setActivePixelData={noop}
           onStartRenderImage={onStartRenderImage}
         />
       )}
@@ -608,6 +661,7 @@ export const CallsOnRenderFrameWhenRenderingFails = (): JSX.Element => {
           rawMarkerData={noMarkersMarkerData}
           config={config}
           saveConfig={noop}
+          setActivePixelData={noop}
           onStartRenderImage={onStartRenderImage}
         />
       )}

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -11,23 +11,71 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Image, CompressedImage } from "@foxglove/studio-base/types/Messages";
+import { MessageEvent } from "@foxglove/studio-base/players/types";
+import {
+  Image,
+  CompressedImage,
+  ImageMarker,
+  ImageMarkerArray,
+} from "@foxglove/studio-base/types/Messages";
 import Rpc, { Channel } from "@foxglove/studio-base/util/Rpc";
 import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
 
 import { renderImage } from "./renderImage";
-import { Dimensions, RawMarkerData, RenderOptions } from "./util";
+import {
+  Dimensions,
+  idColorToIndex,
+  flattenImageMarkers,
+  RawMarkerData,
+  RenderDimensions,
+  RenderOptions,
+  PanZoom,
+  ZoomMode,
+} from "./util";
+
+type RenderState = {
+  canvas: OffscreenCanvas;
+  dimensions?: RenderDimensions;
+  hitmap: OffscreenCanvas;
+  markers: ImageMarker[];
+};
 
 class ImageCanvasWorker {
-  private _idToCanvas: {
-    [key: string]: OffscreenCanvas;
-  } = {};
+  private readonly _renderStates: Record<string, RenderState> = {};
 
   constructor(rpc: Rpc) {
     setupWorker(rpc);
 
     rpc.receive("initialize", async ({ id, canvas }: { id: string; canvas: OffscreenCanvas }) => {
-      this._idToCanvas[id] = canvas;
+      this._renderStates[id] = {
+        canvas,
+        hitmap: new OffscreenCanvas(canvas.width, canvas.height),
+        markers: [],
+      };
+    });
+
+    rpc.receive("mouseMove", async ({ id, x, y }: { id: string; x: number; y: number }) => {
+      const state = this._renderStates[id];
+      if (!state) {
+        return undefined;
+      }
+
+      const matrix = (state.dimensions?.transform ?? new DOMMatrix()).inverse();
+      const point = new DOMPoint(x, y).matrixTransform(matrix);
+      const pixel = state.canvas.getContext("2d")?.getImageData(x, y, 1, 1);
+      const hit = state.hitmap.getContext("2d")?.getImageData(x, y, 1, 1);
+      const markerIndex = hit ? idColorToIndex(hit.data) : undefined;
+
+      if (pixel) {
+        return {
+          color: { r: pixel.data[0], g: pixel.data[1], b: pixel.data[2], a: pixel.data[3] },
+          position: { x: Math.round(point.x), y: Math.round(point.y) },
+          markerIndex,
+          marker: markerIndex != undefined ? state.markers[markerIndex] : undefined,
+        };
+      } else {
+        return undefined;
+      }
     });
 
     rpc.receive(
@@ -36,14 +84,14 @@ class ImageCanvasWorker {
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       (args: {
         id: string;
-        zoomMode: "fit" | "fill" | "other";
-        panZoom: { x: number; y: number; scale: number };
-        viewport: { width: number; height: number };
+        zoomMode: ZoomMode;
+        panZoom: PanZoom;
+        viewport: Dimensions;
         imageMessage?: Image | CompressedImage;
         imageMessageDatatype?: string;
         rawMarkerData: RawMarkerData;
         options: RenderOptions;
-      }): Promise<Dimensions | undefined> => {
+      }): Promise<RenderDimensions | undefined> => {
         const {
           id,
           zoomMode,
@@ -55,28 +103,36 @@ class ImageCanvasWorker {
           options,
         } = args;
 
-        const canvas = this._idToCanvas[id];
-        if (!canvas) {
+        const render = this._renderStates[id];
+        if (!render) {
           return Promise.resolve(undefined);
         }
 
-        if (canvas.width !== viewport.width) {
-          canvas.width = viewport.width;
+        if (render.canvas.width !== viewport.width) {
+          render.canvas.width = viewport.width;
+          render.hitmap.width = viewport.width;
         }
 
-        if (canvas.height !== viewport.height) {
-          canvas.height = viewport.height;
+        if (render.canvas.height !== viewport.height) {
+          render.canvas.height = viewport.height;
+          render.hitmap.height = viewport.height;
         }
+
+        // Flatten markers because we need to be able to index into them for hitmapping.
+        render.markers = flattenImageMarkers(
+          rawMarkerData.markers as MessageEvent<ImageMarker | ImageMarkerArray>[],
+        );
 
         return renderImage({
-          canvas,
+          canvas: render.canvas,
+          hitmapCanvas: render.hitmap,
           zoomMode,
           panZoom,
           imageMessage,
           imageMessageDatatype,
           rawMarkerData,
           options,
-        });
+        }).then((dimensions) => (render.dimensions = dimensions));
       },
     );
   }

--- a/packages/studio-base/src/panels/ImageView/Toolbar.tsx
+++ b/packages/studio-base/src/panels/ImageView/Toolbar.tsx
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Box, Stack, Typography } from "@mui/material";
+import { ReactElement, useEffect, useState } from "react";
+import Tree from "react-json-tree";
+
+import ExpandingToolbar, {
+  ToolGroup,
+  ToolGroupFixedSizePane,
+} from "@foxglove/studio-base/components/ExpandingToolbar";
+import { PixelData } from "@foxglove/studio-base/panels/ImageView/util";
+import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+const style = {
+  values: {
+    color: colors.HIGHLIGHT,
+  },
+};
+
+enum TabName {
+  SELECTED_POINT = "Selected Point",
+}
+
+export function ObjectPane({ pixelData }: { pixelData: PixelData | undefined }): ReactElement {
+  const jsonTreeTheme = useJsonTreeTheme();
+
+  return (
+    <Stack spacing={1}>
+      <Box>
+        <Typography variant="caption">Position:</Typography>
+        <Stack direction="row" spacing={1} sx={style.values}>
+          <Box>X:{pixelData?.position.x}</Box>
+          <Box>Y:{pixelData?.position.y}</Box>
+        </Stack>
+      </Box>
+      <Box>
+        <Typography variant="caption">Color:</Typography>
+        <Stack direction="row" spacing={1} sx={style.values}>
+          <Box>R:{pixelData?.color.r}</Box>
+          <Box>G:{pixelData?.color.g}</Box>
+          <Box>B:{pixelData?.color.b}</Box>
+          <Box>A:{pixelData?.color.a}</Box>
+        </Stack>
+      </Box>
+      {pixelData?.marker && (
+        <Box>
+          <Typography variant="caption">Marker:</Typography>
+          <Tree
+            data={pixelData?.marker}
+            hideRoot
+            invertTheme={false}
+            theme={{ ...jsonTreeTheme, tree: { margin: 0 } }}
+          />
+        </Box>
+      )}
+    </Stack>
+  );
+}
+
+export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JSX.Element {
+  const [selectedTab, setSelectedTab] = useState<TabName | undefined>();
+
+  useEffect(() => {
+    if (pixelData) {
+      setSelectedTab(TabName.SELECTED_POINT);
+    }
+  }, [pixelData]);
+
+  return (
+    <Stack sx={{ position: "absolute", top: 0, right: 0, mr: 2, mt: 6, zIndex: "drawer" }}>
+      <ExpandingToolbar
+        tooltip="Inspect objects"
+        iconName="CursorDefault"
+        selectedTab={selectedTab}
+        onSelectTab={setSelectedTab}
+      >
+        <ToolGroup name={TabName.SELECTED_POINT}>
+          <ToolGroupFixedSizePane>
+            {pixelData && <ObjectPane pixelData={pixelData} />}
+            {!pixelData && (
+              <Box sx={{ color: "secondary.dark" }}>Click an object to select it.</Box>
+            )}
+          </ToolGroupFixedSizePane>
+        </ToolGroup>
+      </ExpandingToolbar>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -19,7 +19,7 @@ import MenuDownIcon from "@mdi/svg/svg/menu-down.svg";
 import WavesIcon from "@mdi/svg/svg/waves.svg";
 import cx from "classnames";
 import { last, uniq } from "lodash";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
@@ -35,6 +35,7 @@ import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipe
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
+import { Toolbar } from "@foxglove/studio-base/panels/ImageView/Toolbar";
 import { IMAGE_DATATYPES } from "@foxglove/studio-base/panels/ImageView/renderImage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -55,6 +56,8 @@ import {
   getRelatedMarkerTopics,
   getMarkerOptions,
   groupTopics,
+  PixelData,
+  ZoomMode,
 } from "./util";
 
 const { useMemo, useCallback } = React;
@@ -68,7 +71,7 @@ type DefaultConfig = {
 
 export type Config = DefaultConfig & {
   transformMarkers: boolean;
-  mode?: "fit" | "fill" | "other";
+  mode?: ZoomMode;
   smooth?: boolean;
   zoom?: number;
   pan?: { x: number; y: number };
@@ -275,6 +278,7 @@ function ImageView(props: Props) {
     () => getTopicsByTopicName(topics)[cameraTopic],
     [cameraTopic, topics],
   );
+  const [activePixelData, setActivePixelData] = useState<PixelData | undefined>();
 
   // Namespaces represent marker topics based on the camera topic prefix (e.g. "/camera_front_medium")
   const { allCameraNamespaces, imageTopicsByNamespace, allImageTopics } = useMemo(() => {
@@ -632,7 +636,7 @@ function ImageView(props: Props) {
   const showEmptyState = !imageMessage || (shouldSynchronize && !synchronizedMessages);
 
   return (
-    <Flex col clip>
+    <Flex col clip style={{ position: "relative" }}>
       {toolbar}
       <div style={{ display: "flex", flexDirection: "column", width: "100%", height: "100%" }}>
         {/* Always render the ImageCanvas because it's expensive to unmount and start up. */}
@@ -644,6 +648,7 @@ function ImageView(props: Props) {
             config={config}
             saveConfig={saveConfig}
             onStartRenderImage={onStartRenderImage}
+            setActivePixelData={setActivePixelData}
           />
         )}
         {/* If rendered, EmptyState will hide the always-present ImageCanvas */}
@@ -659,6 +664,7 @@ function ImageView(props: Props) {
         )}
         {!showEmptyState && renderBottomBar()}
       </div>
+      <Toolbar pixelData={activePixelData} />
     </Flex>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
This implements selectable markers for the image panel analogous to the interactive markers in the 3d panel.

**Description**
This implements selectable markers by rendering a hitmap in parallel with rendering the image and markers. The hitmap is used to lookup marker values for x,y coordinates.

Note that currently this always renders the hitmap. The performance hit doesn't seem that significant in my testing and it keeps the code simpler but we could conceivably have this only generate the hitmap when the user is trying to interact with the image view at the cost of extra complexity.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->

<img width="475" alt="Screen Shot 2022-01-04 at 9 44 36 AM" src="https://user-images.githubusercontent.com/93935560/148093519-f6863534-9dae-4398-83d7-255a18a3c5c0.png">
