### PR TITLE
quicklook: add mcap0 indexed support

### DIFF
--- a/desktop/quicklook/FileInfoDisplay.tsx
+++ b/desktop/quicklook/FileInfoDisplay.tsx
@@ -12,7 +12,7 @@ import bagIcon from "../../resources/icon/BagIcon.png";
 import mcapIcon from "../../resources/icon/McapIcon.png";
 import Flash from "./Flash";
 import formatByteSize from "./formatByteSize";
-import { FileInfo, TopicInfo } from "./getInfo";
+import { FileInfo, TopicInfo } from "./types";
 
 const log = Logger.getLogger(__filename);
 
@@ -123,7 +123,7 @@ const Datatype = styled.div`
 function TopicRow({ info: { topic, datatype, numMessages, numConnections } }: { info: TopicInfo }) {
   return (
     <TopicRowWrapper>
-      <MessageCount>{numMessages.toLocaleString()}</MessageCount>
+      <MessageCount>{numMessages?.toLocaleString()}</MessageCount>
       <TopicNameAndDatatype>
         <TopicName>{topic}</TopicName>
         <Datatype>
@@ -136,7 +136,7 @@ function TopicRow({ info: { topic, datatype, numMessages, numConnections } }: { 
 }
 
 function formatCount(count: number | bigint | undefined, noun: string): string | undefined {
-  if (count == undefined) {
+  if (count == undefined || count === 0 || count === 0n) {
     return undefined;
   }
   return `${count.toLocaleString()} ${noun}${count === 1 || count === 1n ? "" : "s"}`;
@@ -184,9 +184,12 @@ export default function FileInfoDisplay({
           {fileInfo?.compressionTypes && (
             <SummaryRow>
               Compression:{" "}
-              {fileInfo.compressionTypes.length === 0
+              {fileInfo.compressionTypes.size === 0
                 ? "none"
-                : fileInfo.compressionTypes.filter(Boolean).join(", ")}
+                : Array.from(fileInfo.compressionTypes)
+                    .filter(Boolean)
+                    .sort((a, b) => a.localeCompare(b))
+                    .join(", ")}
             </SummaryRow>
           )}
           {fileInfo?.startTime && (

--- a/desktop/quicklook/formatByteSize.test.ts
+++ b/desktop/quicklook/formatByteSize.test.ts
@@ -6,8 +6,8 @@ import formatByteSize from "./formatByteSize";
 
 describe("formatByteSize", () => {
   it.each([
-    [0, "0 B"],
-    [1023, "1023 B"],
+    [0, "0 Bytes"],
+    [1023, "1023 Bytes"],
     [1024, "1.0 KiB"],
     [1023.9 * Math.pow(1024, 1), "1023.9 KiB"],
     [1023.9 * Math.pow(1024, 1) + 1, "1.0 MiB"],

--- a/desktop/quicklook/formatByteSize.ts
+++ b/desktop/quicklook/formatByteSize.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export default function formatByteSize(size: number): string {
-  const suffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  const suffixes = ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
   let value = size;
   let suffix = 0;
   while (value > 1023.9 && suffix + 1 < suffixes.length) {

--- a/desktop/quicklook/getIndexedMcapInfo.ts
+++ b/desktop/quicklook/getIndexedMcapInfo.ts
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Mcap0IndexedReader, Mcap0Types } from "@foxglove/mcap";
+import { fromNanoSec } from "@foxglove/rostime";
+
+import { FileInfo, TopicInfo } from "./types";
+
+export default async function getIndexedMcapInfo(
+  file: File,
+  decompressHandlers: Mcap0Types.DecompressHandlers,
+): Promise<FileInfo> {
+  const reader = await Mcap0IndexedReader.Initialize({
+    readable: {
+      size: async () => BigInt(file.size),
+      read: async (offset, length) => {
+        if (offset + length > Number.MAX_SAFE_INTEGER) {
+          throw new Error(`Read too large: offset ${offset}, length ${length}`);
+        }
+        const buffer = await file.slice(Number(offset), Number(offset + length)).arrayBuffer();
+        return new Uint8Array(buffer);
+      },
+    },
+    decompressHandlers,
+  });
+
+  if (reader.channelInfosById.size === 0 || reader.schemasById.size === 0) {
+    throw new Error(
+      "Mcap summary does not contain channel info or schemas, cannot use indexed reading",
+    );
+  }
+
+  const topicInfosByTopic = new Map<string, TopicInfo>();
+  for (const channel of reader.channelInfosById.values()) {
+    const info = topicInfosByTopic.get(channel.topic);
+    const schema = reader.schemasById.get(channel.schemaId);
+    const numMessages = reader.statistics?.channelMessageCounts.get(channel.id);
+    if (info != undefined) {
+      if (schema != undefined && info.datatype !== schema.name) {
+        info.datatype = "(multiple)";
+      }
+      if (numMessages != undefined) {
+        info.numMessages = (info.numMessages ?? 0n) + numMessages;
+      }
+      info.numConnections++;
+    } else {
+      topicInfosByTopic.set(channel.topic, {
+        topic: channel.topic,
+        datatype: schema?.name ?? "(unknown)",
+        numMessages,
+        numConnections: 1,
+      });
+    }
+  }
+  const topics = [...topicInfosByTopic.values()].sort((a, b) => a.topic.localeCompare(b.topic));
+
+  let startTime: bigint | undefined;
+  let endTime: bigint | undefined;
+  const compressionTypes = new Set<string>();
+  for (const chunk of reader.chunkIndexes) {
+    compressionTypes.add(chunk.compression);
+    if (startTime == undefined || chunk.startTime < startTime) {
+      startTime = chunk.startTime;
+    }
+    if (endTime == undefined || chunk.endTime > endTime) {
+      endTime = chunk.endTime;
+    }
+  }
+  return {
+    fileType: "MCAP v0, indexed",
+    numChunks: reader.chunkIndexes.length,
+    numAttachments: reader.attachmentIndexes.length,
+    totalMessages: reader.statistics?.messageCount,
+    startTime: startTime != undefined ? fromNanoSec(startTime) : undefined,
+    endTime: endTime != undefined ? fromNanoSec(endTime) : undefined,
+    topics,
+    compressionTypes,
+  };
+}

--- a/desktop/quicklook/getInfo.ts
+++ b/desktop/quicklook/getInfo.ts
@@ -6,37 +6,23 @@ import decompressLZ4 from "wasm-lz4";
 
 import Logger from "@foxglove/log";
 import {
-  Mcap0IndexedReader,
   Mcap0StreamReader,
-  McapPre0To0StreamReader,
+  McapPre0Reader,
   Mcap0Types,
   detectVersion,
   DETECT_VERSION_BYTES_REQUIRED,
 } from "@foxglove/mcap";
 import { Bag } from "@foxglove/rosbag";
 import { BlobReader } from "@foxglove/rosbag/web";
-import { Time, fromNanoSec, isLessThan, isGreaterThan } from "@foxglove/rostime";
+
+import getIndexedMcapInfo from "./getIndexedMcapInfo";
+import getStreamedMcapInfo, {
+  processMcap0Record,
+  processMcapPre0Record,
+} from "./getStreamedMcapInfo";
+import { FileInfo, TopicInfo } from "./types";
 
 const log = Logger.getLogger(__filename);
-
-export type TopicInfo = {
-  topic: string;
-  datatype: string;
-  numMessages: bigint;
-  numConnections: number;
-};
-
-export type FileInfo = {
-  loadMoreInfo?: (reportProgress: (progress: number) => void) => Promise<FileInfo>;
-  fileType?: string | undefined;
-  numChunks?: number;
-  numAttachments?: number;
-  totalMessages?: bigint;
-  startTime?: Time | undefined;
-  endTime?: Time | undefined;
-  topics?: TopicInfo[];
-  compressionTypes?: string[];
-};
 
 export async function getBagInfo(file: File): Promise<FileInfo> {
   const bag = new Bag(new BlobReader(file));
@@ -53,17 +39,20 @@ export async function getBagInfo(file: File): Promise<FileInfo> {
   const topicInfosByTopic = new Map<string, TopicInfo>();
   for (const { topic, type: datatype, conn } of bag.connections.values()) {
     const info = topicInfosByTopic.get(topic);
+    const numMessages = numMessagesByConnectionIndex[conn];
     if (info != undefined) {
       if (info.datatype !== datatype) {
         info.datatype = "(multiple)";
       }
-      info.numMessages += numMessagesByConnectionIndex[conn] ?? 0n;
+      if (numMessages != undefined) {
+        info.numMessages = (info.numMessages ?? 0n) + numMessages;
+      }
       info.numConnections++;
     } else {
       topicInfosByTopic.set(topic, {
         topic,
         datatype: datatype ?? "(unknown)",
-        numMessages: numMessagesByConnectionIndex[conn] ?? 0n,
+        numMessages,
         numConnections: 1,
       });
     }
@@ -103,11 +92,8 @@ export async function getMcapInfo(file: File): Promise<FileInfo> {
         loadMoreInfo: async (reportProgress) =>
           await getStreamedMcapInfo(
             file,
-            new Mcap0StreamReader({
-              includeChunks: true,
-              decompressHandlers,
-              validateCrcs: true,
-            }),
+            new Mcap0StreamReader({ includeChunks: true, decompressHandlers, validateCrcs: true }),
+            processMcap0Record,
             "MCAP v0, unindexed",
             reportProgress,
           ),
@@ -119,179 +105,15 @@ export async function getMcapInfo(file: File): Promise<FileInfo> {
         loadMoreInfo: async (reportProgress) =>
           await getStreamedMcapInfo(
             file,
-            new McapPre0To0StreamReader({
+            new McapPre0Reader({
               includeChunks: true,
               validateChunkCrcs: false,
               decompressHandlers,
             }),
+            processMcapPre0Record,
             "MCAP pre-v0",
             reportProgress,
           ),
       };
   }
-}
-
-async function getIndexedMcapInfo(file: File, decompressHandlers: Mcap0Types.DecompressHandlers) {
-  const reader = await Mcap0IndexedReader.Initialize({
-    readable: {
-      size: async () => BigInt(file.size),
-      read: async (offset, length) => {
-        if (offset + length > Number.MAX_SAFE_INTEGER) {
-          throw new Error(`Read too large: offset ${offset}, length ${length}`);
-        }
-        const buffer = await file.slice(Number(offset), Number(offset + length)).arrayBuffer();
-        return new Uint8Array(buffer);
-      },
-    },
-    decompressHandlers,
-  });
-
-  const topicInfosByTopic = new Map<string, TopicInfo>();
-  for (const channel of reader.channelInfosById.values()) {
-    const info = topicInfosByTopic.get(channel.topicName);
-    if (info != undefined) {
-      if (info.datatype !== channel.schemaName) {
-        info.datatype = "(multiple)";
-      }
-      info.numMessages += reader.statistics?.channelMessageCounts.get(channel.channelId) ?? 0n;
-      info.numConnections++;
-    } else {
-      topicInfosByTopic.set(channel.topicName, {
-        topic: channel.topicName,
-        datatype: (channel as Partial<typeof channel>).schemaName ?? "(unknown)",
-        numMessages: reader.statistics?.channelMessageCounts.get(channel.channelId) ?? 0n,
-        numConnections: 1,
-      });
-    }
-  }
-  const topics = [...topicInfosByTopic.values()].sort((a, b) => a.topic.localeCompare(b.topic));
-
-  let startTime: bigint | undefined;
-  let endTime: bigint | undefined;
-  const compressionTypes = new Set<string>();
-  for (const chunk of reader.chunkIndexes) {
-    compressionTypes.add(chunk.compression);
-    if (startTime == undefined || chunk.startTime < startTime) {
-      startTime = chunk.startTime;
-    }
-    if (endTime == undefined || chunk.endTime > endTime) {
-      endTime = chunk.endTime;
-    }
-  }
-  return {
-    fileType: "MCAP v0, indexed",
-    numChunks: reader.chunkIndexes.length,
-    numAttachments: reader.attachmentIndexes.length,
-    totalMessages: reader.statistics?.messageCount,
-    startTime: startTime != undefined ? fromNanoSec(startTime) : undefined,
-    endTime: endTime != undefined ? fromNanoSec(endTime) : undefined,
-    topics,
-    compressionTypes: Array.from(compressionTypes).sort((a, b) => a.localeCompare(b)),
-  };
-}
-
-async function getStreamedMcapInfo(
-  file: File,
-  mcapStreamReader: Mcap0Types.McapStreamReader,
-  fileType: string,
-  reportProgress: (progress: number) => void,
-): Promise<FileInfo> {
-  let totalMessages = 0n;
-  let numChunks = 0;
-  let numAttachments = 0;
-  let startTime: Time | undefined;
-  let endTime: Time | undefined;
-  const compressionTypes = new Set<string>();
-  const topicInfosByTopic = new Map<string, TopicInfo & { connectionIds: Set<number> }>();
-  const channelInfosById = new Map<number, Mcap0Types.TypedMcapRecords["ChannelInfo"]>();
-
-  function processRecord(record: Mcap0Types.TypedMcapRecord) {
-    switch (record.type) {
-      case "Chunk":
-        numChunks++;
-        compressionTypes.add(record.compression);
-        return;
-
-      case "Attachment":
-        numAttachments++;
-        break;
-
-      case "ChannelInfo": {
-        channelInfosById.set(record.channelId, record);
-        const info = topicInfosByTopic.get(record.topicName);
-        if (info != undefined) {
-          if (info.datatype !== record.schemaName) {
-            info.datatype = "(multiple)";
-          }
-          if (!info.connectionIds.has(record.channelId)) {
-            info.connectionIds.add(record.channelId);
-            info.numConnections++;
-          }
-        } else {
-          topicInfosByTopic.set(record.topicName, {
-            topic: record.topicName,
-            datatype: record.schemaName,
-            numMessages: 0n,
-            numConnections: 1,
-            connectionIds: new Set([record.channelId]),
-          });
-        }
-        return;
-      }
-
-      case "Message": {
-        const channel = channelInfosById.get(record.channelId);
-        if (channel) {
-          const info = topicInfosByTopic.get(channel.topicName);
-          if (info != undefined) {
-            info.numMessages++;
-          }
-        }
-        totalMessages++;
-        const timestamp = fromNanoSec(record.recordTime);
-        if (!startTime || isLessThan(timestamp, startTime)) {
-          startTime = timestamp;
-        }
-        if (!endTime || isGreaterThan(timestamp, endTime)) {
-          endTime = timestamp;
-        }
-        return;
-      }
-
-      case "AttachmentIndex":
-      case "Statistics":
-      case "Unknown":
-      case "Header":
-      case "Footer":
-      case "MessageIndex":
-      case "ChunkIndex":
-        break;
-    }
-  }
-
-  // Use file.slice() rather than file.stream().getReader().read() because the latter has terrible
-  // performance in Safari (~50x slower than Chrome).
-  const chunkSize = 1024 * 1024;
-  let bytesRead = 0;
-  for (let offset = 0; offset < file.size; offset += chunkSize) {
-    const buffer = await file.slice(offset, offset + chunkSize).arrayBuffer();
-    mcapStreamReader.append(new Uint8Array(buffer));
-    for (let record; (record = mcapStreamReader.nextRecord()); ) {
-      processRecord(record);
-    }
-    bytesRead += buffer.byteLength;
-    reportProgress(bytesRead / file.size);
-  }
-
-  const topics = [...topicInfosByTopic.values()].sort((a, b) => a.topic.localeCompare(b.topic));
-  return {
-    fileType,
-    numChunks,
-    numAttachments,
-    totalMessages,
-    startTime,
-    endTime,
-    topics,
-    compressionTypes: Array.from(compressionTypes).sort((a, b) => a.localeCompare(b)),
-  };
 }

--- a/desktop/quicklook/getStreamedMcapInfo.ts
+++ b/desktop/quicklook/getStreamedMcapInfo.ts
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Mcap0Types, McapPre0Types } from "@foxglove/mcap";
+import { Time, fromNanoSec, isLessThan, isGreaterThan } from "@foxglove/rostime";
+
+import { TopicInfo, FileInfo } from "./types";
+
+type McapInfo = {
+  totalMessages: bigint;
+  numChunks: number;
+  numAttachments: number;
+  startTime: Time | undefined;
+  endTime: Time | undefined;
+  compressionTypes: Set<string>;
+  topicInfosByTopic: Map<string, TopicInfo & { connectionIds: Set<number> }>;
+  topicNamesByChannelId: Map<number, string>;
+  schemaNamesById: Map<number, string>;
+};
+
+export function processMcapPre0Record(info: McapInfo, record: McapPre0Types.McapRecord): void {
+  switch (record.type) {
+    case "Chunk":
+      info.numChunks++;
+      info.compressionTypes.add(record.compression);
+      return;
+
+    case "ChannelInfo": {
+      info.topicNamesByChannelId.set(record.id, record.topic);
+      const chanInfo = info.topicInfosByTopic.get(record.topic);
+      if (chanInfo != undefined) {
+        if (chanInfo.datatype !== record.schemaName) {
+          chanInfo.datatype = "(multiple)";
+        }
+        if (!chanInfo.connectionIds.has(record.id)) {
+          chanInfo.connectionIds.add(record.id);
+          chanInfo.numConnections++;
+        }
+      } else {
+        info.topicInfosByTopic.set(record.topic, {
+          topic: record.topic,
+          datatype: record.schemaName,
+          numMessages: 0n,
+          numConnections: 1,
+          connectionIds: new Set([record.id]),
+        });
+      }
+      return;
+    }
+
+    case "Message": {
+      const topic = record.channelInfo.topic;
+      const topicInfo = info.topicInfosByTopic.get(topic);
+      if (topicInfo != undefined) {
+        topicInfo.numMessages = (topicInfo.numMessages ?? 0n) + 1n;
+      }
+
+      info.totalMessages++;
+      const timestamp = fromNanoSec(record.timestamp);
+      if (!info.startTime || isLessThan(timestamp, info.startTime)) {
+        info.startTime = timestamp;
+      }
+      if (!info.endTime || isGreaterThan(timestamp, info.endTime)) {
+        info.endTime = timestamp;
+      }
+      return;
+    }
+
+    case "Footer":
+      break;
+  }
+}
+
+export function processMcap0Record(info: McapInfo, record: Mcap0Types.TypedMcapRecord): void {
+  switch (record.type) {
+    case "Chunk":
+      info.numChunks++;
+      info.compressionTypes.add(record.compression);
+      return;
+
+    case "Attachment":
+      info.numAttachments++;
+      break;
+
+    case "Schema":
+      info.schemaNamesById.set(record.id, record.name);
+      break;
+
+    case "ChannelInfo": {
+      info.topicNamesByChannelId.set(record.id, record.topic);
+      const chanInfo = info.topicInfosByTopic.get(record.topic);
+      const schemaName = info.schemaNamesById.get(record.schemaId);
+      if (chanInfo != undefined) {
+        if (schemaName != undefined && chanInfo.datatype !== schemaName) {
+          chanInfo.datatype = "(multiple)";
+        }
+        if (!chanInfo.connectionIds.has(record.id)) {
+          chanInfo.connectionIds.add(record.id);
+          chanInfo.numConnections++;
+        }
+      } else {
+        info.topicInfosByTopic.set(record.topic, {
+          topic: record.topic,
+          datatype: schemaName ?? "(unknown)",
+          numMessages: 0n,
+          numConnections: 1,
+          connectionIds: new Set([record.id]),
+        });
+      }
+      return;
+    }
+
+    case "Message": {
+      const topic = info.topicNamesByChannelId.get(record.channelId);
+      if (topic != undefined) {
+        const topicInfo = info.topicInfosByTopic.get(topic);
+        if (topicInfo != undefined) {
+          topicInfo.numMessages = (topicInfo.numMessages ?? 0n) + 1n;
+        }
+      }
+      info.totalMessages++;
+      const timestamp = fromNanoSec(record.logTime);
+      if (!info.startTime || isLessThan(timestamp, info.startTime)) {
+        info.startTime = timestamp;
+      }
+      if (!info.endTime || isGreaterThan(timestamp, info.endTime)) {
+        info.endTime = timestamp;
+      }
+      return;
+    }
+
+    case "AttachmentIndex":
+    case "Statistics":
+    case "Unknown":
+    case "Header":
+    case "Footer":
+    case "MessageIndex":
+    case "ChunkIndex":
+    case "Metadata":
+    case "MetadataIndex":
+    case "SummaryOffset":
+    case "DataEnd":
+      break;
+  }
+}
+
+interface GenericMcapStreamReader<R> {
+  done(): boolean;
+  bytesRemaining(): number;
+  append(data: Uint8Array): void;
+  nextRecord(): R | undefined;
+}
+
+export default async function getStreamedMcapInfo<R>(
+  file: File,
+  mcapStreamReader: GenericMcapStreamReader<R>,
+  processRecord: (info: McapInfo, record: R) => void,
+  fileType: string,
+  reportProgress: (progress: number) => void,
+): Promise<FileInfo> {
+  const info: McapInfo = {
+    totalMessages: 0n,
+    numChunks: 0,
+    numAttachments: 0,
+    startTime: undefined,
+    endTime: undefined,
+    compressionTypes: new Set(),
+    topicInfosByTopic: new Map(),
+    topicNamesByChannelId: new Map(),
+    schemaNamesById: new Map(),
+  };
+
+  // Use file.slice() rather than file.stream().getReader().read() because the latter has terrible
+  // performance in Safari (~50x slower than Chrome).
+  const chunkSize = 1024 * 1024;
+  let bytesRead = 0;
+  for (let offset = 0; offset < file.size; offset += chunkSize) {
+    const buffer = await file.slice(offset, offset + chunkSize).arrayBuffer();
+    mcapStreamReader.append(new Uint8Array(buffer));
+    for (let record; (record = mcapStreamReader.nextRecord()) != undefined; ) {
+      processRecord(info, record);
+    }
+    bytesRead += buffer.byteLength;
+    reportProgress(bytesRead / file.size);
+  }
+
+  const topics = [...info.topicInfosByTopic.values()].sort((a, b) =>
+    a.topic.localeCompare(b.topic),
+  );
+  return { ...info, fileType, topics };
+}

--- a/desktop/quicklook/types.ts
+++ b/desktop/quicklook/types.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Time } from "@foxglove/rostime";
+
+export type TopicInfo = {
+  topic: string;
+  datatype: string;
+  numMessages: bigint | undefined;
+  numConnections: number;
+};
+
+export type FileInfo = {
+  loadMoreInfo?: (reportProgress: (progress: number) => void) => Promise<FileInfo>;
+  fileType?: string | undefined;
+  numChunks?: number;
+  numAttachments?: number;
+  totalMessages?: bigint;
+  startTime?: Time | undefined;
+  endTime?: Time | undefined;
+  topics?: TopicInfo[];
+  compressionTypes?: Set<string>;
+};

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -36,7 +36,7 @@
     "@foxglove/den": "workspace:*",
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
-    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302",
+    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=09b43c06f609325ddbf37d1009a11edcffdc892a",
     "@foxglove/regl-worldview": "2.4.0",
     "@foxglove/ros1": "1.4.0",
     "@foxglove/ros2": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,14 +2304,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/mcap@github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302":
+"@foxglove/mcap@github:foxglove/mcap#workspace=@foxglove/mcap&commit=09b43c06f609325ddbf37d1009a11edcffdc892a":
   version: 0.1.0
-  resolution: "@foxglove/mcap@https://github.com/foxglove/mcap.git#workspace=%40foxglove%2Fmcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
+  resolution: "@foxglove/mcap@https://github.com/foxglove/mcap.git#workspace=%40foxglove%2Fmcap&commit=09b43c06f609325ddbf37d1009a11edcffdc892a"
   dependencies:
     "@foxglove/crc": ^0.0.3
     heap-js: ^2.1.6
     tslib: ^2
-  checksum: 7d7c0edf708a7d6a8d517fc1fe9260e86ec812b88f669a1450008c86933d8f9a826c426b8a77ec3ccdab2ae14088a9fd11b9ea2be44f7b1410d41073a597ef05
+  checksum: 4dfea0d708fd9fabf700e98e20a2adf8f40c47e1bcbb3c82cc4049c12639dc0463348cce1d28cf450dac7e623f7ec04e689ee6cecd3a7db832a2878959e98821
   languageName: node
   linkType: hard
 
@@ -2495,7 +2495,7 @@ __metadata:
     "@foxglove/den": "workspace:*"
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
-    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=e9250ff2130a5f28a59cdd625dd1a7f9388a4302"
+    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=09b43c06f609325ddbf37d1009a11edcffdc892a"
     "@foxglove/regl-worldview": 2.4.0
     "@foxglove/ros1": 1.4.0
     "@foxglove/ros2": 3.1.0


### PR DESCRIPTION
**User-Facing Changes**
None


**Description**
Indexed mcap0 files can be displayed using the summary info, assuming chunk indexes, channel infos, and schemas are all present:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/14237/153072686-cef7dd45-2467-4da5-a626-9109112df290.png">