### PR TITLE
Fix nondeterministic ErrorBoundary stories

### DIFF
--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -47,7 +47,7 @@ export const Default: Story = () => {
 export const ShowingDetails: Story = () => {
   return (
     <DndProvider backend={HTML5Backend}>
-      <ErrorBoundary showErrorDetails>
+      <ErrorBoundary showErrorDetails hideErrorSourceLocations>
         <Broken />
       </ErrorBoundary>
     </DndProvider>

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -13,6 +13,7 @@ import ErrorDisplay from "./ErrorDisplay";
 type Props = {
   actions?: JSX.Element;
   showErrorDetails?: boolean;
+  hideErrorSourceLocations?: boolean;
 };
 
 type State = {
@@ -46,6 +47,7 @@ export default class ErrorBoundary extends Component<PropsWithChildren<Props>, S
       return (
         <ErrorDisplay
           showErrorDetails={this.props.showErrorDetails}
+          hideErrorSourceLocations={this.props.hideErrorSourceLocations}
           error={this.state.currentError.error}
           errorInfo={this.state.currentError.errorInfo}
           content={


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This restores some logic that was removed in https://github.com/foxglove/studio/pull/2021. 

Since #2940, the storybook screenshots became flaky because file hashes and the chromatic URL would appear in screenshots ([example](https://www.chromatic.com/test?appId=603ec8bf7908b500231841e2&id=62201256deddcb003a991eb7)). The restored logic strips out these locations in storybook to make the screenshots deterministic.