### PR TITLE
Fix same nodeTransformerWorker being used across tabs

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -114,15 +114,18 @@ export default class UserNodePlayer implements Player {
 
   // exposed as a static to allow testing to mock/replace
   static CreateNodeTransformWorker = (): SharedWorker => {
-    return new SharedWorker(new URL("./nodeTransformerWorker/index", import.meta.url));
+    return new SharedWorker(new URL("./nodeTransformerWorker/index", import.meta.url), {
+      // Although we are using SharedWorkers, we do not actually want to share worker instances
+      // between tabs. We achieve this by passing in a unique name.
+      name: uuidv4(),
+    });
   };
 
   // exposed as a static to allow testing to mock/replace
   static CreateNodeRuntimeWorker = (): SharedWorker => {
     return new SharedWorker(new URL("./nodeRuntimeWorker/index", import.meta.url), {
-      // Although we are using SharedWorkers, each nodeRuntimeWorker uses a single global variable
-      // for the compiled `nodeCallback` function, so we need a separate worker per user node. We
-      // achieve this by passing in a unique name.
+      // Although we are using SharedWorkers, we do not actually want to share worker instances
+      // between tabs. We achieve this by passing in a unique name.
       name: uuidv4(),
     });
   };


### PR DESCRIPTION
**User-Facing Changes**
Fixed a `no receiver registered for generateRosLib` error when using Node Playground in multiple tabs/windows at the same time.

**Description**
Fixes https://github.com/foxglove/studio/issues/2780. Basically the same fix as https://github.com/foxglove/studio/pull/2216, but for the nodeTransformerWorker: these workers were not designed to be actually shared between tabs (e.g. they do various logic in `onconnect` assuming that it'll only happen once, and they may be `close()`d by one tab when another could still be using it). Both of these have unique ids in upstream webviz and we accidentally removed them, but I only replaced one in #2216.
