### PR TITLE
Add setSpeed capability to Data Platform Player; disable playback speed dropdown when setSpeed is not supported

### DIFF
--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -53,6 +53,7 @@ export default function PlaybackSpeedControls(): JSX.Element {
   return (
     <DefaultButton
       data-test="PlaybackSpeedControls-Dropdown"
+      disabled={setPlaybackSpeed == undefined}
       menuProps={{
         calloutProps: {
           calloutMaxWidth: 80,

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -29,6 +29,7 @@ import {
   AdvertiseOptions,
   MessageEvent,
   Player,
+  PlayerCapabilities,
   PlayerMetricsCollectorInterface,
   PlayerPresence,
   PlayerProblem,
@@ -50,7 +51,7 @@ import streamMessages from "./streamMessages";
 
 const log = Logger.getLogger(__filename);
 
-const CAPABILITIES: string[] = ["playbackControl"];
+const CAPABILITIES = [PlayerCapabilities.playbackControl, PlayerCapabilities.setSpeed];
 
 type FoxgloveDataPlatformPlayerOpts = {
   consoleApi: ConsoleApi;


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue where setting playback speed did not work with data streamed from Foxglove Data Platform.

**Description**
Fixes https://github.com/foxglove/studio/issues/2577