### PR TITLE
Render DataSourceInfo Duration using app time format

### DIFF
--- a/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
@@ -5,14 +5,13 @@
 import { ITextStyles, Stack, Text, useTheme } from "@fluentui/react";
 import { useMemo } from "react";
 
+import Duration from "@foxglove/studio-base/components/Duration";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Timestamp from "@foxglove/studio-base/components/Timestamp";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
-import { formatDuration } from "@foxglove/studio-base/util/formatTime";
-import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { MultilineMiddleTruncate } from "./MultilineMiddleTruncate";
 
@@ -26,6 +25,8 @@ function DataSourceInfo(): JSX.Element {
   const startTime = useMessagePipeline(selectStartTime);
   const endTime = useMessagePipeline(selectEndTime);
   const playerName = useMessagePipeline(selectPlayerName);
+
+  const duration = startTime && endTime ? subtractTimes(endTime, startTime) : undefined;
 
   const subheaderStyles = useMemo(
     () =>
@@ -69,7 +70,7 @@ function DataSourceInfo(): JSX.Element {
           <Timestamp horizontal time={startTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
-            00:00:00
+            &mdash;
           </Text>
         )}
       </Stack>
@@ -80,24 +81,20 @@ function DataSourceInfo(): JSX.Element {
           <Timestamp horizontal time={endTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
-            00:00:00
+            &mdash;
           </Text>
         )}
       </Stack>
 
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>Duration</Text>
-        <Text
-          variant="small"
-          styles={{
-            root: {
-              fontFamily: startTime && endTime ? fonts.MONOSPACE : undefined,
-              color: theme.palette.neutralSecondary,
-            },
-          }}
-        >
-          {startTime && endTime ? formatDuration(subtractTimes(endTime, startTime)) : "00:00:00"}
-        </Text>
+        {duration ? (
+          <Duration duration={duration} />
+        ) : (
+          <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
+            &mdash;
+          </Text>
+        )}
       </Stack>
     </Stack>
   );

--- a/packages/studio-base/src/components/Duration.stories.tsx
+++ b/packages/studio-base/src/components/Duration.stories.tsx
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Stack } from "@fluentui/react";
+import { ComponentProps, useState } from "react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import { makeConfiguration } from "@foxglove/studio-base/util/makeConfiguration";
+
+import Duration from "./Duration";
+
+export default {
+  component: Duration,
+  title: "components/Duration",
+};
+
+type Props = ComponentProps<typeof Duration>;
+
+function DurationStory(props: Props): JSX.Element {
+  const [secAppConfig] = useState(() =>
+    makeConfiguration([
+      [AppSetting.TIME_FORMAT, "SEC"],
+      [AppSetting.TIMEZONE, "UTC"],
+    ]),
+  );
+  const [todAppConfig] = useState(() =>
+    makeConfiguration([
+      [AppSetting.TIME_FORMAT, "TOD"],
+      [AppSetting.TIMEZONE, "UTC"],
+    ]),
+  );
+
+  return (
+    <Stack tokens={{ padding: 16, childrenGap: 16 }}>
+      <AppConfigurationContext.Provider value={secAppConfig}>
+        <Duration {...props} />
+      </AppConfigurationContext.Provider>
+      <AppConfigurationContext.Provider value={todAppConfig}>
+        <Duration {...props} />
+      </AppConfigurationContext.Provider>
+    </Stack>
+  );
+}
+
+export function Zero(): JSX.Element {
+  return <DurationStory duration={{ sec: 0, nsec: 0 }} />;
+}
+
+export function Hour(): JSX.Element {
+  return <DurationStory duration={{ sec: 3600, nsec: 123456789 }} />;
+}
+
+export function HourMinuteSeconds(): JSX.Element {
+  return <DurationStory duration={{ sec: 23485, nsec: 123456789 }} />;
+}

--- a/packages/studio-base/src/components/Duration.tsx
+++ b/packages/studio-base/src/components/Duration.tsx
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Stack, Text, useTheme } from "@fluentui/react";
+import { useMemo } from "react";
+
+import { Time } from "@foxglove/rostime";
+import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+type Props = {
+  duration: Time;
+};
+
+/**
+ * Duration component renders a formatted duration { sec, nsec } value according to the current
+ * app time format setting.
+ *
+ * */
+export default function Duration(props: Props): JSX.Element {
+  const { duration } = props;
+  const theme = useTheme();
+  const { formatDuration } = useAppTimeFormat();
+
+  const durationStr = useMemo(() => formatDuration(duration), [duration, formatDuration]);
+
+  return (
+    <Stack horizontal verticalAlign="center" grow={0}>
+      <Text
+        variant="small"
+        styles={{
+          root: {
+            fontFamily: fonts.MONOSPACE,
+            color: theme.palette.neutralSecondary,
+          },
+        }}
+      >
+        {durationStr}
+      </Text>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -16,13 +16,12 @@ import { useCallback, useMemo } from "react";
 import { subtract as subtractTimes, toSec } from "@foxglove/rostime";
 import { Topic } from "@foxglove/studio";
 import CopyText from "@foxglove/studio-base/components/CopyText";
+import Duration from "@foxglove/studio-base/components/Duration";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Timestamp from "@foxglove/studio-base/components/Timestamp";
-import { formatDuration } from "@foxglove/studio-base/util/formatTime";
-import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import helpContent from "./index.help.md";
 
@@ -96,17 +95,7 @@ function SourceInfo() {
           </Stack>
           <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
             <Text styles={subheaderStyles}>Duration</Text>
-            <Text
-              variant="small"
-              styles={{
-                root: {
-                  fontFamily: fonts.MONOSPACE,
-                  color: theme.palette.neutralSecondary,
-                },
-              }}
-            >
-              {formatDuration(duration)}
-            </Text>
+            <Duration duration={duration} />
           </Stack>
         </Stack>
         <DetailsList


### PR DESCRIPTION


**User-Facing Changes**
Duration values in the Data Source Sidebar and Data Source Info panel conform to the time format application setting. For _seconds_ the value is displayed as decimal seconds. For _time-of-day_ the value is displayed as h:mm:ss.sssssssss.

<img width="267" alt="Screen Shot 2022-01-08 at 7 23 11 AM" src="https://user-images.githubusercontent.com/84792/148649991-48090422-b007-4b79-a65c-677419bc1e08.png">
<img width="308" alt="Screen Shot 2022-01-08 at 7 23 24 AM" src="https://user-images.githubusercontent.com/84792/148649992-13eaede9-1f2e-4bec-94c0-c2d945da6abd.png">
<img width="291" alt="Screen Shot 2022-01-08 at 7 23 32 AM" src="https://user-images.githubusercontent.com/84792/148649993-5569e5f4-d36a-49d0-b789-5b8168538d00.png">


**Description**
Rendering the duration on the DataSourceInfo sidebar or panel uses the global app time format. If the time format is seconds, then the duration is displayed as decimal seconds. If the time format is time-of-day, then the duration is displayed as h:mm:ss.sssssssss.

Fixes: #2481

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
