### PR TITLE
Fix open url parsing logic to handle query params etc.

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Remote.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Remote.tsx
@@ -20,6 +20,14 @@ type RemoteProps = {
   availableSources: IDataSourceFactory[];
 };
 
+function maybeParseURL(urlString: string): undefined | URL {
+  try {
+    return new URL(urlString);
+  } catch {
+    return undefined;
+  }
+}
+
 export default function Remote(props: RemoteProps): JSX.Element {
   const { onCancel, onBack, availableSources } = props;
 
@@ -32,8 +40,9 @@ export default function Remote(props: RemoteProps): JSX.Element {
       return;
     }
 
-    const extension = path.extname(currentUrl);
-    if (extension.length === 0) {
+    const parsedUrl = maybeParseURL(currentUrl);
+    const extension = parsedUrl ? path.extname(parsedUrl.pathname) : undefined;
+    if (extension == undefined || extension.length === 0) {
       setErrorMessage("URL must end with a filename and extension");
       return;
     }

--- a/packages/studio-base/src/components/OpenDialog/Remote.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Remote.tsx
@@ -20,14 +20,6 @@ type RemoteProps = {
   availableSources: IDataSourceFactory[];
 };
 
-function maybeParseURL(urlString: string): undefined | URL {
-  try {
-    return new URL(urlString);
-  } catch {
-    return undefined;
-  }
-}
-
 export default function Remote(props: RemoteProps): JSX.Element {
   const { onCancel, onBack, availableSources } = props;
 
@@ -40,28 +32,32 @@ export default function Remote(props: RemoteProps): JSX.Element {
       return;
     }
 
-    const parsedUrl = maybeParseURL(currentUrl);
-    const extension = parsedUrl ? path.extname(parsedUrl.pathname) : undefined;
-    if (extension == undefined || extension.length === 0) {
-      setErrorMessage("URL must end with a filename and extension");
-      return;
-    }
+    try {
+      const parsedUrl = new URL(currentUrl);
+      const extension = path.extname(parsedUrl.pathname);
+      if (extension.length === 0) {
+        setErrorMessage("URL must end with a filename and extension");
+        return;
+      }
 
-    // find remote supporting this extension
-    const foundSource = availableSources.find((source) => {
-      return source.type === "remote-file" && source.supportedFileTypes?.includes(extension);
-    });
-    if (!foundSource) {
-      setErrorMessage(`No remote data sources available for ${extension} files`);
-      return;
-    }
+      // find remote supporting this extension
+      const foundSource = availableSources.find((source) => {
+        return source.type === "remote-file" && source.supportedFileTypes?.includes(extension);
+      });
+      if (!foundSource) {
+        setErrorMessage(`No remote data sources available for ${extension} files`);
+        return;
+      }
 
-    selectSource(foundSource.id, {
-      type: "connection",
-      params: {
-        url: currentUrl,
-      },
-    });
+      selectSource(foundSource.id, {
+        type: "connection",
+        params: {
+          url: currentUrl,
+        },
+      });
+    } catch (error) {
+      setErrorMessage(`"${currentUrl}" is not a valid url`);
+    }
   }, [availableSources, currentUrl, selectSource]);
 
   return (

--- a/packages/studio-base/src/components/OpenDialog/Remote.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Remote.tsx
@@ -41,7 +41,12 @@ export default function Remote(props: RemoteProps): JSX.Element {
     }
 
     const parsedUrl = maybeParseURL(currentUrl);
-    const extension = parsedUrl ? path.extname(parsedUrl.pathname) : undefined;
+    if (!parsedUrl) {
+      setErrorMessage(`${currentUrl} is not a valid URL`);
+      return;
+    }
+
+    const extension = path.extname(parsedUrl.pathname);
     if (extension == undefined || extension.length === 0) {
       setErrorMessage("URL must end with a filename and extension");
       return;

--- a/packages/studio-base/src/components/OpenDialog/Remote.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Remote.tsx
@@ -20,6 +20,14 @@ type RemoteProps = {
   availableSources: IDataSourceFactory[];
 };
 
+function maybeParseURL(urlString: string): undefined | URL {
+  try {
+    return new URL(urlString);
+  } catch {
+    return undefined;
+  }
+}
+
 export default function Remote(props: RemoteProps): JSX.Element {
   const { onCancel, onBack, availableSources } = props;
 
@@ -32,32 +40,28 @@ export default function Remote(props: RemoteProps): JSX.Element {
       return;
     }
 
-    try {
-      const parsedUrl = new URL(currentUrl);
-      const extension = path.extname(parsedUrl.pathname);
-      if (extension.length === 0) {
-        setErrorMessage("URL must end with a filename and extension");
-        return;
-      }
-
-      // find remote supporting this extension
-      const foundSource = availableSources.find((source) => {
-        return source.type === "remote-file" && source.supportedFileTypes?.includes(extension);
-      });
-      if (!foundSource) {
-        setErrorMessage(`No remote data sources available for ${extension} files`);
-        return;
-      }
-
-      selectSource(foundSource.id, {
-        type: "connection",
-        params: {
-          url: currentUrl,
-        },
-      });
-    } catch (error) {
-      setErrorMessage(`"${currentUrl}" is not a valid url`);
+    const parsedUrl = maybeParseURL(currentUrl);
+    const extension = parsedUrl ? path.extname(parsedUrl.pathname) : undefined;
+    if (extension == undefined || extension.length === 0) {
+      setErrorMessage("URL must end with a filename and extension");
+      return;
     }
+
+    // find remote supporting this extension
+    const foundSource = availableSources.find((source) => {
+      return source.type === "remote-file" && source.supportedFileTypes?.includes(extension);
+    });
+    if (!foundSource) {
+      setErrorMessage(`No remote data sources available for ${extension} files`);
+      return;
+    }
+
+    selectSource(foundSource.id, {
+      type: "connection",
+      params: {
+        url: currentUrl,
+      },
+    });
   }, [availableSources, currentUrl, selectSource]);
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue in the the open remote location dialog.

**Description**
This uses the `URL` class to parse the provided URL string instead of trying to extract the extension directly.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2726 