### PR TITLE
Allow missing object properties in JSON data

### DIFF
--- a/packages/mcap-support/src/parseJsonSchema.test.ts
+++ b/packages/mcap-support/src/parseJsonSchema.test.ts
@@ -199,4 +199,45 @@ describe("parseJsonSchema", () => {
       expect(postprocessValue(value)).toEqual(expectedValue);
     },
   );
+
+  it("allows missing sub-properties", () => {
+    const { postprocessValue } = parseJsonSchema(
+      {
+        type: "object",
+        properties: {
+          foo: { type: "number" },
+          bar: {
+            type: "object",
+            properties: { baz: { type: "object", properties: { quux: { type: "number" } } } },
+          },
+        },
+      },
+      "Root",
+    );
+    expect(postprocessValue({ foo: 3 })).toEqual({ foo: 3 });
+  });
+  it("allows missing sub-properties in arrays", () => {
+    const { postprocessValue } = parseJsonSchema(
+      {
+        type: "object",
+        properties: {
+          arr: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                foo: { type: "number" },
+                bar: {
+                  type: "object",
+                  properties: { baz: { type: "object", properties: { quux: { type: "number" } } } },
+                },
+              },
+            },
+          },
+        },
+      },
+      "Root",
+    );
+    expect(postprocessValue({ arr: [{ foo: 3 }] })).toEqual({ arr: [{ foo: 3 }] });
+  });
 });

--- a/packages/mcap-support/src/parseJsonSchema.ts
+++ b/packages/mcap-support/src/parseJsonSchema.ts
@@ -83,7 +83,10 @@ export function parseJsonSchema(
           );
           const prevPostprocess = postprocessObject;
           postprocessObject = (value) => {
-            value[fieldName] = postprocessNestedObject(value[fieldName] as Record<string, unknown>);
+            const fieldValue = value[fieldName];
+            if (fieldValue != undefined && typeof fieldValue === "object") {
+              value[fieldName] = postprocessNestedObject(fieldValue as Record<string, unknown>);
+            }
             return prevPostprocess(value);
           };
           fields.push({ name: fieldName, type: nestedTypeName, isComplex: true });


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash when handling JSON messages that are missing nested sub-properties defined in the JSON Schema.

**Description**
Fixes https://github.com/foxglove/studio/issues/2887
