### PR TITLE
Clamp currentTime to start/end for FoxgloveDataPlatformPlayer

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -174,7 +174,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       this._end = coverageEnd;
     }
 
-    // During startup, seekPlayback might get called to set the currentTime This might change the
+    // During startup, seekPlayback might get called to set the currentTime. This might change the
     // currentTime from the initial value set in the constructor. So we clamp the currentTime to the
     // new start/end range in the event.
     this._currentTime = clampTime(this._currentTime, this._start, this._end);

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -168,12 +168,13 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     if (isLessThan(this._start, coverageStart)) {
       log.debug("Reduced start time from", this._start, "to", coverageStart);
       this._start = coverageStart;
-      this._currentTime = this._start;
     }
     if (isGreaterThan(this._end, coverageEnd)) {
       log.debug("Reduced end time from", this._end, "to", coverageEnd);
       this._end = coverageEnd;
     }
+
+    this._currentTime = clampTime(this._currentTime, this._start, this._end);
 
     const topics: Topic[] = [];
     const datatypes: RosDatatypes = new Map();

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -174,6 +174,9 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       this._end = coverageEnd;
     }
 
+    // During startup, seekPlayback might get called to set the currentTime This might change the
+    // currentTime from the initial value set in the constructor. So we clamp the currentTime to the
+    // new start/end range in the event.
     this._currentTime = clampTime(this._currentTime, this._start, this._end);
 
     const topics: Topic[] = [];


### PR DESCRIPTION


**User-Facing Changes**
When opening a data platform deep link, the player keeps the requested current time even if it has to resize the start/end range.

**Description**
When the player is given a start/end range that does not match available coverage, it will clamp the start/end range to a valid coverage range. Prior to this change, this would also unconditionally set the currentTime to the start time even if the currentTime fell within the new valid range. This change clamps the currentTime to the new valid range.

Fixes: #2821

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
