### PR TITLE
Improve preloading for data platform.

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -227,12 +227,14 @@ export default class MessageMemoryCache {
       messages: insertMessages,
     });
 
+    // Create new array to clear later memoizations.
+    this._blockCache.blocks = [...this._blockCache.blocks];
+
     // Build & insert new cache block for this range.
     this._blockCache.blocks.splice(spliceIdx, deleteCount, {
       messagesByTopic: groupBy(insertMessages, (m) => m.topic),
       sizeInBytes: sumBy(insertMessages, (m) => m.sizeInBytes),
     });
-    this._blockCache.blocks = [...this._blockCache.blocks]; // Needed to clear later memoizations.
     this._blockCache.startTime = this.loadedRanges[0]?.range.start ?? { sec: 0, nsec: 0 };
   }
 

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -232,6 +232,7 @@ export default class MessageMemoryCache {
       messagesByTopic: groupBy(insertMessages, (m) => m.topic),
       sizeInBytes: sumBy(insertMessages, (m) => m.sizeInBytes),
     });
+    this._blockCache.blocks = [...this._blockCache.blocks]; // Needed to clear later memoizations.
     this._blockCache.startTime = this.loadedRanges[0]?.range.start ?? { sec: 0, nsec: 0 };
   }
 


### PR DESCRIPTION
**User-Facing Changes**
This improves the preloading behavior for the data platform player.

**Description**
Downstream code heavily memoizes the `blocks` returned by the player so we need to rebuild this array when we get new messages in order for that code to recognize we have new blocks.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
