### PR TITLE
Schema encoding fixes for MCAP/WebSocket data sources

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -42,16 +42,20 @@ function parsedDefinitionsToDatatypes(
 /**
  * Process a channel/schema and extract information that can be used to deserialize messages on the
  * channel, and schemas in the format expected by Studio's RosDatatypes.
+ *
+ * See:
+ * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-message-encodings.md
+ * - https://github.com/foxglove/mcap/blob/main/docs/specification/well-known-schema-encodings.md
  */
 export function parseChannel(channel: Channel): ParsedChannel {
   if (channel.messageEncoding === "json") {
-    if (channel.schema?.encoding !== "protobuf") {
+    if (channel.schema?.encoding !== "jsonschema") {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
             ? "no encoding"
             : `schema encoding '${channel.schema.encoding}'`
-        } is not supported (expected protobuf)`,
+        } is not supported (expected jsonschema)`,
       );
     }
     const textDecoder = new TextDecoder();
@@ -77,13 +81,13 @@ export function parseChannel(channel: Channel): ParsedChannel {
   }
 
   if (channel.messageEncoding === "protobuf") {
-    if (channel.schema?.encoding !== "proto") {
+    if (channel.schema?.encoding !== "protobuf") {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
             ? "no encoding"
             : `schema encoding '${channel.schema.encoding}'`
-        } is not supported (expected proto)`,
+        } is not supported (expected protobuf)`,
       );
     }
     const root = protobufjs.Root.fromDescriptor(FileDescriptorSet.decode(channel.schema.data));

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -149,7 +149,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
             schemaEncoding = "jsonschema";
             schemaData = new TextEncoder().encode(channel.schema);
           } else if (channel.encoding === "protobuf") {
-            schemaEncoding = "proto";
+            schemaEncoding = "protobuf";
             schemaData = new Uint8Array(base64.length(channel.schema));
             if (base64.decode(channel.schema, schemaData, 0) !== schemaData.byteLength) {
               throw new Error(`Failed to decode base64 schema on channel ${channel.id}`);


### PR DESCRIPTION
**User-Facing Changes**
Fixes a bug where WebSocket connections using `json` encoding would fail to connect, and `jsonschema` was not accepted as a schema encoding in MCAP files that use `json` message encoding. Updates the schema encoding requirement from `proto` to `protobuf` per https://github.com/foxglove/mcap/pull/207.