### PR TITLE
Change cog icon to menu icon in panel toolbar

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -95,7 +95,7 @@ export const PanelNotFound = (): JSX.Element => {
       <PanelSetup
         onMount={() => {
           setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-settings]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
           }, DEFAULT_CLICK_DELAY);
         }}
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
@@ -140,8 +140,8 @@ export const RemoveUnknownPanel = (): JSX.Element => {
       <PanelSetup
         onMount={() => {
           setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-settings]")[0] as any).click();
-            (document.querySelectorAll("[data-test=panel-settings-remove]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu-remove]")[0] as any).click();
           }, DEFAULT_CLICK_DELAY);
         }}
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
@@ -189,8 +189,8 @@ export const FullScreen = (): JSX.Element => {
         omitDragAndDrop
         onMount={() => {
           setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-settings]")[0] as any).click();
-            (document.querySelectorAll("[data-test=panel-settings-fullscreen]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu-fullscreen]")[0] as any).click();
           }, DEFAULT_CLICK_DELAY);
         }}
       >

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { ContextualMenu, IContextualMenuItem, makeStyles } from "@fluentui/react";
-import CogIcon from "@mdi/svg/svg/cog.svg";
+import MenuIcon from "@mdi/svg/svg/menu.svg";
 import { useCallback, useContext, useMemo, useRef } from "react";
 import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
 
@@ -164,7 +164,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
           onClick: () => {
             panelContext?.enterFullscreen();
           },
-          "data-test": "panel-settings-fullscreen",
+          "data-test": "panel-menu-fullscreen",
           iconProps: {
             iconName: "FullScreenMaximize",
             styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
@@ -195,7 +195,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
       text: "Remove panel",
       onClick: close,
       iconProps: { iconName: "Delete" },
-      "data-test": "panel-settings-remove",
+      "data-test": "panel-menu-remove",
     });
     return items;
   }, [close, isUnknownPanel, openSettings, panelContext, split, swap]);
@@ -215,13 +215,8 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         target={buttonRef}
         onDismiss={() => setIsOpen(false)}
       />
-      <Icon
-        fade
-        tooltip="Panel settings"
-        dataTest="panel-settings"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <CogIcon className={styles.icon} />
+      <Icon fade tooltip="More" dataTest="panel-menu" onClick={() => setIsOpen(!isOpen)}>
+        <MenuIcon className={styles.icon} />
       </Icon>
     </div>
   );

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -1,0 +1,228 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { ContextualMenu, IContextualMenuItem, makeStyles } from "@fluentui/react";
+import CogIcon from "@mdi/svg/svg/cog.svg";
+import { useCallback, useContext, useMemo, useRef } from "react";
+import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
+
+import Icon from "@foxglove/studio-base/components/Icon";
+import PanelContext from "@foxglove/studio-base/components/PanelContext";
+import PanelList, { PanelSelection } from "@foxglove/studio-base/components/PanelList";
+import { getPanelTypeFromMosaic } from "@foxglove/studio-base/components/PanelToolbar/utils";
+import {
+  useCurrentLayoutActions,
+  useSelectedPanels,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+
+type Props = {
+  isOpen: boolean;
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setIsOpen: (_: boolean) => void;
+  isUnknownPanel: boolean;
+};
+
+const useStyles = makeStyles({
+  icon: {
+    fontSize: 14,
+    margin: "0 0.2em",
+  },
+});
+
+export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Props): JSX.Element {
+  const styles = useStyles();
+  const panelContext = useContext(PanelContext);
+  const tabId = panelContext?.tabId;
+  const { mosaicActions } = useContext(MosaicContext);
+  const { mosaicWindowActions } = useContext(MosaicWindowContext);
+  const {
+    getCurrentLayoutState: getCurrentLayout,
+    closePanel,
+    splitPanel,
+    swapPanel,
+  } = useCurrentLayoutActions();
+  const { setSelectedPanelIds } = useSelectedPanels();
+
+  const getPanelType = useCallback(
+    () => getPanelTypeFromMosaic(mosaicWindowActions, mosaicActions),
+    [mosaicActions, mosaicWindowActions],
+  );
+
+  const close = useCallback(() => {
+    closePanel({
+      tabId,
+      root: mosaicActions.getRoot() as MosaicNode<string>,
+      path: mosaicWindowActions.getPath(),
+    });
+  }, [closePanel, mosaicActions, mosaicWindowActions, tabId]);
+
+  const split = useCallback(
+    (id: string | undefined, direction: "row" | "column") => {
+      const type = getPanelType();
+      if (id == undefined || type == undefined) {
+        throw new Error("Trying to split unknown panel!");
+      }
+
+      const config = getCurrentLayout().selectedLayout?.data?.configById[id] ?? {};
+      splitPanel({
+        id,
+        tabId,
+        direction,
+        root: mosaicActions.getRoot() as MosaicNode<string>,
+        path: mosaicWindowActions.getPath(),
+        config,
+      });
+    },
+    [getCurrentLayout, getPanelType, mosaicActions, mosaicWindowActions, splitPanel, tabId],
+  );
+
+  const swap = useCallback(
+    (id?: string) =>
+      ({ type, config, relatedConfigs }: PanelSelection) => {
+        // Reselecting current panel type is a no-op.
+        if (type === panelContext?.type) {
+          setIsOpen(false);
+          return;
+        }
+
+        swapPanel({
+          tabId,
+          originalId: id ?? "",
+          type,
+          root: mosaicActions.getRoot() as MosaicNode<string>,
+          path: mosaicWindowActions.getPath(),
+          config: config ?? {},
+          relatedConfigs,
+        });
+      },
+    [mosaicActions, mosaicWindowActions, panelContext?.type, setIsOpen, swapPanel, tabId],
+  );
+
+  const { openPanelSettings } = useWorkspace();
+  const openSettings = useCallback(() => {
+    if (panelContext?.id != undefined) {
+      setSelectedPanelIds([panelContext.id]);
+      openPanelSettings();
+    }
+  }, [setSelectedPanelIds, openPanelSettings, panelContext?.id]);
+
+  const menuItems: IContextualMenuItem[] = useMemo(() => {
+    const items: IContextualMenuItem[] = [
+      {
+        key: "settings",
+        text: "Panel settings",
+        onClick: openSettings,
+        iconProps: { iconName: "SingleColumnEdit" },
+        disabled: !(panelContext?.hasSettings ?? false),
+      },
+      {
+        key: "change-panel",
+        text: "Change panel",
+        onClick: openSettings,
+        iconProps: {
+          iconName: "ShapeSubtract",
+          styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
+        },
+        subMenuProps: {
+          items: [{ key: "dummy" }],
+          calloutProps: {
+            // https://github.com/foxglove/studio/issues/2205
+            // https://github.com/microsoft/fluentui/issues/18839
+            // Lie to the callout and tell it the height of the content so that it keeps the top
+            // edge anchored as the user searches panels and the PanelList changes height.
+            calloutMaxHeight: 310,
+            finalHeight: 310,
+            styles: {
+              calloutMain: { overflowY: "auto !important" },
+            },
+          },
+          onRenderMenuList: () => (
+            <PanelList
+              selectedPanelTitle={panelContext?.title}
+              onPanelSelect={swap(panelContext?.id)}
+            />
+          ),
+        },
+      },
+    ];
+    if (!isUnknownPanel) {
+      items.push(
+        {
+          key: "fullscreen",
+          text: "Fullscreen",
+          onClick: () => {
+            panelContext?.enterFullscreen();
+          },
+          "data-test": "panel-settings-fullscreen",
+          iconProps: {
+            iconName: "FullScreenMaximize",
+            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
+          },
+        },
+        {
+          key: "hsplit",
+          text: "Split horizontal",
+          onClick: () => split(panelContext?.id, "column"),
+          iconProps: {
+            iconName: "SplitHorizontal",
+            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
+          },
+        },
+        {
+          key: "vsplit",
+          text: "Split vertical",
+          onClick: () => split(panelContext?.id, "row"),
+          iconProps: {
+            iconName: "SplitVertical",
+            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
+          },
+        },
+      );
+    }
+    items.push({
+      key: "remove",
+      text: "Remove panel",
+      onClick: close,
+      iconProps: { iconName: "Delete" },
+      "data-test": "panel-settings-remove",
+    });
+    return items;
+  }, [close, isUnknownPanel, openSettings, panelContext, split, swap]);
+
+  const buttonRef = useRef<HTMLDivElement>(ReactNull);
+
+  const type = getPanelType();
+  if (type == undefined) {
+    return <></>;
+  }
+
+  return (
+    <div ref={buttonRef}>
+      <ContextualMenu
+        hidden={!isOpen}
+        items={menuItems}
+        target={buttonRef}
+        onDismiss={() => setIsOpen(false)}
+      />
+      <Icon
+        fade
+        tooltip="Panel settings"
+        dataTest="panel-settings"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <CogIcon className={styles.icon} />
+      </Icon>
+    </div>
+  );
+}

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { makeStyles } from "@fluentui/react";
+import DragIcon from "@mdi/svg/svg/drag.svg";
+import cx from "classnames";
+import { useContext } from "react";
+
+import Icon from "@foxglove/studio-base/components/Icon";
+import PanelContext from "@foxglove/studio-base/components/PanelContext";
+
+import { PanelActionsDropdown } from "./PanelActionsDropdown";
+
+const PANEL_TOOLBAR_HEIGHT = 26;
+const PANEL_TOOLBAR_SPACING = 4;
+
+type PanelToolbarControlsProps = {
+  floating?: boolean;
+  additionalIcons?: React.ReactNode;
+  menuOpen: boolean;
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setMenuOpen: (_: boolean) => void;
+  showControls?: boolean;
+  showPanelName?: boolean;
+  isUnknownPanel: boolean;
+};
+
+const useStyles = makeStyles({
+  iconContainer: {
+    paddingTop: PANEL_TOOLBAR_SPACING,
+    display: "flex",
+    flex: "0 0 auto",
+    alignItems: "center",
+    marginLeft: PANEL_TOOLBAR_SPACING,
+    flexDirection: "row",
+    minHeight: PANEL_TOOLBAR_HEIGHT - PANEL_TOOLBAR_SPACING,
+    padding: "2px 2px 2px 6px",
+
+    svg: {
+      fontSize: 14,
+    },
+  },
+  panelName: {
+    fontSize: 10,
+    opacity: 0.5,
+    marginRight: 4,
+  },
+  icon: {
+    fontSize: 14,
+    margin: "0 0.2em",
+  },
+  dragIcon: {
+    cursor: "move",
+  },
+});
+
+// Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
+// whole PanelToolbar when only children change.
+export const PanelToolbarControls = React.memo(function PanelToolbarControls({
+  menuOpen,
+  setMenuOpen,
+  additionalIcons,
+  showControls = false,
+  floating = false,
+  isUnknownPanel,
+  showPanelName = false,
+}: PanelToolbarControlsProps) {
+  const panelContext = useContext(PanelContext);
+  const styles = useStyles();
+
+  return (
+    <div
+      style={showControls ? { display: "flex" } : {}}
+      className={cx(styles.iconContainer, {
+        panelToolbarHovered: !floating,
+      })}
+    >
+      {showPanelName && panelContext && (
+        <div className={styles.panelName}>{panelContext.title}</div>
+      )}
+      {additionalIcons}
+      <PanelActionsDropdown
+        isOpen={menuOpen}
+        setIsOpen={setMenuOpen}
+        isUnknownPanel={isUnknownPanel}
+      />
+      {!isUnknownPanel && panelContext?.connectToolbarDragHandle && (
+        <span ref={panelContext?.connectToolbarDragHandle} data-test="mosaic-drag-handle">
+          <Icon fade tooltip="Move panel (shortcut: ` or ~)">
+            <DragIcon className={cx(styles.icon, styles.dragIcon)} />
+          </Icon>
+        </span>
+      )}
+    </div>
+  );
+});

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -62,7 +62,7 @@ class PanelToolbarWithOpenMenu extends React.PureComponent<{ hideToolbars?: bool
           if (el) {
             // wait for Dimensions
             setTimeout(() => {
-              const gearIcon = el.querySelector("[data-test=panel-settings] > svg");
+              const gearIcon = el.querySelector("[data-test=panel-menu] > svg");
               gearIcon?.parentElement?.click();
             }, 100);
           }

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -10,29 +10,22 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { ContextualMenu, IContextualMenuItem, makeStyles } from "@fluentui/react";
+import { makeStyles } from "@fluentui/react";
 import AlertIcon from "@mdi/svg/svg/alert.svg";
-import CogIcon from "@mdi/svg/svg/cog.svg";
-import DragIcon from "@mdi/svg/svg/drag.svg";
 import FullscreenExitIcon from "@mdi/svg/svg/fullscreen-exit.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import cx from "classnames";
-import { useContext, useState, useCallback, useMemo, useRef } from "react";
-import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
+import { useContext, useState, useMemo } from "react";
 import { useResizeDetector } from "react-resize-detector";
 
 import Icon from "@foxglove/studio-base/components/Icon";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
-import PanelList, { PanelSelection } from "@foxglove/studio-base/components/PanelList";
-import { getPanelTypeFromMosaic } from "@foxglove/studio-base/components/PanelToolbar/utils";
-import {
-  useCurrentLayoutActions,
-  useSelectedPanels,
-} from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useHelpInfo } from "@foxglove/studio-base/context/HelpInfoContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import { PanelToolbarControls } from "./PanelToolbarControls";
 
 type Props = {
   children?: React.ReactNode;
@@ -44,29 +37,10 @@ type Props = {
   backgroundColor?: string;
 };
 
-export const PANEL_TOOLBAR_HEIGHT = 26;
-export const PANEL_TOOLBAR_SPACING = 4;
+const PANEL_TOOLBAR_HEIGHT = 26;
+const PANEL_TOOLBAR_SPACING = 4;
 
 const useStyles = makeStyles((theme) => ({
-  iconContainer: {
-    paddingTop: PANEL_TOOLBAR_SPACING,
-    display: "flex",
-    flex: "0 0 auto",
-    alignItems: "center",
-    marginLeft: PANEL_TOOLBAR_SPACING,
-    flexDirection: "row",
-    minHeight: PANEL_TOOLBAR_HEIGHT - PANEL_TOOLBAR_SPACING,
-    padding: "2px 2px 2px 6px",
-
-    svg: {
-      fontSize: 14,
-    },
-  },
-  panelName: {
-    fontSize: 10,
-    opacity: 0.5,
-    marginRight: 4,
-  },
   panelToolbarContainer: {
     transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
     display: "flex",
@@ -108,256 +82,7 @@ const useStyles = makeStyles((theme) => ({
     fontSize: 14,
     margin: "0 0.2em",
   },
-  dragIcon: {
-    cursor: "move",
-  },
 }));
-
-function PanelActionsDropdown({
-  isOpen,
-  setIsOpen,
-  isUnknownPanel,
-}: {
-  isOpen: boolean;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setIsOpen: (_: boolean) => void;
-  isUnknownPanel: boolean;
-}) {
-  const styles = useStyles();
-  const panelContext = useContext(PanelContext);
-  const tabId = panelContext?.tabId;
-  const { mosaicActions } = useContext(MosaicContext);
-  const { mosaicWindowActions } = useContext(MosaicWindowContext);
-  const {
-    getCurrentLayoutState: getCurrentLayout,
-    closePanel,
-    splitPanel,
-    swapPanel,
-  } = useCurrentLayoutActions();
-  const { setSelectedPanelIds } = useSelectedPanels();
-
-  const getPanelType = useCallback(
-    () => getPanelTypeFromMosaic(mosaicWindowActions, mosaicActions),
-    [mosaicActions, mosaicWindowActions],
-  );
-
-  const close = useCallback(() => {
-    closePanel({
-      tabId,
-      root: mosaicActions.getRoot() as MosaicNode<string>,
-      path: mosaicWindowActions.getPath(),
-    });
-  }, [closePanel, mosaicActions, mosaicWindowActions, tabId]);
-
-  const split = useCallback(
-    (id: string | undefined, direction: "row" | "column") => {
-      const type = getPanelType();
-      if (id == undefined || type == undefined) {
-        throw new Error("Trying to split unknown panel!");
-      }
-
-      const config = getCurrentLayout().selectedLayout?.data?.configById[id] ?? {};
-      splitPanel({
-        id,
-        tabId,
-        direction,
-        root: mosaicActions.getRoot() as MosaicNode<string>,
-        path: mosaicWindowActions.getPath(),
-        config,
-      });
-    },
-    [getCurrentLayout, getPanelType, mosaicActions, mosaicWindowActions, splitPanel, tabId],
-  );
-
-  const swap = useCallback(
-    (id?: string) =>
-      ({ type, config, relatedConfigs }: PanelSelection) => {
-        // Reselecting current panel type is a no-op.
-        if (type === panelContext?.type) {
-          setIsOpen(false);
-          return;
-        }
-
-        swapPanel({
-          tabId,
-          originalId: id ?? "",
-          type,
-          root: mosaicActions.getRoot() as MosaicNode<string>,
-          path: mosaicWindowActions.getPath(),
-          config: config ?? {},
-          relatedConfigs,
-        });
-      },
-    [mosaicActions, mosaicWindowActions, panelContext?.type, setIsOpen, swapPanel, tabId],
-  );
-
-  const { openPanelSettings } = useWorkspace();
-  const openSettings = useCallback(() => {
-    if (panelContext?.id != undefined) {
-      setSelectedPanelIds([panelContext.id]);
-      openPanelSettings();
-    }
-  }, [setSelectedPanelIds, openPanelSettings, panelContext?.id]);
-
-  const menuItems: IContextualMenuItem[] = useMemo(() => {
-    const items: IContextualMenuItem[] = [
-      {
-        key: "settings",
-        text: "Panel settings",
-        onClick: openSettings,
-        iconProps: { iconName: "SingleColumnEdit" },
-        disabled: !(panelContext?.hasSettings ?? false),
-      },
-      {
-        key: "change-panel",
-        text: "Change panel",
-        onClick: openSettings,
-        iconProps: {
-          iconName: "ShapeSubtract",
-          styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
-        },
-        subMenuProps: {
-          items: [{ key: "dummy" }],
-          calloutProps: {
-            // https://github.com/foxglove/studio/issues/2205
-            // https://github.com/microsoft/fluentui/issues/18839
-            // Lie to the callout and tell it the height of the content so that it keeps the top
-            // edge anchored as the user searches panels and the PanelList changes height.
-            calloutMaxHeight: 310,
-            finalHeight: 310,
-            styles: {
-              calloutMain: { overflowY: "auto !important" },
-            },
-          },
-          onRenderMenuList: () => (
-            <PanelList
-              selectedPanelTitle={panelContext?.title}
-              onPanelSelect={swap(panelContext?.id)}
-            />
-          ),
-        },
-      },
-    ];
-    if (!isUnknownPanel) {
-      items.push(
-        {
-          key: "fullscreen",
-          text: "Fullscreen",
-          onClick: () => {
-            panelContext?.enterFullscreen();
-          },
-          "data-test": "panel-settings-fullscreen",
-          iconProps: {
-            iconName: "FullScreenMaximize",
-            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
-          },
-        },
-        {
-          key: "hsplit",
-          text: "Split horizontal",
-          onClick: () => split(panelContext?.id, "column"),
-          iconProps: {
-            iconName: "SplitHorizontal",
-            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
-          },
-        },
-        {
-          key: "vsplit",
-          text: "Split vertical",
-          onClick: () => split(panelContext?.id, "row"),
-          iconProps: {
-            iconName: "SplitVertical",
-            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
-          },
-        },
-      );
-    }
-    items.push({
-      key: "remove",
-      text: "Remove panel",
-      onClick: close,
-      iconProps: { iconName: "Delete" },
-      "data-test": "panel-settings-remove",
-    });
-    return items;
-  }, [close, isUnknownPanel, openSettings, panelContext, split, swap]);
-
-  const buttonRef = useRef<HTMLDivElement>(ReactNull);
-
-  const type = getPanelType();
-  if (type == undefined) {
-    return ReactNull;
-  }
-
-  return (
-    <div ref={buttonRef}>
-      <ContextualMenu
-        hidden={!isOpen}
-        items={menuItems}
-        target={buttonRef}
-        onDismiss={() => setIsOpen(false)}
-      />
-      <Icon
-        fade
-        tooltip="Panel settings"
-        dataTest="panel-settings"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <CogIcon className={styles.icon} />
-      </Icon>
-    </div>
-  );
-}
-
-type PanelToolbarControlsProps = Pick<Props, "additionalIcons" | "floating"> & {
-  menuOpen: boolean;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setMenuOpen: (_: boolean) => void;
-  showControls?: boolean;
-  showPanelName?: boolean;
-  isUnknownPanel: boolean;
-};
-
-// Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
-// whole PanelToolbar when only children change.
-const PanelToolbarControls = React.memo(function PanelToolbarControls({
-  menuOpen,
-  setMenuOpen,
-  additionalIcons,
-  showControls = false,
-  floating = false,
-  isUnknownPanel,
-  showPanelName = false,
-}: PanelToolbarControlsProps) {
-  const panelContext = useContext(PanelContext);
-  const styles = useStyles();
-
-  return (
-    <div
-      style={showControls ? { display: "flex" } : {}}
-      className={cx(styles.iconContainer, {
-        panelToolbarHovered: !floating,
-      })}
-    >
-      {showPanelName && panelContext && (
-        <div className={styles.panelName}>{panelContext.title}</div>
-      )}
-      {additionalIcons}
-      <PanelActionsDropdown
-        isOpen={menuOpen}
-        setIsOpen={setMenuOpen}
-        isUnknownPanel={isUnknownPanel}
-      />
-      {!isUnknownPanel && panelContext?.connectToolbarDragHandle && (
-        <span ref={panelContext?.connectToolbarDragHandle} data-test="mosaic-drag-handle">
-          <Icon fade tooltip="Move panel (shortcut: ` or ~)">
-            <DragIcon className={cx(styles.icon, styles.dragIcon)} />
-          </Icon>
-        </span>
-      )}
-    </div>
-  );
-});
 
 // Panel toolbar should be added to any panel that's part of the
 // react-mosaic layout.  It adds a drag handle, remove/replace controls


### PR DESCRIPTION
**User-Facing Changes**

Change the panel toolbar cog icon to a menu icon.

| Before | After |
| --- | --- |
|<img width="219" alt="Screen Shot 2022-01-10 at 8 53 55 PM" src="https://user-images.githubusercontent.com/84792/148883599-ab4aea8b-5a2e-473e-b8ed-58a7335c6e17.png">|<img width="212" alt="Screen Shot 2022-01-10 at 8 54 04 PM" src="https://user-images.githubusercontent.com/84792/148883597-cb57a3fe-48e4-4f02-ac55-bd5b4fd0db5f.png">|

**Description**
The menu icon is more appropriate for this action because it opens a context menu. This better aligns the icon with the action.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
