### PR TITLE
Set publishers before trying to get topics in ros1 player.

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -140,10 +140,11 @@ export default class Ros1Player implements Player {
     }
 
     await this._rosNode.start();
-    await this._requestTopics();
 
     // Process any advertise requests made before our node was ready.
     this.setPublishers(this._requestedPublishers);
+
+    await this._requestTopics();
 
     this._presence = PlayerPresence.PRESENT;
   };

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -144,6 +144,8 @@ export default class Ros1Player implements Player {
     // Process any advertise requests made before our node was ready.
     this.setPublishers(this._requestedPublishers);
 
+    // Request topics *after* setting publishers in case we want to subscribe
+    // to topics we are publishing.
     await this._requestTopics();
 
     this._presence = PlayerPresence.PRESENT;

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -110,7 +110,7 @@ export default class Ros1Player implements Player {
       return await net.createSocket(options.host, options.port);
     };
     const tcpServer = await net.createServer();
-    void tcpServer.listen(undefined, hostname, 10);
+    await tcpServer.listen(undefined, hostname, 10);
 
     if (this._rosNode == undefined) {
       const rosNode = new RosNode({


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with publishing and subscribing to topics on startup.

**Description**
#2574 improved our handling of `advertise` calls made when the ROS1 player was still starting up by queing them and retrying them once the player was ready. This builds on that fix to wait to request topics until that second attempt to advertise topics is made so that any freshly advertised topics are available to subscribers.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2057 