### PR TITLE
Quick Look preview visual updates for small viewports

### DIFF
--- a/desktop/quicklook/FileInfoDisplay.tsx
+++ b/desktop/quicklook/FileInfoDisplay.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import styled from "styled-components";
 
 import Logger from "@foxglove/log";
@@ -12,6 +12,7 @@ import bagIcon from "../../resources/icon/BagIcon.png";
 import mcapIcon from "../../resources/icon/McapIcon.png";
 import Flash from "./Flash";
 import formatByteSize from "./formatByteSize";
+import * as styleConstants from "./styleConstants";
 import { FileInfo, TopicInfo } from "./types";
 
 const log = Logger.getLogger(__filename);
@@ -50,6 +51,10 @@ const IconContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  @media (max-width: ${styleConstants.breakpoints.narrowMaxWidth}) {
+    display: none;
+  }
 `;
 
 const FileType = styled.span`
@@ -63,10 +68,13 @@ const TimeLabel = styled.span`
 `;
 
 const TopicList = styled.table`
-  width: 100%;
-  max-width: 100%;
   word-break: break-word;
   border-spacing: 0 4px;
+
+  @media (max-width: ${styleConstants.breakpoints.narrowMaxWidth}) {
+    margin-left: -${styleConstants.bodyPadding};
+    margin-right: -${styleConstants.bodyPadding};
+  }
 `;
 
 const TopicRowWrapper = styled.tr`
@@ -80,11 +88,15 @@ const TopicRowWrapper = styled.tr`
     }
     > :first-child {
       background: var(--zebra-color);
-      border-radius: 4px 0 0 4px;
+      @media (min-width: ${styleConstants.breakpoints.narrowMinWidth}) {
+        border-radius: 4px 0 0 4px;
+      }
     }
     > :last-child {
       background: var(--zebra-color);
-      border-radius: 0 4px 4px 0;
+      @media (min-width: ${styleConstants.breakpoints.narrowMinWidth}) {
+        border-radius: 0 4px 4px 0;
+      }
     }
   }
   border-collapse: separate;
@@ -120,6 +132,17 @@ const Datatype = styled.div`
   opacity: 0.5;
 `;
 
+const HideNarrow = styled.div`
+  @media (max-width: ${styleConstants.breakpoints.narrowMaxWidth}) {
+    display: none;
+  }
+`;
+const ShowNarrow = styled.div`
+  @media (min-width: ${styleConstants.breakpoints.narrowMinWidth}) {
+    display: none;
+  }
+`;
+
 function TopicRow({ info: { topic, datatype, numMessages, numConnections } }: { info: TopicInfo }) {
   return (
     <TopicRowWrapper>
@@ -139,7 +162,7 @@ function formatCount(count: number | bigint | undefined, noun: string): string |
   if (count == undefined || count === 0 || count === 0n) {
     return undefined;
   }
-  return `${count.toLocaleString()} ${noun}${count === 1 || count === 1n ? "" : "s"}`;
+  return `${count.toLocaleString()}\xa0${noun}${count === 1 || count === 1n ? "" : "s"}`;
 }
 
 export default function FileInfoDisplay({
@@ -151,13 +174,20 @@ export default function FileInfoDisplay({
   fileInfo?: FileInfo;
   error?: Error;
 }): JSX.Element {
+  const compressionTypes = useMemo(
+    () =>
+      fileInfo?.compressionTypes &&
+      Array.from(fileInfo.compressionTypes)
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b)),
+    [fileInfo?.compressionTypes],
+  );
   useEffect(() => error && console.error(error), [error]);
   return (
-    <div style={{ width: "100%" }}>
+    <div style={{ width: "100%", display: "flex", flexDirection: "column" }}>
       <div
         style={{
           display: "flex",
-          flexFlow: "row wrap",
           alignItems: "center",
           justifyContent: "center",
           marginBottom: 16,
@@ -165,10 +195,21 @@ export default function FileInfoDisplay({
       >
         <IconContainer>
           <img src={fileStats.name.endsWith(".mcap") ? mcapIcon : bagIcon} style={{ width: 128 }} />
-          {fileInfo?.fileType && <FileType>{fileInfo.fileType}</FileType>}
+          {fileInfo?.fileType && (
+            <HideNarrow>
+              <FileType>{fileInfo.fileType}</FileType>
+            </HideNarrow>
+          )}
         </IconContainer>
-        <div style={{ display: "flex", flexDirection: "column", minWidth: 300, flex: "1 1 0" }}>
-          <FileName>{fileStats.name}</FileName>
+        <div style={{ display: "flex", flexDirection: "column", flex: "1 1 0" }}>
+          <HideNarrow>
+            <FileName>{fileStats.name}</FileName>
+          </HideNarrow>
+          {fileInfo?.fileType && (
+            <ShowNarrow>
+              <FileType>{fileInfo.fileType}</FileType>
+            </ShowNarrow>
+          )}
           <SummaryRow>
             {fileInfo &&
               [
@@ -181,15 +222,9 @@ export default function FileInfoDisplay({
                 .filter(Boolean)
                 .join(", ")}
           </SummaryRow>
-          {fileInfo?.compressionTypes && (
+          {compressionTypes && (
             <SummaryRow>
-              Compression:{" "}
-              {fileInfo.compressionTypes.size === 0
-                ? "none"
-                : Array.from(fileInfo.compressionTypes)
-                    .filter(Boolean)
-                    .sort((a, b) => a.localeCompare(b))
-                    .join(", ")}
+              Compression: {compressionTypes.length === 0 ? "none" : compressionTypes.join(", ")}
             </SummaryRow>
           )}
           {fileInfo?.startTime && (

--- a/desktop/quicklook/FileInfoDisplay.tsx
+++ b/desktop/quicklook/FileInfoDisplay.tsx
@@ -217,7 +217,7 @@ export default function FileInfoDisplay({
                 formatCount(fileInfo.numChunks, "chunk"),
                 formatCount(fileInfo.totalMessages, "message"),
                 formatCount(fileInfo.numAttachments, "attachment"),
-                formatByteSize(fileStats.size),
+                formatByteSize(fileStats.size).replace(/ /g, "\xa0"),
               ]
                 .filter(Boolean)
                 .join(", ")}

--- a/desktop/quicklook/formatByteSize.ts
+++ b/desktop/quicklook/formatByteSize.ts
@@ -10,5 +10,5 @@ export default function formatByteSize(size: number): string {
     value /= 1024;
     suffix++;
   }
-  return `${value.toFixed(suffix === 0 ? 0 : 1)}\xa0${suffixes[suffix]}`;
+  return `${value.toFixed(suffix === 0 ? 0 : 1)} ${suffixes[suffix]}`;
 }

--- a/desktop/quicklook/formatByteSize.ts
+++ b/desktop/quicklook/formatByteSize.ts
@@ -10,5 +10,5 @@ export default function formatByteSize(size: number): string {
     value /= 1024;
     suffix++;
   }
-  return `${value.toFixed(suffix === 0 ? 0 : 1)} ${suffixes[suffix]}`;
+  return `${value.toFixed(suffix === 0 ? 0 : 1)}\xa0${suffixes[suffix]}`;
 }

--- a/desktop/quicklook/getBagInfo.ts
+++ b/desktop/quicklook/getBagInfo.ts
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Bag } from "@foxglove/rosbag";
+import { BlobReader } from "@foxglove/rosbag/web";
+
+import { FileInfo, TopicInfo } from "./types";
+
+export async function getBagInfo(file: File): Promise<FileInfo> {
+  const bag = new Bag(new BlobReader(file));
+  await bag.open();
+  const numMessagesByConnectionIndex = Array.from(bag.connections.values(), () => 0n);
+  let totalMessages = 0n;
+  for (const chunk of bag.chunkInfos) {
+    for (const { conn, count } of chunk.connections) {
+      numMessagesByConnectionIndex[conn] += BigInt(count);
+      totalMessages += BigInt(count);
+    }
+  }
+
+  const topicInfosByTopic = new Map<string, TopicInfo>();
+  for (const { topic, type: datatype, conn } of bag.connections.values()) {
+    const info = topicInfosByTopic.get(topic);
+    const numMessages = numMessagesByConnectionIndex[conn];
+    if (info != undefined) {
+      if (info.datatype !== datatype) {
+        info.datatype = "(multiple)";
+      }
+      if (numMessages != undefined) {
+        info.numMessages = (info.numMessages ?? 0n) + numMessages;
+      }
+      info.numConnections++;
+    } else {
+      topicInfosByTopic.set(topic, {
+        topic,
+        datatype: datatype ?? "(unknown)",
+        numMessages,
+        numConnections: 1,
+      });
+    }
+  }
+  const topics = [...topicInfosByTopic.values()].sort((a, b) => a.topic.localeCompare(b.topic));
+  return {
+    fileType: undefined,
+    totalMessages,
+    numChunks: bag.chunkInfos.length,
+    startTime: bag.startTime ?? undefined,
+    endTime: bag.endTime ?? undefined,
+    topics,
+  };
+}

--- a/desktop/quicklook/getMcapInfo.ts
+++ b/desktop/quicklook/getMcapInfo.ts
@@ -10,61 +10,15 @@ import {
   DETECT_VERSION_BYTES_REQUIRED,
 } from "@foxglove/mcap";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
-import { Bag } from "@foxglove/rosbag";
-import { BlobReader } from "@foxglove/rosbag/web";
 
 import getIndexedMcapInfo from "./getIndexedMcapInfo";
 import getStreamedMcapInfo, {
   processMcap0Record,
   processMcapPre0Record,
 } from "./getStreamedMcapInfo";
-import { FileInfo, TopicInfo } from "./types";
+import { FileInfo } from "./types";
 
 const log = Logger.getLogger(__filename);
-
-export async function getBagInfo(file: File): Promise<FileInfo> {
-  const bag = new Bag(new BlobReader(file));
-  await bag.open();
-  const numMessagesByConnectionIndex = Array.from(bag.connections.values(), () => 0n);
-  let totalMessages = 0n;
-  for (const chunk of bag.chunkInfos) {
-    for (const { conn, count } of chunk.connections) {
-      numMessagesByConnectionIndex[conn] += BigInt(count);
-      totalMessages += BigInt(count);
-    }
-  }
-
-  const topicInfosByTopic = new Map<string, TopicInfo>();
-  for (const { topic, type: datatype, conn } of bag.connections.values()) {
-    const info = topicInfosByTopic.get(topic);
-    const numMessages = numMessagesByConnectionIndex[conn];
-    if (info != undefined) {
-      if (info.datatype !== datatype) {
-        info.datatype = "(multiple)";
-      }
-      if (numMessages != undefined) {
-        info.numMessages = (info.numMessages ?? 0n) + numMessages;
-      }
-      info.numConnections++;
-    } else {
-      topicInfosByTopic.set(topic, {
-        topic,
-        datatype: datatype ?? "(unknown)",
-        numMessages,
-        numConnections: 1,
-      });
-    }
-  }
-  const topics = [...topicInfosByTopic.values()].sort((a, b) => a.topic.localeCompare(b.topic));
-  return {
-    fileType: undefined,
-    totalMessages,
-    numChunks: bag.chunkInfos.length,
-    startTime: bag.startTime ?? undefined,
-    endTime: bag.endTime ?? undefined,
-    topics,
-  };
-}
 
 export async function getMcapInfo(file: File): Promise<FileInfo> {
   const mcapVersion = detectVersion(

--- a/desktop/quicklook/index.tsx
+++ b/desktop/quicklook/index.tsx
@@ -13,7 +13,9 @@ import Logger from "@foxglove/log";
 
 import FileInfoDisplay from "./FileInfoDisplay";
 import Flash from "./Flash";
-import { getBagInfo, getMcapInfo } from "./getInfo";
+import { getBagInfo } from "./getBagInfo";
+import { getMcapInfo } from "./getMcapInfo";
+import * as styleConstants from "./styleConstants";
 
 const log = Logger.getLogger(__filename);
 
@@ -40,7 +42,8 @@ const GlobalStyle = createGlobalStyle`
     }
   }
   body {
-    padding: 10px;
+    padding: ${styleConstants.bodyPadding};
+    min-width: 150px;
     font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont;
     @media (prefers-color-scheme: dark) {
       color: #fff;

--- a/desktop/quicklook/styleConstants.ts
+++ b/desktop/quicklook/styleConstants.ts
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const bodyPadding = "10px";
+
+export const breakpoints = {
+  narrowMaxWidth: "399.99px",
+  narrowMinWidth: "400px",
+};

--- a/desktop/webpack.config.ts
+++ b/desktop/webpack.config.ts
@@ -6,7 +6,7 @@ import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import type { Configuration } from "webpack";
-import type { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
+import "webpack-dev-server";
 
 import packageJson from "../package.json";
 import main from "./webpack.main.config";
@@ -14,17 +14,13 @@ import preload from "./webpack.preload.config";
 import quicklook from "./webpack.quicklook.config";
 import renderer from "./webpack.renderer.config";
 
-interface WebpackConfiguration extends Configuration {
-  devServer?: WebpackDevServerConfiguration;
-}
-
 const isRelease = process.env.RELEASE != undefined;
 
 // The appdata directory is derived from the product name. To have a separate directory
 // for our production and development builds we change the product name when using dev or serve.
 const productName = isRelease ? packageJson.productName : `${packageJson.productName} Dev`;
 
-const devServerConfig: WebpackConfiguration = {
+const devServerConfig: Configuration = {
   // Use empty entry to avoid webpack default fallback to /src
   entry: {},
 

--- a/desktop/webpack.quicklook.config.ts
+++ b/desktop/webpack.quicklook.config.ts
@@ -8,9 +8,18 @@ import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import ReactRefreshTypescript from "react-refresh-typescript";
+import createStyledComponentsTransformer from "typescript-plugin-styled-components";
 import { Configuration, ProvidePlugin } from "webpack";
+import "webpack-dev-server";
 
 import type { WebpackArgv } from "@foxglove/studio-base/WebpackArgv";
+
+const styledComponentsTransformer = createStyledComponentsTransformer({
+  getDisplayName: (filename, bindingName) => {
+    const sanitizedFilename = path.relative(__dirname, filename).replace(/[^a-zA-Z0-9_-]/g, "_");
+    return bindingName != undefined ? `${bindingName}__${sanitizedFilename}` : sanitizedFilename;
+  },
+});
 
 export default (_env: unknown, argv: WebpackArgv): Configuration => {
   const isDev = argv.mode === "development";
@@ -48,6 +57,7 @@ export default (_env: unknown, argv: WebpackArgv): Configuration => {
               projectReferences: true,
               getCustomTransformers: () => ({
                 before: [
+                  styledComponentsTransformer,
                   // only include refresh plugin when using webpack server
                   ...(isServe ? [ReactRefreshTypescript()] : []),
                 ],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:dev": "webpack --mode development --progress --config desktop/webpack.config.ts",
     "build:prod": "webpack --mode production --progress --config desktop/webpack.config.ts",
     "serve": "webpack serve --mode development --progress --config desktop/webpack.config.ts",
+    "serve:quicklook": "webpack serve --mode development --progress --config desktop/webpack.quicklook.config.ts",
     "web:build:dev": "webpack --mode development --progress --config web/webpack.config.ts",
     "web:build:prod": "webpack --mode production --progress --config web/webpack.config.ts",
     "web:serve": "webpack serve --mode development --progress --config web/webpack.config.ts",


### PR DESCRIPTION
**User-Facing Changes**
Improved macOS Quick Look preview when displayed at small sizes (such as in the Get Info window in Finder).

**Description**

- Added `yarn serve:quicklook` for faster development
- Added styled-components transformer (which we already using in our other webpack builds) for better CSS class names
- Added breakpoint for small sizes
- Remove extra table padding at small sizes
- Use some non-breaking spaces to avoid breaking in weird places
- Fixed filtering of `compression` values so that `""` displays as `Compression: none`

Before:

<img width="272" alt="image" src="https://user-images.githubusercontent.com/14237/156275284-ea322d75-e238-4276-a00d-f75725a44f64.png">

After:

<img width="200" alt="Screen Shot 2022-03-01 at 4 59 03 PM" src="https://user-images.githubusercontent.com/14237/156275151-bd1f5286-2fed-418a-a9e0-1333672f0f1c.png"> <img width="400" alt="Screen Shot 2022-03-01 at 4 59 13 PM" src="https://user-images.githubusercontent.com/14237/156275170-f75c8830-0d8e-4bc4-8c56-046e0a1b529f.png">
