### PR TITLE
Clear user session on API 401 response.

### DIFF
--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -79,6 +79,7 @@ type ApiResponse<T> = { status: number; json: T };
 class ConsoleApi {
   private _baseUrl: string;
   private _authHeader?: string;
+  private _responseObserver: undefined | ((response: Response) => void);
 
   constructor(baseUrl: string) {
     this._baseUrl = baseUrl;
@@ -86,6 +87,10 @@ class ConsoleApi {
 
   setAuthHeader(header: string): void {
     this._authHeader = header;
+  }
+
+  setResponseObserver(observer: undefined | ((response: Response) => void)): void {
+    this._responseObserver = observer;
   }
 
   async orgs(): Promise<Org[]> {
@@ -182,6 +187,7 @@ class ConsoleApi {
     };
 
     const res = await fetch(fullUrl, fullConfig);
+    this._responseObserver?.(res);
     if (res.status !== 200 && !allowedStatuses.includes(res.status)) {
       const json = (await res.json().catch((err) => {
         throw new Error(`Status ${res.status}: ${err.message}`);


### PR DESCRIPTION
**User-Facing Changes**
This improves our handling of stale authenticated sessions in studio.

**Description**
The idea here is to attach an observer to `ConsoleAPI` and listen for any 401 response. On receiving a 401 we clear the user session. 

Alternatively we could try a more comprehensive solution that involved custom error boundaries and adding custom error handler hooks to all the places we call the API but that would require much more significant changes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #1952 