### PR TITLE
Increase top margin of image panel topic selector icon.

### DIFF
--- a/packages/studio-base/src/panels/ImageView/Toolbar.tsx
+++ b/packages/studio-base/src/panels/ImageView/Toolbar.tsx
@@ -70,7 +70,7 @@ export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JS
   }, [pixelData]);
 
   return (
-    <Stack sx={{ position: "absolute", top: 0, right: 0, mr: 2, mt: 6, zIndex: "drawer" }}>
+    <Stack sx={{ position: "absolute", top: 0, right: 0, mr: 2, mt: 8, zIndex: "drawer" }}>
       <ExpandingToolbar
         tooltip="Inspect objects"
         iconName="CursorDefault"


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with margins on the new image view inspector icon.

**Description**
This just increases the top margin of the icon. It's hard to do a more intelligent fix since the toolbar wraps and hence has unpredictable height.

<img width="379" alt="Screen Shot 2022-01-12 at 1 05 12 PM" src="https://user-images.githubusercontent.com/93935560/149213749-3f4aca2c-6b3e-4152-9e6b-b14a6cc765b2.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2658 