### PR TITLE
Node Playground: remove "/studio_node" prefix requirement

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
@@ -42,7 +42,7 @@ const DiagnosticsSection = ({ diagnostics }: Props): ReactElement => {
   };
 
   return diagnostics.length > 0 ? (
-    <ul>
+    <ul style={{ listStyle: "none", padding: 0 }}>
       {diagnostics.map(({ severity, message, source, startColumn, startLineNumber }, i) => {
         const severityLabel =
           (invert(DiagnosticSeverity) as Record<string, keyof typeof DiagnosticSeverity>)[

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -709,7 +709,7 @@ describe("UserNodePlayer", () => {
       ]);
     });
 
-    it("should error if a user nodes outputs to an existing input topic", async () => {
+    it("should error if a user node outputs to an existing input topic", async () => {
       const fakePlayer = new FakePlayer();
       const mockSetNodeDiagnostics = jest.fn();
       const userNodePlayer = new UserNodePlayer(fakePlayer, {

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -709,6 +709,56 @@ describe("UserNodePlayer", () => {
       ]);
     });
 
+    it("should error if a user nodes outputs to an existing input topic", async () => {
+      const fakePlayer = new FakePlayer();
+      const mockSetNodeDiagnostics = jest.fn();
+      const userNodePlayer = new UserNodePlayer(fakePlayer, {
+        ...defaultUserNodeActions,
+        setUserNodeDiagnostics: mockSetNodeDiagnostics,
+      });
+      const [done] = setListenerHelper(userNodePlayer);
+
+      void userNodePlayer.setUserNodes({
+        [`${DEFAULT_STUDIO_NODE_PREFIX}1`]: {
+          name: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
+          sourceCode: nodeUserCode,
+        },
+      });
+      userNodePlayer.setSubscriptions([{ topic: `${DEFAULT_STUDIO_NODE_PREFIX}1` }]);
+
+      void fakePlayer.emit({
+        activeData: {
+          ...basicPlayerState,
+          messages: [upstreamFirst],
+          messageOrder: "receiveTime",
+          currentTime: upstreamFirst.receiveTime,
+          topics: [
+            { name: "/np_input", datatype: "std_msgs/Header" },
+            { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, datatype: "Something" },
+          ],
+          datatypes: new Map(
+            Object.entries({ foo: { definitions: [] }, "std_msgs/Header": { definitions: [] } }),
+          ),
+        },
+      });
+
+      const { messages, topics }: any = await done;
+
+      expect(messages).toHaveLength(1);
+      expect(topics).toEqual([
+        { name: "/np_input", datatype: "std_msgs/Header" },
+        { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, datatype: "Something" },
+      ]);
+      expect(mockSetNodeDiagnostics).toHaveBeenCalledWith(`${DEFAULT_STUDIO_NODE_PREFIX}1`, [
+        {
+          source: Sources.OutputTopicChecker,
+          severity: DiagnosticSeverity.Error,
+          message: `Output topic "${DEFAULT_STUDIO_NODE_PREFIX}1" is already present in the data source`,
+          code: ErrorCodes.OutputTopicChecker.EXISTING_TOPIC,
+        },
+      ]);
+    });
+
     it("should handle multiple user nodes", async () => {
       const fakePlayer = new FakePlayer();
       const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
@@ -996,7 +1046,7 @@ describe("UserNodePlayer", () => {
     });
     it("properly sets diagnostics when there is an error", async () => {
       const code = `
-        export const inputs = ["/np_input"];
+        export const inputs = ["/np_input_does_not_exist"];
         export const output = "/bad_prefix";
         export default (messages: any): any => {};
       `;
@@ -1018,8 +1068,8 @@ describe("UserNodePlayer", () => {
         {
           severity: DiagnosticSeverity.Error,
           message: expect.any(String),
-          source: Sources.OutputTopicChecker,
-          code: ErrorCodes.OutputTopicChecker.BAD_PREFIX,
+          source: Sources.InputTopicsChecker,
+          code: ErrorCodes.InputTopicsChecker.NO_TOPIC_AVAIL,
         },
       ]);
     });

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -544,7 +544,10 @@ export default class UserNodePlayer implements Player {
 
     const validNodeRegistrations: NodeRegistration[] = [];
     const playerTopics = new Set(this._lastPlayerStateActiveData.topics.map((topic) => topic.name));
-    const outputTopics = new Set<string>();
+    const allNodeOutputs = new Set(
+      allNodeRegistrations.map(({ nodeData }) => nodeData.outputTopic),
+    );
+    const seenNodeOutputs = new Set<string>();
 
     for (const nodeRegistration of allNodeRegistrations) {
       const { nodeData, nodeId } = nodeRegistration;
@@ -556,7 +559,7 @@ export default class UserNodePlayer implements Player {
       }
 
       // Create diagnostic errors if more than one node outputs to the same topic
-      if (outputTopics.has(nodeData.outputTopic)) {
+      if (seenNodeOutputs.has(nodeData.outputTopic)) {
         this._setUserNodeDiagnostics(nodeId, [
           ...nodeData.diagnostics,
           {
@@ -568,7 +571,7 @@ export default class UserNodePlayer implements Player {
         ]);
         continue;
       }
-      outputTopics.add(nodeData.outputTopic);
+      seenNodeOutputs.add(nodeData.outputTopic);
 
       // Create diagnostic errors if node outputs overlap with real topics
       if (playerTopics.has(nodeData.outputTopic)) {
@@ -582,6 +585,15 @@ export default class UserNodePlayer implements Player {
           },
         ]);
         continue;
+      }
+
+      // Throw if nodes use other nodes' outputs as inputs. We should never get here because we
+      // already prevent outputs from being the same as real topics in the data source, and we
+      // already filter out input topics that aren't present in the data source.
+      for (const input of nodeData.inputTopics) {
+        if (allNodeOutputs.has(input)) {
+          throw new Error(`Input "${input}" cannot equal another node's output`);
+        }
       }
 
       validNodeRegistrations.push(nodeRegistration);

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -10,7 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { isEqual, groupBy, partition } from "lodash";
+import { isEqual } from "lodash";
 import memoizeWeak from "memoize-weak";
 import shallowequal from "shallowequal";
 import { v4 as uuidv4 } from "uuid";
@@ -51,7 +51,6 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { UserNode, UserNodes } from "@foxglove/studio-base/types/panels";
 import Rpc from "@foxglove/studio-base/util/Rpc";
 import { basicDatatypes, foxgloveDatatypes } from "@foxglove/studio-base/util/datatypes";
-import { DEFAULT_STUDIO_NODE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 
 const log = Log.getLogger(__filename);
 
@@ -86,7 +85,7 @@ export default class UserNodePlayer implements Player {
   private _memoizedNodeTopics: readonly Topic[] = [];
 
   private _subscriptions: SubscribePayload[] = [];
-  private _validTopics = new Set<string>();
+  private _nodeSubscriptions = new Set<string>();
   private _userNodes: UserNodes = {};
 
   // listener for state updates
@@ -216,7 +215,7 @@ export default class UserNodePlayer implements Player {
       const messagePromises = [];
       for (const nodeRegistration of nodeRegistrations) {
         if (
-          this._validTopics.has(nodeRegistration.output.name) &&
+          this._nodeSubscriptions.has(nodeRegistration.output.name) &&
           nodeRegistration.inputs.includes(message.topic)
         ) {
           const messagePromise = nodeRegistration.processMessage(message, globalVariables);
@@ -511,9 +510,6 @@ export default class UserNodePlayer implements Player {
   // - When a user node is updated, added or deleted
   // - When we seek (in order to reset state)
   // - When a new child player is added
-  //
-  // For the time being, resetWorkers is a catchall for these circumstances. As
-  // performance bottlenecks are identified, it will be subject to change.
   private async _resetWorkers(): Promise<void> {
     if (!this._lastPlayerStateActiveData) {
       return;
@@ -546,34 +542,50 @@ export default class UserNodePlayer implements Player {
       ),
     );
 
-    // Filter out nodes with compilation errors
-    const nodeRegistrations: Array<NodeRegistration> = allNodeRegistrations.filter(
-      ({ nodeData, nodeId }) => {
-        const hasError = hasTransformerErrors(nodeData);
-        if (hasError) {
-          this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
-        }
-        return !hasError;
-      },
-    );
+    const validNodeRegistrations: NodeRegistration[] = [];
+    const playerTopics = new Set(this._lastPlayerStateActiveData.topics.map((topic) => topic.name));
+    const outputTopics = new Set<string>();
 
-    // Create diagnostic errors if more than one node outputs to the same topic
-    const nodesByOutputTopic = groupBy(nodeRegistrations, ({ output }) => output.name);
-    const [validNodeRegistrations, duplicateNodeRegistrations] = partition(
-      nodeRegistrations,
-      (nodeReg) => nodeReg === nodesByOutputTopic[nodeReg.output.name]?.[0],
-    );
-    duplicateNodeRegistrations.forEach(({ nodeId, nodeData }) => {
-      this._setUserNodeDiagnostics(nodeId, [
-        ...nodeData.diagnostics,
-        {
-          severity: DiagnosticSeverity.Error,
-          message: `Output "${nodeData.outputTopic}" must be unique`,
-          source: Sources.OutputTopicChecker,
-          code: ErrorCodes.OutputTopicChecker.NOT_UNIQUE,
-        },
-      ]);
-    });
+    for (const nodeRegistration of allNodeRegistrations) {
+      const { nodeData, nodeId } = nodeRegistration;
+
+      // Filter out nodes with compilation errors
+      if (hasTransformerErrors(nodeData)) {
+        this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
+        continue;
+      }
+
+      // Create diagnostic errors if more than one node outputs to the same topic
+      if (outputTopics.has(nodeData.outputTopic)) {
+        this._setUserNodeDiagnostics(nodeId, [
+          ...nodeData.diagnostics,
+          {
+            severity: DiagnosticSeverity.Error,
+            message: `Output "${nodeData.outputTopic}" must be unique`,
+            source: Sources.OutputTopicChecker,
+            code: ErrorCodes.OutputTopicChecker.NOT_UNIQUE,
+          },
+        ]);
+        continue;
+      }
+      outputTopics.add(nodeData.outputTopic);
+
+      // Create diagnostic errors if node outputs overlap with real topics
+      if (playerTopics.has(nodeData.outputTopic)) {
+        this._setUserNodeDiagnostics(nodeId, [
+          ...nodeData.diagnostics,
+          {
+            severity: DiagnosticSeverity.Error,
+            message: `Output topic "${nodeData.outputTopic}" is already present in the data source`,
+            source: Sources.OutputTopicChecker,
+            code: ErrorCodes.OutputTopicChecker.EXISTING_TOPIC,
+          },
+        ]);
+        continue;
+      }
+
+      validNodeRegistrations.push(nodeRegistration);
+    }
 
     this._nodeRegistrations = validNodeRegistrations;
     const nodeTopics = this._nodeRegistrations.map(({ output }) => output);
@@ -728,39 +740,32 @@ export default class UserNodePlayer implements Player {
   setSubscriptions(subscriptions: SubscribePayload[]): void {
     this._subscriptions = subscriptions;
 
-    const mappedTopics: string[] = [];
+    const nodeSubscriptions = new Set<string>();
     const realTopicSubscriptions: SubscribePayload[] = [];
-    const nodeSubscriptions: SubscribePayload[] = [];
     for (const subscription of subscriptions) {
-      // For performance, only check topics that start with DEFAULT_STUDIO_NODE_PREFIX.
-      if (!subscription.topic.startsWith(DEFAULT_STUDIO_NODE_PREFIX)) {
-        realTopicSubscriptions.push(subscription);
-        continue;
-      }
-
-      nodeSubscriptions.push(subscription);
-
       // When subscribing to the same node multiple times, only subscribe to the underlying
       // topics once. This is not strictly necessary, but it makes debugging a bit easier.
-      if (mappedTopics.includes(subscription.topic)) {
+      if (nodeSubscriptions.has(subscription.topic)) {
         continue;
       }
-      mappedTopics.push(subscription.topic);
 
       const nodeRegistration = this._nodeRegistrations.find(
         (info) => info.output.name === subscription.topic,
       );
-      if (nodeRegistration) {
-        for (const inputTopic of nodeRegistration.inputs) {
-          realTopicSubscriptions.push({
-            topic: inputTopic,
-            requester: { type: "node", name: nodeRegistration.output.name },
-          });
-        }
+      if (!nodeRegistration) {
+        realTopicSubscriptions.push(subscription);
+        continue;
+      }
+      nodeSubscriptions.add(subscription.topic);
+      for (const inputTopic of nodeRegistration.inputs) {
+        realTopicSubscriptions.push({
+          topic: inputTopic,
+          requester: { type: "node", name: nodeRegistration.output.name },
+        });
       }
     }
 
-    this._validTopics = new Set(nodeSubscriptions.map((sub) => sub.topic));
+    this._nodeSubscriptions = nodeSubscriptions;
     this._player.setSubscriptions(realTopicSubscriptions);
   }
 

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -21,7 +21,6 @@ import {
 } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/generateTypesLib";
 import {
   getOutputTopic,
-  validateOutputTopic,
   validateInputTopics,
   compile,
   extractDatatypes,
@@ -162,14 +161,6 @@ describe("pipeline", () => {
       expect(diagnostics[0]?.code).toEqual(ErrorCodes.OutputTopicChecker.NO_OUTPUTS);
     });
   });
-  describe("validateOutputTopic", () => {
-    it.each(["/bad_prefix"])("errs on bad topic prefixes", (outputTopic) => {
-      const { diagnostics } = validateOutputTopic({ ...baseNodeData, outputTopic });
-      expect(diagnostics.length).toEqual(1);
-      expect(diagnostics[0]?.severity).toEqual(DiagnosticSeverity.Error);
-      expect(diagnostics[0]?.code).toEqual(ErrorCodes.OutputTopicChecker.BAD_PREFIX);
-    });
-  });
   describe("validateInputTopics", () => {
     it.each([
       [["/foo"], ["/bar"]],
@@ -183,25 +174,9 @@ describe("pipeline", () => {
       expect(diagnostics[0]?.severity).toEqual(DiagnosticSeverity.Error);
       expect(diagnostics[0]?.code).toEqual(ErrorCodes.InputTopicsChecker.NO_TOPIC_AVAIL);
     });
-    it("errs when a node tries to input another user node", () => {
-      const { diagnostics } = validateInputTopics(
-        { ...baseNodeData, inputTopics: [`${DEFAULT_STUDIO_NODE_PREFIX}my_topic`] },
-        [],
-      );
-      expect(diagnostics.length).toEqual(1);
-      expect(diagnostics[0]?.severity).toEqual(DiagnosticSeverity.Error);
-      expect(diagnostics[0]?.code).toEqual(ErrorCodes.InputTopicsChecker.CIRCULAR_IMPORT);
-    });
   });
 
   describe("compile", () => {
-    it("should return an error if a node does not start with the default prefix", () => {
-      const { diagnostics } = compose(compile, getInputTopics)(
-        { ...baseNodeData, name: "/bad_name" },
-        [],
-      );
-      expect(diagnostics[0]?.code).toEqual(ErrorCodes.Other.FILENAME);
-    });
     it.each(["const x: string = 'hello foxglove'", "const num: number = 1222"])(
       "can compile",
       (sourceCode) => {

--- a/packages/studio-base/src/players/UserNodePlayer/types.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/types.ts
@@ -31,7 +31,6 @@ export const Sources = {
   InputTopicsChecker: "InputTopicsChecker",
   OutputTopicChecker: "OutputTopicChecker",
   Runtime: "Runtime",
-  Other: "Other",
 };
 
 export const ErrorCodes = {
@@ -59,18 +58,14 @@ export const ErrorCodes = {
   },
   InputTopicsChecker: {
     NO_TOPIC_AVAIL: 1,
-    CIRCULAR_IMPORT: 2,
-    NO_INPUTS_EXPORT: 3,
-    EMPTY_INPUTS_EXPORT: 4,
-    BAD_INPUTS_TYPE: 5,
+    NO_INPUTS_EXPORT: 2,
+    EMPTY_INPUTS_EXPORT: 3,
+    BAD_INPUTS_TYPE: 4,
   },
   OutputTopicChecker: {
     NO_OUTPUTS: 1,
-    BAD_PREFIX: 2,
-    NOT_UNIQUE: 3,
-  },
-  Other: {
-    FILENAME: 1,
+    NOT_UNIQUE: 2,
+    EXISTING_TOPIC: 3,
   },
 };
 


### PR DESCRIPTION
**User-Facing Changes**
Removed the requirement for Node Playground node output topics to start with a "`/studio_node`" prefix.

**Description**
Resolves #2210