### PR TITLE
Add `displayName` to all React Contexts

### DIFF
--- a/desktop/renderer/context/NativeStorageContext.ts
+++ b/desktop/renderer/context/NativeStorageContext.ts
@@ -9,6 +9,7 @@ import { Storage } from "../../common/types";
 const NativeStorageContext = createContext<Storage | undefined>(
   (global as { storageBridge?: Storage }).storageBridge,
 );
+NativeStorageContext.displayName = "NativeStorageContext";
 
 export function useNativeStorage(): Storage {
   const nativeStorage = useContext(NativeStorageContext);

--- a/packages/studio-base/src/components/ChildToggle/index.tsx
+++ b/packages/studio-base/src/components/ChildToggle/index.tsx
@@ -42,6 +42,7 @@ type ContainsOpenProps = {
 
 // eslint-disable-next-line @foxglove/no-boolean-parameters
 const Context = React.createContext((_opening: boolean) => {});
+Context.displayName = "ChildToggleContainsOpenContext";
 
 // Component for detecting if any child component is opened or not. Handy for
 // not hiding things when there is a dropdown open or so.

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -137,6 +137,7 @@ function defaultRenderErrorDetails(props: ErrorRendererProps): JSX.Element {
 }
 
 export const HideErrorSourceLocations = createContext(false);
+HideErrorSourceLocations.displayName = "HideErrorSourceLocationsContext";
 
 export default class ErrorBoundary extends Component<PropsWithChildren<Props>, State> {
   override state: State = {

--- a/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.stories.tsx
@@ -54,6 +54,7 @@ class MockPanelCatalog implements PanelCatalog {
 }
 
 const MockHelpInfoContext = createContext<IHelpInfo | undefined>(undefined);
+MockHelpInfoContext.displayName = "MockHelpInfoContext";
 function MockHelpInfoProvider({ children }: React.PropsWithChildren<unknown>): JSX.Element {
   const helpInfo = useRef<HelpInfo>({ title: "Some title", content: <>Some help content</> });
   const helpInfoListeners = useRef(new Set<(_: HelpInfo) => void>());

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -66,6 +66,7 @@ export type MessagePipelineContext = {
 
 // exported only for MockMessagePipelineProvider
 export const ContextInternal = createSelectableContext<MessagePipelineContext>();
+ContextInternal.displayName = "MessagePipelineContext";
 
 /**
  * useMessagePipelineGetter returns a function to access the current message pipeline context.

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -34,6 +34,7 @@ export type PanelContextType<T> = {
 };
 // Context used for components to know which panel they are inside
 const PanelContext = React.createContext<PanelContextType<PanelConfig> | undefined>(undefined);
+PanelContext.displayName = "PanelContext";
 
 export function usePanelContext(): PanelContextType<PanelConfig> {
   const context = React.useContext(PanelContext);

--- a/packages/studio-base/src/context/AnalyticsContext.ts
+++ b/packages/studio-base/src/context/AnalyticsContext.ts
@@ -8,6 +8,7 @@ import IAnalytics from "@foxglove/studio-base/services/IAnalytics";
 import NullAnalytics from "@foxglove/studio-base/services/NullAnalytics";
 
 const AnalyticsContext = createContext<IAnalytics>(new NullAnalytics());
+AnalyticsContext.displayName = "AnalyticsContext";
 
 export function useAnalytics(): IAnalytics {
   return useContext(AnalyticsContext);

--- a/packages/studio-base/src/context/AppConfigurationContext.ts
+++ b/packages/studio-base/src/context/AppConfigurationContext.ts
@@ -22,6 +22,7 @@ export interface AppConfiguration {
 }
 
 const AppConfigurationContext = createContext<AppConfiguration | undefined>(undefined);
+AppConfigurationContext.displayName = "AppConfigurationContext";
 
 export function useAppConfiguration(): AppConfiguration {
   const storage = useContext(AppConfigurationContext);

--- a/packages/studio-base/src/context/AssetsContext.tsx
+++ b/packages/studio-base/src/context/AssetsContext.tsx
@@ -23,6 +23,7 @@ const AssetsContext = createContext<Assets>({
   },
   assets: [],
 });
+AssetsContext.displayName = "AssetsContext";
 
 export interface AssetLoader {
   /**

--- a/packages/studio-base/src/context/ConsoleApiContext.ts
+++ b/packages/studio-base/src/context/ConsoleApiContext.ts
@@ -7,6 +7,7 @@ import { createContext, useContext } from "react";
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 
 const ConsoleApiContext = createContext<ConsoleApi | undefined>(undefined);
+ConsoleApiContext.displayName = "ConsoleApiContext";
 
 function useConsoleApi(): ConsoleApi {
   const api = useContext(ConsoleApiContext);

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -101,6 +101,7 @@ export type SelectedPanelActions = {
 };
 
 const CurrentLayoutContext = createContext<ICurrentLayout | undefined>(undefined);
+CurrentLayoutContext.displayName = "CurrentLayoutContext";
 
 export function usePanelMosaicId(): string {
   return useGuaranteedContext(CurrentLayoutContext).mosaicId;

--- a/packages/studio-base/src/context/CurrentUserContext.ts
+++ b/packages/studio-base/src/context/CurrentUserContext.ts
@@ -24,6 +24,7 @@ const CurrentUserContext = createContext<CurrentUser>({
   signIn: () => {},
   signOut: async () => {},
 });
+CurrentUserContext.displayName = "CurrentUserContext";
 
 export function useCurrentUser(): CurrentUser {
   return useContext(CurrentUserContext);

--- a/packages/studio-base/src/context/ExtensionLoaderContext.ts
+++ b/packages/studio-base/src/context/ExtensionLoaderContext.ts
@@ -36,6 +36,7 @@ export interface ExtensionLoader {
 }
 
 const ExtensionLoaderContext = createContext<ExtensionLoader | undefined>(undefined);
+ExtensionLoaderContext.displayName = "ExtensionLoaderContext";
 
 export function useExtensionLoader(): ExtensionLoader {
   const extensionLoader = useContext(ExtensionLoaderContext);

--- a/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
+++ b/packages/studio-base/src/context/ExtensionMarketplaceContext.ts
@@ -26,6 +26,7 @@ export interface ExtensionMarketplace {
 }
 
 const ExtensionMarketplaceContext = createContext<ExtensionMarketplace | undefined>(undefined);
+ExtensionMarketplaceContext.displayName = "ExtensionMarketplaceContext";
 
 export function useExtensionMarketplace(): ExtensionMarketplace {
   const extensionMarketplace = useContext(ExtensionMarketplaceContext);

--- a/packages/studio-base/src/context/ExtensionRegistryContext.ts
+++ b/packages/studio-base/src/context/ExtensionRegistryContext.ts
@@ -20,6 +20,7 @@ export interface ExtensionRegistry {
 }
 
 const ExtensionRegistryContext = createContext<ExtensionRegistry | undefined>(undefined);
+ExtensionRegistryContext.displayName = "ExtensionRegistryContext";
 
 export function useExtensionRegistry(): ExtensionRegistry {
   const extensionRegistry = useContext(ExtensionRegistryContext);

--- a/packages/studio-base/src/context/HelpInfoContext.ts
+++ b/packages/studio-base/src/context/HelpInfoContext.ts
@@ -26,6 +26,7 @@ export type HelpInfoActions = {
 };
 
 const HelpInfoContext = createContext<IHelpInfo | undefined>(undefined);
+HelpInfoContext.displayName = "HelpInfoContext";
 
 export function useHelpInfo(): HelpInfoActions {
   const ctx = useGuaranteedContext(HelpInfoContext);

--- a/packages/studio-base/src/context/HoverValueContext.tsx
+++ b/packages/studio-base/src/context/HoverValueContext.tsx
@@ -26,6 +26,7 @@ type HoverValueContext = Readonly<{
 }>;
 
 const Context = createSelectableContext<HoverValueContext>();
+Context.displayName = "HoverValueContext";
 
 export function useClearHoverValue(): HoverValueContext["clearHoverValue"] {
   return useContextSelector(

--- a/packages/studio-base/src/context/LayoutManagerContext.ts
+++ b/packages/studio-base/src/context/LayoutManagerContext.ts
@@ -7,6 +7,7 @@ import { createContext, useContext } from "react";
 import { ILayoutManager } from "@foxglove/studio-base/services/ILayoutManager";
 
 const LayoutManagerContext = createContext<ILayoutManager | undefined>(undefined);
+LayoutManagerContext.displayName = "LayoutManagerContext";
 
 export function useLayoutManager(): ILayoutManager {
   const ctx = useContext(LayoutManagerContext);

--- a/packages/studio-base/src/context/LayoutStorageContext.ts
+++ b/packages/studio-base/src/context/LayoutStorageContext.ts
@@ -7,6 +7,7 @@ import { createContext, useContext } from "react";
 import { ILayoutStorage } from "@foxglove/studio-base/services/ILayoutStorage";
 
 const LayoutStorageContext = createContext<ILayoutStorage | undefined>(undefined);
+LayoutStorageContext.displayName = "LayoutStorageContext";
 
 export function useLayoutStorage(): ILayoutStorage {
   const ctx = useContext(LayoutStorageContext);

--- a/packages/studio-base/src/context/LayoutStorageDebuggingContext.ts
+++ b/packages/studio-base/src/context/LayoutStorageDebuggingContext.ts
@@ -15,4 +15,7 @@ type ILayoutStorageDebugging = {
   injectDelete: (id: LayoutID) => Promise<void>;
 };
 
-export default createContext<ILayoutStorageDebugging | undefined>(undefined);
+const LayoutStorageDebuggingContext = createContext<ILayoutStorageDebugging | undefined>(undefined);
+LayoutStorageDebuggingContext.displayName = "LayoutStorageDebuggingContext";
+
+export default LayoutStorageDebuggingContext;

--- a/packages/studio-base/src/context/LinkHandlerContext.ts
+++ b/packages/studio-base/src/context/LinkHandlerContext.ts
@@ -5,4 +5,7 @@ import { createContext } from "react";
 
 // This context provides a function that handles link clicks, for example to handle app-internal
 // links by showing a modal dialog rather than actualy navigating.
-export default createContext<(event: React.MouseEvent, href: string) => void>(() => {});
+const LinkHandlerContext = createContext<(event: React.MouseEvent, href: string) => void>(() => {});
+LinkHandlerContext.displayName = "LinkHandlerContext";
+
+export default LinkHandlerContext;

--- a/packages/studio-base/src/context/ModalContext.ts
+++ b/packages/studio-base/src/context/ModalContext.ts
@@ -6,10 +6,13 @@ import { createContext } from "react";
 
 // The ModalContext provides a hook to render elements inside a modal host -- this is usually a
 // provider of a theme that modal elements also need to access.
-export default createContext<{
+const ModalContext = createContext<{
   // Add an element to the modal host.
   // Returns a function to remove the added element.
   addModalElement: (_: React.ReactNode) => () => void;
 }>({
   addModalElement: () => () => {},
 });
+ModalContext.displayName = "ModalContext";
+
+export default ModalContext;

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -28,6 +28,7 @@ export interface NativeAppMenu {
 }
 
 const NativeAppMenuContext = createContext<NativeAppMenu | undefined>(undefined);
+NativeAppMenuContext.displayName = "NativeAppMenuContext";
 
 export function useNativeAppMenu(): NativeAppMenu | undefined {
   return useContext(NativeAppMenuContext);

--- a/packages/studio-base/src/context/NativeWindowContext.ts
+++ b/packages/studio-base/src/context/NativeWindowContext.ts
@@ -10,6 +10,7 @@ export interface NativeWindow {
 }
 
 const NativeWindowContext = createContext<NativeWindow | undefined>(undefined);
+NativeWindowContext.displayName = "NativeWindowContext";
 
 export function useNativeWindow(): NativeWindow | undefined {
   return useContext(NativeWindowContext);

--- a/packages/studio-base/src/context/PanelCatalogContext.ts
+++ b/packages/studio-base/src/context/PanelCatalogContext.ts
@@ -44,6 +44,7 @@ export interface PanelCatalog {
 }
 
 const PanelCatalogContext = createContext<PanelCatalog | undefined>(undefined);
+PanelCatalogContext.displayName = "PanelCatalogContext";
 
 export function usePanelCatalog(): PanelCatalog {
   const panelCatalog = useContext(PanelCatalogContext);

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -95,6 +95,7 @@ const PlayerSelectionContext = createContext<PlayerSelection>({
   availableSources: [],
   recentSources: [],
 });
+PlayerSelectionContext.displayName = "PlayerSelectionContext";
 
 export function usePlayerSelection(): PlayerSelection {
   return useContext(PlayerSelectionContext);

--- a/packages/studio-base/src/context/RemoteLayoutStorageContext.ts
+++ b/packages/studio-base/src/context/RemoteLayoutStorageContext.ts
@@ -7,6 +7,7 @@ import { createContext, useContext } from "react";
 import { IRemoteLayoutStorage } from "@foxglove/studio-base/services/IRemoteLayoutStorage";
 
 const RemoteLayoutStorageContext = createContext<IRemoteLayoutStorage | undefined>(undefined);
+RemoteLayoutStorageContext.displayName = "RemoteLayoutStorageContext";
 
 export function useRemoteLayoutStorage(): IRemoteLayoutStorage | undefined {
   return useContext(RemoteLayoutStorageContext);

--- a/packages/studio-base/src/context/UserNodeStateContext.tsx
+++ b/packages/studio-base/src/context/UserNodeStateContext.tsx
@@ -29,6 +29,7 @@ export const UserNodeStateContext = createContext<
     }
   | undefined
 >(undefined);
+UserNodeStateContext.displayName = "UserNodeStateContext";
 
 export function UserNodeStateProvider({ children }: React.PropsWithChildren<unknown>): JSX.Element {
   const [state, setState] = useState<UserNodeState>({ rosLib: ros_lib_dts, nodeStates: {} });

--- a/packages/studio-base/src/context/UserProfileStorageContext.ts
+++ b/packages/studio-base/src/context/UserProfileStorageContext.ts
@@ -17,6 +17,7 @@ export type UserProfileStorage = {
 };
 
 export const UserProfileStorageContext = createContext<UserProfileStorage | undefined>(undefined);
+UserProfileStorageContext.displayName = "UserProfileStorageContext";
 
 export function useUserProfileStorage(): UserProfileStorage {
   const storage = useContext(UserProfileStorageContext);

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -19,6 +19,7 @@ export const WorkspaceContext = createContext({
     throw new Error("Must be in a WorkspaceContext.Provider to open layout browser");
   },
 });
+WorkspaceContext.displayName = "WorkspaceContext";
 
 export function useWorkspace(): {
   panelSettingsOpen: boolean;

--- a/packages/studio-base/src/panels/Tab/TabDndContext.ts
+++ b/packages/studio-base/src/panels/Tab/TabDndContext.ts
@@ -31,3 +31,4 @@ export type TabActions = {
 export const TabDndContext = createContext<{
   preventTabDrop: boolean;
 }>({ preventTabDrop: false });
+TabDndContext.displayName = "TabDndContext";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/ThreeDimensionalVizContext.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/ThreeDimensionalVizContext.ts
@@ -44,3 +44,4 @@ export const ThreeDimensionalVizContext = React.createContext<{
   colorOverrideByVariable: {},
   setColorOverrideByVariable: noop,
 });
+ThreeDimensionalVizContext.displayName = "ThreeDimensionalVizContext";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/useTopicTree.ts
@@ -729,3 +729,4 @@ export default function useTopicTree({
 }
 
 export const TopicTreeContext = createContext<UseTreeOutput | undefined>(undefined);
+TopicTreeContext.displayName = "TopicTreeContext";

--- a/packages/studio-base/src/panels/WelcomePanel/SubscribeContext.ts
+++ b/packages/studio-base/src/panels/WelcomePanel/SubscribeContext.ts
@@ -9,6 +9,7 @@ import subscribeToNewsletter from "./subscribeToNewsletter";
 type SubscribeNewsletterFn = (email: string) => Promise<void> | void;
 
 const SubscribeContext = createContext<SubscribeNewsletterFn>(subscribeToNewsletter);
+SubscribeContext.displayName = "SubscribeContext";
 
 function useSubscribeContext(): SubscribeNewsletterFn {
   return useContext(SubscribeContext);

--- a/packages/studio-base/src/stories/ReadySignalContext.ts
+++ b/packages/studio-base/src/stories/ReadySignalContext.ts
@@ -7,6 +7,7 @@ import { createContext, useCallback, useContext, useRef } from "react";
 type ReadySignal = () => void;
 
 const ReadySignalContext = createContext<ReadySignal | undefined>(undefined);
+ReadySignalContext.displayName = "ReadySignalContext";
 
 /**
  * useReadySignal returns a function that can be called to indicate a story is ready to be captured

--- a/packages/studio-base/src/util/createSelectableContext.tsx
+++ b/packages/studio-base/src/util/createSelectableContext.tsx
@@ -32,6 +32,7 @@ export type SelectableContextHandle<T> = {
 export type SelectableContext<T> = {
   readonly Provider: ComponentType<{ value: T; children?: ReactNode }>;
   readonly _ctx: Context<SelectableContextHandle<T> | undefined>;
+  displayName?: string;
 };
 
 // Create a context for use with useContextSelector
@@ -74,5 +75,14 @@ export default function createSelectableContext<T>(): SelectableContext<T> {
   return {
     Provider,
     _ctx: ctx,
+
+    // eslint-disable-next-line no-restricted-syntax
+    get displayName() {
+      return ctx.displayName;
+    },
+    // eslint-disable-next-line no-restricted-syntax
+    set displayName(value) {
+      ctx.displayName = value;
+    },
   };
 }

--- a/packages/studio-base/src/util/createSelectableContext.tsx
+++ b/packages/studio-base/src/util/createSelectableContext.tsx
@@ -72,17 +72,20 @@ export default function createSelectableContext<T>(): SelectableContext<T> {
     return <ctx.Provider value={handle}>{children}</ctx.Provider>;
   }
 
+  let displayName: string | undefined;
   return {
     Provider,
     _ctx: ctx,
 
     // eslint-disable-next-line no-restricted-syntax
     get displayName() {
-      return ctx.displayName;
+      return displayName;
     },
     // eslint-disable-next-line no-restricted-syntax
     set displayName(value) {
-      ctx.displayName = value;
+      displayName = value;
+      ctx.displayName = `${value}.Impl`;
+      Object.assign(Provider, { displayName: `${value}.Provider` });
     },
   };
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Improves component tree readability in the react dev tools.

before | after
--- | ---
<img width="431" alt="Screen Shot 2022-01-12 at 4 03 20 PM" src="https://user-images.githubusercontent.com/14237/149242328-da27ef90-52e2-4c16-a9c0-12a52b0c5070.png"> | <img width="520" alt="Screen Shot 2022-01-12 at 4 02 26 PM" src="https://user-images.githubusercontent.com/14237/149242318-6d48a5a0-96f9-4630-b7d7-1ef3cc3f856f.png">