### PR TITLE
Add topic error for OccupancyGrids with incorrect data length

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -568,6 +568,13 @@ export default class SceneBuilder implements MarkerProvider {
     const name = `${topic}/${type}`;
 
     const { header, info, data } = message;
+    if (info.width * info.height !== data.length) {
+      this._setTopicError(
+        topic,
+        `OccupancyGrid data length (${data.length}) does not match width*height (${info.width}x${info.height}).`,
+      );
+      return;
+    }
     const mappedMessage = {
       header: {
         frame_id: header.frame_id,


### PR DESCRIPTION
**User-Facing Changes**
None (only matters for invalid data)

**Description**
Fixes https://github.com/foxglove/studio/issues/2549 by displaying a topic error:

<img width="434" alt="Screen Shot 2022-01-07 at 6 17 55 PM" src="https://user-images.githubusercontent.com/14237/148627884-a701a46a-56c6-4bc3-b629-91a68924d471.png">