### PR TITLE
Update rosbridge player to re-subscribe to all topics

### DIFF
--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -383,6 +383,20 @@ export default class RosbridgePlayer implements Player {
       return;
     }
 
+    // Unsubscribe from all topics. When a panel subscribes to an existing topic, we want it to
+    // receive the last message on the topic. This is especially important for topics like
+    // `/tf_static` which publish a latching message once.
+    //
+    // Rather than maintaining a cache of the last message on every subscribed topic within our RosbridgePlayer,
+    // we perform an unsubscribe/re-subscribe cycle. This makes rosbridge server drop its subscriptions
+    // and make new ones. When it does this, latching publishers will re-send their last message.
+    //
+    // Rosbridge server will forward that message and all panels will receive the latched message.
+    for (const [topicName, topic] of this._topicSubscriptions) {
+      topic.unsubscribe();
+      this._topicSubscriptions.delete(topicName);
+    }
+
     // Subscribe to additional topics used by Ros1Player itself
     this._addInternalSubscriptions(subscriptions);
 
@@ -394,11 +408,12 @@ export default class RosbridgePlayer implements Player {
       .map(({ topic }) => topic)
       .filter((topicName) => availableTopicsByTopicName[topicName]);
 
-    // Subscribe to all topics that we aren't subscribed to yet.
+    // Subscribe to topics
     for (const topicName of topicNames) {
       if (this._topicSubscriptions.has(topicName)) {
         continue;
       }
+
       const topic = new roslib.Topic({
         ros: this._rosClient,
         name: topicName,
@@ -470,14 +485,6 @@ export default class RosbridgePlayer implements Player {
         this._emitState();
       });
       this._topicSubscriptions.set(topicName, topic);
-    }
-
-    // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const [topicName, topic] of this._topicSubscriptions) {
-      if (!topicNames.includes(topicName)) {
-        topic.unsubscribe();
-        this._topicSubscriptions.delete(topicName);
-      }
     }
   }
 


### PR DESCRIPTION
**User-Facing Changes**
When connected to Rosbridge and opening multiple panels that need latching topics (like `/tf_static`), all panels will receive the message.

Previously only the first panel to subscribe would receive the message.

**Description**


Previously, new panel subscriptions to existing latching topics would
never receive the latched message. This happened because the RosbridgePlayer would ignore subscriptions to topics it was already subscribed to but would not send any previous messages on these topics to the new subscribers.

This change updates RosbridgePlayer logic to perform an unsubscribe/resubscribe cycle whenever the topic subscriptions change. This allows the underlying rosbridge server to process the subscription again and send any latched messages.

See: #2343



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
