### PR TITLE
Remove fullscreen entry from panel toolbar context menu

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -189,8 +189,7 @@ export const FullScreen = (): JSX.Element => {
         omitDragAndDrop
         onMount={() => {
           setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
-            (document.querySelectorAll("[data-test=panel-menu-fullscreen]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-toolbar-fullscreen]")[0] as any).click();
           }, DEFAULT_CLICK_DELAY);
         }}
       >

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -159,18 +159,6 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
     if (!isUnknownPanel) {
       items.push(
         {
-          key: "fullscreen",
-          text: "Fullscreen",
-          onClick: () => {
-            panelContext?.enterFullscreen();
-          },
-          "data-test": "panel-menu-fullscreen",
-          iconProps: {
-            iconName: "FullScreenMaximize",
-            styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
-          },
-        },
-        {
           key: "hsplit",
           text: "Split horizontal",
           onClick: () => split(panelContext?.id, "column"),

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -124,7 +124,12 @@ export default React.memo<Props>(function PanelToolbar({
           </Icon>
         )}
         {isFullscreen === false && (
-          <Icon fade tooltip="Fullscreen" onClick={enterFullscreen}>
+          <Icon
+            fade
+            tooltip="Fullscreen"
+            dataTest="panel-toolbar-fullscreen"
+            onClick={enterFullscreen}
+          >
             <FullscreenIcon />
           </Icon>
         )}


### PR DESCRIPTION


**User-Facing Changes**
The fullscreen item is removed from the panel toolbar context menu.

**Description**
The panel toolbar already has a fullscreen icon for quick access. Having this in the context menu is redundant.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
