### PR TITLE
Move Chart pauseFrame from render to effect, enable strict mode

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -127,7 +127,7 @@ export const Basic: Story = (_args) => {
 
   return (
     <div style={divStyle}>
-      <ChartComponent {...props} onChartUpdate={readySignal} />
+      <ChartComponent {...props} onFinishRender={readySignal} />
     </div>
   );
 };
@@ -140,7 +140,7 @@ export const WithDatalabels: Story = (_args) => {
 
   return (
     <div style={divStyle}>
-      <ChartComponent {...propsWithDatalabels} onChartUpdate={readySignal} />
+      <ChartComponent {...propsWithDatalabels} onFinishRender={readySignal} />
     </div>
   );
 };
@@ -179,7 +179,7 @@ export const AllowsClickingOnDatalabels: Story = (_args) => {
             )}`
           : "Have not clicked datalabel"}
       </div>
-      <ChartComponent {...propsWithDatalabels} onChartUpdate={doClick} onClick={onClick} />
+      <ChartComponent {...propsWithDatalabels} onFinishRender={doClick} onClick={onClick} />
     </div>
   );
 };

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -50,6 +50,9 @@ type Props = {
   // called when the chart scales have updated (happens for zoom/pan/reset)
   onScalesUpdate?: (scales: RpcScales, opt: { userInteraction: boolean }) => void;
 
+  // called when the chart is about to start rendering new data
+  onStartRender?: () => void;
+
   // called when the chart has finished updating with new data
   onChartUpdate?: () => void;
 
@@ -101,7 +104,7 @@ function Chart(props: Props): JSX.Element {
   const zoomEnabled = props.options.plugins?.zoom?.zoom?.enabled ?? false;
   const panEnabled = props.options.plugins?.zoom?.pan?.enabled ?? false;
 
-  const { type, data, options, width, height, onChartUpdate } = props;
+  const { type, data, options, width, height, onStartRender, onChartUpdate } = props;
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -212,6 +215,10 @@ function Chart(props: Props): JSX.Element {
 
     return out;
   }, [data, height, options, width]);
+
+  useLayoutEffect(() => {
+    onStartRender?.();
+  }, [getNewUpdateMessage, onStartRender]);
 
   const { error: updateError } = useAsync(async () => {
     if (!sendWrapperRef.current) {

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -216,10 +216,6 @@ function Chart(props: Props): JSX.Element {
     return out;
   }, [data, height, options, width]);
 
-  useLayoutEffect(() => {
-    onStartRender?.();
-  }, [getNewUpdateMessage, onStartRender]);
-
   const { error: updateError } = useAsync(async () => {
     if (!sendWrapperRef.current) {
       return;
@@ -239,6 +235,7 @@ function Chart(props: Props): JSX.Element {
 
       initialized.current = true;
 
+      onStartRender?.();
       const offscreenCanvas =
         "transferControlToOffscreen" in canvas ? canvas.transferControlToOffscreen() : canvas;
       const scales = await sendWrapperRef.current<RpcScales>(
@@ -254,10 +251,6 @@ function Chart(props: Props): JSX.Element {
         },
         [offscreenCanvas],
       );
-
-      if (!isMounted()) {
-        return;
-      }
 
       // once we are initialized, we can allow other handlers to send to the rpc endpoint
       rpcSendRef.current = sendWrapperRef.current;
@@ -276,14 +269,11 @@ function Chart(props: Props): JSX.Element {
       return;
     }
 
+    onStartRender?.();
     const scales = await rpcSendRef.current<RpcScales>("update", newUpdateMessage);
-    if (!isMounted()) {
-      return;
-    }
-
     maybeUpdateScales(scales);
     onChartUpdate?.();
-  }, [getNewUpdateMessage, isMounted, maybeUpdateScales, onChartUpdate, type]);
+  }, [getNewUpdateMessage, maybeUpdateScales, onChartUpdate, onStartRender, type]);
 
   useLayoutEffect(() => {
     const canvas = canvasRef.current;

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -54,7 +54,7 @@ type Props = {
   onStartRender?: () => void;
 
   // called when the chart has finished updating with new data
-  onChartUpdate?: () => void;
+  onFinishRender?: () => void;
 
   // called when a user hovers over an element
   // uses the chart.options.hover configuration
@@ -104,7 +104,7 @@ function Chart(props: Props): JSX.Element {
   const zoomEnabled = props.options.plugins?.zoom?.zoom?.enabled ?? false;
   const panEnabled = props.options.plugins?.zoom?.pan?.enabled ?? false;
 
-  const { type, data, options, width, height, onStartRender, onChartUpdate } = props;
+  const { type, data, options, width, height, onStartRender, onFinishRender } = props;
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -256,7 +256,7 @@ function Chart(props: Props): JSX.Element {
       rpcSendRef.current = sendWrapperRef.current;
 
       maybeUpdateScales(scales);
-      onChartUpdate?.();
+      onFinishRender?.();
       return;
     }
 
@@ -272,8 +272,8 @@ function Chart(props: Props): JSX.Element {
     onStartRender?.();
     const scales = await rpcSendRef.current<RpcScales>("update", newUpdateMessage);
     maybeUpdateScales(scales);
-    onChartUpdate?.();
-  }, [getNewUpdateMessage, maybeUpdateScales, onChartUpdate, onStartRender, type]);
+    onFinishRender?.();
+  }, [getNewUpdateMessage, maybeUpdateScales, onFinishRender, onStartRender, type]);
 
   useLayoutEffect(() => {
     const canvas = canvasRef.current;

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -167,9 +167,9 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     useCallback((messagePipeline) => messagePipeline.pauseFrame, []),
   );
 
-  // when data changes, we pause and wait for onChartUpdate to resume
   const resumeFrame = useRef<() => void | undefined>();
 
+  // when data changes, we pause and wait for onFinishRender to resume
   const onStartRender = useCallback(() => {
     if (resumeFrame.current) {
       if (process.env.NODE_ENV === "development") {
@@ -185,7 +185,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   // resumes any paused frames
   // since we render in a web-worker we need to pause/resume the message pipeline to keep
   // our plot rendeirng in-sync with data rendered elsewhere in the app
-  const onChartUpdate = useCallback(() => {
+  const onFinishRender = useCallback(() => {
     const current = resumeFrame.current;
     resumeFrame.current = undefined;
 
@@ -198,9 +198,9 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   useEffect(() => {
     // cleanup paused frames on unmount or dataset changes
     return () => {
-      onChartUpdate();
+      onFinishRender();
     };
-  }, [pauseFrame, onChartUpdate]);
+  }, [pauseFrame, onFinishRender]);
 
   const hoverBar = useRef<HTMLDivElement>(ReactNull);
 
@@ -815,12 +815,12 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     onClick: props.onClick,
     onScalesUpdate,
     onStartRender,
-    onChartUpdate,
+    onFinishRender,
     onHover,
   };
 
   // avoid rendering if width/height are 0 - usually on initial mount
-  // so we don't trigger onChartUpdate if we know we will immediately resize
+  // so we don't trigger onFinishRender if we know we will immediately resize
   if (width === 0 || height === 0) {
     return <></>;
   }

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -200,7 +200,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     return () => {
       onChartUpdate();
     };
-  }, [pauseFrame, onChartUpdate, whoami]);
+  }, [pauseFrame, onChartUpdate]);
 
   const hoverBar = useRef<HTMLDivElement>(ReactNull);
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -170,6 +170,18 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   // when data changes, we pause and wait for onChartUpdate to resume
   const resumeFrame = useRef<() => void | undefined>();
 
+  const onStartRender = useCallback(() => {
+    if (resumeFrame.current) {
+      if (process.env.NODE_ENV === "development") {
+        log.warn("force resumed paused frame");
+      }
+      resumeFrame.current();
+    }
+    // during streaming the message pipeline should not give us any more data until we finish
+    // rendering this update
+    resumeFrame.current = pauseFrame("TimeBasedChart");
+  }, [pauseFrame]);
+
   // resumes any paused frames
   // since we render in a web-worker we need to pause/resume the message pipeline to keep
   // our plot rendeirng in-sync with data rendered elsewhere in the app
@@ -183,18 +195,18 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     }
   }, []);
 
-  const hoverBar = useRef<HTMLDivElement>(ReactNull);
-
-  const [globalBounds, setGlobalBounds] = useGlobalXBounds({ enabled: isSynced });
-
-  const linesToHide = useMemo(() => props.linesToHide ?? {}, [props.linesToHide]);
-
   useEffect(() => {
     // cleanup paused frames on unmount or dataset changes
     return () => {
       onChartUpdate();
     };
-  }, [pauseFrame, onChartUpdate]);
+  }, [pauseFrame, onChartUpdate, whoami]);
+
+  const hoverBar = useRef<HTMLDivElement>(ReactNull);
+
+  const [globalBounds, setGlobalBounds] = useGlobalXBounds({ enabled: isSynced });
+
+  const linesToHide = useMemo(() => props.linesToHide ?? {}, [props.linesToHide]);
 
   // some callbacks don't need to re-create when the current scales change, so we keep a ref
   const currentScalesRef = useRef<RpcScales | undefined>(undefined);
@@ -659,21 +671,11 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   }, [invalidateDownsample, throttledDownsample, visibleDatasets]);
 
   const downsampledData = useMemo(() => {
-    if (resumeFrame.current) {
-      if (process.env.NODE_ENV === "development") {
-        log.warn("force resumed paused frame");
-      }
-      resumeFrame.current();
-    }
-    // during streaming the message pipeline should not give us any more data until we finish
-    // rendering this update
-    resumeFrame.current = pauseFrame("TimeBasedChart");
-
     return {
       labels,
       datasets: downsampledDatasets,
     };
-  }, [pauseFrame, labels, downsampledDatasets]);
+  }, [labels, downsampledDatasets]);
 
   const options = useMemo<ChartOptions>(() => {
     return {
@@ -812,6 +814,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     data: downsampledData,
     onClick: props.onClick,
     onScalesUpdate,
+    onStartRender,
     onChartUpdate,
     onHover,
   };

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -138,7 +138,7 @@ export function Basic(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onChartUpdate={readySignal}
+        onFinishRender={readySignal}
       />
     </PanelSetup>
   );
@@ -157,7 +157,7 @@ export function CustomMinMaxWindow(): JSX.Element {
           minYVal: "0.5",
           maxYVal: "4.5",
         }}
-        onChartUpdate={readySignal}
+        onFinishRender={readySignal}
       />
     </PanelSetup>
   );
@@ -170,7 +170,7 @@ export function CustomMinMaxVal(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" }, maxYVal: "10" }}
-        onChartUpdate={readySignal}
+        onFinishRender={readySignal}
       />
     </PanelSetup>
   );
@@ -209,7 +209,7 @@ export function WithTooltip(): JSX.Element {
       <PanelSetup fixture={fixture}>
         <TwoDimensionalPlot
           overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-          onChartUpdate={readySignal}
+          onFinishRender={readySignal}
         />
       </PanelSetup>
     </div>
@@ -238,7 +238,7 @@ export function ShowResetAfterHorizontalZoom(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onChartUpdate={step}
+        onFinishRender={step}
       />
     </PanelSetup>
   );
@@ -258,7 +258,7 @@ export function ShowResetAfterVerticalZoom(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onChartUpdate={step}
+        onFinishRender={step}
       />
     </PanelSetup>
   );
@@ -278,7 +278,7 @@ export function ShowResetZoom(): JSX.Element {
     <PanelSetup fixture={fixture}>
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onChartUpdate={step}
+        onFinishRender={step}
       />
     </PanelSetup>
   );
@@ -307,7 +307,7 @@ export function ResetZoom(): JSX.Element {
     >
       <TwoDimensionalPlot
         overrideConfig={{ path: { value: "/plot_a.versions[0]" } }}
-        onChartUpdate={step}
+        onFinishRender={step}
       />
     </PanelSetup>
   );

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -87,7 +87,7 @@ type Config = {
 type Props = {
   config: Config;
   saveConfig: (arg0: Partial<Config>) => void;
-  onChartUpdate?: () => void;
+  onFinishRender?: () => void;
 };
 export type Line = {
   order?: number;
@@ -129,7 +129,7 @@ export type PlotMessage = {
 
 function TwoDimensionalPlot(props: Props) {
   const theme = useTheme();
-  const { config, saveConfig, onChartUpdate } = props;
+  const { config, saveConfig, onFinishRender } = props;
   const { path, minXVal, maxXVal, minYVal, maxYVal, pointRadiusOverride } = config;
   const [hasUserPannedOrZoomed, setHasUserPannedOrZoomed] = React.useState<boolean>(false);
   const [hasVerticalExclusiveZoom, setHasVerticalExclusiveZoom] = React.useState<boolean>(false);
@@ -449,7 +449,7 @@ function TwoDimensionalPlot(props: Props) {
               onScalesUpdate={onScaleBoundsUpdate}
               onHover={onHover}
               data={data}
-              onChartUpdate={onChartUpdate}
+              onFinishRender={onFinishRender}
             />
             {hasUserPannedOrZoomed && (
               <SResetZoom>

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -454,7 +454,6 @@ export default Panel(
   Object.assign(Plot, {
     panelType: "Plot",
     defaultConfig,
-    supportsStrictMode: false,
     configSchema,
   }),
 );

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -437,6 +437,5 @@ export default Panel(
   Object.assign(StateTransitions, {
     panelType: "StateTransitions",
     defaultConfig,
-    supportsStrictMode: false,
   }),
 );


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes strict mode issues with Plot and State Transitions panels by not calling pauseFrame during render/useMemo