### PR TITLE
Sort headerStamp series in the plot panel

### DIFF
--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -92,7 +92,7 @@ export default function TimestampMethodDropdown(props: Props): JSX.Element {
   );
 
   const timestampMethods = [
-    { label: "Receive time", value: "recieveTime" },
+    { label: "Receive time", value: "receiveTime" },
     { label: "header.stamp", value: "headerStamp" },
   ] as { label: string; value: TimestampMethod }[];
 

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -101,6 +101,7 @@ function getDatumsForMessagePathItem(
       });
     }
   }
+
   const hasMismatchedData =
     isCustomScale(xAxisVal) && (!xItem || yItem.queriedData.length !== xItem.queriedData.length);
   return { data, hasMismatchedData };
@@ -185,6 +186,17 @@ function getDatasetsFromMessagePlotPath({
         // If we have a scatter plot, we can't take the derivative, so instead show nothing
         rangeData = [];
       }
+    }
+
+    // Messages are provided in receive time order but header stamps might be out of order
+    // This would create zig-zag lines connecting the wrong points. Sorting the header stamp values (x)
+    // results in the datums being in the correct order for connected lines.
+    //
+    // An example is when messages at the same receive time have different header stamps. The receive
+    // time ordering is undefined (could be different for different data sources), but the header stamps
+    // still need sorting so the plot renders correctly.
+    if (path.timestampMethod === "headerStamp") {
+      rangeData.sort((a, b) => a.x - b.x);
     }
 
     // NaN points are not displayed, and result in a break in the line.


### PR DESCRIPTION


**User-Facing Changes**
When viewing a "header stamp" series in the plot panel, the plot correctly visualizes the header data in header stamp order regardless of the order on the incoming messages.

**Description**
The contract studio has when providing messages in "receive time" order is that the messages are provided in increasing receive time order. However, within a single receive time, there are no further guarantees about message ordering. If there are multiple messages at a receive time with different header stamps, these could cause the plot to render lines "out-of-order" when an earlier header stamp appeared in the dataset after a later header stamp (both at the same receive time).

This change fixes the "out-of-order" header stamp issue by sorting the dataset when using the header stamp method for a series. This ensures that the data is visualized in increasing header stamp order.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
