### PR TITLE
Default to development backend routes in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ $ yarn start        # launch electron
 # To launch the browser app:
 $ yarn web:serve
 
-# To launch the browser app using the dev backend server:
-$ yarn web:serve:dev
-
 # To launch the browser app using a local instance of the backend server:
 $ yarn web:serve:local
 

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -80,7 +80,7 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
     plugins: [
       ...plugins,
       ...(appWebpackConfig.plugins ?? []),
-      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND)),
+      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND ?? argv.mode)),
       new HtmlWebpackPlugin({
         templateContent: `
   <!doctype html>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "web:build:dev": "webpack --mode development --progress --config web/webpack.config.ts",
     "web:build:prod": "webpack --mode production --progress --config web/webpack.config.ts",
     "web:serve": "webpack serve --mode development --progress --config web/webpack.config.ts",
-    "web:serve:dev": "webpack serve --mode development --progress --config web/webpack.config.ts --env FOXGLOVE_BACKEND=dev",
     "web:serve:local": "webpack serve --mode development --progress --config web/webpack.config.ts --env FOXGLOVE_BACKEND=local",
     "license-check": "ts-node ci/license-check.ts",
     "lint": "TIMING=1 eslint --report-unused-disable-directives --fix .",

--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -10,7 +10,7 @@ function serverURLsForBackend(backend: string): { api: string; console: string }
     };
   }
 
-  if (backend === "dev") {
+  if (backend === "development") {
     return {
       api: "https://api-dev.foxglove.dev",
       console: "https://console-dev.foxglove.dev",

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -102,7 +102,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     plugins: [
       ...plugins,
       ...(appWebpackConfig.plugins ?? []),
-      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND)),
+      new EnvironmentPlugin(buildEnvironmentDefaults(argv.env?.FOXGLOVE_BACKEND ?? argv.mode)),
       new CopyPlugin({
         patterns: [{ from: "../public" }],
       }),


### PR DESCRIPTION

**User-Facing Changes**
None.

**Description**
Use the webpack _mode_ as the default value for determining which url routes to use. This changes the default routes in development to the development routes for web and desktop.

FOXGLOVE_BACKEND can still override the mode.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
