### PR TITLE
Wrap TransformTree with RosTransformTree that normalizes frame names according to ROS convention

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.stories.tsx
@@ -5,7 +5,7 @@
 import { action } from "@storybook/addon-actions";
 import { Story } from "@storybook/react";
 
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { RosTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 
 import FollowTFControl from "./FollowTFControl";
 
@@ -18,7 +18,7 @@ export const NoTransformsNoFollow: Story = () => {
   return (
     <FollowTFControl
       followMode="no-follow"
-      transforms={new TransformTree()}
+      transforms={new RosTransformTree()}
       onFollowChange={action("onFollowChange")}
     />
   );
@@ -29,14 +29,14 @@ export const NoTransforms: Story = () => {
     <FollowTFControl
       followTf="some_frame"
       followMode="no-follow"
-      transforms={new TransformTree()}
+      transforms={new RosTransformTree()}
       onFollowChange={action("onFollowChange")}
     />
   );
 };
 
 export const FollowNotFound: Story = () => {
-  const tree = new TransformTree();
+  const tree = new RosTransformTree();
   tree.getOrCreateFrame("new_frame");
 
   return (
@@ -50,7 +50,7 @@ export const FollowNotFound: Story = () => {
 };
 
 export const Following: Story = () => {
-  const tree = new TransformTree();
+  const tree = new RosTransformTree();
   tree.getOrCreateFrame("new_frame");
 
   return (

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -21,7 +21,7 @@ import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import { FollowMode } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-import { TransformTree, CoordinateFrame } from "./transforms";
+import { RosTransformTree, CoordinateFrame } from "./transforms";
 
 type TfTreeNode = {
   tf: CoordinateFrame;
@@ -83,7 +83,7 @@ const buildTfTree = (transforms: CoordinateFrame[]): TfTree => {
 };
 
 type Props = {
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   followTf?: string;
   followMode: FollowMode;
   onFollowChange: (tfId?: string, followMode?: FollowMode) => void;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -24,7 +24,7 @@ import { MarkerMatcher } from "@foxglove/studio-base/panels/ThreeDimensionalViz/
 import VelodyneCloudConverter from "@foxglove/studio-base/panels/ThreeDimensionalViz/VelodyneCloudConverter";
 import {
   CoordinateFrame,
-  TransformTree,
+  RosTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   MarkerProvider,
@@ -97,7 +97,7 @@ type MarkerMatchersByTopic = {
 const missingTransformMessage = (
   renderFrameId: string,
   error: ErrorDetails,
-  transforms: TransformTree,
+  transforms: RosTransformTree,
 ): string => {
   if (error.frameIds.size === 0) {
     throw new Error(`Missing transform error has no frameIds`);
@@ -113,7 +113,7 @@ const missingTransformMessage = (
 
 export function getSceneErrorsByTopic(
   sceneErrors: SceneErrors,
-  transforms: TransformTree,
+  transforms: RosTransformTree,
 ): {
   [topicName: string]: string[];
 } {
@@ -176,7 +176,7 @@ export function filterOutSupersededMessages<T extends Pick<MessageEvent<unknown>
 
 function computeMarkerPose(
   marker: Marker,
-  transforms: TransformTree,
+  transforms: RosTransformTree,
   renderFrame: CoordinateFrame,
   fixedFrame: CoordinateFrame,
   currentTime: Time,
@@ -222,7 +222,7 @@ export default class SceneBuilder implements MarkerProvider {
   collectors: {
     [key: string]: MessageCollector;
   } = {};
-  private _transforms?: TransformTree;
+  private _transforms?: RosTransformTree;
   private _missingTfFrameIds = new Set<string>();
   private _clock?: Time;
   private _playerId?: string;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.test.tsx
@@ -23,7 +23,7 @@ import {
   getHighlightedIndices,
   useSearchMatches,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/SearchText";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { RosTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { TextMarker, TF } from "@foxglove/studio-base/types/Messages";
 import { MARKER_MSG_TYPES } from "@foxglove/studio-base/util/globalConstants";
 
@@ -182,8 +182,8 @@ describe("<SearchText />", () => {
   describe("useCurrentMatchPosition", () => {
     const p = (x: number = 0, y = x, z = x) => ({ x, y, z });
     const q = (x = 0, y = 0, z = 0, w = 0) => ({ x, y, z, w });
-    const getTf = (): TransformTree => {
-      const tree = new TransformTree();
+    const getTf = (): RosTransformTree => {
+      const tree = new RosTransformTree();
       const tf: TF = {
         header,
         child_frame_id: CHILD_FRAME_ID,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -21,7 +21,7 @@ import { Time } from "@foxglove/rostime";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import useDeepChangeDetector from "@foxglove/studio-base/hooks/useDeepChangeDetector";
 import { Interactive } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/types";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { RosTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { TextMarker, Color } from "@foxglove/studio-base/types/Messages";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
@@ -147,7 +147,7 @@ type SearchTextComponentProps = SearchTextProps & {
   renderFrameId?: string;
   fixedFrameId?: string;
   currentTime: Time;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
 };
 
 // Exported for tests.
@@ -168,7 +168,7 @@ export const useSearchMatches = ({
   fixedFrameId?: string;
   currentTime: Time;
   searchTextOpen: boolean;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
 }): void => {
   const hasCurrentMatchChanged = useDeepChangeDetector([currentMatch], { initiallyTrue: true });
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -69,7 +69,7 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import {
   CoordinateFrame,
-  TransformTree,
+  RosTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   FollowMode,
@@ -96,12 +96,12 @@ export type LayoutToolbarSharedProps = {
   onCameraStateChange: (arg0: CameraState) => void;
   onFollowChange: (followTf?: string, followMode?: FollowMode) => void;
   saveConfig: Save3DConfig;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   isPlaying?: boolean;
 };
 
 export type LayoutTopicSettingsSharedProps = {
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   topics: readonly Topic[];
   saveConfig: Save3DConfig;
 };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -31,7 +31,7 @@ import { UrdfSettings } from "@foxglove/studio-base/panels/ThreeDimensionalViz/T
 import {
   CoordinateFrame,
   Transform,
-  TransformTree,
+  RosTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   Color,
@@ -170,7 +170,7 @@ export default class UrdfBuilder implements MarkerProvider {
     }
   }
 
-  private update(transforms: TransformTree): void {
+  private update(transforms: RosTransformTree): void {
     if (!this._urdf) {
       return;
     }
@@ -410,7 +410,7 @@ function getColor(visual: UrdfVisual, robot: UrdfRobot): Color {
 
 function updatePose(
   marker: Marker,
-  transforms: TransformTree,
+  transforms: RosTransformTree,
   renderFrame: CoordinateFrame,
   fixedFrame: CoordinateFrame,
   time: Time,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -33,7 +33,7 @@ import WorldMarkers, {
 import { LAYER_INDEX_DEFAULT_BASE } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 import {
   CoordinateFrame,
-  TransformTree,
+  RosTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import withHighlights from "@foxglove/studio-base/panels/ThreeDimensionalViz/withHighlights";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -60,7 +60,7 @@ type Props = WorldSearchTextProps & {
   cameraState: CameraState;
   children?: React.ReactNode;
   isPlaying: boolean;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   renderFrame: CoordinateFrame;
   fixedFrame: CoordinateFrame;
   currentTime: Time;
@@ -83,7 +83,7 @@ function getMarkers({
 }: {
   markers: InteractiveMarkersByType;
   markerProviders: MarkerProvider[];
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   renderFrame: CoordinateFrame;
   fixedFrame: CoordinateFrame;
   time: Time;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
@@ -25,7 +25,7 @@ import {
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { InteractionData } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/types";
 import { LinkedGlobalVariables } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { RosTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { FollowMode } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { InstancedLineListMarker, MutablePose } from "@foxglove/studio-base/types/Messages";
 
@@ -36,7 +36,7 @@ type MutableVec4 = [number, number, number, number];
 // Get the camera target position and orientation
 function getTargetPose(
   followTf: string | undefined,
-  transforms: TransformTree,
+  transforms: RosTransformTree,
 ): TargetPose | undefined {
   if (followTf != undefined && transforms.hasFrame(followTf)) {
     return { target: [0, 0, 0], targetOrientation: [0, 0, 0, 1] };
@@ -61,7 +61,7 @@ export function useTransformedCameraState({
   configCameraState: Partial<CameraState>;
   followTf?: string;
   followMode: FollowMode;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   poseInRenderFrame?: MutablePose;
 }): CameraState {
   const transformedCameraState = { ...configCameraState };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/RosTransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/RosTransformTree.ts
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Duration, Time } from "@foxglove/rostime";
+import { MutablePose, Pose, TF } from "@foxglove/studio-base/types/Messages";
+
+import { CoordinateFrame } from "./CoordinateFrame";
+import { Transform } from "./Transform";
+import { TransformTree } from "./TransformTree";
+import { quatFromValues, vec3FromValues } from "./geometry";
+
+/**
+ * RosTransformTree is a wrapper for TransformTree that normalizes transform
+ * names according to the ROS convention of always prefixing "/" to transforms.
+ */
+export class RosTransformTree {
+  private _tree = new TransformTree();
+
+  addTransform(frameId: string, parentFrameId: string, time: Time, transform: Transform): void {
+    this._tree.addTransform(rosFrameId(frameId), rosFrameId(parentFrameId), time, transform);
+  }
+
+  addTransformMessage(tf: TF): void {
+    const t = tf.transform.translation;
+    const q = tf.transform.rotation;
+    const transform = new Transform(
+      vec3FromValues(t.x, t.y, t.z),
+      quatFromValues(q.x, q.y, q.z, q.w),
+    );
+    this.addTransform(tf.child_frame_id, tf.header.frame_id, tf.header.stamp, transform);
+  }
+
+  hasFrame(id: string): boolean {
+    return this._tree.hasFrame(rosFrameId(id));
+  }
+
+  frame(id: string): CoordinateFrame | undefined {
+    return this._tree.frame(rosFrameId(id));
+  }
+
+  getOrCreateFrame(id: string): CoordinateFrame {
+    return this._tree.getOrCreateFrame(rosFrameId(id));
+  }
+
+  frames(): ReadonlyMap<string, CoordinateFrame> {
+    return this._tree.frames();
+  }
+
+  apply(
+    output: MutablePose,
+    input: Pose,
+    frameId: string,
+    rootFrameId: string | undefined,
+    srcFrameId: string,
+    dstTime: Time,
+    srcTime: Time,
+    maxDelta?: Duration,
+  ): MutablePose | undefined {
+    return this._tree.apply(
+      output,
+      input,
+      rosFrameId(frameId),
+      rootFrameId != undefined ? rosFrameId(rootFrameId) : undefined,
+      rosFrameId(srcFrameId),
+      dstTime,
+      srcTime,
+      maxDelta,
+    );
+  }
+
+  static Clone(tree: RosTransformTree): RosTransformTree {
+    const newTree = new RosTransformTree();
+    // eslint-disable-next-line no-underscore-dangle
+    newTree._tree = tree._tree;
+    return newTree;
+  }
+}
+
+function rosFrameId(frameId: string): string {
+  return frameId[0] === "/" ? frameId : "/" + frameId;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
@@ -7,5 +7,5 @@
 export const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
 
 export * from "./CoordinateFrame";
+export * from "./RosTransformTree";
 export * from "./Transform";
-export * from "./TransformTree";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -37,7 +37,7 @@ import {
 import { TopicSettingsCollection } from "./SceneBuilder";
 import { ColorOverrideByVariable, ColorOverride } from "./TopicTree/Layout";
 import { TopicDisplayMode } from "./TopicTree/types";
-import { CoordinateFrame, TransformTree } from "./transforms";
+import { CoordinateFrame, RosTransformTree } from "./transforms";
 
 /** @deprecated */
 type ColorOverrideBySourceIdxByVariable = Record<string, ColorOverride[]>;
@@ -74,7 +74,7 @@ export type RenderMarkerArgs = {
   add: MarkerCollector;
   renderFrame: CoordinateFrame;
   fixedFrame: CoordinateFrame;
-  transforms: TransformTree;
+  transforms: RosTransformTree;
   time: Time;
 };
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -17,13 +17,13 @@ import {
   TF_DATATYPES,
   TRANSFORM_STAMPED_DATATYPES,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { RosTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { Frame, MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
 
 type TfMessage = { transforms: TF[] };
 
-function consumeTfs(tfs: MessageEvent<TfMessage>[], transforms: TransformTree): void {
+function consumeTfs(tfs: MessageEvent<TfMessage>[], transforms: RosTransformTree): void {
   for (const { message } of tfs) {
     const parsedMessage = message;
     for (const tf of parsedMessage.transforms) {
@@ -32,7 +32,7 @@ function consumeTfs(tfs: MessageEvent<TfMessage>[], transforms: TransformTree): 
   }
 }
 
-function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree): void {
+function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: RosTransformTree): void {
   for (const { message } of tfs) {
     transforms.addTransformMessage(message);
   }
@@ -47,16 +47,16 @@ function consumeSingleTfs(tfs: MessageEvent<TF>[], transforms: TransformTree): v
  * If the frame is undefined, transform accumulation is reset and all existing transforms are discarded.
  */
 // eslint-disable-next-line @foxglove/no-boolean-parameters
-function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): TransformTree {
+function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): RosTransformTree {
   const topicsToDatatypes = useMemo(() => {
     return new Map<string, string>(topics.map((topic) => [topic.name, topic.datatype]));
   }, [topics]);
 
-  const transformsRef = useRef(new TransformTree());
+  const transformsRef = useRef(new RosTransformTree());
 
-  return useMemo<TransformTree>(() => {
+  return useMemo<RosTransformTree>(() => {
     if (reset) {
-      transformsRef.current = new TransformTree();
+      transformsRef.current = new RosTransformTree();
     }
 
     const transforms = transformsRef.current;
@@ -109,7 +109,7 @@ function useTransforms(topics: readonly Topic[], frame: Frame, reset: boolean): 
 
     // clone the transforms object if there were updates
     // This creates a new reference identity for the returned transforms so memoization can update
-    const newTransforms = TransformTree.Clone(transforms);
+    const newTransforms = RosTransformTree.Clone(transforms);
     return (transformsRef.current = newTransforms);
   }, [reset, frame, topicsToDatatypes]);
 }


### PR DESCRIPTION
**User-Facing Changes**

Coordinate frame names (`frame_id` and `child_frame_id`) are normalized according to ROS convention, by prefixing with a "/" if not present
