### PR TITLE
Remove panel name from panel toolbar

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -33,7 +33,6 @@ type PanelToolbarControlsProps = {
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setMenuOpen: (_: boolean) => void;
   showControls?: boolean;
-  showPanelName?: boolean;
 };
 
 const useStyles = makeStyles({
@@ -50,11 +49,6 @@ const useStyles = makeStyles({
     svg: {
       fontSize: 14,
     },
-  },
-  panelName: {
-    fontSize: 10,
-    opacity: 0.5,
-    marginRight: 4,
   },
   icon: {
     fontSize: 14,
@@ -75,7 +69,6 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   mousePresent = false,
   setMenuOpen,
   showControls = false,
-  showPanelName = false,
 }: PanelToolbarControlsProps) {
   const panelContext = useContext(PanelContext);
   const styles = useStyles();
@@ -84,9 +77,6 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
 
   return (
     <div style={{ display: shouldShow ? "flex" : "none" }} className={cx(styles.iconContainer)}>
-      {showPanelName && panelContext && (
-        <div className={styles.panelName}>{panelContext.title}</div>
-      )}
       {additionalIcons}
       <PanelActionsDropdown
         isOpen={menuOpen}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -16,7 +16,6 @@ import FullscreenIcon from "@mdi/svg/svg/fullscreen.svg";
 import HelpCircleOutlineIcon from "@mdi/svg/svg/help-circle-outline.svg";
 import cx from "classnames";
 import { useContext, useState, useMemo, useRef } from "react";
-import { useResizeDetector } from "react-resize-detector";
 
 import Icon from "@foxglove/studio-base/components/Icon";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
@@ -155,15 +154,6 @@ export default React.memo<Props>(function PanelToolbar({
     exitFullscreen,
   ]);
 
-  // Use a debounce and 0 refresh rate to avoid triggering a resize observation while handling
-  // and existing resize observation.
-  // https://github.com/maslianok/react-resize-detector/issues/45
-  const { width, ref: sizeRef } = useResizeDetector({
-    handleHeight: false,
-    refreshRate: 0,
-    refreshMode: "debounce",
-  });
-
   // floating toolbars only show when hovered - but hovering over a context menu would hide the toolbar
   // showToolbar is used to force-show elements even if not hovered
   const showToolbar = menuOpen || !!isUnknownPanel;
@@ -178,27 +168,24 @@ export default React.memo<Props>(function PanelToolbar({
   }
 
   return (
-    <div ref={sizeRef}>
-      <div
-        ref={containerRef}
-        className={cx(styles.panelToolbarContainer, {
-          floating,
-          hasChildren: Boolean(children),
-        })}
-        style={{ backgroundColor, display: shouldShow ? "flex" : "none" }}
-      >
-        {children}
-        <PanelToolbarControls
-          showControls={showToolbar || alwaysVisible}
-          mousePresent={mousePresent}
-          floating={floating}
-          showPanelName={(width ?? 0) > 360}
-          additionalIcons={additionalIconsWithHelp}
-          isUnknownPanel={!!isUnknownPanel}
-          menuOpen={menuOpen}
-          setMenuOpen={setMenuOpen}
-        />
-      </div>
+    <div
+      ref={containerRef}
+      className={cx(styles.panelToolbarContainer, {
+        floating,
+        hasChildren: Boolean(children),
+      })}
+      style={{ backgroundColor, display: shouldShow ? "flex" : "none" }}
+    >
+      {children}
+      <PanelToolbarControls
+        showControls={showToolbar || alwaysVisible}
+        mousePresent={mousePresent}
+        floating={floating}
+        additionalIcons={additionalIconsWithHelp}
+        isUnknownPanel={!!isUnknownPanel}
+        menuOpen={menuOpen}
+        setMenuOpen={setMenuOpen}
+      />
     </div>
   );
 });


### PR DESCRIPTION
**User-Facing Changes**
The panel name is no longer displayed in the panel toolbar

Before
<img width="392" alt="Screen Shot 2022-01-15 at 4 40 06 PM" src="https://user-images.githubusercontent.com/84792/149642819-b39d52d9-4d77-4653-9ca0-fb4eda56e43e.png">

After
<img width="399" alt="Screen Shot 2022-01-15 at 4 35 28 PM" src="https://user-images.githubusercontent.com/84792/149642820-7d91468a-8845-4d4d-a616-25e90ba8eba5.png">


**Description**
The panel name shows up in the panel toolbar when a panel is considered wide enough. Even with this logic, the panel name takes up valuable toolbar space when there are other controls in the toolbar.

Seeing the panel name is not important to visualization and diagnostic of the users dataset so we remove it in favor of more space for other UI elements.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
