### PR TITLE
Disable tracking of out-of-order messages, which leaked memory

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -35,6 +35,7 @@ class MessageOrderTracker {
   private lastMessageTopic?: string;
   private lastLastSeekTime?: number;
   private warningTimeout?: ReturnType<typeof setTimeout>;
+  private trackIncorrectMessages = false; // set this to true to debug out of order messages
   private incorrectMessages: MessageEvent<unknown>[] = [];
 
   update(playerState: PlayerState): void {
@@ -73,23 +74,29 @@ class MessageOrderTracker {
         const currentTimeDrift = Math.abs(toSec(subtractTimes(messageTime, currentTime)));
 
         if (currentTimeDrift > DRIFT_THRESHOLD_SEC) {
-          this.incorrectMessages.push(message);
+          if (this.trackIncorrectMessages) {
+            this.incorrectMessages.push(message);
+          }
           if (!this.warningTimeout) {
             this.warningTimeout = setTimeout(() => {
               // timeout has fired, we need to clear so a new timeout registers if there are more messages
               this.warningTimeout = undefined;
-              // reset incorrect message queue before posting warning so we never keep incorrectMessages around
-              const tempMessages = this.incorrectMessages;
+              // reset incorrect message queue before posting warning so we never keep
+              // incorrectMessages around. The browser console will keep messages in memory when
+              // logged, so disable logging of messages unless explicitly enabled.
+              const info = {
+                currentTime,
+                lastSeekTime,
+                messageOrder,
+                messageTime,
+                incorrectMessages: this.trackIncorrectMessages
+                  ? this.incorrectMessages
+                  : "not being tracked",
+              };
               this.incorrectMessages = [];
               log.warn(
                 `${messageOrder} very different from player.currentTime; without updating lastSeekTime`,
-                {
-                  currentTime,
-                  lastSeekTime,
-                  messageOrder,
-                  messageTime,
-                  tempMessages,
-                },
+                info,
               );
             }, WAIT_FOR_SEEK_SEC * 1000);
           }

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -35,7 +35,14 @@ class MessageOrderTracker {
   private lastMessageTopic?: string;
   private lastLastSeekTime?: number;
   private warningTimeout?: ReturnType<typeof setTimeout>;
-  private trackIncorrectMessages = false; // set this to true to debug out of order messages
+
+  /**
+   * Set this to `true` to debug out-of-order messages. It is disabled by default in production
+   * because logging messages to the console prevents them from getting garbage-collected as long as
+   * the console is not cleared.
+   */
+  private trackIncorrectMessages = false;
+
   private incorrectMessages: MessageEvent<unknown>[] = [];
 
   update(playerState: PlayerState): void {


### PR DESCRIPTION
**User-Facing Changes**
Fixed a memory leak when the app received many out-of-order messages due to the presence of the `/clock` topic.

**Description**
Out of order messages were being logged to the dev console. The memory debugger showed the console itself was responsible for retaining memory. So we disable logging of out of order messages unless explicitly enabled for debugging purposes.

This is a follow up to https://github.com/foxglove/studio/pull/2185. That fix prevented all the messages from being held in memory by the VM, but they were still held by the browser console when logged.

<img width="417" alt="image" src="https://user-images.githubusercontent.com/14237/152861021-ca136970-a9fc-4f2d-872f-248775d54fd9.png">
