### PR TITLE
Avoid automatically highlighting the first entry in the Add Panel List

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -363,8 +363,7 @@ function PanelList(props: Props): JSX.Element {
           if (existing == undefined) {
             return allFilteredPanels.length - 1;
           }
-          const newIdx = (existing - 1) % (allFilteredPanels.length - 1);
-          return newIdx >= 0 ? newIdx : allFilteredPanels.length + newIdx;
+          return (existing - 1 + allFilteredPanels.length) % allFilteredPanels.length;
         });
       } else if (e.key === "Enter" && highlightedPanel) {
         onPanelSelect({

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -360,6 +360,11 @@ function PanelList(props: Props): JSX.Element {
         });
       } else if (e.key === "ArrowUp") {
         setHighlightedPanelIdx((existing) => {
+          // nothing to highlight if there are no entries
+          if (allFilteredPanels.length <= 0) {
+            return undefined;
+          }
+
           if (existing == undefined) {
             return allFilteredPanels.length - 1;
           }

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -290,8 +290,12 @@ function PanelList(props: Props): JSX.Element {
   );
 
   const handleSearchChange = React.useCallback((e: React.SyntheticEvent<HTMLInputElement>) => {
-    setSearchQuery(e.currentTarget.value);
-    setHighlightedPanelIdx(0);
+    const query = e.currentTarget.value;
+    setSearchQuery(query);
+
+    // When there is a search query, automatically highlight the first (0th) item.
+    // When the user erases the query, remove the highlight.
+    setHighlightedPanelIdx(query ? 0 : undefined);
   }, []);
 
   const panelCatalog = usePanelCatalog();
@@ -347,11 +351,21 @@ function PanelList(props: Props): JSX.Element {
       if (mode === "grid") {
         return;
       }
-      if (e.key === "ArrowDown" && highlightedPanelIdx != undefined) {
-        setHighlightedPanelIdx((highlightedPanelIdx + 1) % allFilteredPanels.length);
-      } else if (e.key === "ArrowUp" && highlightedPanelIdx != undefined) {
-        const newIdx = (highlightedPanelIdx - 1) % (allFilteredPanels.length - 1);
-        setHighlightedPanelIdx(newIdx >= 0 ? newIdx : allFilteredPanels.length + newIdx);
+      if (e.key === "ArrowDown") {
+        setHighlightedPanelIdx((existing) => {
+          if (existing == undefined) {
+            return 0;
+          }
+          return (existing + 1) % allFilteredPanels.length;
+        });
+      } else if (e.key === "ArrowUp") {
+        setHighlightedPanelIdx((existing) => {
+          if (existing == undefined) {
+            return allFilteredPanels.length - 1;
+          }
+          const newIdx = (existing - 1) % (allFilteredPanels.length - 1);
+          return newIdx >= 0 ? newIdx : allFilteredPanels.length + newIdx;
+        });
       } else if (e.key === "Enter" && highlightedPanel) {
         onPanelSelect({
           type: highlightedPanel.type,
@@ -360,7 +374,7 @@ function PanelList(props: Props): JSX.Element {
         });
       }
     },
-    [allFilteredPanels.length, highlightedPanel, highlightedPanelIdx, mode, onPanelSelect],
+    [allFilteredPanels.length, highlightedPanel, mode, onPanelSelect],
   );
 
   const displayPanelListItem = React.useCallback(
@@ -426,7 +440,6 @@ function PanelList(props: Props): JSX.Element {
             onChange={handleSearchChange}
             onKeyDown={onKeyDown}
             onBlur={() => setHighlightedPanelIdx(undefined)}
-            onFocus={() => setHighlightedPanelIdx(0)}
             autoFocus
           />
         </Stack>


### PR DESCRIPTION
**User-Facing Changes**

When showing the add panel list, no entries are highlighted by default. If a user types in the search box, the first entry is highlighted - allowing for quickly filtering and pressing "enter" to add the panel.

When the user clears the search box, highlighting is removed.

Keyboard navigation works as before - with "key down" moving down the list and "key up" moving up. Both wrapping around at each end of the list.

Fixes: #1589



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
