### PR TITLE
Build Stack component without use of sx prop

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -11,7 +11,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Link, Text, useTheme } from "@fluentui/react";
-import { Box, Stack } from "@mui/material";
+import { Box } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { extname } from "path";
 import {
@@ -54,6 +54,7 @@ import Preferences from "@foxglove/studio-base/components/Preferences";
 import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
 import Sidebar, { SidebarItem } from "@foxglove/studio-base/components/Sidebar";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { URLStateSyncAdapter } from "@foxglove/studio-base/components/URLStateSyncAdapter";
 import { useAssets } from "@foxglove/studio-base/context/AssetsContext";
 import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";

--- a/packages/studio-base/src/components/Stack.stories.tsx
+++ b/packages/studio-base/src/components/Stack.stories.tsx
@@ -36,7 +36,7 @@ function Box({ children }: PropsWithChildren<StackProps>): JSX.Element {
 
 export function Default(): JSX.Element {
   return (
-    <Stack padding={2} gap={2} fullHeight>
+    <Stack data-test padding={2} gap={2} fullHeight>
       <Stack direction="row" gap={2}>
         {ITEMS.map((_, index) => (
           <Stack flex="auto" key={index}>

--- a/packages/studio-base/src/components/Stack.stories.tsx
+++ b/packages/studio-base/src/components/Stack.stories.tsx
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useTheme } from "@mui/material";
+import { PropsWithChildren } from "react";
+
+import Stack, { StackProps } from "./Stack";
+
+export default {
+  component: Stack,
+  title: "components/Stack",
+};
+
+const ITEMS = new Array(3).fill({});
+
+function Box({ children }: PropsWithChildren<StackProps>): JSX.Element {
+  const theme = useTheme();
+
+  return (
+    <Stack
+      alignItems="center"
+      justifyContent="center"
+      padding={1}
+      style={{
+        textAlign: "center",
+        border: `1px solid ${theme.palette.divider}`,
+        backgroundColor: theme.palette.action.hover,
+        height: "100%",
+      }}
+    >
+      {children}
+    </Stack>
+  );
+}
+
+export function Default(): JSX.Element {
+  return (
+    <Stack padding={2} gap={2} fullHeight>
+      <Stack direction="row" gap={2}>
+        {ITEMS.map((_, index) => (
+          <Stack flex="auto" key={index}>
+            <Box>{`Row item ${index + 1}`}</Box>
+          </Stack>
+        ))}
+      </Stack>
+      <Stack flexGrow={2} justifyContent="space-between" gap={2}>
+        <Stack direction="row" gap={2} justifyContent="flex-start">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Row item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+        <Stack direction="row" justifyContent="center" gap={2} alignSelf="center">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Row item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+        <Stack direction="row" justifyContent="flex-end" gap={2} alignSelf="flex-end">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Row item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+      </Stack>
+      <Stack gap={2} justifyContent="space-between">
+        {ITEMS.map((_, index) => (
+          <Stack flex="auto" key={index}>
+            <Box>{`Col item ${index + 1}`}</Box>
+          </Stack>
+        ))}
+      </Stack>
+      <Stack flex="auto" gap={2} justifyContent="space-between">
+        <Stack gap={2} alignSelf="flex-start">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Col item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+        <Stack gap={2} alignSelf="center">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Col item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+        <Stack gap={2} alignSelf="flex-end">
+          {ITEMS.map((_, index) => (
+            <Box key={index}>{`Col item ${index + 1}`}</Box>
+          ))}
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -220,5 +220,5 @@ export type StackProps = {
   order?: number;
 
   /** CSS styles to apply to the component. */
-  style?: React.CSSProperties;
+  style?: CSSProperties;
 };

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { generateUtilityClass, unstable_composeClasses as composeClasses } from "@mui/base";
+import { styled as muiStyled, Theme, useTheme } from "@mui/material";
+import cx from "classnames";
+import { ElementType, PropsWithChildren } from "react";
+
+function getStackUtilityClass(slot: string): string {
+  return generateUtilityClass("FoxgloveStack", slot);
+}
+
+const StackRoot = muiStyled("div", {
+  name: "FoxgloveStack",
+  slot: "Root",
+  overridesResolver: (_props, styles) => {
+    return [styles.root];
+  },
+})(({ theme, ownerState }: { theme: Theme; ownerState: StackProps }) => ({
+  display: "flex",
+  flexDirection: ownerState.direction,
+  flexWrap: ownerState.wrap,
+  justifyContent: ownerState.justifyContent,
+  alignItems: ownerState.alignItems,
+  alignContent: ownerState.alignContent,
+  alignSelf: ownerState.alignSelf,
+  gap: typeof ownerState.gap === "number" ? theme.spacing(ownerState.gap) : ownerState.gap,
+  padding:
+    typeof ownerState.padding === "number" ? theme.spacing(ownerState.padding) : ownerState.padding,
+  flex: typeof ownerState.flex === "number" ? ownerState.flex : ownerState.flex,
+
+  ...(ownerState.fullHeight === true && {
+    height: "100%",
+  }),
+}));
+
+export default function Stack(props: PropsWithChildren<StackProps>): JSX.Element {
+  const theme = useTheme();
+
+  const {
+    alignItems,
+    alignSelf,
+    className,
+    component = "div",
+    direction = "column",
+    flex,
+    flexBasis,
+    flexGrow,
+    flexShrink,
+    fullHeight = false,
+    gap,
+    justifyContent,
+    padding,
+    wrap,
+    style,
+    ...other
+  } = props;
+
+  const ownerState = {
+    ...props,
+    alignItems,
+    alignSelf,
+    direction,
+    flex,
+    flexBasis,
+    flexGrow,
+    flexShrink,
+    fullHeight,
+    gap,
+    justifyContent,
+    padding,
+    wrap,
+  };
+
+  const classes = composeClasses({ root: ["root"] }, getStackUtilityClass, ownerState.classes);
+
+  return (
+    <StackRoot
+      as={component}
+      className={cx(classes.root, className)}
+      ownerState={ownerState}
+      theme={theme}
+      style={style}
+      {...other}
+    />
+  );
+}
+
+export type StackProps = {
+  /**
+   * Override or extend the styles applied to the component.
+   */
+  classes?: {
+    root: string;
+  };
+
+  /**
+   * @ignore
+   */
+  className?: string;
+
+  /**
+   * The component used for the root node.
+   * Either a string to use a HTML element or a component.
+   */
+  component?: ElementType;
+
+  /**
+   * Defines the `flex-direction` style property.
+   * @default 'column'
+   */
+  direction?: "column" | "column-reverse" | "row-reverse" | "row";
+
+  /**
+   * Make stack 100% height.
+   */
+  fullHeight?: boolean;
+
+  /**
+   * Defines the `flex-wrap` style property.
+   */
+  wrap?: "nowrap" | "wrap" | "wrap-reverse";
+
+  /**
+   * Defines the `justify-content` style property.
+   */
+  justifyContent?:
+    | "flex-start"
+    | "flex-end"
+    | "center"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+    | "start"
+    | "end"
+    | "left"
+    | "right";
+
+  /**
+   * Defines the `align-items` style property.
+   */
+  alignItems?:
+    | "stretch"
+    | "flex-start"
+    | "flex-end"
+    | "center"
+    | "baseline"
+    | "first baseline"
+    | "last baseline"
+    | "start"
+    | "end"
+    | "self-start"
+    | "self-end";
+
+  /**
+   * Defines the `align-content` style property.
+   */
+  alignContent?:
+    | "flex-start"
+    | "flex-end"
+    | "center"
+    | "space-between"
+    | "space-around"
+    | "space-evenly"
+    | "stretch"
+    | "start"
+    | "end"
+    | "baseline"
+    | "first baseline"
+    | "last baseline";
+
+  /**
+   * Defines the `align-self` style property.
+   */
+  alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "baseline" | "stretch";
+
+  /**
+   * Defines the `gap` style property.
+   */
+  gap?: number | string;
+
+  /**
+   * Defines the `padding` style property.
+   */
+  padding?: number | string;
+
+  /**
+   * Defines the `flex` style property.
+   */
+  flex?: number | string;
+
+  /**
+   * Defines the `flex-grow` style property.
+   */
+  flexGrow?: number;
+
+  /**
+   * Defines the `flex-shrink` style property.
+   */
+  flexShrink?: number;
+
+  /**
+   * Defines the `flex-basis` style property.
+   */
+  flexBasis?: number | string;
+
+  /**
+   * CSS styles to apply to the component.
+   */
+  style?: React.CSSProperties;
+};

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -141,9 +141,7 @@ export type StackProps = {
     root: string;
   };
 
-  /**
-   * @ignore
-   */
+  /** Class name applied to the root element. */
   className?: string;
 
   /**

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -5,7 +5,7 @@
 import { generateUtilityClass, unstable_composeClasses as composeClasses } from "@mui/base";
 import { styled as muiStyled, Theme, useTheme } from "@mui/material";
 import cx from "classnames";
-import { ElementType, PropsWithChildren } from "react";
+import { ElementType, CSSProperties, PropsWithChildren } from "react";
 
 function getStackUtilityClass(slot: string): string {
   return generateUtilityClass("FoxgloveStack", slot);
@@ -158,7 +158,7 @@ export type StackProps = {
    * Defines the `flex-direction` style property.
    * @default 'column'
    */
-  direction?: "column" | "column-reverse" | "row-reverse" | "row";
+  direction?: CSSProperties["flexDirection"];
 
   /**
    * Make stack 100% height.
@@ -168,60 +168,27 @@ export type StackProps = {
   /**
    * Defines the `flex-wrap` style property.
    */
-  wrap?: "nowrap" | "wrap" | "wrap-reverse";
+  wrap?: CSSProperties["flexWrap"];
 
   /**
    * Defines the `justify-content` style property.
    */
-  justifyContent?:
-    | "flex-start"
-    | "flex-end"
-    | "center"
-    | "space-between"
-    | "space-around"
-    | "space-evenly"
-    | "start"
-    | "end"
-    | "left"
-    | "right";
+  justifyContent?: CSSProperties["justifyContent"];
 
   /**
    * Defines the `align-items` style property.
    */
-  alignItems?:
-    | "stretch"
-    | "flex-start"
-    | "flex-end"
-    | "center"
-    | "baseline"
-    | "first baseline"
-    | "last baseline"
-    | "start"
-    | "end"
-    | "self-start"
-    | "self-end";
+  alignItems?: CSSProperties["alignItems"];
 
   /**
    * Defines the `align-content` style property.
    */
-  alignContent?:
-    | "flex-start"
-    | "flex-end"
-    | "center"
-    | "space-between"
-    | "space-around"
-    | "space-evenly"
-    | "stretch"
-    | "start"
-    | "end"
-    | "baseline"
-    | "first baseline"
-    | "last baseline";
+  alignContent?: CSSProperties["alignContent"];
 
   /**
    * Defines the `align-self` style property.
    */
-  alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "baseline" | "stretch";
+  alignSelf?: CSSProperties["alignSelf"];
 
   /**
    * Defines the `gap` style property using theme.spacing increments.

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -136,9 +136,7 @@ export default function Stack(props: PropsWithChildren<StackProps>): JSX.Element
 }
 
 export type StackProps = {
-  /**
-   * Override or extend the styles applied to the component.
-   */
+  /** Override or extend the styles applied to the component. */
   classes?: {
     root: string;
   };
@@ -160,113 +158,69 @@ export type StackProps = {
    */
   direction?: CSSProperties["flexDirection"];
 
-  /**
-   * Make stack 100% height.
-   */
+  /** Make stack 100% height. */
   fullHeight?: boolean;
 
-  /**
-   * Defines the `flex-wrap` style property.
-   */
+  /** Defines the `flex-wrap` style property. */
   wrap?: CSSProperties["flexWrap"];
 
-  /**
-   * Defines the `justify-content` style property.
-   */
+  /** Defines the `justify-content` style property. */
   justifyContent?: CSSProperties["justifyContent"];
 
-  /**
-   * Defines the `align-items` style property.
-   */
+  /** Defines the `align-items` style property. */
   alignItems?: CSSProperties["alignItems"];
 
-  /**
-   * Defines the `align-content` style property.
-   */
+  /** Defines the `align-content` style property. */
   alignContent?: CSSProperties["alignContent"];
 
-  /**
-   * Defines the `align-self` style property.
-   */
+  /** Defines the `align-self` style property. */
   alignSelf?: CSSProperties["alignSelf"];
 
-  /**
-   * Defines the `gap` style property using theme.spacing increments.
-   */
+  /** Defines the `gap` style property using `theme.spacing` increments. */
   gap?: number;
 
-  /**
-   * Defines the `rowGap` style property using theme.spacing increments.
-   */
+  /** Defines the `rowGap` style property using `theme.spacing` increments. */
   gapX?: number;
 
-  /**
-   * Defines the `columnGap` style property using theme.spacing increments.
-   */
+  /** Defines the `columnGap` style property using `theme.spacing` increments. */
   gapY?: number;
 
-  /**
-   * Defines the `padding` style property using theme.spacing increments.
-   */
+  /** Defines the `padding` style property using `theme.spacing` increments. */
   padding?: number;
 
-  /**
-   * Defines the horizontal `padding` style property using theme.spacing increments.
-   */
+  /** Defines the horizontal `padding` style property using `theme.spacing` increments. */
   paddingX?: number;
 
-  /**
-   * Defines the vertical `padding` style property using theme.spacing increments.
-   */
+  /** Defines the vertical `padding` style property using `theme.spacing` increments. */
   paddingY?: number;
 
-  /**
-   * Defines the vertical `padding-top` style property using theme.spacing increments.
-   */
+  /** Defines the vertical `padding-top` style property using `theme.spacing` increments. */
   paddingTop?: number;
 
-  /**
-   * Defines the vertical `padding-bottom` style property using theme.spacing increments.
-   */
+  /** Defines the vertical `padding-bottom` style property using `theme.spacing` increments. */
   paddingBottom?: number;
 
-  /**
-   * Defines the vertical `padding-left` style property using theme.spacing increments.
-   */
+  /** Defines the vertical `padding-left` style property using `theme.spacing` increments. */
   paddingLeft?: number;
 
-  /**
-   * Defines the vertical `padding-right` style property using theme.spacing increments.
-   */
+  /** Defines the vertical `padding-right` style property using `theme.spacing` increments. */
   paddingRight?: number;
 
-  /**
-   * Defines the `flex` style property.
-   */
+  /** Defines the `flex` style property. */
   flex?: number | string;
 
-  /**
-   * Defines the `flex-grow` style property.
-   */
+  /** Defines the `flex-grow` style property. */
   flexGrow?: number;
 
-  /**
-   * Defines the `flex-shrink` style property.
-   */
+  /** Defines the `flex-shrink` style property. */
   flexShrink?: number;
 
-  /**
-   * Defines the `flex-basis` style property.
-   */
+  /** Defines the `flex-basis` style property. */
   flexBasis?: number | string;
 
-  /**
-   * Defines the `order` property.
-   */
+  /** Defines the `order` property. */
   order?: number;
 
-  /**
-   * CSS styles to apply to the component.
-   */
+  /** CSS styles to apply to the component. */
   style?: React.CSSProperties;
 };

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -25,13 +25,43 @@ const StackRoot = muiStyled("div", {
   alignItems: ownerState.alignItems,
   alignContent: ownerState.alignContent,
   alignSelf: ownerState.alignSelf,
-  gap: typeof ownerState.gap === "number" ? theme.spacing(ownerState.gap) : ownerState.gap,
-  padding:
-    typeof ownerState.padding === "number" ? theme.spacing(ownerState.padding) : ownerState.padding,
-  flex: typeof ownerState.flex === "number" ? ownerState.flex : ownerState.flex,
+  flex: ownerState.flex,
+  order: ownerState.order,
 
   ...(ownerState.fullHeight === true && {
     height: "100%",
+  }),
+  ...(ownerState.gap != undefined && {
+    gap: theme.spacing(ownerState.gap),
+  }),
+  ...(ownerState.gapX != undefined && {
+    rowGap: theme.spacing(ownerState.gapX),
+  }),
+  ...(ownerState.gapY != undefined && {
+    columnGap: theme.spacing(ownerState.gapY),
+  }),
+  ...(ownerState.padding != undefined && {
+    padding: theme.spacing(ownerState.padding),
+  }),
+  ...(ownerState.paddingX != undefined && {
+    paddingLeft: theme.spacing(ownerState.paddingX),
+    paddingRight: theme.spacing(ownerState.paddingX),
+  }),
+  ...(ownerState.paddingY != undefined && {
+    paddingTop: theme.spacing(ownerState.paddingY),
+    paddingBottom: theme.spacing(ownerState.paddingY),
+  }),
+  ...(ownerState.paddingTop != undefined && {
+    paddingTop: theme.spacing(ownerState.paddingTop),
+  }),
+  ...(ownerState.paddingBottom != undefined && {
+    paddingBottom: theme.spacing(ownerState.paddingBottom),
+  }),
+  ...(ownerState.paddingLeft != undefined && {
+    paddingLeft: theme.spacing(ownerState.paddingLeft),
+  }),
+  ...(ownerState.paddingRight != undefined && {
+    paddingRight: theme.spacing(ownerState.paddingRight),
   }),
 }));
 
@@ -50,8 +80,17 @@ export default function Stack(props: PropsWithChildren<StackProps>): JSX.Element
     flexShrink,
     fullHeight = false,
     gap,
+    gapX,
+    gapY,
     justifyContent,
+    order,
     padding,
+    paddingX,
+    paddingY,
+    paddingTop,
+    paddingBottom,
+    paddingLeft,
+    paddingRight,
     wrap,
     style,
     ...other
@@ -68,8 +107,17 @@ export default function Stack(props: PropsWithChildren<StackProps>): JSX.Element
     flexShrink,
     fullHeight,
     gap,
+    gapX,
+    gapY,
     justifyContent,
+    order,
     padding,
+    paddingX,
+    paddingY,
+    paddingTop,
+    paddingBottom,
+    paddingLeft,
+    paddingRight,
     wrap,
   };
 
@@ -176,14 +224,54 @@ export type StackProps = {
   alignSelf?: "auto" | "flex-start" | "flex-end" | "center" | "baseline" | "stretch";
 
   /**
-   * Defines the `gap` style property.
+   * Defines the `gap` style property using theme.spacing increments.
    */
-  gap?: number | string;
+  gap?: number;
 
   /**
-   * Defines the `padding` style property.
+   * Defines the `rowGap` style property using theme.spacing increments.
    */
-  padding?: number | string;
+  gapX?: number;
+
+  /**
+   * Defines the `columnGap` style property using theme.spacing increments.
+   */
+  gapY?: number;
+
+  /**
+   * Defines the `padding` style property using theme.spacing increments.
+   */
+  padding?: number;
+
+  /**
+   * Defines the horizontal `padding` style property using theme.spacing increments.
+   */
+  paddingX?: number;
+
+  /**
+   * Defines the vertical `padding` style property using theme.spacing increments.
+   */
+  paddingY?: number;
+
+  /**
+   * Defines the vertical `padding-top` style property using theme.spacing increments.
+   */
+  paddingTop?: number;
+
+  /**
+   * Defines the vertical `padding-bottom` style property using theme.spacing increments.
+   */
+  paddingBottom?: number;
+
+  /**
+   * Defines the vertical `padding-left` style property using theme.spacing increments.
+   */
+  paddingLeft?: number;
+
+  /**
+   * Defines the vertical `padding-right` style property using theme.spacing increments.
+   */
+  paddingRight?: number;
 
   /**
    * Defines the `flex` style property.
@@ -204,6 +292,11 @@ export type StackProps = {
    * Defines the `flex-basis` style property.
    */
   flexBasis?: number | string;
+
+  /**
+   * Defines the `order` property.
+   */
+  order?: number;
 
   /**
    * CSS styles to apply to the component.


### PR DESCRIPTION
**Description**
Hey the Stack component was great. But… `sx` prop. Here is an alternate version using the `styled` from material-ui without using the sx prop


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
