### PR TITLE
Patch zstd-codec to remove extra ArrayBuffer copy

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -21,12 +21,13 @@
     "prepack": "tsc -b"
   },
   "devDependencies": {
+    "@types/zstd-codec": "workspace:*",
     "typescript": "4.5.5"
   },
   "dependencies": {
     "@foxglove/wasm-bz2": "0.1.0",
     "@protobufjs/base64": "1.1.2",
     "wasm-lz4": "2.0.0",
-    "zstd-codec": "0.1.4"
+    "zstd-codec": "patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch"
   }
 }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -109,7 +109,6 @@
     "@types/uuid": "8.3.4",
     "@types/wicg-file-system-access": "2020.9.4",
     "@types/ws": "8.2.2",
-    "@types/zstd-codec": "workspace:*",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "amplitude-js": "8.16.1",
     "argparse": "2.0.1",
@@ -205,7 +204,6 @@
     "uuid": "8.3.2",
     "wasm-lz4": "2.0.0",
     "webpack": "5.68.0",
-    "xacro-parser": "0.3.8",
-    "zstd-codec": "0.1.4"
+    "xacro-parser": "0.3.8"
   }
 }

--- a/patches/zstd-codec.patch
+++ b/patches/zstd-codec.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/helpers.js b/lib/helpers.js
+index ce3fee061613361e41f3b84ac2447e152196ee6d..ceea656401f1257c6ded5863e8e779b25c4103ef 100644
+--- a/lib/helpers.js
++++ b/lib/helpers.js
+@@ -1,7 +1,7 @@
+ class ArrayBufferHelper {
+     static transfer(old_buffer, new_capacity) {
+         const bytes = new Uint8Array(new ArrayBuffer(new_capacity));
+-        bytes.set(new Uint8Array(old_buffer.slice(0, new_capacity)));
++        bytes.set(new Uint8Array(old_buffer, 0, Math.min(new_capacity, old_buffer.byteLength)));
+         return bytes.buffer;
+     }
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,9 +2310,10 @@ __metadata:
   dependencies:
     "@foxglove/wasm-bz2": 0.1.0
     "@protobufjs/base64": 1.1.2
+    "@types/zstd-codec": "workspace:*"
     typescript: 4.5.5
     wasm-lz4: 2.0.0
-    zstd-codec: 0.1.4
+    zstd-codec: "patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch"
   languageName: unknown
   linkType: soft
 
@@ -2580,7 +2581,6 @@ __metadata:
     "@types/uuid": 8.3.4
     "@types/wicg-file-system-access": 2020.9.4
     "@types/ws": 8.2.2
-    "@types/zstd-codec": "workspace:*"
     "@wojtekmaj/enzyme-adapter-react-17": 0.6.6
     amplitude-js: 8.16.1
     argparse: 2.0.1
@@ -2677,7 +2677,6 @@ __metadata:
     wasm-lz4: 2.0.0
     webpack: 5.68.0
     xacro-parser: 0.3.8
-    zstd-codec: 0.1.4
   languageName: unknown
   linkType: soft
 
@@ -25469,6 +25468,13 @@ __metadata:
   version: 0.1.4
   resolution: "zstd-codec@npm:0.1.4"
   checksum: 8689bc0defc4f387d1be990b8b8ca8ca56690d17dfc8dd4703db798465b92a21e64e54e886acfaa376147d9d07d879a68627b09fddc34a0c93f0dc5c610a790c
+  languageName: node
+  linkType: hard
+
+"zstd-codec@patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch::locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support":
+  version: 0.1.4
+  resolution: "zstd-codec@patch:zstd-codec@npm%3A0.1.4#../../patches/zstd-codec.patch::version=0.1.4&hash=a862de&locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support"
+  checksum: 08a5e329950cb926581ea3a0a46131676e05fcbcdc59faebe2d7c66036562694c9a266140183848facb08fa06e5f6db7e55e23dac27f219e7dbb69f124b62554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Apply the changes from https://github.com/yoshihitoh/zstd-codec/pull/226. Since that PR has not gotten any attention yet, I figured it would be useful to bring this perf improvement in temporarily as a patch.