### PR TITLE
Add support for ROS_PACKAGE_PATH values with multiple paths

### DIFF
--- a/desktop/main/fixtures/packages/foo/package.xml
+++ b/desktop/main/fixtures/packages/foo/package.xml
@@ -1,0 +1,9 @@
+<package format="2">
+  <name>foo</name>
+  <version>1.2.3</version>
+  <description>
+    This package provides foo capability.
+  </description>
+  <maintainer email="john@example.com">John Doe</maintainer>
+  <license>MOT</license>
+</package>

--- a/desktop/main/rosPackageResources.test.ts
+++ b/desktop/main/rosPackageResources.test.ts
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import path from "path";
+
+import { findRosPackageRoot, rosPackageNameAtPath } from "./rosPackageResources";
+
+const FIXTURES_ROOT = path.join(__dirname, "./fixtures");
+const PACKAGES_ROOT = path.join(FIXTURES_ROOT, "./packages");
+
+describe("rosPackageResources", () => {
+  describe("rosPackageNameAtPath", () => {
+    it("should read package name from package.xml file at path", async () => {
+      const name = await rosPackageNameAtPath(path.join(PACKAGES_ROOT, "./foo"));
+      expect(name).toEqual("foo");
+    });
+  });
+
+  describe("findRosPackageRoot", () => {
+    it("should find package within rosPackagePath", async () => {
+      const packagePath = await findRosPackageRoot("foo", { rosPackagePath: PACKAGES_ROOT });
+      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
+    });
+
+    it("should find package within multiple rosPackagePaths", async () => {
+      const packagePath = await findRosPackageRoot("foo", {
+        rosPackagePath: `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`,
+      });
+      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
+    });
+
+    it("should find package within process.env.ROS_PACKAGE_PATH", async () => {
+      process.env.ROS_PACKAGE_PATH = `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`;
+      try {
+        const packagePath = await findRosPackageRoot("foo");
+        expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
+      } finally {
+        process.env.ROS_PACKAGE_PATH = undefined;
+      }
+    });
+  });
+});


### PR DESCRIPTION

**User-Facing Changes**
Users with a ROS_PACKAGE_PATH containing multiple paths separated by a path delimeter are able to use package:// urls in the desktop app.

**Description**


Ros package paths are allowed to contain multiple paths separated the platform specific path delimiter. This fixes our path finding logic to support paths containing the path delimeter.

https://wiki.ros.org/ROS/EnvironmentVariables#ROS_PACKAGE_PATH

Fixes #2705


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
