### PR TITLE
Show context menu when clicking overlapping markers

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -621,16 +621,31 @@ export default function Layout({
     toggleDebug,
   } = useMemo(() => {
     return {
-      onClick: (_ev: React.MouseEvent, args?: ReglClickInfo) => {
+      onClick: (ev: React.MouseEvent, args?: ReglClickInfo) => {
         // Don't set any clicked objects when measuring distance or drawing polygons.
         if (callbackInputsRef.current.isDrawing) {
           return;
         }
         const newClickedObjects =
           (args?.objects as MouseEventObject[] | undefined) ?? ([] as MouseEventObject[]);
-        const newSelectedObject = newClickedObjects.length === 1 ? newClickedObjects[0] : undefined;
 
-        selectObject(newSelectedObject);
+        // With multiple objects we update the selection state with all possible objects
+        if (newClickedObjects.length > 1) {
+          setSelectionState((prevState) => {
+            return {
+              ...prevState,
+              selectedObject: undefined,
+              clickedObjects: newClickedObjects,
+              clickedPosition: {
+                clientX: ev.clientX,
+                clientY: ev.clientY,
+              },
+            };
+          });
+          return;
+        }
+
+        selectObject(newClickedObjects[0]);
       },
       onControlsOverlayClick: (ev: React.MouseEvent<HTMLDivElement>) => {
         if (!containerRef.current) {


### PR DESCRIPTION

**User-Facing Changes**
Clicking overlapping markers in the 3d panel shows a menu to select the specific marker.

**Description**
When clicking on overlapping markers in the 3d panel, display a menu to select the specific marker to inspect. Prior to this fix, clicking overlapping markers resulted in one being selected with no way to select others.

This functionality was broken by https://github.com/foxglove/studio/pull/2617

Fixes: #2844

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
