### PR TITLE
Fix duplicate .bag item in Open Dialog's "Open local file" option

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -73,12 +73,17 @@ export default function Start(props: IStartProps): JSX.Element {
     [theme],
   );
 
+  const supportedLocalFiles = useMemo(
+    () => Array.from(new Set(supportedFileExtensions)).join(", "),
+    [supportedFileExtensions],
+  );
+
   const startItems: IButtonProps[] = useMemo(
     () => [
       {
         id: "open-local-file",
         children: "Open local file",
-        secondaryText: `Supports ${supportedFileExtensions.join(", ")} files`,
+        secondaryText: `Supports ${supportedLocalFiles} files`,
         iconProps: { iconName: "OpenFile" },
         onClick: () => onSelectView("file"),
       },
@@ -104,7 +109,7 @@ export default function Start(props: IStartProps): JSX.Element {
         onClick: () => onSelectView("demo"),
       },
     ],
-    [onSelectView, supportedFileExtensions],
+    [onSelectView, supportedLocalFiles],
   );
 
   const recentItems: IButtonProps[] = useMemo(() => {


### PR DESCRIPTION
**User-Facing Changes**
- Fix duplicate `.bag` item in Open Dialog's "Open local file" option

<img width="495" alt="Screen Shot 2022-01-10 at 1 19 25 PM" src="https://user-images.githubusercontent.com/6993359/148841117-4266c06c-0bc7-4217-b804-ec6a532cca5d.png">




<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
