### PR TITLE
Fix memory leak of player state from previous players

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/usePlayerState.ts
+++ b/packages/studio-base/src/components/MessagePipeline/usePlayerState.ts
@@ -30,7 +30,7 @@ type UpdatePlayerStateAction = {
   renderDone?: () => void;
 };
 
-type Action = UpdateSubscriberAction | UpdatePlayerStateAction;
+export type MessagePipelineStateAction = UpdateSubscriberAction | UpdatePlayerStateAction;
 
 // Update state with a subscriber. Any new topics for the subscriber are tracked in newTopicsBySubscriberId
 // to receive the last message on their newly subscribed topics.
@@ -159,7 +159,10 @@ function updatePlayerStateAction(
   };
 }
 
-function reduce(prevSubscriberState: InternalState, action: Action): InternalState {
+function reduce(
+  prevSubscriberState: InternalState,
+  action: MessagePipelineStateAction,
+): InternalState {
   switch (action.type) {
     case "update-player-state":
       return updatePlayerStateAction(prevSubscriberState, action);


### PR DESCRIPTION
**User-Facing Changes**
Mitigated a memory leak that happened when loading different data sources repeatedly.

**Description**
Improves https://github.com/foxglove/studio/issues/2896 – not clear if it is totally fixed. There is still some unwanted memory growth and retention of ArrayBuffers, which we can address in separate PRs. However, the amount of growth between snapshots is greatly reduced.

Before | After
--- | ---
<img width="167" alt="image" src="https://user-images.githubusercontent.com/14237/155431075-adc6670f-abbe-43c7-808f-60e87ec7c67f.png"> | <img width="145" alt="image" src="https://user-images.githubusercontent.com/14237/155429626-f1f8615e-8433-46bc-b1aa-45768418e610.png">


Copying the code comment here: 
>  The creation of the player listener is extracted as a separate function to prevent memory leaks.
>  When multiple closures are created inside of an outer function, V8 allocates one "context" object
>  to be shared by all the inner closures, holding the shared variables they access. As long as any
>  of the inner closures are still alive, the context and **all** the shared variables stay alive.
>  
>  In the case of MessagePipelineProvider, when the `listener` closure was created directly inside
>  the useEffect above, it would end up retaining a shared context that also retained the player
>  `state` variable returned by `usePlayerState()`, even though the listener closure didn't actually
>  use it. In particular, each time a new player was created in the useEffect, this caused it to
>  retain the old player's state (via the listener closure), creating a "linked list" effect that
>  caused the last state produced by each player (and therefore also its preloaded message blocks)
>  to be retained indefinitely as new data sources were swapped in.
>  
>  To avoid this problem, we extract the closure creation into a module-level function where it
>  won't see variables from outer scopes that are potentially retained in the shared context due to
>  their use in other closures.
>  
>  This type of leak is discussed at:
>  - https://bugs.chromium.org/p/chromium/issues/detail?id=315190
>  - http://point.davidglasser.net/2013/06/27/surprising-javascript-memory-leak.html
>  - https://stackoverflow.com/questions/53985411/understanding-javascript-closure-variable-capture-in-v8
> 

Diagram of object references contributing to the leak:

```mermaid
flowchart LR
p1[new player]
p1listener[<code>listener</code> closure<br>not using <code>state</code>]
p1-->p1listener
p1listener-->context1

subgraph context1[shared closure context]
  render_done1[previous <code>state.renderDone</code>]
  player1[previous player]
end
messages1[message data,<br>lazy readers, etc]
listener1[<code>listener</code>]
player1-->messages1
player1-->listener1
other_closure1[other closures using<br><code>state</code> or <code>player</code>]
other_closure1-->context1
style other_closure1 fill:#fff,stroke-dasharray: 3 3;

render_done1-->context2
listener1-->context2
subgraph context2[shared closure context]
  render_done2[previous <code>state.renderDone</code>]
  player2[previous player]
end
messages2[message data,<br>lazy readers, etc]
listener2[<code>listener</code>]
player2-->messages2
player2-->listener2
other_closure2[other closures using<br><code>state</code> or <code>player</code>]
other_closure2--->context2
style other_closure2 fill:#fff,stroke-dasharray: 3 3;

render_done2-->context3
listener2-->context3
subgraph context3[shared closure context]
  render_done3[previous <code>state.renderDone</code>]
  player3[previous player]
end
messages3[message data,<br>lazy readers, etc]
listener3[<code>listener</code>]
player3-->messages3
player3-->listener3
other_closure3[other closures using<br><code>state</code> or <code>player</code>]
other_closure3--->context3
style other_closure3 fill:#fff,stroke-dasharray: 3 3;

render_done3-->etc[...]
listener3-->etc[...]
```

It looks like some variation of this in the memory inspector, potentially with different closures/variables in play:

<img width="727" alt="image" src="https://user-images.githubusercontent.com/14237/155431705-6dad45ad-15c8-4ffe-8429-59e8670b5094.png">
