### PR TITLE
Update worker data providers to forward notifications

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
@@ -13,6 +13,7 @@
 
 import { Time } from "@foxglove/rostime";
 import Rpc from "@foxglove/studio-base/util/Rpc";
+import { setupReceiveReportErrorHandler } from "@foxglove/studio-base/util/RpcMainThreadUtils";
 
 import {
   RandomAccessDataProvider,
@@ -39,8 +40,12 @@ export default class WorkerBagDataProvider implements RandomAccessDataProvider {
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
+    // close any previous initialized workers
+    await this.close();
+
     this.worker = WorkerDataProviderWorker();
     this.rpc = new Rpc(this.worker);
+    setupReceiveReportErrorHandler(this.rpc);
 
     const { progressCallback, reportMetadataCallback } = extensionPoint;
 

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
@@ -14,6 +14,7 @@
 import { Time } from "@foxglove/rostime";
 import { Options } from "@foxglove/studio-base/randomAccessDataProviders/Rosbag2DataProvider";
 import Rpc from "@foxglove/studio-base/util/Rpc";
+import { setupReceiveReportErrorHandler } from "@foxglove/studio-base/util/RpcMainThreadUtils";
 
 import {
   RandomAccessDataProvider,
@@ -38,8 +39,12 @@ export default class WorkerRosbag2DataProvider implements RandomAccessDataProvid
   }
 
   async initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult> {
+    // close any previous initialized workers
+    await this.close();
+
     this.worker = WorkerDataProviderWorker();
     this.rpc = new Rpc(this.worker);
+    setupReceiveReportErrorHandler(this.rpc);
 
     const { progressCallback, reportMetadataCallback } = extensionPoint;
 


### PR DESCRIPTION

**User-Facing Changes**
Initialization errors with rosbag loading are shown to the user.

**Description**
When the old data provider descriptor logic was removed, the new worker
logic did not properly connect the sendNotification handlers for workers
back to the main thread.

This change connects sendNotification calls so those appear back to the main thread.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
