### PR TITLE
Render grid using native GL lines, remove line width setting

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
@@ -115,7 +115,7 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
           onMouseMove={noop}
           onMouseUp={noop}
         >
-          <GlLineLists>{collector.data.glLineList}</GlLineLists>
+          <GlLineLists glLineLists={collector.data.glLineList} />
         </Worldview>
         <SExpectedResult>A 10x10 grid should be rendered</SExpectedResult>
       </div>
@@ -153,7 +153,7 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
           onMouseMove={noop}
           onMouseUp={noop}
         >
-          <GlLineLists>{collector.data.glLineList}</GlLineLists>
+          <GlLineLists glLineLists={collector.data.glLineList} />
         </Worldview>
         <SExpectedResult>A magenta rectangle should be rendered, offset down</SExpectedResult>
       </div>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/GridBuilder.stories.tsx
@@ -15,9 +15,10 @@ import { storiesOf } from "@storybook/react";
 import { noop } from "lodash";
 import styled from "styled-components";
 
-import { DEFAULT_CAMERA_STATE, Lines, Worldview } from "@foxglove/regl-worldview";
+import { DEFAULT_CAMERA_STATE, Worldview } from "@foxglove/regl-worldview";
 import { TopicSettingsCollection } from "@foxglove/studio-base/panels/ThreeDimensionalViz/SceneBuilder";
 import { GridSettings } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor/GridSettingsEditor";
+import GlLineLists from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/GlLineLists";
 import { CoordinateFrame } from "@foxglove/studio-base/panels/ThreeDimensionalViz/transforms";
 import useTransforms from "@foxglove/studio-base/panels/ThreeDimensionalViz/useTransforms";
 import {
@@ -26,6 +27,7 @@ import {
   CubeListMarker,
   CubeMarker,
   CylinderMarker,
+  GlLineListMarker,
   InstancedLineListMarker,
   LaserScan,
   LineListMarker,
@@ -55,7 +57,7 @@ const SExpectedResult = styled.div`
 
 class MockMarkerCollector implements MarkerCollector {
   data = {
-    instancedLineList: [] as InstancedLineListMarker[],
+    glLineList: [] as GlLineListMarker[],
   };
 
   arrow(_arg0: ArrowMarker): void {}
@@ -75,8 +77,9 @@ class MockMarkerCollector implements MarkerCollector {
   grid(_arg0: OccupancyGridMessage): void {}
   pointcloud(_arg0: PointCloud): void {}
   laserScan(_arg0: LaserScan): void {}
-  instancedLineList(arg0: InstancedLineListMarker): void {
-    this.data.instancedLineList.push(arg0);
+  instancedLineList(_arg0: InstancedLineListMarker): void {}
+  glLineList(arg0: Readonly<{ color: Float32Array; points: Float32Array }>): void {
+    this.data.glLineList.push(arg0);
   }
 }
 
@@ -112,7 +115,7 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
           onMouseMove={noop}
           onMouseUp={noop}
         >
-          <Lines>{collector.data.instancedLineList}</Lines>
+          <GlLineLists>{collector.data.glLineList}</GlLineLists>
         </Worldview>
         <SExpectedResult>A 10x10 grid should be rendered</SExpectedResult>
       </div>
@@ -124,7 +127,6 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
     const gridBuilder = new GridBuilder();
     const settings: GridSettings = {
       heightOffset: -3,
-      lineWidth: 3,
       overrideColor: { r: 1, g: 0, b: 1, a: 1 },
       subdivisions: 0,
       width: 5,
@@ -151,11 +153,9 @@ storiesOf("panels/ThreeDimensionalViz/GridBuilder", module)
           onMouseMove={noop}
           onMouseUp={noop}
         >
-          <Lines>{collector.data.instancedLineList}</Lines>
+          <GlLineLists>{collector.data.glLineList}</GlLineLists>
         </Worldview>
-        <SExpectedResult>
-          A magenta rectangle with thick lines should be rendered, offset down
-        </SExpectedResult>
+        <SExpectedResult>A magenta rectangle should be rendered, offset down</SExpectedResult>
       </div>
     );
   });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/GridSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/GridSettingsEditor.tsx
@@ -21,7 +21,6 @@ import { SLabel, SDescription, SInput } from "./common";
 
 export type GridSettings = {
   overrideColor?: Color;
-  lineWidth?: number;
   width?: number;
   subdivisions?: number;
   heightOffset?: number;
@@ -41,21 +40,6 @@ export default function GridSettingsEditor(
       <ColorPicker
         color={settings.overrideColor ?? DEFAULT_GRID_COLOR}
         onChange={(newColor) => onFieldChange("overrideColor", newColor)}
-      />
-
-      <SLabel>Line width</SLabel>
-      <SInput
-        data-test="line-width-input"
-        type="number"
-        placeholder={"1"}
-        value={settings.lineWidth ?? ""}
-        min={0.1}
-        max={2}
-        step={0.1}
-        onChange={(e) => {
-          const isInputValid = !isNaN(parseFloat(e.target.value));
-          onFieldChange("lineWidth", isInputValid ? parseFloat(e.target.value) : undefined);
-        }}
       />
 
       <SLabel>Width</SLabel>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/World.tsx
@@ -43,6 +43,7 @@ import {
   CubeListMarker,
   CubeMarker,
   CylinderMarker,
+  GlLineListMarker,
   LineListMarker,
   LineStripMarker,
   MeshMarker,
@@ -114,6 +115,7 @@ function getMarkers({
     sphereList: (o) => markers.sphereList.push(o as Interactive<SphereListMarker>),
     text: (o) => markers.text.push(o as Interactive<TextMarker>),
     triangleList: (o) => markers.triangleList.push(o as unknown as MarkerWithInteractionData),
+    glLineList: (o) => markers.glLineList.push(o as Interactive<GlLineListMarker>),
   };
 
   const args = { add: collector, transforms, renderFrame, fixedFrame, time };
@@ -175,6 +177,7 @@ function World(
     sphereList: [],
     text: [],
     triangleList: [],
+    glLineList: [],
   };
   for (const key in markersRef.current) {
     (markersRef.current as Record<string, unknown[]>)[key]!.length = 0;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
@@ -33,6 +33,7 @@ import {
   PointClouds,
   PoseMarkers,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands";
+import GlLineLists from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/GlLineLists";
 import MeshMarkers, {
   LoadModelOptions,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/MeshMarkers";
@@ -53,6 +54,7 @@ import {
   TextMarker,
   ColorMarker,
   MeshMarker,
+  GlLineListMarker,
 } from "@foxglove/studio-base/types/Messages";
 import { ReglColor } from "@foxglove/studio-base/util/colorUtils";
 
@@ -81,6 +83,7 @@ export type InteractiveMarkersByType = {
   sphereList: Interactive<SphereListMarker>[];
   text: Interactive<TextMarker>[];
   triangleList: MarkerWithInteractionData[];
+  glLineList: Interactive<GlLineListMarker>[];
 };
 
 // Generate an alphabet for text makers with the most
@@ -162,6 +165,7 @@ export default function WorldMarkers({
     sphere,
     sphereList,
     triangleList,
+    glLineList,
   } = markersByType;
 
   // GLTextAtlas download is shared among all instances of World, but we should only load the GLText command once we
@@ -221,11 +225,8 @@ export default function WorldMarkers({
       <Lines getChildrenForHitmap={getChildrenForHitmap} layerIndex={layerIndex}>
         {[...instancedLineList, ...groupedLines]}
       </Lines>
-      <MeshMarkers
-        layerIndex={layerIndex}
-        markers={mesh}
-        loadModelOptions={loadModelOptions}
-      ></MeshMarkers>
+      <MeshMarkers layerIndex={layerIndex} markers={mesh} loadModelOptions={loadModelOptions} />
+      <GlLineLists>{glLineList}</GlLineLists>
     </>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/WorldMarkers.tsx
@@ -226,7 +226,7 @@ export default function WorldMarkers({
         {[...instancedLineList, ...groupedLines]}
       </Lines>
       <MeshMarkers layerIndex={layerIndex} markers={mesh} loadModelOptions={loadModelOptions} />
-      <GlLineLists>{glLineList}</GlLineLists>
+      <GlLineLists glLineLists={glLineList} />
     </>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/GlLineLists.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/GlLineLists.tsx
@@ -62,11 +62,13 @@ const rawCommand = (regl: REGL.Regl) => {
 };
 
 type Props = CommonCommandProps & {
-  // TypeScript doesn't allow us to pass an array variable if `children` is set to an array type here
-  // https://github.com/microsoft/TypeScript/issues/30711#issuecomment-485013588
-  children: React.ReactNode;
+  glLineLists: GlLineListMarker[];
 };
 
 export default function GlLineLists(props: Props): JSX.Element {
-  return <Command getChildrenForHitmap={undefined} {...props} reglCommand={rawCommand} />;
+  return (
+    <Command getChildrenForHitmap={undefined} {...props} reglCommand={rawCommand}>
+      {props.glLineLists}
+    </Command>
+  );
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/GlLineLists.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/GlLineLists.tsx
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import type REGL from "regl";
+
+import { Command, defaultBlend, CommonCommandProps } from "@foxglove/regl-worldview";
+import { GlLineListMarker } from "@foxglove/studio-base/types/Messages";
+
+type Uniforms = {
+  color: Float32Array;
+};
+type Attributes = {
+  point: Float32Array;
+};
+type CommandProps = GlLineListMarker;
+
+const rawCommand = (regl: REGL.Regl) => {
+  return regl<Uniforms, Attributes, CommandProps, Record<string, never>, REGL.DefaultContext>({
+    primitive: "lines",
+
+    vert: `
+    precision lowp float;
+
+    uniform mat4 projection, view;
+    attribute vec3 point;
+
+    void main () {
+      gl_Position = projection * view * vec4(point, 1);
+    }
+    `,
+    frag: `
+    precision lowp float;
+    uniform vec4 color;
+    void main () {
+      gl_FragColor = color;
+    }
+    `,
+    blend: defaultBlend,
+
+    depth: { enable: true, mask: true },
+
+    attributes: {
+      point: regl.prop("points"),
+    },
+
+    uniforms: {
+      color: regl.prop("color"),
+    },
+
+    count: (_ctx, props) => props.points.length / 3,
+  });
+};
+
+type Props = CommonCommandProps & {
+  // TypeScript doesn't allow us to pass an array variable if `children` is set to an array type here
+  // https://github.com/microsoft/TypeScript/issues/30711#issuecomment-485013588
+  children: React.ReactNode;
+};
+
+export default function GlLineLists(props: Props): JSX.Element {
+  return <Command getChildrenForHitmap={undefined} {...props} reglCommand={rawCommand} />;
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
@@ -4,9 +4,10 @@
 
 import { quat, vec3 } from "gl-matrix";
 
-import { Worldview, Lines, DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
+import { Worldview, DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
 import GridBuilder from "@foxglove/studio-base/panels/ThreeDimensionalViz/GridBuilder";
 
+import GlLineLists from "./GlLineLists";
 import OccupancyGrids from "./OccupancyGrids";
 
 export default {
@@ -62,7 +63,7 @@ export function Rotations(): JSX.Element {
       cameraMode="perspective"
       hideDebug
     >
-      <Lines>{[GridBuilder.BuildGrid({ width: 20, subdivisions: 19 })]}</Lines>
+      <GlLineLists>{[GridBuilder.BuildGrid({ width: 20, subdivisions: 19 })]}</GlLineLists>
       <OccupancyGrids>
         {[
           makeGrid([-5, 5, 0], quat.rotateX(quat.create(), identity, 0)),

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.stories.tsx
@@ -63,7 +63,7 @@ export function Rotations(): JSX.Element {
       cameraMode="perspective"
       hideDebug
     >
-      <GlLineLists>{[GridBuilder.BuildGrid({ width: 20, subdivisions: 19 })]}</GlLineLists>
+      <GlLineLists glLineLists={[GridBuilder.BuildGrid({ width: 20, subdivisions: 19 })]} />
       <OccupancyGrids>
         {[
           makeGrid([-5, 5, 0], quat.rotateX(quat.create(), identity, 0)),

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/types.ts
@@ -32,6 +32,7 @@ import {
   ColorMarker,
   PoseStamped,
   MeshMarker,
+  GlLineListMarker,
 } from "@foxglove/studio-base/types/Messages";
 
 import { ColorOverrideByVariable, ColorOverride } from "./Layout";
@@ -68,6 +69,7 @@ export interface MarkerCollector {
   pointcloud(arg0: PointCloud): void;
   laserScan(arg0: LaserScan): void;
   instancedLineList(arg0: InstancedLineListMarker): void;
+  glLineList(arg0: GlLineListMarker): void;
 }
 
 export type MouseEventName = "onDoubleClick" | "onMouseMove" | "onMouseDown" | "onMouseUp";

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
@@ -38,17 +38,16 @@ const withHighlights = (
     const nonHighlightedMarkersByType: Partial<InteractiveMarkersByType> = {};
 
     // Partition the markersByType into two sets: highlighted and non-highlighted
-    Object.entries(markersByType).forEach(([type, markers]) => {
-      const [highlightedMarkers, nonHighlightedMarkers] = partition(
+    for (const [type, markers] of Object.entries(markersByType)) {
+      const [highlightedMarkers, nonHighlightedMarkers] = partition<Interactive<unknown>>(
         markers,
-        (marker: Interactive<unknown>) =>
-          mightActuallyBePartial(marker).interactionData?.highlighted,
+        (marker) => mightActuallyBePartial(marker).interactionData?.highlighted,
       );
 
       (highlightedMarkersByType as Record<string, unknown>)[type] = highlightedMarkers;
       (nonHighlightedMarkersByType as Record<string, unknown>)[type] = nonHighlightedMarkers;
       hasHighlightedMarkers = hasHighlightedMarkers || highlightedMarkers.length > 0;
-    });
+    }
 
     return (
       <>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
@@ -60,7 +60,6 @@ const withHighlights = (
           }}
         />
         <Cover
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           color={[0, 0, 0, hasHighlightedMarkers ? 0.6 : 0]}
           layerIndex={LAYER_INDEX_HIGHLIGHT_OVERLAY}
           overwriteDepthBuffer

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/withHighlights.tsx
@@ -14,6 +14,7 @@
 import { partition } from "lodash";
 import { ComponentType } from "react";
 
+import { Interactive } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/types";
 import {
   InteractiveMarkersByType,
   WorldMarkerProps,
@@ -40,7 +41,8 @@ const withHighlights = (
     Object.entries(markersByType).forEach(([type, markers]) => {
       const [highlightedMarkers, nonHighlightedMarkers] = partition(
         markers,
-        (marker) => mightActuallyBePartial(marker).interactionData?.highlighted,
+        (marker: Interactive<unknown>) =>
+          mightActuallyBePartial(marker).interactionData?.highlighted,
       );
 
       (highlightedMarkersByType as Record<string, unknown>)[type] = highlightedMarkers;

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -212,6 +212,11 @@ export type TextMarker = Readonly<
   }
 >;
 
+export type GlLineListMarker = Readonly<{
+  color: Float32Array;
+  points: Float32Array;
+}>;
+
 export type MeshMarker = Readonly<
   BaseMarker & {
     type: 10;


### PR DESCRIPTION
**User-Facing Changes**
Improved 3D panel grid rendering for large grids; removed the line width setting for grids.

**Description**
Closes #2742.

In investigating this ticket, we learned that the problem with our scale-invariant line rendering is that the [two](https://github.com/foxglove/regl-worldview/blob/92df7aad8d28d15a811d5daaed672261c507e27a/src/commands/Lines.js#L173-L176) [places](https://github.com/foxglove/regl-worldview/blob/92df7aad8d28d15a811d5daaed672261c507e27a/src/commands/Lines.js#L144-L145) where we manually multiply/divide by `w` does not match the way the GPU handles vertex positions in extreme cases, such as `w < 0` (a vertex behind the camera). This is because the GPU [performs clipping](https://stackoverflow.com/a/41087445/23649) before perspective division. Additionally, [varying values may be incorrect](https://webglfundamentals.org/webgl/lessons/webgl-3d-perspective-correct-texturemapping.html) when implementing perspective division manually.

A complete fix to the instanced line renderer does not seem within reach in the short term, so to address the issue this PR converts the Grid feature to use native GL lines and removes the thickness setting. (Although the GL line width is configurable, the limits may vary by browser/platform and [MDN recommends](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/lineWidth) to only use the default thickness of 1.)