### PR TITLE
Add timeout to RosbridgePlayer getTopicsAndRawTypes

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -205,7 +205,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   // When a player is activated, hide the open dialog.
   useLayoutEffect(() => {
-    if (playerPresence === PlayerPresence.PRESENT) {
+    if (
+      playerPresence === PlayerPresence.PRESENT ||
+      playerPresence === PlayerPresence.INITIALIZING
+    ) {
       setShowOpenDialog(undefined);
     }
   }, [playerPresence]);


### PR DESCRIPTION

**User-Facing Changes**
There is additional user feedback if a Rosbridge connection is unable to lookup topics and raw types.

**Description**



Some versions of Rosbridge Suite would hang on getTopicsAndRawTypes requests. This change adds timeout logic and problems reporting so the user
has feedback on what went wrong. Previously this hang would provide no feedback and the user would be left with no indication on why studio is not displaying their data.

Fixes: #2715

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
