### PR TITLE
Move MessageBlock and BlockCache types to player/types

### DIFF
--- a/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
@@ -23,7 +23,7 @@ import {
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
-import { MemoryCacheBlock } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
+import { MessageBlock as PlayerMessageBlock } from "@foxglove/studio-base/players/types";
 
 export type MessageBlock = {
   readonly [topicName: string]: readonly MessageEvent<unknown>[];
@@ -33,7 +33,7 @@ export type MessageBlock = {
 // That said, MessageBlock identity will change when the set of topics changes, so consumers should
 // prefer to use the identity of topic-block message arrays where possible.
 const filterBlockByTopics = memoizeWeak(
-  (block: MemoryCacheBlock | undefined, topics: readonly string[]): MessageBlock => {
+  (block: PlayerMessageBlock | undefined, topics: readonly string[]): MessageBlock => {
     if (!block) {
       // For our purposes, a missing MemoryCacheBlock just means "no topics have been cached for
       // this block". This is semantically different to an empty array per topic, but not different
@@ -91,7 +91,7 @@ export function useBlocksByTopic(topics: readonly string[]): readonly MessageBlo
 
   useSubscribeToTopicsForBlocks(requestedTopics);
 
-  const allBlocks = useMessagePipeline<readonly (MemoryCacheBlock | undefined)[] | undefined>(
+  const allBlocks = useMessagePipeline<readonly (PlayerMessageBlock | undefined)[] | undefined>(
     useCallback((ctx) => ctx.playerState.progress.messageCache?.blocks, []),
   );
 

--- a/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
+++ b/packages/studio-base/src/PanelAPI/useBlocksByTopic.ts
@@ -22,8 +22,11 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
-import { SubscribePayload, MessageEvent } from "@foxglove/studio-base/players/types";
-import { MessageBlock as PlayerMessageBlock } from "@foxglove/studio-base/players/types";
+import {
+  SubscribePayload,
+  MessageEvent,
+  MessageBlock as PlayerMessageBlock,
+} from "@foxglove/studio-base/players/types";
 
 export type MessageBlock = {
   readonly [topicName: string]: readonly MessageEvent<unknown>[];

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -17,7 +17,7 @@ import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { fromSec } from "@foxglove/rostime";
 import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
-import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
+import { BlockCache } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";

--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -14,7 +14,7 @@
 import { useCallback } from "react";
 import TestUtils from "react-dom/test-utils";
 
-import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
+import { BlockCache } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/MessageMemoryCache.ts
@@ -5,11 +5,7 @@
 import { groupBy, sumBy } from "lodash";
 
 import { areEqual, isGreaterThan, isLessThan, Time, toString } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio-base/players/types";
-import {
-  BlockCache,
-  MemoryCacheBlock,
-} from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
+import { MessageEvent, BlockCache, MessageBlock } from "@foxglove/studio-base/players/types";
 import { Range } from "@foxglove/studio-base/util/ranges";
 
 /** Represents a half-open time interval: [start, end) */
@@ -64,14 +60,14 @@ function getMessagesFromLoadedRange(messages: MessageEvent<unknown>[], requestRa
  * An in-memory cache of preloaded messages over a time range.
  */
 export default class MessageMemoryCache {
-  private _blockCache: { blocks: (undefined | MemoryCacheBlock)[]; startTime: Time } = {
+  private _blockCache: { blocks: (undefined | MessageBlock)[]; startTime: Time } = {
     blocks: [],
     startTime: { sec: 0, nsec: 0 },
   };
   private minTime: Time;
   private maxTime: Time;
   private loadedRanges: Array<{
-    block: MemoryCacheBlock;
+    block: MessageBlock;
     range: TimeRange;
     messages: MessageEvent<unknown>[];
   }> = [];
@@ -282,7 +278,7 @@ export default class MessageMemoryCache {
   // Rebuilds block cache, interspersing empty blocks where there are time gaps
   // in our loaded ranges.
   private _rebuildBlockCache() {
-    const newBlocks: (undefined | MemoryCacheBlock)[] = [];
+    const newBlocks: (undefined | MessageBlock)[] = [];
     for (let i = 0; i < this.loadedRanges.length; i++) {
       if (
         i > 0 &&

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -15,7 +15,6 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
-import { BlockCache } from "@foxglove/studio-base/randomAccessDataProviders/MemoryCacheDataProvider";
 import {
   AverageThroughput,
   RandomAccessDataProviderStall,
@@ -230,6 +229,20 @@ export type RosValue =
 export type RosObject = Readonly<{
   [property: string]: RosValue;
 }>;
+
+// For each memory block we store the actual messages (grouped by topic), and a total byte size of
+// the underlying ArrayBuffers.
+export type MessageBlock = {
+  readonly messagesByTopic: {
+    readonly [topic: string]: MessageEvent<unknown>[];
+  };
+  readonly sizeInBytes: number;
+};
+
+export type BlockCache = {
+  blocks: readonly (MessageBlock | undefined)[];
+  startTime: Time;
+};
 
 // Contains different kinds of progress indications
 export type Progress = Readonly<{

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -24,7 +24,7 @@ import {
   subtract as subtractTimes,
   toNanoSec,
 } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { MessageBlock } from "@foxglove/studio-base/players/types";
 import {
   RandomAccessDataProvider,
   ExtensionPoint,
@@ -56,21 +56,7 @@ export const MAX_BLOCK_SIZE_BYTES = 50e6; // Number of bytes in a block before w
 // See: https://github.com/foxglove/studio/pull/1733
 const DEFAULT_CACHE_SIZE_BYTES = 1.0e9;
 
-// For each memory block we store the actual messages (grouped by topic), and a total byte size of
-// the underlying ArrayBuffers.
-export type MemoryCacheBlock = {
-  readonly messagesByTopic: {
-    readonly [topic: string]: MessageEvent<unknown>[];
-  };
-  readonly sizeInBytes: number;
-};
-
-export type BlockCache = {
-  blocks: readonly (MemoryCacheBlock | undefined)[];
-  startTime: Time;
-};
-
-const EMPTY_BLOCK: MemoryCacheBlock = {
+const EMPTY_BLOCK: MessageBlock = {
   messagesByTopic: {},
   sizeInBytes: 0,
 };
@@ -240,7 +226,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   // The actual blocks that contain the messages. Blocks have a set "width" in terms of nanoseconds
   // since the start time of the log. If a block has some messages for a topic, then by definition
   // it has *all* messages for that topic and timespan.
-  private _blocks: (MemoryCacheBlock | undefined)[] = [];
+  private _blocks: (MessageBlock | undefined)[] = [];
 
   // The start time of the log. Used for computing from and to nanoseconds since the start.
   private _startTime: Time = { sec: 0, nsec: 0 };
@@ -708,7 +694,7 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
 
     // Update our state.
     this._recentBlockRanges = newRecentRanges;
-    const newBlocks: (MemoryCacheBlock | undefined)[] = Array.from({ length: this._blocks.length });
+    const newBlocks: (MessageBlock | undefined)[] = Array.from({ length: this._blocks.length });
 
     for (let blockIndex = 0; blockIndex < this._blocks.length; blockIndex++) {
       if (this._blocks[blockIndex] && blockIndexesToKeep.has(blockIndex)) {


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
These types are used within the PlayerState and should exist in the player types file rather than the random access files so they can be used by players other than random access.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
