### PR TITLE
Clear problems when re-establishing ROS1 connection

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -233,6 +233,7 @@ export default class Ros1Player implements Player {
       // Fetch the full graph topology
       await this._updateConnectionGraph(rosNode);
 
+      this._clearProblem(Problem.Connection, { skipEmit: true });
       this._presence = PlayerPresence.PRESENT;
       this._emitState();
     } catch (error) {


### PR DESCRIPTION


**User-Facing Changes**
Users no longer see stale connection errors when their ROS1 connection re-connects.

**Description**

This change cleares any connection problems from the ROS1 connection when it is re-established. Prior to this change, the connection problems would persist even once the player reconnected.

Fixes: #2865
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
