### PR TITLE
Update SceneBuilder to check for required PointCloud fields.

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -995,7 +995,7 @@ export default class SceneBuilder implements MarkerProvider {
         if (missingFields.length > 0) {
           this._setTopicError(
             topic.name,
-            `Missing required fields entry for field names: ${missingFields}`,
+            `Point cloud is missing required fields: ${missingFields}`,
           );
           return;
         }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -974,8 +974,34 @@ export default class SceneBuilder implements MarkerProvider {
         return add.triangleList(marker);
       case 101:
         return add.grid(marker);
-      case 102:
+      case 102: {
+        // PointCloud decoding requires x, y, and z fields and will fail if all are not present.
+        // We check for the fields here so we can present the user with a topic error prior to decoding.
+        const fieldNames: { [key: string]: boolean } = {};
+        for (const field of marker.fields) {
+          fieldNames[field.name] = true;
+        }
+
+        let missingFields = "";
+        if (fieldNames.x == undefined) {
+          missingFields += "x";
+        }
+        if (fieldNames.y == undefined) {
+          missingFields += " y";
+        }
+        if (fieldNames.z == undefined) {
+          missingFields += " z";
+        }
+        if (missingFields.length > 0) {
+          this._setTopicError(
+            topic.name,
+            `Missing required fields entry for field names: ${missingFields}`,
+          );
+          return;
+        }
+
         return add.pointcloud(marker);
+      }
       case 103:
         return add.poseMarker(marker);
       case 104:

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/memoization.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/memoization.ts
@@ -24,7 +24,7 @@ export function updateMarkerCache(
   markers: PointCloudMarker[],
 ): Map<Uint8Array, MemoizedMarker> {
   const markerCache = new Map<Uint8Array, MemoizedMarker>();
-  markers.forEach((marker) => {
+  for (const marker of markers) {
     let decoded = existing.get(marker.data);
     // Check if a decoded marker already exists in cache. If not, decode it and save it for later use
     // Compare 'settings' by deep-equality since they may be change by user. Also, the instance is different when re-rendering Layout
@@ -46,7 +46,7 @@ export function updateMarkerCache(
     decoded.marker.pose = marker.pose;
 
     markerCache.set(marker.data, decoded);
-  });
+  }
   return markerCache;
 }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -1972,6 +1972,89 @@ export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
   );
 }
 
+// Should display a topic error to the user when the PointCloud message is missing the necessary
+// field descriptions.
+SensorMsgs_PointCloud2_InsufficientFields.parameters = { colorScheme: "dark" };
+export function SensorMsgs_PointCloud2_InsufficientFields(): JSX.Element {
+  const topics: Topic[] = [{ name: "/pointcloud", datatype: "sensor_msgs/PointCloud2" }];
+
+  const SCALE = 10 / 128;
+
+  function f(x: number, y: number) {
+    return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
+  }
+
+  const data = new Uint8Array(128 * 128 * 12);
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  for (let y = 0; y < 128; y++) {
+    for (let x = 0; x < 128; x++) {
+      const i = (y * 128 + x) * 12;
+      view.setFloat32(i + 0, x * SCALE - 5, true);
+      view.setFloat32(i + 4, y * SCALE - 5, true);
+      view.setFloat32(i + 8, f(x, y) * 5, true);
+    }
+  }
+
+  const pointCloud: MessageEvent<PointCloud2> = {
+    topic: "/pointcloud",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      type: 102,
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      height: 1,
+      width: 128 * 128,
+      fields: [
+        { name: "x", offset: 0, datatype: 7, count: 1 },
+        { name: "y", offset: 4, datatype: 7, count: 1 },
+      ],
+      is_bigendian: false,
+      point_step: 12,
+      row_step: 128 * 128 * 12,
+      data,
+      is_dense: 1,
+    },
+    sizeInBytes: 0,
+  };
+
+  const fixture = useDelayedFixture({
+    datatypes,
+    topics,
+    frame: {
+      "/pointcloud": [pointCloud],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 0, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDimensionalViz
+        overrideConfig={{
+          ...ThreeDimensionalViz.defaultConfig,
+          checkedKeys: ["name:Topics", "t:/pointcloud", `t:${FOXGLOVE_GRID_TOPIC}`],
+          expandedKeys: ["name:Topics", "t:/pointcloud", `t:${FOXGLOVE_GRID_TOPIC}`],
+          pinTopics: true,
+          followTf: "sensor",
+          cameraState: {
+            distance: 13.5,
+            perspective: true,
+            phi: 1.22,
+            targetOffset: [0.25, -0.5, 0],
+            thetaOffset: -0.33,
+            fovy: 0.75,
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 LargeTransform.parameters = { colorScheme: "dark" };
 export function LargeTransform(): JSX.Element {
   const topics: Topic[] = [

--- a/packages/studio-base/src/util/sendNotification.ts
+++ b/packages/studio-base/src/util/sendNotification.ts
@@ -48,7 +48,7 @@ const defaultNotificationHandler: NotificationHandler = (
   type: NotificationType,
   severity: NotificationSeverity,
 ): void => {
-  if (!inWebWorker()) {
+  if (inWebWorker()) {
     const webWorkerError =
       "Web Worker has uninitialized sendNotification function; this means this error message cannot show up in the UI (so we show it here in the console instead).";
     if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
**User-Facing Changes**
Rather than crashing the app when fields are missing from the PointCloud message, the user is shown a topic error next to the malformed topic.

![image](https://user-images.githubusercontent.com/84792/151906297-9f05f38a-bab2-429f-b2f1-b2718f5fb033.png)

Any other rendering errors result in a panel crash.

**Description**
PointCloud rendering requires field descriptions for x, y, and z fields. This change updates SceneBuilder to check for these fields prior to adding the point cloud to the collector. This allows the UI to display a topic error for the malformed topic better informing the user to errors with their data.

Fixes: #2759

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
