### PR TITLE
Add /clock support to ROS2 data source

### DIFF
--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -11,7 +11,7 @@ import { RosNode } from "@foxglove/ros2";
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { definitions as foxgloveDefs } from "@foxglove/rosmsg-msgs-foxglove";
-import { Time, fromMillis } from "@foxglove/rostime";
+import { Time, fromMillis, toSec } from "@foxglove/rostime";
 import { Reliability } from "@foxglove/rtps";
 import { ParameterValue } from "@foxglove/studio";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
@@ -61,11 +61,8 @@ export default class Ros2Player implements Player {
   private _providerDatatypes = new Map<string, RosMsgDefinition>(); // All known ROS 2 message definitions.
   private _publishedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of publisher IDs publishing each topic.
   private _subscribedTopics = new Map<string, Set<string>>(); // A map of topic names to the set of subscriber IDs subscribed to each topic.
-  // private _services = new Map<string, Set<string>>(); // A map of service names to service provider IDs that provide each service.
-  // private _parameters = new Map<string, ParameterValue>(); // rosparams
   private _start?: Time; // The time at which we started playing.
-  // private _clockTime?: Time; // The most recent published `/clock` time, if available
-  // private _clockReceived: Time = { sec: 0, nsec: 0 }; // The local time when `_clockTime` was last received
+  private _clockTime?: Time; // The most recent published `/clock` time, if available
   private _requestedSubscriptions: SubscribePayload[] = []; // Requested subscriptions by setSubscriptions()
   private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
   private _messageOrder: TimestampMethod = "receiveTime";
@@ -216,30 +213,6 @@ export default class Ros2Player implements Player {
         this.setSubscriptions(this._requestedSubscriptions);
       }
 
-      // Subscribe to all parameters
-      // try {
-      //   const params = await rosNode.subscribeAllParams();
-      //   if (!isEqual(params, this._parameters)) {
-      //     this._parameters = new Map();
-      //     params.forEach((value, key) => this._parameters.set(key, value));
-      //   }
-      //   this._clearProblem(Problem.Parameters, true);
-      // } catch (error) {
-      //   this._addProblem(
-      //     Problem.Parameters,
-      //     {
-      //       severity: "warn",
-      //       message: "ROS parameter fetch failed",
-      //       tip: `Ensure that roscore is running and accessible at: ${this._url}`,
-      //       error,
-      //     },
-      //     true,
-      //   );
-      // }
-
-      // Fetch the full graph topology
-      this._updateConnectionGraph(rosNode);
-
       this._presence = PlayerPresence.PRESENT;
       this._emitState();
     } catch (error) {
@@ -344,7 +317,7 @@ export default class Ros2Player implements Player {
       return;
     }
 
-    // Subscribe to additional topics used by Ros1Player itself
+    // Subscribe to additional topics used by Player itself
     this._addInternalSubscriptions(subscriptions);
 
     // Filter down to topics we can actually subscribe to
@@ -400,8 +373,8 @@ export default class Ros2Player implements Player {
         msgDefinition,
       });
 
-      subscription.on("message", (timestamp, message, data, _pub) =>
-        this._handleMessage(topicName, timestamp, message, data.byteLength, true),
+      subscription.on("message", (_timestamp, message, data, _pub) =>
+        this._handleMessage(topicName, message, data.byteLength, true),
       );
       subscription.on("error", (err) => {
         log.error(`Subscription error for ${topicName}: ${err}`);
@@ -426,7 +399,6 @@ export default class Ros2Player implements Player {
 
   private _handleMessage = (
     topic: string,
-    timestamp: Time,
     message: unknown,
     sizeInBytes: number,
     // This is a hot path so we avoid extra object allocation from a parameters struct
@@ -437,8 +409,7 @@ export default class Ros2Player implements Player {
       return;
     }
 
-    // const receiveTime = fromMillis(Date.now());
-    const receiveTime = timestamp;
+    const receiveTime = this._getCurrentTime();
 
     if (external && !this._hasReceivedMessage) {
       this._hasReceivedMessage = true;
@@ -457,90 +428,15 @@ export default class Ros2Player implements Player {
       return;
     }
 
-    // const validPublishers = publishers.filter(({ topic }) => topic.length > 0 && topic !== "/");
-    // const topics = new Set<string>(validPublishers.map(({ topic }) => topic));
-
     // Clear all problems related to publishing
     this._clearPublishProblems({ skipEmit: false });
-
-    // Unadvertise any topics that were previously published and no longer appear in the list
-    // for (const topic of this._rosNode.publications.keys()) {
-    //   if (!topics.has(topic)) {
-    //     this._rosNode.unadvertise(topic);
-    //   }
-    // }
-
-    // // Unadvertise any topics where the dataType changed
-    // for (const { topic, datatype } of validPublishers) {
-    //   const existingPub = this._rosNode.publications.get(topic);
-    //   if (existingPub != undefined && existingPub.dataType !== datatype) {
-    //     this._rosNode.unadvertise(topic);
-    //   }
-    // }
-
-    // // Advertise new topics
-    // for (const { topic, datatype: dataType, datatypes } of validPublishers) {
-    //   if (this._rosNode.publications.has(topic)) {
-    //     continue;
-    //   }
-
-    //   const msgdefProblemId = `msgdef:${topic}`;
-    //   const advertiseProblemId = `advertise:${topic}`;
-
-    //   // Try to retrieve the ROS message definition for this topic
-    //   let msgdef: RosMsgDefinition[];
-    //   try {
-    //     msgdef = rosDatatypesToMessageDefinition(datatypes, dataType);
-    //   } catch (error) {
-    //     this._addProblem(msgdefProblemId, {
-    //       severity: "warn",
-    //       message: `Unknown message definition for "${topic}"`,
-    //       tip: `Try subscribing to the topic "${topic} before publishing to it`,
-    //     });
-    //     continue;
-    //   }
-
-    //   // Advertise this topic to ROS as being published by us
-    //   this._rosNode.advertise({ topic, dataType, messageDefinition: msgdef }).catch((error) =>
-    //     this._addProblem(advertiseProblemId, {
-    //       severity: "error",
-    //       message: `Failed to advertise "${topic}"`,
-    //       error,
-    //     }),
-    //   );
-    // }
 
     this._emitState();
   }
 
-  setParameter(_key: string, _value: ParameterValue): void {
-    // log.debug(`Ros1Player.setParameter(key=${key}, value=${value})`);
-    // this._rosNode?.setParameter(key, value);
-  }
+  setParameter(_key: string, _value: ParameterValue): void {}
 
-  publish(_payload: PublishPayload): void {
-    // const problemId = `publish:${topic}`;
-    // if (this._rosNode != undefined) {
-    //   if (this._rosNode.isAdvertising(topic)) {
-    //     this._rosNode
-    //       .publish(topic, msg)
-    //       .then(() => this._clearProblem(problemId))
-    //       .catch((error) =>
-    //         this._addProblem(problemId, {
-    //           severity: "error",
-    //           message: `Publishing to ${topic} failed`,
-    //           error,
-    //         }),
-    //       );
-    //   } else {
-    //     this._addProblem(problemId, {
-    //       severity: "warn",
-    //       message: `Unable to publish to "${topic}"`,
-    //       tip: `ROS1 may be disconnected. Please try again in a moment`,
-    //     });
-    //   }
-    // }
-  }
+  publish(_payload: PublishPayload): void {}
 
   // Bunch of unsupported stuff. Just don't do anything for these.
   requestBackfill(): void {
@@ -555,67 +451,31 @@ export default class Ros2Player implements Player {
     if (subscriptions.find((sub) => sub.topic === "/clock") == undefined) {
       subscriptions.unshift({
         topic: "/clock",
-        requester: { type: "other", name: "Ros1Player" },
+        requester: { type: "other", name: "Ros2Player" },
       });
     }
   }
 
-  private _handleInternalMessage(_msg: MessageEvent<unknown>): void {
-    // const maybeClockMsg = msg.message as { clock?: Time };
-    // if (msg.topic === "/clock" && maybeClockMsg.clock && !isNaN(maybeClockMsg.clock?.sec)) {
-    //   const time = maybeClockMsg.clock;
-    //   const seconds = toSec(maybeClockMsg.clock);
-    //   if (isNaN(seconds)) {
-    //     return;
-    //   }
-    //   if (this._clockTime == undefined) {
-    //     this._start = time;
-    //   }
-    //   this._clockTime = time;
-    //   this._clockReceived = msg.receiveTime;
-    // }
-  }
+  private _handleInternalMessage(msg: MessageEvent<unknown>): void {
+    const maybeClockMsg = msg.message as { clock?: Time };
+    if (msg.topic === "/clock" && maybeClockMsg.clock && !isNaN(maybeClockMsg.clock.sec)) {
+      const time = maybeClockMsg.clock;
+      const seconds = toSec(maybeClockMsg.clock);
+      if (isNaN(seconds)) {
+        return;
+      }
 
-  private _updateConnectionGraph(_rosNode: RosNode): void {
-    //     try {
-    //       const graph = await rosNode.getSystemState();
-    //       if (
-    //         !isEqual(this._publishedTopics, graph.publishers) ||
-    //         !isEqual(this._subscribedTopics, graph.subscribers) ||
-    //         !isEqual(this._services, graph.services)
-    //       ) {
-    //         this._publishedTopics = graph.publishers;
-    //         this._subscribedTopics = graph.subscribers;
-    //         this._services = graph.services;
-    //       }
-    //       this._clearProblem(Problem.Graph, true);
-    //     } catch (error) {
-    //       this._addProblem(
-    //         Problem.Graph,
-    //         {
-    //           severity: "warn",
-    //           message: "Unable to update connection graph",
-    //           tip: `The connection graph contains information about publishers and subscribers. A
-    // stale graph may result in missing topics you expect. Ensure that roscore is reachable at ${this._url}.`,
-    //           error,
-    //         },
-    //         true,
-    //       );
-    //       this._publishedTopics = new Map();
-    //       this._subscribedTopics = new Map();
-    //       this._services = new Map();
-    //     }
+      if (this._clockTime == undefined) {
+        this._start = time;
+      }
+
+      this._clockTime = time;
+      (msg as { receiveTime: Time }).receiveTime = this._getCurrentTime();
+    }
   }
 
   private _getCurrentTime(): Time {
-    const now = fromMillis(Date.now());
-    return now;
-    // if (this._clockTime == undefined) {
-    //   return now;
-    // }
-
-    // const delta = subtractTimes(now, this._clockReceived);
-    // return addTimes(this._clockTime, delta);
+    return this._clockTime ?? fromMillis(Date.now());
   }
 }
 


### PR DESCRIPTION


**User-Facing Changes**
When connecting to a running ROS2 system using the ROS2 connection, studio subscribes to the `/clock` topic. Any messages received on the clock topic put the player into a "simulation time" mode where the clock time is used as the currentTime and the receiveTime for messages. This allows Studio to mirror behavior of the ROS2 system when running with simulated time.

**Description**
Update the Ros2Player to handle /clock messages. A /clock message updates the internal time of the player. This time is the time assigned as the _receiveTime_ for new messages. It is also the "currentTime" the player exposes for player state.

Fixes: #2825

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
