### PR TITLE
Fix bounds jitter on synced plots.

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -456,7 +456,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
     // If we're the source of global bounds then use our current values
     // to avoid scale feedback jitter.
-    if (globalBounds?.sourceId === componentId) {
+    if (globalBounds?.sourceId === componentId && globalBounds.userInteraction) {
       return { min: undefined, max: undefined };
     }
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -454,6 +454,12 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       return { min: undefined, max: undefined };
     }
 
+    // If we're the source of global bounds then use our current values
+    // to avoid scale feedback jitter.
+    if (globalBounds?.sourceId === componentId) {
+      return { min: undefined, max: undefined };
+    }
+
     let min: number | undefined;
     let max: number | undefined;
 
@@ -491,6 +497,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
     return { min, max };
   }, [
+    componentId,
     currentTime,
     datasetBounds.x.max,
     datasetBounds.x.min,


### PR DESCRIPTION
**User-Facing Changes**
This improves user interactions on synced plots.

**Description**
The issue seems to be caused by a jittery feedback loop of zooming -> new global bounds being applied to the view with which the user is interacting. The fix here is to skip applying global bounds again to the view that's the source of the global bounds.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2639 