### PR TITLE
Mark JSON.stringify as possibly returning undefined.

### DIFF
--- a/ci/bump-nightly-version.ts
+++ b/ci/bump-nightly-version.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
   pkg.version = `${ver}-nightly.${date}.${sha}`;
 
   // Write package.json
-  await fs.writeFile(PACKAGE_JSON_PATH, JSON.stringify(pkg, undefined, 2) + "\n", "utf8");
+  await fs.writeFile(PACKAGE_JSON_PATH, JSON.stringify(pkg, undefined, 2) ?? "" + "\n", "utf8");
 }
 
 if (require.main === module) {

--- a/desktop/renderer/components/ConsoleApiCurrentUserProvider.tsx
+++ b/desktop/renderer/components/ConsoleApiCurrentUserProvider.tsx
@@ -40,7 +40,7 @@ export default function ConsoleApiCurrentUserProvider(
     undefined,
     {
       raw: false,
-      serializer: (value: User) => JSON.stringify(value),
+      serializer: (value: User) => JSON.stringify(value) ?? "",
       deserializer: (value: string) => JSON.parse(value) as User,
     },
   );

--- a/desktop/renderer/services/NativeStorageAppConfiguration.ts
+++ b/desktop/renderer/services/NativeStorageAppConfiguration.ts
@@ -59,7 +59,7 @@ export default class NativeStorageAppConfiguration implements AppConfiguration {
       await this._ctx.put(
         NativeStorageAppConfiguration.STORE_NAME,
         NativeStorageAppConfiguration.STORE_KEY,
-        JSON.stringify(newConfig),
+        JSON.stringify(newConfig) ?? "",
       );
       this._currentValue = newConfig;
     });

--- a/desktop/renderer/services/NativeStorageLayoutStorage.ts
+++ b/desktop/renderer/services/NativeStorageLayoutStorage.ts
@@ -54,7 +54,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
   }
 
   async put(namespace: string, layout: Layout): Promise<Layout> {
-    const content = JSON.stringify(layout);
+    const content = JSON.stringify(layout) ?? "";
     await this._ctx.put(NativeStorageLayoutStorage.STORE_PREFIX + namespace, layout.id, content);
     return layout;
   }
@@ -104,7 +104,7 @@ export default class NativeStorageLayoutStorage implements ILayoutStorage {
         await this._ctx.put(
           NativeStorageLayoutStorage.STORE_PREFIX + namespace,
           layout.id,
-          JSON.stringify(layout),
+          JSON.stringify(layout) ?? "",
         );
         await this._ctx.delete(NativeStorageLayoutStorage.LEGACY_STORE_NAME, layout.id);
       } catch (err) {

--- a/packages/studio-base/src/components/GlobalVariablesTable/index.tsx
+++ b/packages/studio-base/src/components/GlobalVariablesTable/index.tsx
@@ -197,7 +197,7 @@ function LinkedGlobalVariableRow({ name }: { name: string }): ReactElement {
       <td>${name}</td>
       <td width="100%">
         <JSONInput
-          value={JSON.stringify(globalVariables[name] ?? "")}
+          value={JSON.stringify(globalVariables[name]) ?? ""}
           onChange={(newVal) => setGlobalVariables({ [name]: newVal })}
         />
       </td>
@@ -339,7 +339,7 @@ function GlobalVariablesTable(): ReactElement {
                   dataTest={`global-variable-value-input-${JSON.stringify(
                     globalVariables[name] ?? "",
                   )}`}
-                  value={JSON.stringify(globalVariables[name] ?? "")}
+                  value={JSON.stringify(globalVariables[name]) ?? ""}
                   onChange={(newVal) => setGlobalVariables({ [name]: newVal })}
                 />
               </td>

--- a/packages/studio-base/src/components/JsonInput.tsx
+++ b/packages/studio-base/src/components/JsonInput.tsx
@@ -174,8 +174,9 @@ export function ValidatedInputBase({
 
 export default function JsonInput(props: BaseProps): JSX.Element {
   function stringify(val: unknown) {
-    return JSON.stringify(val, undefined, 2);
+    return JSON.stringify(val, undefined, 2) ?? "";
   }
+
   return (
     <SEditBox>
       <ValidatedInputBase parse={JSON.parse} stringify={stringify} {...props} />

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -230,7 +230,7 @@ export default function LayoutBrowser({
 
   const onExportLayout = useCallbackWithToast(
     async (item: Layout) => {
-      const content = JSON.stringify(item.working?.data ?? item.baseline.data, undefined, 2);
+      const content = JSON.stringify(item.working?.data ?? item.baseline.data, undefined, 2) ?? "";
       downloadTextFile(content, `${item.name}.json`);
       void analytics.logEvent(AppEvent.LAYOUT_EXPORT, { permission: item.permission });
     },

--- a/packages/studio-base/src/components/ShareJsonModal.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.tsx
@@ -33,7 +33,7 @@ export default function ShareJsonModal({
   title,
 }: Props): React.ReactElement {
   const theme = useTheme();
-  const [value, setValue] = useState(JSON.stringify(initialValue, undefined, 2));
+  const [value, setValue] = useState(JSON.stringify(initialValue, undefined, 2) ?? "");
   const [copied, setCopied] = useState(false);
 
   const { decodedValue, error } = useMemo(() => {

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.tsx
@@ -251,7 +251,7 @@ export default function ImageCanvas(props: Props): JSX.Element {
           imageMessage: msg,
           imageMessageDatatype,
           options,
-          rawMarkerData: JSON.parse(JSON.stringify(rawMarkers)),
+          rawMarkerData: JSON.parse(JSON.stringify(rawMarkers) ?? ""),
         });
       };
 

--- a/packages/studio-base/src/panels/Log/FilterBar.tsx
+++ b/packages/studio-base/src/panels/Log/FilterBar.tsx
@@ -149,7 +149,7 @@ export default function FilterBar(props: FilterBarProps): JSX.Element {
           <Icon
             style={{ padding: "1px 0px 0px 6px" }}
             onClick={() => {
-              void clipboard.copy(JSON.stringify(props.messages, undefined, 2));
+              void clipboard.copy(JSON.stringify(props.messages, undefined, 2) ?? "");
             }}
             tooltip="Copy log to clipboard"
           >

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -22,7 +22,7 @@ const EMPTY_MESSAGE: NavSatFixMsg = {
   position_covariance: [1, 0, 0, 0, 1, 0, 0, 0, 1],
   position_covariance_type: NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN,
 };
-const OFFSET_MESSAGE = JSON.parse(JSON.stringify(EMPTY_MESSAGE)) as NavSatFixMsg;
+const OFFSET_MESSAGE = JSON.parse(JSON.stringify(EMPTY_MESSAGE) ?? "") as NavSatFixMsg;
 OFFSET_MESSAGE.latitude += 0.1;
 OFFSET_MESSAGE.longitude += 0.1;
 

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -122,7 +122,7 @@ function Parameters(): ReactElement {
             </thead>
             <tbody>
               {parameterNames.map((name) => {
-                const value = JSON.stringify(parameters.get(name) ?? "");
+                const value = JSON.stringify(parameters.get(name)) ?? "";
                 return (
                   <AnimatedRow
                     key={`parameter-${name}`}

--- a/packages/studio-base/src/panels/RawMessages/HighlightedValue.tsx
+++ b/packages/studio-base/src/panels/RawMessages/HighlightedValue.tsx
@@ -27,8 +27,8 @@ export default function HighlightedValue({ itemLabel }: Props): JSX.Element {
   const itemLabelContainsChange = splitItemLabel.length === 2;
   if (itemLabelContainsChange) {
     const [before, after] = splitItemLabel;
-    const beforeText = JSON.parse(JSON.stringify(before));
-    const afterText = JSON.parse(JSON.stringify(after));
+    const beforeText = JSON.parse(JSON.stringify(before) ?? "");
+    const afterText = JSON.parse(JSON.stringify(after) ?? "");
     return (
       <DiffSpan style={{ color: diffLabels.CHANGED.color }}>
         <MaybeCollapsedValue itemLabel={beforeText} />

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/CameraInfo/index.tsx
@@ -159,7 +159,7 @@ export default function CameraInfo({
               tooltip="Copy cameraState"
               small
               onClick={() => {
-                void clipboard.copy(JSON.stringify(cameraState, undefined, 2));
+                void clipboard.copy(JSON.stringify(cameraState, undefined, 2) ?? "");
               }}
             >
               Copy

--- a/packages/studio-base/src/providers/UserProfileLocalStorageProvider.tsx
+++ b/packages/studio-base/src/providers/UserProfileLocalStorageProvider.tsx
@@ -24,7 +24,7 @@ export default function UserProfileLocalStorageProvider({
     return item != undefined ? (JSON.parse(item) as UserProfile) : DEFAULT_PROFILE;
   }, []);
   const setUserProfile = useCallback(async (profile: UserProfile) => {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(profile));
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(profile) ?? "");
   }, []);
   const storage = useShallowMemo({
     getUserProfile,

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1ParseMessagesDataProvider.test.ts
@@ -91,7 +91,7 @@ describe.skip("ParseMessagesDataProvider", () => {
         return {
           topic: event.topic,
           receiveTime: event.receiveTime,
-          message: JSON.parse(JSON.stringify(event.message)),
+          message: JSON.parse(JSON.stringify(event.message) ?? ""),
         };
       }),
     ).toEqual([

--- a/packages/studio-base/src/typings/index.d.ts
+++ b/packages/studio-base/src/typings/index.d.ts
@@ -7,5 +7,6 @@
 import "./extensions";
 import "./react";
 import "./fluentui";
+import "./overrides";
 import "./styled-components";
 import "./webpack-defines";

--- a/packages/studio-base/src/typings/overrides.d.ts
+++ b/packages/studio-base/src/typings/overrides.d.ts
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable no-restricted-syntax */
+
+// We extend the type definition of JSON.stringify because in some cases
+// it can return undefined. This isn't strictly correct but it at least
+// forces callers to handle the undefined case and prevent crashes.
+// See issue https://github.com/microsoft/TypeScript/issues/18879
+declare global {
+  interface JSON {
+    stringify(
+      value: any,
+      replacer?: (this: any, key: string, value: any) => any,
+      space?: string | number,
+    ): undefined | string;
+
+    stringify(
+      value: any,
+      replacer?: (number | string)[] | null,
+      space?: string | number,
+    ): undefined | string;
+  }
+}
+
+export {};

--- a/web/src/components/LocalStorageLayoutStorageProvider.tsx
+++ b/web/src/components/LocalStorageLayoutStorageProvider.tsx
@@ -47,7 +47,10 @@ export default function LocalStorageLayoutStorageProvider(
       },
 
       async put(namespace: string, layout: Layout): Promise<Layout> {
-        localStorage.setItem(`${KEY_PREFIX}.${namespace}.${layout.id}`, JSON.stringify(layout));
+        localStorage.setItem(
+          `${KEY_PREFIX}.${namespace}.${layout.id}`,
+          JSON.stringify(layout) ?? "",
+        );
         return layout;
       },
 
@@ -97,7 +100,7 @@ export default function LocalStorageLayoutStorageProvider(
               const layout = migrateLayout(JSON.parse(item));
               localStorage.setItem(
                 `${KEY_PREFIX}.${namespace}.${layout.id}`,
-                JSON.stringify(layout),
+                JSON.stringify(layout) ?? "",
               );
               localStorage.removeItem(key);
             } catch (err) {

--- a/web/src/services/LocalStorageAppConfiguration.ts
+++ b/web/src/services/LocalStorageAppConfiguration.ts
@@ -28,7 +28,10 @@ export default class LocalStorageAppConfiguration implements AppConfiguration {
     if (value == undefined) {
       localStorage.removeItem(LocalStorageAppConfiguration.KEY_PREFIX + key);
     } else {
-      localStorage.setItem(LocalStorageAppConfiguration.KEY_PREFIX + key, JSON.stringify(value));
+      localStorage.setItem(
+        LocalStorageAppConfiguration.KEY_PREFIX + key,
+        JSON.stringify(value) ?? "",
+      );
     }
     const listeners = this.changeListeners.get(key);
     if (listeners) {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The typescript return type for `JSON.stringify` is `string` but it can in fact return `undefined` as well. This overrides the typing for this function to indicate that this is possible and force users of the function to handle this case.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
