### PR TITLE
Fix playback bar getting stuck in drag mode

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -34,7 +34,7 @@ const sharedTickStyles = css`
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
 
-  margin-left: -6px; /* -6px seems to line up better than -5px */
+  margin-left: -5px;
 `;
 
 const TopTick = styled.div`

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -127,12 +127,11 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const latestStartTime = useLatest(startTime);
   const onHoverOver = useCallback(
-    (ev: React.MouseEvent<HTMLDivElement>, value: number) => {
+    (x: number, value: number) => {
       if (!latestStartTime.current || el.current == undefined) {
         return;
       }
       const currentEl = el.current;
-      const x = ev.clientX;
       // fix the y position of the tooltip to float on top of the playback bar
       const y = currentEl.getBoundingClientRect().top;
 
@@ -224,7 +223,6 @@ export default function Scrubber(props: Props): JSX.Element {
           disabled={min == undefined || max == undefined}
           step={step}
           value={value}
-          draggable
           onHoverOver={onHoverOver}
           onHoverOut={onHoverOut}
           onChange={onChange}

--- a/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Slider.stories.tsx
@@ -67,13 +67,7 @@ export const Examples: Story = () => {
       </div>
       <p>draggable</p>
       <div style={{ backgroundColor: "cornflowerblue", height: 20, width: 500 }}>
-        <Slider
-          draggable
-          min={10}
-          max={200}
-          onChange={(v) => setDraggableValue(v)}
-          value={draggableValue}
-        />
+        <Slider min={10} max={200} onChange={(v) => setDraggableValue(v)} value={draggableValue} />
       </div>
     </div>
   );
@@ -87,7 +81,6 @@ export const CustomRenderer: Story = () => {
       <p>Customize slider UI using renderSlider</p>
       <div style={{ backgroundColor: "cornflowerblue", height: 20, width: 500 }}>
         <Slider
-          draggable
           min={10}
           max={200}
           onChange={(v) => setDraggableValue(v)}


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where scrubbing on the playback bar only worked as long as the mouse was actually kept on the playback bar, and could get "stuck" if the mouse was released when outside of the playback bar.

**Description**
Fixes https://github.com/foxglove/studio/issues/2900. This behavior was previously working and regressed in https://github.com/foxglove/studio/pull/1805. The mouseup and mousemove events are now tracked on the window instead of the slider element when the mouse is pressed, which improves the UX by allowing a drag to move outside the playback bar and continue working, and allows us to correctly track mouseup even when it happens outside the playback bar (or outside the window). Additionally, a mouseenter/mouseleave pair are used to track the "mouse inside" state, which allows us to hide the tooltip on mouse up, if the mouse was outside the slider.

https://user-images.githubusercontent.com/14237/155650472-8216f61d-0b98-4bc1-9f78-e25f624adca2.mov


