### PR TITLE
Create and select a default layout if no layout is active. 

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -20,6 +20,7 @@ import React, {
   Suspense,
   useRef,
   LazyExoticComponent,
+  useEffect,
 } from "react";
 import { useDrop } from "react-dnd";
 import {
@@ -41,8 +42,10 @@ import {
   useCurrentLayoutSelector,
   usePanelMosaicId,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { PanelsState } from "@foxglove/studio-base/index";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
@@ -185,12 +188,51 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
 
 const selectedLayoutSelector = (state: LayoutState) => state.selectedLayout;
 
+const DefaultLayout: PanelsState = {
+  configById: {
+    "3D Panel!18i6zy7": {
+      pinTopics: true,
+    },
+    "RawMessages!os6rgs": {},
+    "ImageViewPanel!3mnp456": {},
+  },
+  globalVariables: {},
+  userNodes: {},
+  linkedGlobalVariables: [],
+  playbackConfig: {
+    messageOrder: "receiveTime",
+    speed: 1,
+  },
+  layout: {
+    first: "3D Panel!18i6zy7",
+    second: {
+      first: "ImageViewPanel!3mnp456",
+      second: "RawMessages!os6rgs",
+      direction: "column",
+      splitPercentage: 30,
+    },
+    direction: "row",
+    splitPercentage: 70,
+  },
+} as const;
+
 export default function PanelLayout(): JSX.Element {
   const { changePanelLayout } = useCurrentLayoutActions();
   const { openLayoutBrowser } = useWorkspace();
   const selectedLayout = useCurrentLayoutSelector(selectedLayoutSelector);
+  const layoutMangager = useLayoutManager();
+  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
-  const layoutLoading = selectedLayout?.loading;
+  useEffect(() => {
+    // Create and select a default layout if no layout is active.
+    if (selectedLayout == undefined) {
+      void layoutMangager
+        .saveNewLayout({ name: "Default", data: DefaultLayout, permission: "CREATOR_WRITE" })
+        .then((layout) => setSelectedLayoutId(layout.id));
+    }
+  }, [layoutMangager, selectedLayout, setSelectedLayoutId]);
+
+  const layoutLoading = selectedLayout?.loading ?? false;
   const onChange = useCallback(
     (newLayout: MosaicNode<string> | undefined) => {
       if (newLayout != undefined) {
@@ -199,9 +241,10 @@ export default function PanelLayout(): JSX.Element {
     },
     [changePanelLayout],
   );
+
   if (selectedLayout?.data) {
     return <UnconnectedPanelLayout layout={selectedLayout.data.layout} onChange={onChange} />;
-  } else if (layoutLoading === true) {
+  } else if (layoutLoading) {
     return (
       <EmptyState>
         <Spinner size={SpinnerSize.large} />

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -20,7 +20,6 @@ import React, {
   Suspense,
   useRef,
   LazyExoticComponent,
-  useEffect,
 } from "react";
 import { useDrop } from "react-dnd";
 import {
@@ -42,10 +41,8 @@ import {
   useCurrentLayoutSelector,
   usePanelMosaicId,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
-import { PanelsState } from "@foxglove/studio-base/index";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
@@ -188,51 +185,12 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
 
 const selectedLayoutSelector = (state: LayoutState) => state.selectedLayout;
 
-const DefaultLayout: PanelsState = {
-  configById: {
-    "3D Panel!18i6zy7": {
-      pinTopics: true,
-    },
-    "RawMessages!os6rgs": {},
-    "ImageViewPanel!3mnp456": {},
-  },
-  globalVariables: {},
-  userNodes: {},
-  linkedGlobalVariables: [],
-  playbackConfig: {
-    messageOrder: "receiveTime",
-    speed: 1,
-  },
-  layout: {
-    first: "3D Panel!18i6zy7",
-    second: {
-      first: "ImageViewPanel!3mnp456",
-      second: "RawMessages!os6rgs",
-      direction: "column",
-      splitPercentage: 30,
-    },
-    direction: "row",
-    splitPercentage: 70,
-  },
-} as const;
-
 export default function PanelLayout(): JSX.Element {
   const { changePanelLayout } = useCurrentLayoutActions();
   const { openLayoutBrowser } = useWorkspace();
   const selectedLayout = useCurrentLayoutSelector(selectedLayoutSelector);
-  const layoutMangager = useLayoutManager();
-  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
-  useEffect(() => {
-    // Create and select a default layout if no layout is active.
-    if (selectedLayout == undefined) {
-      void layoutMangager
-        .saveNewLayout({ name: "Default", data: DefaultLayout, permission: "CREATOR_WRITE" })
-        .then((layout) => setSelectedLayoutId(layout.id));
-    }
-  }, [layoutMangager, selectedLayout, setSelectedLayoutId]);
-
-  const layoutLoading = selectedLayout?.loading ?? false;
+  const layoutLoading = selectedLayout?.loading;
   const onChange = useCallback(
     (newLayout: MosaicNode<string> | undefined) => {
       if (newLayout != undefined) {
@@ -241,10 +199,9 @@ export default function PanelLayout(): JSX.Element {
     },
     [changePanelLayout],
   );
-
   if (selectedLayout?.data) {
     return <UnconnectedPanelLayout layout={selectedLayout.data.layout} onChange={onChange} />;
-  } else if (layoutLoading) {
+  } else if (layoutLoading === true) {
     return (
       <EmptyState>
         <Spinner size={SpinnerSize.large} />

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
@@ -3,7 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { PanelsState } from "@foxglove/studio-base/index";
+import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 
+/**
+ * This is loaded when the user has no layout selected on application launch
+ * to avoid presenting the user with a blank layout.
+ */
 export const defaultLayout: PanelsState = {
   configById: {
     "3D Panel!18i6zy7": {
@@ -15,10 +20,7 @@ export const defaultLayout: PanelsState = {
   globalVariables: {},
   userNodes: {},
   linkedGlobalVariables: [],
-  playbackConfig: {
-    messageOrder: "receiveTime",
-    speed: 1,
-  },
+  playbackConfig: { ...defaultPlaybackConfig },
   layout: {
     first: "3D Panel!18i6zy7",
     second: {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PanelsState } from "@foxglove/studio-base/index";
+
+export const defaultLayout: PanelsState = {
+  configById: {
+    "3D Panel!18i6zy7": {
+      pinTopics: true,
+    },
+    "RawMessages!os6rgs": {},
+    "ImageViewPanel!3mnp456": {},
+  },
+  globalVariables: {},
+  userNodes: {},
+  linkedGlobalVariables: [],
+  playbackConfig: {
+    messageOrder: "receiveTime",
+    speed: 1,
+  },
+  layout: {
+    first: "3D Panel!18i6zy7",
+    second: {
+      first: "ImageViewPanel!3mnp456",
+      second: "RawMessages!os6rgs",
+      direction: "column",
+      splitPercentage: 30,
+    },
+    direction: "row",
+    splitPercentage: 70,
+  },
+} as const;


### PR DESCRIPTION
**User-Facing Changes**
This prevents users landing in a state with no layout.

**Description**
The idea here is to create and select a default layout when no layout is active.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2611 