### PR TITLE
Simplify findReturnType in node playground ast.ts

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -1413,7 +1413,7 @@ describe("pipeline", () => {
           export default (msg: any): MyAny => {
             return () => 1;
           };`,
-        error: ErrorCodes.DatatypeExtraction.NO_TYPEOF,
+        error: ErrorCodes.DatatypeExtraction.NO_FUNCTIONS,
       },
       {
         description: "Nested typeof func",
@@ -1482,7 +1482,7 @@ describe("pipeline", () => {
           export default (msg: any): Pos[keyof Pos] => {
             return { pos: { x: 1, y: 2 } };
           };`,
-        error: ErrorCodes.DatatypeExtraction.INVALID_INDEXED_ACCESS,
+        error: ErrorCodes.DatatypeExtraction.LIMITED_UNIONS,
       },
       {
         description: "Indexed access type with non-string index",
@@ -1491,7 +1491,7 @@ describe("pipeline", () => {
           export default (msg: any): Pos[3] => {
             throw new Error();
           };`,
-        error: ErrorCodes.DatatypeExtraction.INVALID_INDEXED_ACCESS,
+        error: ErrorCodes.DatatypeExtraction.BAD_TYPE_RETURN,
       },
     ];
 

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -1155,6 +1155,81 @@ describe("pipeline", () => {
         datatypes: baseDatatypes,
         outputDatatype: "std_msgs/ColorRGBA",
       },
+      {
+        description: "Should handle deep subtype lookup",
+        sourceCode: `
+          import { Input } from "ros";
+
+          type MessageBySchemaName = {
+            "std_msgs/Header": {
+              frame_id: string;
+              seq: number;
+              stamp: {
+                sec: number,
+                nsec: number,
+              };
+            };
+            "pkg/Custom": {
+              header: MessageBySchemaName["std_msgs/Header"];
+            };
+          };
+
+          type Message<T extends keyof MessageBySchemaName> = MessageBySchemaName[T];
+
+          export const inputs = ["/some_topic"];
+          export const output = "/studio_node/sample";
+
+          type PoseStamped = Message<"pkg/Custom">;
+          type Output = PoseStamped;
+
+          const publisher = (message: Input<"/some_topic">): Output => {
+            return {
+              header: { frame_id: "foo", seq: 0, stamp: { sec: 0, nsec: 0 } },
+            };
+          };
+          export default publisher;`,
+        datatypes: new Map(
+          Object.entries({
+            "/studio_node/main": {
+              definitions: [
+                {
+                  arrayLength: undefined,
+                  isArray: false,
+                  isComplex: true,
+                  name: "header",
+                  type: "/studio_node/main/header",
+                },
+              ],
+            },
+            "/studio_node/main/header": {
+              definitions: [
+                {
+                  arrayLength: undefined,
+                  isArray: false,
+                  isComplex: false,
+                  name: "frame_id",
+                  type: "string",
+                },
+                {
+                  arrayLength: undefined,
+                  isArray: false,
+                  isComplex: false,
+                  name: "seq",
+                  type: "float64",
+                },
+                {
+                  arrayLength: undefined,
+                  isArray: false,
+                  isComplex: false,
+                  name: "stamp",
+                  type: "time",
+                },
+              ],
+            },
+          }),
+        ),
+        outputDatatype: "/studio_node/main",
+      },
       /*
       ERRORS
     */

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
@@ -17,9 +17,9 @@ import { filterMap } from "@foxglove/den/collection";
 import { formatInterfaceName } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/generateRosLib";
 import {
   constructDatatypes,
-  findReturnType,
   findDefaultExportFunction,
   DatatypeExtractionError,
+  findReturnType,
 } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/ast";
 import { getNodeProjectConfig } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/projectConfig";
 import {
@@ -421,7 +421,7 @@ export const extractDatatypes = (nodeData: NodeData): NodeData => {
       throw new Error("Your node must default export a function");
     }
 
-    const typeNode = findReturnType(typeChecker, 0, exportNode);
+    const typeNode = findReturnType(typeChecker, exportNode);
 
     const { outputDatatype, datatypes } = constructDatatypes(
       typeChecker,

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -236,20 +236,16 @@ export const findReturnType = (
     throw new DatatypeExtractionError(badTypeReturnError);
   }
 
-  switch (declaration.kind) {
-    case ts.SyntaxKind.InterfaceDeclaration:
-      return declaration as ts.InterfaceDeclaration;
-    case ts.SyntaxKind.TypeLiteral:
-      return declaration as ts.TypeLiteralNode;
-    case ts.SyntaxKind.MappedType:
-      throw new DatatypeExtractionError(noMappedTypes);
-    case ts.SyntaxKind.ClassDeclaration:
-      throw new DatatypeExtractionError(classError);
-    case ts.SyntaxKind.FunctionType:
-    case ts.SyntaxKind.ArrowFunction:
-    case ts.SyntaxKind.FunctionDeclaration:
-      throw new DatatypeExtractionError(functionError);
-    default:
+  if (ts.isTypeLiteralNode(declaration)) {
+    return declaration;
+  } else if (ts.isInterfaceDeclaration(declaration)) {
+    return declaration;
+  } else if (ts.isMappedTypeNode(declaration)) {
+    throw new DatatypeExtractionError(noMappedTypes);
+  } else if (ts.isClassDeclaration(declaration)) {
+    throw new DatatypeExtractionError(classError);
+  } else if (ts.isFunctionLike(declaration)) {
+    throw new DatatypeExtractionError(functionError);
   }
 
   throw new DatatypeExtractionError(badTypeReturnError);

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -302,17 +302,6 @@ export const constructDatatypes = (
         const typeLiteral = tsNode as ts.TypeLiteralNode;
         const symbolName = maybeSymbol(tsNode)?.name;
 
-        // The 'json' type is special because rosbagjs represents it as a primitive field
-        if (isNodeFromRosModule(typeLiteral) && symbolName === "json") {
-          return {
-            name,
-            type: "json",
-            isArray: false,
-            isComplex: false,
-            arrayLength: undefined,
-          };
-        }
-
         const messageDefinition =
           symbolName != undefined ? messageDefinitionMap[symbolName] : undefined;
 
@@ -524,8 +513,17 @@ export const constructDatatypes = (
       case ts.SyntaxKind.AnyKeyword:
         throw new DatatypeExtractionError(noNestedAny);
 
-      default:
-        throw new Error(`Unhandled node kind (${tsNode.kind}) for field (${name})`);
+      default: {
+        const locationType = checker.getTypeAtLocation(tsNode);
+
+        const symbol = locationType.symbol;
+        const declaration = symbol.declarations?.[0];
+        if (symbol.declarations?.length !== 1 || !declaration) {
+          throw new DatatypeExtractionError(badTypeReturnError);
+        }
+
+        return getRosMsgField(name, declaration, false, undefined, typeMap, innerDepth + 1);
+      }
     }
   };
 

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -30,7 +30,6 @@ import {
   noTuples,
   limitedUnionsError,
   noNestedAny,
-  invalidIndexedAccessError,
 } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/errors";
 import {
   DiagnosticSeverity,
@@ -190,154 +189,70 @@ export const findDefaultExportFunction = (
 };
 
 export const findReturnType = (
-  checker: ts.TypeChecker,
-  depth: number = 1,
+  typeChecker: ts.TypeChecker,
   node: ts.Node,
 ): ts.TypeLiteralNode | ts.InterfaceDeclaration => {
-  if (depth > MAX_DEPTH) {
-    throw new Error(`Max AST traversal depth exceeded ${MAX_DEPTH}.`);
+  const resolveType = typeChecker.getTypeAtLocation(node);
+
+  const signatures = resolveType.getCallSignatures();
+  const signature = signatures[0];
+  if (signatures.length !== 1 || !signature) {
+    throw new DatatypeExtractionError(nonFuncError);
   }
 
-  const visitNext = findReturnType.bind(undefined, checker, depth + 1);
+  const fullReturnType = typeChecker.getReturnTypeOfSignature(signature);
+  const nonNullable = fullReturnType.getNonNullableType();
 
-  switch (node.kind) {
-    case ts.SyntaxKind.TypeLiteral:
-      return node as ts.TypeLiteralNode;
+  // In some future we could support intersection types where all the fields are known
+  if (nonNullable.isIntersection()) {
+    throw new DatatypeExtractionError(noIntersectionTypesError);
+  } else if (nonNullable.isClass()) {
+    throw new DatatypeExtractionError(classError);
+  } else if (nonNullable.isUnion()) {
+    throw new DatatypeExtractionError(limitedUnionsError);
+  }
+
+  const symbol = nonNullable.getSymbol();
+  if (!symbol) {
+    throw new DatatypeExtractionError(badTypeReturnError);
+  }
+
+  if (!symbol.declarations || symbol.declarations.length === 0) {
+    throw new DatatypeExtractionError(badTypeReturnError);
+  }
+
+  // If there are multiple declarations for the symbol, filter down to only
+  // the interface ones. However, if there is only one, use that one to provide better errors
+  let declaration: ts.Declaration | undefined;
+  if (symbol.declarations.length === 1) {
+    declaration = symbol.declarations[0];
+  } else {
+    declaration = symbol.declarations.filter(
+      (decl) => decl.kind === ts.SyntaxKind.InterfaceDeclaration,
+    )[0];
+  }
+
+  if (!declaration) {
+    throw new DatatypeExtractionError(badTypeReturnError);
+  }
+
+  switch (declaration.kind) {
     case ts.SyntaxKind.InterfaceDeclaration:
-      return node as ts.InterfaceDeclaration;
-    case ts.SyntaxKind.ArrowFunction: {
-      const nextNode = findChild(node, [
-        ts.SyntaxKind.TypeReference,
-        ts.SyntaxKind.TypeLiteral,
-        ts.SyntaxKind.IntersectionType, // Unhandled type--let next recursive call handle error.
-        ts.SyntaxKind.UnionType,
-        ts.SyntaxKind.IndexedAccessType,
-      ]);
-      if (nextNode) {
-        return visitNext(nextNode);
-      }
-      throw new DatatypeExtractionError(badTypeReturnError);
-    }
-    case ts.SyntaxKind.Identifier: {
-      const symbol = checker.getSymbolAtLocation(node);
-      if (!symbol?.valueDeclaration) {
-        throw new DatatypeExtractionError(nonFuncError);
-      }
-      return visitNext(symbol.valueDeclaration);
-    }
-    case ts.SyntaxKind.VariableDeclaration: {
-      const nextNode = findChild(node, [ts.SyntaxKind.TypeReference, ts.SyntaxKind.ArrowFunction]);
-      if (!nextNode) {
-        throw new DatatypeExtractionError(nonFuncError);
-      }
-      return visitNext(nextNode);
-    }
-    case ts.SyntaxKind.TypeReference: {
-      const typeRef = node as ts.TypeReferenceNode;
-      const symbol = checker.getSymbolAtLocation(typeRef.typeName);
-      if (!symbol) {
-        throw new DatatypeExtractionError(badTypeReturnError);
-      }
-      const nextNode = findDeclaration(symbol, [
-        ts.SyntaxKind.TypeAliasDeclaration,
-        ts.SyntaxKind.InterfaceDeclaration,
-        ts.SyntaxKind.ClassDeclaration,
-        ts.SyntaxKind.ImportSpecifier,
-      ]);
-      if (!nextNode) {
-        throw new DatatypeExtractionError(badTypeReturnError);
-      }
-      return visitNext(nextNode);
-    }
-    case ts.SyntaxKind.FunctionDeclaration: {
-      const nextNode = findChild(node, [ts.SyntaxKind.TypeReference, ts.SyntaxKind.TypeLiteral]);
-      if (!nextNode) {
-        throw new DatatypeExtractionError(badTypeReturnError);
-      }
-      return visitNext(nextNode);
-    }
-    case ts.SyntaxKind.FunctionType: {
-      return visitNext((node as ts.FunctionTypeNode).type);
-    }
-    case ts.SyntaxKind.TypeAliasDeclaration: {
-      return visitNext((node as ts.TypeAliasDeclaration).type);
-    }
-    case ts.SyntaxKind.ImportSpecifier: {
-      const declaration = findImportedTypeDeclaration(checker, node, [
-        ts.SyntaxKind.TypeLiteral,
-        ts.SyntaxKind.InterfaceDeclaration,
-      ]);
-      if (!declaration) {
-        throw new DatatypeExtractionError(badTypeReturnError);
-      }
-      return visitNext(declaration);
-    }
-
-    case ts.SyntaxKind.IndexedAccessType: {
-      const indexedNode = node as ts.IndexedAccessTypeNode;
-      const declaration = visitNext(indexedNode.objectType);
-
-      if (!ts.isLiteralTypeNode(indexedNode.indexType)) {
-        throw new DatatypeExtractionError({
-          ...invalidIndexedAccessError,
-          message: "Indexed access is only allowed with string literal indexes",
-        });
-      }
-      if (!ts.isStringLiteral(indexedNode.indexType.literal)) {
-        throw new DatatypeExtractionError({
-          ...invalidIndexedAccessError,
-          message: "Indexed access is only allowed with string literal indexes",
-        });
-      }
-      const indexedProperty = indexedNode.indexType.literal.text;
-
-      const next = declaration.members.find((member): member is ts.PropertySignature => {
-        return (
-          ts.isPropertySignature(member) &&
-          (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name)) &&
-          member.name.text === indexedProperty
-        );
-      });
-      if (!next || !next.type) {
-        throw new DatatypeExtractionError({
-          ...invalidIndexedAccessError,
-          message: `Couldn't find member ${indexedProperty} in indexed access`,
-        });
-      }
-      return visitNext(next.type);
-    }
-
-    case ts.SyntaxKind.TypeQuery:
-      throw new DatatypeExtractionError(noTypeOfError);
-
+      return declaration as ts.InterfaceDeclaration;
+    case ts.SyntaxKind.TypeLiteral:
+      return declaration as ts.TypeLiteralNode;
     case ts.SyntaxKind.MappedType:
       throw new DatatypeExtractionError(noMappedTypes);
-
-    case ts.SyntaxKind.AnyKeyword:
-    case ts.SyntaxKind.LiteralType: {
-      throw new DatatypeExtractionError(badTypeReturnError);
-    }
-    case ts.SyntaxKind.IntersectionType:
-      throw new DatatypeExtractionError(noIntersectionTypesError);
-    case ts.SyntaxKind.ClassDeclaration: {
+    case ts.SyntaxKind.ClassDeclaration:
       throw new DatatypeExtractionError(classError);
-    }
-    case ts.SyntaxKind.UnionType: {
-      const remainingTypes = (node as ts.UnionTypeNode).types.filter(
-        ({ kind }) => kind !== ts.SyntaxKind.UndefinedKeyword,
-      );
-      if (remainingTypes.length !== 1) {
-        throw new DatatypeExtractionError(limitedUnionsError);
-      }
-      const remaining = remainingTypes[0];
-      if (!remaining) {
-        throw new DatatypeExtractionError(badTypeReturnError);
-      }
-      return visitNext(remaining);
-    }
+    case ts.SyntaxKind.FunctionType:
+    case ts.SyntaxKind.ArrowFunction:
+    case ts.SyntaxKind.FunctionDeclaration:
+      throw new DatatypeExtractionError(functionError);
     default:
-      throw new Error("Unhandled node kind.");
   }
+
+  throw new DatatypeExtractionError(badTypeReturnError);
 };
 
 export const constructDatatypes = (

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/errors.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/errors.ts
@@ -114,9 +114,3 @@ export const noMappedTypes = {
   source: Sources.DatatypeExtraction,
   code: ErrorCodes.DatatypeExtraction.NO_MAPPED_TYPES,
 };
-
-export const invalidIndexedAccessError = {
-  severity: DiagnosticSeverity.Error,
-  source: Sources.DatatypeExtraction,
-  code: ErrorCodes.DatatypeExtraction.INVALID_INDEXED_ACCESS,
-};


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Rather than writing our own AST traversal to find the return type, leverage getTypeAtLocation from the TypeChecker to fully resolve the type. This provides wider syntax support for resolving valid types.

This change is required to support the new syntax used by https://github.com/foxglove/studio/pull/2790.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
