### PR TITLE
Improve usability for Diagnostic Detail panel

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -11,11 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Autocomplete, TextField } from "@mui/material";
 import { sortBy } from "lodash";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
-import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import Flex from "@foxglove/studio-base/components/Flex";
 import Panel from "@foxglove/studio-base/components/Panel";
@@ -26,8 +26,9 @@ import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 
 import DiagnosticStatus from "./DiagnosticStatus";
 import helpContent from "./DiagnosticStatusPanel.help.md";
-import useDiagnostics, { DiagnosticAutocompleteEntry } from "./useDiagnostics";
-import { DiagnosticInfo, getDisplayName, trimHardwareId } from "./util";
+import useAvailableDiagnostics from "./useAvailableDiagnostics";
+import useDiagnostics from "./useDiagnostics";
+import { getDisplayName } from "./util";
 
 export type Config = {
   selectedHardwareId?: string;
@@ -54,20 +55,6 @@ function DiagnosticStatusPanel(props: Props) {
     collapsedSections = [],
   } = config;
 
-  const onSelect = useCallback(
-    (_value: string, entry: DiagnosticAutocompleteEntry, autocomplete: IAutocomplete) => {
-      const hasNewHardwareId = config.selectedHardwareId !== entry.hardware_id;
-      const hasNewName = config.selectedName !== entry.name;
-      saveConfig({
-        selectedHardwareId: entry.hardware_id,
-        selectedName: entry.name,
-        collapsedSections: hasNewHardwareId || hasNewName ? [] : config.collapsedSections,
-      });
-      autocomplete.blur();
-    },
-    [config, saveConfig],
-  );
-
   const topicToRenderMenu = (
     <TopicToRenderMenu
       topicToRender={topicToRender}
@@ -82,54 +69,102 @@ function DiagnosticStatusPanel(props: Props) {
     />
   );
 
-  const selectedDisplayName =
-    selectedHardwareId != undefined
-      ? getDisplayName(selectedHardwareId, selectedName ?? "")
-      : undefined;
+  const availableDiagnostics = useAvailableDiagnostics(topicToRender);
 
-  const diagnostics = useDiagnostics(topicToRender);
-  const [selectedItem, selectedItems] = useMemo(() => {
-    let selItem: DiagnosticInfo | undefined; // selected by name+hardware_id
-    let selItems: DiagnosticInfo[] | undefined; // [selectedItem], or all diagnostics with selectedHardwareId if no name is selected
-    if (selectedHardwareId != undefined) {
-      const items = [];
-      const diagnosticsByName = diagnostics.diagnosticsByNameByTrimmedHardwareId.get(
-        trimHardwareId(selectedHardwareId),
-      );
-      if (diagnosticsByName != undefined) {
-        for (const diagnostic of diagnosticsByName.values()) {
-          if (selectedName == undefined || selectedName === diagnostic.status.name) {
-            items.push(diagnostic);
-            if (selectedName != undefined) {
-              selItem = diagnostic;
-            }
-          }
+  // generate Autocomplete entries from the available diagnostics
+  const autocompleteOptions = useMemo(() => {
+    const items = [];
+
+    for (const [hardwareId, nameSet] of availableDiagnostics) {
+      if (hardwareId) {
+        items.push({ label: hardwareId, hardwareId, name: undefined });
+      }
+
+      for (const name of nameSet) {
+        if (name) {
+          const label = getDisplayName(hardwareId, name);
+          items.push({ label, hardwareId, name });
         }
       }
-      selItems = items;
     }
-    return [selItem, selItems];
+
+    return items;
+  }, [availableDiagnostics]);
+
+  const selectedDisplayName = useMemo(() => {
+    return selectedHardwareId != undefined
+      ? getDisplayName(selectedHardwareId, selectedName ?? "")
+      : undefined;
+  }, [selectedHardwareId, selectedName]);
+
+  const selectedAutocompleteOption = useMemo(() => {
+    return (
+      autocompleteOptions.find((item) => {
+        return item.label === selectedDisplayName;
+      }) ?? ReactNull
+    );
+  }, [autocompleteOptions, selectedDisplayName]);
+
+  const diagnostics = useDiagnostics(topicToRender);
+
+  const filteredDiagnostics = useMemo(() => {
+    const diagnosticsByName = diagnostics.get(selectedHardwareId ?? "");
+    const items = [];
+
+    if (diagnosticsByName != undefined) {
+      for (const diagnostic of diagnosticsByName.values()) {
+        if (selectedName == undefined || selectedName === diagnostic.status.name) {
+          items.push(diagnostic);
+        }
+      }
+    }
+
+    return items;
   }, [diagnostics, selectedHardwareId, selectedName]);
+
+  // If there are available options but none match the user input we show a No matches
+  // but if we don't have any options at all then we show waiting for diagnostics...
+  const noOptionsText =
+    autocompleteOptions.length > 0 ? "No matches" : "Waiting for diagnostics...";
 
   return (
     <Flex scroll scrollX col>
       <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
         <Autocomplete
-          placeholder={selectedDisplayName ?? "Select a diagnostic"}
-          items={diagnostics.sortedAutocompleteEntries}
-          getItemText={(entry) => entry.displayName}
-          getItemValue={(entry) => entry.id}
-          onSelect={onSelect}
-          selectedItem={
-            // selected item is only used with getItemValue
-            selectedItem ? { ...selectedItem, hardware_id: "", sortKey: "" } : undefined
-          }
-          inputStyle={{ height: "100%" }}
+          disablePortal
+          blurOnSelect={true}
+          options={autocompleteOptions}
+          value={selectedAutocompleteOption ?? ReactNull}
+          noOptionsText={noOptionsText}
+          onChange={(_ev, value) => {
+            if (!value) {
+              saveConfig({
+                selectedHardwareId: undefined,
+                selectedName: undefined,
+              });
+              return;
+            }
+
+            saveConfig({
+              selectedHardwareId: value?.hardwareId,
+              selectedName: value.name,
+            });
+          }}
+          fullWidth
+          size="small"
+          renderInput={(params) => (
+            <TextField
+              variant="standard"
+              {...params}
+              InputProps={{ ...params.InputProps, disableUnderline: true }}
+              placeholder={selectedDisplayName}
+            />
+          )}
         />
       </PanelToolbar>
-      {selectedItems != undefined && selectedItems.length > 0 ? (
+      {filteredDiagnostics != undefined && filteredDiagnostics.length > 0 ? (
         <Flex col scroll>
-          {sortBy(selectedItems, ({ status }) => status.name.toLowerCase()).map((item) => (
+          {sortBy(filteredDiagnostics, ({ status }) => status.name.toLowerCase()).map((item) => (
             <DiagnosticStatus
               key={item.id}
               info={item}

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -133,6 +133,7 @@ function DiagnosticStatusPanel(props: Props) {
         <Autocomplete
           disablePortal
           blurOnSelect={true}
+          disabled={autocompleteOptions.length === 0}
           options={autocompleteOptions}
           value={selectedAutocompleteOption ?? ReactNull}
           noOptionsText={noOptionsText}

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -247,7 +247,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
         fontSize: "12px",
       }}
       value={hardwareIdFilter}
-      placeholder="Filter hardware id"
+      placeholder="Filter"
       onChange={(e) => saveConfig({ hardwareIdFilter: e.target.value })}
     />
   );
@@ -268,7 +268,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   const diagnostics = useDiagnostics(topicToRender);
   const summary = useMemo(() => {
-    if (diagnostics.diagnosticsByNameByTrimmedHardwareId.size === 0) {
+    if (diagnostics.size === 0) {
       return (
         <EmptyState>
           Waiting for <code>{topicToRender}</code> messages
@@ -280,8 +280,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
       if (name == undefined || trimmedHardwareId == undefined) {
         return;
       }
-      const diagnosticsByName =
-        diagnostics.diagnosticsByNameByTrimmedHardwareId.get(trimmedHardwareId);
+      const diagnosticsByName = diagnostics.get(trimmedHardwareId);
       return diagnosticsByName?.get(name);
     });
 

--- a/packages/studio-base/src/panels/diagnostics/useAvailableDiagnostics.ts
+++ b/packages/studio-base/src/panels/diagnostics/useAvailableDiagnostics.ts
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
+import { MessageEvent } from "@foxglove/studio-base/players/types";
+
+import { DiagnosticStatusArrayMsg } from "./util";
+
+type DiagnosticNameSet = Set<string>;
+type UseAvailableDiagnosticResult = Map<string, DiagnosticNameSet>;
+
+// Exported for tests
+export function addMessages(
+  previousAvailableDiagnostics: UseAvailableDiagnosticResult,
+  messages: readonly MessageEvent<unknown>[],
+): UseAvailableDiagnosticResult {
+  // If we detect new hardware ids or names we need to create a new instance of available diagnostics
+  // so downstream consumers know it changed by observing the object reference changing
+  let modified = false;
+
+  for (const message of messages as MessageEvent<DiagnosticStatusArrayMsg>[]) {
+    const { status: statusArray }: DiagnosticStatusArrayMsg = message.message;
+    if (statusArray.length === 0) {
+      continue;
+    }
+
+    for (const status of statusArray) {
+      const hardwareId = status.hardware_id ?? "";
+      const name = status.name;
+
+      const nameSet = previousAvailableDiagnostics.get(hardwareId);
+      if (!nameSet) {
+        modified = true;
+        previousAvailableDiagnostics.set(hardwareId, new Set<string>([name]));
+      } else if (!nameSet.has(name) && name) {
+        modified = true;
+        nameSet.add(name);
+      }
+    }
+  }
+
+  return modified ? new Map(previousAvailableDiagnostics) : previousAvailableDiagnostics;
+}
+
+const EmptyMap = () => new Map();
+
+export default function useAvailableDiagnostics(topic: string): UseAvailableDiagnosticResult {
+  return useMessageReducer<UseAvailableDiagnosticResult>({
+    topics: [topic],
+    restore: EmptyMap,
+    addMessages,
+  });
+}

--- a/packages/studio-base/src/panels/diagnostics/useDiagnostics.test.ts
+++ b/packages/studio-base/src/panels/diagnostics/useDiagnostics.test.ts
@@ -14,10 +14,10 @@
 
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
-import { addMessages, defaultDiagnosticsBuffer } from "./useDiagnostics";
+import { addMessages } from "./useDiagnostics";
 import { computeDiagnosticInfo, DiagnosticInfo, DiagnosticStatusArrayMsg, LEVELS } from "./util";
 
-const messageAtLevel = (level: number): MessageEvent<DiagnosticStatusArrayMsg> => ({
+const buildMessageAtLevel = (level: number): MessageEvent<DiagnosticStatusArrayMsg> => ({
   message: {
     status: [
       {
@@ -36,63 +36,25 @@ const messageAtLevel = (level: number): MessageEvent<DiagnosticStatusArrayMsg> =
 });
 
 const diagnosticInfoAtLevel = (level: number): DiagnosticInfo => {
-  const { message } = messageAtLevel(level);
+  const { message } = buildMessageAtLevel(level);
   return computeDiagnosticInfo(message.status[0]!, message.header.stamp);
 };
 
 describe("addMessages", () => {
   it("adds a message at the right warning level", () => {
-    const message = messageAtLevel(LEVELS.OK);
+    const message = buildMessageAtLevel(LEVELS.OK);
     const info = diagnosticInfoAtLevel(LEVELS.OK);
-    const hardwareId = `|${info.status.hardware_id}|`;
-    expect(addMessages(defaultDiagnosticsBuffer(), [message])).toEqual({
-      diagnosticsByNameByTrimmedHardwareId: new Map([
-        [info.status.hardware_id, new Map([[info.status.name, info]])],
-      ]),
-      sortedAutocompleteEntries: [
-        {
-          displayName: info.status.hardware_id,
-          hardware_id: info.status.hardware_id,
-          id: hardwareId,
-          name: undefined,
-          sortKey: info.status.hardware_id.toLowerCase(),
-        },
-        {
-          displayName: info.displayName,
-          hardware_id: info.status.hardware_id,
-          id: info.id,
-          name: info.status.name,
-          sortKey: info.displayName.toLowerCase(),
-        },
-      ],
-    });
+    expect(addMessages(new Map(), [message])).toEqual(
+      new Map([[info.status.hardware_id, new Map([[info.status.name, info]])]]),
+    );
   });
 
   it("can move a message from one level to another", () => {
-    const message1 = messageAtLevel(LEVELS.OK);
-    const message2 = messageAtLevel(LEVELS.ERROR);
+    const message1 = buildMessageAtLevel(LEVELS.OK);
+    const message2 = buildMessageAtLevel(LEVELS.ERROR);
     const info = diagnosticInfoAtLevel(LEVELS.ERROR);
-    const hardwareId = `|${info.status.hardware_id}|`;
-    expect(addMessages(defaultDiagnosticsBuffer(), [message1, message2])).toEqual({
-      diagnosticsByNameByTrimmedHardwareId: new Map([
-        [info.status.hardware_id, new Map([[info.status.name, info]])],
-      ]),
-      sortedAutocompleteEntries: [
-        {
-          displayName: info.status.hardware_id,
-          hardware_id: info.status.hardware_id,
-          id: hardwareId,
-          name: undefined,
-          sortKey: info.status.hardware_id.toLowerCase(),
-        },
-        {
-          displayName: info.displayName,
-          hardware_id: info.status.hardware_id,
-          id: info.id,
-          name: info.status.name,
-          sortKey: info.displayName.toLowerCase(),
-        },
-      ],
-    });
+    expect(addMessages(new Map(), [message1, message2])).toEqual(
+      new Map([[info.status.hardware_id, new Map([[info.status.name, info]])]]),
+    );
   });
 });

--- a/packages/studio-base/src/panels/diagnostics/useDiagnostics.ts
+++ b/packages/studio-base/src/panels/diagnostics/useDiagnostics.ts
@@ -11,125 +11,48 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { sortedIndexBy } from "lodash";
-
-import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
+import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
-import {
-  DiagnosticStatusArrayMsg,
-  DiagnosticsById,
-  DiagnosticId,
-  computeDiagnosticInfo,
-  getDiagnosticId,
-  trimHardwareId,
-} from "./util";
+import { DiagnosticStatusArrayMsg, DiagnosticsById, computeDiagnosticInfo } from "./util";
 
-export type DiagnosticAutocompleteEntry = {
-  name?: string; // undefined for "combined hardware_id" entries for showing diagnostics with any name.
-  hardware_id: string;
-  id: DiagnosticId;
-  displayName: string;
-  sortKey: string;
-};
-
-export type DiagnosticsBuffer = {
-  diagnosticsByNameByTrimmedHardwareId: Map<string, DiagnosticsById>;
-  sortedAutocompleteEntries: DiagnosticAutocompleteEntry[];
-};
-
-// Returns whether the buffer has been modified
-function maybeAddMessageToBuffer(
-  buffer: DiagnosticsBuffer,
-  message: MessageEvent<DiagnosticStatusArrayMsg>,
-): boolean {
-  const { header, status: statusArray }: DiagnosticStatusArrayMsg = message.message;
-  if (statusArray.length === 0) {
-    return false;
-  }
-
-  for (const status of statusArray) {
-    const info = computeDiagnosticInfo(status, header.stamp);
-    let newHardwareId = false;
-    let newDiagnostic = false;
-    const trimmedHardwareId = trimHardwareId(status.hardware_id);
-    const hardwareDiagnosticsByName =
-      buffer.diagnosticsByNameByTrimmedHardwareId.get(trimmedHardwareId);
-    if (hardwareDiagnosticsByName == undefined) {
-      newHardwareId = true;
-      newDiagnostic = true;
-      buffer.diagnosticsByNameByTrimmedHardwareId.set(
-        trimmedHardwareId,
-        new Map([[status.name, info]]),
-      );
-    } else {
-      const previousNumberOfDiagnostics = hardwareDiagnosticsByName.size;
-      hardwareDiagnosticsByName.set(status.name, info);
-      newDiagnostic = hardwareDiagnosticsByName.size > previousNumberOfDiagnostics;
-    }
-
-    // add to sortedAutocompleteEntries if we haven't seen this id before
-    if (newDiagnostic) {
-      const newEntry = {
-        hardware_id: status.hardware_id,
-        name: status.name,
-        id: info.id,
-        displayName: info.displayName,
-        sortKey: info.displayName.replace(/^\//, "").toLowerCase(),
-      };
-      const index = sortedIndexBy(buffer.sortedAutocompleteEntries, newEntry, "displayName");
-      buffer.sortedAutocompleteEntries.splice(index, 0, newEntry);
-
-      if (newHardwareId) {
-        const newHardwareEntry = {
-          hardware_id: info.status.hardware_id,
-          id: getDiagnosticId(status.hardware_id),
-          name: undefined,
-          displayName: info.status.hardware_id,
-          sortKey: info.status.hardware_id.replace(/^\//, "").toLowerCase(),
-        };
-        const hardwareIdx = sortedIndexBy(
-          buffer.sortedAutocompleteEntries,
-          newHardwareEntry,
-          "displayName",
-        );
-        buffer.sortedAutocompleteEntries.splice(hardwareIdx, 0, newHardwareEntry);
-      }
-    }
-  }
-  return true;
-}
+type UseDiagnosticsResult = Map<string, DiagnosticsById>;
 
 // Exported for tests
 export function addMessages(
-  buffer: DiagnosticsBuffer,
-  messages: readonly MessageEvent<unknown>[],
-): DiagnosticsBuffer {
+  prevResult: UseDiagnosticsResult,
+  msgEvents: readonly MessageEvent<unknown>[],
+): UseDiagnosticsResult {
   // maybeAddMessageToBuffer mutates the buffer instead of doing an immutable update for performance
   // reasons. There are large numbers of diagnostics messages, and often many diagnostics panels in
   // a layout.
   let modified = false;
-  for (const message of messages) {
-    modified =
-      maybeAddMessageToBuffer(buffer, message as MessageEvent<DiagnosticStatusArrayMsg>) ||
-      modified;
+  for (const msgEvent of msgEvents as MessageEvent<DiagnosticStatusArrayMsg>[]) {
+    const { header, status: statusArray }: DiagnosticStatusArrayMsg = msgEvent.message;
+
+    for (const status of statusArray) {
+      const info = computeDiagnosticInfo(status, header.stamp);
+      const hardwareId = status.hardware_id;
+      const hardwareDiagnosticsByName = prevResult.get(hardwareId);
+      if (hardwareDiagnosticsByName == undefined) {
+        modified = true;
+        prevResult.set(hardwareId, new Map([[status.name, info]]));
+      } else {
+        modified = true;
+        hardwareDiagnosticsByName.set(status.name, info);
+      }
+    }
   }
   // We shallow-copy the buffer when it changes to help users know when to rerender.
-  return modified ? { ...buffer } : buffer;
+  return modified ? new Map(prevResult) : prevResult;
 }
 
-// Exported for tests
-export function defaultDiagnosticsBuffer(): DiagnosticsBuffer {
-  return {
-    diagnosticsByNameByTrimmedHardwareId: new Map(),
-    sortedAutocompleteEntries: [],
-  };
-}
+const EmptyMap = () => new Map();
 
-export default function useDiagnostics(topic: string): DiagnosticsBuffer {
-  return PanelAPI.useMessageReducer<DiagnosticsBuffer>({
+export default function useDiagnostics(topic: string): UseDiagnosticsResult {
+  return useMessageReducer<UseDiagnosticsResult>({
     topics: [topic],
-    restore: defaultDiagnosticsBuffer,
+    restore: EmptyMap,
     addMessages,
   });
 }

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -17,8 +17,6 @@ import { Time } from "@foxglove/rostime";
 import { Header } from "@foxglove/studio-base/types/Messages";
 import fuzzyFilter from "@foxglove/studio-base/util/fuzzyFilter";
 
-import { DiagnosticsBuffer } from "./useDiagnostics";
-
 // Trim the message if it's too long. We sometimes get crazy massive messages here that can
 // otherwise crash our entire UI. I looked at a bunch of messages manually and they are typically
 // way smaller than 5KB, so this is a very generous maximum. But feel free to increase it more if
@@ -84,10 +82,13 @@ export function getDiagnosticId(hardwareId: string, name?: string): DiagnosticId
 }
 
 export function getDisplayName(hardwareId: string, name: string): string {
-  if (name.indexOf(hardwareId) === 0) {
-    return name;
-  }
-  return name.length > 0 ? `${hardwareId}: ${name}` : hardwareId;
+  return name.length > 0
+    ? hardwareId.length > 0
+      ? `${hardwareId}: ${name}`
+      : `${name}`
+    : hardwareId.length > 0
+    ? `${hardwareId}`
+    : `(empty)`;
 }
 
 // ensures the diagnostic status message's name consists of both the hardware id and the name
@@ -115,9 +116,11 @@ export function computeDiagnosticInfo(
   };
 }
 
-export function getDiagnosticsByLevel(buffer: DiagnosticsBuffer): Map<number, DiagnosticInfo[]> {
+export function getDiagnosticsByLevel(
+  diagnosticsByHardwareId: Map<string, DiagnosticsById>,
+): Map<number, DiagnosticInfo[]> {
   const ret = new Map<number, DiagnosticInfo[]>();
-  for (const diagnosticsByName of buffer.diagnosticsByNameByTrimmedHardwareId.values()) {
+  for (const diagnosticsByName of diagnosticsByHardwareId.values()) {
     for (const diagnostic of diagnosticsByName.values()) {
       const statuses = ret.get(diagnostic.status.level);
       if (statuses) {

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -109,7 +109,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
     },
     MuiPaper: {
       defaultProps: {
-        elevation: 0,
+        elevation: 2,
         square: true,
       },
     },


### PR DESCRIPTION
**User-Facing Changes**
The Autocomplete widget is replaced with a different autocomplete widget. The overall experience is similar to before (you can type to filter the list). The new widget resolves some UX strangeness from the previous widget described in more detail below.

We've also removed the code paths which strip away a leading "/" from the hardware id as well as the code paths which remove the hardware_id string from the _name_ field. Both of these looked like webviz "cruisisms" and don't seem to be something that should be done for all ROS and non-ros users.

**Description**
The autocomplete in the Diagnostic Detail panel would hide available options once the user selected one. To change to a different diagnostic the user has to click the input, realize they can delete their text, delete all the text and type again to find their entry.

This change switches the autocomplete input to the mui Autocomplete component. This component exhibits better UX behavior. When focusing on the input, the user is shown all available entries with their current entry highlighted. This also resolves some glitches with the dropdown.

This change also modifies the autocomplete options logic to ignore empty hardware ids with no name from showing in the autocomplete options list. These entries would create blanks in the dropdown list.

Fixes: #2379



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
