### PR TITLE
Add support to detect existing datatype from node playground

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -276,6 +276,19 @@ export const constructDatatypes = (
     };
   }
 
+  // In this case, we've detected that the return type comes from the generated types file.
+  // We can look up the datatype name by finding it in the file. The name will be the property name
+  // under which the type exists.
+  if (node.getSourceFile().fileName === "/studio_node/generatedTypes.ts") {
+    if (ts.isPropertySignature(node.parent) && ts.isStringLiteral(node.parent.name)) {
+      const datatype = node.parent.name.text;
+      return {
+        outputDatatype: datatype,
+        datatypes: baseDatatypes,
+      };
+    }
+  }
+
   let datatypes: RosDatatypes = new Map();
 
   const getRosMsgField = (


### PR DESCRIPTION

**User-Facing Changes**
In Node Playground, when using a Message from the `./types` utility as an output type results in publishing messages of that same datatype.

**Description**
When using the `./types` utility file for Message datatypes as output type, node playground detects the original datatype name and sets the node output datatype to the original datatype name. These datatype names matter to other parts of studio which rely on datatype name matching.

This behavior mirrors the existing behavior for the generated "ros" library.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
