### PR TITLE
Fix logic for tooltip hover presence.

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -407,20 +407,23 @@ function Chart(props: Props): JSX.Element {
 
   const { onHover } = props;
   const onMouseMove = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
-      mousePresentRef.current = true; // Mouse must be present if we get the move event.
+    async (event: React.MouseEvent<HTMLCanvasElement>) => {
+      mousePresentRef.current = true; // The mouse must be present if we're getting this event.
+
       if (onHover == undefined || rpcSendRef.current == undefined) {
         return;
       }
 
-      void rpcSendRef
-        .current<RpcElement[]>("getElementsAtEvent", { event: rpcMouseEvent(event) })
-        .then((elements) => {
-          // Check again if mouse has left the canvas while waiting for the RPC call.
-          if (isMounted() && mousePresentRef.current) {
-            onHover(elements);
-          }
-        });
+      const elements = await rpcSendRef.current<RpcElement[]>("getElementsAtEvent", {
+        event: rpcMouseEvent(event),
+      });
+
+      // Check mouse presence again in case the mouse has left the canvas while we
+      // were waiting for the RPC call.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (isMounted() && mousePresentRef.current) {
+        onHover(elements);
+      }
     },
     [onHover, isMounted],
   );

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -400,15 +400,10 @@ function Chart(props: Props): JSX.Element {
     });
   }, []);
 
-  // Since hover events are handled via rpc, we might get a response back when we've
-  // already hovered away from the chart. We gate calling onHover by whether the mouse is still
-  // present on the component
-  const mousePresentRef = useRef(false);
-
   const { onHover } = props;
   const onMouseMove = useCallback(
     async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (onHover && mousePresentRef.current) {
+      if (onHover) {
         if (!rpcSendRef.current) {
           return;
         }
@@ -427,12 +422,7 @@ function Chart(props: Props): JSX.Element {
     [onHover, isMounted],
   );
 
-  const onMouseEnter = useCallback(() => {
-    mousePresentRef.current = true;
-  }, []);
-
   const onMouseLeave = useCallback(() => {
-    mousePresentRef.current = false;
     onHover?.([]);
   }, [onHover]);
 
@@ -496,7 +486,6 @@ function Chart(props: Props): JSX.Element {
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
-      onMouseEnter={onMouseEnter}
       onMouseUp={onMouseUp}
       style={{ width, height, cursor: "crosshair" }}
     />

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -400,29 +400,37 @@ function Chart(props: Props): JSX.Element {
     });
   }, []);
 
+  // Since hover events are handled via rpc, we might get a response back when we've
+  // already hovered away from the chart. We gate calling onHover by whether the mouse is still
+  // present on the component
+  const mousePresentRef = useRef(false);
+
   const { onHover } = props;
   const onMouseMove = useCallback(
-    async (event: React.MouseEvent<HTMLCanvasElement>) => {
-      if (onHover) {
-        if (!rpcSendRef.current) {
-          return;
-        }
-
-        const elements = await rpcSendRef.current<RpcElement[]>("getElementsAtEvent", {
-          event: rpcMouseEvent(event),
-        });
-
-        if (!isMounted()) {
-          return;
-        }
-
-        onHover(elements);
+    (event: React.MouseEvent<HTMLCanvasElement>) => {
+      mousePresentRef.current = true; // Mouse must be present if we get the move event.
+      if (onHover == undefined || rpcSendRef.current == undefined) {
+        return;
       }
+
+      void rpcSendRef
+        .current<RpcElement[]>("getElementsAtEvent", { event: rpcMouseEvent(event) })
+        .then((elements) => {
+          // Check again if mouse has left the canvas while waiting for the RPC call.
+          if (isMounted() && mousePresentRef.current) {
+            onHover(elements);
+          }
+        });
     },
     [onHover, isMounted],
   );
 
+  const onMouseEnter = useCallback(() => {
+    mousePresentRef.current = true;
+  }, []);
+
   const onMouseLeave = useCallback(() => {
+    mousePresentRef.current = false;
     onHover?.([]);
   }, [onHover]);
 
@@ -486,6 +494,7 @@ function Chart(props: Props): JSX.Element {
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
+      onMouseEnter={onMouseEnter}
       onMouseUp={onMouseUp}
       style={{ width, height, cursor: "crosshair" }}
     />


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue that prevents tooltips from being shown on newly selected message paths in plots.

**Description**
The existing logic tracks a "mouse present" state and sets it to false when the mouse leaves the canvas. This seems to be incorrect when the mouse leaves in order to select a new path for the series and the mouse enter event when the user hovers the plot again doesn't register. This patch just assumes if we get a `onMouseMove` event then the cursor must be hovering the canvas.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2704 