### PR TITLE
Add support for foxglove.RawImage to Image panel

### DIFF
--- a/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
+++ b/packages/studio-base/src/panels/ImageView/HitmapRenderContext.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { indexToIDColor } from "@foxglove/studio-base/panels/ImageView/util";
+import { indexToIDColor } from "./util";
 
 /**
  * This wraps a canvas rendering context to also render all context commands in parallel

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -15,12 +15,13 @@ import { Story } from "@storybook/react";
 import { range, noop } from "lodash";
 import { useEffect, useMemo, useRef } from "react";
 
-import ImageView, { Config } from "@foxglove/studio-base/panels/ImageView";
-import ImageCanvas from "@foxglove/studio-base/panels/ImageView/ImageCanvas";
-import { renderImage } from "@foxglove/studio-base/panels/ImageView/renderImage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { CameraInfo, ImageMarker, ImageMarkerType } from "@foxglove/studio-base/types/Messages";
+
+import ImageCanvas from "./ImageCanvas";
+import ImageView, { Config } from "./index";
+import { renderImage } from "./renderImage";
 
 const cameraInfo: CameraInfo = {
   width: 400,

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.stories.tsx
@@ -15,6 +15,7 @@ import { Story } from "@storybook/react";
 import { range, noop } from "lodash";
 import { useEffect, useMemo, useRef } from "react";
 
+import { NormalizedImageMessage } from "@foxglove/studio-base/panels/ImageView/normalizeMessage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { CameraInfo, ImageMarker, ImageMarkerType } from "@foxglove/studio-base/types/Messages";
@@ -42,9 +43,9 @@ const cameraInfo: CameraInfo = {
   },
 };
 
-const imageFormat = "image/png";
-
 function useImageMessage() {
+  const imageFormat = "image/png";
+
   const [imageData, setImageData] = React.useState<Uint8Array | undefined>();
   React.useEffect(() => {
     const canvas = document.createElement("canvas");
@@ -77,10 +78,24 @@ function useImageMessage() {
     return {
       topic: "/foo",
       receiveTime: { sec: 0, nsec: 0 },
-      message: { format: imageFormat, data: imageData },
+      message: { header: { stamp: { sec: 0, nsec: 0 } }, format: imageFormat, data: imageData },
       sizeInBytes: 0,
     };
   }, [imageData]);
+}
+
+function useNormalizedImageMessage(): NormalizedImageMessage | undefined {
+  const imageMessage = useImageMessage();
+  if (!imageMessage) {
+    return undefined;
+  }
+
+  return {
+    type: "compressed",
+    stamp: imageMessage.message.header.stamp,
+    format: imageMessage.message.format,
+    data: imageMessage.message.data,
+  };
 }
 
 function marker(
@@ -291,7 +306,7 @@ function RGBStory({ encoding }: { encoding: string }) {
       image={{
         topic: "/foo",
         receiveTime: { sec: 0, nsec: 0 },
-        message: { data, width, height, encoding },
+        message: { header: { stamp: { sec: 0, nsec: 0 } }, data, width, height, encoding },
         sizeInBytes: 0,
       }}
       rawMarkerData={noMarkersMarkerData}
@@ -334,7 +349,7 @@ function BayerStory({ encoding }: { encoding: string }) {
       image={{
         topic: "/foo",
         receiveTime: { sec: 0, nsec: 0 },
-        message: { data, width, height, encoding },
+        message: { header: { stamp: { sec: 0, nsec: 0 } }, data, width, height, encoding },
         sizeInBytes: 0,
       }}
       rawMarkerData={noMarkersMarkerData}
@@ -371,7 +386,14 @@ function Mono16Story({
       image={{
         topic: "/foo",
         receiveTime: { sec: 0, nsec: 0 },
-        message: { data, width, height, encoding: "16UC1", is_bigendian: bigEndian ? 1 : 0 },
+        message: {
+          header: { stamp: { sec: 0, nsec: 0 } },
+          data,
+          width,
+          height,
+          encoding: "16UC1",
+          is_bigendian: bigEndian ? 1 : 0,
+        },
         sizeInBytes: 0,
       }}
       rawMarkerData={noMarkersMarkerData}
@@ -454,7 +476,7 @@ MarkersOriginal.parameters = {
 };
 
 export const MarkersWithHitmap: Story = (_args) => {
-  const imageMessage = useImageMessage();
+  const imageMessage = useNormalizedImageMessage();
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
   const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
 
@@ -482,8 +504,7 @@ export const MarkersWithHitmap: Story = (_args) => {
         viewport: { width, height },
         zoomMode: "fill",
       },
-      imageMessage: imageMessage?.message as any,
-      imageMessageDatatype: "sensor_msgs/Image",
+      imageMessage,
       rawMarkerData: {
         markers,
         cameraInfo,
@@ -503,7 +524,7 @@ export const MarkersWithHitmap: Story = (_args) => {
 export const MarkersWithRotations: Story = (_args) => {
   const width = 300;
   const height = 200;
-  const imageMessage = useImageMessage();
+  const imageMessage = useNormalizedImageMessage();
   const canvasRefs = useRef<Array<HTMLCanvasElement | ReactNull>>([]);
   const geometries = useMemo(
     () => [
@@ -538,8 +559,7 @@ export const MarkersWithRotations: Story = (_args) => {
           zoomMode: "fill",
           ...geometries[i],
         },
-        imageMessage: imageMessage?.message as any,
-        imageMessageDatatype: "sensor_msgs/Image",
+        imageMessage,
         rawMarkerData: {
           markers,
           cameraInfo,
@@ -679,7 +699,13 @@ export const ErrorState = (): JSX.Element => {
       image={{
         topic: "/foo",
         receiveTime: { sec: 0, nsec: 0 },
-        message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
+        message: {
+          header: { stamp: { sec: 0, nsec: 0 } },
+          data: new Uint8Array([]),
+          width: 100,
+          height: 50,
+          encoding: "Foo",
+        },
         sizeInBytes: 0,
       }}
       rawMarkerData={noMarkersMarkerData}
@@ -724,7 +750,13 @@ export const CallsOnRenderFrameWhenRenderingFails = (): JSX.Element => {
           image={{
             topic: "/foo",
             receiveTime: { sec: 0, nsec: 0 },
-            message: { data: new Uint8Array([]), width: 100, height: 50, encoding: "Foo" },
+            message: {
+              header: { stamp: { sec: 0, nsec: 0 } },
+              data: new Uint8Array([]),
+              width: 100,
+              height: 50,
+              encoding: "Foo",
+            },
             sizeInBytes: 0,
           }}
           rawMarkerData={noMarkersMarkerData}

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -70,7 +70,7 @@ class ImageCanvasWorker {
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       (args: RenderArgs & { id: string }): Promise<RenderDimensions | undefined> => {
-        const { id, geometry, imageMessage, imageMessageDatatype, rawMarkerData, options } = args;
+        const { id, geometry, imageMessage, rawMarkerData, options } = args;
 
         const render = this._renderStates[id];
         if (!render) {
@@ -97,7 +97,6 @@ class ImageCanvasWorker {
           geometry,
           hitmapCanvas: render.hitmap,
           imageMessage,
-          imageMessageDatatype,
           options,
           rawMarkerData,
         }).then((dimensions) => (render.dimensions = dimensions));

--- a/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
+++ b/packages/studio-base/src/panels/ImageView/ImageCanvas.worker.ts
@@ -17,7 +17,8 @@ import Rpc, { Channel } from "@foxglove/studio-base/util/Rpc";
 import { setupWorker } from "@foxglove/studio-base/util/RpcWorkerUtils";
 
 import { renderImage } from "./renderImage";
-import { flattenImageMarkers, idColorToIndex, RenderArgs, RenderDimensions } from "./util";
+import type { RenderArgs, RenderDimensions } from "./types";
+import { flattenImageMarkers, idColorToIndex } from "./util";
 
 type RenderState = {
   canvas: OffscreenCanvas;

--- a/packages/studio-base/src/panels/ImageView/Toolbar.tsx
+++ b/packages/studio-base/src/panels/ImageView/Toolbar.tsx
@@ -11,9 +11,10 @@ import ExpandingToolbar, {
   ToolGroupFixedSizePane,
 } from "@foxglove/studio-base/components/ExpandingToolbar";
 import { usePanelMousePresence } from "@foxglove/studio-base/hooks/usePanelMousePresence";
-import { PixelData } from "@foxglove/studio-base/panels/ImageView/util";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import { PixelData } from "./types";
 
 const style = {
   values: {

--- a/packages/studio-base/src/panels/ImageView/decodings.ts
+++ b/packages/studio-base/src/panels/ImageView/decodings.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { RenderOptions } from "@foxglove/studio-base/panels/ImageView/util";
+import { RenderOptions } from "./types";
 
 export function decodeYUV(
   yuv: Int8Array,

--- a/packages/studio-base/src/panels/ImageView/index.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.stories.tsx
@@ -6,8 +6,9 @@ import { useRef } from "react";
 import TestUtils from "react-dom/test-utils";
 
 import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
-import ImageView from "@foxglove/studio-base/panels/ImageView";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import ImageView from "./index";
 
 export default {
   title: "panels/ImageView",

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -34,7 +34,6 @@ import { Item, SubMenu } from "@foxglove/studio-base/components/Menu";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import { Toolbar } from "@foxglove/studio-base/panels/ImageView/Toolbar";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { StampedMessage } from "@foxglove/studio-base/types/Messages";
@@ -47,6 +46,7 @@ import toggle from "@foxglove/studio-base/util/toggle";
 
 import ImageCanvas from "./ImageCanvas";
 import ImageEmptyState from "./ImageEmptyState";
+import { Toolbar } from "./Toolbar";
 import helpContent from "./index.help.md";
 import { NORMALIZABLE_IMAGE_DATATYPES } from "./normalizeMessage";
 import type { PixelData, ZoomMode } from "./types";

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -20,11 +20,11 @@ import WavesIcon from "@mdi/svg/svg/waves.svg";
 import { Stack } from "@mui/material";
 import cx from "classnames";
 import { last, uniq } from "lodash";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
-import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
+import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import Autocomplete from "@foxglove/studio-base/components/Autocomplete";
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
 import DropdownItem from "@foxglove/studio-base/components/Dropdown/DropdownItem";
@@ -34,34 +34,25 @@ import { Item, SubMenu } from "@foxglove/studio-base/components/Menu";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { Toolbar } from "@foxglove/studio-base/panels/ImageView/Toolbar";
-import { IMAGE_DATATYPES } from "@foxglove/studio-base/panels/ImageView/renderImage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
-import { CameraInfo, StampedMessage } from "@foxglove/studio-base/types/Messages";
+import { StampedMessage } from "@foxglove/studio-base/types/Messages";
 import { PanelConfigSchema, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
-import { getSynchronizingReducers } from "@foxglove/studio-base/util/synchronizeMessages";
 import { formatTimeRaw, getTimestampForMessage } from "@foxglove/studio-base/util/time";
 import toggle from "@foxglove/studio-base/util/toggle";
 
 import ImageCanvas from "./ImageCanvas";
 import ImageEmptyState from "./ImageEmptyState";
 import helpContent from "./index.help.md";
-import {
-  getCameraInfoTopic,
-  getCameraNamespace,
-  getRelatedMarkerTopics,
-  getMarkerOptions,
-  groupTopics,
-  PixelData,
-  ZoomMode,
-} from "./util";
-
-const { useMemo, useCallback } = React;
+import { NORMALIZABLE_IMAGE_DATATYPES } from "./normalizeMessage";
+import type { PixelData, ZoomMode } from "./types";
+import { useCameraInfo } from "./useCameraInfo";
+import { useOptionallySynchronizedMessages } from "./useOptionallySynchronizedMessages";
+import { getCameraNamespace, getRelatedMarkerTopics, getMarkerOptions, groupTopics } from "./util";
 
 type DefaultConfig = {
   cameraTopic: string;
@@ -213,34 +204,6 @@ const ToggleComponent = ({
 
 const canTransformMarkersByTopic = (topic: string) => !topic.includes("rect");
 
-function useOptionallySynchronizedMessages(
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  shouldSynchronize: boolean,
-  topics: readonly string[],
-) {
-  const memoizedTopics = useDeepMemo(topics);
-  const reducers = useMemo(
-    () =>
-      shouldSynchronize
-        ? getSynchronizingReducers(memoizedTopics)
-        : {
-            restore: (previousValue) => ({
-              messagesByTopic: previousValue ? previousValue.messagesByTopic : {},
-              synchronizedMessages: undefined,
-            }),
-            addMessage: ({ messagesByTopic }, newMessage) => ({
-              messagesByTopic: { ...messagesByTopic, [newMessage.topic]: [newMessage] },
-              synchronizedMessages: undefined,
-            }),
-          },
-    [shouldSynchronize, memoizedTopics],
-  );
-  return PanelAPI.useMessageReducer({
-    topics,
-    ...reducers,
-  });
-}
-
 const AddTopic = ({
   onSelectTopic,
   topics,
@@ -273,7 +236,7 @@ function ImageView(props: Props) {
     customMarkerTopicOptions = NO_CUSTOM_OPTIONS,
   } = config;
   const theme = useTheme();
-  const { topics } = PanelAPI.useDataSourceInfo();
+  const { topics } = useDataSourceInfo();
   const cameraTopicFullObject = useMemo(
     () => getTopicsByTopicName(topics)[cameraTopic],
     [cameraTopic, topics],
@@ -282,7 +245,9 @@ function ImageView(props: Props) {
 
   // Namespaces represent marker topics based on the camera topic prefix (e.g. "/camera_front_medium")
   const { allCameraNamespaces, imageTopicsByNamespace, allImageTopics } = useMemo(() => {
-    const imageTopics = topics.filter(({ datatype }) => IMAGE_DATATYPES.includes(datatype));
+    const imageTopics = topics.filter(({ datatype }) =>
+      NORMALIZABLE_IMAGE_DATATYPES.includes(datatype),
+    );
     const topicsByNamespace = groupTopics(imageTopics);
     return {
       allImageTopics: imageTopics,
@@ -434,15 +399,7 @@ function ImageView(props: Props) {
     );
   }, [cameraTopic, classes.dropdown, imageTopicsByNamespace, onChangeCameraTopic]);
 
-  const cameraInfoTopic = getCameraInfoTopic(cameraTopic);
-  const cameraInfo = PanelAPI.useMessageReducer<CameraInfo | undefined>({
-    topics: cameraInfoTopic != undefined ? [cameraInfoTopic] : [],
-    restore: useCallback((value) => value, []),
-    addMessage: useCallback(
-      (_value: CameraInfo | undefined, { message }: MessageEvent<unknown>) => message as CameraInfo,
-      [],
-    ),
-  });
+  const cameraInfo = useCameraInfo(cameraTopic);
 
   const shouldSynchronize = config.synchronize && enabledMarkerTopics.length > 0;
   const imageAndMarkerTopics = useShallowMemo([cameraTopic, ...enabledMarkerTopics]);

--- a/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
+++ b/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { CompressedImage, Image } from "@foxglove/studio-base/types/Messages";
+
+type RawImageMessage = {
+  type: "raw";
+  stamp: { sec: number; nsec: number };
+  width: number;
+  height: number;
+  is_bigendian: boolean;
+  encoding: string;
+  step: number;
+  data: Uint8Array;
+};
+
+type CompressedImageMessage = {
+  type: "compressed";
+  stamp: { sec: number; nsec: number };
+  format: string;
+  data: Uint8Array;
+};
+
+type FoxgloveRawImageMessage = {
+  timestamp: bigint;
+  width: number;
+  height: number;
+  encoding: string;
+  step: number;
+  data: Uint8Array;
+};
+
+export type NormalizedImageMessage = RawImageMessage | CompressedImageMessage;
+
+// Supported datatypes for normalization
+export const NORMALIZABLE_IMAGE_DATATYPES = [
+  "sensor_msgs/Image",
+  "sensor_msgs/msg/Image",
+  "ros.sensor_msgs.Image",
+  "sensor_msgs/CompressedImage",
+  "sensor_msgs/msg/CompressedImage",
+  "ros.sensor_msgs.CompressedImage",
+  "foxglove.RawImage",
+];
+
+/**
+ * Convert a message based on datatype to a NormalizedImageMessage
+ * A NormalizedImageMessage defines consistent semantics across different frameworks
+ */
+export function normalizeImageMessage(
+  message: unknown,
+  datatype: string,
+): NormalizedImageMessage | undefined {
+  switch (datatype) {
+    case "foxglove.RawImage": {
+      const typedMessage = message as FoxgloveRawImageMessage;
+      const sec = typedMessage.timestamp / 1000000000n;
+      const stamp = {
+        sec: Number(sec),
+        nsec: Number(typedMessage.timestamp - sec * 1000000000n),
+      };
+      return {
+        type: "raw",
+        stamp,
+        width: typedMessage.width,
+        height: typedMessage.height,
+        is_bigendian: false,
+        encoding: typedMessage.encoding,
+        step: typedMessage.step,
+        data: typedMessage.data,
+      };
+    }
+    case "sensor_msgs/Image":
+    case "sensor_msgs/msg/Image":
+    case "ros.sensor_msgs.Image": {
+      const typedMessage = message as Image;
+      return {
+        type: "raw",
+        stamp: typedMessage.header.stamp,
+        width: typedMessage.width,
+        height: typedMessage.height,
+        is_bigendian: typedMessage.is_bigendian,
+        encoding: typedMessage.encoding,
+        step: typedMessage.step,
+        data: typedMessage.data,
+      };
+    }
+    case "sensor_msgs/CompressedImage":
+    case "sensor_msgs/msg/CompressedImage":
+    case "ros.sensor_msgs.CompressedImage": {
+      const typedMessage = message as CompressedImage;
+      return {
+        type: "compressed",
+        stamp: typedMessage.header.stamp,
+        format: typedMessage.format,
+        data: typedMessage.data,
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -12,12 +12,11 @@
 //   You may not use this file except in compliance with the License.
 
 import { HitmapRenderContext } from "@foxglove/studio-base/panels/ImageView/HitmapRenderContext";
+import { NormalizedImageMessage } from "@foxglove/studio-base/panels/ImageView/normalizeMessage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import {
-  Image,
   ImageMarker,
   Color,
-  CompressedImage,
   ImageMarkerArray,
   ImageMarkerType,
   Point2D,
@@ -37,9 +36,7 @@ import {
   decodeMono8,
   decodeMono16,
 } from "./decodings";
-import {
-  buildMarkerData,
-  calculateZoomScale,
+import type {
   MarkerData,
   PanZoom,
   RenderableCanvas,
@@ -47,21 +44,8 @@ import {
   RenderDimensions,
   RenderGeometry,
   RenderOptions,
-} from "./util";
-
-const UNCOMPRESSED_IMAGE_DATATYPES = [
-  "sensor_msgs/Image",
-  "sensor_msgs/msg/Image",
-  "ros.sensor_msgs.Image",
-];
-export const IMAGE_DATATYPES = [
-  "sensor_msgs/Image",
-  "sensor_msgs/msg/Image",
-  "ros.sensor_msgs.Image",
-  "sensor_msgs/CompressedImage",
-  "sensor_msgs/msg/CompressedImage",
-  "ros.sensor_msgs.CompressedImage",
-];
+} from "./types";
+import { buildMarkerData, calculateZoomScale } from "./util";
 
 // Just globally keep track of if we've shown an error in rendering, since typically when you get
 // one error, you'd then get a whole bunch more, which is spammy.
@@ -77,13 +61,12 @@ export async function renderImage({
   hitmapCanvas,
   geometry,
   imageMessage,
-  imageMessageDatatype,
   rawMarkerData,
   options,
 }: RenderArgs & { canvas: RenderableCanvas; hitmapCanvas: RenderableCanvas | undefined }): Promise<
   RenderDimensions | undefined
 > {
-  if (!imageMessage || imageMessageDatatype == undefined) {
+  if (!imageMessage) {
     clearCanvas(canvas);
     return undefined;
   }
@@ -101,7 +84,7 @@ export async function renderImage({
   }
 
   try {
-    const bitmap = await decodeMessageToBitmap(imageMessage, imageMessageDatatype, options);
+    const bitmap = await decodeMessageToBitmap(imageMessage, options);
 
     if (options?.resizeCanvas === true) {
       canvas.width = bitmap.width;
@@ -136,76 +119,62 @@ function maybeUnrectifyPoint(cameraModel: PinholeCameraModel | undefined, point:
 // Potentially performance-sensitive; await can be expensive
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 function decodeMessageToBitmap(
-  imageMessage: Partial<Image> | Partial<CompressedImage>,
-  datatype: string,
+  imageMessage: NormalizedImageMessage,
   options: RenderOptions = {},
 ): Promise<ImageBitmap> {
-  let image: ImageData | HTMLImageElement | Blob;
   const { data: rawData } = imageMessage;
   if (!(rawData instanceof Uint8Array)) {
     throw new Error("Message must have data of type Uint8Array");
   }
 
-  // In a Websocket context, we don't know whether the message is compressed or
-  // raw. Our subscription interface for the WebsocketPlayer can request
-  // compressed verisons of topics, in which case the message datatype can
-  // differ from the one recorded during initialization. So here we just check
-  // for properties consistent with either datatype, and render accordingly.
-  if (
-    UNCOMPRESSED_IMAGE_DATATYPES.includes(datatype) &&
-    "encoding" in imageMessage &&
-    imageMessage.encoding
-  ) {
-    const { is_bigendian, width, height, encoding } = imageMessage as Image;
-    image = new ImageData(width, height);
-    switch (encoding) {
-      case "yuv422":
-        decodeYUV(rawData as unknown as Int8Array, width, height, image.data);
-        break;
-      case "rgb8":
-        decodeRGB8(rawData, width, height, image.data);
-        break;
-      case "bgr8":
-      case "8UC3":
-        decodeBGR8(rawData, width, height, image.data);
-        break;
-      case "32FC1":
-        decodeFloat1c(rawData, width, height, is_bigendian, image.data);
-        break;
-      case "bayer_rggb8":
-        decodeBayerRGGB8(rawData, width, height, image.data);
-        break;
-      case "bayer_bggr8":
-        decodeBayerBGGR8(rawData, width, height, image.data);
-        break;
-      case "bayer_gbrg8":
-        decodeBayerGBRG8(rawData, width, height, image.data);
-        break;
-      case "bayer_grbg8":
-        decodeBayerGRBG8(rawData, width, height, image.data);
-        break;
-      case "mono8":
-      case "8UC1":
-        decodeMono8(rawData, width, height, image.data);
-        break;
-      case "mono16":
-      case "16UC1":
-        decodeMono16(rawData, width, height, is_bigendian, image.data, options);
-        break;
-      default:
-        throw new Error(`Unsupported encoding ${encoding}`);
+  switch (imageMessage.type) {
+    case "compressed": {
+      const image = new Blob([rawData], { type: `image/${imageMessage.format}` });
+      return self.createImageBitmap(image);
     }
-  } else if (
-    IMAGE_DATATYPES.includes(datatype) ||
-    ("format" in imageMessage && imageMessage.format)
-  ) {
-    const { format } = imageMessage as CompressedImage;
-    image = new Blob([rawData], { type: `image/${format}` });
-  } else {
-    throw new Error(`Message type is not usable for rendering images.`);
+    case "raw": {
+      const { is_bigendian, width, height, encoding } = imageMessage;
+      const image = new ImageData(width, height);
+      switch (encoding) {
+        case "yuv422":
+          decodeYUV(rawData as unknown as Int8Array, width, height, image.data);
+          break;
+        case "rgb8":
+          decodeRGB8(rawData, width, height, image.data);
+          break;
+        case "bgr8":
+        case "8UC3":
+          decodeBGR8(rawData, width, height, image.data);
+          break;
+        case "32FC1":
+          decodeFloat1c(rawData, width, height, is_bigendian, image.data);
+          break;
+        case "bayer_rggb8":
+          decodeBayerRGGB8(rawData, width, height, image.data);
+          break;
+        case "bayer_bggr8":
+          decodeBayerBGGR8(rawData, width, height, image.data);
+          break;
+        case "bayer_gbrg8":
+          decodeBayerGBRG8(rawData, width, height, image.data);
+          break;
+        case "bayer_grbg8":
+          decodeBayerGRBG8(rawData, width, height, image.data);
+          break;
+        case "mono8":
+        case "8UC1":
+          decodeMono8(rawData, width, height, image.data);
+          break;
+        case "mono16":
+        case "16UC1":
+          decodeMono16(rawData, width, height, is_bigendian, image.data, options);
+          break;
+        default:
+          throw new Error(`Unsupported encoding ${encoding}`);
+      }
+      return self.createImageBitmap(image);
+    }
   }
-
-  return self.createImageBitmap(image);
 }
 
 function clearCanvas(canvas?: RenderableCanvas) {

--- a/packages/studio-base/src/panels/ImageView/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/renderImage.ts
@@ -11,8 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { HitmapRenderContext } from "@foxglove/studio-base/panels/ImageView/HitmapRenderContext";
-import { NormalizedImageMessage } from "@foxglove/studio-base/panels/ImageView/normalizeMessage";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import {
   ImageMarker,
@@ -23,6 +21,7 @@ import {
 } from "@foxglove/studio-base/types/Messages";
 import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
+import { HitmapRenderContext } from "./HitmapRenderContext";
 import PinholeCameraModel from "./PinholeCameraModel";
 import {
   decodeYUV,
@@ -36,6 +35,7 @@ import {
   decodeMono8,
   decodeMono16,
 } from "./decodings";
+import { NormalizedImageMessage } from "./normalizeMessage";
 import type {
   MarkerData,
   PanZoom,

--- a/packages/studio-base/src/panels/ImageView/types.ts
+++ b/packages/studio-base/src/panels/ImageView/types.ts
@@ -3,10 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import type { MessageEvent } from "@foxglove/studio";
-import type { NormalizedImageMessage } from "@foxglove/studio-base/panels/ImageView/normalizeMessage";
 import type { CameraInfo, ImageMarker } from "@foxglove/studio-base/types/Messages";
 
 import type PinholeCameraModel from "./PinholeCameraModel";
+import type { NormalizedImageMessage } from "./normalizeMessage";
 
 export type PanZoom = { x: number; y: number; scale: number };
 

--- a/packages/studio-base/src/panels/ImageView/types.ts
+++ b/packages/studio-base/src/panels/ImageView/types.ts
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { MessageEvent } from "@foxglove/studio";
+import type { NormalizedImageMessage } from "@foxglove/studio-base/panels/ImageView/normalizeMessage";
+import type { CameraInfo, ImageMarker } from "@foxglove/studio-base/types/Messages";
+
+import type PinholeCameraModel from "./PinholeCameraModel";
+
+export type PanZoom = { x: number; y: number; scale: number };
+
+export type ZoomMode = "fit" | "fill" | "other";
+
+export type Dimensions = { width: number; height: number };
+
+export type RawMarkerData = {
+  markers: MessageEvent<unknown>[];
+  transformMarkers: boolean;
+  cameraInfo?: CameraInfo;
+};
+
+export type RenderOptions = {
+  imageSmoothing?: boolean;
+  minValue?: number;
+  maxValue?: number;
+
+  // resize the canvas element to fit the bitmap
+  // default is false
+  resizeCanvas?: boolean;
+};
+
+export type RenderGeometry = {
+  flipVertical: boolean;
+  flipHorizontal: boolean;
+  panZoom: PanZoom;
+  rotation: number;
+  viewport: Dimensions;
+  zoomMode: ZoomMode;
+};
+
+export type RenderArgs = {
+  // an undefined imageMessage clears the canvas
+  imageMessage?: NormalizedImageMessage;
+  geometry: RenderGeometry;
+  options?: RenderOptions;
+  rawMarkerData: RawMarkerData;
+};
+
+export type PixelData = {
+  color: { r: number; g: number; b: number; a: number };
+  position: { x: number; y: number };
+  markerIndex?: number;
+  marker?: ImageMarker;
+};
+
+export type RenderableCanvas = HTMLCanvasElement | OffscreenCanvas;
+
+export type RenderDimensions = Dimensions & { transform: DOMMatrix };
+
+export type MarkerData = {
+  markers: MessageEvent<unknown>[];
+  originalWidth?: number; // undefined means no scaling is needed (use the image's size)
+  originalHeight?: number; // undefined means no scaling is needed (use the image's size)
+  cameraModel?: PinholeCameraModel; // undefined means no transformation is needed
+};

--- a/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
+++ b/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback } from "react";
+
+import { MessageEvent } from "@foxglove/studio";
+import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
+import { CameraInfo } from "@foxglove/studio-base/types/Messages";
+
+import { getCameraInfoTopic } from "./util";
+
+export function useCameraInfo(cameraTopic: string): CameraInfo | undefined {
+  // move lines below to useCameraInfo
+  const cameraInfoTopic = getCameraInfoTopic(cameraTopic);
+  return useMessageReducer<CameraInfo | undefined>({
+    topics: cameraInfoTopic != undefined ? [cameraInfoTopic] : [],
+    restore: useCallback((value) => value, []),
+    addMessage: useCallback(
+      (_value: CameraInfo | undefined, { message }: MessageEvent<unknown>) => message as CameraInfo,
+      [],
+    ),
+  });
+}

--- a/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
+++ b/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
@@ -11,7 +11,6 @@ import { CameraInfo } from "@foxglove/studio-base/types/Messages";
 import { getCameraInfoTopic } from "./util";
 
 export function useCameraInfo(cameraTopic: string): CameraInfo | undefined {
-  // move lines below to useCameraInfo
   const cameraInfoTopic = getCameraInfoTopic(cameraTopic);
   return useMessageReducer<CameraInfo | undefined>({
     topics: cameraInfoTopic != undefined ? [cameraInfoTopic] : [],

--- a/packages/studio-base/src/panels/ImageView/useOptionallySynchronizedMessages.tsx
+++ b/packages/studio-base/src/panels/ImageView/useOptionallySynchronizedMessages.tsx
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useMemo } from "react";
+
+import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
+import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
+import {
+  getSynchronizingReducers,
+  ReducedValue,
+} from "@foxglove/studio-base/util/synchronizeMessages";
+
+export function useOptionallySynchronizedMessages(
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  shouldSynchronize: boolean,
+  topics: readonly string[],
+): ReducedValue {
+  const memoizedTopics = useDeepMemo(topics);
+  const reducers = useMemo(
+    () =>
+      shouldSynchronize
+        ? getSynchronizingReducers(memoizedTopics)
+        : {
+            restore: (previousValue) => ({
+              messagesByTopic: previousValue ? previousValue.messagesByTopic : {},
+              synchronizedMessages: undefined,
+            }),
+            addMessage: ({ messagesByTopic }, newMessage) => ({
+              messagesByTopic: { ...messagesByTopic, [newMessage.topic]: [newMessage] },
+              synchronizedMessages: undefined,
+            }),
+          },
+    [shouldSynchronize, memoizedTopics],
+  );
+  return useMessageReducer({
+    topics,
+    ...reducers,
+  });
+}

--- a/packages/studio-base/src/panels/ImageView/util.ts
+++ b/packages/studio-base/src/panels/ImageView/util.ts
@@ -12,72 +12,10 @@
 //   You may not use this file except in compliance with the License.
 
 import { Topic, MessageEvent } from "@foxglove/studio-base/players/types";
-import {
-  CameraInfo,
-  CompressedImage,
-  Image,
-  ImageMarker,
-  ImageMarkerArray,
-} from "@foxglove/studio-base/types/Messages";
+import { ImageMarker, ImageMarkerArray } from "@foxglove/studio-base/types/Messages";
 
 import PinholeCameraModel from "./PinholeCameraModel";
-
-export type PanZoom = { x: number; y: number; scale: number };
-
-export type ZoomMode = "fit" | "fill" | "other";
-
-export type RenderOptions = {
-  imageSmoothing?: boolean;
-  minValue?: number;
-  maxValue?: number;
-
-  // resize the canvas element to fit the bitmap
-  // default is false
-  resizeCanvas?: boolean;
-};
-
-export type RenderGeometry = {
-  flipVertical: boolean;
-  flipHorizontal: boolean;
-  panZoom: PanZoom;
-  rotation: number;
-  viewport: Dimensions;
-  zoomMode: ZoomMode;
-};
-
-export type RenderArgs = {
-  imageMessage?: Image | CompressedImage;
-  imageMessageDatatype?: string;
-  geometry: RenderGeometry;
-  options?: RenderOptions;
-  rawMarkerData: RawMarkerData;
-};
-
-export type Dimensions = { width: number; height: number };
-
-export type PixelData = {
-  color: { r: number; g: number; b: number; a: number };
-  position: { x: number; y: number };
-  markerIndex?: number;
-  marker?: ImageMarker;
-};
-
-export type RenderableCanvas = HTMLCanvasElement | OffscreenCanvas;
-
-export type RawMarkerData = {
-  markers: MessageEvent<unknown>[];
-  transformMarkers: boolean;
-  cameraInfo?: CameraInfo;
-};
-
-export type RenderDimensions = Dimensions & { transform: DOMMatrix };
-
-export type MarkerData = {
-  markers: MessageEvent<unknown>[];
-  originalWidth?: number; // undefined means no scaling is needed (use the image's size)
-  originalHeight?: number; // undefined means no scaling is needed (use the image's size)
-  cameraModel?: PinholeCameraModel; // undefined means no transformation is needed
-};
+import { Dimensions, MarkerData, RawMarkerData, ZoomMode } from "./types";
 
 export function calculateZoomScale(
   bitmap: Dimensions,

--- a/packages/studio-base/src/util/synchronizeMessages.ts
+++ b/packages/studio-base/src/util/synchronizeMessages.ts
@@ -106,7 +106,7 @@ function getSynchronizedMessages(
   return synchronizedMessages;
 }
 
-type ReducedValue = {
+export type ReducedValue = {
   messagesByTopic: MessagesByTopic;
   synchronizedMessages?: MessageByTopic;
 };


### PR DESCRIPTION

**User-Facing Changes**
Users can visualize foxglove.RawImage via the image panel.

Field | Type | Required | Description
-- | -- | -- | --
timestamp | timestamp | ✓ | Timestamp of the image.
width | uint32 | ✓ | Image width
height | uint32 | ✓ | Image height
encoding | string | ✓ | Encoding of the raw image data
step | uint32 | ✓ | Byte length of a single row
data | bytes | ✓ | Raw image data


**Description**
foxglove.RawImage is our custom RawImage message. This allows non-ros users to publish images in the foxglove.RawImage message format and display them in the image panel.

Support is accomplished by normalizing all image message types into a NormalizedImageMessage. This union type supports raw and compressed images. Once normalized, other functions only need to understand the normalized message rather than each specific framework's datatypes.

Fixes: #2838

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
