### PR TITLE
Hide select marker context menu when selecting an object

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -601,6 +601,8 @@ export default function Layout({
     (newSelectedObject?: MouseEventObject) => {
       setSelectionState({
         ...callbackInputsRef.current.selectionState,
+        clickedObjects: [],
+        clickedPosition: { clientX: 0, clientY: 0 },
         selectedObject: newSelectedObject,
       });
       updateInteractionsTabVisibility(newSelectedObject);


### PR DESCRIPTION

**User-Facing Changes**
When selecting an object in the 3d panel, hide the selection popup.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
