### PR TITLE
Remove zoom in instructions from plot tooltip overflow message.

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -48,11 +48,7 @@ const useStyles = makeStyles((theme) => ({
 function OverflowMessage() {
   const classes = useStyles();
 
-  return (
-    <div className={classes.overflow}>
-      &lt;Multiple values under cursor. Zoom in to see more.&gt;
-    </div>
-  );
+  return <div className={classes.overflow}>&lt;multiple values under cursor&gt;</div>;
 }
 
 export default function TimeBasedChartTooltipContent(


### PR DESCRIPTION
**User-Facing Changes**
Remove the "zoom in to see more" portion of the plot panel tooltip overflow message.

**Description**
Telling the user to zoom in doesn't make sense in some cases such as points with different y values but the same x values so  we'll remove it for now pending a more data aware implementation.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
