### PR TITLE
Fix imageview flickering during zoom.

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -345,12 +345,12 @@ export default function ImageCanvas(props: Props): JSX.Element {
 
     // can't set width/height of canvas after transferring control to offscreen
     // so we need to send the width/height to rpc
-    const targetWidth = width * devicePixelRatio;
-    const targetHeight = height * devicePixelRatio;
+    const targetWidth = Math.floor(width * devicePixelRatio);
+    const targetHeight = Math.floor(height * devicePixelRatio);
 
     const computedViewbox = {
-      x: panX * devicePixelRatio,
-      y: panY * devicePixelRatio,
+      x: Math.floor(panX * devicePixelRatio),
+      y: Math.floor(panY * devicePixelRatio),
       scale: scaleValue,
     };
 


### PR DESCRIPTION
**User-Facing Changes**
This fixes the flickering in the image view during zooming.

**Description**
The fix here is easy. We were trying to assign a fractional width & height to the canvas so we were effectively clearing the canvas unnecessarily on each render. All we need to do is make sure we pass integer values for the canvas viewport width and height.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2516 