### PR TITLE
Remove ResizeObserver error suppression for sentry

### DIFF
--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -41,7 +41,6 @@ if (allowCrashReporting && typeof process.env.SENTRY_DSN === "string") {
         return integration.name !== "Breadcrumbs";
       });
     },
-    ignoreErrors: ["ResizeObserver loop limit exceeded"],
   });
 }
 

--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -44,7 +44,6 @@ if (isCrashReportingEnabled && typeof process.env.SENTRY_DSN === "string") {
         return integration.name !== "Breadcrumbs";
       });
     },
-    ignoreErrors: ["ResizeObserver loop limit exceeded"],
   });
 }
 

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -31,7 +31,6 @@ if (typeof process.env.SENTRY_DSN === "string") {
         return integration.name !== "Breadcrumbs";
       });
     },
-    ignoreErrors: ["ResizeObserver loop limit exceeded"],
   });
 }
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
https://github.com/foxglove/studio/pull/1698 fixed instances of the resize observer errors. This change allows us to collect these errors in sentry again for monitoring if this error comes back.

Fixes: #1790

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
