### PR TITLE
Respect color for meshes with `mesh_use_embedded_materials: false` and STL meshes in URDFs

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -37,7 +37,7 @@
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302",
-    "@foxglove/regl-worldview": "2.3.0",
+    "@foxglove/regl-worldview": "2.4.0",
     "@foxglove/ros1": "1.4.0",
     "@foxglove/ros2": "3.1.0",
     "@foxglove/rosbag": "0.1.2",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/UrdfBuilder.ts
@@ -343,7 +343,10 @@ export default class UrdfBuilder extends EventEmitter<EventTypes> implements Mar
       color: getColor(visual, robot),
       frame_locked: true,
       mesh_resource: mesh.filename,
-      mesh_use_embedded_materials: true,
+      mesh_use_embedded_materials:
+        visual.material == undefined ||
+        // RViz ignores the URDF-specified material when the Collada mesh has an embedded material
+        (visual.geometry.geometryType === "mesh" && visual.geometry.filename.endsWith(".dae")),
     };
     return marker;
   }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/MeshMarkers.tsx
@@ -112,15 +112,19 @@ function MeshMarkers({ markers, loadModelOptions, layerIndex }: MeshMarkerProps)
 
   for (let i = 0; i < markers.length; i++) {
     const marker = markers[i]!;
-    const { mesh_resource, color } = marker;
+    const { mesh_resource, mesh_use_embedded_materials, color } = marker;
     if (!mesh_resource) {
       continue;
     }
     const url = rewritePackageUrl(mesh_resource, { rosPackagePath });
     const alpha = (color?.a ?? 0) > 0 ? color!.a : 1;
 
-    const newMarker = { ...marker, alpha };
-    delete newMarker.color;
+    const newMarker = {
+      ...marker,
+      alpha,
+      overrideColor: mesh_use_embedded_materials ? undefined : color,
+    };
+    delete newMarker.color; // color field is used for hitmap
 
     models.push(
       <GLTFScene

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -2108,10 +2108,20 @@ endsolid AssimpScene`),
     sizeInBytes: 0,
   };
 
+  const coloredMesh = {
+    ...mesh,
+    message: {
+      ...mesh.message,
+      id: "coloredMesh",
+      mesh_use_embedded_materials: false,
+      pose: { ...mesh.message.pose, position: { x: -1, y: 0, z: 0 } },
+    },
+  };
+
   const fixture = useDelayedFixture({
     datatypes,
     topics,
-    frame: { "/markers": [mesh] },
+    frame: { "/markers": [mesh, coloredMesh] },
     capabilities: [],
     activeData: { currentTime: { sec: 0, nsec: 0 } },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2325,9 +2325,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/regl-worldview@npm:2.3.0":
-  version: 2.3.0
-  resolution: "@foxglove/regl-worldview@npm:2.3.0"
+"@foxglove/regl-worldview@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@foxglove/regl-worldview@npm:2.4.0"
   dependencies:
     "@babel/runtime": ^7.3.1
     "@mapbox/tiny-sdf": ^1.1.1
@@ -2345,7 +2345,7 @@ __metadata:
   peerDependencies:
     react: 16.x
     react-dom: 16.x
-  checksum: 6a0c7a0bc94be0dc6c0b02c73ad2ce7fde1776773a5ec75b8ccf87540acb6aca6fbd9b583a6406602b126d3fd49746829327681f5d3c3eb2b3681a5c100418b3
+  checksum: c509b5307845d436c182a3a6eaf6253ba449af3bfe40b1acd4938ebfc12bfb53fc9a037dee51a6e6bfd9c4b1d582b11eba4b82401b0f756505034b50758f2c2c
   languageName: node
   linkType: hard
 
@@ -2496,7 +2496,7 @@ __metadata:
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
-    "@foxglove/regl-worldview": 2.3.0
+    "@foxglove/regl-worldview": 2.4.0
     "@foxglove/ros1": 1.4.0
     "@foxglove/ros2": 3.1.0
     "@foxglove/rosbag": 0.1.2


### PR DESCRIPTION
**User-Facing Changes**
- Mesh markers with `mesh_use_embedded_materials: false` are now rendered using the color specified in the marker.
- URDF visual elements using STL meshes now respect the material color specified in the URDF.

**Description**
Use https://github.com/foxglove/regl-worldview/pull/14 to override the color of meshes that don't have embedded materials.

Known issues:
If a URDF points at a .glb mesh, or even for .dae, we don't actually check whether or not the mesh contains embedded materials. Theoretically we might want to enable the URDF-provided color only if the mesh doesn't actually contain one, but this would require refactoring the pipeline so that we can inspect the parsed glTF object when deciding what color settings to pass into the GLTFScene renderer.

<img width="722" alt="image" src="https://user-images.githubusercontent.com/14237/151601225-36aa11e8-5b0e-4fe8-8ea3-f36b156f0ac0.png">
