### PR TITLE
Include default values for protobuf message fields in WebSocket player and MCAP provider

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -77,7 +77,10 @@ function parseChannel(channel: Channel): ParsedChannel {
     const type = root.lookupType(channel.schemaName);
 
     const deserializer = (data: ArrayBufferView) => {
-      return type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+      return type.toObject(
+        type.decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength)),
+        { defaults: true },
+      );
     };
 
     const datatypes: RosDatatypes = new Map();

--- a/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
@@ -118,7 +118,7 @@ export default class McapDataProvider implements RandomAccessDataProvider {
             messages.push({
               topic: channelInfo.info.topic,
               receiveTime,
-              message: channelInfo.messageDeserializer.toObject(protoMsg),
+              message: channelInfo.messageDeserializer.toObject(protoMsg, { defaults: true }),
               sizeInBytes: record.data.byteLength,
             });
           } else {


### PR DESCRIPTION
**User-Facing Changes**
Default values are now shown in Protobuf messages when using the WebSocket player or MCAP files.
`bytes` now display correctly as Uint8Arrays in the Raw Messages panel when using the WebSocket player.

**Description**
Fixes #2708

By passing `{defaults: true}` to `toObject`, we produce an object that includes all the default values.

When `toObject` was not used, the Raw Messages panel would call `toJSON` (which is defined for protobuf message classes) which would convert bytes to base64. After passing through `toObject`, `toJSON` is no longer defined so Uint8Arrays show up correctly in the panel (and any other app features that relied on `toJSON`).