### PR TITLE
Update PanelExtensionContext#subscribe to handle empty arrays

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.test.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.test.tsx
@@ -379,4 +379,32 @@ describe("PanelExtensionAdapter", () => {
     // force a re-render to make sure we call init panel once
     handle.setProps({});
   });
+
+  it("should unsubscribe from all topics when subscribing to empty topics array", (done) => {
+    const initPanel = (context: PanelExtensionContext) => {
+      context.subscribe([]);
+    };
+
+    mount(
+      <ThemeProvider isDark>
+        <MockPanelContextProvider>
+          <PanelSetup
+            fixture={{
+              capabilities: [PlayerCapabilities.advertise],
+              topics: [],
+              datatypes: new Map(),
+              frame: {},
+              layout: "UnknownPanel!4co6n9d",
+              setSubscriptions: (_, payload) => {
+                expect(payload).toEqual([]);
+                done();
+              },
+            }}
+          >
+            <PanelExtensionAdapter config={{}} saveConfig={() => {}} initPanel={initPanel} />
+          </PanelSetup>
+        </MockPanelContextProvider>
+      </ThemeProvider>,
+    );
+  });
 });

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -386,9 +386,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       },
 
       subscribe: (topics: string[]) => {
-        if (topics.length === 0) {
-          return;
-        }
+        subscribedTopicsRef.current.clear();
 
         // If the player has loaded all the blocks, the blocks reference won't change so our message
         // pipeline handler for allFrames won't create a new set of all frames for the newly
@@ -402,7 +400,9 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
           subscribedTopicsRef.current.add(topic);
         }
 
-        requestBackfill();
+        if (topics.length > 0) {
+          requestBackfill();
+        }
       },
 
       advertise: capabilities.includes(PlayerCapabilities.advertise)

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -69,6 +69,7 @@ export type Fixture = {
   savedProps?: SavedProps;
   publish?: (request: PublishPayload) => void;
   setPublishers?: (publisherId: string, advertisements: AdvertiseOptions[]) => void;
+  setSubscriptions?: ComponentProps<typeof MockMessagePipelineProvider>["setSubscriptions"];
 };
 
 type Props = {
@@ -230,6 +231,7 @@ function UnconnectedPanelSetup(props: Props): JSX.Element | ReactNull {
     progress,
     publish,
     setPublishers,
+    setSubscriptions,
   } = props.fixture ?? {};
   let dTypes = datatypes;
   if (!dTypes) {
@@ -264,6 +266,7 @@ function UnconnectedPanelSetup(props: Props): JSX.Element | ReactNull {
         progress={progress}
         publish={publish}
         setPublishers={setPublishers}
+        setSubscriptions={setSubscriptions}
       >
         <PanelCatalogContext.Provider value={mockPanelCatalog}>
           <AppConfigurationContext.Provider value={mockAppConfiguration}>

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -160,6 +160,9 @@ declare module "@foxglove/studio" {
 
     /**
      * Subscribe to an array of topic names.
+     *
+     * Subscribe will update the current subscriptions to the list of topic names. Passing an empty
+     * array will unsubscribe from all topics.
      */
     subscribe(topics: string[]): void;
 


### PR DESCRIPTION

**User-Facing Changes**
PanelExtensionContext#subscribe api unsubscribes from all topics when an empty topic list is provided.

**Description**

When invoking subscribe with an array of topics, the expected behavior
is to set the current subscriptions to the list of topics. This results in unsubscribing from topics not present in the latest array of topics to subscribe. This was correctly handled for topic arrays of length 1 or more but was incorrectly handled for empty topic arrays.

This change updates the logic to handle empty topic arrays in the same manner.

Fixes: #2679


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
