### PR TITLE
Update mcap dependency

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -36,7 +36,7 @@
     "@foxglove/den": "workspace:*",
     "@foxglove/electron-socket": "1.3.1",
     "@foxglove/hooks": "workspace:*",
-    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=8a731dcb1a7a6375374f5c1197e74d03d414078d",
+    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=2ac4d4fc0762774ebc5c3d2a03fa12ab4063f4dd",
     "@foxglove/mcap-support": "workspace:*",
     "@foxglove/regl-worldview": "2.4.0",
     "@foxglove/ros1": "1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,14 +2316,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/mcap@github:foxglove/mcap#workspace=@foxglove/mcap&commit=8a731dcb1a7a6375374f5c1197e74d03d414078d":
+"@foxglove/mcap@github:foxglove/mcap#workspace=@foxglove/mcap&commit=2ac4d4fc0762774ebc5c3d2a03fa12ab4063f4dd":
   version: 0.1.0
-  resolution: "@foxglove/mcap@https://github.com/foxglove/mcap.git#workspace=%40foxglove%2Fmcap&commit=8a731dcb1a7a6375374f5c1197e74d03d414078d"
+  resolution: "@foxglove/mcap@https://github.com/foxglove/mcap.git#workspace=%40foxglove%2Fmcap&commit=2ac4d4fc0762774ebc5c3d2a03fa12ab4063f4dd"
   dependencies:
     "@foxglove/crc": ^0.0.3
     heap-js: ^2.1.6
     tslib: ^2
-  checksum: 54733836e2d507ea1230f81a71d3e89ee2f65edf864dd7c6fcf250c7d174d51d2b431595dc1e1df75fe19e2eb294d70ad2e0da8438b66388d5289aa1a1cbb8ab
+  checksum: 420cf34a0065910346147c72d0f04322dfc4f61fd121c890f8a4ea3cc650c4434f94c9bce0fa0005513dae545059cf30e224ea005989aeaaddc4518497d23364
   languageName: node
   linkType: hard
 
@@ -2507,7 +2507,7 @@ __metadata:
     "@foxglove/den": "workspace:*"
     "@foxglove/electron-socket": 1.3.1
     "@foxglove/hooks": "workspace:*"
-    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=8a731dcb1a7a6375374f5c1197e74d03d414078d"
+    "@foxglove/mcap": "github:foxglove/mcap#workspace=@foxglove/mcap&commit=2ac4d4fc0762774ebc5c3d2a03fa12ab4063f4dd"
     "@foxglove/mcap-support": "workspace:*"
     "@foxglove/regl-worldview": 2.4.0
     "@foxglove/ros1": 1.4.0


### PR DESCRIPTION
**User-Facing Changes**
MCAP files with out-of-order messages can now be played back in order in Studio.

**Description**
Update for https://github.com/foxglove/mcap/pull/215 and https://github.com/foxglove/mcap/pull/220.