### PR TITLE
Fixed: Panel settings editor doesn't correctly read default config values

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -199,6 +199,25 @@ type ComponentConstructorType<P> = { displayName?: string } & (
   | { (props: P): React.ReactElement<unknown> | ReactNull }
 );
 
+const areConfigKeysEqual = (
+  firstConfig: Record<string, unknown>,
+  secondConfig: Record<string, unknown>,
+): boolean => {
+  const firstConfigKeys = Object.keys(firstConfig).sort();
+  const secondConfigKeys = Object.keys(secondConfig).sort();
+
+  if (firstConfigKeys.length !== secondConfigKeys.length) {
+    return false;
+  }
+
+  for (let i = 0; i < firstConfigKeys.length; i++) {
+    if (firstConfigKeys[i] !== secondConfigKeys[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
 // HOC that wraps panel in an error boundary and flex box.
 // Gives panel a `config` and `saveConfig`.
 //   export default Panel(MyPanelComponent)
@@ -281,6 +300,8 @@ export default function Panel<
       if ((!savedConfig || Object.keys(savedConfig).length === 0) && !savedDefaultConfig.current) {
         savedDefaultConfig.current = true;
         saveConfig(defaultConfig);
+      } else if (savedConfig && !areConfigKeysEqual(savedConfig, defaultConfig)) {
+        saveConfig({ ...defaultConfig, ...savedConfig });
       }
     }, [defaultConfig, saveConfig, savedConfig]);
 

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -4,7 +4,7 @@
 
 import { DefaultButton, Link, Text, useTheme } from "@fluentui/react";
 import { Stack } from "@mui/material";
-import { StrictMode, useMemo, useEffect, useState } from "react";
+import { StrictMode, useMemo, useState } from "react";
 import { useAsync, useUnmount } from "react-use";
 
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
@@ -79,16 +79,6 @@ export default function PanelSettings({
   }, [selectedPanelId, showShareModal, getCurrentLayout, savePanelConfigs]);
 
   const [config, saveConfig] = useConfigById<Record<string, unknown>>(selectedPanelId);
-  const [configWithDefaults, setConfigWithDefaults] = useState(config);
-
-  useEffect(() => {
-    panelInfo
-      ?.module()
-      .then((result): void =>
-        setConfigWithDefaults({ ...result?.default.defaultConfig, ...config }),
-      )
-      .catch((): void => {});
-  }, [config, panelInfo]);
 
   const { value: schema, error } = useAsync(async () => {
     if (panelInfo?.type == undefined) {
@@ -161,13 +151,9 @@ export default function PanelSettings({
           </div>
         )}
         <div>
-          {schema && configWithDefaults ? (
+          {schema ? (
             <StrictMode>
-              <SchemaEditor
-                configSchema={schema}
-                config={configWithDefaults}
-                saveConfig={saveConfig}
-              />
+              <SchemaEditor configSchema={schema} config={config} saveConfig={saveConfig} />
             </StrictMode>
           ) : (
             <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -4,7 +4,7 @@
 
 import { DefaultButton, Link, Text, useTheme } from "@fluentui/react";
 import { Stack } from "@mui/material";
-import { StrictMode, useMemo, useState } from "react";
+import { StrictMode, useMemo, useEffect, useState } from "react";
 import { useAsync, useUnmount } from "react-use";
 
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
@@ -79,6 +79,16 @@ export default function PanelSettings({
   }, [selectedPanelId, showShareModal, getCurrentLayout, savePanelConfigs]);
 
   const [config, saveConfig] = useConfigById<Record<string, unknown>>(selectedPanelId);
+  const [configWithDefaults, setConfigWithDefaults] = useState(config);
+
+  useEffect(() => {
+    panelInfo
+      ?.module()
+      .then((result): void =>
+        setConfigWithDefaults({ ...result?.default.defaultConfig, ...config }),
+      )
+      .catch((): void => {});
+  }, [config, panelInfo]);
 
   const { value: schema, error } = useAsync(async () => {
     if (panelInfo?.type == undefined) {
@@ -151,9 +161,13 @@ export default function PanelSettings({
           </div>
         )}
         <div>
-          {schema ? (
+          {schema && configWithDefaults ? (
             <StrictMode>
-              <SchemaEditor configSchema={schema} config={config} saveConfig={saveConfig} />
+              <SchemaEditor
+                configSchema={schema}
+                config={configWithDefaults}
+                saveConfig={saveConfig}
+              />
             </StrictMode>
           ) : (
             <Text styles={{ root: { color: theme.palette.neutralTertiary } }}>


### PR DESCRIPTION
**User-Facing Changes**
- Fixed a bug where the panel settings editor didn't correctly read default config values


**Description**
When a panel config is updated to include new fields, an existing panel's config did not correctly read the new fields' default values. 

Resolves #2739