### PR TITLE
Upgrade xacro-parser

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -201,6 +201,6 @@
     "uuid": "8.3.2",
     "wasm-lz4": "2.0.0",
     "webpack": "5.65.0",
-    "xacro-parser": "0.3.7"
+    "xacro-parser": "0.3.8"
   }
 }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -201,6 +201,6 @@
     "uuid": "8.3.2",
     "wasm-lz4": "2.0.0",
     "webpack": "5.65.0",
-    "xacro-parser": "0.3.5"
+    "xacro-parser": "0.3.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,7 +2660,7 @@ __metadata:
     uuid: 8.3.2
     wasm-lz4: 2.0.0
     webpack: 5.65.0
-    xacro-parser: 0.3.5
+    xacro-parser: 0.3.7
   languageName: unknown
   linkType: soft
 
@@ -23904,6 +23904,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^4.5.5":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.5.4#~builtin<compat/typescript>":
   version: 4.5.4
   resolution: "typescript@patch:typescript@npm%3A4.5.4#~builtin<compat/typescript>::version=4.5.4&hash=ddd1e8"
@@ -23911,6 +23921,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 270255355c3236076dbbd0900ff0b7b159fac7e6a95f9ed8c59f57361c7dace9f1fbffd3b5eb21377c7f636027382ad89eb64b2acfbcd9e08574f04cfc75ca3d
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=ddd1e8"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 9cdde4aae20b2904431f3f2ca8acaf3b0cc52faddf68aa88b288c9d0520221817da43783a756fce7ab9360033ada0371c3ff93dfc4bdb4b13f6e9bac64e1658d
   languageName: node
   linkType: hard
 
@@ -25387,12 +25407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xacro-parser@npm:0.3.5":
-  version: 0.3.5
-  resolution: "xacro-parser@npm:0.3.5"
+"xacro-parser@npm:0.3.7":
+  version: 0.3.7
+  resolution: "xacro-parser@npm:0.3.7"
   dependencies:
     expr-eval: ^2.0.2
-  checksum: 75e987c581d63de15f2bff4fc37e32f192ef2762167001452f89b3627328b8afb155be5c2c4aac8370aedbb21047989d191310d41f5178fdf0c14700737a2d31
+    typescript: ^4.5.5
+  checksum: 0b195838b4cf3670dc8930a91b7310c1c55b3f91e3f32e0c181f0f864d152b6e87c4cc238a2a6f007ff958c44556df1f8c075366c031c51df363eb81acdae18a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2660,7 +2660,7 @@ __metadata:
     uuid: 8.3.2
     wasm-lz4: 2.0.0
     webpack: 5.65.0
-    xacro-parser: 0.3.7
+    xacro-parser: 0.3.8
   languageName: unknown
   linkType: soft
 
@@ -23904,16 +23904,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.5.5":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
-  languageName: node
-  linkType: hard
-
 "typescript@patch:typescript@4.5.4#~builtin<compat/typescript>":
   version: 4.5.4
   resolution: "typescript@patch:typescript@npm%3A4.5.4#~builtin<compat/typescript>::version=4.5.4&hash=ddd1e8"
@@ -23921,16 +23911,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 270255355c3236076dbbd0900ff0b7b159fac7e6a95f9ed8c59f57361c7dace9f1fbffd3b5eb21377c7f636027382ad89eb64b2acfbcd9e08574f04cfc75ca3d
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^4.5.5#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=ddd1e8"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 9cdde4aae20b2904431f3f2ca8acaf3b0cc52faddf68aa88b288c9d0520221817da43783a756fce7ab9360033ada0371c3ff93dfc4bdb4b13f6e9bac64e1658d
   languageName: node
   linkType: hard
 
@@ -25407,13 +25387,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xacro-parser@npm:0.3.7":
-  version: 0.3.7
-  resolution: "xacro-parser@npm:0.3.7"
+"xacro-parser@npm:0.3.8":
+  version: 0.3.8
+  resolution: "xacro-parser@npm:0.3.8"
   dependencies:
     expr-eval: ^2.0.2
-    typescript: ^4.5.5
-  checksum: 0b195838b4cf3670dc8930a91b7310c1c55b3f91e3f32e0c181f0f864d152b6e87c4cc238a2a6f007ff958c44556df1f8c075366c031c51df363eb81acdae18a
+  checksum: 894c66ca1b6bc2ee513161962d15f054f9e5e3cd8d1a10295af728a2c39858e9bb21f8a1585add64cfb5cc4dcdeca7f84e52f4809e2a67f54d3f3de46d4d1a36
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Improved URDF loading: .urdf.xacro files using `$(arg)` substitution and `<xacro:arg>` defaults and are now supported.

**Description**
Closes https://github.com/foxglove/studio/issues/2762.
Upgrade xacro-parser to pull in new feature from https://github.com/gkjohnson/xacro-parser/pull/79.
Tested manually with `package://ur_description/urdf/ur10_robot.urdf.xacro`.