### PR TITLE
Change panel error boundary reset to also clear the error

### DIFF
--- a/packages/studio-base/src/components/PanelErrorBoundary.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.tsx
@@ -65,7 +65,10 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
                   variant="outlined"
                   title="reset panel settings to default values"
                   color="error"
-                  onClick={this.props.onResetPanel}
+                  onClick={() => {
+                    this.setState({ currentError: undefined });
+                    this.props.onResetPanel();
+                  }}
                 >
                   Reset Panel
                 </Button>


### PR DESCRIPTION
**User-Facing Changes**
Clicking "Reset" on a crashed panel will clear the error before resetting the panel.


**Description**
When clicking the "Reset" button on a panel error boundary, the panel would reset but the error would not be cleared from the boundary. This change clears the error from the boundary and then resets the panel.






<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
