### PR TITLE
Show dashes for missing message counts for data platform topics.

### DIFF
--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -161,7 +161,7 @@ function SourceInfo() {
               onRender: (topic) =>
                 topic.numMessages != undefined
                   ? `${(topic.numMessages / toSec(duration)).toFixed(2)} Hz`
-                  : "-",
+                  : "–",
             },
           ]}
         />

--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -152,7 +152,7 @@ function SourceInfo() {
               name: "Message count",
               fieldName: "numMessages",
               minWidth: 0,
-              onRender: (topic) => topic.numMessages?.toLocaleString() ?? "-",
+              onRender: (topic) => topic.numMessages?.toLocaleString() ?? "–",
             },
             {
               key: "frequency",

--- a/packages/studio-base/src/panels/SourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/SourceInfo/index.tsx
@@ -152,8 +152,7 @@ function SourceInfo() {
               name: "Message count",
               fieldName: "numMessages",
               minWidth: 0,
-              data: "number",
-              isPadded: true,
+              onRender: (topic) => topic.numMessages?.toLocaleString() ?? "-",
             },
             {
               key: "frequency",
@@ -162,7 +161,7 @@ function SourceInfo() {
               onRender: (topic) =>
                 topic.numMessages != undefined
                   ? `${(topic.numMessages / toSec(duration)).toFixed(2)} Hz`
-                  : "",
+                  : "-",
             },
           ]}
         />

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -82,6 +82,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   private _currentTime: Time;
   private _lastSeekTime?: number;
   private _topics: Topic[] = [];
+  private _topicCounts = new Map<string, number>();
   private _datatypes: RosDatatypes = new Map();
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
@@ -363,6 +364,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     }
     this._currentPreloadTask?.abort();
     this._currentPreloadTask = undefined;
+    this._topicCounts = new Map();
   }
 
   private _startPreloadTaskIfNeeded() {
@@ -424,6 +426,13 @@ export default class FoxgloveDataPlatformPlayer implements Player {
           fullyLoadedFractionRanges: preloadedMessages.fullyLoadedFractionRanges(),
           messageCache: preloadedMessages.getBlockCache(),
         };
+        for (const message of messages) {
+          this._topicCounts.set(message.topic, (this._topicCounts.get(message.topic) ?? 0) + 1);
+        }
+        this._topics = this._topics.map((t) => ({
+          ...t,
+          numMessages: this._topicCounts.get(t.name),
+        }));
         this._loadedMoreMessages?.resolve();
         this._loadedMoreMessages = undefined;
         this._emitState();

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -82,7 +82,6 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   private _currentTime: Time;
   private _lastSeekTime?: number;
   private _topics: Topic[] = [];
-  private _topicCounts = new Map<string, number>();
   private _datatypes: RosDatatypes = new Map();
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
@@ -364,7 +363,6 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     }
     this._currentPreloadTask?.abort();
     this._currentPreloadTask = undefined;
-    this._topicCounts = new Map();
   }
 
   private _startPreloadTaskIfNeeded() {
@@ -426,13 +424,6 @@ export default class FoxgloveDataPlatformPlayer implements Player {
           fullyLoadedFractionRanges: preloadedMessages.fullyLoadedFractionRanges(),
           messageCache: preloadedMessages.getBlockCache(),
         };
-        for (const message of messages) {
-          this._topicCounts.set(message.topic, (this._topicCounts.get(message.topic) ?? 0) + 1);
-        }
-        this._topics = this._topics.map((t) => ({
-          ...t,
-          numMessages: this._topicCounts.get(t.name),
-        }));
         this._loadedMoreMessages?.resolve();
         this._loadedMoreMessages = undefined;
         this._emitState();


### PR DESCRIPTION
**User-Facing Changes**
This displays dashes if message counts are not available for a data source.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2901 