### PR TITLE
Show panel thumbnails and descriptions in panel sidebar and menu

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -22,7 +22,9 @@ import {
   List,
   ListItem,
   ListItemButton,
+  ListItemIcon,
   ListItemText,
+  Paper,
   Stack,
   Typography,
 } from "@mui/material";
@@ -141,23 +143,7 @@ function DraggablePanelItem({
   }, [highlighted]);
 
   const { ref: tooltipRef, tooltip } = useTooltip({
-    contents:
-      mode === "grid" ? (
-        panel.description
-      ) : (
-        <Stack width={200}>
-          {panel.thumbnail != undefined && <img src={panel.thumbnail} alt={panel.title} />}
-          <Stack padding={1} spacing={0.5}>
-            <Typography variant="body2" style={{ fontWeight: "bold" }}>
-              {panel.title}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {panel.description}
-            </Typography>
-          </Stack>
-        </Stack>
-      ),
-    placement: mode === "grid" ? undefined : "right",
+    contents: panel.description,
     delay: 200,
   });
   const mergedRef = useCallback(
@@ -168,6 +154,7 @@ function DraggablePanelItem({
     },
     [connectDragSource, tooltipRef, scrollRef],
   );
+  const { isInverted } = useTheme();
   switch (mode) {
     case "grid":
       return (
@@ -208,9 +195,27 @@ function DraggablePanelItem({
             sx={{
               cursor: "grab",
               backgroundColor: highlighted ? (theme) => theme.palette.action.focus : undefined,
-              paddingY: 0.25,
+              paddingY: 0.5,
             }}
           >
+            <ListItemIcon sx={{ width: 64, paddingRight: 1 }}>
+              {panel.thumbnail ? (
+                <Paper
+                  variant="outlined"
+                  component="img"
+                  src={panel.thumbnail}
+                  alt={panel.title}
+                  sx={{
+                    borderRadius: 1,
+                    maxWidth: "100%",
+                    // show border only in dark mode to avoid thumbnails blending into the background
+                    border: isInverted ? undefined : "none",
+                  }}
+                />
+              ) : (
+                <Paper variant="outlined" sx={{ borderRadius: 1, height: 42, width: "100%" }} />
+              )}
+            </ListItemIcon>
             <ListItemText
               primary={
                 <span data-test={`panel-menu-item ${panel.title}`}>
@@ -218,6 +223,12 @@ function DraggablePanelItem({
                 </span>
               }
               primaryTypographyProps={{ fontWeight: checked ? "bold" : undefined }}
+              secondary={panel.description}
+              secondaryTypographyProps={{
+                variant: "caption",
+                marginTop: "0 !important", // overrides CssBaseline
+                lineHeight: 1.2,
+              }}
             />
           </ListItemButton>
         </ListItem>


### PR DESCRIPTION
**User-Facing Changes**
Panel thumbnails and descriptions are now shown in the "Add panel" sidebar and the "Change panel" menu.

**Description**
<img width="1205" alt="image" src="https://user-images.githubusercontent.com/14237/150607985-9bdc9993-3c39-4694-9b7f-bc292f8a608b.png">

