### PR TITLE
Fix startup state url handling

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -32,10 +32,6 @@ import URDFAssetLoader from "@foxglove/studio-base/services/URDFAssetLoader";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 type AppProps = {
-  /**
-   * Set to true to force loading the welcome layout for demo mode. Normally the demo is only shown
-   * on first launch and not subsequent launches.
-   */
   availableSources: IDataSourceFactory[];
   deepLinks?: string[];
 };

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -2,8 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo } from "react";
-import { useMount } from "react-use";
+import { useLayoutEffect, useRef } from "react";
 
 import Log from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -15,7 +14,7 @@ import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLa
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
-import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import { AppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
@@ -27,32 +26,32 @@ const log = Log.getLogger(__filename);
  * Restores our session state from any deep link we were passed on startup.
  */
 export function useInitialDeepLinkState(deepLinks: string[]): void {
-  const urlState = useMessagePipeline(selectUrlState);
-  const stableUrlState = useDeepMemo(urlState);
+  const stableUrlState = useDeepMemo(useMessagePipeline(selectUrlState));
   const { selectSource } = usePlayerSelection();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
   const [launchPreference, setLaunchPreference] = useSessionStorageValue(
     AppSetting.LAUNCH_PREFERENCE,
   );
   const seekPlayback = useMessagePipeline(selectSeek);
-  const appUrlState = useMemo(() => {
+
+  const appUrlRef = useRef<AppURLState | undefined>();
+  if (!appUrlRef.current) {
     const firstLink = deepLinks[0];
     if (firstLink) {
       try {
-        return parseAppURLState(new URL(firstLink));
+        appUrlRef.current = parseAppURLState(new URL(firstLink));
       } catch (error) {
         log.error(error);
-        return undefined;
       }
-    } else {
-      return undefined;
     }
-  }, [deepLinks]);
+  }
+
+  const shouldSeekTimeRef = useRef(false);
 
   // Set a sessionStorage preference for web if we have a stable URL state.
   // This allows us to avoid asking for the preference immediately on
   // launch of an empty session and makes refreshes do the right thing.
-  useMount(() => {
+  useLayoutEffect(() => {
     if (isDesktopApp()) {
       return;
     }
@@ -60,32 +59,47 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     if (stableUrlState && !launchPreference) {
       setLaunchPreference("web");
     }
-  });
+  }, [launchPreference, setLaunchPreference, stableUrlState]);
 
-  // Load app state from deeplink url if present.
-  useMount(() => {
-    if (appUrlState == undefined) {
+  useLayoutEffect(() => {
+    const urlState = appUrlRef.current;
+    if (!urlState) {
       return;
     }
 
-    if (appUrlState.ds && appUrlState.dsParams) {
-      console.log("select source", appUrlState);
-      selectSource(appUrlState.ds, { type: "connection", params: appUrlState.dsParams });
+    // Apply any available datasource args
+    if (urlState.ds && urlState.dsParams) {
+      log.debug("Initialising source from url", urlState);
+      selectSource(urlState.ds, { type: "connection", params: urlState.dsParams });
+      urlState.ds = undefined;
+      urlState.dsParams = undefined;
+      shouldSeekTimeRef.current = true;
     }
 
-    if (appUrlState.layoutId != undefined) {
-      setSelectedLayoutId(appUrlState.layoutId);
+    // Apply any available layout id
+    if (urlState.layoutId != undefined) {
+      log.debug(`Initializing layout from url: ${urlState.layoutId}`);
+      setSelectedLayoutId(urlState.layoutId);
+      urlState.layoutId = undefined;
     }
-  });
+  }, [selectSource, setSelectedLayoutId]);
 
-  // Sync to url time once our source has loaded and playback control is available.
-  // seekPlayback will be undefined until the new source has loaded.
-  // fixme - only set first time? what if the source doesn't support seek?
-  useMount(() => {
-    if (appUrlState?.time == undefined || !seekPlayback) {
+  useLayoutEffect(() => {
+    const urlState = appUrlRef.current;
+    if (urlState?.time == undefined || !seekPlayback) {
       return;
     }
 
-    seekPlayback(appUrlState.time);
-  });
+    if (!shouldSeekTimeRef.current) {
+      log.debug("Clearing urlState time");
+      urlState.time = undefined;
+      return;
+    }
+
+    shouldSeekTimeRef.current = false;
+
+    log.debug(`Seeking to url time:`, urlState.time);
+    seekPlayback(urlState.time);
+    urlState.time = undefined;
+  }, [seekPlayback]);
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -69,14 +69,8 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
 
     if (appUrlState.ds && appUrlState.dsParams) {
+      console.log("select source", appUrlState);
       selectSource(appUrlState.ds, { type: "connection", params: appUrlState.dsParams });
-    }
-  });
-
-  // Select layout from deeplink URL if present.
-  useMount(() => {
-    if (appUrlState == undefined) {
-      return;
     }
 
     if (appUrlState.layoutId != undefined) {
@@ -86,6 +80,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
 
   // Sync to url time once our source has loaded and playback control is available.
   // seekPlayback will be undefined until the new source has loaded.
+  // fixme - only set first time? what if the source doesn't support seek?
   useMount(() => {
     if (appUrlState?.time == undefined || !seekPlayback) {
       return;

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -2,7 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
+import { useMount } from "react-use";
 
 import Log from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -51,7 +52,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
   // Set a sessionStorage preference for web if we have a stable URL state.
   // This allows us to avoid asking for the preference immediately on
   // launch of an empty session and makes refreshes do the right thing.
-  useEffect(() => {
+  useMount(() => {
     if (isDesktopApp()) {
       return;
     }
@@ -59,10 +60,10 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     if (stableUrlState && !launchPreference) {
       setLaunchPreference("web");
     }
-  }, [launchPreference, setLaunchPreference, stableUrlState]);
+  });
 
   // Load app state from deeplink url if present.
-  useEffect(() => {
+  useMount(() => {
     if (appUrlState == undefined) {
       return;
     }
@@ -70,10 +71,10 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     if (appUrlState.ds && appUrlState.dsParams) {
       selectSource(appUrlState.ds, { type: "connection", params: appUrlState.dsParams });
     }
-  }, [appUrlState, selectSource]);
+  });
 
   // Select layout from deeplink URL if present.
-  useEffect(() => {
+  useMount(() => {
     if (appUrlState == undefined) {
       return;
     }
@@ -81,15 +82,15 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     if (appUrlState.layoutId != undefined) {
       setSelectedLayoutId(appUrlState.layoutId);
     }
-  }, [appUrlState, setSelectedLayoutId]);
+  });
 
   // Sync to url time once our source has loaded and playback control is available.
   // seekPlayback will be undefined until the new source has loaded.
-  useEffect(() => {
+  useMount(() => {
     if (appUrlState?.time == undefined || !seekPlayback) {
       return;
     }
 
     seekPlayback(appUrlState.time);
-  }, [appUrlState, seekPlayback]);
+  });
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useLayoutEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import Log from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -51,7 +51,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
   // Set a sessionStorage preference for web if we have a stable URL state.
   // This allows us to avoid asking for the preference immediately on
   // launch of an empty session and makes refreshes do the right thing.
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (isDesktopApp()) {
       return;
     }
@@ -61,7 +61,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
   }, [launchPreference, setLaunchPreference, stableUrlState]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const urlState = appUrlRef.current;
     if (!urlState) {
       return;
@@ -84,7 +84,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
   }, [selectSource, setSelectedLayoutId]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const urlState = appUrlRef.current;
     if (urlState?.time == undefined || !seekPlayback) {
       return;

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -21,11 +21,27 @@ const selectCanSeek = (ctx: MessagePipelineContext) =>
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 
+// when we go to update the url, we should use the latest version of the url
+// we should also cancel this
 const debouncedURLUpdate = debounce(
-  (url: URL) => window.history.replaceState(undefined, "", url.href),
+  (url: URL) => {
+    console.log("set url", url);
+    window.history.replaceState(undefined, "", url.href);
+  },
   500,
   { leading: true },
 );
+
+// during startup
+// we have some state captured in the url
+// our first pass into this hook gives us empty values
+// cause we have not yet started
+// then the other hook - initialdeeplinkstate runs and sets the source
+// and now we have a source set but have an empty url
+
+// stableUrlState isn't available?
+
+// a source is selected, but
 
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
@@ -38,7 +54,10 @@ export function useStateToURLSynchronization(): void {
   const stableUrlState = useDeepMemo(urlState);
   const { selectedSource } = usePlayerSelection();
 
+  console.log({ urlState, stableUrlState });
+
   useEffect(() => {
+    console.log({ canSeek, currentTime, layoutId, selectedSource, stableUrlState });
     // Electron has its own concept of what the app URL is. If we want to do anything
     // here for desktop we'll need to find some other method of encoding the state
     // like perhaps the URL hash.

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useCallback, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import {
@@ -76,7 +76,7 @@ export function useStateToURLSynchronization(): void {
   // differ from our reference values, we update the unsavedAppState
   const referenceAppStateRef = useRef<AppURLState>({});
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     // Electron has its own concept of what the app URL is. If we want to do anything
     // here for desktop we'll need to find some other method of encoding the state
     // like perhaps the URL hash.

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -2,46 +2,32 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { debounce } from "lodash";
-import { useEffect } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
-import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  LayoutState,
+  useCurrentLayoutSelector,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
-import { encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
+import {
+  AppURLState,
+  encodeAppURLState,
+  parseAppURLState,
+} from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectCanSeek = (ctx: MessagePipelineContext) =>
   ctx.playerState.capabilities.includes(PlayerCapabilities.playbackControl);
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
-
-// when we go to update the url, we should use the latest version of the url
-// we should also cancel this
-const debouncedURLUpdate = debounce(
-  (url: URL) => {
-    console.log("set url", url);
-    window.history.replaceState(undefined, "", url.href);
-  },
-  500,
-  { leading: true },
-);
-
-// during startup
-// we have some state captured in the url
-// our first pass into this hook gives us empty values
-// cause we have not yet started
-// then the other hook - initialdeeplinkstate runs and sets the source
-// and now we have a source set but have an empty url
-
-// stableUrlState isn't available?
-
-// a source is selected, but
+const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
 
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
@@ -50,14 +36,47 @@ export function useStateToURLSynchronization(): void {
   const canSeek = useMessagePipeline(selectCanSeek);
   const currentTime = useMessagePipeline(selectCurrentTime);
   const urlState = useMessagePipeline(selectUrlState);
-  const layoutId = useCurrentLayoutSelector((layout) => layout.selectedLayout?.id);
+  const layoutId = useCurrentLayoutSelector(selectLayoutId);
   const stableUrlState = useDeepMemo(urlState);
   const { selectedSource } = usePlayerSelection();
 
-  console.log({ urlState, stableUrlState });
+  // unsavedAppStateRef contains the app state that will be saved to the url
+  // It starts out as the current url state values
+  const unusavedAppStateRef = useRef<AppURLState>();
+  function getUnsavedAppState(): AppURLState {
+    return (unusavedAppStateRef.current ??= parseAppURLState(new URL(window.location.href)) ?? {});
+  }
 
-  useEffect(() => {
-    console.log({ canSeek, currentTime, layoutId, selectedSource, stableUrlState });
+  // Write the unsaved app state to the url
+  const updateUrl = useCallback(() => {
+    const unsavedAppState = getUnsavedAppState();
+
+    const url = encodeAppURLState(new URL(window.location.href), {
+      ds: unsavedAppState.ds,
+      layoutId: unsavedAppState.layoutId,
+      time: unsavedAppState.time,
+      dsParams: unsavedAppState.dsParams,
+    });
+
+    window.history.replaceState(undefined, "", url.href);
+  }, []);
+
+  // Debounce url updates to prevent thrashing when currentTime updates tne unsaved state
+  const queueUpdateUrl = useDebouncedCallback(updateUrl, 500, {
+    leading: true,
+    maxWait: 500,
+  });
+
+  // During startup, many of the values (selectedSource, layoutId, etc) start out undefined.
+  // We don't want their initial undefined state to clear the url state only to add it back
+  // immediately. Conversely, if a value goes from being defined to undefined, we want to clear
+  // the url state value.
+  //
+  // referenceAppStateRef lets us accomplish this. We start with an empty state and as the values
+  // differ from our reference values, we update the unsavedAppState
+  const referenceAppStateRef = useRef<AppURLState>({});
+
+  useLayoutEffect(() => {
     // Electron has its own concept of what the app URL is. If we want to do anything
     // here for desktop we'll need to find some other method of encoding the state
     // like perhaps the URL hash.
@@ -65,14 +84,32 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
-    const url = encodeAppURLState(new URL(window.location.href), {
-      ds: selectedSource?.id,
-      layoutId,
-      time: canSeek ? currentTime : undefined,
-      dsParams: stableUrlState,
-    });
+    const unsavedAppState = getUnsavedAppState();
 
-    // Debounce updates to avoid spamming changes to the address bar.
-    debouncedURLUpdate(url);
-  }, [canSeek, currentTime, layoutId, selectedSource, stableUrlState]);
+    if (referenceAppStateRef.current.layoutId !== layoutId) {
+      unsavedAppState.layoutId = layoutId;
+    }
+
+    if (referenceAppStateRef.current.ds !== selectedSource?.id) {
+      unsavedAppState.ds = selectedSource?.id;
+    }
+
+    if (referenceAppStateRef.current.dsParams !== stableUrlState) {
+      unsavedAppState.dsParams = stableUrlState;
+    }
+
+    const time = canSeek ? currentTime : undefined;
+    if (referenceAppStateRef.current.time !== time) {
+      unsavedAppState.time = time;
+    }
+
+    referenceAppStateRef.current = {
+      layoutId,
+      ds: selectedSource?.id,
+      dsParams: stableUrlState,
+      time,
+    };
+
+    queueUpdateUrl();
+  }, [canSeek, currentTime, layoutId, queueUpdateUrl, selectedSource, stableUrlState]);
 }


### PR DESCRIPTION
**User-Facing Changes**
When loading a data source via url, the url bar does not flicker and remove the source only to add it back.

**Description**

useInitialDeepLinkState is updated to only apply url state once. This is accomplished by starting with the initial url state and removing the items already applied. With this change, we also track whether the _time_ field should be applied. If the url state contains a time field but no data source, we should not apply the time field when the user selects a datasource manually.

useStateToURLSynchronization is updated to ignore startup undefined values which resulted in clearing the url bar values and quickly adding the values back. The logic is updated to remove values that do become undefined after having been defined before.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
