### PR TITLE
Fix ErrorDisplay scrolling and styling tweaks

### DIFF
--- a/packages/studio-base/src/.storybook/preview.tsx
+++ b/packages/studio-base/src/.storybook/preview.tsx
@@ -98,8 +98,15 @@ function WithContextProviders(Child: Story, ctx: StoryContext): JSX.Element {
       }
 
       {(colorScheme === "light" || colorScheme.startsWith("both")) && (
-        // Set a transform to make this the root for position:fixed elements
-        <div style={{ position: "relative", transform: "scale(1)", flexGrow: 1 }}>
+        <div
+          style={{
+            position: "relative",
+            transform: "scale(1)", // Set a transform to make this the root for position:fixed elements
+            flexGrow: 1,
+            flexBasis: "50%",
+            overflow: "hidden",
+          }}
+        >
           <ReadySignalContext.Provider
             value={needsCombinedReadySignal ? readySignal1 : readySignal}
           >
@@ -114,8 +121,15 @@ function WithContextProviders(Child: Story, ctx: StoryContext): JSX.Element {
         </div>
       )}
       {(colorScheme === "dark" || colorScheme.startsWith("both")) && (
-        // Set a transform to make this the root for position:fixed elements
-        <div style={{ position: "relative", transform: "scale(1)", flexGrow: 1 }}>
+        <div
+          style={{
+            position: "relative",
+            transform: "scale(1)", // Set a transform to make this the root for position:fixed elements
+            flexGrow: 1,
+            flexBasis: "50%",
+            overflow: "hidden",
+          }}
+        >
           <ReadySignalContext.Provider
             value={needsCombinedReadySignal ? readySignal2 : readySignal}
           >

--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -43,3 +43,13 @@ export const Default: Story = () => {
     </DndProvider>
   );
 };
+
+export const ShowingDetails: Story = () => {
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <ErrorBoundary showErrorDetails>
+        <Broken />
+      </ErrorBoundary>
+    </DndProvider>
+  );
+};

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -31,18 +31,16 @@ export default class ErrorBoundary extends Component<PropsWithChildren<Props>, S
   override render(): ReactNode {
     if (this.state.currentError) {
       const actions = this.props.actions ?? (
-        <>
-          <Stack direction="row" spacing={1}>
-            <Box flexGrow={1} />
-            <Button
-              variant="outlined"
-              color="secondary"
-              onClick={() => this.setState({ currentError: undefined })}
-            >
-              Dismiss
-            </Button>
-          </Stack>
-        </>
+        <Stack direction="row" spacing={1}>
+          <Box flexGrow={1} />
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={() => this.setState({ currentError: undefined })}
+          >
+            Dismiss
+          </Button>
+        </Stack>
       );
       return (
         <ErrorDisplay
@@ -50,11 +48,11 @@ export default class ErrorBoundary extends Component<PropsWithChildren<Props>, S
           errorInfo={this.state.currentError.errorInfo}
           content={
             <p>
-              Something went wrong in the app.{" "}
+              Something went wrong.{" "}
               <Link color="inherit" onClick={() => this.setState({ currentError: undefined })}>
                 Dismiss this error
               </Link>{" "}
-              to continue using the app. If the issue persists try restarting the app.
+              to continue using the app. If the issue persists, try restarting the app.
             </p>
           }
           actions={actions}

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -12,6 +12,7 @@ import ErrorDisplay from "./ErrorDisplay";
 
 type Props = {
   actions?: JSX.Element;
+  showErrorDetails?: boolean;
 };
 
 type State = {
@@ -44,6 +45,7 @@ export default class ErrorBoundary extends Component<PropsWithChildren<Props>, S
       );
       return (
         <ErrorDisplay
+          showErrorDetails={this.props.showErrorDetails}
           error={this.state.currentError.error}
           errorInfo={this.state.currentError.errorInfo}
           content={

--- a/packages/studio-base/src/components/ErrorDisplay.tsx
+++ b/packages/studio-base/src/components/ErrorDisplay.tsx
@@ -70,13 +70,14 @@ type ErrorDisplayProps = {
   errorInfo?: ErrorInfo;
   content?: JSX.Element;
   actions?: JSX.Element;
+  showErrorDetails?: boolean;
 };
 
 function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
   const styles = useStyles();
   const { error, errorInfo } = props;
 
-  const [showErrorDetails, setShowErrorDetails] = useState(false);
+  const [showErrorDetails, setShowErrorDetails] = useState(props.showErrorDetails ?? false);
 
   const errorDetails = useMemo(() => {
     if (!showErrorDetails) {

--- a/packages/studio-base/src/components/ErrorDisplay.tsx
+++ b/packages/studio-base/src/components/ErrorDisplay.tsx
@@ -12,12 +12,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: "column",
     height: "100%",
     padding: theme.spacing(2),
+    overflow: "auto",
   },
   alertContainer: {
     display: "flex",
     flexDirection: "column",
     flexGrow: 1,
-    overflow: "hidden",
   },
   errorDetailHeader: {
     fontWeight: "bold",
@@ -28,8 +28,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: theme.spacing(2),
   },
   errorDetailContainer: {
-    flexGrow: 2,
     overflowY: "auto",
+    background: theme.palette.background.paper,
+    padding: theme.spacing(1),
   },
   actions: {
     paddingTop: theme.spacing(2),
@@ -109,22 +110,18 @@ function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
           {props.title ?? "The app encountered an unexpected error"}
         </Typography>
         <Stack spacing={2}>
-          <div>
-            <Typography variant="body1" component="div">
-              {props.content}
-            </Typography>
-          </div>
+          <Typography variant="body1" component="div">
+            {props.content}
+          </Typography>
           <Divider />
-          <div>
-            <Typography variant="subtitle2">{error?.message}</Typography>
-          </div>
-          <div>
-            <Link color="secondary" onClick={() => setShowErrorDetails(!showErrorDetails)}>
-              {showErrorDetails ? "Hide" : "Show"} details
-            </Link>
-          </div>
+          <Typography variant="subtitle2" component="code" fontWeight="bold">
+            {error?.message}
+          </Typography>
+          <Link color="secondary" onClick={() => setShowErrorDetails(!showErrorDetails)}>
+            {showErrorDetails ? "Hide" : "Show"} details
+          </Link>
+          {errorDetails && <div className={styles.errorDetailContainer}>{errorDetails}</div>}
         </Stack>
-        <div className={styles.errorDetailContainer}>{errorDetails}</div>
       </div>
       <div className={styles.actions}>{props.actions}</div>
     </div>

--- a/packages/studio-base/src/components/PanelErrorBoundary.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.tsx
@@ -33,16 +33,16 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
     if (this.state.currentError) {
       return (
         <ErrorDisplay
-          title="The panel encountered an unexpected error"
+          title="This panel encountered an unexpected error"
           error={this.state.currentError.error}
           errorInfo={this.state.currentError.errorInfo}
           content={
             <p>
-              Something went wrong in the panel.{" "}
+              Something went wrong in this panel.{" "}
               <Link color="inherit" onClick={() => this.setState({ currentError: undefined })}>
                 Dismiss this error
               </Link>{" "}
-              to continue using the panel. If the issue persists try resetting the panel.
+              to continue using this panel. If the issue persists, try resetting the panel.
             </p>
           }
           actions={
@@ -51,7 +51,7 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
                 <Box flexGrow={1} />
                 <Button
                   variant="text"
-                  title="remove the panel"
+                  title="Remove this panel from the layout"
                   color="error"
                   onClick={this.props.onRemovePanel}
                 >
@@ -59,7 +59,7 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
                 </Button>
                 <Button
                   variant="outlined"
-                  title="reset panel settings to default values"
+                  title="Reset panel settings to default values"
                   color="error"
                   onClick={() => {
                     this.setState({ currentError: undefined });

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -140,7 +140,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       },
       styleOverrides: {
         root: {
-          cursor: "ppointer",
+          cursor: "pointer",
         },
       },
     },


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
- Fix #2931 by making error boundary scrollable
- Use monospace font for error message
- Add a background to the error stack
- Fix the `cursor` style on links
- Remove some extraneous styles & elements