### PR TITLE
Prevent zooming below a threshold in Image Panel.

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -314,7 +314,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
     setContainer,
     panZoomHandlers,
   } = usePanZoom({
-    minZoom: 0.25,
+    minZoom: 0.5,
     initialPan: config.pan,
     initialZoom: config.zoom,
   });

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -314,6 +314,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
     setContainer,
     panZoomHandlers,
   } = usePanZoom({
+    minZoom: 0.25,
     initialPan: config.pan,
     initialZoom: config.zoom,
   });


### PR DESCRIPTION
**User-Facing Changes**
This prevents zooming below a fixed factor in the Image Panel to make it harder for users to lose track of the content at tiny zoom levels.

**Description**
This simply hard caps the minimum zoom at 0.25.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2514 