### PR TITLE
Re-subscribe to all topics when changing subscribers for ros1

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -342,6 +342,18 @@ export default class Ros1Player implements Player {
       return;
     }
 
+    // Unsubscribe from all topics.
+    // When a panel subscribes to an existing topic, we want it to receive the last message on the
+    // topic. This is especially important for topics like `/tf_static` which publish a latching
+    // message once.
+    //
+    // Rather than maintaining a cache of the last message on every subscribed topic, we perform an
+    // unsubscribe/re-subscribe cycle. This causes us to establish new subscriptions to all our
+    // topics. With the new subscriptions, latching publishers will re-send their last message.
+    for (const topicName of this._rosNode.subscriptions.keys()) {
+      this._rosNode.unsubscribe(topicName);
+    }
+
     // Subscribe to additional topics used by Ros1Player itself
     this._addInternalSubscriptions(subscriptions);
 
@@ -378,15 +390,6 @@ export default class Ros1Player implements Player {
           error,
         });
       });
-    }
-
-    // Unsubscribe from topics that we are subscribed to but shouldn't be.
-    for (const topicName of this._rosNode.subscriptions.keys()) {
-      if (!topicNames.includes(topicName)) {
-        {
-          this._rosNode.unsubscribe(topicName);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
**User-Facing Changes**
When connected to ROS1 and opening multiple panels that need latching topics (like /tf_static), all panels will receive the message.

Previously only the first panel to subscribe would receive the message.

**Description**

Previously, new panel subscriptions to existing latching topics would never receive the latched message. This happened because the Ros1Player would ignore subscriptions to topics it was already subscribed to but would not send any previous messages on these topics to the new subscribers.

This change updates Ros1Player to performan an unsubscribe/subsribe cycle whenever the topic subscriptions change. This establishes new subscriptions which re-send any latched messages.

See: #2343




<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
