### PR TITLE
Fixes clicking in the upper area of a panel

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -55,11 +55,14 @@ const useStyles = makeStyles((theme) => ({
       // leave some room for possible scrollbar
       paddingRight: 8,
       top: 0,
-      width: "100%",
       zIndex: 5000,
       backgroundColor: "transparent",
 
       "&.hasChildren": {
+        // If the toolbar has children - set the width to 100% to takeup the entire panel width
+        // If the toolbar does not have children, then the width should be only the controls
+        // so the div does not interfere with other panel elements.
+        width: "100%",
         left: 0,
         backgroundColor: theme.palette.neutralLighterAlt,
       },

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: "transparent",
 
       "&.hasChildren": {
-        // If the toolbar has children - set the width to 100% to takeup the entire panel width
+        // If the toolbar has children, set the width to 100% to take up the entire panel width.
         // If the toolbar does not have children, then the width should be only the controls
         // so the div does not interfere with other panel elements.
         width: "100%",


### PR DESCRIPTION

**User-Facing Changes**
The user is able to click the upper area of panels with hidden floating toolbars.

**Description**
When using a floating toolbar, the hidden toolbar would prevent clicking the upper area of a panel. This regressed in https://github.com/foxglove/studio/pull/2877. This change fixes the bug by setting the width of the toolbar to 100% for toolbars with children and no set width for no children. This lets the panel toolbar container size to the controls rather than across the entire panel.

Fixes: #2987


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
