### PR TITLE
Fix panel toolbar hover to reveal.

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -48,6 +48,7 @@ import Icon from "@foxglove/studio-base/components/Icon";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelErrorBoundary from "@foxglove/studio-base/components/PanelErrorBoundary";
+import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
 import {
   useCurrentLayoutActions,
   useSelectedPanels,
@@ -69,47 +70,7 @@ import {
   getPathFromNode,
   updateTabPanelLayout,
 } from "@foxglove/studio-base/util/layout";
-import { colors, spacing } from "@foxglove/studio-base/util/sharedStyleConstants";
-
-const PanelRoot = styled.div<{ fullscreen: boolean; selected: boolean }>`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
-  overflow: hidden;
-  z-index: ${({ fullscreen }) => (fullscreen ? 10000 : 1)};
-  background-color: ${({ theme }) => (theme.isInverted ? colors.DARK : colors.LIGHT)};
-  position: ${({ fullscreen }) => (fullscreen ? "fixed" : "relative")};
-  border: ${({ fullscreen }) => (fullscreen ? "4px solid rgba(110, 81, 238, 0.3)" : "none")};
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: ${({ fullscreen }) => (fullscreen ? spacing.PLAYBACK_CONTROL_HEIGHT : 0)};
-
-  // To use css to hide/show toolbars on hover we use a global panelToolbar class
-  // because the PanelToolbar component is currently added within each panels render
-  // function rather than handling by the panel HOC
-
-  .panelToolbarHovered {
-    display: none;
-  }
-  :hover .panelToolbarHovered {
-    display: flex;
-  }
-  :after {
-    content: "";
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    opacity: ${({ selected }) => (selected ? 1 : 0)};
-    border: 1px solid ${colors.ACCENT};
-    position: absolute;
-    pointer-events: none;
-    transition: ${({ selected }) =>
-      selected ? "opacity 0.125s ease-out" : "opacity 0.05s ease-out"};
-    z-index: 100000;
-  }
-`;
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 const ActionsOverlay = styled.div`
   cursor: pointer;

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -13,7 +13,6 @@
 
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { createGlobalStyle } from "styled-components";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
@@ -110,16 +109,9 @@ export const PanelNotFoundLight = Object.assign(PanelNotFound.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
 
-const PanelToolbarShown = createGlobalStyle`
-  .panelToolbarHovered {
-    display: flex !important;
-  }
-`;
-
 export const PanelWithError = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
-      <PanelToolbarShown />
       <PanelSetup
         panelCatalog={new MockPanelCatalog()}
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import styled from "styled-components";
+
+import { colors, spacing } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+// This is in a separate file to prevent circular import issues.
+export const PanelRoot = styled.div<{ fullscreen: boolean; selected: boolean }>`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  overflow: hidden;
+  z-index: ${({ fullscreen }) => (fullscreen ? 10000 : 1)};
+  background-color: ${({ theme }) => (theme.isInverted ? colors.DARK : colors.LIGHT)};
+  position: ${({ fullscreen }) => (fullscreen ? "fixed" : "relative")};
+  border: ${({ fullscreen }) => (fullscreen ? "4px solid rgba(110, 81, 238, 0.3)" : "none")};
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: ${({ fullscreen }) => (fullscreen ? spacing.PLAYBACK_CONTROL_HEIGHT : 0)};
+
+  :after {
+    content: "";
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: ${({ selected }) => (selected ? 1 : 0)};
+    border: 1px solid ${colors.ACCENT};
+    position: absolute;
+    pointer-events: none;
+    transition: ${({ selected }) =>
+      selected ? "opacity 0.125s ease-out" : "opacity 0.05s ease-out"};
+    z-index: 100000;
+  }
+`;

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -25,8 +25,10 @@ const PANEL_TOOLBAR_HEIGHT = 26;
 const PANEL_TOOLBAR_SPACING = 4;
 
 type PanelToolbarControlsProps = {
+  floating?: boolean;
   additionalIcons?: React.ReactNode;
   menuOpen: boolean;
+  mousePresent?: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setMenuOpen: (_: boolean) => void;
   showControls?: boolean;
@@ -66,18 +68,22 @@ const useStyles = makeStyles({
 // Keep controls, which don't change often, in a pure component in order to avoid re-rendering the
 // whole PanelToolbar when only children change.
 export const PanelToolbarControls = React.memo(function PanelToolbarControls({
-  menuOpen,
-  setMenuOpen,
   additionalIcons,
-  showControls = false,
+  floating = false,
   isUnknownPanel,
+  menuOpen,
+  mousePresent = false,
+  setMenuOpen,
+  showControls = false,
   showPanelName = false,
 }: PanelToolbarControlsProps) {
   const panelContext = useContext(PanelContext);
   const styles = useStyles();
 
+  const shouldShow = showControls ? true : floating ? true : mousePresent;
+
   return (
-    <div style={{ display: showControls ? "flex" : "none" }} className={cx(styles.iconContainer)}>
+    <div style={{ display: shouldShow ? "flex" : "none" }} className={cx(styles.iconContainer)}>
       {showPanelName && panelContext && (
         <div className={styles.panelName}>{panelContext.title}</div>
       )}

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -25,7 +25,6 @@ const PANEL_TOOLBAR_HEIGHT = 26;
 const PANEL_TOOLBAR_SPACING = 4;
 
 type PanelToolbarControlsProps = {
-  floating?: boolean;
   additionalIcons?: React.ReactNode;
   menuOpen: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
@@ -71,7 +70,6 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   setMenuOpen,
   additionalIcons,
   showControls = false,
-  floating = false,
   isUnknownPanel,
   showPanelName = false,
 }: PanelToolbarControlsProps) {
@@ -79,12 +77,7 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   const styles = useStyles();
 
   return (
-    <div
-      style={showControls ? { display: "flex" } : {}}
-      className={cx(styles.iconContainer, {
-        panelToolbarHovered: !floating,
-      })}
-    >
+    <div style={{ display: showControls ? "flex" : "none" }} className={cx(styles.iconContainer)}>
       {showPanelName && panelContext && (
         <div className={styles.panelName}>{panelContext.title}</div>
       )}

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -25,15 +25,15 @@ const PANEL_TOOLBAR_HEIGHT = 26;
 const PANEL_TOOLBAR_SPACING = 4;
 
 type PanelToolbarControlsProps = {
-  floating?: boolean;
   additionalIcons?: React.ReactNode;
+  floating?: boolean;
+  isUnknownPanel: boolean;
   menuOpen: boolean;
   mousePresent?: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setMenuOpen: (_: boolean) => void;
   showControls?: boolean;
   showPanelName?: boolean;
-  isUnknownPanel: boolean;
 };
 
 const useStyles = makeStyles({

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -107,7 +107,7 @@ storiesOf("components/PanelToolbar", module)
   .add("non-floating (narrow)", () => {
     return (
       <MosaicWrapper>
-        <PanelToolbar helpContent={<div />}>
+        <PanelToolbar alwaysVisible helpContent={<div />}>
           <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
             Some controls here
           </div>
@@ -119,7 +119,7 @@ storiesOf("components/PanelToolbar", module)
   .add("non-floating (wide with panel name)", () => {
     return (
       <MosaicWrapper width={500}>
-        <PanelToolbar helpContent={<div />}>
+        <PanelToolbar alwaysVisible helpContent={<div />}>
           <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
             Some controls here
           </div>
@@ -136,7 +136,7 @@ storiesOf("components/PanelToolbar", module)
     );
     return (
       <MosaicWrapper width={500}>
-        <PanelToolbar helpContent={<div />} additionalIcons={additionalIcons}>
+        <PanelToolbar helpContent={<div />} additionalIcons={additionalIcons} alwaysVisible>
           <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
             Some controls here
           </div>

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -15,13 +15,14 @@ import FullscreenExitIcon from "@mdi/svg/svg/fullscreen-exit.svg";
 import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import cx from "classnames";
-import { useContext, useState, useMemo } from "react";
+import { useContext, useState, useMemo, useRef } from "react";
 import { useResizeDetector } from "react-resize-detector";
 
 import Icon from "@foxglove/studio-base/components/Icon";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import { useHelpInfo } from "@foxglove/studio-base/context/HelpInfoContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
 
 import { PanelToolbarControls } from "./PanelToolbarControls";
 
@@ -156,28 +157,32 @@ export default React.memo<Props>(function PanelToolbar({
     refreshMode: "debounce",
   });
 
-  if (hideToolbars) {
-    return ReactNull;
-  }
-
   // floating toolbars only show when hovered - but hovering over a context menu would hide the toolbar
   // showToolbar is used to force-show elements even if not hovered
   const showToolbar = menuOpen || !!isUnknownPanel;
 
+  const containerRef = useRef<HTMLDivElement>(ReactNull);
+
+  const mousePresent = usePanelMousePresence(containerRef);
+  const shouldShow = floating ? showToolbar || mousePresent : true;
+
+  if (hideToolbars) {
+    return ReactNull;
+  }
+
   return (
     <div ref={sizeRef}>
       <div
+        ref={containerRef}
         className={cx(styles.panelToolbarContainer, {
-          panelToolbarHovered: floating,
           floating,
           hasChildren: Boolean(children),
         })}
-        style={showToolbar ? { display: "flex", backgroundColor } : { backgroundColor }}
+        style={{ backgroundColor, display: shouldShow ? "flex" : "none" }}
       >
         {children}
         <PanelToolbarControls
-          showControls={showToolbar}
-          floating={floating}
+          showControls={showToolbar || mousePresent}
           showPanelName={(width ?? 0) > 360}
           additionalIcons={additionalIconsWithHelp}
           isUnknownPanel={!!isUnknownPanel}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -182,7 +182,9 @@ export default React.memo<Props>(function PanelToolbar({
       >
         {children}
         <PanelToolbarControls
-          showControls={showToolbar || mousePresent}
+          showControls={showToolbar}
+          mousePresent={mousePresent}
+          floating={floating}
           showPanelName={(width ?? 0) > 360}
           additionalIcons={additionalIconsWithHelp}
           isUnknownPanel={!!isUnknownPanel}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -27,13 +27,14 @@ import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMouse
 import { PanelToolbarControls } from "./PanelToolbarControls";
 
 type Props = {
+  additionalIcons?: React.ReactNode;
+  alwaysVisible?: boolean;
+  backgroundColor?: string;
   children?: React.ReactNode;
   floating?: boolean;
   helpContent?: React.ReactNode;
-  additionalIcons?: React.ReactNode;
   hideToolbars?: boolean;
   isUnknownPanel?: boolean;
-  backgroundColor?: string;
 };
 
 const PANEL_TOOLBAR_HEIGHT = 26;
@@ -88,12 +89,13 @@ const useStyles = makeStyles((theme) => ({
 // and has a place to add custom controls via it's children property
 export default React.memo<Props>(function PanelToolbar({
   additionalIcons,
+  alwaysVisible = false,
+  backgroundColor,
   children,
   floating = false,
   helpContent,
   hideToolbars = false,
   isUnknownPanel = false,
-  backgroundColor,
 }: Props) {
   const styles = useStyles();
   const { isFullscreen, enterFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
@@ -164,7 +166,7 @@ export default React.memo<Props>(function PanelToolbar({
   const containerRef = useRef<HTMLDivElement>(ReactNull);
 
   const mousePresent = usePanelMousePresence(containerRef);
-  const shouldShow = floating ? showToolbar || mousePresent : true;
+  const shouldShow = alwaysVisible || (floating ? showToolbar || mousePresent : true);
 
   if (hideToolbars) {
     return ReactNull;
@@ -182,7 +184,7 @@ export default React.memo<Props>(function PanelToolbar({
       >
         {children}
         <PanelToolbarControls
-          showControls={showToolbar}
+          showControls={showToolbar || alwaysVisible}
           mousePresent={mousePresent}
           floating={floating}
           showPanelName={(width ?? 0) > 360}

--- a/packages/studio-base/src/hooks/usePanelMousePresence.tsx
+++ b/packages/studio-base/src/hooks/usePanelMousePresence.tsx
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MutableRefObject, useCallback, useEffect, useState } from "react";
+
+import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
+
+/**
+ * Tracks the presence of the mouse in the parent panel.
+ *
+ * @param ref The element to hide and show on panel hove
+ * @returns True if the mouse is currently within the parent panel.
+ */
+export function usePanelMousePresence(ref: MutableRefObject<HTMLElement | ReactNull>): boolean {
+  const [present, setPresent] = useState(false);
+
+  const listener = useCallback(
+    (ev: MouseEvent) => {
+      if (!ref.current) {
+        return;
+      }
+
+      if (ev.type === "mouseenter") {
+        setPresent(true);
+      } else {
+        setPresent(false);
+      }
+    },
+    [ref],
+  );
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    const parent: HTMLElement | ReactNull = element.closest(PanelRoot);
+    parent?.addEventListener("mouseenter", listener);
+    parent?.addEventListener("mouseleave", listener);
+
+    return () => {
+      parent?.removeEventListener("mouseenter", listener);
+      parent?.removeEventListener("mouseleave", listener);
+    };
+  }, [ref, listener]);
+
+  return present;
+}

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from "uuid";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import { LegacyButton } from "@foxglove/studio-base/components/LegacyStyledComponents";
 import { Item } from "@foxglove/studio-base/components/Menu";
+import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
 import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { CompressedImage, Image } from "@foxglove/studio-base/types/Messages";
 import Rpc from "@foxglove/studio-base/util/Rpc";
@@ -53,13 +54,6 @@ const useStyles = makeStyles((theme) => ({
     width: "100%",
     height: "100%",
     position: "relative",
-
-    "&:hover > [data-zoom-menu]": {
-      display: "block",
-    },
-    "&:hover > [data-magnify-icon]": {
-      display: "block",
-    },
   },
   magnify: {
     position: "absolute !important" as unknown as "absolute",
@@ -68,7 +62,6 @@ const useStyles = makeStyles((theme) => ({
     zIndex: 102,
     opacity: 1,
     backgroundColor: `${theme.palette.neutralLight} !important`,
-    display: "none",
 
     ".hoverScreenshot &": {
       display: "block",
@@ -94,7 +87,6 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.semanticColors.menuBackground,
     width: 145,
     borderRadius: "4%",
-    display: "none",
     boxShadow: theme.effects.elevation64,
 
     ".hoverScreenshot &": {
@@ -421,7 +413,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
 
   const zoomContextMenu = useMemo(() => {
     return (
-      <div className={classes.zoomContextMenu} data-zoom-menu>
+      <div className={classes.zoomContextMenu}>
         <div className={cx(classes.menuItem, classes.notInteractive)}>
           Scroll or use the buttons below to zoom
         </div>
@@ -538,6 +530,10 @@ export default function ImageCanvas(props: Props): JSX.Element {
       });
   }
 
+  const zoomRef = useRef<HTMLDivElement>(ReactNull);
+
+  const mousePresent = usePanelMousePresence(zoomRef);
+
   const keyDownHandlers = useMemo(() => {
     return {
       "=": zoomIn,
@@ -567,14 +563,12 @@ export default function ImageCanvas(props: Props): JSX.Element {
           items={[{ key: "download", text: "Download Image", onClick: onDownloadImage }]}
         />
       )}
-      {openZoomContext && zoomContextMenu}
-      <LegacyButton
-        className={classes.magnify}
-        onClick={() => setOpenZoomContext((old) => !old)}
-        data-magnify-icon
-      >
-        <MagnifyIcon />
-      </LegacyButton>
+      <div ref={zoomRef} style={{ visibility: mousePresent ? "visible" : "hidden" }}>
+        {openZoomContext && zoomContextMenu}
+        <LegacyButton className={classes.magnify} onClick={() => setOpenZoomContext((old) => !old)}>
+          <MagnifyIcon />
+        </LegacyButton>
+      </div>
     </div>
   );
 }

--- a/packages/studio-base/src/panels/ImageView/Toolbar.tsx
+++ b/packages/studio-base/src/panels/ImageView/Toolbar.tsx
@@ -3,13 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box, Stack, Typography } from "@mui/material";
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useEffect, useRef, useState } from "react";
 import Tree from "react-json-tree";
 
 import ExpandingToolbar, {
   ToolGroup,
   ToolGroupFixedSizePane,
 } from "@foxglove/studio-base/components/ExpandingToolbar";
+import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
 import { PixelData } from "@foxglove/studio-base/panels/ImageView/util";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -61,6 +62,7 @@ export function ObjectPane({ pixelData }: { pixelData: PixelData | undefined }):
 }
 
 export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JSX.Element {
+  const ref = useRef<HTMLDivElement>(ReactNull);
   const [selectedTab, setSelectedTab] = useState<TabName | undefined>();
 
   useEffect(() => {
@@ -69,15 +71,18 @@ export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JS
     }
   }, [pixelData]);
 
+  const mousePresent = usePanelMousePresence(ref);
+
   return (
     <Stack
-      data-pixel-inspector
+      ref={ref}
       sx={{
         position: "absolute",
         top: 0,
         right: 0,
         mr: 2,
         mt: 8,
+        visibility: mousePresent ? "visible" : "hidden",
         zIndex: "drawer",
       }}
     >

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -94,12 +94,6 @@ type Props = {
 const useStyles = makeStyles(() => ({
   root: {
     position: "relative",
-    "[data-pixel-inspector]": {
-      visibility: "hidden",
-    },
-    "&:hover > [data-pixel-inspector]": {
-      visibility: "visible",
-    },
   },
   controls: {
     display: "flex",


### PR DESCRIPTION
**User-Facing Changes**
This improves the hover interaction to hide & show toolbars in tab panels.

**Description**
This supplies a new `usePanelMousePresence` hook that tracks the presence of the mouse within the parent panel that can be used by child components to control their visibility.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2377 

https://user-images.githubusercontent.com/93935560/149392145-6027c167-142f-4bb6-ab91-9a6aeea77c00.mov
