### PR TITLE
Always use header.stamp for marker lifetime expiration, add topic warning when receiving an already expired marker

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
@@ -106,10 +106,10 @@ describe("MessageCollector", () => {
     collector.addMarker(marker, getName(marker));
     expect(collector.getMessages()).toHaveLength(1);
 
-    collector.setClock({ sec: 100, nsec: 100 + lifetimeNanos });
+    collector.setClock({ sec: 100, nsec: 90 + lifetimeNanos });
     expect(collector.getMessages()).toHaveLength(1);
 
-    collector.setClock({ sec: 100, nsec: 100 + lifetimeNanos + 1 });
+    collector.setClock({ sec: 100, nsec: 90 + lifetimeNanos + 1 });
     expect(collector.getMessages()).toHaveLength(0);
 
     collector.addMarker(marker, getName(marker));


### PR DESCRIPTION
**User-Facing Changes**

- Markers with lifetimes will expire relative to header.stamp, not receive time
- A topic warning is shown when an already expired marker is received

**Description**

We previously had two separate places in the codebase that were checking marker expirations, so markers would not be rendered if currentTime > either header.stamp OR receiveTime. The code has been refactored to share a single implementation that uses header.stamp unless it is not available, then falls back to receiveTime (should not be the case for any currently renderable message types).

There is now an additional sanity check when first processing an incoming marker message. If the marker is expired before we can even process it, a topic warning is shown. This will hopefully help users troubleshoot why markers are not appearing, in the case where a lifetime is set but header.stamp is unset (0) or far back in the past.
