### PR TITLE
Make reselecting the same panel type a no-op.

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -172,6 +172,12 @@ function PanelActionsDropdown({
   const swap = useCallback(
     (id?: string) =>
       ({ type, config, relatedConfigs }: PanelSelection) => {
+        // Reselecting current panel type is a no-op.
+        if (type === panelContext?.type) {
+          setIsOpen(false);
+          return;
+        }
+
         swapPanel({
           tabId,
           originalId: id ?? "",
@@ -182,7 +188,7 @@ function PanelActionsDropdown({
           relatedConfigs,
         });
       },
-    [mosaicActions, mosaicWindowActions, swapPanel, tabId],
+    [mosaicActions, mosaicWindowActions, panelContext?.type, setIsOpen, swapPanel, tabId],
   );
 
   const { openPanelSettings } = useWorkspace();


### PR DESCRIPTION
**User-Facing Changes**
This makes reselecting the current panel type a no op instead of resetting the panel.

**Description**
This simply checks if the selected panel type is the same as the current panel and closes the menu.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2182 