### PR TITLE
Fix disappearing plot legend.

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -194,8 +194,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.text.secondary,
     backgroundColor: theme.palette.background.paper,
     borderTop: `${theme.palette.background.default} solid 1px`,
-    flexDirection: ({ legendDisplay }: StyleProps) =>
-      legendDisplay === "top" ? "column" : undefined,
+    flexDirection: ({ legendDisplay }: StyleProps) => (legendDisplay === "top" ? "column" : "row"),
   },
   rootFloating: {
     cursor: "pointer",


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the display of the legend on plot panels.

**Description**
The plot legend disappears when you change its position from `top` to `left` in settings. We just need to specify a value for the `flexDirection` of the parent element in all cases instead of leaving it undefined.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2964 