### PR TITLE
DP player: clamp time when seeking based on initial URL state

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -489,7 +489,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
 
   seekPlayback(time: Time, _backfillDuration?: Time): void {
     log.debug("Seek", time);
-    this._currentTime = time;
+    this._currentTime = clampTime(time, this._start, this._end);
     this._lastSeekTime = Date.now();
     this._nextFrame = [];
     this._currentPreloadTask?.abort();


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug when loading data from Foxglove Data Platform with a `&time=` URL parameter that was outside the start/end range.

**Description**
Tangentially related: https://github.com/foxglove/studio/pull/2837