### PR TITLE
Fix parameter updating

### DIFF
--- a/packages/studio-base/src/components/input/JSONInput.tsx
+++ b/packages/studio-base/src/components/input/JSONInput.tsx
@@ -11,24 +11,42 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { useTheme } from "@fluentui/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledComponents";
 
 const keyValMap: Record<string, number> = { ArrowDown: -1, ArrowUp: 1 };
 
+/**
+ * JSONInput displays a json value and allows the user to edit the value.
+ */
 export function JSONInput(props: {
   value: string;
   dataTest?: string;
-  onChange: (arg0: unknown) => void;
+  onChange: (newValue: unknown) => void;
 }): React.ReactElement {
   const theme = useTheme();
+
+  // The JSONInput is semi-controlled.
+  // We need to avoid updating the input text when the user is actively editing the input.
+  // The _internalValue_ is the latest value to display. When editing, the editingRef prevents
+  // updates to the internal value from new props. When not editing, new props can update the value.
   const [internalValue, setInternalValue] = useState<string>(props.value);
-  const lastPropsValue = useRef<string>(props.value);
-  if (lastPropsValue.current !== props.value) {
-    lastPropsValue.current = props.value;
+  const editingRef = useRef(false);
+
+  // keep track of the last prop value we've seen so if we leave edit mode with no changes
+  // we can update the input field to the value
+  const lastPropValueRef = useRef<string | undefined>(props.value);
+  lastPropValueRef.current = props.value;
+
+  useEffect(() => {
+    if (editingRef.current) {
+      return;
+    }
+
     setInternalValue(props.value);
-  }
+  }, [props.value]);
+
   const parsedValue = parseJson(internalValue);
   const isValid = parsedValue != undefined;
   return (
@@ -37,7 +55,19 @@ export function JSONInput(props: {
       data-test={props.dataTest ?? "json-input"}
       type="text"
       value={internalValue}
+      onFocus={() => {
+        editingRef.current = true;
+      }}
+      onBlur={() => {
+        editingRef.current = false;
+        // when we are done editing we might have an updated value to set
+        if (lastPropValueRef.current != undefined) {
+          setInternalValue(lastPropValueRef.current);
+        }
+      }}
       onChange={(e) => {
+        // we've updated out own value and don't want to use any intermediate value
+        lastPropValueRef.current = undefined;
         setInternalValue(e.target.value);
         const newParsedValue = parseJson(e.target.value);
         if (newParsedValue != undefined) {
@@ -48,6 +78,8 @@ export function JSONInput(props: {
         const val = keyValMap[e.key];
         if (typeof parsedValue === "number" && val != undefined) {
           const newParsedValue = parsedValue + val;
+
+          lastPropValueRef.current = undefined;
           setInternalValue(`${newParsedValue}`);
           props.onChange(newParsedValue);
         }

--- a/packages/studio-base/src/components/input/JSONInput.tsx
+++ b/packages/studio-base/src/components/input/JSONInput.tsx
@@ -66,7 +66,7 @@ export function JSONInput(props: {
         }
       }}
       onChange={(e) => {
-        // we've updated out own value and don't want to use any intermediate value
+        // we've updated our own value and don't want to use any intermediate value
         lastPropValueRef.current = undefined;
         setInternalValue(e.target.value);
         const newParsedValue = parseJson(e.target.value);

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -11,7 +11,6 @@ import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 export type DataSourceFactoryInitializeArgs = {
   metricsCollector: PlayerMetricsCollectorInterface;
   unlimitedMemoryCache: boolean;
-  rosHostname?: string;
   folder?: FileSystemDirectoryHandle;
   file?: File;
   files?: File[];

--- a/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
@@ -42,7 +42,11 @@ class Ros1SocketDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const hostname = args?.rosHostname ?? "localhost";
+    const hostname = args?.hostname ?? "localhost";
+    if (typeof hostname !== "string") {
+      throw new Error(`Unable to initialize Ros1. Invalid hostname ${hostname}`);
+    }
+
     return new Ros1Player({
       url,
       hostname,

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -84,7 +84,7 @@ export default class Ros1Player implements Player {
   private _emitTimer?: ReturnType<typeof setTimeout>;
 
   constructor({ url, hostname, metricsCollector }: Ros1PlayerOpts) {
-    log.info(`initializing Ros1Player (url=${url})`);
+    log.info(`initializing Ros1Player (url=${url}, hostname=${hostname})`);
     this._metricsCollector = metricsCollector;
     this._url = url;
     this._hostname = hostname;


### PR DESCRIPTION

**User-Facing Changes**
ROS1 Native connection users will receive parameter updates when connected to a remote machine (assuming their ROS_HOSTNAME is correct).

**Description**

This change fixes two issues. The first is with the Ros1DataSourceFactory. The factory was initializing the Ros1Player using the wrong argument name. The argument name is _hostname_ which matches the form field _id_ configured within the same factory.

The second change fixes JSONInput. JSONInput displays json to the user and allows them to edit the json. To accomplish this, the component has internal state that tracks the latest value of the value prop. It also had logic to update the state if the value was different from the prop. This set state was called in render producing a side effect.

Instead of setting the state in render and tracking the previous prop value with a ref, we track the _editing_ state and set the internal state value only when the user is not editing the component.

Fixes: #2644



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
