### PR TITLE
Add DialogHostIdContext for controlling modal attachment

### DIFF
--- a/packages/studio-base/src/components/DeviceCodeDialog.tsx
+++ b/packages/studio-base/src/components/DeviceCodeDialog.tsx
@@ -20,6 +20,7 @@ import { useAsync, useMountedState } from "react-use";
 
 import Logger from "@foxglove/log";
 import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import { Session } from "@foxglove/studio-base/services/ConsoleApi";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -54,6 +55,7 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
   const theme = useTheme();
   const isMounted = useMountedState();
   const api = useConsoleApi();
+  const hostId = useDialogHostId();
   const { onClose } = props;
 
   const { value: deviceCode, error: deviceCodeError } = useAsync(async () => {
@@ -159,7 +161,7 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
     signinError != undefined
   ) {
     return (
-      <Dialog hidden={false} title="Error">
+      <Dialog hidden={false} title="Error" modalProps={{ layerProps: { hostId } }}>
         {deviceCodeError?.message ?? deviceResponseError?.message ?? signinError?.message}
         <DialogFooter>
           <PrimaryButton text="Done" onClick={() => onClose?.()} />
@@ -169,7 +171,7 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
   }
 
   return (
-    <Dialog hidden={false} minWidth={440} title="Sign in">
+    <Dialog hidden={false} minWidth={440} title="Sign in" modalProps={{ layerProps: { hostId } }}>
       {dialogContent}
       <DialogFooter styles={{ action: { display: "block" } }}>
         <div className={classes.spinnerWrapper}>

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
@@ -17,6 +17,7 @@ import { Stack } from "@mui/material";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useLatest, useUnmount } from "react-use";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
 
@@ -40,6 +41,7 @@ export function UnsavedChangesPrompt({
   defaultPersonalCopyName?: string;
 }): JSX.Element {
   const theme = useTheme();
+  const hostId = useDialogHostId();
 
   const options = useMemo<
     (IChoiceGroupOption & { key: Exclude<UnsavedChangesResolution["type"], "cancel"> })[]
@@ -109,6 +111,7 @@ export function UnsavedChangesPrompt({
       hidden={false}
       onDismiss={handleCancel}
       dialogContentProps={{ title: `“${layout.name}” has unsaved changes` }}
+      modalProps={{ layerProps: { hostId } }}
       minWidth={320}
       maxWidth={320}
     >

--- a/packages/studio-base/src/components/NotificationModal.tsx
+++ b/packages/studio-base/src/components/NotificationModal.tsx
@@ -4,6 +4,7 @@
 
 import { Dialog, Text, TextField, useTheme, IModalProps } from "@fluentui/react";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import { NotificationMessage } from "@foxglove/studio-base/util/sendNotification";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -15,6 +16,7 @@ export default function NotificationModal({
   onRequestClose: IModalProps["onDismiss"];
 }): React.ReactElement {
   const theme = useTheme();
+  const hostId = useDialogHostId();
 
   const displayPropsBySeverity = {
     error: theme.semanticColors.errorBackground,
@@ -36,6 +38,7 @@ export default function NotificationModal({
         subText,
         showCloseButton: true,
       }}
+      modalProps={{ layerProps: { hostId } }}
       minWidth={700}
     >
       {details instanceof Error ? (

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -7,6 +7,7 @@ import { Stack } from "@mui/material";
 import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { useMountedState } from "react-use";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import {
   IDataSourceFactory,
   usePlayerSelection,
@@ -33,6 +34,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   const theme = useTheme();
 
   const openFile = useOpenFile(availableSources);
+  const hostId = useDialogHostId();
 
   const firstSampleSource = useMemo(() => {
     return availableSources.find((source) => source.type === "sample");
@@ -141,6 +143,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
           // We enable event bubbling so a user can drag&drop files or folders onto the app even when
           // the dialog is shown.
           eventBubblingEnabled: true,
+          hostId,
         },
         styles: {
           main: {

--- a/packages/studio-base/src/components/ShareJsonModal.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.tsx
@@ -13,6 +13,7 @@ import {
 import { Stack } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import clipboard from "@foxglove/studio-base/util/clipboard";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -33,6 +34,7 @@ export default function ShareJsonModal({
   title,
 }: Props): React.ReactElement {
   const theme = useTheme();
+  const hostId = useDialogHostId();
   const [value, setValue] = useState(JSON.stringify(initialValue, undefined, 2) ?? "");
   const [copied, setCopied] = useState(false);
 
@@ -69,6 +71,7 @@ export default function ShareJsonModal({
         subText: `Paste a new ${noun} to use it, or copy this one to share it:`,
         showCloseButton: true,
       }}
+      modalProps={{ layerProps: { hostId } }}
       maxWidth={`calc(100vw - ${theme.spacing.l2})`}
     >
       <TextField

--- a/packages/studio-base/src/context/DialogHostIdContext.ts
+++ b/packages/studio-base/src/context/DialogHostIdContext.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+
+const DialogHostIdContext = createContext<string | undefined>(undefined);
+DialogHostIdContext.displayName = "DialogHostIdContext";
+
+function useDialogHostId(): string | undefined {
+  return useContext(DialogHostIdContext);
+}
+
+export { useDialogHostId };
+export default DialogHostIdContext;

--- a/packages/studio-base/src/hooks/useConfirm.tsx
+++ b/packages/studio-base/src/hooks/useConfirm.tsx
@@ -14,6 +14,7 @@
 import { DefaultButton, Dialog, DialogFooter } from "@fluentui/react";
 import { useCallback, useEffect, useContext, useRef } from "react";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
 
 type ConfirmVariant = "danger" | "primary";
@@ -56,6 +57,8 @@ function ConfirmModal(props: ConfirmModalProps) {
   useEffect(() => {
     return () => onComplete("cancel");
   }, [onComplete]);
+
+  const hostId = useDialogHostId();
 
   const confirmStyle = props.variant ?? "primary";
 
@@ -100,6 +103,7 @@ function ConfirmModal(props: ConfirmModalProps) {
       hidden={false}
       onDismiss={() => onComplete("cancel")}
       dialogContentProps={{ title: props.title }}
+      modalProps={{ layerProps: { hostId } }}
       minWidth={320}
       maxWidth={480}
     >

--- a/packages/studio-base/src/hooks/usePrompt.tsx
+++ b/packages/studio-base/src/hooks/usePrompt.tsx
@@ -5,6 +5,7 @@
 import { DefaultButton, Dialog, DialogFooter, PrimaryButton, TextField } from "@fluentui/react";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
 
 type PromptOptions = {
@@ -63,11 +64,14 @@ function ModalPrompt({
     return () => onComplete(undefined);
   }, [onComplete]);
 
+  const hostId = useDialogHostId();
+
   return (
     <Dialog
       hidden={false}
       onDismiss={() => onComplete(undefined)}
       dialogContentProps={{ title, subText }}
+      modalProps={{ layerProps: { hostId } }}
     >
       <form
         onSubmit={(event) => {

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -15,6 +15,10 @@ export {
   useConsoleApi,
 } from "@foxglove/studio-base/context/ConsoleApiContext";
 export { default as ConsoleApiRemoteLayoutStorageProvider } from "@foxglove/studio-base/providers/ConsoleApiRemoteLayoutStorageProvider";
+export {
+  default as DialogHostIdContext,
+  useDialogHostId,
+} from "@foxglove/studio-base/context/DialogHostIdContext";
 export { default as App } from "./App";
 export type { NetworkInterface, OsContext } from "./OsContext";
 export { default as ErrorBoundary } from "./components/ErrorBoundary";

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -9,6 +9,7 @@ import { ReactNode, useCallback, useLayoutEffect, useMemo, useState } from "reac
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { PanelExtensionContext, Topic } from "@foxglove/studio";
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { darkFluentTheme, lightFluentTheme } from "@foxglove/studio-base/theme/createFluentTheme";
 
@@ -71,6 +72,7 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
 
   const [topics, setTopics] = useState<readonly Topic[] | undefined>();
   const [showSettings, setShowSettings] = useState<boolean>(false);
+  const hostId = useDialogHostId();
 
   const onChangeConfig = useCallback(
     (newConfig: Config) => {
@@ -238,6 +240,7 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
       </Stack>
       <Dialog
         dialogContentProps={{ title: "Teleop panel settings", showCloseButton: true }}
+        modalProps={{ layerProps: { hostId } }}
         hidden={!showSettings}
         onDismiss={() => setShowSettings(false)}
         maxWidth={480}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/TopicSettingsModal.tsx
@@ -16,6 +16,7 @@ import { isEmpty, omit } from "lodash";
 import React, { useCallback } from "react";
 
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
+import { useDialogHostId } from "@foxglove/studio-base/context/DialogHostIdContext";
 import { topicSettingsEditorForDatatype } from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicSettingsEditor";
 import { Topic } from "@foxglove/studio-base/players/types";
 
@@ -85,6 +86,7 @@ function TopicSettingsModal({
   setCurrentEditingTopic,
   settingsByKey,
 }: Props) {
+  const hostId = useDialogHostId();
   const topicSettingsKey = `t:${topicName}`;
   const onSettingsChange = useCallback(
     (
@@ -129,6 +131,7 @@ function TopicSettingsModal({
         subText: currentEditingTopic.datatype,
         showCloseButton: true,
       }}
+      modalProps={{ layerProps: { hostId } }}
       maxWidth={480}
       minWidth={480}
     >


### PR DESCRIPTION
Allows users to specify the id of a DOM element to be used as the parent element for modals.

**User-Facing Changes**
None.

**Description**
Enables the inclusion of a provider to control which DOM node to which modals will be appended. If not provided, the default behavior of being added to the end of the document is retained.

Sample: <DialogHostIdContext.Provider value={"my-cool-div"} />