### PR TITLE
Split up key handlers to stabilize handlers during user interactions.

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -486,6 +486,8 @@ export default function Panel<
       [cmdKeyPressed, parentPanelContext],
     );
 
+    // We use two separate sets of key handlers because the panel context and exitFullScreen
+    // change often and invalidate our key handlers during user interactions.
     const { keyUpHandlers, keyDownHandlers } = useMemo(
       () => ({
         keyUpHandlers: {
@@ -504,11 +506,17 @@ export default function Panel<
           "`": () => setQuickActionsKeyPressed(true),
           "~": () => setQuickActionsKeyPressed(true),
           Shift: () => setShiftKeyPressed(true),
-          Escape: () => exitFullscreen(),
           Meta: () => setCmdKeyPressed(true),
         },
       }),
-      [selectAllPanels, cmdKeyPressed, exitFullscreen],
+      [selectAllPanels, cmdKeyPressed],
+    );
+
+    const fullScreenKeyHandlers = useMemo(
+      () => ({
+        Escape: () => exitFullscreen(),
+      }),
+      [exitFullscreen],
     );
 
     /* Ensure user exits full-screen mode when leaving window, even if key is still pressed down */
@@ -589,6 +597,7 @@ export default function Panel<
           }}
         >
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
+          <KeyListener global keyDownHandlers={fullScreenKeyHandlers} />
           <PanelRoot
             onClick={onPanelRootClick}
             onMouseMove={onMouseMove}


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the hotkey overlay in tab panels.

**Description**
The issue was that key handlers were being uninstalled and reinstalled during a user interaction and this prevented the panels from receiving coherent state updates. The solution here is to split out the frequently changing key handlers into a separate set of handlers.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2666 