### PR TITLE
Add setting for controlling automatic update behavior for desktop

### DIFF
--- a/desktop/main/StudioAppUpdater.ts
+++ b/desktop/main/StudioAppUpdater.ts
@@ -6,12 +6,17 @@ import { captureException } from "@sentry/electron";
 import { autoUpdater } from "electron-updater";
 
 import Logger from "@foxglove/log";
+import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
+
+import { getAppSetting } from "./settings";
 
 const log = Logger.getLogger(__filename);
 
-type AppUpdateMode = "none" | "default" | "start";
+function isNetworkError(err: unknown) {
+  if (!(err instanceof Error)) {
+    return false;
+  }
 
-function isNetworkError(err: Error) {
   return (
     err.message === "net::ERR_INTERNET_DISCONNECTED" ||
     err.message === "net::ERR_PROXY_CONNECTION_FAILED" ||
@@ -23,8 +28,7 @@ function isNetworkError(err: Error) {
 }
 
 class StudioAppUpdater {
-  private updateMode: AppUpdateMode | undefined;
-
+  private started: boolean = false;
   // Seconds to wait after app startup to check and download updates.
   // This gives the user time to disable app updates for new installations
   private initialUpdateDelaySec = 60 * 10;
@@ -35,50 +39,42 @@ class StudioAppUpdater {
   /**
    * Start the update process.
    */
-  start(updateMode: AppUpdateMode): void {
-    if (updateMode === "none") {
+  start(): void {
+    if (this.started) {
+      log.info(`StudioAppUpdater already running`);
       return;
     }
+    this.started = true;
 
-    if (this.updateMode != undefined) {
-      throw new Error("Cannot start StudioAppUpdater again");
-    }
-
-    this.updateMode = updateMode;
-    log.info(`Starting automatic updates with mode: ${this.updateMode}`);
-
-    if (this.updateMode === "start") {
-      this.checkForUpdatesAndNotify();
-    } else {
-      setTimeout(() => {
-        this.checkForUpdatesAndNotify();
-      }, this.initialUpdateDelaySec * 1000);
-    }
+    log.info(`Starting update loop`);
+    setTimeout(() => {
+      void this.maybeCheckForUpdates();
+    }, this.initialUpdateDelaySec * 1000);
   }
 
   // Check for updates and download.
   //
   // When using the "default" update mode, the app will continue to check for updates periodically
-  private checkForUpdatesAndNotify(): void {
-    log.info("Checking for updates");
-    autoUpdater
-      .checkForUpdatesAndNotify()
-      .catch((err: Error) => {
-        if (isNetworkError(err)) {
-          log.warn(`Network error checking for updates: ${err}`);
-        } else {
-          captureException(err);
-        }
-      })
-      .finally(() => {
-        // Only the default mode has periodic checking for updates
-        if (this.updateMode !== "default") {
-          return;
-        }
-        setTimeout(() => {
-          this.checkForUpdatesAndNotify();
-        }, this.updateCheckIntervalSec * 1000);
-      });
+  private async maybeCheckForUpdates(): Promise<void> {
+    try {
+      // The user may have changed the app update setting so we load it again
+      const appUpdatesEnabled = getAppSetting<boolean>(AppSetting.UPDATES_ENABLED);
+
+      if (appUpdatesEnabled ?? true) {
+        log.info("Checking for updates");
+        await autoUpdater.checkForUpdatesAndNotify();
+      }
+    } catch (err) {
+      if (isNetworkError(err)) {
+        log.warn(`Network error checking for updates: ${err}`);
+      } else {
+        captureException(err);
+      }
+    } finally {
+      setTimeout(() => {
+        void this.maybeCheckForUpdates();
+      }, this.updateCheckIntervalSec * 1000);
+    }
   }
 
   private static instance: StudioAppUpdater;

--- a/desktop/main/StudioAppUpdater.ts
+++ b/desktop/main/StudioAppUpdater.ts
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { captureException } from "@sentry/electron";
+import { autoUpdater } from "electron-updater";
+
+import Logger from "@foxglove/log";
+
+const log = Logger.getLogger(__filename);
+
+type AppUpdateMode = "none" | "default" | "start";
+
+function isNetworkError(err: Error) {
+  return (
+    err.message === "net::ERR_INTERNET_DISCONNECTED" ||
+    err.message === "net::ERR_PROXY_CONNECTION_FAILED" ||
+    err.message === "net::ERR_CONNECTION_RESET" ||
+    err.message === "net::ERR_CONNECTION_CLOSE" ||
+    err.message === "net::ERR_NAME_NOT_RESOLVED" ||
+    err.message === "net::ERR_CONNECTION_TIMED_OUT"
+  );
+}
+
+class StudioAppUpdater {
+  private updateMode: AppUpdateMode | undefined;
+
+  // Seconds to wait after app startup to check and download updates.
+  // This gives the user time to disable app updates for new installations
+  private initialUpdateDelaySec = 60 * 10;
+
+  // Seconds to wait after an update check completes before starting a new check
+  private updateCheckIntervalSec = 60 * 60;
+
+  /**
+   * Start the update process.
+   */
+  start(updateMode: AppUpdateMode): void {
+    if (updateMode === "none") {
+      return;
+    }
+
+    if (this.updateMode != undefined) {
+      throw new Error("Cannot start StudioAppUpdater again");
+    }
+
+    this.updateMode = updateMode;
+    log.info(`Starting automatic updates with mode: ${this.updateMode}`);
+
+    if (this.updateMode === "start") {
+      this.checkForUpdatesAndNotify();
+    } else {
+      setTimeout(() => {
+        this.checkForUpdatesAndNotify();
+      }, this.initialUpdateDelaySec * 1000);
+    }
+  }
+
+  // Check for updates and download.
+  //
+  // When using the "default" update mode, the app will continue to check for updates periodically
+  private checkForUpdatesAndNotify(): void {
+    log.info("Checking for updates");
+    autoUpdater
+      .checkForUpdatesAndNotify()
+      .catch((err: Error) => {
+        if (isNetworkError(err)) {
+          log.warn(`Network error checking for updates: ${err}`);
+        } else {
+          captureException(err);
+        }
+      })
+      .finally(() => {
+        // Only the default mode has periodic checking for updates
+        if (this.updateMode !== "default") {
+          return;
+        }
+        setTimeout(() => {
+          this.checkForUpdatesAndNotify();
+        }, this.updateCheckIntervalSec * 1000);
+      });
+  }
+
+  private static instance: StudioAppUpdater;
+  static Instance(): StudioAppUpdater {
+    return (StudioAppUpdater.instance ??= new StudioAppUpdater());
+  }
+}
+
+export default StudioAppUpdater;

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -216,18 +216,14 @@ function main() {
 
     registerRosPackageProtocolHandlers();
 
-    const appUpdateMode = getAppSetting<string>(AppSetting.APP_UPDATE_MODE);
-
     // Only production builds check for automatic updates
     if (process.env.NODE_ENV !== "production") {
       log.info("Automatic updates disabled (development environment)");
     } else if (/-(dev|nightly)/.test(pkgInfo.version)) {
       log.info("Automatic updates disabled (development version)");
-    } else if (appUpdateMode === "none") {
-      log.info("Automatic updates disabled via app settings");
     }
 
-    StudioAppUpdater.Instance().start(appUpdateMode === "default" ? "default" : "start");
+    StudioAppUpdater.Instance().start();
 
     app.setAboutPanelOptions({
       applicationName: pkgInfo.productName,

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -2,18 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Allow console logs in this file
-
 import "colors";
-import { captureException, init as initSentry } from "@sentry/electron";
+import { init as initSentry } from "@sentry/electron";
 import { app, BrowserWindow, ipcMain, Menu, session, nativeTheme } from "electron";
-import { autoUpdater } from "electron-updater";
 import fs from "fs";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 
 import pkgInfo from "../../package.json";
+import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
 import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
@@ -44,17 +42,6 @@ function isFileToOpen(arg: string) {
     // ignore
   }
   return false;
-}
-
-function isNetworkError(err: Error) {
-  return (
-    err.message === "net::ERR_INTERNET_DISCONNECTED" ||
-    err.message === "net::ERR_PROXY_CONNECTION_FAILED" ||
-    err.message === "net::ERR_CONNECTION_RESET" ||
-    err.message === "net::ERR_CONNECTION_CLOSE" ||
-    err.message === "net::ERR_NAME_NOT_RESOLVED" ||
-    err.message === "net::ERR_CONNECTION_TIMED_OUT"
-  );
 }
 
 function updateNativeColorScheme() {
@@ -229,21 +216,18 @@ function main() {
 
     registerRosPackageProtocolHandlers();
 
-    // Only stable builds check for automatic updates
+    const appUpdateMode = getAppSetting<string>(AppSetting.APP_UPDATE_MODE);
+
+    // Only production builds check for automatic updates
     if (process.env.NODE_ENV !== "production") {
       log.info("Automatic updates disabled (development environment)");
     } else if (/-(dev|nightly)/.test(pkgInfo.version)) {
       log.info("Automatic updates disabled (development version)");
-    } else {
-      autoUpdater.checkForUpdatesAndNotify().catch((err) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        if (isNetworkError(err)) {
-          log.warn(`Network error checking for updates: ${err}`);
-        } else {
-          captureException(err);
-        }
-      });
+    } else if (appUpdateMode === "none") {
+      log.info("Automatic updates disabled via app settings");
     }
+
+    StudioAppUpdater.Instance().start(appUpdateMode === "default" ? "default" : "start");
 
     app.setAboutPanelOptions({
       applicationName: pkgInfo.productName,

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -18,5 +18,6 @@ export enum AppSetting {
   COLOR_SCHEME = "colorScheme",
   ENABLE_MCAP_DATA_SOURCE = "sources.mcap",
   OPEN_DIALOG = "ui.open-dialog",
+  APP_UPDATE_MODE = "app-update.mode",
   SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
 }

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -18,6 +18,6 @@ export enum AppSetting {
   COLOR_SCHEME = "colorScheme",
   ENABLE_MCAP_DATA_SOURCE = "sources.mcap",
   OPEN_DIALOG = "ui.open-dialog",
-  APP_UPDATE_MODE = "app-update.mode",
+  UPDATES_ENABLED = "updates.enabled",
   SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
 }

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -8,6 +8,7 @@ import {
   Dropdown,
   IChoiceGroupOption,
   IComboBoxOption,
+  IDropdownOption,
   SelectableOptionMenuItemType,
   Stack,
   Text,
@@ -245,6 +246,41 @@ function MessageFramerate(): React.ReactElement {
   );
 }
 
+function AutoUpdate(): React.ReactElement {
+  const [appUpdateMode, setAppUpdateMode] = useAppConfigurationValue<string>(
+    AppSetting.APP_UPDATE_MODE,
+  );
+
+  const entries: Array<IDropdownOption> = [
+    { key: "default", text: "default - periodically check for updates" },
+    { key: "start", text: "start - check for updates on startup" },
+    { key: "none", text: "none - never check for updates" },
+  ];
+
+  if (!isDesktopApp()) {
+    return <></>;
+  }
+
+  return (
+    <Dropdown
+      label="App update mode"
+      options={entries}
+      openOnKeyboardFocus
+      selectedKey={appUpdateMode}
+      defaultSelectedKey={"default"}
+      onChange={(_event, option) => {
+        if (option) {
+          void setAppUpdateMode(String(option.key));
+        }
+      }}
+      calloutProps={{
+        directionalHint: DirectionalHint.bottomLeftEdge,
+        directionalHintFixed: true,
+      }}
+    />
+  );
+}
+
 function RosPackagePath(): React.ReactElement {
   const [rosPackagePath, setRosPackagePath] = useAppConfigurationValue<string>(
     AppSetting.ROS_PACKAGE_PATH,
@@ -307,6 +343,9 @@ export default function Preferences(): React.ReactElement {
             </Stack.Item>
             <Stack.Item>
               <MessageFramerate />
+            </Stack.Item>
+            <Stack.Item>
+              <AutoUpdate />
             </Stack.Item>
             {!isDesktopApp() && (
               <Stack.Item>

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -8,7 +8,7 @@ import {
   Dropdown,
   IChoiceGroupOption,
   IComboBoxOption,
-  IDropdownOption,
+  Label,
   SelectableOptionMenuItemType,
   Stack,
   Text,
@@ -31,6 +31,8 @@ import fuzzyFilter from "@foxglove/studio-base/util/fuzzyFilter";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const MESSAGE_RATES = [1, 3, 5, 10, 15, 20, 30, 60];
+
+const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
 
 function formatTimezone(name: string) {
   const tz = moment.tz(name);
@@ -247,37 +249,21 @@ function MessageFramerate(): React.ReactElement {
 }
 
 function AutoUpdate(): React.ReactElement {
-  const [appUpdateMode, setAppUpdateMode] = useAppConfigurationValue<string>(
-    AppSetting.APP_UPDATE_MODE,
+  const [updatesEnabled = true, setUpdatedEnabled] = useAppConfigurationValue<boolean>(
+    AppSetting.UPDATES_ENABLED,
   );
 
-  const entries: Array<IDropdownOption> = [
-    { key: "default", text: "default - periodically check for updates" },
-    { key: "start", text: "start - check for updates on startup" },
-    { key: "none", text: "none - never check for updates" },
-  ];
-
-  if (!isDesktopApp()) {
-    return <></>;
-  }
-
   return (
-    <Dropdown
-      label="App update mode"
-      options={entries}
-      openOnKeyboardFocus
-      selectedKey={appUpdateMode}
-      defaultSelectedKey={"default"}
-      onChange={(_event, option) => {
-        if (option) {
-          void setAppUpdateMode(String(option.key));
-        }
-      }}
-      calloutProps={{
-        directionalHint: DirectionalHint.bottomLeftEdge,
-        directionalHintFixed: true,
-      }}
-    />
+    <>
+      <Label>Updates:</Label>
+      <Checkbox
+        checked={updatesEnabled}
+        label="Automatically install updates"
+        onChange={(_, newValue) => {
+          void setUpdatedEnabled(newValue ?? true);
+        }}
+      />
+    </>
   );
 }
 
@@ -286,8 +272,7 @@ function RosPackagePath(): React.ReactElement {
     AppSetting.ROS_PACKAGE_PATH,
   );
 
-  const os = OsContextSingleton;
-  const rosPackagePathPlaceholder = useMemo(() => os?.getEnvVar("ROS_PACKAGE_PATH"), [os]);
+  const rosPackagePathPlaceholder = useMemo(() => os?.getEnvVar("ROS_PACKAGE_PATH"), []);
 
   return (
     <TextField
@@ -326,6 +311,13 @@ export default function Preferences(): React.ReactElement {
     AppSetting.TELEMETRY_ENABLED,
   );
 
+  // automatic updates are a desktop-only setting
+  //
+  // electron-updater does not provide a way to detect if we are on a supported update platform
+  // so we hard-code linux as an _unsupported_ auto-update platform since we cannot auto-update
+  // with our .deb package install method on linux.
+  const supportsAppUpdates = isDesktopApp() && os?.platform !== "linux";
+
   return (
     <SidebarContent title="Preferences">
       <Stack tokens={{ childrenGap: 30 }}>
@@ -344,9 +336,11 @@ export default function Preferences(): React.ReactElement {
             <Stack.Item>
               <MessageFramerate />
             </Stack.Item>
-            <Stack.Item>
-              <AutoUpdate />
-            </Stack.Item>
+            {supportsAppUpdates && (
+              <Stack.Item>
+                <AutoUpdate />
+              </Stack.Item>
+            )}
             {!isDesktopApp() && (
               <Stack.Item>
                 <LaunchDefault />


### PR DESCRIPTION

**User-Facing Changes**
A user can uncheck "Automatically install updates" to prevent the desktop app from automatically updating itself.
<img width="347" alt="Screen Shot 2022-01-11 at 8 15 22 AM" src="https://user-images.githubusercontent.com/84792/148980337-52f5bf07-34fd-44f1-befa-768887f2f80c.png">


**Description**
By default the application checks for updates periodically. The user can override this behavior to disable any automatic updates by unchecking this setting.

The default behavior delays checking for updates for a few minutes to give the user time to change the setting for first time app launch.

This setting only applies to the desktop app and is not available in the web version.

Fixes: #2546

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
