### PR TITLE
Provide our own shim for process global

### DIFF
--- a/ci/lint-unused-exports.ts
+++ b/ci/lint-unused-exports.ts
@@ -11,7 +11,7 @@ import { execOutput } from "./exec";
 // An export is considered unused if it is never imported in any source file.
 //
 // Note: use the "// ts-prune-ignore-next" comment above an export if you would like to mark it
-// as used even tho it appears unused. This might happen for exports which are injected via webpack.
+// as used even though it appears unused. This might happen for exports which are injected via webpack.
 async function main(): Promise<void> {
   const { stdout, status } = await execOutput(
     "ts-prune",

--- a/ci/lint-unused-exports.ts
+++ b/ci/lint-unused-exports.ts
@@ -6,6 +6,12 @@ import { info } from "@actions/core";
 
 import { execOutput } from "./exec";
 
+// Identify unused exports
+//
+// An export is considered unused if it is never imported in any source file.
+//
+// Note: use the "// ts-prune-ignore-next" comment above an export if you would like to mark it
+// as used even tho it appears unused. This might happen for exports which are injected via webpack.
 async function main(): Promise<void> {
   const { stdout, status } = await execOutput(
     "ts-prune",

--- a/packages/studio-base/src/util/process.ts
+++ b/packages/studio-base/src/util/process.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// Provide a shim for global process variable users
+// We avoid using the npm process module since it has unfavorable performance for process.nextTick
+// and uses setTimeout(..., 0). Instead we use queueMicrotask which is much faster.
+const process = {
+  // We want to be able to use Function type for _fn_ param
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  nextTick: (fn: Function, ...args: unknown[]): void => {
+    queueMicrotask(() => {
+      fn(...args);
+    });
+  },
+
+  title: "browser",
+  browser: true,
+  env: {},
+  argv: [],
+};
+
+// ts-prune-ignore-next
+export default process;

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -219,7 +219,7 @@ export function makeConfig(
         React: "react",
         // the buffer module exposes the Buffer class as a property
         Buffer: ["buffer", "Buffer"],
-        process: "process/browser.js",
+        process: ["@foxglove/studio-base/util/process", "default"],
         setImmediate: ["@foxglove/studio-base/util/setImmediate", "default"],
       }),
       new webpack.DefinePlugin({


### PR DESCRIPTION

**User-Facing Changes**
Remote bag files load faster.

**Description**
Rather than use the npm process module, we use our own shim for process. This allows us to use a faster implementation for process.nextTick

Fixes: #2570


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
