### PR TITLE
MessagePathInput: support wrapping topic names in quotes

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -23,7 +23,7 @@ import useGlobalVariables, {
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
-import { getTopicNames, getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
+import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 
 import { RosPath, RosPrimitive } from "./constants";
 import {
@@ -32,7 +32,7 @@ import {
   messagePathsForDatatype,
   validTerminatingStructureItem,
 } from "./messagePathsForDatatype";
-import parseRosPath from "./parseRosPath";
+import parseRosPath, { quoteIdentifierIfNeeded } from "./parseRosPath";
 
 // To show an input field with an autocomplete so the user can enter message paths, use:
 //
@@ -61,7 +61,7 @@ function getFieldPaths(
 ): Map<string, RosMsgField> {
   const output = new Map<string, RosMsgField>();
   for (const topic of topics) {
-    addFieldPathsForType(topic.name, topic.datatype, datatypes, output);
+    addFieldPathsForType(quoteIdentifierIfNeeded(topic.name), topic.datatype, datatypes, output);
   }
   return output;
 }
@@ -266,7 +266,10 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     return getFirstInvalidVariableFromRosPath(rosPath, globalVariables, setGlobalVariables);
   }, [globalVariables, rosPath, setGlobalVariables]);
 
-  const topicNamesAutocompleteItems = useMemo(() => getTopicNames(topics), [topics]);
+  const topicNamesAutocompleteItems = useMemo(
+    () => topics.map(({ name }) => quoteIdentifierIfNeeded(name)),
+    [topics],
+  );
 
   const topicNamesAndFieldsAutocompleteItems = useMemo(
     () => topicNamesAutocompleteItems.concat(Array.from(topicFields.keys())),
@@ -357,13 +360,18 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
             (msgPath) => msgPath !== "" && !msgPath.endsWith(".header.seq"),
           ),
 
-          autocompleteRange: { start: topic.name.length + initialFilterLength, end: Infinity },
+          autocompleteRange: {
+            start: rosPath.topicNameRepr.length + initialFilterLength,
+            end: Infinity,
+          },
           // Filter out filters (hah!) in a pretty crude way, so autocomplete still works
           // when already having specified a filter and you want to see what other object
           // names you can complete it with. Kind of an edge case, and this doesn't work
           // ideally (because it will remove your existing filter if you actually select
           // the autocomplete item), but it's easy to do for now, and nice to have.
-          autocompleteFilterText: path.substr(topic.name.length).replace(/\{[^}]*\}/g, ""),
+          autocompleteFilterText: path
+            .substring(rosPath.topicNameRepr.length)
+            .replace(/\{[^}]*\}/g, ""),
         };
       }
     } else if (invalidGlobalVariablesVariable) {

--- a/packages/studio-base/src/components/MessagePathSyntax/constants.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/constants.ts
@@ -51,6 +51,7 @@ export type MessagePathPart =
 
 export type RosPath = {
   topicName: string;
+  topicNameRepr: string;
   messagePath: MessagePathPart[];
   modifier?: string;
 };

--- a/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
+++ b/packages/studio-base/src/components/MessagePathSyntax/grammar.ne
@@ -14,7 +14,7 @@
 #
 # For more examples, please see parseRosPath.test.js
 main -> topicName messagePath:? modifier:?
-  {% (d) => ({ topicName: d[0], messagePath: d[1] || [], modifier: d[2] }) %}
+  {% (d) => ({ topicName: d[0].value, topicNameRepr: d[0].repr, messagePath: d[1] || [], modifier: d[2] }) %}
 
 ## Primitives
 
@@ -41,10 +41,26 @@ value -> integer  {% (d) => d[0] %}
 	   | variable {% (d) => d[0] %}
 
 ## Topic part. Basically an id but with (optional) slashes.
-topicName -> slashID:+     {% (d) => d[0].join("") %}
-           | id slashID:*  {% (d) => d[0] + d[1].join("") %}
+topicName -> slashID:+     {% (d) => ({ value: d[0].join(""), repr: d[0].join("") }) %}
+           | id slashID:*  {% (d) => ({ value: d[0] + d[1].join(""), repr: d[0] + d[1].join("") }) %}
+           | quotedID      {% id %}
 slashID -> "/" id:?
   {% (d) => d.join("") %}
+
+quotedID ->
+  "\""
+  (
+    [^"\\]
+    | "\\\\" {% d => "\\" %}
+    | "\\\"" {% d => `"` %}
+  ):*
+  "\""
+  {%
+    d => ({
+      value: d[1].join(''),
+      repr: `"${d[1].join('').replace(/[\\"]/g, char => `\\${char}`)}"`
+    })
+  %}
 
 ## `messagePath` part.
 

--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.test.ts
@@ -21,6 +21,7 @@ describe("parseRosPath", () => {
   it("parses valid strings", () => {
     expect(parseRosPath("/some0/nice_topic.with[99].stuff[0]")).toEqual({
       topicName: "/some0/nice_topic",
+      topicNameRepr: "/some0/nice_topic",
       messagePath: [
         { type: "name", name: "with" },
         { type: "slice", start: 99, end: 99 },
@@ -31,6 +32,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/some0/nice_topic.with[99].stuff[0].@derivative")).toEqual({
       topicName: "/some0/nice_topic",
+      topicNameRepr: "/some0/nice_topic",
       messagePath: [
         { type: "name", name: "with" },
         { type: "slice", start: 99, end: 99 },
@@ -41,6 +43,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("some0/nice_topic.with[99].stuff[0]")).toEqual({
       topicName: "some0/nice_topic",
+      topicNameRepr: "some0/nice_topic",
       messagePath: [
         { type: "name", name: "with" },
         { type: "slice", start: 99, end: 99 },
@@ -51,14 +54,53 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("some_nice_topic")).toEqual({
       topicName: "some_nice_topic",
+      topicNameRepr: "some_nice_topic",
       messagePath: [],
       modifier: MISSING,
     });
   });
 
+  it("parses quoted topic name with escapes", () => {
+    expect(parseRosPath(String.raw`"/foo/bar".baz`)).toEqual({
+      topicName: "/foo/bar",
+      topicNameRepr: String.raw`"/foo/bar"`,
+      messagePath: [{ type: "name", name: "baz" }],
+      modifier: MISSING,
+    });
+    expect(parseRosPath(String.raw`"\"/foo/bar\"".baz`)).toEqual({
+      topicName: `"/foo/bar"`,
+      topicNameRepr: String.raw`"\"/foo/bar\""`,
+      messagePath: [{ type: "name", name: "baz" }],
+      modifier: MISSING,
+    });
+    expect(parseRosPath(String.raw`"\"".baz`)).toEqual({
+      topicName: `"`,
+      topicNameRepr: String.raw`"\""`,
+      messagePath: [{ type: "name", name: "baz" }],
+      modifier: MISSING,
+    });
+    expect(parseRosPath(String.raw`"\\".baz`)).toEqual({
+      topicName: "\\",
+      topicNameRepr: String.raw`"\\"`,
+      messagePath: [{ type: "name", name: "baz" }],
+      modifier: MISSING,
+    });
+    expect(parseRosPath(String.raw`"\\a".baz`)).toEqual({
+      topicName: "\\a",
+      topicNameRepr: String.raw`"\\a"`,
+      messagePath: [{ type: "name", name: "baz" }],
+      modifier: MISSING,
+    });
+    expect(parseRosPath(String.raw`""".baz`)).toBeUndefined();
+    expect(parseRosPath(String.raw`"\a".baz`)).toBeUndefined();
+    expect(parseRosPath(String.raw`"\".baz`)).toBeUndefined();
+    expect(parseRosPath(String.raw`"x.baz`)).toBeUndefined();
+  });
+
   it("parses slices", () => {
     expect(parseRosPath("/topic.foo[0].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 0, end: 0 },
@@ -68,6 +110,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[1:3].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 1, end: 3 },
@@ -77,6 +120,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[1:].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 1, end: Infinity },
@@ -86,6 +130,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[:10].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 0, end: 10 },
@@ -95,6 +140,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[:].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 0, end: Infinity },
@@ -104,6 +150,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[$a].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -117,6 +164,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[$a:$b].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -130,6 +178,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[$a:].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -143,6 +192,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[$a:5].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: { variableName: "a", startLoc: "/topic.foo[".length }, end: 5 },
@@ -152,6 +202,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[:$b].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 0, end: { variableName: "b", startLoc: "/topic.foo[:".length } },
@@ -161,6 +212,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo[2:$b].bar")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         { type: "slice", start: 2, end: { variableName: "b", startLoc: "/topic.foo[2:".length } },
@@ -177,6 +229,7 @@ describe("parseRosPath", () => {
       ),
     ).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -244,6 +297,7 @@ describe("parseRosPath", () => {
   it("parses filters on top level topic", () => {
     expect(parseRosPath("/topic{foo=='bar'}{baz==2}.a[3].b{x=='y'}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         {
           type: "filter",
@@ -280,6 +334,7 @@ describe("parseRosPath", () => {
   it("parses filters with global variables", () => {
     expect(parseRosPath("/topic.foo{bar==$}.a{bar==$my_var_1}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -305,14 +360,21 @@ describe("parseRosPath", () => {
   });
 
   it("parses unfinished strings", () => {
-    expect(parseRosPath("/")).toEqual({ topicName: "/", messagePath: [], modifier: MISSING });
+    expect(parseRosPath("/")).toEqual({
+      topicName: "/",
+      topicNameRepr: "/",
+      messagePath: [],
+      modifier: MISSING,
+    });
     expect(parseRosPath("/topic.")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [{ type: "name", name: "" }],
       modifier: MISSING,
     });
     expect(parseRosPath("/topic.hi.")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "hi" },
         { type: "name", name: "" },
@@ -321,11 +383,13 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.hi.@")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [{ type: "name", name: "hi" }],
       modifier: "",
     });
     expect(parseRosPath("/topic.foo{}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -341,6 +405,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo{bar}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -356,6 +421,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo{==1}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {
@@ -371,6 +437,7 @@ describe("parseRosPath", () => {
     });
     expect(parseRosPath("/topic.foo{==-3}")).toEqual({
       topicName: "/topic",
+      topicNameRepr: "/topic",
       messagePath: [
         { type: "name", name: "foo" },
         {

--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
@@ -21,6 +21,13 @@ import grammar from "./grammar.ne";
 
 const grammarObj = Grammar.fromCompiled(grammar);
 
+export function quoteIdentifierIfNeeded(name: string): string {
+  if (name.match(/^[a-zA-Z0-9_/]+$/)) {
+    return name;
+  }
+  return `"${name.replace(/[\\"]/g, (char) => `\\${char}`)}"`;
+}
+
 const parseRosPath = memoize((path: string): RosPath | undefined => {
   // Need to create a new Parser object for every new string to parse (should be cheap).
   const parser = new Parser(grammarObj);

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -16,8 +16,6 @@ import { useCallback, useMemo, useRef } from "react";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
-import { TypicalFilterNames } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
-import parseRosPath from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import useChangeDetector from "@foxglove/studio-base/hooks/useChangeDetector";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import useGlobalVariables, {
@@ -32,7 +30,9 @@ import {
 } from "@foxglove/studio-base/util/selectors";
 
 import { MessagePathFilter, MessagePathStructureItem, RosPath } from "./constants";
+import { TypicalFilterNames } from "./isTypicalFilterName";
 import { messagePathStructures } from "./messagePathsForDatatype";
+import parseRosPath, { quoteIdentifierIfNeeded } from "./parseRosPath";
 
 export type MessagePathDataItem = {
   value: unknown; // The actual value.
@@ -374,7 +374,7 @@ export function getMessagePathDataItems(
   }
   const structure = structures[topic.datatype];
   if (structure) {
-    traverse(message.message, 0, filledInPath.topicName, structure);
+    traverse(message.message, 0, quoteIdentifierIfNeeded(filledInPath.topicName), structure);
   }
   return queriedData;
 }

--- a/packages/studio-base/src/util/selectors.test.ts
+++ b/packages/studio-base/src/util/selectors.test.ts
@@ -12,26 +12,12 @@
 //   You may not use this file except in compliance with the License.
 import {
   constantsByDatatype,
-  getTopicNames,
   getTopicsByTopicName,
   enumValuesByDatatypeAndField,
   extractTypeFromStudioEnumAnnotation,
 } from "@foxglove/studio-base/util/selectors";
 
 describe("selectors", () => {
-  describe("getTopicNames", () => {
-    it("extracts the topic names", () => {
-      expect(
-        getTopicNames([
-          { name: "/abc", datatype: "dummy" },
-          { name: "/aBc/a", datatype: "dummy" },
-          { name: "/aBc/c", datatype: "dummy" },
-          { name: "/abc/b", datatype: "dummy" },
-        ]),
-      ).toEqual(["/abc", "/aBc/a", "/aBc/c", "/abc/b"]);
-    });
-  });
-
   describe("topicsByTopicName", () => {
     it("indexes the topics by topic name", () => {
       expect(

--- a/packages/studio-base/src/util/selectors.ts
+++ b/packages/studio-base/src/util/selectors.ts
@@ -18,11 +18,6 @@ import { createSelector } from "reselect";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
-export const getTopicNames = createSelector(
-  (topics: readonly Topic[]) => topics,
-  (topics: readonly Topic[]): string[] => topics.map((topic) => topic.name),
-);
-
 export const getSanitizedTopics = memoizeWeak(
   (subscribedTopics: Set<string>, providerTopics: Topic[]): string[] => {
     return intersection(


### PR DESCRIPTION
**User-Facing Changes**
Message path syntax now supports wrapping topic names in double quotes, to support topics with special characters. Quotes and backslashes in the string must be escaped with backslashes.

**Description**
Resolves https://github.com/foxglove/studio/issues/2886

<img width="441" alt="image" src="https://user-images.githubusercontent.com/14237/155212816-edb662c1-7d44-4065-ba39-313df0c2cedc.png">
