### PR TITLE
Fix open datasource dialog close logic.

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -205,10 +205,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   // When a player is activated, hide the open dialog.
   useLayoutEffect(() => {
-    if (isPlayerPresent) {
+    if (playerPresence === PlayerPresence.PRESENT) {
       setShowOpenDialog(undefined);
     }
-  }, [isPlayerPresent]);
+  }, [playerPresence]);
 
   const { setHelpInfo } = useHelpInfo();
 


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the open datasource dialog failing to close when a datasource is successfully opened.

**Description**
The logic for closing the dialog wasn't quite correct since it was triggering a `useEffect` only when the player state changed from `NOT_PRESENT`. This changes the logic in the hook to run on all values of playerpresence and close the dialog when the player is present.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2728 