### PR TITLE
Add global vercel headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,14 @@
   },
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "origin" },
+        { "key": "Content-Security-Policy", "value": "base-uri 'self'; upgrade-insecure-requests;" }
+      ]
+    },
+    {
       "source": "/((?:\\w+\\.)?[0-9a-f]{20}\\.(?:js|js\\.map|wasm))",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400, must-revalidate" }]
     }


### PR DESCRIPTION
**User-Facing Changes**

None.

**Description**

This adds a few headers to all routes on the web deployment.

I believe they're low risk: `Content-Security-Policy` is bare-bones and doesn't limit any of the src types; `Referrer-Policy` restricts "referer" header to origin; `X-Frame-Options` prevents iframing of the site. The headers are visible on the preview deployment, and a more thorough run-through there couldn't hurt.