### PR TITLE
Handle deleted layouts better on startup.

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -250,11 +250,13 @@ export default function CurrentLayoutProvider({
       return;
     }
 
+    // Retreive the selected layout id from the user's profile. If there's no layout specified
+    // or we can't load it then save and select a default layout.
     const { currentLayoutId } = await getUserProfile();
-    await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
-
-    // If there's no layout selected then save and select a default layout.
-    if (currentLayoutId == undefined && layoutStateRef.current.selectedLayout == undefined) {
+    const layout = currentLayoutId ? await layoutManager.getLayout(currentLayoutId) : undefined;
+    if (layout) {
+      await setSelectedLayoutId(currentLayoutId, { saveToProfile: false });
+    } else {
       const newLayout = await layoutManager.saveNewLayout({
         name: "Default",
         data: defaultLayout,


### PR DESCRIPTION
**User-Facing Changes**
This improves our handling of deleted layouts on app startup.

**Description**
Currently when the app starts we check if the user's profile has a layout id specified. But we don't validate that the layout specified by that id still exists. This adds a check to verify that the layout can be loaded and if not sets a default layout.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2863 