### PR TITLE
Fix version banner styling

### DIFF
--- a/web/src/VersionBanner.tsx
+++ b/web/src/VersionBanner.tsx
@@ -32,13 +32,14 @@ const useStyles = makeStyles({
     height: "100vh",
   },
   inner: {
+    display: "flex",
+    flexDirection: "column",
     padding: 12,
     gap: 8,
     alignItems: "center",
   },
   closeButton: {
-    fill: "white",
-    position: "absolute",
+    position: "absolute !important" as unknown as "absolute",
     margin: 8,
     right: 0,
     top: 0,
@@ -70,14 +71,17 @@ const VersionBanner = function ({
     <div className={cx(classes.root, { [classes.rootPersistant]: !isDismissable })}>
       <div className={classes.inner}>
         {isDismissable && (
-          <IconButton className={classes.closeButton} onClick={() => setShowBanner(false)}>
-            <CloseIcon color="inherit" />
+          <IconButton
+            color="inherit"
+            className={classes.closeButton}
+            onClick={() => setShowBanner(false)}
+          >
+            <CloseIcon />
           </IconButton>
         )}
 
         <Text styles={{ root: { color: "white", fontSize: "1.1em" } }}>
-          {prompt}
-          <br /> Foxglove Studio currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
+          {prompt} Foxglove Studio currently requires Chrome v{MINIMUM_CHROME_VERSION}+.
         </Text>
 
         {!isChrome && (


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix styling regressions in the version banner from mui/makeStyles conversion.
Closes #2945.

Before

<img width="923" alt="Screen Shot 2022-03-02 at 5 20 34 PM" src="https://user-images.githubusercontent.com/14237/156477954-07dec086-ade4-4b58-9901-c8dab410110f.png">


After

<img width="926" alt="Screen Shot 2022-03-02 at 5 20 27 PM" src="https://user-images.githubusercontent.com/14237/156477959-c5565f04-3e00-469f-b921-f9087eb5c8e3.png">

