### PR TITLE
Fix delay in Cover story

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/Cover.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/Cover.stories.tsx
@@ -34,7 +34,7 @@ storiesOf("panels/ThreeDimensionalViz/Commands/Cover", module)
     const transparentRed = [1, 0, 0, 0.5];
     const transparentBlue = [0, 0, 1, 0.5];
     return (
-      <div style={{ width: 1001, height: 745 }}>
+      <div style={{ width: 1001, height: 745, overflow: "hidden" }}>
         <Worldview
           onClick={noop}
           onCameraStateChange={noop}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes https://github.com/foxglove/studio/issues/756

The lack of overflow:hidden on the container was causing a bunch of "ResizeObserver loop imit exceeded" errors to be spewed out, which delayed the rendering of the purple overlay.
