### PR TITLE
Wrap datasource timestamps in narrow views.

### DIFF
--- a/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
@@ -67,7 +67,7 @@ function DataSourceInfo(): JSX.Element {
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>Start time</Text>
         {startTime ? (
-          <Timestamp horizontal time={startTime} />
+          <Timestamp horizontal time={startTime} wrap />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
             &mdash;
@@ -78,7 +78,7 @@ function DataSourceInfo(): JSX.Element {
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>End time</Text>
         {endTime ? (
-          <Timestamp horizontal time={endTime} />
+          <Timestamp horizontal time={endTime} wrap />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
             &mdash;

--- a/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/ConnectionList/DataSourceInfo.tsx
@@ -67,7 +67,7 @@ function DataSourceInfo(): JSX.Element {
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>Start time</Text>
         {startTime ? (
-          <Timestamp horizontal time={startTime} wrap />
+          <Timestamp horizontal time={startTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
             &mdash;
@@ -78,7 +78,7 @@ function DataSourceInfo(): JSX.Element {
       <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
         <Text styles={subheaderStyles}>End time</Text>
         {endTime ? (
-          <Timestamp horizontal time={endTime} wrap />
+          <Timestamp horizontal time={endTime} />
         ) : (
           <Text variant="small" styles={{ root: { color: theme.palette.neutralSecondary } }}>
             &mdash;

--- a/packages/studio-base/src/components/Timestamp.tsx
+++ b/packages/studio-base/src/components/Timestamp.tsx
@@ -16,6 +16,7 @@ type Props = {
   horizontal?: boolean;
   time: Time;
   timezone?: string;
+  wrap?: boolean;
 };
 
 const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
@@ -26,7 +27,7 @@ function isAbsoluteTime(time: Time): boolean {
 }
 
 export default function Timestamp(props: Props): JSX.Element {
-  const { disableDate = false, horizontal = false, time, timezone } = props;
+  const { disableDate = false, horizontal = false, time, timezone, wrap } = props;
   const theme = useTheme();
   const { formatTime } = useAppTimeFormat();
   const currentTimeStr = useMemo(() => formatTime(time), [time, formatTime]);
@@ -55,8 +56,9 @@ export default function Timestamp(props: Props): JSX.Element {
     <Stack tokens={{ childrenGap: theme.spacing.s2 }}>
       <Stack
         horizontal={horizontal}
-        verticalAlign="center"
         tokens={{ childrenGap: theme.spacing.s2 }}
+        verticalAlign="center"
+        wrap={wrap}
       >
         {!disableDate && (
           <>

--- a/packages/studio-base/src/components/Timestamp.tsx
+++ b/packages/studio-base/src/components/Timestamp.tsx
@@ -16,7 +16,6 @@ type Props = {
   horizontal?: boolean;
   time: Time;
   timezone?: string;
-  wrap?: boolean;
 };
 
 const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
@@ -27,7 +26,7 @@ function isAbsoluteTime(time: Time): boolean {
 }
 
 export default function Timestamp(props: Props): JSX.Element {
-  const { disableDate = false, horizontal = false, time, timezone, wrap } = props;
+  const { disableDate = false, horizontal = false, time, timezone } = props;
   const theme = useTheme();
   const { formatTime } = useAppTimeFormat();
   const currentTimeStr = useMemo(() => formatTime(time), [time, formatTime]);
@@ -58,7 +57,7 @@ export default function Timestamp(props: Props): JSX.Element {
         horizontal={horizontal}
         tokens={{ childrenGap: theme.spacing.s2 }}
         verticalAlign="center"
-        wrap={wrap}
+        wrap
       >
         {!disableDate && (
           <>


### PR DESCRIPTION
**User-Facing Changes**
This improves rendering of datasource timestamps in narrow views.

**Description**
The approach here is to just wrap the text.

<img width="260" alt="Screen Shot 2022-01-14 at 11 35 25 AM" src="https://user-images.githubusercontent.com/93935560/149571528-dcc8dc30-9554-426b-b671-5662e38fa323.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2507 