### PR TITLE
Add foxglove.CameraCalibration support to image panel

### DIFF
--- a/packages/studio-base/src/panels/ImageView/types.ts
+++ b/packages/studio-base/src/panels/ImageView/types.ts
@@ -64,3 +64,14 @@ export type MarkerData = {
   originalHeight?: number; // undefined means no scaling is needed (use the image's size)
   cameraModel?: PinholeCameraModel; // undefined means no transformation is needed
 };
+
+export type FoxgloveCameraCalibration = {
+  timestamp: bigint;
+  width: number;
+  height: number;
+  distortion_model?: string;
+  D?: readonly number[];
+  K?: readonly number[];
+  P?: readonly number[];
+  R?: readonly number[];
+};

--- a/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
+++ b/packages/studio-base/src/panels/ImageView/useCameraInfo.ts
@@ -2,22 +2,63 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { MessageEvent } from "@foxglove/studio";
-import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
+import { useMessageReducer, useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { CameraInfo } from "@foxglove/studio-base/types/Messages";
 
+import type { FoxgloveCameraCalibration } from "./types";
 import { getCameraInfoTopic } from "./util";
 
+function normalizeCameraInfo(message: unknown, datatype: string): CameraInfo | undefined {
+  switch (datatype) {
+    case "sensor_msgs/CameraInfo":
+    case "sensor_msgs/msg/CameraInfo":
+      return message as CameraInfo;
+    case "foxglove.CameraCalibration": {
+      const typedMessage = message as FoxgloveCameraCalibration;
+      return {
+        width: typedMessage.width,
+        height: typedMessage.height,
+        distortion_model: typedMessage.distortion_model ?? "plumb_bob",
+        D: typedMessage.D ?? [],
+        K: typedMessage.K ?? [],
+        P: typedMessage.P ?? [],
+        R: typedMessage.R ?? [],
+      };
+    }
+  }
+
+  return undefined;
+}
+
 export function useCameraInfo(cameraTopic: string): CameraInfo | undefined {
-  const cameraInfoTopic = getCameraInfoTopic(cameraTopic);
+  const { topics } = useDataSourceInfo();
+
+  const { cameraInfoTopics, datatype } = useMemo(() => {
+    const cameraInfoTopic = getCameraInfoTopic(cameraTopic);
+    if (!cameraInfoTopic) {
+      return { cameraInfoTopics: [], datatype: "" };
+    }
+
+    for (const topic of topics) {
+      if (topic.name === cameraInfoTopic) {
+        return { cameraInfoTopics: [cameraInfoTopic], datatype: topic.datatype };
+      }
+    }
+
+    return { cameraInfoTopics: [], datatype: "" };
+  }, [cameraTopic, topics]);
+
   return useMessageReducer<CameraInfo | undefined>({
-    topics: cameraInfoTopic != undefined ? [cameraInfoTopic] : [],
+    topics: cameraInfoTopics,
     restore: useCallback((value) => value, []),
     addMessage: useCallback(
-      (_value: CameraInfo | undefined, { message }: MessageEvent<unknown>) => message as CameraInfo,
-      [],
+      (_value: CameraInfo | undefined, { message }: MessageEvent<unknown>) => {
+        return normalizeCameraInfo(message, datatype);
+      },
+      [datatype],
     ),
   });
 }


### PR DESCRIPTION


**User-Facing Changes**
foxglove.CameraCalibration messages are supported in the image panel and used to correct distortion when displaying markers

**Description**
Fixes: #2847

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
