### PR TITLE
Track expand/collapse state for raw message fields

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -160,7 +160,7 @@
     "react-hover-observer": "2.1.1",
     "react-input-autosize": "3.0.0",
     "react-is": "17.0.2",
-    "react-json-tree": "0.15.1",
+    "react-json-tree": "patch:react-json-tree@npm:0.15.1#../../patches/react-json-tree.patch",
     "react-markdown": "7.1.2",
     "react-monaco-editor": "0.46.0",
     "react-mosaic-component": "5.0.0",

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -327,14 +327,13 @@ function RawMessages(props: Props) {
   );
 
   const renderSingleTopicOrDiffOutput = useCallback(() => {
-    let shouldExpandNode;
-    if (expandAll != undefined) {
-      shouldExpandNode = () => expandAll;
-    } else {
-      shouldExpandNode = (keypath: (string | number)[]) => {
-        return expandedFields.has(keypath.join("~"));
-      };
-    }
+    const shouldExpandNode = (keypath: (string | number)[]) => {
+      if (expandAll != undefined) {
+        return expandAll;
+      }
+
+      return expandedFields.has(keypath.join("~"));
+    };
 
     if (topicPath.length === 0) {
       return <EmptyState>No topic selected</EmptyState>;
@@ -344,6 +343,7 @@ function RawMessages(props: Props) {
         <EmptyState>{`Waiting to diff next messages from "${topicPath}" and "${diffTopicPath}"`}</EmptyState>
       );
     }
+
     if (!baseItem) {
       return <EmptyState>Waiting for next message</EmptyState>;
     }
@@ -412,10 +412,14 @@ function RawMessages(props: Props) {
               </div>
             )}
             <Tree
-              labelRenderer={(raw) => (
-                <DiffSpan onClick={() => onLabelClick(raw)}>{first(raw)}</DiffSpan>
-              )}
+              labelRenderer={(raw) => <DiffSpan>{first(raw)}</DiffSpan>}
               shouldExpandNode={shouldExpandNode}
+              onExpand={(_data, _level, keyPath) => {
+                onLabelClick(keyPath);
+              }}
+              onCollapse={(_data, _level, keyPath) => {
+                onLabelClick(keyPath);
+              }}
               hideRoot
               invertTheme={false}
               getItemString={getItemString}

--- a/patches/react-json-tree.patch
+++ b/patches/react-json-tree.patch
@@ -28,8 +28,8 @@ index a60c350ca0932a94b3c73d163bceb0a276724508..c803f507b3f8187ab6708b52ce30ca1c
  export declare type JSONValueNodeCircularPropsProvidedByJSONNode = SharedCircularPropsProvidedByJSONTree & JSONValueNodeCircularPropsPassedThroughJSONTree;
  interface JSONNestedNodeCircularPropsPassedThroughJSONTree {
      shouldExpandNode: (keyPath: (string | number)[], data: any, level: number) => boolean;
-+    onExpand?: (data: unknown, level: number, keyPath: (string | number)[]);
-+    onCollapse?: (data: unknown, level: number, keyPath: (string | number)[]);
++    onExpand?: (data: unknown, level: number, keyPath: (string | number)[]) => void;
++    onCollapse?: (data: unknown, level: number, keyPath: (string | number)[]) => void;
      hideRoot: boolean;
      getItemString: (nodeType: string, data: any, itemType: React.ReactNode, itemString: string, keyPath: (string | number)[]) => React.ReactNode;
      postprocessValue: (value: any) => any;

--- a/patches/react-json-tree.patch
+++ b/patches/react-json-tree.patch
@@ -1,0 +1,35 @@
+diff --git a/lib/JSONNestedNode.js b/lib/JSONNestedNode.js
+index 544cd314c7217bbd14e5fc1326ab097005f9fe7e..410e4f1d052b969214ee875c5b4b5acfcb3539ca 100644
+--- a/lib/JSONNestedNode.js
++++ b/lib/JSONNestedNode.js
+@@ -123,6 +123,17 @@ var JSONNestedNode = /*#__PURE__*/function (_React$Component) {
+
+     _defineProperty(_assertThisInitialized(_this), "handleClick", function () {
+       if (_this.props.expandable) {
++        const {
++          data,
++          level,
++          keyPath
++        } = _this.props;
++        if (_this.props.onExpand && !_this.state.expanded) {
++          _this.props.onExpand(data, level, keyPath);
++        }
++        if (_this.props.onCollapse && _this.state.expanded) {
++          _this.props.onCollapse(data, level, keyPath);
++        }
+         _this.setState({
+           expanded: !_this.state.expanded
+         });
+diff --git a/lib/types.d.ts b/lib/types.d.ts
+index a60c350ca0932a94b3c73d163bceb0a276724508..c803f507b3f8187ab6708b52ce30ca1c1191fd08 100644
+--- a/lib/types.d.ts
++++ b/lib/types.d.ts
+@@ -13,6 +13,8 @@ interface JSONValueNodeCircularPropsPassedThroughJSONTree {
+ export declare type JSONValueNodeCircularPropsProvidedByJSONNode = SharedCircularPropsProvidedByJSONTree & JSONValueNodeCircularPropsPassedThroughJSONTree;
+ interface JSONNestedNodeCircularPropsPassedThroughJSONTree {
+     shouldExpandNode: (keyPath: (string | number)[], data: any, level: number) => boolean;
++    onExpand?: (data: unknown, level: number, keyPath: (string | number)[]);
++    onCollapse?: (data: unknown, level: number, keyPath: (string | number)[]);
+     hideRoot: boolean;
+     getItemString: (nodeType: string, data: any, itemType: React.ReactNode, itemString: string, keyPath: (string | number)[]) => React.ReactNode;
+     postprocessValue: (value: any) => any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -20469,7 +20469,7 @@ __metadata:
 
 "react-json-tree@patch:react-json-tree@npm:0.15.1#../../patches/react-json-tree.patch::locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base":
   version: 0.15.1
-  resolution: "react-json-tree@patch:react-json-tree@npm%3A0.15.1#../../patches/react-json-tree.patch::version=0.15.1&hash=c5fd14&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
+  resolution: "react-json-tree@patch:react-json-tree@npm%3A0.15.1#../../patches/react-json-tree.patch::version=0.15.1&hash=9ebe07&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
   dependencies:
     "@types/prop-types": ^15.7.4
     prop-types: ^15.7.2
@@ -20477,7 +20477,7 @@ __metadata:
   peerDependencies:
     "@types/react": ^16.3.0 || ^17.0.0
     react: ^16.3.0 || ^17.0.0
-  checksum: 9a7301c0b80154211f86337c772df7f0d51aa2d5d9d51ef54b9b6fb0e87ade04ec48bb202ebb246b833421354863c9b582365a57c8e59344abd877ede26311dd
+  checksum: 4b354e22d51b83d5d2ecb09c2cae48c9a59cd131e97496f0988c574e896073ef9e25dd10ac612c535c6e342cc15c20f5b645b3412556ac69d2c1528e4a020bb5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ __metadata:
     react-hover-observer: 2.1.1
     react-input-autosize: 3.0.0
     react-is: 17.0.2
-    react-json-tree: 0.15.1
+    react-json-tree: "patch:react-json-tree@npm:0.15.1#../../patches/react-json-tree.patch"
     react-markdown: 7.1.2
     react-monaco-editor: 0.46.0
     react-mosaic-component: 5.0.0
@@ -20464,6 +20464,20 @@ __metadata:
     "@types/react": ^16.3.0 || ^17.0.0
     react: ^16.3.0 || ^17.0.0
   checksum: 11402e34d73e409ddc48a03cb4176a2780c381ef219bcb54d527283e1b3ac70737e260f2e45b491452d0326d5b2a4175e0d09593446413805b94464a5f77590e
+  languageName: node
+  linkType: hard
+
+"react-json-tree@patch:react-json-tree@npm:0.15.1#../../patches/react-json-tree.patch::locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base":
+  version: 0.15.1
+  resolution: "react-json-tree@patch:react-json-tree@npm%3A0.15.1#../../patches/react-json-tree.patch::version=0.15.1&hash=c5fd14&locator=%40foxglove%2Fstudio-base%40workspace%3Apackages%2Fstudio-base"
+  dependencies:
+    "@types/prop-types": ^15.7.4
+    prop-types: ^15.7.2
+    react-base16-styling: ^0.8.1
+  peerDependencies:
+    "@types/react": ^16.3.0 || ^17.0.0
+    react: ^16.3.0 || ^17.0.0
+  checksum: 9a7301c0b80154211f86337c772df7f0d51aa2d5d9d51ef54b9b6fb0e87ade04ec48bb202ebb246b833421354863c9b582365a57c8e59344abd877ede26311dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

**User-Facing Changes**
Expanding a field in the raw message panel by clicking the arrow next to the field name behaves like clicking the label. The field is expanded (if collapsed), and the state of the field expansion is remembered through data source looping.

**Description**
When a user clicks on a field label, the raw message panel would remember the field was expanded. If the datasource re-loaded or looped, the panel would re-expand the previously expanded fields.

This behavior was not applied when clicking the arrow next to the label. This change fixes this behavior by registering onExpand and onCollapse handlers on the Tree. These fire when the user clicks on the arrow next to the label.

Fixes: #2688


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
