### PR TITLE
Correctly apply orientation to cube lists and sphere lists

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -37,7 +37,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302",
-    "@foxglove/regl-worldview": "2.0.1",
+    "@foxglove/regl-worldview": "2.1.0",
     "@foxglove/ros1": "1.4.0",
     "@foxglove/ros2": "3.1.0",
     "@foxglove/rosbag": "0.1.2",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -869,45 +869,18 @@ export function ArrowMarkers(): JSX.Element {
 SphereWithStaticTransform.parameters = { colorScheme: "dark" };
 export function SphereWithStaticTransform(): JSX.Element {
   const topics: Topic[] = [
-    { name: "/tf_static", datatype: "geometry_msgs/TransformStamped" },
+    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
     { name: "/sphere", datatype: "visualization_msgs/Marker" },
   ];
 
   const tf1: MessageEvent<TF> = {
-    topic: "/tf_static",
+    topic: "/tf",
     receiveTime: { sec: 10, nsec: 0 },
     message: {
       header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
-      child_frame_id: "camera_aligned_depth_to_color_frame",
-      transform: {
-        translation: {
-          x: -0.0003675934858620167,
-          y: -0.05918709188699722,
-          z: 0.00029044150141999125,
-        },
-        rotation: {
-          x: 0.0010303286835551262,
-          y: -0.002234778832644224,
-          z: 0.0018944572657346725,
-          w: 0.9999951720237732,
-        },
-      },
-    },
-    sizeInBytes: 0,
-  };
-
-  const tf2: MessageEvent<TF> = {
-    topic: "/tf_static",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: {
-        seq: 0,
-        stamp: { sec: 0, nsec: 0 },
-        frame_id: "camera_aligned_depth_to_color_frame",
-      },
       child_frame_id: "camera_color_optical_frame",
       transform: {
-        translation: { x: 0, y: 0, z: 0 },
+        translation: { x: 0.5, y: -0.5, z: 0 },
         rotation: {
           x: -0.5,
           y: 0.5,
@@ -935,9 +908,9 @@ export function SphereWithStaticTransform(): JSX.Element {
       },
       points: [
         {
-          x: -0.22289721353359226,
-          y: -0.10708471275270251,
-          z: 0.6890000000000001,
+          x: 0,
+          y: 0,
+          z: 0.5,
         },
       ],
       scale: { x: 0.1, y: 0.1, z: 0.1 },
@@ -951,7 +924,7 @@ export function SphereWithStaticTransform(): JSX.Element {
     datatypes,
     topics,
     frame: {
-      "/tf_static": [tf1, tf2],
+      "/tf": [tf1],
       "/sphere": [sphere],
     },
     capabilities: [],
@@ -965,26 +938,14 @@ export function SphereWithStaticTransform(): JSX.Element {
       <ThreeDimensionalViz
         overrideConfig={{
           ...ThreeDimensionalViz.defaultConfig,
-          checkedKeys: [
-            "name:Topics",
-            "t:/sphere",
-            "t:/tf",
-            "t:/tf_static",
-            `t:${FOXGLOVE_GRID_TOPIC}`,
-          ],
-          expandedKeys: [
-            "name:Topics",
-            "t:/sphere",
-            "t:/tf",
-            "t:/tf_static",
-            `t:${FOXGLOVE_GRID_TOPIC}`,
-          ],
+          checkedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
+          expandedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
           followTf: "camera_link",
           cameraState: {
-            distance: 5,
+            distance: 4,
             perspective: true,
-            phi: 0.83,
-            targetOffset: [-0.094, 0.85, 0],
+            phi: 1.2,
+            targetOffset: [0, 0, 0],
             thetaOffset: -0.29,
             fovy: 0.75,
             near: 0.01,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -866,8 +866,8 @@ export function ArrowMarkers(): JSX.Element {
   );
 }
 
-SphereWithStaticTransform.parameters = { colorScheme: "dark" };
-export function SphereWithStaticTransform(): JSX.Element {
+SphereListPointsTransform.parameters = { colorScheme: "dark" };
+export function SphereListPointsTransform(): JSX.Element {
   function makeSphere(id: string, color: string, scale: number) {
     return {
       topic: "/sphere",
@@ -965,8 +965,8 @@ export function SphereWithStaticTransform(): JSX.Element {
             distance: 4,
             perspective: true,
             phi: 1.2,
-            targetOffset: [0, 0, 0],
-            thetaOffset: -0.29,
+            targetOffset: [0.5, 0, 0],
+            thetaOffset: -0.5,
             fovy: 0.75,
             near: 0.01,
             far: 5000,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -869,16 +869,16 @@ export function ArrowMarkers(): JSX.Element {
 SphereWithStaticTransform.parameters = { colorScheme: "dark" };
 export function SphereWithStaticTransform(): JSX.Element {
   const topics: Topic[] = [
-    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
+    { name: "/tf_static", datatype: "geometry_msgs/TransformStamped" },
     { name: "/sphere", datatype: "visualization_msgs/Marker" },
   ];
 
   const tf1: MessageEvent<TF> = {
-    topic: "/tf",
+    topic: "/tf_static",
     receiveTime: { sec: 10, nsec: 0 },
     message: {
       header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
-      child_frame_id: "camera_color_frame",
+      child_frame_id: "camera_aligned_depth_to_color_frame",
       transform: {
         translation: { x: 0, y: 0, z: 0 },
         rotation: QUAT_IDENTITY,
@@ -888,10 +888,14 @@ export function SphereWithStaticTransform(): JSX.Element {
   };
 
   const tf2: MessageEvent<TF> = {
-    topic: "/tf",
+    topic: "/tf_static",
     receiveTime: { sec: 10, nsec: 0 },
     message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_frame" },
+      header: {
+        seq: 0,
+        stamp: { sec: 0, nsec: 0 },
+        frame_id: "camera_aligned_depth_to_color_frame",
+      },
       child_frame_id: "camera_color_optical_frame",
       transform: {
         translation: { x: 0.5, y: 0, z: 0 },
@@ -927,7 +931,7 @@ export function SphereWithStaticTransform(): JSX.Element {
     datatypes,
     topics,
     frame: {
-      "/tf": [tf1, tf2],
+      "/tf_static": [tf1, tf2],
       "/sphere": [sphere],
     },
     capabilities: [],
@@ -941,8 +945,20 @@ export function SphereWithStaticTransform(): JSX.Element {
       <ThreeDimensionalViz
         overrideConfig={{
           ...ThreeDimensionalViz.defaultConfig,
-          checkedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
-          expandedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
+          checkedKeys: [
+            "name:Topics",
+            "t:/sphere",
+            "t:/tf",
+            "t:/tf_static",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
+          expandedKeys: [
+            "name:Topics",
+            "t:/sphere",
+            "t:/tf",
+            "t:/tf_static",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
           followTf: "camera_link",
           cameraState: {
             distance: 5,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -868,6 +868,36 @@ export function ArrowMarkers(): JSX.Element {
 
 SphereWithStaticTransform.parameters = { colorScheme: "dark" };
 export function SphereWithStaticTransform(): JSX.Element {
+  function makeSphere(id: string, color: string, scale: number) {
+    return {
+      topic: "/sphere",
+      receiveTime: { sec: 10, nsec: 0 },
+      message: {
+        header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
+        id,
+        ns: "",
+        type: 7,
+        action: 0,
+        frame_locked: false,
+        pose: {
+          position: { x: 0, y: 0, z: 0 },
+          orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        points: [
+          {
+            x: 0,
+            y: 0,
+            z: 0,
+          },
+        ],
+        scale: { x: scale, y: scale, z: scale },
+        color: makeColor(color, 1),
+        lifetime: { sec: 0, nsec: 0 },
+      },
+      sizeInBytes: 0,
+    };
+  }
+
   const topics: Topic[] = [
     { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
     { name: "/sphere", datatype: "visualization_msgs/Marker" },
@@ -892,68 +922,30 @@ export function SphereWithStaticTransform(): JSX.Element {
     sizeInBytes: 0,
   };
 
-  const sphere1: MessageEvent<SphereListMarker> = {
-    topic: "/sphere",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
-      id: "sphere1",
-      ns: "",
-      type: 7,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0, z: 0 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
-      },
-      points: [
-        {
-          x: 0,
-          y: 0,
-          z: 0.5,
-        },
-      ],
-      scale: { x: 0.1, y: 0.1, z: 0.1 },
-      color: makeColor("#f44336", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    sizeInBytes: 0,
-  };
+  const sphere1 = makeSphere("sphere1", "#ff0000", 0.1);
+  sphere1.message.pose.position.x = 0.5;
 
-  const sphere2: MessageEvent<SphereListMarker> = {
-    topic: "/sphere",
-    receiveTime: { sec: 10, nsec: 0 },
-    message: {
-      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
-      id: "sphere2",
-      ns: "",
-      type: 7,
-      action: 0,
-      frame_locked: false,
-      pose: {
-        position: { x: 0, y: 0, z: 0.5 },
-        orientation: { x: 0, y: 0, z: 0, w: 1 },
-      },
-      points: [
-        {
-          x: 0,
-          y: 0,
-          z: 0,
-        },
-      ],
-      scale: { x: 0.1, y: 0.1, z: 0.1 },
-      color: makeColor("#00aacc", 0.5),
-      lifetime: { sec: 0, nsec: 0 },
-    },
-    sizeInBytes: 0,
-  };
+  const sphere2 = makeSphere("sphere2", "#00ff00", 0.1);
+  sphere2.message.pose.position.y = 0.5;
+
+  const sphere3 = makeSphere("sphere3", "#0000ff", 0.1);
+  sphere3.message.pose.position.z = 0.5;
+
+  const sphere4 = makeSphere("sphere4", "#ff0000", 0.2);
+  sphere4.message.points[0]!.x = 0.75;
+
+  const sphere5 = makeSphere("sphere5", "#00ff00", 0.2);
+  sphere5.message.points[0]!.y = 0.75;
+
+  const sphere6 = makeSphere("sphere6", "#0000ff", 0.2);
+  sphere6.message.points[0]!.z = 0.75;
 
   const fixture = useDelayedFixture({
     datatypes,
     topics,
     frame: {
       "/tf": [tf1],
-      "/sphere": [sphere1, sphere2],
+      "/sphere": [sphere1, sphere2, sphere3, sphere4, sphere5, sphere6],
     },
     capabilities: [],
     activeData: {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -880,8 +880,17 @@ export function SphereWithStaticTransform(): JSX.Element {
       header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
       child_frame_id: "camera_aligned_depth_to_color_frame",
       transform: {
-        translation: { x: 0, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+        translation: {
+          x: -0.0003675934858620167,
+          y: -0.05918709188699722,
+          z: 0.00029044150141999125,
+        },
+        rotation: {
+          x: 0.0010303286835551262,
+          y: -0.002234778832644224,
+          z: 0.0018944572657346725,
+          w: 0.9999951720237732,
+        },
       },
     },
     sizeInBytes: 0,
@@ -898,8 +907,13 @@ export function SphereWithStaticTransform(): JSX.Element {
       },
       child_frame_id: "camera_color_optical_frame",
       transform: {
-        translation: { x: 0.5, y: 0, z: 0 },
-        rotation: QUAT_IDENTITY,
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: {
+          x: -0.5,
+          y: 0.5,
+          z: -0.5,
+          w: 0.5,
+        },
       },
     },
     sizeInBytes: 0,
@@ -916,10 +930,16 @@ export function SphereWithStaticTransform(): JSX.Element {
       action: 0,
       frame_locked: false,
       pose: {
-        position: { x: 0.5, y: 0, z: 0 },
+        position: { x: 0, y: 0, z: 0 },
         orientation: { x: 0, y: 0, z: 0, w: 1 },
       },
-      points: [{ x: 0, y: 0, z: 0 }],
+      points: [
+        {
+          x: -0.22289721353359226,
+          y: -0.10708471275270251,
+          z: 0.6890000000000001,
+        },
+      ],
       scale: { x: 0.1, y: 0.1, z: 0.1 },
       color: makeColor("#f44336", 0.5),
       lifetime: { sec: 0, nsec: 0 },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -866,6 +866,102 @@ export function ArrowMarkers(): JSX.Element {
   );
 }
 
+SphereWithStaticTransform.parameters = { colorScheme: "dark" };
+export function SphereWithStaticTransform(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
+    { name: "/sphere", datatype: "visualization_msgs/Marker" },
+  ];
+
+  const tf1: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_link" },
+      child_frame_id: "camera_color_frame",
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const tf2: MessageEvent<TF> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_frame" },
+      child_frame_id: "camera_color_optical_frame",
+      transform: {
+        translation: { x: 0.5, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const sphere: MessageEvent<SphereListMarker> = {
+    topic: "/sphere",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
+      id: "sphere",
+      ns: "",
+      type: 7,
+      action: 0,
+      frame_locked: false,
+      pose: {
+        position: { x: 0.5, y: 0, z: 0 },
+        orientation: { x: 0, y: 0, z: 0, w: 1 },
+      },
+      points: [{ x: 0, y: 0, z: 0 }],
+      scale: { x: 0.1, y: 0.1, z: 0.1 },
+      color: makeColor("#f44336", 0.5),
+      lifetime: { sec: 0, nsec: 0 },
+    },
+    sizeInBytes: 0,
+  };
+
+  const fixture = useDelayedFixture({
+    datatypes,
+    topics,
+    frame: {
+      "/tf": [tf1, tf2],
+      "/sphere": [sphere],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 0, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          checkedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
+          expandedKeys: ["name:Topics", "t:/sphere", "t:/tf", `t:${FOXGLOVE_GRID_TOPIC}`],
+          followTf: "camera_link",
+          cameraState: {
+            distance: 5,
+            perspective: true,
+            phi: 0.83,
+            targetOffset: [-0.094, 0.85, 0],
+            thetaOffset: -0.29,
+            fovy: 0.75,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 TransformInterpolation.parameters = { colorScheme: "dark" };
 export function TransformInterpolation(): JSX.Element {
   const topics: Topic[] = [

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -892,12 +892,12 @@ export function SphereWithStaticTransform(): JSX.Element {
     sizeInBytes: 0,
   };
 
-  const sphere: MessageEvent<SphereListMarker> = {
+  const sphere1: MessageEvent<SphereListMarker> = {
     topic: "/sphere",
     receiveTime: { sec: 10, nsec: 0 },
     message: {
       header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
-      id: "sphere",
+      id: "sphere1",
       ns: "",
       type: 7,
       action: 0,
@@ -920,12 +920,40 @@ export function SphereWithStaticTransform(): JSX.Element {
     sizeInBytes: 0,
   };
 
+  const sphere2: MessageEvent<SphereListMarker> = {
+    topic: "/sphere",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "camera_color_optical_frame" },
+      id: "sphere2",
+      ns: "",
+      type: 7,
+      action: 0,
+      frame_locked: false,
+      pose: {
+        position: { x: 0, y: 0, z: 0.5 },
+        orientation: { x: 0, y: 0, z: 0, w: 1 },
+      },
+      points: [
+        {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+      ],
+      scale: { x: 0.1, y: 0.1, z: 0.1 },
+      color: makeColor("#00aacc", 0.5),
+      lifetime: { sec: 0, nsec: 0 },
+    },
+    sizeInBytes: 0,
+  };
+
   const fixture = useDelayedFixture({
     datatypes,
     topics,
     frame: {
       "/tf": [tf1],
-      "/sphere": [sphere],
+      "/sphere": [sphere1, sphere2],
     },
     capabilities: [],
     activeData: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,9 +2325,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@foxglove/regl-worldview@npm:2.0.1"
+"@foxglove/regl-worldview@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@foxglove/regl-worldview@npm:2.1.0"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2345,7 +2345,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: 91fa9c6dd9819cdeeac5b323d554c417994dc3a8b60b12de382b2929b1213370f6bda5da76d255e75a17ac382c0532e02d361455a0285796393b643aa0307f5b
+  checksum: a67778ec46d6761fb238ff65608e47405f66cde009a7ad295bc99ee39199c21b4bc08d986206cd7b6d426f707146b482696076837e9bb6434977279ed8cda28e
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
-    "@foxglove/regl-worldview": 2.0.1
+    "@foxglove/regl-worldview": 2.1.0
     "@foxglove/ros1": 1.4.0
     "@foxglove/ros2": 3.1.0
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the rendering of some marker types in the 3d view.

**Description**
This uses an updated version of `regl-woldview` that correctly transforms markers that use `points`.

This story screenshot demonstrates spheres positioned either via the `pose` or via `points` aligning correctly on the transformed axes.

<img width="859" alt="Screen Shot 2022-01-25 at 3 13 27 PM" src="https://user-images.githubusercontent.com/93935560/151068809-9de9221c-4741-4049-a101-65c384e78281.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2714 