### PR TITLE
Improve image panel inspector UI.

### DIFF
--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -531,7 +531,11 @@ export default function ImageCanvas(props: Props): JSX.Element {
         x: x * devicePixelRatio,
         y: y * devicePixelRatio,
       })
-      .then((r) => props.setActivePixelData(r));
+      .then((r) => {
+        if (r?.marker) {
+          props.setActivePixelData(r);
+        }
+      });
   }
 
   const keyDownHandlers = useMemo(() => {

--- a/packages/studio-base/src/panels/ImageView/Toolbar.tsx
+++ b/packages/studio-base/src/panels/ImageView/Toolbar.tsx
@@ -70,7 +70,17 @@ export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JS
   }, [pixelData]);
 
   return (
-    <Stack sx={{ position: "absolute", top: 0, right: 0, mr: 2, mt: 8, zIndex: "drawer" }}>
+    <Stack
+      data-pixel-inspector
+      sx={{
+        position: "absolute",
+        top: 0,
+        right: 0,
+        mr: 2,
+        mt: 8,
+        zIndex: "drawer",
+      }}
+    >
       <ExpandingToolbar
         tooltip="Inspect objects"
         iconName="CursorDefault"

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -92,6 +92,15 @@ type Props = {
 };
 
 const useStyles = makeStyles(() => ({
+  root: {
+    position: "relative",
+    "[data-pixel-inspector]": {
+      visibility: "hidden",
+    },
+    "&:hover > [data-pixel-inspector]": {
+      visibility: "visible",
+    },
+  },
   controls: {
     display: "flex",
     flexWrap: "wrap",
@@ -639,7 +648,7 @@ function ImageView(props: Props) {
   const showEmptyState = !imageMessage || (shouldSynchronize && !synchronizedMessages);
 
   return (
-    <Flex col clip style={{ position: "relative" }}>
+    <Flex col clip className={classes.root}>
       {toolbar}
       <div style={{ display: "flex", flexDirection: "column", width: "100%", height: "100%" }}>
         {/* Always render the ImageCanvas because it's expensive to unmount and start up. */}


### PR DESCRIPTION
**User-Facing Changes**
This makes some quick improvements to the usability of the image view inspector.

**Description**
There are two changes here:
1. Only show the inspector when the image panel is hovered.
2. Only show the inspector when the user clicks on a marker, not just any pixel in the image.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
