### PR TITLE
Small mesh rendering fixes

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -37,7 +37,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302",
-    "@foxglove/regl-worldview": "2.1.0",
+    "@foxglove/regl-worldview": "2.2.0",
     "@foxglove/ros1": "1.4.0",
     "@foxglove/ros2": "3.1.0",
     "@foxglove/rosbag": "0.1.2",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseDaeToGlb.ts
@@ -75,11 +75,14 @@ export async function parseDaeToGlb(buffer: ArrayBuffer): Promise<GlbModel> {
 function patchGlb(glb: GlbModel): void {
   // Change all the materials to a consistent shade of blue
   for (const material of glb.json.materials ?? []) {
-    material.pbrMetallicRoughness = {
+    material.pbrMetallicRoughness ??= {
       baseColorFactor: DEFAULT_COLOR,
       metallicFactor: 0,
       roughnessFactor: 1,
     };
+    if (material.pbrMetallicRoughness.baseColorFactor?.[3] === 0) {
+      material.pbrMetallicRoughness.baseColorFactor[3] = 1;
+    }
   }
 
   for (const mesh of glb.json.meshes ?? []) {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseStlToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseStlToGlb.ts
@@ -12,7 +12,7 @@ type Vector3 = [number, number, number];
 type StlData = {
   position: Float32Array;
   normal: Float32Array;
-  indices: Uint16Array;
+  indices: Uint32Array;
   minPosition: Vector3;
   maxPosition: Vector3;
   minNormal: Vector3;
@@ -50,7 +50,7 @@ export function parseStlToGlb(buffer: ArrayBuffer): GlbModel | undefined {
       },
       {
         bufferView: 2,
-        componentType: WebGLRenderingContext.UNSIGNED_SHORT,
+        componentType: WebGLRenderingContext.UNSIGNED_INT,
         count: stlData.indices.length,
         type: "SCALAR",
         min: [0],
@@ -132,19 +132,18 @@ function parseBinary(data: ArrayBuffer): StlData | undefined {
   const header = textDecoder.decode(data.slice(0, 80));
   const scale = getScale(header);
 
-  const reader = new DataView(data);
-  const maxFaces = reader.getUint32(80, true);
-  const faceCount = Math.min(Math.floor((data.byteLength - 84) / 50), maxFaces);
-  const vertexCount = faceCount * 3;
-  const floatCount = vertexCount * 3;
-
   const dataOffset = 84;
   const faceLength = 12 * 4 + 2;
+  const reader = new DataView(data);
+  const maxFaces = reader.getUint32(80, true);
+  const faceCount = Math.min(Math.floor((data.byteLength - dataOffset) / faceLength), maxFaces);
+  const vertexCount = faceCount * 3;
+  const floatCount = vertexCount * 3;
 
   const stlData: StlData = {
     position: new Float32Array(floatCount),
     normal: new Float32Array(floatCount),
-    indices: new Uint16Array(vertexCount),
+    indices: new Uint32Array(vertexCount),
     minPosition: [Infinity, Infinity, Infinity],
     maxPosition: [-Infinity, -Infinity, -Infinity],
     minNormal: [Infinity, Infinity, Infinity],
@@ -252,7 +251,7 @@ function parseAscii(data: string): StlData | undefined {
   return {
     position: new Float32Array(vertices),
     normal: new Float32Array(normals),
-    indices: new Uint16Array(indices),
+    indices: new Uint32Array(indices),
     minPosition,
     maxPosition,
     minNormal,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,9 +2325,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@foxglove/regl-worldview@npm:2.1.0"
+"@foxglove/regl-worldview@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@foxglove/regl-worldview@npm:2.2.0"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2345,7 +2345,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: a67778ec46d6761fb238ff65608e47405f66cde009a7ad295bc99ee39199c21b4bc08d986206cd7b6d426f707146b482696076837e9bb6434977279ed8cda28e
+  checksum: 2a197bf32dc3b769394fb3a3283347573d19e33e4aef9b4149ee6f076ea242a564c4e17a1ae07d9552c125656da933af1dafedf0d452eaffb9bdc64bf5a16387
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
-    "@foxglove/regl-worldview": 2.1.0
+    "@foxglove/regl-worldview": 2.2.0
     "@foxglove/ros1": 1.4.0
     "@foxglove/ros2": 3.1.0
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
Improved support for rendering large STL meshes. Improved material color support for Collada meshes and support unlit materials without normals.

**Description**
- Use Uint32Array instead of Uint16Array for STL → glTF conversion
- Upgrade regl-worldview for https://github.com/foxglove/regl-worldview/pull/11
- Don't override mesh color if there is an existing color