### PR TITLE
Fix transform loading from URDF robot models in 3d panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -21,10 +21,10 @@ import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import { FollowMode } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-import { TransformTree, CoordinateFrame } from "./transforms";
+import { CoordinateFrame, IImmutableTransformTree, IImmutableCoordinateFrame } from "./transforms";
 
 type TfTreeNode = {
-  tf: CoordinateFrame;
+  tf: IImmutableCoordinateFrame;
   children: TfTreeNode[];
   depth: number;
 };
@@ -38,7 +38,7 @@ type TfTree = {
 
 const treeNodeToTfId = (node: TfTreeNode) => node.tf.id;
 
-const buildTfTree = (transforms: CoordinateFrame[]): TfTree => {
+const buildTfTree = (transforms: IImmutableCoordinateFrame[]): TfTree => {
   const tree: TfTree = {
     roots: [],
     nodes: {},
@@ -83,7 +83,7 @@ const buildTfTree = (transforms: CoordinateFrame[]): TfTree => {
 };
 
 type Props = {
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
   followTf?: string;
   followMode: FollowMode;
   onFollowChange: (tfId?: string, followMode?: FollowMode) => void;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
@@ -85,7 +85,12 @@ const fixedFrame = renderFrame;
 
 storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
   .add("renders the default grid", () => {
-    const transforms = useTransforms([], {}, false);
+    const transforms = useTransforms({
+      topics: [],
+      frame: {},
+      reset: false,
+      urdfTransforms: [],
+    });
     const collector = new MockMarkerCollector();
     const gridBuilder = new GridBuilder();
     gridBuilder.renderMarkers({
@@ -114,7 +119,7 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
     );
   })
   .add("renders a customized grid", () => {
-    const transforms = useTransforms([], {}, false);
+    const transforms = useTransforms({ topics: [], frame: {}, reset: false, urdfTransforms: [] });
     const collector = new MockMarkerCollector();
     const gridBuilder = new GridBuilder();
     const settings: GridSettings = {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -23,8 +23,8 @@ import MessageCollector from "@foxglove/studio-base/panels/ThreeDimensionalViz/S
 import { MarkerMatcher } from "@foxglove/studio-base/panels/ThreeDimensionalViz/ThreeDimensionalVizContext";
 import VelodyneCloudConverter from "@foxglove/studio-base/panels/ThreeDimensionalViz/VelodyneCloudConverter";
 import {
-  CoordinateFrame,
-  TransformTree,
+  IImmutableCoordinateFrame,
+  IImmutableTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   MarkerProvider,
@@ -97,7 +97,7 @@ type MarkerMatchersByTopic = {
 const missingTransformMessage = (
   renderFrameId: string,
   error: ErrorDetails,
-  transforms: TransformTree,
+  transforms: IImmutableTransformTree,
 ): string => {
   if (error.frameIds.size === 0) {
     throw new Error(`Missing transform error has no frameIds`);
@@ -113,7 +113,7 @@ const missingTransformMessage = (
 
 export function getSceneErrorsByTopic(
   sceneErrors: SceneErrors,
-  transforms: TransformTree,
+  transforms: IImmutableTransformTree,
 ): {
   [topicName: string]: string[];
 } {
@@ -176,9 +176,9 @@ export function filterOutSupersededMessages<T extends Pick<MessageEvent<unknown>
 
 function computeMarkerPose(
   marker: Marker,
-  transforms: TransformTree,
-  renderFrame: CoordinateFrame,
-  fixedFrame: CoordinateFrame,
+  transforms: IImmutableTransformTree,
+  renderFrame: IImmutableCoordinateFrame,
+  fixedFrame: IImmutableCoordinateFrame,
   currentTime: Time,
 ): Pose | undefined {
   const srcFrame = transforms.frame(marker.header.frame_id);
@@ -222,7 +222,7 @@ export default class SceneBuilder implements MarkerProvider {
   collectors: {
     [key: string]: MessageCollector;
   } = {};
-  private _transforms?: TransformTree;
+  private _transforms?: IImmutableTransformTree;
   private _missingTfFrameIds = new Set<string>();
   private _clock?: Time;
   private _playerId?: string;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -21,7 +21,7 @@ import { Time } from "@foxglove/rostime";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import useDeepChangeDetector from "@foxglove/studio-base/hooks/useDeepChangeDetector";
 import { Interactive } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/types";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { IImmutableTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { TextMarker, Color } from "@foxglove/studio-base/types/Messages";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
@@ -147,7 +147,7 @@ type SearchTextComponentProps = SearchTextProps & {
   renderFrameId?: string;
   fixedFrameId?: string;
   currentTime: Time;
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
 };
 
 // Exported for tests.
@@ -168,7 +168,7 @@ export const useSearchMatches = ({
   fixedFrameId?: string;
   currentTime: Time;
   searchTextOpen: boolean;
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
 }): void => {
   const hasCurrentMatchChanged = useDeepChangeDetector([currentMatch], { initiallyTrue: true });
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/Layout.tsx
@@ -68,8 +68,8 @@ import {
   getUpdatedGlobalVariablesBySelectedObject,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import {
-  CoordinateFrame,
-  TransformTree,
+  IImmutableCoordinateFrame,
+  IImmutableTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   FollowMode,
@@ -96,12 +96,12 @@ export type LayoutToolbarSharedProps = {
   onCameraStateChange: (arg0: CameraState) => void;
   onFollowChange: (followTf?: string, followMode?: FollowMode) => void;
   saveConfig: Save3DConfig;
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
   isPlaying?: boolean;
 };
 
 export type LayoutTopicSettingsSharedProps = {
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
   topics: readonly Topic[];
   saveConfig: Save3DConfig;
 };
@@ -109,14 +109,15 @@ export type LayoutTopicSettingsSharedProps = {
 type Props = LayoutToolbarSharedProps &
   LayoutTopicSettingsSharedProps & {
     children?: React.ReactNode;
-    renderFrame: CoordinateFrame;
-    fixedFrame: CoordinateFrame;
+    renderFrame: IImmutableCoordinateFrame;
+    fixedFrame: IImmutableCoordinateFrame;
     currentTime: Time;
     resetFrame: boolean;
     frame: Frame;
     helpContent: React.ReactNode | string;
     isPlaying?: boolean;
     config: ThreeDimensionalVizConfig;
+    urdfBuilder: UrdfBuilder;
     saveConfig: Save3DConfig;
     setSubscriptions: (subscriptions: string[]) => void;
     topics: readonly Topic[];
@@ -218,6 +219,7 @@ export default function Layout({
   topics,
   transforms,
   setSubscriptions,
+  urdfBuilder,
   config: {
     autoTextBackgroundColor = false,
     checkedKeys,
@@ -274,13 +276,11 @@ export default function Layout({
 
   const isDrawing = useMemo(() => measureInfo.measureState !== "idle", [measureInfo.measureState]);
 
-  // initialize the GridBuilder, SceneBuilder, and TransformsBuilder
-  const { gridBuilder, sceneBuilder, transformsBuilder, urdfBuilder } = useMemo(
+  const { gridBuilder, sceneBuilder, transformsBuilder } = useMemo(
     () => ({
       gridBuilder: new GridBuilder(),
       sceneBuilder: new SceneBuilder(),
       transformsBuilder: new TransformsBuilder(),
-      urdfBuilder: new UrdfBuilder(),
     }),
     [],
   );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -122,7 +122,7 @@ function TopicSettingsModal({
 
   return (
     <Dialog
-      isOpen
+      hidden={false}
       onDismiss={() => setCurrentEditingTopic(undefined)}
       dialogContentProps={{
         title: currentEditingTopic.name,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/types.ts
@@ -13,7 +13,7 @@
 
 import { Color } from "@foxglove/regl-worldview";
 import { TOPIC_DISPLAY_MODES } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/constants";
-import { IImmutableTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { IImmutableCoordinateFrame } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { Namespace } from "@foxglove/studio-base/types/Messages";
 
@@ -74,7 +74,9 @@ export type UseSceneBuilderAndTransformsDataInput = {
     errorsByTopic: { [topicName: string]: string[] };
   };
   staticallyAvailableNamespacesByTopic: NamespacesByTopic;
-  transforms: IImmutableTransformTree;
+  transforms: {
+    frames(): ReadonlyMap<string, IImmutableCoordinateFrame>;
+  };
 };
 
 export type SceneErrorsByKey = {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/types.ts
@@ -13,7 +13,7 @@
 
 import { Color } from "@foxglove/regl-worldview";
 import { TOPIC_DISPLAY_MODES } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/constants";
-import { CoordinateFrame } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { IImmutableTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { Namespace } from "@foxglove/studio-base/types/Messages";
 
@@ -74,9 +74,7 @@ export type UseSceneBuilderAndTransformsDataInput = {
     errorsByTopic: { [topicName: string]: string[] };
   };
   staticallyAvailableNamespacesByTopic: NamespacesByTopic;
-  transforms: {
-    frames(): ReadonlyMap<string, CoordinateFrame>;
-  };
+  transforms: IImmutableTransformTree;
 };
 
 export type SceneErrorsByKey = {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TransformsBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TransformsBuilder.ts
@@ -14,7 +14,7 @@
 import { quat, vec3 } from "gl-matrix";
 
 import { Time } from "@foxglove/rostime";
-import { CoordinateFrame } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { IImmutableCoordinateFrame } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { ArrowMarker, MutablePose, Point, TextMarker } from "@foxglove/studio-base/types/Messages";
 import { clonePose, emptyPose, setIdentityPose } from "@foxglove/studio-base/util/Pose";
 import { MARKER_MSG_TYPES } from "@foxglove/studio-base/util/globalConstants";
@@ -79,9 +79,9 @@ const originAxes: Axis[] = [
 const getTransformedAxisArrowMarker = (
   id: string,
   axis: Axis,
-  renderFrame: CoordinateFrame,
-  fixedFrame: CoordinateFrame,
-  srcFrame: CoordinateFrame,
+  renderFrame: IImmutableCoordinateFrame,
+  fixedFrame: IImmutableCoordinateFrame,
+  srcFrame: IImmutableCoordinateFrame,
   time: Time,
 ): ArrowMarker => {
   const { unitVector, id: axisId } = axis;
@@ -103,9 +103,9 @@ const getTransformedAxisArrowMarker = (
 
 const getAxesArrowMarkers = (
   id: string,
-  renderFrame: CoordinateFrame,
-  fixedFrame: CoordinateFrame,
-  srcFrame: CoordinateFrame,
+  renderFrame: IImmutableCoordinateFrame,
+  fixedFrame: IImmutableCoordinateFrame,
+  srcFrame: IImmutableCoordinateFrame,
   time: Time,
 ): ArrowMarker[] => {
   return originAxes.map((axis) =>
@@ -168,9 +168,9 @@ function reproject(a: Point, b: Point, distance: number): Point {
 // Exported for tests
 export const getArrowToParentMarker = (
   id: string,
-  renderFrame: CoordinateFrame,
-  fixedFrame: CoordinateFrame,
-  srcFrame: CoordinateFrame,
+  renderFrame: IImmutableCoordinateFrame,
+  fixedFrame: IImmutableCoordinateFrame,
+  srcFrame: IImmutableCoordinateFrame,
   time: Time,
 ): ArrowMarker | undefined => {
   const parent = srcFrame.parent();
@@ -226,9 +226,9 @@ export default class TransformsBuilder implements MarkerProvider {
   addMarkersForTransform(
     add: MarkerCollector,
     id: string,
-    renderFrame: CoordinateFrame,
-    fixedFrame: CoordinateFrame,
-    srcFrame: CoordinateFrame,
+    renderFrame: IImmutableCoordinateFrame,
+    fixedFrame: IImmutableCoordinateFrame,
+    srcFrame: IImmutableCoordinateFrame,
     time: Time,
   ): void {
     setIdentityPose(tempPose);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { EventEmitter } from "eventemitter3";
 import { quat, vec3 } from "gl-matrix";
 import { isEqual } from "lodash";
 
@@ -29,9 +30,9 @@ import { rewritePackageUrl } from "@foxglove/studio-base/context/AssetsContext";
 import { TopicSettingsCollection } from "@foxglove/studio-base/panels/ThreeDimensionalViz/SceneBuilder";
 import { UrdfSettings } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/UrdfSettingsEditor";
 import {
-  CoordinateFrame,
+  IImmutableCoordinateFrame,
+  IImmutableTransformTree,
   Transform,
-  TransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   Color,
@@ -46,7 +47,7 @@ import { clonePose } from "@foxglove/studio-base/util/Pose";
 import { URDF_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
-import { MarkerProvider, RenderMarkerArgs } from "./types";
+import { MarkerProvider, RenderMarkerArgs, TransformLink } from "./types";
 
 export const DEFAULT_COLOR: Color = { r: 36 / 255, g: 142 / 255, b: 255 / 255, a: 1 };
 
@@ -57,23 +58,21 @@ type Quaternion = { x: number; y: number; z: number; w: number };
 
 const log = Logger.getLogger(__filename);
 
-export default class UrdfBuilder implements MarkerProvider {
+type EventTypes = {
+  transforms: (transforms: TransformLink[]) => void;
+};
+
+export default class UrdfBuilder extends EventEmitter<EventTypes> implements MarkerProvider {
   private _urdf?: UrdfRobot;
   private _boxes: CubeMarker[] = [];
   private _spheres: SphereMarker[] = [];
   private _cylinders: CylinderMarker[] = [];
   private _meshes: MeshMarker[] = [];
   private _visible = true;
-  private _needsUpdate = false;
   private _settings: UrdfSettings = {};
   private _urdfData?: string;
 
   renderMarkers = ({ add, transforms, renderFrame, fixedFrame, time }: RenderMarkerArgs): void => {
-    if (this._needsUpdate) {
-      this._needsUpdate = false;
-      this.update(transforms);
-    }
-
     if (!this._visible) {
       return;
     }
@@ -164,27 +163,27 @@ export default class UrdfBuilder implements MarkerProvider {
     try {
       log.debug(`Parsing ${text.length} byte URDF`);
       this._urdf = await parseRobot(text, fileFetcher);
-      this._needsUpdate = true;
+
+      const transforms = Array.from(this._urdf.joints.values()).map((joint) => {
+        const t = joint.origin.xyz;
+        const q = eulerToQuaternion(joint.origin.rpy);
+        const translation: vec3 = [t.x, t.y, t.z];
+        const rotation: quat = [q.x, q.y, q.z, q.w];
+        const transform = new Transform(translation, rotation);
+        const transformLink: TransformLink = {
+          parent: joint.parent,
+          child: joint.child,
+          transform,
+        };
+        return transformLink;
+      });
+
+      log.debug("Transforms from from urdf: ", transforms);
+      this.emit("transforms", transforms);
+      this.createMarkers();
     } catch (err) {
       throw new Error(`Failed to parse ${text.length} byte URDF: ${err}`);
     }
-  }
-
-  private update(transforms: TransformTree): void {
-    if (!this._urdf) {
-      return;
-    }
-
-    for (const joint of this._urdf.joints.values()) {
-      const t = joint.origin.xyz;
-      const q = eulerToQuaternion(joint.origin.rpy);
-      const translation: vec3 = [t.x, t.y, t.z];
-      const rotation: quat = [q.x, q.y, q.z, q.w];
-      const tf = new Transform(translation, rotation);
-      transforms.addTransform(joint.child, joint.parent, TIME_ZERO, tf);
-    }
-
-    this.createMarkers();
   }
 
   createMarkers(): void {
@@ -410,9 +409,9 @@ function getColor(visual: UrdfVisual, robot: UrdfRobot): Color {
 
 function updatePose(
   marker: Marker,
-  transforms: TransformTree,
-  renderFrame: CoordinateFrame,
-  fixedFrame: CoordinateFrame,
+  transforms: IImmutableTransformTree,
+  renderFrame: IImmutableCoordinateFrame,
+  fixedFrame: IImmutableCoordinateFrame,
   time: Time,
 ): boolean {
   const srcFrame = transforms.frame(marker.header.frame_id);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -164,7 +164,7 @@ export default class UrdfBuilder extends EventEmitter<EventTypes> implements Mar
       log.debug(`Parsing ${text.length} byte URDF`);
       this._urdf = await parseRobot(text, fileFetcher);
 
-      const transforms = Array.from(this._urdf.joints.values()).map((joint) => {
+      const transforms = Array.from(this._urdf.joints.values(), (joint) => {
         const t = joint.origin.xyz;
         const q = eulerToQuaternion(joint.origin.rpy);
         const translation: vec3 = [t.x, t.y, t.z];

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -178,9 +178,11 @@ export default class UrdfBuilder extends EventEmitter<EventTypes> implements Mar
         return transformLink;
       });
 
+      // createMarkers before emit so if the emit triggers a repaint the markers are ready
+      this.createMarkers();
+
       log.debug("Transforms from from urdf: ", transforms);
       this.emit("transforms", transforms);
-      this.createMarkers();
     } catch (err) {
       throw new Error(`Failed to parse ${text.length} byte URDF: ${err}`);
     }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -181,7 +181,7 @@ export default class UrdfBuilder extends EventEmitter<EventTypes> implements Mar
       // createMarkers before emit so if the emit triggers a repaint the markers are ready
       this.createMarkers();
 
-      log.debug("Transforms from from urdf: ", transforms);
+      log.debug("Transforms from urdf: ", transforms);
       this.emit("transforms", transforms);
     } catch (err) {
       throw new Error(`Failed to parse ${text.length} byte URDF: ${err}`);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -32,8 +32,8 @@ import WorldMarkers, {
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/WorldMarkers";
 import { LAYER_INDEX_DEFAULT_BASE } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 import {
-  CoordinateFrame,
-  TransformTree,
+  IImmutableCoordinateFrame,
+  IImmutableTransformTree,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import withHighlights from "@foxglove/studio-base/panels/ThreeDimensionalViz/withHighlights";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -60,9 +60,9 @@ type Props = WorldSearchTextProps & {
   cameraState: CameraState;
   children?: React.ReactNode;
   isPlaying: boolean;
-  transforms: TransformTree;
-  renderFrame: CoordinateFrame;
-  fixedFrame: CoordinateFrame;
+  transforms: IImmutableTransformTree;
+  renderFrame: IImmutableCoordinateFrame;
+  fixedFrame: IImmutableCoordinateFrame;
   currentTime: Time;
   markerProviders: MarkerProvider[];
   onCameraStateChange: (arg0: CameraState) => void;
@@ -83,9 +83,9 @@ function getMarkers({
 }: {
   markers: InteractiveMarkersByType;
   markerProviders: MarkerProvider[];
-  transforms: TransformTree;
-  renderFrame: CoordinateFrame;
-  fixedFrame: CoordinateFrame;
+  transforms: IImmutableTransformTree;
+  renderFrame: IImmutableCoordinateFrame;
+  fixedFrame: IImmutableCoordinateFrame;
   time: Time;
 }): void {
   // These casts seem wrong - some type definitions around MarkerProvider or MarkerCollector are not

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -25,6 +25,7 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import Layout from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/Layout";
+import UrdfBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/UrdfBuilder";
 import helpContent from "@foxglove/studio-base/panels/ThreeDimensionalViz/index.help.md";
 import {
   useTransformedCameraState,
@@ -32,11 +33,12 @@ import {
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import {
   CoordinateFrame,
-  DEFAULT_FRAME_IDS,
+  IImmutableCoordinateFrame,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import {
   FollowMode,
   ThreeDimensionalVizConfig,
+  TransformLink,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { MutablePose } from "@foxglove/studio-base/types/Messages";
 import { PanelConfigSchema, SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -54,6 +56,8 @@ export type Props = {
   config: ThreeDimensionalVizConfig;
   saveConfig: Save3DConfig;
 };
+
+const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
 
 const TIME_ZERO = { sec: 0, nsec: 0 };
 
@@ -117,14 +121,21 @@ function BaseRenderer(props: Props): JSX.Element {
     setSubscribedTopics(uniq(newTopics));
   }, []);
 
+  const [urdfTransforms, setUrdfTransforms] = useState<TransformLink[]>([]);
+
   const { reset: resetFrame, frame } = useFrame(subscribedTopics);
-  const transforms = useTransforms(topics, frame, resetFrame);
+  const transforms = useTransforms({
+    topics,
+    frame,
+    reset: resetFrame,
+    urdfTransforms,
+  });
   const currentTime = useMessagePipeline(selectCurrentTime);
   const isPlaying = useMessagePipeline(selectIsPlaying);
 
   const orphanedFrame = useMemo(() => new CoordinateFrame("(empty)", undefined), []);
 
-  const renderFrame = useMemo<CoordinateFrame>(() => {
+  const renderFrame = useMemo<IImmutableCoordinateFrame>(() => {
     // If the user specified a followTf, do not fall back to any other (valid) frame
     if (followTf) {
       return transforms.frame(followTf) ?? new CoordinateFrame(followTf, undefined);
@@ -337,6 +348,18 @@ function BaseRenderer(props: Props): JSX.Element {
     [autoSyncCameraState, saveCameraStateDebounced, updatePanelConfigs],
   );
 
+  const urdfBuilder = useMemo(() => new UrdfBuilder(), []);
+  useLayoutEffect(() => {
+    const handle = (newTransforms: TransformLink[]) => {
+      setUrdfTransforms((existing) => [...existing, ...newTransforms]);
+    };
+
+    urdfBuilder.on("transforms", handle);
+    return () => {
+      urdfBuilder.off("transforms", handle);
+    };
+  }, [urdfBuilder]);
+
   return (
     <Layout
       cameraState={transformedCameraState}
@@ -350,12 +373,13 @@ function BaseRenderer(props: Props): JSX.Element {
       frame={frame}
       helpContent={helpContent}
       isPlaying={isPlaying}
+      topics={topics}
+      transforms={transforms}
+      urdfBuilder={urdfBuilder}
       onAlignXYAxis={onAlignXYAxis}
       onCameraStateChange={onCameraStateChange}
       onFollowChange={onFollowChange}
       saveConfig={saveConfig}
-      topics={topics}
-      transforms={transforms}
       setSubscriptions={setSubscriptions}
     />
   );

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -351,7 +351,7 @@ function BaseRenderer(props: Props): JSX.Element {
   const urdfBuilder = useMemo(() => new UrdfBuilder(), []);
   useLayoutEffect(() => {
     const handle = (newTransforms: TransformLink[]) => {
-      setUrdfTransforms((existing) => [...existing, ...newTransforms]);
+      setUrdfTransforms((existing) => existing.concat(newTransforms));
     };
 
     urdfBuilder.on("transforms", handle);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/threeDimensionalVizUtils.ts
@@ -25,7 +25,7 @@ import {
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { InteractionData } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/types";
 import { LinkedGlobalVariables } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
-import { TransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
+import { IImmutableTransformTree } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import { FollowMode } from "@foxglove/studio-base/panels/ThreeDimensionalViz/types";
 import { InstancedLineListMarker, MutablePose } from "@foxglove/studio-base/types/Messages";
 
@@ -36,7 +36,7 @@ type MutableVec4 = [number, number, number, number];
 // Get the camera target position and orientation
 function getTargetPose(
   followTf: string | undefined,
-  transforms: TransformTree,
+  transforms: IImmutableTransformTree,
 ): TargetPose | undefined {
   if (followTf != undefined && transforms.hasFrame(followTf)) {
     return { target: [0, 0, 0], targetOrientation: [0, 0, 0, 1] };
@@ -61,7 +61,7 @@ export function useTransformedCameraState({
   configCameraState: Partial<CameraState>;
   followTf?: string;
   followMode: FollowMode;
-  transforms: TransformTree;
+  transforms: IImmutableTransformTree;
   poseInRenderFrame?: MutablePose;
 }): CameraState {
   const transformedCameraState = { ...configCameraState };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/IImmutableCoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/IImmutableCoordinateFrame.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Duration, Time } from "@foxglove/rostime";
+import { MutablePose, Pose } from "@foxglove/studio-base/types/Messages";
+
+/**
+ * IImmutableCoordinateFrame allows for read only access to lookup frames
+ * or perform interpolation between frames.
+ */
+export interface IImmutableCoordinateFrame {
+  readonly id: string;
+
+  parent(): IImmutableCoordinateFrame | undefined;
+  root(): IImmutableCoordinateFrame;
+
+  applyLocal(
+    out: MutablePose,
+    input: Pose,
+    srcFrame: IImmutableCoordinateFrame,
+    time: Time,
+    maxDelta?: Duration,
+  ): MutablePose | undefined;
+
+  apply(
+    out: MutablePose,
+    input: Pose,
+    rootFrame: IImmutableCoordinateFrame,
+    srcFrame: IImmutableCoordinateFrame,
+    dstTime: Time,
+    srcTime: Time,
+    maxDelta?: Duration,
+  ): MutablePose | undefined;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/IImmutableTransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/IImmutableTransformTree.ts
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Duration, Time } from "@foxglove/rostime";
+import { MutablePose, Pose } from "@foxglove/studio-base/types/Messages";
+
+import { IImmutableCoordinateFrame } from "./IImmutableCoordinateFrame";
+
+/**
+ * IImmutableTransformTree allows for read only access to lookup frames
+ * or perform interpolation between frames.
+ */
+export interface IImmutableTransformTree {
+  hasFrame(id: string): boolean;
+  frame(id: string): IImmutableCoordinateFrame | undefined;
+
+  frames(): ReadonlyMap<string, IImmutableCoordinateFrame>;
+
+  apply(
+    output: MutablePose,
+    input: Pose,
+    frameId: string,
+    rootFrameId: string | undefined,
+    srcFrameId: string,
+    dstTime: Time,
+    srcTime: Time,
+    maxDelta?: Duration,
+  ): MutablePose | undefined;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/transforms/index.ts
@@ -4,8 +4,9 @@
 
 // REP 105 specifies a set of conventional frame ids
 // https://www.ros.org/reps/rep-0105.html
-export const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
 
 export * from "./CoordinateFrame";
 export * from "./Transform";
 export * from "./TransformTree";
+export * from "./IImmutableTransformTree";
+export * from "./IImmutableCoordinateFrame";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -37,7 +37,7 @@ import {
 import { TopicSettingsCollection } from "./SceneBuilder";
 import { ColorOverrideByVariable, ColorOverride } from "./TopicTree/Layout";
 import { TopicDisplayMode } from "./TopicTree/types";
-import { CoordinateFrame, TransformTree } from "./transforms";
+import { IImmutableCoordinateFrame, IImmutableTransformTree, Transform } from "./transforms";
 
 /** @deprecated */
 type ColorOverrideBySourceIdxByVariable = Record<string, ColorOverride[]>;
@@ -72,9 +72,9 @@ export interface MarkerCollector {
 
 export type RenderMarkerArgs = {
   add: MarkerCollector;
-  renderFrame: CoordinateFrame;
-  fixedFrame: CoordinateFrame;
-  transforms: TransformTree;
+  renderFrame: IImmutableCoordinateFrame;
+  fixedFrame: IImmutableCoordinateFrame;
+  transforms: IImmutableTransformTree;
   time: Time;
 };
 
@@ -103,5 +103,14 @@ export type ThreeDimensionalVizConfig = {
   colorOverrideByVariable?: ColorOverrideByVariable;
   disableAutoOpenClickedObject?: boolean;
 } & PreviousThreeDimensionalVizConfig;
+
+/**
+ * TransformLink describes the transform between two coordinate frames.
+ */
+export type TransformLink = {
+  parent: string;
+  child: string;
+  transform: Transform;
+};
 
 export type FollowMode = "follow" | "follow-orientation" | "no-follow";


### PR DESCRIPTION
**User-Facing Changes**
The 3d scene updates with newly added transforms when setting the robot model.

**Description**

URDF models may contain joints. These joints represent transforms between different frames of the robot. 3D panel is able to add this frame information to the transform tree.

This change fixes update behavior in the 3d panel when loading URDF models with joints. Previously, the UrdfBuilder would add the joint transforms directly to the transform tree. This approach did not inform the react loop to run or for the transform tree to invalidate itself and create a new instance (as required by hook dependencies).

Instead, UrdfBuilder is now an event emitter that emits new transforms. The 3d panel components register event handlers and pass along the urdf transform information back through useTransforms. All other uses of the transform tree should be immutable. Only useTransforms can mutate the transform tree.

Fixes: #2199



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
