### PR TITLE
Disable minimization in storybook build to improve performance

### DIFF
--- a/packages/studio-base/src/.storybook/main.ts
+++ b/packages/studio-base/src/.storybook/main.ts
@@ -27,6 +27,10 @@ module.exports = {
 
     return {
       ...config,
+      optimization: {
+        ...config.optimization,
+        minimize: false, // disabling minification improves build performance
+      },
       resolve: {
         ...studioWebpackConfig.resolve,
         alias: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The storybook config used TerserPlugin for minimization which was slow. We don't really need minimization for storybook, so just disable it. Cuts `yarn storybook:build` time in half on my M1 Pro.