### PR TITLE
Make status, position_covariance and position_covariance_type optional in Map panel

### DIFF
--- a/packages/studio-base/src/panels/Map/FilteredPointLayer.ts
+++ b/packages/studio-base/src/panels/Map/FilteredPointLayer.ts
@@ -105,17 +105,24 @@ function FilteredPointLayer(args: Args): FeatureGroup {
 }
 
 function getAccuracy(msg: NavSatFixMsg): number | undefined {
+  const covariance = msg.position_covariance;
+  if (!covariance) {
+    return undefined;
+  }
+
   switch (msg.position_covariance_type) {
+    case undefined:
+      return undefined;
     case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_UNKNOWN:
       return undefined;
     case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_DIAGONAL_KNOWN: {
-      const eastVariance = msg.position_covariance[0];
-      const northVariance = msg.position_covariance[4];
+      const eastVariance = covariance[0];
+      const northVariance = covariance[4];
       return Math.sqrt(Math.max(eastVariance, northVariance));
     }
     case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_APPROXIMATED:
     case NavSatFixPositionCovarianceType.COVARIANCE_TYPE_KNOWN: {
-      const K = msg.position_covariance;
+      const K = covariance;
       const Klatlon = [
         [K[0], K[1], K[2]],
         [K[3], K[4], K[5]],

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -369,7 +369,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       }
 
       const hasFix = (ev: MessageEvent<NavSatFixMsg>) =>
-        ev.message.status.status !== NavSatFixStatus.STATUS_NO_FIX;
+        ev.message.status?.status !== NavSatFixStatus.STATUS_NO_FIX;
       const noFixEvents = events.filter((ev) => !hasFix(ev));
       const fixEvents = events.filter(hasFix);
 

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -25,7 +25,8 @@ import FilteredPointLayer, {
 } from "@foxglove/studio-base/panels/Map/FilteredPointLayer";
 import { Topic } from "@foxglove/studio-base/players/types";
 
-import { NavSatFixMsg, NavSatFixStatus, Point } from "./types";
+import { hasFix } from "./support";
+import { NavSatFixMsg, Point } from "./types";
 
 const COLOR_HISTORY = "#6771ef";
 const COLOR_ACTIVE_FIX = "#ec1515";
@@ -368,8 +369,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
         continue;
       }
 
-      const hasFix = (ev: MessageEvent<NavSatFixMsg>) =>
-        ev.message.status?.status !== NavSatFixStatus.STATUS_NO_FIX;
       const noFixEvents = events.filter((ev) => !hasFix(ev));
       const fixEvents = events.filter(hasFix);
 

--- a/packages/studio-base/src/panels/Map/support.ts
+++ b/packages/studio-base/src/panels/Map/support.ts
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@foxglove/studio";
+
+import { NavSatFixMsg, NavSatFixStatus } from "./types";
+
+/**
+ * @returns true if the message event status indicates there is a fix
+ */
+function hasFix(ev: MessageEvent<NavSatFixMsg>): boolean {
+  switch (ev.message.status?.status) {
+    case NavSatFixStatus.STATUS_GBAS_FIX:
+    case NavSatFixStatus.STATUS_SBAS_FIX:
+    case NavSatFixStatus.STATUS_FIX:
+      return true;
+    case NavSatFixStatus.STATUS_NO_FIX:
+    case undefined:
+    default:
+      return false;
+  }
+}
+
+export { hasFix };

--- a/packages/studio-base/src/panels/Map/types.ts
+++ b/packages/studio-base/src/panels/Map/types.ts
@@ -38,7 +38,7 @@ export type NavSatFixMsg = {
   latitude: number;
   longitude: number;
   altitude?: number;
-  status: { status: NavSatFixStatus; service: NavSatFixService };
-  position_covariance: Matrix3x3;
-  position_covariance_type: NavSatFixPositionCovarianceType;
+  status?: { status: NavSatFixStatus; service: NavSatFixService };
+  position_covariance?: Matrix3x3;
+  position_covariance_type?: NavSatFixPositionCovarianceType;
 };


### PR DESCRIPTION


**User-Facing Changes**
`foxglove.LocationFix` messages without position_convariance are displayed in the Map panel without crashing the panel.

**Description**
`foxglove.LocationFix` messages do not require these fields. This updates the Map panel logic to allow these fields to be omitted. If they are present the map panel will visualize them.

Fixes: #2884

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
