### PR TITLE
Improve error message for failed remote bag requests

### DIFF
--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -100,3 +100,20 @@ export const ErrorWithJsxElementDetails = (): JSX.Element => {
 ErrorWithJsxElementDetails.parameters = { colorScheme: "light" };
 export const ErrorWithJsxElementDetailsDark = ErrorWithJsxElementDetails.bind(undefined);
 ErrorWithJsxElementDetailsDark.parameters = { colorScheme: "dark" };
+
+export const ErrorWithNewlineDetails = (): JSX.Element => {
+  return (
+    <NotificationModal
+      onRequestClose={() => {}}
+      notification={{
+        id: "1",
+        message: "Error 1",
+        details: "Some details.\n\nWith a newline.",
+        read: false,
+        created: new Date(),
+        severity: "error",
+      }}
+    />
+  );
+};
+ErrorWithNewlineDetails.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/NotificationModal.tsx
+++ b/packages/studio-base/src/components/NotificationModal.tsx
@@ -58,7 +58,9 @@ export default function NotificationModal({
           underlined={false}
         />
       ) : details != undefined && details !== "" ? (
-        <Text>{details}</Text>
+        <Text style={{ whiteSpace: "pre-line" /* allow newlines in the details message */ }}>
+          {details}
+        </Text>
       ) : (
         "No details provided"
       )}

--- a/packages/studio-base/src/util/BrowserHttpReader.ts
+++ b/packages/studio-base/src/util/BrowserHttpReader.ts
@@ -13,6 +13,7 @@
 
 import { FileReader, FileStream } from "@foxglove/studio-base/util/CachedFilelike";
 import FetchReader from "@foxglove/studio-base/util/FetchReader";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 // A file reader that reads from a remote HTTP URL, for usage in the browser (not for node.js).
 export default class BrowserHttpReader implements FileReader {
@@ -35,7 +36,14 @@ export default class BrowserHttpReader implements FileReader {
       response = await fetch(this._url, { signal: controller.signal });
       controller.abort();
     } catch (error) {
-      throw new Error(`Fetching remote file failed. <${this._url}> ${error}`);
+      let errMsg = `Fetching remote file failed. ${error}`;
+
+      if (!isDesktopApp()) {
+        errMsg +=
+          "Sometimes this is due to a CORS configuration error on the server. Make sure CORS is enabled.";
+      }
+
+      throw new Error(errMsg);
     }
     if (!response.ok) {
       throw new Error(
@@ -43,7 +51,15 @@ export default class BrowserHttpReader implements FileReader {
       );
     }
     if (response.headers.get("accept-ranges") !== "bytes") {
-      throw new Error(`Remote file does not support HTTP Range Requests. <${this._url}>`);
+      let errMsg =
+        "Support for HTTP Range requests was not detected on the remote file.\n\nConfirm the resource has an 'Accept-Ranges: bytes' header.";
+
+      if (!isDesktopApp()) {
+        errMsg +=
+          "\n\nSometimes this is due to a CORS configuration error on the server. Make sure CORS is enabled with Access-Control-Allow-Origin, and that Access-Control-Expose-Headers includes Accept-Ranges.";
+      }
+
+      throw new Error(errMsg);
     }
     const size = response.headers.get("content-length");
     if (size == undefined) {

--- a/packages/studio-base/src/util/BrowserHttpReader.ts
+++ b/packages/studio-base/src/util/BrowserHttpReader.ts
@@ -40,7 +40,7 @@ export default class BrowserHttpReader implements FileReader {
 
       if (!isDesktopApp()) {
         errMsg +=
-          "Sometimes this is due to a CORS configuration error on the server. Make sure CORS is enabled.";
+          "\n\nSometimes this is due to a CORS configuration error on the server. Make sure CORS is enabled.";
       }
 
       throw new Error(errMsg);


### PR DESCRIPTION


**User-Facing Changes**
When failing to load a remote url from a server, the user is shown an error message with more details on what might be misconfigured.

**Description**
In the web app, remote bag requests may fail due due to CORS errors. This change improves the error message to call out which parts of the CORS configuration should be verified to ensure compatability with studio.

Fixes: #2651

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
