### PR TITLE
Improve error reporting for PointCloud2 x/y/z fields

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/buffers.ts
@@ -132,13 +132,35 @@ export function createPositionBuffer({
   stride: number;
 }): VertexBuffer {
   const { x: xField, y: yField, z: zField } = fields;
-  if (!xField || !yField || !zField) {
-    throw new Error("Cannot create a position buffer without x, y, and z fields");
+  if (!xField?.reader) {
+    throw new Error(
+      `${
+        xField ? `Unsupported datatype ${xField.datatype} for` : "Missing"
+      } x field in point cloud. Point clouds cannot be displayed without readable x, y, and z fields.`,
+    );
+  }
+  if (!yField?.reader) {
+    throw new Error(
+      `${
+        yField ? `Unsupported datatype ${yField.datatype} for` : "Missing"
+      } y field in point cloud. Point clouds cannot be displayed without readable x, y, and z fields.`,
+    );
+  }
+  if (!zField?.reader) {
+    throw new Error(
+      `${
+        zField ? `Unsupported datatype ${zField.datatype} for` : "Missing"
+      } z field in point cloud. Point clouds cannot be displayed without readable x, y, and z fields.`,
+    );
   }
 
   // Check if all position components are stored next to each other
   const positionIsValid =
-    yField.offset - xField.offset === FLOAT_SIZE && zField.offset - yField.offset === FLOAT_SIZE;
+    xField.datatype === DATATYPE.FLOAT32 &&
+    yField.datatype === DATATYPE.FLOAT32 &&
+    zField.datatype === DATATYPE.FLOAT32 &&
+    yField.offset - xField.offset === FLOAT_SIZE &&
+    zField.offset - yField.offset === FLOAT_SIZE;
   if (positionIsValid && hasValidStride(stride)) {
     // Create a VBO for positions by recasting the data array into a float array
     // This will give us the correct values for (x,y,z) tuples.


### PR DESCRIPTION
**User-Facing Changes**
Improved error reporting for certain invalid PointCloud2 messages.

**Description**
When a field datatype is not recognized, the `extractValues` function will return `NaN` for its values. This is undesirable for x/y/z fields because the point cloud will silently fail to display points rather than displaying an error to the user. To fix this I improved the error handling to throw earlier if the field datatype was not recognized.

There was also some special-case handling for x/y/z fields which uses a fast-path `reinterpretBufferToFloat` function, even if the field datatypes were not float32 😱  This could mean that if the user forgot to set the datatype field, the points might actually show up in the correct locations even though the data is technically incorrect. Added a check for the float32 datatype in the fast path to fix this.