### PR TITLE
Add foxglove.CompressedImage support to Image panel

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -48,7 +48,7 @@
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",
     "@foxglove/rosmsg-serialization": "1.3.0",
     "@foxglove/rosmsg2-serialization": "1.0.5",
-    "@foxglove/rostime": "1.1.1",
+    "@foxglove/rostime": "1.1.2",
     "@foxglove/studio": "workspace:*",
     "@foxglove/ulog": "2.1.2",
     "@foxglove/velodyne-cloud": "1.0.0",

--- a/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
+++ b/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { fromNanoSec } from "@foxglove/rostime";
 import { CompressedImage, Image } from "@foxglove/studio-base/types/Messages";
 
 type RawImageMessage = {
@@ -63,11 +64,7 @@ export function normalizeImageMessage(
   switch (datatype) {
     case "foxglove.RawImage": {
       const typedMessage = message as FoxgloveRawImageMessage;
-      const sec = typedMessage.timestamp / 1000000000n;
-      const stamp = {
-        sec: Number(sec),
-        nsec: Number(typedMessage.timestamp - sec * 1000000000n),
-      };
+      const stamp = fromNanoSec(typedMessage.timestamp);
       return {
         type: "raw",
         stamp,
@@ -107,11 +104,7 @@ export function normalizeImageMessage(
     }
     case "foxglove.CompressedImage": {
       const typedMessage = message as FoxgloveCompressedImageMessage;
-      const sec = typedMessage.timestamp / 1000000000n;
-      const stamp = {
-        sec: Number(sec),
-        nsec: Number(typedMessage.timestamp - sec * 1000000000n),
-      };
+      const stamp = fromNanoSec(typedMessage.timestamp);
       return {
         type: "compressed",
         stamp,

--- a/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
+++ b/packages/studio-base/src/panels/ImageView/normalizeMessage.ts
@@ -31,6 +31,13 @@ type FoxgloveRawImageMessage = {
   data: Uint8Array;
 };
 
+type FoxgloveCompressedImageMessage = {
+  type: "compressed";
+  timestamp: bigint;
+  format: string;
+  data: Uint8Array;
+};
+
 export type NormalizedImageMessage = RawImageMessage | CompressedImageMessage;
 
 // Supported datatypes for normalization
@@ -42,6 +49,7 @@ export const NORMALIZABLE_IMAGE_DATATYPES = [
   "sensor_msgs/msg/CompressedImage",
   "ros.sensor_msgs.CompressedImage",
   "foxglove.RawImage",
+  "foxglove.CompressedImage",
 ];
 
 /**
@@ -93,6 +101,20 @@ export function normalizeImageMessage(
       return {
         type: "compressed",
         stamp: typedMessage.header.stamp,
+        format: typedMessage.format,
+        data: typedMessage.data,
+      };
+    }
+    case "foxglove.CompressedImage": {
+      const typedMessage = message as FoxgloveCompressedImageMessage;
+      const sec = typedMessage.timestamp / 1000000000n;
+      const stamp = {
+        sec: Number(sec),
+        nsec: Number(typedMessage.timestamp - sec * 1000000000n),
+      };
+      return {
+        type: "compressed",
+        stamp,
         format: typedMessage.format,
         data: typedMessage.data,
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,7 +2467,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rostime@npm:1.1.1, @foxglove/rostime@npm:^1.1.0, @foxglove/rostime@npm:^1.1.1":
+"@foxglove/rostime@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@foxglove/rostime@npm:1.1.2"
+  checksum: a4f93001ccfa011f679af9a3d1e04c2d3c499848a9845856bf17f23cf9369ab975b27cd9fd048187002468de6852861bfb2292d5cfcbd85ff43afc274e1279e8
+  languageName: node
+  linkType: hard
+
+"@foxglove/rostime@npm:^1.1.0, @foxglove/rostime@npm:^1.1.1":
   version: 1.1.1
   resolution: "@foxglove/rostime@npm:1.1.1"
   checksum: f3882c7b9b3e5704d12bd7923cf4986cc76c1efb442ae94917967c61740d02591b462af3235fc00e4c83a164a862c94a07318d4c0c8064e96853475112fd741e
@@ -2519,7 +2526,7 @@ __metadata:
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3
     "@foxglove/rosmsg-serialization": 1.3.0
     "@foxglove/rosmsg2-serialization": 1.0.5
-    "@foxglove/rostime": 1.1.1
+    "@foxglove/rostime": 1.1.2
     "@foxglove/studio": "workspace:*"
     "@foxglove/ulog": 2.1.2
     "@foxglove/velodyne-cloud": 1.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,17 +2467,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rostime@npm:1.1.2":
+"@foxglove/rostime@npm:1.1.2, @foxglove/rostime@npm:^1.1.0, @foxglove/rostime@npm:^1.1.1":
   version: 1.1.2
   resolution: "@foxglove/rostime@npm:1.1.2"
   checksum: a4f93001ccfa011f679af9a3d1e04c2d3c499848a9845856bf17f23cf9369ab975b27cd9fd048187002468de6852861bfb2292d5cfcbd85ff43afc274e1279e8
-  languageName: node
-  linkType: hard
-
-"@foxglove/rostime@npm:^1.1.0, @foxglove/rostime@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@foxglove/rostime@npm:1.1.1"
-  checksum: f3882c7b9b3e5704d12bd7923cf4986cc76c1efb442ae94917967c61740d02591b462af3235fc00e4c83a164a862c94a07318d4c0c8064e96853475112fd741e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


**User-Facing Changes**
Users can visualize foxglove.CompressedImage messages in the image panel.

**Description**
Fixes: #2848

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
