### PR TITLE
Fix gaps in data platform plots

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -70,7 +70,11 @@ export default class MessageMemoryCache {
   };
   private minTime: Time;
   private maxTime: Time;
-  private loadedRanges: Array<{ range: TimeRange; messages: MessageEvent<unknown>[] }> = [];
+  private loadedRanges: Array<{
+    block: MemoryCacheBlock;
+    range: TimeRange;
+    messages: MessageEvent<unknown>[];
+  }> = [];
 
   constructor(totalRange: TimeRange) {
     this.minTime = totalRange.start;
@@ -225,17 +229,13 @@ export default class MessageMemoryCache {
     this.loadedRanges.splice(spliceIdx, deleteCount, {
       range: { start: insertStart, end: insertEnd },
       messages: insertMessages,
+      block: {
+        messagesByTopic: groupBy(insertMessages, (m) => m.topic),
+        sizeInBytes: sumBy(insertMessages, (m) => m.sizeInBytes),
+      },
     });
 
-    // Create new array to clear later memoizations.
-    this._blockCache.blocks = [...this._blockCache.blocks];
-
-    // Build & insert new cache block for this range.
-    this._blockCache.blocks.splice(spliceIdx, deleteCount, {
-      messagesByTopic: groupBy(insertMessages, (m) => m.topic),
-      sizeInBytes: sumBy(insertMessages, (m) => m.sizeInBytes),
-    });
-    this._blockCache.startTime = this.loadedRanges[0]?.range.start ?? { sec: 0, nsec: 0 };
+    this._rebuildBlockCache();
   }
 
   /** Remove all messages and preloaded ranges. */
@@ -277,5 +277,22 @@ export default class MessageMemoryCache {
    */
   getBlockCache(): BlockCache {
     return this._blockCache;
+  }
+
+  // Rebuilds block cache, interspersing empty blocks where there are time gaps
+  // in our loaded ranges.
+  private _rebuildBlockCache() {
+    const newBlocks: MemoryCacheBlock[] = [];
+    for (let i = 0; i < this.loadedRanges.length; i++) {
+      if (
+        i > 0 &&
+        isLessThan(this.loadedRanges[i - 1]!.range.end, this.loadedRanges[i]!.range.start)
+      ) {
+        newBlocks.push({ messagesByTopic: {}, sizeInBytes: 0 });
+      }
+      newBlocks.push(this.loadedRanges[i]!.block);
+    }
+    this._blockCache.blocks = newBlocks;
+    this._blockCache.startTime = this.loadedRanges[0]?.range.start ?? { sec: 0, nsec: 0 };
   }
 }

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -64,7 +64,7 @@ function getMessagesFromLoadedRange(messages: MessageEvent<unknown>[], requestRa
  * An in-memory cache of preloaded messages over a time range.
  */
 export default class MessageMemoryCache {
-  private _blockCache: { blocks: MemoryCacheBlock[]; startTime: Time } = {
+  private _blockCache: { blocks: (undefined | MemoryCacheBlock)[]; startTime: Time } = {
     blocks: [],
     startTime: { sec: 0, nsec: 0 },
   };
@@ -282,13 +282,13 @@ export default class MessageMemoryCache {
   // Rebuilds block cache, interspersing empty blocks where there are time gaps
   // in our loaded ranges.
   private _rebuildBlockCache() {
-    const newBlocks: MemoryCacheBlock[] = [];
+    const newBlocks: (undefined | MemoryCacheBlock)[] = [];
     for (let i = 0; i < this.loadedRanges.length; i++) {
       if (
         i > 0 &&
         isLessThan(this.loadedRanges[i - 1]!.range.end, this.loadedRanges[i]!.range.start)
       ) {
-        newBlocks.push({ messagesByTopic: {}, sizeInBytes: 0 });
+        newBlocks.push(undefined);
       }
       newBlocks.push(this.loadedRanges[i]!.block);
     }


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with plotting incompletely fetched data platform data.

**Description**
Currently when we plot data fetched from data platform we incorrectly connect discontiguous segments. This adds logic to insert empty blocks where we have gaps in our fetched data.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2956 

Screenshot of plot with gaps in data after this patch:
<img width="786" alt="Screen Shot 2022-03-02 at 9 47 24 AM" src="https://user-images.githubusercontent.com/93935560/156408282-5924bd6f-e87c-4d6f-97f5-a298b984254b.png">
