### PR TITLE
Mimic ROS2 publisher QoS profile when subscribing

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -39,7 +39,7 @@
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f",
     "@foxglove/regl-worldview": "2.0.1",
     "@foxglove/ros1": "1.4.0",
-    "@foxglove/ros2": "2.0.0",
+    "@foxglove/ros2": "3.0.1",
     "@foxglove/rosbag": "0.1.2",
     "@foxglove/rosbag2-web": "4.0.3",
     "@foxglove/rosmsg": "3.0.0",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -39,7 +39,7 @@
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f",
     "@foxglove/regl-worldview": "2.0.1",
     "@foxglove/ros1": "1.4.0",
-    "@foxglove/ros2": "1.0.8",
+    "@foxglove/ros2": "2.0.0",
     "@foxglove/rosbag": "0.1.2",
     "@foxglove/rosbag2-web": "4.0.3",
     "@foxglove/rosmsg": "3.0.0",

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -170,7 +170,7 @@ export default class Ros2Player implements Player {
       for (const [topic, endpoints] of rosNode.getPublishedTopics().entries()) {
         const dataTypes = new Set<string>();
         for (const endpoint of endpoints) {
-          dataTypes.add(endpoint.dataType);
+          dataTypes.add(endpoint.rosDataType);
         }
         const dataType = dataTypes.values().next().value as string;
         if (dataTypes.size > 1) {
@@ -184,6 +184,8 @@ export default class Ros2Player implements Player {
         } else {
           this._problems.removeProblem(`subscription:${topic}`);
         }
+
+        topics.push({ name: topic, datatype: dataType });
       }
 
       // Sort them for easy comparison
@@ -276,6 +278,7 @@ export default class Ros2Player implements Player {
       presence: this._presence,
       progress: {},
       capabilities: CAPABILITIES,
+      name: "ROS2",
       playerId: this._id,
       problems: this._problems.problems(),
 

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { isEqual, sortBy } from "lodash";
+import { debounce } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { Sockets } from "@foxglove/electron-socket/renderer";
@@ -12,6 +13,7 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { definitions as foxgloveDefs } from "@foxglove/rosmsg-msgs-foxglove";
 import { Time, fromMillis } from "@foxglove/rostime";
+import { Reliability } from "@foxglove/rtps";
 import { ParameterValue } from "@foxglove/studio";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
@@ -68,7 +70,7 @@ export default class Ros2Player implements Player {
   private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
   private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
   private _messageOrder: TimestampMethod = "receiveTime";
-  private _requestTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _requestTopics().
+  private _updateTopicsTimeout?: ReturnType<typeof setTimeout>; // setTimeout() handle for _updateTopics().
   private _hasReceivedMessage = false;
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
@@ -121,6 +123,9 @@ export default class Ros2Player implements Player {
       });
       this._rosNode = rosNode;
 
+      // When new publications are discovered, immediately call _updateTopics()
+      rosNode.on("discoveredPublication", (_pub) => debounce(() => this._updateTopics(), 500));
+
       // rosNode.on("paramUpdate", ({ key, value, prevValue, callerId }) => {
       //   log.debug("paramUpdate", key, value, prevValue, callerId);
       //   this._parameters = new Map(rosNode.parameters);
@@ -128,28 +133,15 @@ export default class Ros2Player implements Player {
     }
 
     await this._rosNode.start();
-    await this._requestTopics();
+
+    this._updateTopics();
     this._presence = PlayerPresence.PRESENT;
   };
 
-  private _addProblem(
-    id: string,
-    problem: PlayerProblem,
-    { skipEmit = false }: { skipEmit?: boolean } = {},
-  ): void {
+  private _addProblemAndEmit(id: string, problem: PlayerProblem): void {
     this._problems.addProblem(id, problem);
-    if (!skipEmit) {
-      this._emitState();
-    }
+    this._emitState();
   }
-
-  // private _clearProblem(id: string, skipEmit = false): void {
-  //   if (this._problems.removeProblem(id)) {
-  //     if (!skipEmit) {
-  //       this._emitState();
-  //     }
-  //   }
-  // }
 
   private _clearPublishProblems({ skipEmit = false }: { skipEmit?: boolean } = {}) {
     if (
@@ -164,9 +156,9 @@ export default class Ros2Player implements Player {
     }
   }
 
-  private _requestTopics = async (): Promise<void> => {
-    if (this._requestTopicsTimeout) {
-      clearTimeout(this._requestTopicsTimeout);
+  private _updateTopics = (): void => {
+    if (this._updateTopicsTimeout) {
+      clearTimeout(this._updateTopicsTimeout);
     }
     const rosNode = this._rosNode;
     if (!rosNode || this._closed) {
@@ -174,8 +166,27 @@ export default class Ros2Player implements Player {
     }
 
     try {
-      const topicArrays = rosNode.getPublishedTopics();
-      const topics = topicArrays.map(([name, datatype]) => ({ name, datatype }));
+      // Convert the map of topics to publication endpoints to a list of topics
+      const topics: Topic[] = [];
+      for (const [topic, endpoints] of rosNode.getPublishedTopics().entries()) {
+        const dataTypes = new Set<string>();
+        for (const endpoint of endpoints) {
+          dataTypes.add(endpoint.dataType);
+        }
+        const dataType = dataTypes.values().next().value as string;
+        if (dataTypes.size > 1) {
+          this._problems.addProblem(`subscription:${topic}`, {
+            severity: "warn",
+            message: `Multiple data types for topic "${topic}": ${Array.from(dataTypes).join(
+              ", ",
+            )}`,
+            tip: `Only data type "${dataType}" will be used`,
+          });
+        } else {
+          this._problems.removeProblem(`subscription:${topic}`);
+        }
+      }
+
       // Sort them for easy comparison
       const sortedTopics: Topic[] = sortBy(topics, "name");
 
@@ -185,10 +196,10 @@ export default class Ros2Player implements Player {
 
       if (!isEqual(sortedTopics, this._providerTopics)) {
         this._providerTopics = sortedTopics;
-      }
 
-      // Try subscribing again, since we might now be able to subscribe to some new topics.
-      this.setSubscriptions(this._requestedSubscriptions);
+        // Try subscribing again, since we might be able to subscribe to additional topics
+        this.setSubscriptions(this._requestedSubscriptions);
+      }
 
       // Subscribe to all parameters
       // try {
@@ -212,25 +223,21 @@ export default class Ros2Player implements Player {
       // }
 
       // Fetch the full graph topology
-      await this._updateConnectionGraph(rosNode);
+      this._updateConnectionGraph(rosNode);
 
       this._presence = PlayerPresence.PRESENT;
       this._emitState();
     } catch (error) {
       this._presence = PlayerPresence.INITIALIZING;
-      this._addProblem(
-        Problem.Connection,
-        {
-          severity: "error",
-          message: "ROS connection failed",
-          tip: `Ensure a ROS 2 DDS system is running on the local network and UDP multicast is supported`,
-          error,
-        },
-        { skipEmit: false },
-      );
+      this._addProblemAndEmit(Problem.Connection, {
+        severity: "error",
+        message: "ROS connection failed",
+        tip: `Ensure a ROS 2 DDS system is running on the local network and UDP multicast is supported`,
+        error,
+      });
     } finally {
-      // Regardless of what happens, request topics again in a little bit.
-      this._requestTopicsTimeout = setTimeout(this._requestTopics, 3000);
+      // Regardless of what happens, update topics again in a little bit
+      this._updateTopicsTimeout = setTimeout(this._updateTopics, 3000);
     }
   };
 
@@ -324,34 +331,58 @@ export default class Ros2Player implements Player {
     // Subscribe to additional topics used by Ros1Player itself
     this._addInternalSubscriptions(subscriptions);
 
-    // See what topics we actually can subscribe to.
+    // Filter down to topics we can actually subscribe to
     const availableTopicsByTopicName = getTopicsByTopicName(this._providerTopics ?? []);
     const topicNames = subscriptions
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
 
-    // Subscribe to all topics that we aren't subscribed to yet.
+    const publishedTopics = this._rosNode.getPublishedTopics();
+
+    // Subscribe to all topics that we aren't subscribed to yet
     for (const topicName of topicNames) {
-      const availTopic = availableTopicsByTopicName[topicName];
-      if (!availTopic || this._rosNode.subscriptions.has(topicName)) {
+      const availableTopic = availableTopicsByTopicName[topicName];
+      if (!availableTopic || this._rosNode.subscriptions.has(topicName)) {
         continue;
       }
+      const dataType = availableTopic.datatype;
 
-      const { datatype: dataType } = availTopic;
+      // Find the first reliable publisher for this topic to mimic its QoS profile
+      const rosEndpoint = publishedTopics
+        .get(topicName)
+        ?.find((pub) => pub.reliability.kind === Reliability.Reliable);
+      if (!rosEndpoint) {
+        this._problems.addProblem(`subscription:${topicName}`, {
+          severity: "warn",
+          message: `No reliable publisher for "${topicName}"`,
+          tip: `Best-effort subscriptions are not supported yet`,
+        });
+        continue;
+      } else {
+        this._problems.removeProblem(`subscription:${topicName}`);
+      }
 
       // Try to retrieve the ROS message definition for this topic
       let msgDefinition: RosMsgDefinition[] | undefined;
       try {
         msgDefinition = rosDatatypesToMessageDefinition(this._providerDatatypes, dataType);
+        this._problems.removeProblem(`msgdef:${topicName}`);
       } catch (error) {
-        this._addProblem(`msgdef:${topicName}`, {
+        this._problems.addProblem(`msgdef:${topicName}`, {
           severity: "warn",
           message: `Unknown message definition for "${topicName}"`,
           tip: `Only core ROS 2 data types are currently supported`,
         });
       }
 
-      const subscription = this._rosNode.subscribe({ topic: topicName, dataType, msgDefinition });
+      const subscription = this._rosNode.subscribe({
+        topic: topicName,
+        dataType,
+        durability: rosEndpoint.durability,
+        history: rosEndpoint.history,
+        reliability: rosEndpoint.reliability,
+        msgDefinition,
+      });
 
       subscription.on("message", (timestamp, message, data, _pub) =>
         this._handleMessage(topicName, timestamp, message, data.byteLength, true),
@@ -520,7 +551,7 @@ export default class Ros2Player implements Player {
     // }
   }
 
-  private async _updateConnectionGraph(_rosNode: RosNode): Promise<void> {
+  private _updateConnectionGraph(_rosNode: RosNode): void {
     //     try {
     //       const graph = await rosNode.getSystemState();
     //       if (

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -2,8 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { isEqual, sortBy } from "lodash";
-import { debounce } from "lodash";
+import { debounce, isEqual, sortBy } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { Sockets } from "@foxglove/electron-socket/renderer";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,15 +2360,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ros2@npm:1.0.8":
-  version: 1.0.8
-  resolution: "@foxglove/ros2@npm:1.0.8"
+"@foxglove/ros2@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@foxglove/ros2@npm:2.0.0"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
     "@foxglove/rosmsg2-serialization": ^1.0.5
-    "@foxglove/rtps": ^1.2.5
+    "@foxglove/rtps": ^1.4.0
     eventemitter3: ^4.0.7
-  checksum: 846763e1e6608d1e7f4ee6752d26adafe463abdd43cbc457de8dc7587ea499b9007f57d4517399b0db0027661d590a33ed221198dc03de38026dc1ecb12615f5
+  checksum: a53193098c88376e8e09795d91316b4cfe06fa73ca241b7660017c867b88bb4a303bb752271c83921c88126eca6832f156fe4f3cb731433690639ff8054f4c70
   languageName: node
   linkType: hard
 
@@ -2461,15 +2461,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rtps@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "@foxglove/rtps@npm:1.2.5"
+"@foxglove/rtps@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@foxglove/rtps@npm:1.4.0"
   dependencies:
     "@foxglove/cdr": ^2.0.0
-    "@foxglove/rostime": ^1.1.0
-    avl: ^1.5.2
+    "@foxglove/rostime": ^1.1.1
+    avl: ^1.5.3
     eventemitter3: ^4.0.7
-  checksum: 3d10b2aafe17bfa20f3421119b068e11ce72cb2b4fbb4eda07c367b7fffa9ceeff21e870a4c83e8fa28f5dccac4e45f9941571c09461a970b99b33f667f3f3b5
+  checksum: 420ab1d4c4e3ab04881a4ee5e7e7198f4e531f24bddc79fa8c585251167321dba966c8d348b79b94497286d705102f0fa371f7c74ca9f3e6939cd60c8a09a15e
   languageName: node
   linkType: hard
 
@@ -2497,7 +2497,7 @@ __metadata:
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f"
     "@foxglove/regl-worldview": 2.0.1
     "@foxglove/ros1": 1.4.0
-    "@foxglove/ros2": 1.0.8
+    "@foxglove/ros2": 2.0.0
     "@foxglove/rosbag": 0.1.2
     "@foxglove/rosbag2-web": 4.0.3
     "@foxglove/rosmsg": 3.0.0
@@ -7782,7 +7782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"avl@npm:^1.5.2":
+"avl@npm:^1.5.3":
   version: 1.5.3
   resolution: "avl@npm:1.5.3"
   checksum: 19ab9bff1eec3de86188313342fc8843e695db174aa355217ca2c0e2ec925a415f2c65d83c6772238c8d646cf6310cae5d92cc0ef5d76fc0348eef9c1eac06aa

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,15 +2360,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ros2@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@foxglove/ros2@npm:2.0.0"
+"@foxglove/ros2@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@foxglove/ros2@npm:3.0.1"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
     "@foxglove/rosmsg2-serialization": ^1.0.5
     "@foxglove/rtps": ^1.4.0
     eventemitter3: ^4.0.7
-  checksum: a53193098c88376e8e09795d91316b4cfe06fa73ca241b7660017c867b88bb4a303bb752271c83921c88126eca6832f156fe4f3cb731433690639ff8054f4c70
+  checksum: 88a4062a6c7e275069fb81b3b6d4ff0a011e70dbdd1b17292be1116eca8b35b8701d5477ed08bfbf958234d11e2ee07d7ca364e81e7cda37fc9df97cd91109fe
   languageName: node
   linkType: hard
 
@@ -2497,7 +2497,7 @@ __metadata:
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=3ab57caf1139c9ad4bcd756988d874caabd12f1f"
     "@foxglove/regl-worldview": 2.0.1
     "@foxglove/ros1": 1.4.0
-    "@foxglove/ros2": 2.0.0
+    "@foxglove/ros2": 3.0.1
     "@foxglove/rosbag": 0.1.2
     "@foxglove/rosbag2-web": 4.0.3
     "@foxglove/rosmsg": 3.0.0


### PR DESCRIPTION
**User-facing changes**

- ROS2 native supports subscriptions to topics with volatile durability

**Description**

Previously, subscriptions were always made with TransientLocal durability under the hood in the @foxglove/ros2 library. Now, we only subscribe to topics where we observe at least one reliable (not best-effort) publisher. Data source warnings are created if multiple datatypes are detected for the same topic name, or if there are only best-effort publishers for a topic we are attempting to subscribe to.