### PR TITLE
Support image rotation and mirroring in the image panel.

### DIFF
--- a/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
+++ b/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
@@ -163,6 +163,12 @@ export class HitmapRenderContext {
     this._hctx?.restore();
   }
 
+  rotate(angle: number): void {
+    const rads = (angle * Math.PI) / 180;
+    this._ctx.rotate(rads);
+    this._hctx?.rotate(rads);
+  }
+
   save(): void {
     this._ctx.save();
     this._hctx?.save();

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -473,8 +473,14 @@ export const MarkersWithHitmap: Story = (_args) => {
     void renderImage({
       canvas: canvasRef.current,
       hitmapCanvas: hitmapRef.current,
-      zoomMode: "fill",
-      panZoom: { x: 0, y: 0, scale: 1 },
+      geometry: {
+        flipHorizontal: false,
+        flipVertical: false,
+        panZoom: { x: 0, y: 0, scale: 1 },
+        rotation: 0,
+        viewport: { width, height },
+        zoomMode: "fill",
+      },
       imageMessage: imageMessage?.message as any,
       imageMessageDatatype: "sensor_msgs/Image",
       rawMarkerData: {
@@ -489,6 +495,68 @@ export const MarkersWithHitmap: Story = (_args) => {
     <div style={{ backgroundColor: "white", padding: "1rem" }}>
       <canvas ref={canvasRef} style={{ width, height }} />
       <canvas ref={hitmapRef} style={{ width, height }} />
+    </div>
+  );
+};
+
+export const MarkersWithRotations: Story = (_args) => {
+  const width = 300;
+  const height = 200;
+  const imageMessage = useImageMessage();
+  const canvasRefs = useRef<Array<HTMLCanvasElement | ReactNull>>([]);
+  const geometries = useMemo(
+    () => [
+      { rotation: 0 },
+      { rotation: 90 },
+      { rotation: 180 },
+      { rotation: 270 },
+      { flipHorizontal: true },
+      { flipVertical: true },
+    ],
+    [],
+  );
+
+  useEffect(() => {
+    canvasRefs.current.forEach((canvas, i) => {
+      if (!canvas) {
+        return;
+      }
+
+      canvas.width = 2 * width;
+      canvas.height = 2 * height;
+
+      void renderImage({
+        canvas,
+        hitmapCanvas: undefined,
+        geometry: {
+          flipHorizontal: false,
+          flipVertical: false,
+          panZoom: { x: 0, y: 0, scale: 1 },
+          rotation: 0,
+          viewport: { width, height },
+          zoomMode: "fill",
+          ...geometries[i],
+        },
+        imageMessage: imageMessage?.message as any,
+        imageMessageDatatype: "sensor_msgs/Image",
+        rawMarkerData: {
+          markers,
+          cameraInfo,
+          transformMarkers: true,
+        },
+      });
+    });
+  }, [geometries, imageMessage]);
+
+  return (
+    <div>
+      {geometries.map((r, i) => (
+        <canvas
+          key={JSON.stringify(r)}
+          ref={(ref) => (canvasRefs.current[i] = ref)}
+          style={{ width, height }}
+        />
+      ))}
     </div>
   );
 };

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -147,7 +147,7 @@ const webWorkerManager = new WebWorkerManager(() => {
 }, 1);
 
 type RenderImage = (
-  args: RenderArgs & { canvas: RenderableCanvas; viewport: Dimensions },
+  args: RenderArgs & { canvas: RenderableCanvas },
 ) => Promise<Dimensions | undefined>;
 
 const supportsOffscreenCanvas =
@@ -202,8 +202,8 @@ export default function ImageCanvas(props: Props): JSX.Element {
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       const renderInMain: RenderImage = (args) => {
-        const targetWidth = args.viewport.width;
-        const targetHeight = args.viewport.height;
+        const targetWidth = args.geometry.viewport.width;
+        const targetHeight = args.geometry.viewport.height;
 
         if (targetWidth !== canvas.width) {
           canvas.width = targetWidth;
@@ -223,13 +223,11 @@ export default function ImageCanvas(props: Props): JSX.Element {
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       const workerRender: RenderImage = (args) => {
         const {
-          zoomMode: zoom,
-          panZoom,
-          viewport,
+          geometry,
           imageMessage,
           imageMessageDatatype,
-          rawMarkerData: rawMarkers,
           options,
+          rawMarkerData: rawMarkers,
         } = args;
 
         if (!imageMessage) {
@@ -255,18 +253,13 @@ export default function ImageCanvas(props: Props): JSX.Element {
                 width: imageMessage.width,
               };
 
-        return worker.send<
-          Dimensions | undefined,
-          RenderArgs & { id: string; viewport: Dimensions }
-        >("renderImage", {
+        return worker.send<Dimensions | undefined, RenderArgs & { id: string }>("renderImage", {
+          geometry,
           id,
-          zoomMode: zoom,
-          panZoom,
-          viewport,
           imageMessage: msg,
           imageMessageDatatype,
-          rawMarkerData: JSON.parse(JSON.stringify(rawMarkers)),
           options,
+          rawMarkerData: JSON.parse(JSON.stringify(rawMarkers)),
         });
       };
 
@@ -353,9 +346,11 @@ export default function ImageCanvas(props: Props): JSX.Element {
     try {
       return await doRenderImage({
         canvas: canvasRef.current ?? undefined,
-        zoomMode: zoomMode ?? "fit",
-        panZoom: computedViewbox,
-        viewport: { width: targetWidth, height: targetHeight },
+        geometry: {
+          panZoom: computedViewbox,
+          viewport: { width: targetWidth, height: targetHeight },
+          zoomMode: zoomMode ?? "fit",
+        },
         imageMessage,
         imageMessageDatatype: topic?.datatype,
         rawMarkerData,
@@ -471,7 +466,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
   const onDownloadImage = useCallback(() => {
     const canvas = canvasRef.current;
 
-    if (!canvas || !image || !topic) {
+    if (!canvas || !image || !topic || width == undefined || height == undefined) {
       return;
     }
 
@@ -485,8 +480,11 @@ export default function ImageCanvas(props: Props): JSX.Element {
     void renderImage({
       canvas: tempCanvas,
       hitmapCanvas: undefined,
-      zoomMode: "other",
-      panZoom: { x: 0, y: 0, scale: 1 },
+      geometry: {
+        panZoom: { x: 0, y: 0, scale: 1 },
+        zoomMode: "other",
+        viewport: { width, height },
+      },
       imageMessage,
       imageMessageDatatype: topic.datatype,
       rawMarkerData: { markers: [], transformMarkers: false },
@@ -514,7 +512,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
         downloadFiles([{ blob, fileName }]);
       }, "image/png");
     });
-  }, [image, topic, renderOptions]);
+  }, [image, topic, width, height, renderOptions]);
 
   function onCanvasClick(event: MouseEvent<HTMLCanvasElement>) {
     const boundingRect = event.currentTarget.getBoundingClientRect();

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -347,7 +347,10 @@ export default function ImageCanvas(props: Props): JSX.Element {
       return await doRenderImage({
         canvas: canvasRef.current ?? undefined,
         geometry: {
+          flipHorizontal: config.flipHorizontal ?? false,
+          flipVertical: config.flipVertical ?? false,
           panZoom: computedViewbox,
+          rotation: config.rotation ?? 0,
           viewport: { width: targetWidth, height: targetHeight },
           zoomMode: zoomMode ?? "fit",
         },
@@ -360,19 +363,20 @@ export default function ImageCanvas(props: Props): JSX.Element {
       finishRender();
     }
   }, [
-    doRenderImage,
-    width,
-    height,
+    config,
     devicePixelRatio,
-    panX,
-    panY,
-    scaleValue,
+    doRenderImage,
+    height,
     image?.message,
     onStartRenderImage,
-    zoomMode,
-    topic?.datatype,
+    panX,
+    panY,
     rawMarkerData,
     renderOptions,
+    scaleValue,
+    topic?.datatype,
+    width,
+    zoomMode,
   ]);
 
   const [openZoomContext, setOpenZoomContext] = useState(false);
@@ -481,9 +485,12 @@ export default function ImageCanvas(props: Props): JSX.Element {
       canvas: tempCanvas,
       hitmapCanvas: undefined,
       geometry: {
+        flipHorizontal: config.flipHorizontal ?? false,
+        flipVertical: config.flipVertical ?? false,
         panZoom: { x: 0, y: 0, scale: 1 },
-        zoomMode: "other",
+        rotation: config.rotation ?? 0,
         viewport: { width, height },
+        zoomMode: "other",
       },
       imageMessage,
       imageMessageDatatype: topic.datatype,
@@ -512,7 +519,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
         downloadFiles([{ blob, fileName }]);
       }, "image/png");
     });
-  }, [image, topic, width, height, renderOptions]);
+  }, [image, topic, width, height, config, renderOptions]);
 
   function onCanvasClick(event: MouseEvent<HTMLCanvasElement>) {
     const boundingRect = event.currentTarget.getBoundingClientRect();

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -32,7 +32,7 @@ import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import { Config, SaveImagePanelConfig } from "./index";
 import { renderImage } from "./renderImage";
-import { Dimensions, PixelData, RawMarkerData, RenderOptions, PanZoom, ZoomMode } from "./util";
+import { Dimensions, PixelData, RawMarkerData, RenderableCanvas, RenderArgs } from "./util";
 
 type OnFinishRenderImage = () => void;
 
@@ -146,16 +146,9 @@ const webWorkerManager = new WebWorkerManager(() => {
   return new Worker(new URL("ImageCanvas.worker", import.meta.url));
 }, 1);
 
-type RenderImage = (args: {
-  canvas: HTMLCanvasElement | OffscreenCanvas;
-  zoomMode: ZoomMode;
-  panZoom: PanZoom;
-  viewport: Dimensions;
-  imageMessage?: Image | CompressedImage;
-  imageMessageDatatype?: string;
-  rawMarkerData: RawMarkerData;
-  options?: RenderOptions;
-}) => Promise<Dimensions | undefined>;
+type RenderImage = (
+  args: RenderArgs & { canvas: RenderableCanvas; viewport: Dimensions },
+) => Promise<Dimensions | undefined>;
 
 const supportsOffscreenCanvas =
   typeof HTMLCanvasElement.prototype.transferControlToOffscreen === "function";
@@ -250,16 +243,22 @@ export default function ImageCanvas(props: Props): JSX.Element {
             ? {
                 data: imageMessage.data,
                 format: imageMessage.format,
+                header: imageMessage.header,
               }
             : {
                 data: imageMessage.data,
-                width: imageMessage.width,
-                height: imageMessage.height,
                 encoding: imageMessage.encoding,
+                header: imageMessage.header,
+                height: imageMessage.height,
                 is_bigendian: imageMessage.is_bigendian,
+                step: imageMessage.step,
+                width: imageMessage.width,
               };
 
-        return worker.send<Dimensions | undefined>("renderImage", {
+        return worker.send<
+          Dimensions | undefined,
+          RenderArgs & { id: string; viewport: Dimensions }
+        >("renderImage", {
           id,
           zoomMode: zoom,
           panZoom,

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -12,25 +12,17 @@
 //   You may not use this file except in compliance with the License.
 
 import { MessageEvent } from "@foxglove/studio-base/players/types";
-import {
-  Image,
-  CompressedImage,
-  ImageMarker,
-  ImageMarkerArray,
-} from "@foxglove/studio-base/types/Messages";
+import { ImageMarker, ImageMarkerArray } from "@foxglove/studio-base/types/Messages";
 import Rpc, { Channel } from "@foxglove/studio-base/util/Rpc";
 import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
 
 import { renderImage } from "./renderImage";
 import {
   Dimensions,
-  idColorToIndex,
   flattenImageMarkers,
-  RawMarkerData,
+  idColorToIndex,
+  RenderArgs,
   RenderDimensions,
-  RenderOptions,
-  PanZoom,
-  ZoomMode,
 } from "./util";
 
 type RenderState = {
@@ -82,16 +74,9 @@ class ImageCanvasWorker {
       "renderImage",
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
-      (args: {
-        id: string;
-        zoomMode: ZoomMode;
-        panZoom: PanZoom;
-        viewport: Dimensions;
-        imageMessage?: Image | CompressedImage;
-        imageMessageDatatype?: string;
-        rawMarkerData: RawMarkerData;
-        options: RenderOptions;
-      }): Promise<RenderDimensions | undefined> => {
+      (
+        args: RenderArgs & { id: string; viewport: Dimensions },
+      ): Promise<RenderDimensions | undefined> => {
         const {
           id,
           zoomMode,

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -17,13 +17,7 @@ import Rpc, { Channel } from "@foxglove/studio-base/util/Rpc";
 import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
 
 import { renderImage } from "./renderImage";
-import {
-  Dimensions,
-  flattenImageMarkers,
-  idColorToIndex,
-  RenderArgs,
-  RenderDimensions,
-} from "./util";
+import { flattenImageMarkers, idColorToIndex, RenderArgs, RenderDimensions } from "./util";
 
 type RenderState = {
   canvas: OffscreenCanvas;
@@ -74,33 +68,22 @@ class ImageCanvasWorker {
       "renderImage",
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
-      (
-        args: RenderArgs & { id: string; viewport: Dimensions },
-      ): Promise<RenderDimensions | undefined> => {
-        const {
-          id,
-          zoomMode,
-          panZoom,
-          viewport,
-          imageMessage,
-          imageMessageDatatype,
-          rawMarkerData,
-          options,
-        } = args;
+      (args: RenderArgs & { id: string }): Promise<RenderDimensions | undefined> => {
+        const { id, geometry, imageMessage, imageMessageDatatype, rawMarkerData, options } = args;
 
         const render = this._renderStates[id];
         if (!render) {
           return Promise.resolve(undefined);
         }
 
-        if (render.canvas.width !== viewport.width) {
-          render.canvas.width = viewport.width;
-          render.hitmap.width = viewport.width;
+        if (render.canvas.width !== geometry.viewport.width) {
+          render.canvas.width = geometry.viewport.width;
+          render.hitmap.width = geometry.viewport.width;
         }
 
-        if (render.canvas.height !== viewport.height) {
-          render.canvas.height = viewport.height;
-          render.hitmap.height = viewport.height;
+        if (render.canvas.height !== geometry.viewport.height) {
+          render.canvas.height = geometry.viewport.height;
+          render.hitmap.height = geometry.viewport.height;
         }
 
         // Flatten markers because we need to be able to index into them for hitmapping.
@@ -110,13 +93,12 @@ class ImageCanvasWorker {
 
         return renderImage({
           canvas: render.canvas,
+          geometry,
           hitmapCanvas: render.hitmap,
-          zoomMode,
-          panZoom,
           imageMessage,
           imageMessageDatatype,
-          rawMarkerData,
           options,
+          rawMarkerData,
         }).then((dimensions) => (render.dimensions = dimensions));
       },
     );

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -70,15 +70,18 @@ type DefaultConfig = {
 };
 
 export type Config = DefaultConfig & {
-  transformMarkers: boolean;
-  mode?: ZoomMode;
-  smooth?: boolean;
-  zoom?: number;
-  pan?: { x: number; y: number };
-  zoomPercentage?: number;
-  minValue?: number;
+  flipHorizontal?: boolean;
+  flipVertical?: boolean;
   maxValue?: number;
+  minValue?: number;
+  mode?: ZoomMode;
+  pan?: { x: number; y: number };
+  rotation?: number;
   saveStoryConfig?: () => void;
+  smooth?: boolean;
+  transformMarkers: boolean;
+  zoom?: number;
+  zoomPercentage?: number;
 };
 
 export type SaveImagePanelConfig = SaveConfig<Config>;
@@ -686,6 +689,27 @@ const configSchema: PanelConfigSchema<Config> = [
     key: "smooth",
     type: "toggle",
     title: "Bilinear smoothing",
+  },
+  {
+    key: "flipHorizontal",
+    type: "toggle",
+    title: "Flip horizontally",
+  },
+  {
+    key: "flipVertical",
+    type: "toggle",
+    title: "Flip vertically",
+  },
+  {
+    key: "rotation",
+    type: "dropdown",
+    title: "Rotation",
+    options: [
+      { value: 0, text: "0°" },
+      { value: 90, text: "90°" },
+      { value: 180, text: "180°" },
+      { value: 270, text: "270°" },
+    ],
   },
   {
     key: "minValue",

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -674,13 +674,14 @@ function ImageView(props: Props) {
 
 const defaultConfig: Config = {
   cameraTopic: "",
-  enabledMarkerTopics: [],
   customMarkerTopicOptions: [],
-  transformMarkers: false,
-  synchronize: false,
+  enabledMarkerTopics: [],
   mode: "fit",
-  zoom: 1,
   pan: { x: 0, y: 0 },
+  rotation: 0,
+  synchronize: false,
+  transformMarkers: false,
+  zoom: 1,
 };
 
 const configSchema: PanelConfigSchema<Config> = [

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -229,7 +229,11 @@ function render({
   imageSmoothing: boolean;
   markerData: MarkerData | undefined;
 }): RenderDimensions | undefined {
-  const bitmapDimensions = { width: bitmap.width, height: bitmap.height };
+  const bitmapDimensions =
+    geometry.rotation % 180 === 0
+      ? { width: bitmap.width, height: bitmap.height }
+      : { width: bitmap.height, height: bitmap.width };
+
   const canvasCtx = canvas.getContext("2d");
   if (!canvasCtx) {
     return;
@@ -242,7 +246,7 @@ function render({
   const viewportW = canvas.width;
   const viewportH = canvas.height;
 
-  const imageViewportScale = calculateZoomScale(bitmap, canvas, geometry.zoomMode);
+  const imageViewportScale = calculateZoomScale(bitmapDimensions, canvas, geometry.zoomMode);
 
   const ctx = new HitmapRenderContext(canvasCtx, hitmapCanvas);
   ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -255,6 +259,18 @@ function render({
 
   ctx.scale(geometry.panZoom.scale, geometry.panZoom.scale);
   ctx.scale(imageViewportScale, imageViewportScale);
+
+  if (geometry.flipHorizontal) {
+    ctx.scale(-1, 1);
+  }
+
+  if (geometry.flipVertical) {
+    ctx.scale(1, -1);
+  }
+
+  if (geometry.rotation != undefined) {
+    ctx.rotate(geometry.rotation);
+  }
 
   // center the image in the viewport
   // also sets 0,0 as the upper left corner of the image since markers are drawn from 0,0 on the image

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -40,11 +40,12 @@ import {
 import {
   buildMarkerData,
   calculateZoomScale,
-  RawMarkerData,
   MarkerData,
+  PanZoom,
+  RenderableCanvas,
+  RenderArgs,
   RenderDimensions,
   RenderOptions,
-  PanZoom,
   ZoomMode,
 } from "./util";
 
@@ -69,7 +70,6 @@ let hasLoggedCameraModelError: boolean = false;
 // Size threshold below which we do fast point rendering as rects.
 // Empirically 3 seems like a good threshold here.
 const FAST_POINT_SIZE_THRESHOlD = 3;
-type RenderableCanvas = HTMLCanvasElement | OffscreenCanvas;
 
 // Given a canvas, an image message, and marker info, render the image to the canvas.
 export async function renderImage({
@@ -81,16 +81,9 @@ export async function renderImage({
   imageMessageDatatype,
   rawMarkerData,
   options,
-}: {
-  canvas: RenderableCanvas;
-  hitmapCanvas: RenderableCanvas | undefined;
-  zoomMode: ZoomMode;
-  panZoom: PanZoom;
-  imageMessage?: Image | CompressedImage;
-  imageMessageDatatype?: string;
-  rawMarkerData: RawMarkerData;
-  options?: RenderOptions;
-}): Promise<RenderDimensions | undefined> {
+}: RenderArgs & { canvas: RenderableCanvas; hitmapCanvas: RenderableCanvas | undefined }): Promise<
+  RenderDimensions | undefined
+> {
   if (!imageMessage || imageMessageDatatype == undefined) {
     clearCanvas(canvas);
     return undefined;

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -45,8 +45,8 @@ import {
   RenderableCanvas,
   RenderArgs,
   RenderDimensions,
+  RenderGeometry,
   RenderOptions,
-  ZoomMode,
 } from "./util";
 
 const UNCOMPRESSED_IMAGE_DATATYPES = [
@@ -75,8 +75,7 @@ const FAST_POINT_SIZE_THRESHOlD = 3;
 export async function renderImage({
   canvas,
   hitmapCanvas,
-  zoomMode,
-  panZoom,
+  geometry,
   imageMessage,
   imageMessageDatatype,
   rawMarkerData,
@@ -111,9 +110,8 @@ export async function renderImage({
 
     const dimensions = render({
       canvas,
+      geometry,
       hitmapCanvas,
-      zoomMode,
-      panZoom,
       bitmap,
       imageSmoothing,
       markerData,
@@ -210,26 +208,24 @@ function decodeMessageToBitmap(
   return self.createImageBitmap(image);
 }
 
-function clearCanvas(canvas?: HTMLCanvasElement | OffscreenCanvas) {
+function clearCanvas(canvas?: RenderableCanvas) {
   if (canvas) {
     canvas.getContext("2d")?.clearRect(0, 0, canvas.width, canvas.height);
   }
 }
 
 function render({
-  canvas,
-  hitmapCanvas,
-  zoomMode,
-  panZoom,
   bitmap,
+  canvas,
+  geometry,
+  hitmapCanvas,
   imageSmoothing,
   markerData,
 }: {
-  canvas: RenderableCanvas;
-  hitmapCanvas: RenderableCanvas | undefined;
-  zoomMode: ZoomMode;
-  panZoom: PanZoom;
   bitmap: ImageBitmap;
+  canvas: RenderableCanvas;
+  geometry: RenderGeometry;
+  hitmapCanvas: RenderableCanvas | undefined;
   imageSmoothing: boolean;
   markerData: MarkerData | undefined;
 }): RenderDimensions | undefined {
@@ -246,7 +242,7 @@ function render({
   const viewportW = canvas.width;
   const viewportH = canvas.height;
 
-  const imageViewportScale = calculateZoomScale(bitmap, canvas, zoomMode);
+  const imageViewportScale = calculateZoomScale(bitmap, canvas, geometry.zoomMode);
 
   const ctx = new HitmapRenderContext(canvasCtx, hitmapCanvas);
   ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -255,9 +251,9 @@ function render({
 
   // translate x/y from the center of the canvas
   ctx.translate(viewportW / 2, viewportH / 2);
-  ctx.translate(panZoom.x, panZoom.y);
+  ctx.translate(geometry.panZoom.x, geometry.panZoom.y);
 
-  ctx.scale(panZoom.scale, panZoom.scale);
+  ctx.scale(geometry.panZoom.scale, geometry.panZoom.scale);
   ctx.scale(imageViewportScale, imageViewportScale);
 
   // center the image in the viewport
@@ -279,7 +275,7 @@ function render({
       ctx,
       markers as MessageEvent<ImageMarker | ImageMarkerArray>[],
       cameraModel,
-      panZoom,
+      geometry.panZoom,
     );
   } catch (err) {
     console.warn("error painting markers:", err);

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -12,7 +12,13 @@
 //   You may not use this file except in compliance with the License.
 
 import { Topic, MessageEvent } from "@foxglove/studio-base/players/types";
-import { CameraInfo, ImageMarker, ImageMarkerArray } from "@foxglove/studio-base/types/Messages";
+import {
+  CameraInfo,
+  CompressedImage,
+  Image,
+  ImageMarker,
+  ImageMarkerArray,
+} from "@foxglove/studio-base/types/Messages";
 
 import PinholeCameraModel from "./PinholeCameraModel";
 
@@ -30,6 +36,15 @@ export type RenderOptions = {
   resizeCanvas?: boolean;
 };
 
+export type RenderArgs = {
+  imageMessage?: Image | CompressedImage;
+  imageMessageDatatype?: string;
+  options?: RenderOptions;
+  panZoom: PanZoom;
+  rawMarkerData: RawMarkerData;
+  zoomMode: ZoomMode;
+};
+
 export type Dimensions = { width: number; height: number };
 
 export type PixelData = {
@@ -38,6 +53,8 @@ export type PixelData = {
   markerIndex?: number;
   marker?: ImageMarker;
 };
+
+export type RenderableCanvas = HTMLCanvasElement | OffscreenCanvas;
 
 export type RawMarkerData = {
   markers: MessageEvent<unknown>[];

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -37,7 +37,10 @@ export type RenderOptions = {
 };
 
 export type RenderGeometry = {
+  flipVertical: boolean;
+  flipHorizontal: boolean;
   panZoom: PanZoom;
+  rotation: number;
   viewport: Dimensions;
   zoomMode: ZoomMode;
 };

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -36,13 +36,18 @@ export type RenderOptions = {
   resizeCanvas?: boolean;
 };
 
+export type RenderGeometry = {
+  panZoom: PanZoom;
+  viewport: Dimensions;
+  zoomMode: ZoomMode;
+};
+
 export type RenderArgs = {
   imageMessage?: Image | CompressedImage;
   imageMessageDatatype?: string;
+  geometry: RenderGeometry;
   options?: RenderOptions;
-  panZoom: PanZoom;
   rawMarkerData: RawMarkerData;
-  zoomMode: ZoomMode;
 };
 
 export type Dimensions = { width: number; height: number };

--- a/packages/studio-base/src/util/Rpc.ts
+++ b/packages/studio-base/src/util/Rpc.ts
@@ -135,9 +135,9 @@ export default class Rpc {
   // send a message across the rpc boundary to a receiver on the other side
   // this returns a promise for the receiver's response.  If there is no registered
   // receiver for the given topic, this method throws
-  async send<TResult>(
+  async send<TResult, TData = unknown>(
     topic: string,
-    data?: unknown,
+    data?: TData,
     transfer?: (Transferable | OffscreenCanvas)[],
   ): Promise<TResult> {
     const id = this._messageId++;


### PR DESCRIPTION
**User-Facing Changes**
This implements rotation and both horizontal and vertical mirroring in the image panel.

**Description**
This exposes settings for rotation and mirroring in the image view settings panel. The implementation is straightforward. We just pass the additional parameters to the image worker that does the rendering. The only tricky consideration is that the calculation for the viewbox and zoom fit & fill modes needs to take rotation into account.

This also slightly refactors & tightens up the typing in the image rendering code.

<img width="1840" alt="Screen Shot 2022-01-10 at 12 47 44 PM" src="https://user-images.githubusercontent.com/93935560/148843970-03b446f8-ba0b-43a4-96bb-49c06b9f6975.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2523 