### PR TITLE
Fix word selection in Raw Messages by adding invisible space

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -139,6 +139,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: "100%",
     lineHeight: "20px",
   },
+  invisibleSpace: {
+    // https://stackoverflow.com/questions/62319014/make-text-selection-treat-adjacent-elements-as-separate-words
+    fontSize: 0,
+  },
 }));
 
 function RawMessages(props: Props) {
@@ -414,7 +418,12 @@ function RawMessages(props: Props) {
               </div>
             )}
             <Tree
-              labelRenderer={(raw) => <DiffSpan>{first(raw)}</DiffSpan>}
+              labelRenderer={(raw) => (
+                <>
+                  <DiffSpan>{first(raw)}</DiffSpan>
+                  <span className={classes.invisibleSpace}>&nbsp;</span>
+                </>
+              )}
               shouldExpandNode={shouldExpandNode}
               onExpand={(_data, _level, keyPath) => {
                 onLabelClick(keyPath);


### PR DESCRIPTION
**User-Facing Changes**
Improved double-clicking to select text values in the Raw Messages panel.

**Description**
Fixes #2928