### PR TITLE
Fix useLatestMessageDataItem to keep last message

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
@@ -145,7 +145,7 @@ describe("useLatestMessageDataItem", () => {
     ]);
   });
 
-  it("updates when topics and datatypes becomes available", async () => {
+  it("restores previously received message when topics and datatypes becomes available", async () => {
     const { result, rerender } = renderHook(({ path }) => useLatestMessageDataItem(path), {
       initialProps: {
         path: "/topic{value==2}.value",

--- a/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useLatestMessageDataItem.test.tsx
@@ -13,7 +13,7 @@
 import { renderHook } from "@testing-library/react-hooks";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
-import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -141,6 +141,39 @@ describe("useLatestMessageDataItem", () => {
       {
         messageEvent: fixtureMessages[1],
         queriedData: [{ path: "/topic{value==1}", value: fixtureMessages[1]?.message }],
+      },
+    ]);
+  });
+
+  it("updates when topics and datatypes becomes available", async () => {
+    const { result, rerender } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+      initialProps: {
+        path: "/topic{value==2}.value",
+        datatypes: new Map(),
+        topics: [] as Topic[],
+      },
+      wrapper({ children, datatypes: rosDatatypes, topics: rosTopics }) {
+        return (
+          <MockCurrentLayoutProvider>
+            <MockMessagePipelineProvider
+              messages={fixtureMessages}
+              topics={rosTopics}
+              datatypes={rosDatatypes}
+            >
+              {children}
+            </MockMessagePipelineProvider>
+          </MockCurrentLayoutProvider>
+        );
+      },
+    });
+
+    expect(result.all).toEqual([undefined]);
+    rerender({ path: "/topic{value==2}.value", datatypes, topics });
+    expect(result.all).toEqual([
+      undefined,
+      {
+        messageEvent: fixtureMessages[2],
+        queriedData: [{ path: "/topic{value==2}.value", value: 2 }],
       },
     ]);
   });

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -166,13 +166,11 @@ function RawMessages(props: Props) {
   })[topicName];
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems([topicPath]);
   const prevTickMsg = consecutiveMsgs?.[consecutiveMsgs.length - 2];
-  const [prevTickObj, currTickObj] = [
-    prevTickMsg && {
-      messageEvent: prevTickMsg,
-      queriedData: cachedGetMessagePathDataItems(topicPath, prevTickMsg) ?? [],
-    },
-    useLatestMessageDataItem(topicPath),
-  ];
+  const prevTickObj = prevTickMsg && {
+    messageEvent: prevTickMsg,
+    queriedData: cachedGetMessagePathDataItems(topicPath, prevTickMsg) ?? [],
+  };
+  const currTickObj = useLatestMessageDataItem(topicPath);
 
   const diffTopicObj = useLatestMessageDataItem(diffEnabled ? diffTopicPath : "");
 


### PR DESCRIPTION


**User-Facing Changes**
Raw Message panel more reliably shows the latest message on startup for messages on latching topics.

**Description**
Previously useLatestMessageDataItem would lose the latest message on a topic when the queriedData was undefined (invalid path). The path is invalid until topics and datatypes are updated which happened after addMessages was invoked in useLatestMessageDataItem.

This change updates addMessages to keep the latest message event even when the path is invalid. When restore is called, the path becomes valid and the last message can be checked against the path.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
