### PR TITLE
Fall back to Marker.color when Marker.colors.length < Marker.points.length, add TRIANGLE_LIST to storybook

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -948,6 +948,22 @@ export default class SceneBuilder implements MarkerProvider {
         break;
     }
 
+    // If this marker has fewer colors specified than the number of points,
+    // use Marker.color for the remaining points
+    const markerWithPoints = marker as { points?: Point[]; colors?: Color[]; color?: Color };
+    if (
+      markerWithPoints.points &&
+      markerWithPoints.points.length > 0 &&
+      markerWithPoints.colors &&
+      markerWithPoints.colors.length > 0 &&
+      markerWithPoints.colors.length < markerWithPoints.points.length
+    ) {
+      const color = markerWithPoints.color ?? { r: 0, g: 0, b: 0, a: 1 };
+      while (markerWithPoints.colors.length < markerWithPoints.points.length) {
+        markerWithPoints.colors.push(color);
+      }
+    }
+
     // allow topic settings to override renderable marker command (see MarkerSettingsEditor.js)
     const { overrideCommand } = this._settingsByKey[`t:${topic.name}`] ?? {};
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -30,6 +30,7 @@ import {
   SphereMarker,
   TextMarker,
   TF,
+  TriangleListMarker,
 } from "@foxglove/studio-base/types/Messages";
 import { hexToColorObj } from "@foxglove/studio-base/util/colorUtils";
 import { FOXGLOVE_GRID_TOPIC } from "@foxglove/studio-base/util/globalConstants";
@@ -610,6 +611,37 @@ export function Markers(): JSX.Element {
     sizeInBytes: 0,
   };
 
+  const triangleList: MessageEvent<TriangleListMarker> = {
+    topic: "/markers",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      id: `triangleList`,
+      ns: "",
+      type: 11,
+      action: 0,
+      frame_locked: false,
+      pose: {
+        position: { x: 1, y: -1, z: 0 },
+        orientation: { x: 0, y: 0, z: 0, w: 1 },
+      },
+      scale: { x: 0.5, y: 0.5, z: 0.5 },
+      color: makeColor("#3f51b5", 0.5),
+      points: [
+        { x: 0, y: 0.25, z: 0 },
+        { x: 0.25, y: -0.25, z: 0 },
+        { x: -0.25, y: -0.25, z: 0 },
+
+        { x: 0.25, y: -0.25, z: 0 },
+        { x: -0.25, y: -0.25, z: 0 },
+        { x: 0, y: -0.5, z: 0 },
+      ],
+      colors: [makeColor("#f44336", 0.5), makeColor("#4caf50", 0.5), makeColor("#2196f3", 0.5)],
+      lifetime: { sec: 0, nsec: 0 },
+    },
+    sizeInBytes: 0,
+  };
+
   const fixture = useDelayedFixture({
     datatypes,
     topics,
@@ -627,6 +659,7 @@ export function Markers(): JSX.Element {
         points,
         text,
         mesh,
+        triangleList,
       ],
     },
     capabilities: [],


### PR DESCRIPTION
**User-Facing Changes**

For `visualization_msgs/Marker` messages, the color field will be used if the colors array is not empty but has fewer entries than the points field

**Description**

Also adds TRIANGLE_LIST rendering to the Markers story
