### PR TITLE
Fix Collada and STL mesh orientation; add option to ignore <up_axis> in Collada meshes

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -37,7 +37,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302",
-    "@foxglove/regl-worldview": "2.2.0",
+    "@foxglove/regl-worldview": "2.2.1",
     "@foxglove/ros1": "1.4.0",
     "@foxglove/ros2": "3.1.0",
     "@foxglove/rosbag": "0.1.2",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -235,6 +235,7 @@ export default function Layout({
     disableAutoOpenClickedObject = false,
     useThemeBackgroundColor,
     customBackgroundColor,
+    ignoreColladaUpAxis = false,
   },
 }: Props): React.ReactElement {
   const [filterText, setFilterText] = useState(""); // Topic tree text for filtering to see certain topics.
@@ -735,6 +736,8 @@ export default function Layout({
       : "#303030"
     : customBackgroundColor;
 
+  const loadModelOptions = useMemo(() => ({ ignoreColladaUpAxis }), [ignoreColladaUpAxis]);
+
   return (
     <ThreeDimensionalVizContext.Provider value={threeDimensionalVizContextValue}>
       <TopicTreeContext.Provider value={topicTreeData}>
@@ -819,6 +822,7 @@ export default function Layout({
               setSearchTextMatches={setSearchTextMatches}
               searchTextMatches={searchTextMatches}
               selectedMatchIndex={selectedMatchIndex}
+              loadModelOptions={loadModelOptions}
             >
               {children}
               <div>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -30,6 +30,7 @@ import WorldMarkers, {
   InteractiveMarkersByType,
   MarkerWithInteractionData,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/WorldMarkers";
+import { LoadModelOptions } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/MeshMarkers";
 import { LAYER_INDEX_DEFAULT_BASE } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 import {
   IImmutableCoordinateFrame,
@@ -71,6 +72,7 @@ type Props = WorldSearchTextProps & {
   onMouseDown?: MouseHandler;
   onMouseMove?: MouseHandler;
   onMouseUp?: MouseHandler;
+  loadModelOptions: LoadModelOptions;
 };
 
 function getMarkers({
@@ -145,6 +147,7 @@ function World(
     searchTextOpen,
     selectedMatchIndex,
     searchTextMatches,
+    loadModelOptions,
   }: Props,
   ref: typeof Worldview,
 ) {
@@ -232,6 +235,7 @@ function World(
           layerIndex: LAYER_INDEX_DEFAULT_BASE,
           clearCachedMarkers: false,
           cameraDistance: cameraState.distance ?? DEFAULT_CAMERA_STATE.distance,
+          loadModelOptions,
         }}
       />
     </Worldview>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -235,7 +235,6 @@ function World(
           markersByType: processedMarkersByType,
           layerIndex: LAYER_INDEX_DEFAULT_BASE,
           clearCachedMarkers: false,
-          cameraDistance: cameraState.distance ?? DEFAULT_CAMERA_STATE.distance,
           cameraDistance:
             mightActuallyBePartial(cameraState).distance ?? DEFAULT_CAMERA_STATE.distance,
           loadModelOptions,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
@@ -33,7 +33,9 @@ import {
   PointClouds,
   PoseMarkers,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands";
-import MeshMarkers from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/MeshMarkers";
+import MeshMarkers, {
+  LoadModelOptions,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/MeshMarkers";
 import {
   LAYER_INDEX_TEXT,
   LAYER_INDEX_OCCUPANCY_GRIDS,
@@ -103,6 +105,7 @@ export type WorldMarkerProps = {
   markersByType: InteractiveMarkersByType;
   clearCachedMarkers: boolean;
   cameraDistance: number;
+  loadModelOptions: LoadModelOptions;
 };
 
 // Average a list of color markers into a single output color value. The returned value is the
@@ -137,6 +140,7 @@ export default function WorldMarkers({
   layerIndex,
   markersByType,
   clearCachedMarkers,
+  loadModelOptions,
 }: WorldMarkerProps): JSX.Element {
   const getChildrenForHitmap = useMemo(() => createInstancedGetChildrenForHitmap(1), []);
   const {
@@ -217,7 +221,11 @@ export default function WorldMarkers({
       <Lines getChildrenForHitmap={getChildrenForHitmap} layerIndex={layerIndex}>
         {[...instancedLineList, ...groupedLines]}
       </Lines>
-      <MeshMarkers layerIndex={layerIndex} markers={mesh}></MeshMarkers>
+      <MeshMarkers
+        layerIndex={layerIndex}
+        markers={mesh}
+        loadModelOptions={loadModelOptions}
+      ></MeshMarkers>
     </>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -402,6 +402,11 @@ const configSchema: PanelConfigSchema<ThreeDimensionalVizConfig> = [
     title: "Automatically determine background color based on the color scheme",
   },
   { key: "customBackgroundColor", type: "color", title: "Background color" },
+  {
+    key: "ignoreColladaUpAxis",
+    type: "toggle",
+    title: "Ignore <up_axis> in Collada meshes",
+  },
 ];
 
 BaseRenderer.displayName = "ThreeDimensionalViz";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -102,6 +102,7 @@ export type ThreeDimensionalVizConfig = {
   autoSyncCameraState?: boolean;
   colorOverrideByVariable?: ColorOverrideByVariable;
   disableAutoOpenClickedObject?: boolean;
+  ignoreColladaUpAxis?: boolean;
 } & PreviousThreeDimensionalVizConfig;
 
 /**

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseStlToGlb.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/utils/parseStlToGlb.ts
@@ -5,6 +5,8 @@
 // The STL parsing logic is adapted from the MIT licensed ts-three-stl-loader at
 // <https://github.com/GarrettCannon/ts-three-stl-loader/blob/8db9d94fb609aa010555b70f99c37083c2ca0814/src/index.ts>
 
+import { quat } from "gl-matrix";
+
 import { GlbModel } from "@foxglove/studio-base/panels/ThreeDimensionalViz/utils/GlbModel";
 import type { GlTf } from "@foxglove/studio-base/panels/ThreeDimensionalViz/utils/gltf";
 
@@ -78,7 +80,17 @@ export function parseStlToGlb(buffer: ArrayBuffer): GlbModel | undefined {
       },
     ],
     meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2, material: 0 }] }],
-    nodes: [{ mesh: 0, rotation: [-Math.SQRT1_2, 0, 0, Math.SQRT1_2] }], // Z-up to Y-up
+    nodes: [
+      {
+        mesh: 0,
+        // Z-up to Y-up
+        rotation: quat.rotateZ(
+          [0, 0, 0, 0],
+          quat.rotateX([0, 0, 0, 0], [0, 0, 0, 1], -Math.PI / 2),
+          -Math.PI / 2,
+        ) as [number, number, number, number],
+      },
+    ],
     scene: 0,
     scenes: [{ nodes: [0] }],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,9 +2325,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@foxglove/regl-worldview@npm:2.2.0"
+"@foxglove/regl-worldview@npm:2.2.1":
+  version: 2.2.1
+  resolution: "@foxglove/regl-worldview@npm:2.2.1"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2345,7 +2345,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: 2a197bf32dc3b769394fb3a3283347573d19e33e4aef9b4149ee6f076ea242a564c4e17a1ae07d9552c125656da933af1dafedf0d452eaffb9bdc64bf5a16387
+  checksum: 00e3fc543747e6e2f683a519c989de9c34f7dfc7b6c8304514fb0bc28db70784d2e16976d495d79bd59d24ede116967922dfa22c2e57b3844c6cd0f45f8609f4
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
-    "@foxglove/regl-worldview": 2.2.0
+    "@foxglove/regl-worldview": 2.2.1
     "@foxglove/ros1": 1.4.0
     "@foxglove/ros2": 3.1.0
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
- Fixed orientation problems for STL and Collada meshes.
- Fixed a 3D panel crash when rendering a Collada mesh containing unsupported primitive types.
- Added a 3D panel setting to ignore `<up_axis>` in Collada meshes for improved RViz compatibility.

**Description**
RViz ignores the `<up_axis>` in a Collada file (https://github.com/ros-visualization/rviz/issues/1045). We support it, but this ends up causing issues with users who transition from RViz to Studio and don't realize that their URDF and Collada mesh are not in agreement about orientation settings. To maintain compatibility, this PR adds a setting to the 3D panel to make it ignore the `<up_axis>` (and thus behave more like RViz).

This PR also fixes the orientation adjustments made to both STL and Collada meshes, and upgrades regl-worldview for https://github.com/foxglove/regl-worldview/pull/12 (found via ur_description/ur3_robot.urdf.xacro).

Fixes https://github.com/foxglove/studio/issues/2706


https://user-images.githubusercontent.com/14237/151471184-c9b221ed-104a-47c5-87db-b6f8777d7bed.mov

Current implementation:

<img width="1006" alt="Screen Shot 2022-01-27 at 4 28 14 PM" src="https://user-images.githubusercontent.com/14237/151470935-78eb79da-1fa8-45ef-acc7-b1caaffe072d.png">

This PR (visual elements, mostly Collada):

<img width="1031" alt="Screen Shot 2022-01-27 at 4 31 46 PM" src="https://user-images.githubusercontent.com/14237/151470999-b0d6df9c-3859-4940-af51-f88b9a989e60.png">

This PR (collision elements, mostly primitives + STL):

<img width="808" alt="Screen Shot 2022-01-27 at 4 13 15 PM" src="https://user-images.githubusercontent.com/14237/151471056-597d52bd-6e8d-42a2-8a27-8fd5d650d3b5.png">
