### PR TITLE
Add overscroll-behavior:none on body

### DIFF
--- a/packages/studio-base/src/components/GlobalCss.tsx
+++ b/packages/studio-base/src/components/GlobalCss.tsx
@@ -27,6 +27,11 @@ body {
   font-feature-settings: ${({ theme }) => theme.fonts.small.fontFeatureSettings};
   font-size: ${({ theme }) => theme.fonts.small.fontSize};
   font-weight: ${({ theme }) => theme.fonts.small.fontWeight};
+
+  // Prevent scroll "bouncing" since the app workspace is not scrollable. Allows individual
+  // scrollable elements to be scrolled without the whole page moving (even if they don't
+  // preventDefault on scroll events).
+  overscroll-behavior: none;
 }
 #root {
   height: 100%;


### PR DESCRIPTION
**User-Facing Changes**
Not worth mentioning

**Description**
When scrolling to zoom on a plot with a trackpad, the whole page would move due to the native overscroll "bouncing" behavior. Since our app workspace does not scroll, there's no need for a bounce to indicate the end of the content has been reached.