### PR TITLE
Expose block cache from foxglove DP player.

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.test.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.test.ts
@@ -131,6 +131,30 @@ describe("MessageMemoryCache", () => {
     ]);
   });
 
+  it("generates a block cache from loaded ranges", () => {
+    const cache = new MessageMemoryCache({ start: fromSec(0), end: fromSec(5) });
+
+    cache.insert({ start: fromSec(2), end: fromSec(3) }, [
+      { topic: "ta", receiveTime: fromSec(2), message: "ta", sizeInBytes: 0 },
+    ]);
+    cache.insert({ start: fromSec(1), end: fromSec(2) }, [
+      { topic: "tb", receiveTime: fromSec(1), message: "tb", sizeInBytes: 0 },
+    ]);
+
+    expect(cache.getBlockCache()).toEqual({
+      blocks: [
+        {
+          messagesByTopic: {
+            ta: [{ message: "ta", receiveTime: { nsec: 0, sec: 2 }, sizeInBytes: 0, topic: "ta" }],
+            tb: [{ message: "tb", receiveTime: { nsec: 0, sec: 1 }, sizeInBytes: 0, topic: "tb" }],
+          },
+          sizeInBytes: 0,
+        },
+      ],
+      startTime: { nsec: 0, sec: 1 },
+    });
+  });
+
   it("merges inserted range with previous and next ranges", () => {
     const cache = new MessageMemoryCache({ start: fromSec(0), end: fromSec(5) });
 

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -432,6 +432,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
         preloadedMessages.insert(range, messages);
         this._progress = {
           fullyLoadedFractionRanges: preloadedMessages.fullyLoadedFractionRanges(),
+          messageCache: preloadedMessages.getBlockCache(),
         };
         this._loadedMoreMessages?.resolve();
         this._loadedMoreMessages = undefined;


### PR DESCRIPTION
**User-Facing Changes**
This will improve preloading behavior for the Foxglove Data Platform player.

**Description**
`FoxgloveDataPlatformPlayer` uses its own memory cache implementation and this cache doesn't expose cached messages in the blocks format that some panels expect. This patch just exposes the cached messages in blocks as well as the format used internally by `FoxgloveDataPlatformPlayer`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #1964 