### PR TITLE
Fix crashes resulting from negative hover times

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -90,7 +90,12 @@ export default function PlaybackBarHoverTicks(props: Props): JSX.Element {
   });
 
   const hoverTimeDisplay = useMemo(() => {
-    if (!hoverValue || hoverValue.type !== "PLAYBACK_SECONDS" || !startTime) {
+    if (
+      !hoverValue ||
+      hoverValue.type !== "PLAYBACK_SECONDS" ||
+      !startTime ||
+      hoverValue.value < 0
+    ) {
       return undefined;
     }
     const stamp = add(startTime, fromSec(hoverValue.value));

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -423,9 +423,10 @@ function Plot(props: Props) {
       if (!seekPlayback || !start || seekSeconds == undefined || xAxisVal !== "timestamp") {
         return;
       }
-      // The player validates and clamps the time.
-      const seekTime = addTimes(start, fromSec(seekSeconds));
-      seekPlayback(seekTime);
+      // Avoid normalizing a negative time if the clicked point had x < 0.
+      if (seekSeconds >= 0) {
+        seekPlayback(addTimes(start, fromSec(seekSeconds)));
+      }
     },
     [messagePipeline, xAxisVal],
   );


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash when hovering or clicking on a negative timestamp in the Plot panel.

**Description**
When hovering on a negative x-axis value in the plot, if the hovered absolute time (start time + negative elapsed time) was <0, the app would crash when attempting to normalize the time value for display in the playback bar. Once that was fixed, it would crash when _clicking_ on the negative time.

This issue was particularly noticeable when using "simulated" timestamp values, i.e. data which starts from time 0, because you don't have to pan/zoom very far to be able to access negative plot ranges that trigger the crash.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/14237/156228481-3130d8a6-b523-433d-9fe0-ee41568e412d.png">
