### PR TITLE
Fix miscellaneous typos in panel settings

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -481,12 +481,12 @@ const configSchema: PanelConfigSchema<PlotConfig> = [
   {
     key: "showXAxisLabels",
     type: "toggle",
-    title: "Show x-axis labels",
+    title: "Show x-axis label",
   },
   {
     key: "showYAxisLabels",
     type: "toggle",
-    title: "Show y-axis labels",
+    title: "Show y-axis label",
   },
   { key: "maxYValue", type: "number", title: "Y max", placeholder: "auto", allowEmpty: true },
   { key: "minYValue", type: "number", title: "Y min", placeholder: "auto", allowEmpty: true },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -405,7 +405,7 @@ const configSchema: PanelConfigSchema<ThreeDimensionalVizConfig> = [
   {
     key: "ignoreColladaUpAxis",
     type: "toggle",
-    title: "Ignore <up_axis> in Collada meshes",
+    title: "Ignore <up_axis> in COLLADA meshes",
   },
   { key: "clickToPublishPoseEstimateTopic", type: "text", title: "Pose estimate topic" },
   { key: "clickToPublishPoseTopic", type: "text", title: "Pose topic" },


### PR DESCRIPTION
**User-Facing Changes**
Revise minor typos in various panels' settings:
- Collada --> COLLADA (3D panel)
- Show x-axis labels --> Show y-axis label (Plot panel)
- Show y-axis labels --> Show y-axis label (Plot panel)