### PR TITLE
Refactor timestamp method dropdown into a component

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -18,7 +18,6 @@ import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanel
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { basicDatatypes } from "@foxglove/studio-base/util/datatypes";
-import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import MessagePathInput from "./MessagePathInput";
 
@@ -115,7 +114,6 @@ const clickInput = (el: HTMLDivElement) => {
 
 function MessagePathInputStory(props: { path: string; prioritizedDatatype?: string }) {
   const [path, setPath] = React.useState(props.path);
-  const [timestampMethod, setTimestampMethod] = React.useState<TimestampMethod>("receiveTime");
 
   return (
     <MockPanelContextProvider>
@@ -126,8 +124,6 @@ function MessagePathInputStory(props: { path: string; prioritizedDatatype?: stri
             path={path}
             prioritizedDatatype={props.prioritizedDatatype}
             onChange={(newPath) => setPath(newPath)}
-            onTimestampMethodChange={setTimestampMethod}
-            timestampMethod={timestampMethod}
           />
         </Flex>
       </PanelSetup>
@@ -137,7 +133,6 @@ function MessagePathInputStory(props: { path: string; prioritizedDatatype?: stri
 
 function MessagePathPerformanceStory(props: { path: string; prioritizedDatatype?: string }) {
   const [path, setPath] = React.useState(props.path);
-  const [timestampMethod, setTimestampMethod] = React.useState<TimestampMethod>("receiveTime");
 
   return (
     <MockPanelContextProvider>
@@ -148,8 +143,6 @@ function MessagePathPerformanceStory(props: { path: string; prioritizedDatatype?
             path={path}
             prioritizedDatatype={props.prioritizedDatatype}
             onChange={(newPath) => setPath(newPath)}
-            onTimestampMethodChange={setTimestampMethod}
-            timestampMethod={timestampMethod}
           />
         </Flex>
       </PanelSetup>

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -11,21 +11,19 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { IconButton, IButtonStyles, Stack, useTheme } from "@fluentui/react";
+import { Stack } from "@fluentui/react";
 import { flatten, flatMap, partition } from "lodash";
 import { CSSProperties, useCallback, useMemo } from "react";
 
 import { RosMsgField } from "@foxglove/rosmsg";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
-import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import useGlobalVariables, {
   GlobalVariables,
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { getTopicNames, getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
-import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import { RosPath, RosPrimitive } from "./constants";
 import {
@@ -35,41 +33,6 @@ import {
   validTerminatingStructureItem,
 } from "./messagePathsForDatatype";
 import parseRosPath from "./parseRosPath";
-
-// To show an input field with an autocomplete so the user can enter message paths, use:
-//
-//  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
-//
-// To limit the autocomplete items to only certain types of values, you can use
-//
-//  <MessagePathInput types={["message", "array", "primitives"]} />
-//
-// Or use actual ROS primitive types:
-//
-//  <MessagePathInput types={["uint16", "float64"]} />
-//
-// If you don't use timestamps, you might want to hide the warning icon that we show when selecting
-// a topic that has no header: `<MessagePathInput hideTimestampWarning>`.
-//
-// If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
-// which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
-// avoid creating anonymous functions on every render (which will prevent the component from
-// rendering unnecessarily).
-
-function topicHasNoHeaderStamp(topic: Topic, datatypes: RosDatatypes): boolean {
-  const structureTraversalResult = traverseStructure(
-    messagePathStructures(datatypes)[topic.datatype],
-    [
-      { type: "name", name: "header" },
-      { type: "name", name: "stamp" },
-    ],
-  );
-
-  return (
-    !structureTraversalResult.valid ||
-    !validTerminatingStructureItem(structureTraversalResult.structureItem, ["time"])
-  );
-}
 
 // Get a list of Message Path strings for all of the fields (recursively) in a list of topics
 function getFieldPaths(
@@ -183,8 +146,6 @@ type MessagePathInputBaseProps = {
   inputStyle?: CSSProperties;
   disableAutocomplete?: boolean; // Treat this as a normal input, with no autocomplete.
   prioritizedDatatype?: string;
-  timestampMethod?: TimestampMethod;
-  onTimestampMethodChange?: (arg0: TimestampMethod, index?: number) => void;
 };
 
 export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
@@ -192,41 +153,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 ) {
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
   const { datatypes, topics } = PanelAPI.useDataSourceInfo();
-  const theme = useTheme();
-
-  const dropdownStyles: Partial<IButtonStyles> = useMemo(
-    () => ({
-      root: {
-        backgroundColor: "transparent",
-        color: theme.semanticColors.disabledText,
-        borderColor: "transparent",
-        fontSize: 12,
-        height: 24,
-        padding: "0 2px 0 4px",
-        cursor: "pointer",
-      },
-      rootHovered: {
-        color: theme.semanticColors.buttonText,
-        padding: "0 2px 0 4px",
-        backgroundColor: theme.semanticColors.buttonBackgroundHovered,
-      },
-      rootPressed: { backgroundColor: theme.semanticColors.buttonBackgroundPressed },
-      menuIcon: {
-        fontSize: "1em",
-        height: "1em",
-        color: "inherit",
-        marginLeft: 0,
-
-        svg: {
-          fill: "currentColor",
-          height: "1em",
-          width: "1em",
-          display: "block",
-        },
-      },
-    }),
-    [theme],
-  );
 
   const {
     supportsMathModifiers,
@@ -236,7 +162,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     autoSize,
     placeholder,
     noMultiSlices,
-    timestampMethod,
     inputStyle,
     disableAutocomplete = false,
   } = props;
@@ -297,15 +222,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
       }
     },
     [onChangeProp, path, props.index, topicFields, validTypes],
-  );
-
-  const onTimestampMethodChangeProp = props.onTimestampMethodChange;
-
-  const onTimestampMethodChange = useCallback(
-    (value: TimestampMethod) => {
-      onTimestampMethodChangeProp?.(value, props.index);
-    },
-    [onTimestampMethodChangeProp, props.index],
   );
 
   const rosPath = useMemo(() => parseRosPath(path), [path]);
@@ -469,10 +385,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     globalVariables,
   ]);
 
-  const noHeaderStamp = useMemo(() => {
-    return topic ? topicHasNoHeaderStamp(topic, datatypes) : false;
-  }, [datatypes, topic]);
-
   const orderedAutocompleteItems = useMemo(() => {
     if (prioritizedDatatype == undefined) {
       return autocompleteItems;
@@ -492,13 +404,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
   const hasError =
     usesUnsupportedMathModifier ||
     (autocompleteType != undefined && !disableAutocomplete && path.length > 0);
-
-  const timestampButton = useTooltip({
-    contents: noHeaderStamp
-      ? "header.stamp is not present in this topic"
-      : "Timestamp used for x-axis",
-    placement: "top",
-  });
 
   return (
     <Stack
@@ -532,44 +437,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
           disableAutoSelect
         />
       </Stack.Item>
-      {timestampMethod != undefined && (
-        <Stack.Item>
-          {timestampButton.tooltip}
-          <IconButton
-            elementRef={timestampButton.ref}
-            checked={timestampMethod === "headerStamp" && noHeaderStamp}
-            menuIconProps={{ iconName: "ClockOutline" }}
-            menuProps={{
-              styles: {
-                subComponentStyles: {
-                  menuItem: {
-                    root: { height: 24 },
-                    label: { fontSize: theme.fonts.small.fontSize },
-                    secondaryText: { fontSize: theme.fonts.small.fontSize },
-                  },
-                },
-              },
-              items: [
-                {
-                  key: "receiveTime",
-                  text: "receive time",
-                  canCheck: true,
-                  checked: timestampMethod === "receiveTime",
-                  onClick: () => onTimestampMethodChange("receiveTime"),
-                },
-                {
-                  key: "headerStamp",
-                  text: "header.stamp",
-                  canCheck: true,
-                  checked: timestampMethod === "headerStamp",
-                  onClick: () => onTimestampMethodChange("headerStamp"),
-                },
-              ],
-            }}
-            styles={dropdownStyles}
-          />
-        </Stack.Item>
-      )}
     </Stack>
   );
 });

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Stack } from "@mui/material";
 import { flatten, flatMap, partition } from "lodash";
 import { CSSProperties, useCallback, useMemo } from "react";
 
@@ -425,23 +426,32 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     (autocompleteType != undefined && !disableAutocomplete && path.length > 0);
 
   return (
-    <Autocomplete
-      items={orderedAutocompleteItems}
-      filterText={autocompleteFilterText}
-      value={path}
-      onChange={onChange}
-      onSelect={(value, _item, autocomplete) =>
-        onSelect(value, autocomplete, autocompleteType, autocompleteRange)
-      }
-      hasError={hasError}
-      autocompleteKey={autocompleteType}
-      placeholder={
-        placeholder != undefined && placeholder !== "" ? placeholder : "/some/topic.msgs[0].field"
-      }
-      autoSize={autoSize}
-      inputStyle={inputStyle} // Disable autoselect since people often construct complex queries, and it's very annoying
-      // to have the entire input selected whenever you want to make a change to a part it.
-      disableAutoSelect
-    />
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      alignItems="center"
+      flexGrow={1}
+      flexShrink={0}
+      spacing={0.25}
+    >
+      <Autocomplete
+        items={orderedAutocompleteItems}
+        filterText={autocompleteFilterText}
+        value={path}
+        onChange={onChange}
+        onSelect={(value, _item, autocomplete) =>
+          onSelect(value, autocomplete, autocompleteType, autocompleteRange)
+        }
+        hasError={hasError}
+        autocompleteKey={autocompleteType}
+        placeholder={
+          placeholder != undefined && placeholder !== "" ? placeholder : "/some/topic.msgs[0].field"
+        }
+        autoSize={autoSize}
+        inputStyle={inputStyle} // Disable autoselect since people often construct complex queries, and it's very annoying
+        // to have the entire input selected whenever you want to make a change to a part it.
+        disableAutoSelect
+      />
+    </Stack>
   );
 });

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Stack } from "@fluentui/react";
 import { flatten, flatMap, partition } from "lodash";
 import { CSSProperties, useCallback, useMemo } from "react";
 
@@ -33,6 +32,26 @@ import {
   validTerminatingStructureItem,
 } from "./messagePathsForDatatype";
 import parseRosPath from "./parseRosPath";
+
+// To show an input field with an autocomplete so the user can enter message paths, use:
+//
+//  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
+//
+// To limit the autocomplete items to only certain types of values, you can use
+//
+//  <MessagePathInput types={["message", "array", "primitives"]} />
+//
+// Or use actual ROS primitive types:
+//
+//  <MessagePathInput types={["uint16", "float64"]} />
+//
+// If you don't use timestamps, you might want to hide the warning icon that we show when selecting
+// a topic that has no header: `<MessagePathInput hideTimestampWarning>`.
+//
+// If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
+// which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
+// avoid creating anonymous functions on every render (which will prevent the component from
+// rendering unnecessarily).
 
 // Get a list of Message Path strings for all of the fields (recursively) in a list of topics
 function getFieldPaths(
@@ -406,37 +425,23 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     (autocompleteType != undefined && !disableAutocomplete && path.length > 0);
 
   return (
-    <Stack
-      horizontal
-      horizontalAlign="space-between"
-      verticalAlign="center"
-      grow
-      disableShrink
-      styles={{ root: { ".ms-layer:empty": { margin: 0 } } }}
-      tokens={{ childrenGap: 2 }}
-    >
-      <Stack.Item grow disableShrink>
-        <Autocomplete
-          items={orderedAutocompleteItems}
-          filterText={autocompleteFilterText}
-          value={path}
-          onChange={onChange}
-          onSelect={(value, _item, autocomplete) =>
-            onSelect(value, autocomplete, autocompleteType, autocompleteRange)
-          }
-          hasError={hasError}
-          autocompleteKey={autocompleteType}
-          placeholder={
-            placeholder != undefined && placeholder !== ""
-              ? placeholder
-              : "/some/topic.msgs[0].field"
-          }
-          autoSize={autoSize}
-          inputStyle={inputStyle} // Disable autoselect since people often construct complex queries, and it's very annoying
-          // to have the entire input selected whenever you want to make a change to a part it.
-          disableAutoSelect
-        />
-      </Stack.Item>
-    </Stack>
+    <Autocomplete
+      items={orderedAutocompleteItems}
+      filterText={autocompleteFilterText}
+      value={path}
+      onChange={onChange}
+      onSelect={(value, _item, autocomplete) =>
+        onSelect(value, autocomplete, autocompleteType, autocompleteRange)
+      }
+      hasError={hasError}
+      autocompleteKey={autocompleteType}
+      placeholder={
+        placeholder != undefined && placeholder !== "" ? placeholder : "/some/topic.msgs[0].field"
+      }
+      autoSize={autoSize}
+      inputStyle={inputStyle} // Disable autoselect since people often construct complex queries, and it's very annoying
+      // to have the entire input selected whenever you want to make a change to a part it.
+      disableAutoSelect
+    />
   );
 });

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -2,9 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { IconButton, IButtonStyles, useTheme } from "@fluentui/react";
 import { AccessTime as AccessTimeIcon, Check as CheckIcon } from "@mui/icons-material";
-import { IconButton as MuiIconButton, Menu, MenuItem } from "@mui/material";
+import { IconButton, Menu, MenuItem } from "@mui/material";
 import { useCallback, useMemo } from "react";
 
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
@@ -17,26 +16,6 @@ import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/par
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
-
-// To show an input field with an autocomplete so the user can enter message paths, use:
-//
-//  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
-//
-// To limit the autocomplete items to only certain types of values, you can use
-//
-//  <MessagePathInput types={["message", "array", "primitives"]} />
-//
-// Or use actual ROS primitive types:
-//
-//  <MessagePathInput types={["uint16", "float64"]} />
-//
-// If you don't use timestamps, you might want to hide the warning icon that we show when selecting
-// a topic that has no header: `<MessagePathInput hideTimestampWarning>`.
-//
-// If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
-// which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
-// avoid creating anonymous functions on every render (which will prevent the component from
-// rendering unnecessarily).
 
 function topicHasNoHeaderStamp(topic: Topic, datatypes: RosDatatypes): boolean {
   const structureTraversalResult = traverseStructure(
@@ -69,40 +48,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
   };
 
   const { path, timestampMethod } = props;
-  const theme = useTheme();
-  const dropdownStyles: Partial<IButtonStyles> = useMemo(
-    () => ({
-      root: {
-        backgroundColor: "transparent",
-        color: theme.semanticColors.disabledText,
-        borderColor: "transparent",
-        fontSize: 12,
-        height: 24,
-        padding: "0 2px 0 4px",
-        cursor: "pointer",
-      },
-      rootHovered: {
-        color: theme.semanticColors.buttonText,
-        padding: "0 2px 0 4px",
-        backgroundColor: theme.semanticColors.buttonBackgroundHovered,
-      },
-      rootPressed: { backgroundColor: theme.semanticColors.buttonBackgroundPressed },
-      menuIcon: {
-        fontSize: "1em",
-        height: "1em",
-        color: "inherit",
-        marginLeft: 0,
 
-        svg: {
-          fill: "currentColor",
-          height: "1em",
-          width: "1em",
-          display: "block",
-        },
-      },
-    }),
-    [theme],
-  );
   const { datatypes, topics } = PanelAPI.useDataSourceInfo();
   const rosPath = useMemo(() => parseRosPath(path), [path]);
 
@@ -135,7 +81,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
 
   return (
     <>
-      <MuiIconButton
+      <IconButton
         size="small"
         id="timestamp-method-button"
         aria-controls={open ? "basic-menu" : undefined}
@@ -145,7 +91,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
         sx={{ padding: 0.375, color: "text.secondary", "&:hover": { color: "text.primary" } }}
       >
         <AccessTimeIcon fontSize="inherit" />
-      </MuiIconButton>
+      </IconButton>
       <Menu
         id="timestamp-method-menu"
         disablePortal
@@ -159,6 +105,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
         {items.map((item) => (
           <MenuItem
             key={item.value}
+            disabled={noHeaderStamp && item.value === "headerStamp"}
             selected={timestampMethod === item.value}
             onClick={() => {
               onTimestampMethodChange(item.value);

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IconButton, IButtonStyles, useTheme } from "@fluentui/react";
+import { AccessTime as AccessTimeIcon, Check as CheckIcon } from "@mui/icons-material";
+import { IconButton as MuiIconButton, Menu, MenuItem } from "@mui/material";
+import { useCallback, useMemo } from "react";
+
+import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
+import {
+  messagePathStructures,
+  traverseStructure,
+  validTerminatingStructureItem,
+} from "@foxglove/studio-base/components/MessagePathSyntax/messagePathsForDatatype";
+import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+import { Topic } from "@foxglove/studio-base/players/types";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import { TimestampMethod } from "@foxglove/studio-base/util/time";
+
+// To show an input field with an autocomplete so the user can enter message paths, use:
+//
+//  <MessagePathInput path={this.state.path} onChange={path => this.setState({ path })} />
+//
+// To limit the autocomplete items to only certain types of values, you can use
+//
+//  <MessagePathInput types={["message", "array", "primitives"]} />
+//
+// Or use actual ROS primitive types:
+//
+//  <MessagePathInput types={["uint16", "float64"]} />
+//
+// If you don't use timestamps, you might want to hide the warning icon that we show when selecting
+// a topic that has no header: `<MessagePathInput hideTimestampWarning>`.
+//
+// If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
+// which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
+// avoid creating anonymous functions on every render (which will prevent the component from
+// rendering unnecessarily).
+
+function topicHasNoHeaderStamp(topic: Topic, datatypes: RosDatatypes): boolean {
+  const structureTraversalResult = traverseStructure(
+    messagePathStructures(datatypes)[topic.datatype],
+    [
+      { type: "name", name: "header" },
+      { type: "name", name: "stamp" },
+    ],
+  );
+
+  return (
+    !structureTraversalResult.valid ||
+    !validTerminatingStructureItem(structureTraversalResult.structureItem, ["time"])
+  );
+}
+
+type Props = {
+  path: string; // A path of the form `/topic.some_field[:]{id==42}.x`
+  index?: number; // Optional index field which gets passed to `onChange` (so you don't have to create anonymous functions)
+  timestampMethod?: TimestampMethod;
+  onTimestampMethodChange?: (arg0: TimestampMethod, index?: number) => void;
+};
+
+export default function TimestampMethodDropdown(props: Props): JSX.Element {
+  const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const { path, timestampMethod } = props;
+  const theme = useTheme();
+  const dropdownStyles: Partial<IButtonStyles> = useMemo(
+    () => ({
+      root: {
+        backgroundColor: "transparent",
+        color: theme.semanticColors.disabledText,
+        borderColor: "transparent",
+        fontSize: 12,
+        height: 24,
+        padding: "0 2px 0 4px",
+        cursor: "pointer",
+      },
+      rootHovered: {
+        color: theme.semanticColors.buttonText,
+        padding: "0 2px 0 4px",
+        backgroundColor: theme.semanticColors.buttonBackgroundHovered,
+      },
+      rootPressed: { backgroundColor: theme.semanticColors.buttonBackgroundPressed },
+      menuIcon: {
+        fontSize: "1em",
+        height: "1em",
+        color: "inherit",
+        marginLeft: 0,
+
+        svg: {
+          fill: "currentColor",
+          height: "1em",
+          width: "1em",
+          display: "block",
+        },
+      },
+    }),
+    [theme],
+  );
+  const { datatypes, topics } = PanelAPI.useDataSourceInfo();
+  const rosPath = useMemo(() => parseRosPath(path), [path]);
+
+  const topic = useMemo(() => {
+    if (!rosPath) {
+      return undefined;
+    }
+
+    const { topicName } = rosPath;
+    return topics.find(({ name }) => name === topicName);
+  }, [rosPath, topics]);
+
+  const noHeaderStamp = useMemo(() => {
+    return topic ? topicHasNoHeaderStamp(topic, datatypes) : false;
+  }, [datatypes, topic]);
+
+  const onTimestampMethodChangeProp = props.onTimestampMethodChange;
+
+  const onTimestampMethodChange = useCallback(
+    (value: TimestampMethod) => {
+      onTimestampMethodChangeProp?.(value, props.index);
+    },
+    [onTimestampMethodChangeProp, props.index],
+  );
+
+  const items = [
+    { label: "Receive time", value: "recieveTime" },
+    { label: "header.stamp", value: "headerStamp" },
+  ] as { label: string; value: TimestampMethod }[];
+
+  return (
+    <>
+      <MuiIconButton
+        size="small"
+        id="timestamp-method-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        sx={{ padding: 0.375, color: "text.secondary", "&:hover": { color: "text.primary" } }}
+      >
+        <AccessTimeIcon fontSize="inherit" />
+      </MuiIconButton>
+      <Menu
+        id="timestamp-method-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(undefined)}
+        MenuListProps={{
+          "aria-labelledby": "timestamp-method-button",
+        }}
+      >
+        {items.map((item) => (
+          <MenuItem
+            key={item.value}
+            selected={timestampMethod === item.value}
+            onClick={() => {
+              onTimestampMethodChange(item.value);
+              setAnchorEl(undefined);
+            }}
+          >
+            {item.label}
+            {timestampMethod === item.value && <CheckIcon fontSize="inherit" />}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -148,6 +148,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
       </MuiIconButton>
       <Menu
         id="timestamp-method-menu"
+        disablePortal
         anchorEl={anchorEl}
         open={open}
         onClose={() => setAnchorEl(undefined)}

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -74,7 +74,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
     [onTimestampMethodChangeProp, props.index],
   );
 
-  const items = [
+  const timestampMethods = [
     { label: "Receive time", value: "recieveTime" },
     { label: "header.stamp", value: "headerStamp" },
   ] as { label: string; value: TimestampMethod }[];
@@ -100,20 +100,26 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
         onClose={() => setAnchorEl(undefined)}
         MenuListProps={{
           "aria-labelledby": "timestamp-method-button",
+          dense: true,
+        }}
+        sx={{
+          zIndex: 100000,
         }}
       >
-        {items.map((item) => (
+        {timestampMethods.map((method) => (
           <MenuItem
-            key={item.value}
-            disabled={noHeaderStamp && item.value === "headerStamp"}
-            selected={timestampMethod === item.value}
+            key={method.value}
+            disabled={noHeaderStamp && method.value === "headerStamp"}
+            selected={timestampMethod === method.value}
             onClick={() => {
-              onTimestampMethodChange(item.value);
+              onTimestampMethodChange(method.value);
               setAnchorEl(undefined);
             }}
           >
-            {item.label}
-            {timestampMethod === item.value && <CheckIcon fontSize="inherit" />}
+            {method.label}
+            {timestampMethod === method.value && (
+              <CheckIcon fontSize="small" sx={{ marginLeft: 2 }} />
+            )}
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { AccessTime as AccessTimeIcon, Check as CheckIcon } from "@mui/icons-material";
-import { IconButton, Menu, MenuItem } from "@mui/material";
+import { IconButton, IconButtonProps, Menu, MenuItem } from "@mui/material";
 import { useCallback, useMemo } from "react";
 
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
@@ -37,7 +37,7 @@ type Props = {
   index?: number; // Optional index field which gets passed to `onChange` (so you don't have to create anonymous functions)
   timestampMethod?: TimestampMethod;
   onTimestampMethodChange?: (arg0: TimestampMethod, index?: number) => void;
-};
+} & IconButtonProps;
 
 export default function TimestampMethodDropdown(props: Props): JSX.Element {
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
@@ -47,7 +47,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
     setAnchorEl(event.currentTarget);
   };
 
-  const { path, timestampMethod } = props;
+  const { path, timestampMethod, ...rest } = props;
 
   const { datatypes, topics } = PanelAPI.useDataSourceInfo();
   const rosPath = useMemo(() => parseRosPath(path), [path]);
@@ -89,21 +89,19 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
         aria-expanded={open ? "true" : undefined}
         onClick={handleClick}
         sx={{ padding: 0.375, color: "text.secondary", "&:hover": { color: "text.primary" } }}
+        {...rest}
       >
         <AccessTimeIcon fontSize="inherit" />
       </IconButton>
       <Menu
         id="timestamp-method-menu"
-        disablePortal
         anchorEl={anchorEl}
         open={open}
         onClose={() => setAnchorEl(undefined)}
         MenuListProps={{
           "aria-labelledby": "timestamp-method-button",
           dense: true,
-        }}
-        sx={{
-          zIndex: 100000,
+          disablePadding: true,
         }}
       >
         {timestampMethods.map((method) => (

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -207,6 +207,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element | ReactN
             overflow: "auto",
             pointerEvents: "auto",
             [showSidebar ? "height" : "maxHeight"]: "100%",
+            position: "relative",
           })}
         >
           <Stack

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -85,6 +85,7 @@ const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: "transparent",
       borderTop: "none",
       pointerEvents: "none",
+      zIndex: theme.zIndex.mobileStepper,
     },
     legendToggle: {
       cursor: "pointer",
@@ -94,7 +95,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     floatingLegendToggle: {
       marginRight: theme.spacing(0.25),
-      zIndex: 1,
       visibility: "hidden",
       borderRadius: theme.shape.borderRadius,
       backgroundColor: theme.palette.action.focus,
@@ -214,15 +214,15 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element | ReactN
             direction="row"
             alignItems="center"
             padding={0.25}
-            sx={{
+            sx={(theme) => ({
               height: 26,
               position: "sticky",
               top: 0,
               left: 0,
               right: 0,
               bgcolor: "background.paper",
-              zIndex: 3,
-            }}
+              zIndex: theme.zIndex.mobileStepper + 1,
+            })}
           >
             <Box
               sx={{
@@ -267,6 +267,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element | ReactN
           </Stack>
           <Box
             sx={{
+              position: "relative",
               display: "grid",
               gridTemplateColumns: [
                 "auto",
@@ -297,7 +298,17 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element | ReactN
               );
             })}
           </Box>
-          <Box padding={0.5} position="sticky" right={0} left={0} gridColumn="span 4">
+          <Box
+            padding={0.5}
+            gridColumn="span 4"
+            sx={{
+              ...(showSidebar && {
+                position: "sticky",
+                right: 0,
+                left: 0,
+              }),
+            }}
+          >
             <Button
               size="small"
               fullWidth
@@ -367,7 +378,9 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element | ReactN
             {legendContent}
           </SidebarWrapper>
         ) : (
-          <Stack sx={{ overflow: "hidden", height: "100%", zIndex: 1 }}>{legendContent}</Stack>
+          <Stack overflow="hidden" height="100%">
+            {legendContent}
+          </Stack>
         )
       ) : undefined}
     </Stack>

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -4,12 +4,13 @@
 
 import { useTheme as useFluentUITheme } from "@fluentui/react";
 import { Close as CloseIcon, Error as ErrorIcon, Remove as RemoveIcon } from "@mui/icons-material";
-import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import { Box, IconButton, Stack, Tooltip, Typography } from "@mui/material";
 import { ComponentProps, useCallback, useMemo, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
+import TimestampMethodDropdown from "@foxglove/studio-base/components/TimestampMethodDropdown";
 import { useHoverValue } from "@foxglove/studio-base/context/HoverValueContext";
 import { lineColors } from "@foxglove/studio-base/util/plotColors";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
@@ -169,7 +170,6 @@ export default function PlotLegendRow({
           supportsMathModifiers
           path={path.value}
           onChange={onInputChange}
-          onTimestampMethodChange={onInputTimestampMethodChange}
           validTypes={plotableRosTypes}
           placeholder="Enter a topic name or a number"
           index={index}
@@ -199,10 +199,11 @@ export default function PlotLegendRow({
         </Box>
       )}
 
-      <Box
-        display="flex"
+      <Stack
+        direction="row"
         alignItems="center"
         padding={0.25}
+        spacing={0.25}
         visibility="hidden"
         position="sticky"
         right={0}
@@ -212,6 +213,12 @@ export default function PlotLegendRow({
           backgroundBlendMode: "overlay",
         })}
       >
+        <TimestampMethodDropdown
+          path={path.value}
+          onTimestampMethodChange={onInputTimestampMethodChange}
+          index={index}
+          timestampMethod={xAxisVal === "timestamp" ? timestampMethod : undefined}
+        />
         <IconButton
           size="small"
           title={`Remove ${path.value}`}
@@ -224,7 +231,7 @@ export default function PlotLegendRow({
         >
           <CloseIcon fontSize="small" />
         </IconButton>
-      </Box>
+      </Stack>
     </Box>
   );
 }

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -116,7 +116,7 @@ export default function PlotLegendRow({
             bgcolor: "action.hover",
           },
           "& > *:last-child": {
-            visibility: "visible",
+            opacity: 1,
           },
           "& > *": {
             bgcolor: "action.hover",
@@ -204,13 +204,17 @@ export default function PlotLegendRow({
         alignItems="center"
         padding={0.25}
         spacing={0.25}
-        visibility="hidden"
         position="sticky"
         right={0}
         sx={({ palette }) => ({
+          opacity: 0,
           // creates an opaque background for the sticky element
           backgroundImage: `linear-gradient(${palette.background.paper}, ${palette.background.paper})`,
           backgroundBlendMode: "overlay",
+
+          "&:hover": {
+            opacity: 1,
+          },
         })}
       >
         <TimestampMethodDropdown

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -221,6 +221,7 @@ export default function PlotLegendRow({
           path={path.value}
           onTimestampMethodChange={onInputTimestampMethodChange}
           index={index}
+          disabled={!path.value}
           timestampMethod={xAxisVal === "timestamp" ? timestampMethod : undefined}
         />
         <IconButton

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -37,6 +37,7 @@ import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart, {
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
+import TimestampMethodDropdown from "@foxglove/studio-base/components/TimestampMethodDropdown";
 import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
 import {
   ChartData,
@@ -423,6 +424,11 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
                 autoSize
                 validTypes={transitionableRosTypes}
                 noMultiSlices
+              />
+              <TimestampMethodDropdown
+                path={path}
+                index={index}
+                disabled={!path}
                 timestampMethod={timestampMethod}
                 onTimestampMethodChange={onInputTimestampMethodChange}
               />


### PR DESCRIPTION
**User-Facing Changes**
Refactor timestamp method dropdown into self contained component separate from the message path input

<img width="347" alt="Screen Shot 2022-01-21 at 4 25 01 pm" src="https://user-images.githubusercontent.com/924528/150470927-f53a2b14-7539-404a-a9d8-0e5c4c26a041.png">

<img width="385" alt="Screen Shot 2022-01-21 at 4 25 06 pm" src="https://user-images.githubusercontent.com/924528/150470933-47c82ff3-3fc5-4cab-9d8a-4b4d6febf909.png">

**Description**
Hoisting and refactoring mostly working except showing the current method

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
