### PR TITLE
Use stable layout selector

### DIFF
--- a/packages/hooks/src/useMustNotChange.test.ts
+++ b/packages/hooks/src/useMustNotChange.test.ts
@@ -4,15 +4,24 @@
 
 import { renderHook } from "@testing-library/react-hooks";
 
+import Logger from "@foxglove/log";
+
 import { useMustNotChangeImpl } from "./useMustNotChange";
 
 describe("useMustNotChange", () => {
-  it("should throw when value changes", () => {
-    const { result, rerender } = renderHook((val) => useMustNotChangeImpl(val), {
+  it("should log an error when value changes", () => {
+    const errorMock = jest.fn();
+    Logger.channels().forEach((channel) => {
+      if (channel.name().endsWith("useMustNotChange.ts")) {
+        channel.error = errorMock;
+      }
+    });
+
+    const { rerender } = renderHook((val) => useMustNotChangeImpl(val), {
       initialProps: 1,
     });
     rerender(2);
 
-    expect(result.error?.message).toEqual("Value must not change");
+    expect(errorMock).toHaveBeenCalled();
   });
 });

--- a/packages/hooks/src/useMustNotChange.ts
+++ b/packages/hooks/src/useMustNotChange.ts
@@ -4,10 +4,14 @@
 
 import { useRef } from "react";
 
+import Logger from "@foxglove/log";
+
+const log = Logger.getLogger(__filename);
+
 const useMustNotChangeImpl = (value: unknown): void => {
   const valueRef = useRef<unknown | undefined>(value);
   if (valueRef.current !== value) {
-    throw new Error("Value must not change");
+    log.error("Value must not change", valueRef.current);
   }
   valueRef.current = value;
 };

--- a/packages/studio-base/src/PanelAPI/useConfigById.ts
+++ b/packages/studio-base/src/PanelAPI/useConfigById.ts
@@ -13,26 +13,20 @@ import {
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 
+const configSelector = (state: DeepPartial<LayoutState>) => state.selectedLayout?.data?.configById;
+
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels
  * directly, but is for use in internal code that's running outside of regular context providers.
  */
+
 export default function useConfigById<Config extends Record<string, unknown>>(
   panelId: string | undefined,
 ): [Config | undefined, SaveConfig<Config>] {
   const { savePanelConfigs } = useCurrentLayoutActions();
 
-  const configSelector = useCallback(
-    (state: DeepPartial<LayoutState>) => {
-      if (panelId == undefined) {
-        return undefined;
-      }
-      return maybeCast<Config>(state.selectedLayout?.data?.configById?.[panelId]);
-    },
-    [panelId],
-  );
-
-  const config = useCurrentLayoutSelector(configSelector);
+  const configsById = useCurrentLayoutSelector(configSelector);
+  const config = panelId && configsById ? maybeCast<Config>(configsById[panelId]) : undefined;
 
   const saveConfig: SaveConfig<Config> = useCallback(
     (newConfig) => {

--- a/packages/studio-base/src/PanelAPI/useConfigById.ts
+++ b/packages/studio-base/src/PanelAPI/useConfigById.ts
@@ -13,20 +13,26 @@ import {
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 
-const configSelector = (state: DeepPartial<LayoutState>) => state.selectedLayout?.data?.configById;
-
 /**
  * Like `useConfig`, but for a specific panel id. This generally shouldn't be used by panels
  * directly, but is for use in internal code that's running outside of regular context providers.
  */
-
 export default function useConfigById<Config extends Record<string, unknown>>(
   panelId: string | undefined,
 ): [Config | undefined, SaveConfig<Config>] {
   const { savePanelConfigs } = useCurrentLayoutActions();
 
-  const configsById = useCurrentLayoutSelector(configSelector);
-  const config = panelId && configsById ? maybeCast<Config>(configsById[panelId]) : undefined;
+  const configSelector = useCallback(
+    (state: DeepPartial<LayoutState>) => {
+      if (panelId == undefined) {
+        return undefined;
+      }
+      return maybeCast<Config>(state.selectedLayout?.data?.configById?.[panelId]);
+    },
+    [panelId],
+  );
+
+  const config = useCurrentLayoutSelector(configSelector);
 
   const saveConfig: SaveConfig<Config> = useCallback(
     (newConfig) => {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -132,6 +132,7 @@ describe("CurrentLayoutProvider", () => {
       { selectedLayout: { loading: true, id: "example", data: undefined } },
       { selectedLayout: { loading: false, id: "example", data: expectedState } },
     ]);
+    (console.warn as jest.Mock).mockClear();
   });
 
   it("saves new layout selection into UserProfile", async () => {
@@ -180,6 +181,7 @@ describe("CurrentLayoutProvider", () => {
       { selectedLayout: { loading: true, id: "example2", data: undefined } },
       { selectedLayout: { loading: false, id: "example2", data: newLayout } },
     ]);
+    (console.warn as jest.Mock).mockClear();
   });
 
   it("saves layout updates into LayoutStorage", async () => {
@@ -225,6 +227,7 @@ describe("CurrentLayoutProvider", () => {
       { selectedLayout: { loading: false, id: "example", data: TEST_LAYOUT } },
       { selectedLayout: { loading: false, id: "example", data: newState } },
     ]);
+    (console.warn as jest.Mock).mockClear();
   });
 
   it("keeps identity of action functions when modifying layout", async () => {
@@ -262,5 +265,6 @@ describe("CurrentLayoutProvider", () => {
     );
     await act(() => layoutStoragePutCalled);
     expect(result.current.actions.savePanelConfigs).toBe(actions.savePanelConfigs);
+    (console.warn as jest.Mock).mockClear();
   });
 });


### PR DESCRIPTION
**User-Facing Changes**
None.

**Description**
This converts the config selector we use in `useConfigsById` to a stable function.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2932 