### PR TITLE
Allow raw messages panel to complete on messages.

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -337,7 +337,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
       // If we're dealing with a topic name, and we cannot validly end in a message type,
       // add a "." so the user can keep typing to autocomplete the message path.
-      const messageIsValidType = validTypes?.includes("message") === true;
+      const messageIsValidType = validTypes == undefined || validTypes.includes("message");
       const keepGoingAfterTopicName =
         autocompleteType === "topicName" && !messageIsValidType && !isSimpleField;
       const value = keepGoingAfterTopicName ? rawValue + "." : rawValue;


### PR DESCRIPTION
**User-Facing Changes**
This fixes a regression on message path autocomplete in the raw messages panel.

**Description**
The fix here is to treat an absence of the `validTypes` property as allowing autocomplete on all types.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2698 