### PR TITLE
Remove internal studio fields from 3d panel selected object details popup 

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interaction.stories.tsx
@@ -281,7 +281,7 @@ storiesOf("panels/ThreeDimensionalViz/Interactions/Interaction", module)
               object: {
                 ...cloud1,
                 type: 102,
-                interactionData: { topic: "/foo/bar", originalMessage: selectedObject.object },
+                interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
               },
             }}
           />
@@ -294,7 +294,10 @@ storiesOf("panels/ThreeDimensionalViz/Interactions/Interaction", module)
               object: {
                 ...cloud2,
                 type: 102,
-                interactionData: { topic: "/foo/bar", originalMessage: selectedObject.object },
+                interactionData: {
+                  topic: "/foo/bar",
+                  originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+                },
               },
             }}
           />

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Interactions/Interactions.tsx
@@ -55,17 +55,20 @@ const InteractionsBaseComponent = React.memo<PropsWithConfig>(function Interacti
   saveConfig,
 }: PropsWithConfig) {
   const { object } = selectedObject ?? {};
-  const isPointCloud = object ? (object as unknown as { type: number }).type === 102 : false;
+  const selectedInteractionData = getInteractionData(selectedObject);
+
+  const { originalMessage } = selectedInteractionData ?? {};
+
+  const isPointCloud = (object as { type?: number })?.type === 102;
   const maybeFullyDecodedObject = React.useMemo(
     () =>
       isPointCloud
-        ? { ...selectedObject, object: decodeAdditionalFields(object as unknown as PointCloud2) }
-        : selectedObject,
-    [isPointCloud, object, selectedObject],
+        ? decodeAdditionalFields(originalMessage as unknown as PointCloud2)
+        : originalMessage,
+    [isPointCloud, originalMessage],
   );
 
   const { linkedGlobalVariables } = useLinkedGlobalVariables();
-  const selectedInteractionData = selectedObject && getInteractionData(selectedObject);
 
   return (
     <ExpandingToolbar
@@ -86,10 +89,10 @@ const InteractionsBaseComponent = React.memo<PropsWithConfig>(function Interacti
                 </SRow>
               )}
               {isPointCloud && (
-                <PointCloudDetails selectedObject={maybeFullyDecodedObject as SelectedObject} />
+                <PointCloudDetails selectedObject={selectedObject as SelectedObject} />
               )}
               <ObjectDetails
-                selectedObject={maybeFullyDecodedObject as SelectedObject}
+                selectedObject={maybeFullyDecodedObject}
                 interactionData={selectedInteractionData}
               />
             </>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -602,22 +602,15 @@ export default function Layout({
     toggleDebug,
   } = useMemo(() => {
     return {
-      onClick: (ev: React.MouseEvent, args?: ReglClickInfo) => {
+      onClick: (_ev: React.MouseEvent, args?: ReglClickInfo) => {
         // Don't set any clicked objects when measuring distance or drawing polygons.
         if (callbackInputsRef.current.isDrawing) {
           return;
         }
         const newClickedObjects =
           (args?.objects as MouseEventObject[] | undefined) ?? ([] as MouseEventObject[]);
-        const newClickedPosition = { clientX: ev.clientX, clientY: ev.clientY };
         const newSelectedObject = newClickedObjects.length === 1 ? newClickedObjects[0] : undefined;
 
-        // Select the object directly if there is only one or open up context menu if there are many.
-        setSelectionState({
-          ...callbackInputsRef.current.selectionState,
-          clickedObjects: newClickedObjects,
-          clickedPosition: newClickedPosition,
-        });
         selectObject(newSelectedObject);
       },
       onControlsOverlayClick: (ev: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -654,11 +654,8 @@ export default class SceneBuilder implements MarkerProvider {
     const decayTimeInSec = this._settingsByKey[`t:${topic}`]?.decayTime as number | undefined;
     const lifetime =
       decayTimeInSec != undefined && decayTimeInSec !== 0 ? fromSec(decayTimeInSec) : undefined;
-    (this.collectors[topic] as MessageCollector).addNonMarker(
-      topic,
-      mappedMessage as Interactive<unknown>,
-      lifetime,
-    );
+
+    this.collectors[topic]?.addNonMarker(topic, mappedMessage as Interactive<unknown>, lifetime);
   };
 
   setCurrentTime = (currentTime: { sec: number; nsec: number }): void => {
@@ -671,7 +668,7 @@ export default class SceneBuilder implements MarkerProvider {
     }
   };
 
-  // extracts renderable markers from the ros frame
+  // extracts renderable markers from the frame
   render(): void {
     for (const topic of this.topicsToRender) {
       try {
@@ -879,13 +876,11 @@ export default class SceneBuilder implements MarkerProvider {
         );
         marker.interactionData.highlighted = markerMatches;
 
-        // TODO(bmc): once we support more topic settings
-        // flesh this out to be more marker type agnostic
         const settings = this._settingsByKey[`t:${topic.name}`];
         if (settings) {
+          // fixme - should avoid mucking settings
           (marker as { settings?: unknown }).settings = settings;
         }
-
         this._addMarkerToCollector(add, topic, marker, pose);
       }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -878,7 +878,6 @@ export default class SceneBuilder implements MarkerProvider {
 
         const settings = this._settingsByKey[`t:${topic.name}`];
         if (settings) {
-          // fixme - should avoid mucking settings
           (marker as { settings?: unknown }).settings = settings;
         }
         this._addMarkerToCollector(add, topic, marker, pose);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/selection.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { omit, difference, isEmpty, isNil } from "lodash";
+import { difference, isEmpty, isNil } from "lodash";
 
 import { toRGBA, Color } from "@foxglove/regl-worldview";
 import {
@@ -20,6 +20,7 @@ import {
   DEFAULT_MAX_COLOR,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor";
 import { DecodedMarker } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker";
+import { RosObject } from "@foxglove/studio-base/players/types";
 import { PointCloud2, PointField } from "@foxglove/studio-base/types/Messages";
 
 import {
@@ -154,8 +155,10 @@ export function getAdditionalFieldNames(fields: readonly PointField[]): string[]
 
 export function decodeAdditionalFields<T extends PointCloud2>(
   marker: T,
-): Omit<T, "data"> & Record<string, unknown> {
-  const { fields, data, width, row_step, height, point_step } = marker;
+): Omit<T, "data"> & RosObject {
+  const { data, ...markerRest } = marker;
+  const { fields, width, row_step, height, point_step } = markerRest;
+
   const offsets = getFieldOffsetsAndReaders(data, fields);
 
   let pointCount = 0;
@@ -181,7 +184,7 @@ export function decodeAdditionalFields<T extends PointCloud2>(
   }
 
   return {
-    ...omit(marker, "data"), // no need to include data since all fields have been decoded
+    ...markerRest, // no need to include data since all fields have been decoded
     ...otherFieldsValues,
   };
 }

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -141,7 +141,6 @@ type ArrowSize = Readonly<{
   headWidth: number;
 }>;
 
-// TODO: Is this correct?
 export type ArrowMarker = Readonly<
   BaseMarker & {
     type: 0;


### PR DESCRIPTION
**User-Facing Changes**
Selected object data in the 3d panel shows information about the selected object or marker free of any internal implementation fields (i.e. settings, hitmap, etc).

Previously these Studio implementation specific fields would pollute the selected object display resulting in noise and confusion with the user's dataset.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/84792/148858462-5826a178-4603-4254-ba04-e20abd8c6908.png) |![image](https://user-images.githubusercontent.com/84792/148858775-07887217-1633-4c49-99ee-243c008d1b9f.png)|


**Description**
Fixes: #2476


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
