### PR TITLE
Fix extension panel update logic

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme } from "@fluentui/react";
-import { CSSProperties, RefCallback, useCallback, useMemo, useRef, useState } from "react";
+import { CSSProperties, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 
 import Logger from "@foxglove/log";
@@ -22,7 +22,6 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
 import {
   useClearHoverValue,
   useHoverValue,
@@ -112,7 +111,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
   // we use message pipeline selector to capture updates and don't need to request animation frames
   // multiple times so we gate requesting new message frames
-  const rafRequestedRef = useRef(false);
+  const rafRequestedRef = useRef<number | undefined>(undefined);
 
   const hoverValue = useHoverValue({
     componentId: "PanelExtensionAdatper",
@@ -133,14 +132,15 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const colorScheme = useTheme().isInverted ? "dark" : "light";
 
   const renderPanel = useCallback(() => {
-    rafRequestedRef.current = false;
-
-    const ctx = latestPipelineContextRef.current;
-    if (!renderFn || !ctx) {
+    if (!renderFn) {
       return;
     }
 
-    const playerState = ctx.playerState;
+    rafRequestedRef.current = undefined;
+
+    const ctx = latestPipelineContextRef.current;
+
+    const playerState = ctx?.playerState;
     previousPlayerStateRef.current = playerState;
 
     if (renderingRef.current) {
@@ -156,7 +156,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     const renderState: RenderState = prevRenderState.current;
 
     if (watchedFieldsRef.current.has("currentFrame")) {
-      const currentFrame = playerState.activeData?.messages.filter((messageEvent) => {
+      const currentFrame = playerState?.activeData?.messages.filter((messageEvent) => {
         return subscribedTopicsRef.current.has(messageEvent.topic);
       });
       // If there are new frames we render
@@ -170,7 +170,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     }
 
     if (watchedFieldsRef.current.has("parameters")) {
-      const parameters = playerState.activeData?.parameters ?? EmptyParameters;
+      const parameters = playerState?.activeData?.parameters ?? EmptyParameters;
       if (parameters !== renderState.parameters) {
         shouldRender = true;
         renderState.parameters = parameters;
@@ -178,7 +178,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     }
 
     if (watchedFieldsRef.current.has("topics")) {
-      const newTopics = playerState.activeData?.topics ?? EmptyTopics;
+      const newTopics = playerState?.activeData?.topics ?? EmptyTopics;
       if (newTopics !== prevRenderState.current.topics) {
         shouldRender = true;
         renderState.topics = newTopics;
@@ -187,7 +187,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
     if (watchedFieldsRef.current.has("allFrames")) {
       // see comment for prevBlocksRef on why extended message store updates are gated this way
-      const newBlocks = playerState.progress.messageCache?.blocks;
+      const newBlocks = playerState?.progress.messageCache?.blocks;
       if (newBlocks && prevBlocksRef.current !== newBlocks) {
         shouldRender = true;
         const frames: MessageEvent<unknown>[] = (renderState.allFrames = []);
@@ -210,7 +210,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     }
 
     if (watchedFieldsRef.current.has("previewTime")) {
-      const startTime = ctx.playerState.activeData?.startTime;
+      const startTime = playerState?.activeData?.startTime;
       const hoverVal = hoverValueRef.current?.value;
 
       if (startTime != undefined && hoverVal != undefined) {
@@ -260,12 +260,10 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     (ctx: MessagePipelineContext) => {
       latestPipelineContextRef.current = ctx;
 
-      if (!renderFn || rafRequestedRef.current) {
+      if (!renderFn || rafRequestedRef.current != undefined) {
         return;
       }
-
-      rafRequestedRef.current = true;
-      requestAnimationFrame(renderPanel);
+      rafRequestedRef.current = requestAnimationFrame(renderPanel);
     },
     [renderFn, renderPanel],
   );
@@ -406,30 +404,51 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     requestBackfill,
   ]);
 
-  const refCallback = useCallback<RefCallback<HTMLDivElement>>(
-    (node) => {
-      // perform cleanup when the dom node goes away
-      if (node === ReactNull) {
-        latestPipelineContextRef.current?.setSubscriptions(panelId, []);
-        latestPipelineContextRef.current?.setPublishers(panelId, []);
-        return;
-      }
+  const panelContainerRef = useRef<HTMLDivElement>(ReactNull);
 
-      const panelContext: PanelExtensionContext = {
-        panelElement: node,
-        ...partialExtensionContext,
+  // Manage extension lifecycle by calling initPanel() when the panel context changes.
+  //
+  // If we useEffect here instead of useLayoutEffect, the prevRenderState can get polluted with data
+  // from a previous panel instance.
+  useLayoutEffect(() => {
+    if (!panelContainerRef.current) {
+      throw new Error("Expected panel container to be mounted");
+    }
 
-        // eslint-disable-next-line no-restricted-syntax
-        set onRender(renderFunction: RenderFn | undefined) {
-          setRenderFn(() => renderFunction);
-        },
-      };
+    // Reset local state when the panel element is mounted or changes
+    setRenderFn(undefined);
+    prevRenderState.current = {};
+    if (rafRequestedRef.current != undefined) {
+      // Any pending render requests from the previously mounted panel must be canceled, because
+      // when they render they will change prevRenderState. Clearing prevRenderState here allows the
+      // newly mounted panel to receive the correct renderState.
+      cancelAnimationFrame(rafRequestedRef.current);
+      rafRequestedRef.current = undefined;
+    }
 
-      log.info(`Init panel ${panelId}`);
-      initPanel(panelContext);
-    },
-    [initPanel, partialExtensionContext, panelId],
-  );
+    const panelElement = document.createElement("div");
+    panelElement.style.width = "100%";
+    panelElement.style.height = "100%";
+    panelElement.style.overflow = "hidden";
+    panelContainerRef.current.appendChild(panelElement);
+
+    log.info(`Init panel ${panelId}`);
+    initPanel({
+      panelElement,
+      ...partialExtensionContext,
+
+      // eslint-disable-next-line no-restricted-syntax
+      set onRender(renderFunction: RenderFn | undefined) {
+        setRenderFn(() => renderFunction);
+      },
+    });
+
+    return () => {
+      panelElement.remove();
+      latestPipelineContextRef.current?.setSubscriptions(panelId, []);
+      latestPipelineContextRef.current?.setPublishers(panelId, []);
+    };
+  }, [initPanel, panelId, partialExtensionContext]);
 
   const style: CSSProperties = {};
   if (slowRender) {
@@ -445,11 +464,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   return (
     <div style={{ width: "100%", height: "100%", overflow: "hidden", zIndex: 0, ...style }}>
       <PanelToolbar floating helpContent={props.help} />
-      {/* If the ref callback changes it means the panel context changed.
-      We clear the old element and make a new one to re-initialize the panel */}
-      <RemountOnValueChange value={refCallback}>
-        <div style={{ width: "100%", height: "100%", overflow: "hidden" }} ref={refCallback} />
-      </RemountOnValueChange>
+      <div style={{ width: "100%", height: "100%", overflow: "hidden" }} ref={panelContainerRef} />
     </div>
   );
 }

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -4,7 +4,7 @@
 import { ThemeProvider as FluentThemeProvider } from "@fluentui/react";
 import { registerIcons, unregisterIcons } from "@fluentui/style-utilities";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material";
-import { useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useMemo, useState } from "react";
 import { ThemeProvider as StyledThemeProvider } from "styled-components";
 
 import { createMuiTheme, createFluentTheme } from "@foxglove/studio-base/theme";
@@ -32,12 +32,12 @@ export default function ThemeProvider({
     return undefined;
   }, [iconsRegistered]);
 
+  const muiTheme = useMemo(() => createMuiTheme(isDark ? "dark" : "light"), [isDark]);
+  const fluentTheme = useMemo(() => createFluentTheme({ isInverted: isDark }), [isDark]);
+
   if (!iconsRegistered) {
     return ReactNull;
   }
-
-  const muiTheme = createMuiTheme(isDark ? "dark" : "light");
-  const fluentTheme = createFluentTheme({ isInverted: isDark });
 
   return (
     <MuiThemeProvider theme={muiTheme}>


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where extension panels could be rendered with incorrect data when the user loaded a new data source.

**Description**
Due to the use of refs to detect state changes between panel renders, and asynchronous updates provided by `requestAnimationFrame` and React `setState`, extension panels would sometimes receive the wrong state when they were re-initialized during a data source change. To address this issue we `useLayoutEffect` instead of `useEffect` so the updates happen at an earlier point in the React lifecycle, and we make sure to `cancelAnimationFrame` for any older panel instances.

Fixes https://github.com/foxglove/studio/issues/2595
