### PR TITLE
Don't deselect panel on second click with settings open.

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -431,7 +431,7 @@ export default function Panel<
         if (panelSettingsOpen) {
           // Allow clicking with no modifiers to select a panel (and deselect others) when panel settings are open
           e.stopPropagation(); // select the deepest clicked panel, not parent tab panels
-          setSelectedPanelIds(isSelected ? [] : [childId]);
+          setSelectedPanelIds([childId]);
         } else if (e.metaKey || shiftKeyPressed || isSelected) {
           e.stopPropagation(); // select the deepest clicked panel, not parent tab panels
           togglePanelSelected(childId, tabId);


### PR DESCRIPTION
**User-Facing Changes**
This changes the behavior of panel selection when panel settings is open.

**Description**
This just changes the logic on subsequent clicks to not deselect the selected panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2485 