### PR TITLE
Fix diff mode for filtered raw message values

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
@@ -17,7 +17,7 @@ import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
-import { useLatestMessageDataItem } from "./useLatestMessageDataItem";
+import { useMessageDataItem } from "./useMessageDataItem";
 
 const topics = [{ name: "/topic", datatype: "datatype" }];
 const datatypes: RosDatatypes = new Map(
@@ -48,9 +48,9 @@ const fixtureMessages: MessageEvent<unknown>[] = [
   },
 ];
 
-describe("useLatestMessageDataItem", () => {
+describe("useMessageDataItem", () => {
   it("returns empty array by default", async () => {
-    const { result } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+    const { result } = renderHook(({ path }) => useMessageDataItem(path), {
       initialProps: { path: "/topic.value" },
       wrapper({ children }) {
         return (
@@ -66,7 +66,7 @@ describe("useLatestMessageDataItem", () => {
   });
 
   it("uses the latest message", async () => {
-    const { result, rerender } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+    const { result, rerender } = renderHook(({ path }) => useMessageDataItem(path), {
       initialProps: { path: "/topic.value", messages: [fixtureMessages[0]!] },
       wrapper({ children, messages }) {
         return (
@@ -92,7 +92,7 @@ describe("useLatestMessageDataItem", () => {
   });
 
   it("only keeps messages that match the path", async () => {
-    const { result } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+    const { result } = renderHook(({ path }) => useMessageDataItem(path), {
       initialProps: { path: "/topic{value==1}.value" },
       wrapper({ children }) {
         return (
@@ -120,7 +120,7 @@ describe("useLatestMessageDataItem", () => {
   });
 
   it("changing the path gives the new queriedData from the message", async () => {
-    const { result, rerender } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+    const { result, rerender } = renderHook(({ path }) => useMessageDataItem(path), {
       initialProps: { path: "/topic{value==1}.value" },
       wrapper({ children }) {
         return (
@@ -156,7 +156,7 @@ describe("useLatestMessageDataItem", () => {
   });
 
   it("restores previously received message when topics and datatypes becomes available", async () => {
-    const { result, rerender } = renderHook(({ path }) => useLatestMessageDataItem(path), {
+    const { result, rerender } = renderHook(({ path }) => useMessageDataItem(path), {
       initialProps: {
         path: "/topic{value==2}.value",
         datatypes: new Map(),
@@ -192,25 +192,22 @@ describe("useLatestMessageDataItem", () => {
   });
 
   it("keeps a history", async () => {
-    const { result } = renderHook(
-      ({ path }) => useLatestMessageDataItem(path, { historySize: 2 }),
-      {
-        initialProps: { path: "/topic.value" },
-        wrapper({ children }) {
-          return (
-            <MockCurrentLayoutProvider>
-              <MockMessagePipelineProvider
-                messages={fixtureMessages}
-                topics={topics}
-                datatypes={datatypes}
-              >
-                {children}
-              </MockMessagePipelineProvider>
-            </MockCurrentLayoutProvider>
-          );
-        },
+    const { result } = renderHook(({ path }) => useMessageDataItem(path, { historySize: 2 }), {
+      initialProps: { path: "/topic.value" },
+      wrapper({ children }) {
+        return (
+          <MockCurrentLayoutProvider>
+            <MockMessagePipelineProvider
+              messages={fixtureMessages}
+              topics={topics}
+              datatypes={datatypes}
+            >
+              {children}
+            </MockMessagePipelineProvider>
+          </MockCurrentLayoutProvider>
+        );
       },
-    );
+    });
     expect(result.all).toEqual([
       [],
       [

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -135,9 +135,8 @@ function TwoDimensionalPlot(props: Props) {
   const [hasVerticalExclusiveZoom, setHasVerticalExclusiveZoom] = React.useState<boolean>(false);
   const [hasBothAxesZoom, setHasBothAxesZoom] = React.useState<boolean>(false);
 
-  const message = useLatestMessageDataItem(path.value)?.queriedData[0]?.value as
-    | PlotMessage
-    | undefined;
+  const matchedMessages = useLatestMessageDataItem(path.value);
+  const message = matchedMessages[0]?.queriedData[0]?.value as PlotMessage | undefined;
 
   const {
     title,

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -25,7 +25,7 @@ import ChartComponent from "@foxglove/studio-base/components/Chart";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
-import { useLatestMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useLatestMessageDataItem";
+import { useMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useMessageDataItem";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
@@ -135,7 +135,7 @@ function TwoDimensionalPlot(props: Props) {
   const [hasVerticalExclusiveZoom, setHasVerticalExclusiveZoom] = React.useState<boolean>(false);
   const [hasBothAxesZoom, setHasBothAxesZoom] = React.useState<boolean>(false);
 
-  const matchedMessages = useLatestMessageDataItem(path.value);
+  const matchedMessages = useMessageDataItem(path.value);
   const message = matchedMessages[0]?.queriedData[0]?.value as PlotMessage | undefined;
 
   const {

--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -452,6 +452,25 @@ export const multipleMessagesFilter = {
   ),
   topics: [{ name: "/foo", datatype: "custom_message" }],
   frame: {
-    "/foo": [],
+    "/foo": [
+      {
+        topic: "/foo",
+        receiveTime: { sec: 123, nsec: 1 },
+        message: { type: 2, status: "WAITING" },
+        sizeInBytes: 0,
+      },
+      {
+        topic: "/foo",
+        receiveTime: { sec: 123, nsec: 2 },
+        message: { type: 1, status: "FAIL" },
+        sizeInBytes: 0,
+      },
+      {
+        topic: "/foo",
+        receiveTime: { sec: 123, nsec: 3 },
+        message: { type: 2, status: "SUCCESS" },
+        sizeInBytes: 0,
+      },
+    ],
   },
 };

--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -437,3 +437,21 @@ export const multipleNumberMessagesFixture = {
     ],
   },
 };
+
+// ts-prune-ignore-next
+export const multipleMessagesFilter = {
+  datatypes: new Map(
+    Object.entries({
+      custom_message: {
+        definitions: [
+          { type: "uint32", name: "type", isArray: false },
+          { type: "uint32", name: "status", isArray: false },
+        ],
+      },
+    }),
+  ),
+  topics: [{ name: "/foo", datatype: "custom_message" }],
+  frame: {
+    "/foo": [],
+  },
+};

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -12,9 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { storiesOf } from "@storybook/react";
-import { useEffect, useState } from "react";
 
-import { MessageEvent } from "@foxglove/studio";
 import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -239,67 +237,8 @@ storiesOf("panels/RawMessages", module)
     );
   })
   .add("diff consecutive messages with filter", () => {
-    const [state, setState] = useState<{ count: number; messages: MessageEvent<unknown>[] }>({
-      count: 0,
-      messages: [],
-    });
-
-    // Make it look like new messages are arriving to the panel
-    useEffect(() => {
-      switch (state.count) {
-        case 0:
-          setTimeout(() => {
-            setState({
-              count: state.count + 1,
-              messages: [
-                {
-                  topic: "/foo",
-                  receiveTime: { sec: 123, nsec: 1 },
-                  message: { type: 2, status: "WAITING" },
-                  sizeInBytes: 0,
-                },
-              ],
-            });
-          }, 100);
-          break;
-        case 1:
-          setTimeout(() => {
-            setState({
-              count: state.count + 1,
-              messages: [
-                {
-                  topic: "/foo",
-                  receiveTime: { sec: 123, nsec: 2 },
-                  message: { type: 1, status: "FAIL" },
-                  sizeInBytes: 0,
-                },
-              ],
-            });
-          }, 100);
-          break;
-        case 2:
-          setTimeout(() => {
-            setState({
-              count: state.count + 1,
-              messages: [
-                {
-                  topic: "/foo",
-                  receiveTime: { sec: 123, nsec: 3 },
-                  message: { type: 2, status: "SUCCESS" },
-                  sizeInBytes: 0,
-                },
-              ],
-            });
-          }, 100);
-          break;
-      }
-    }, [state]);
-
     return (
-      <PanelSetup
-        fixture={{ ...multipleMessagesFilter, frame: { "/foo": state.messages } }}
-        style={{ width: 380 }}
-      >
+      <PanelSetup fixture={multipleMessagesFilter} style={{ width: 380 }}>
         <RawMessages
           overrideConfig={{
             topicPath: "/foo{type==2}",
@@ -331,7 +270,7 @@ storiesOf("panels/RawMessages", module)
   })
   .add("display correct message when diff is disabled, even with diff method & topic set", () => {
     return (
-      <PanelSetup fixture={multipleNumberMessagesFixture} style={{ width: 380 }}>
+      <PanelSetup fixture={fixture} style={{ width: 380 }}>
         <RawMessages
           overrideConfig={{
             topicPath: "/foo",

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -41,7 +41,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePathSyntax/messagePathsForDatatype";
 import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import { MessagePathDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
-import { useLatestMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useLatestMessageDataItem";
+import { useMessageDataItem } from "@foxglove/studio-base/components/MessagePathSyntax/useMessageDataItem";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -157,8 +157,8 @@ function RawMessages(props: Props) {
   const [expandAll, setExpandAll] = useState<boolean | undefined>(props.defaultExpandAll ?? false);
   const [expandedFields, setExpandedFields] = useState(() => new Set());
 
-  const matchedMessages = useLatestMessageDataItem(topicPath, { historySize: 2 });
-  const diffMessages = useLatestMessageDataItem(diffEnabled ? diffTopicPath : "");
+  const matchedMessages = useMessageDataItem(topicPath, { historySize: 2 });
+  const diffMessages = useMessageDataItem(diffEnabled ? diffTopicPath : "");
 
   const diffTopicObj = diffMessages[0];
   const currTickObj = matchedMessages[matchedMessages.length - 1];

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -20,7 +20,7 @@ import MoreIcon from "@mdi/svg/svg/unfold-more-horizontal.svg";
 import { Stack } from "@mui/material";
 // eslint-disable-next-line no-restricted-imports
 import { first, isEqual, get, last } from "lodash";
-import { useState, useCallback, useMemo, useRef } from "react";
+import { useState, useCallback, useMemo } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
 
@@ -157,29 +157,15 @@ function RawMessages(props: Props) {
   const [expandAll, setExpandAll] = useState<boolean | undefined>(props.defaultExpandAll ?? false);
   const [expandedFields, setExpandedFields] = useState(() => new Set());
 
-  const currTickObj = useLatestMessageDataItem(topicPath);
-  const diffTopicObj = useLatestMessageDataItem(diffEnabled ? diffTopicPath : "");
+  const matchedMessages = useLatestMessageDataItem(topicPath, { historySize: 2 });
+  const diffMessages = useLatestMessageDataItem(diffEnabled ? diffTopicPath : "");
 
-  // currentTickObjRef stores the current value of currTickObj
-  // When currTickObj no longer matches this ref, we update prevTickObjRef
-  const currTickObjRef = useRef<typeof currTickObj>(undefined);
-
-  // prevTickObjRef stores the _previous_ value of currTickObj
-  const prevTickObjRef = useRef<typeof currTickObj>(undefined);
-
-  // When we reset and have no message, clear the previous ref
-  if (currTickObj == undefined) {
-    currTickObjRef.current = undefined;
-  }
-
-  // when current Tick object changes, we update the prevTickObject
-  if (currTickObjRef.current !== currTickObj) {
-    prevTickObjRef.current = currTickObjRef.current;
-    currTickObjRef.current = currTickObj;
-  }
+  const diffTopicObj = diffMessages[0];
+  const currTickObj = matchedMessages[matchedMessages.length - 1];
+  const prevTickObj = matchedMessages[matchedMessages.length - 2];
 
   const inTimetickDiffMode = diffEnabled && diffMethod === PREV_MSG_METHOD;
-  const baseItem = inTimetickDiffMode ? prevTickObjRef.current : currTickObj;
+  const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
   const onTopicPathChange = useCallback(


### PR DESCRIPTION
**User-Facing Changes**
Using raw message panel in "previous topic diff mode" with a filtered path shows you a diff between the previously filtered value and the current filtered value.

Before:

<img src="https://user-images.githubusercontent.com/84792/153676509-0c4fae65-1102-4d40-9c64-c3426fa1989a.png"/>

After:
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/84792/153681352-a5ab7e48-40b4-43e1-917b-7a9bc5706761.png">


**Description**
When using the raw message panel with a message path filter (i.e. `/foo{type=2}`), the raw message panel diff mode would compare the latest filtered value against the previous message on the topic, rather than the previous filtered message.

This change updates the raw message panel logic to track consecutive filtered messages rather than any message on the topic. For users who want to see diff between the current filtered message and any message on the topic, the can select the _custom_ option and enter a message path that only contains their topic.

Fixes: #2784


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
