### PR TITLE
Move plot series timestamp setting into settings modal

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -46,9 +46,6 @@ import parseRosPath, { quoteFieldNameIfNeeded, quoteTopicNameIfNeeded } from "./
 //
 //  <MessagePathInput types={["uint16", "float64"]} />
 //
-// If you don't use timestamps, you might want to hide the warning icon that we show when selecting
-// a topic that has no header: `<MessagePathInput hideTimestampWarning>`.
-//
 // If you are rendering many input fields, you might want to use `<MessagePathInput index={5}>`,
 // which gets passed down to `<MessagePathInput onChange>` as the second parameter, so you can
 // avoid creating anonymous functions on every render (which will prevent the component from

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
@@ -20,6 +20,7 @@ export function DefaultIndex0(): JSX.Element {
   const index = 0;
   return (
     <PathSettingsModal
+      xAxisVal="timestamp"
       path={paths[index]!}
       paths={paths}
       index={index}
@@ -37,6 +38,7 @@ export function DefaultIndex1(): JSX.Element {
   const index = 1;
   return (
     <PathSettingsModal
+      xAxisVal="timestamp"
       path={paths[index]!}
       paths={paths}
       index={index}
@@ -54,6 +56,39 @@ export function CustomColor(): JSX.Element {
   const index = 1;
   return (
     <PathSettingsModal
+      xAxisVal="timestamp"
+      path={paths[index]!}
+      paths={paths}
+      index={index}
+      onDismiss={action("onDismiss")}
+      saveConfig={action("saveConfig")}
+    />
+  );
+}
+
+export function CustomXAxis(): JSX.Element {
+  const paths: PlotPath[] = [
+    { enabled: true, timestampMethod: "receiveTime", value: "/some.path" },
+  ];
+  const index = 0;
+  return (
+    <PathSettingsModal
+      xAxisVal="custom"
+      path={paths[index]!}
+      paths={paths}
+      index={index}
+      onDismiss={action("onDismiss")}
+      saveConfig={action("saveConfig")}
+    />
+  );
+}
+
+export function ReferenceLine(): JSX.Element {
+  const paths: PlotPath[] = [{ enabled: true, timestampMethod: "receiveTime", value: "42" }];
+  const index = 0;
+  return (
+    <PathSettingsModal
+      xAxisVal="timestamp"
       path={paths[index]!}
       paths={paths}
       index={index}

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -16,10 +16,8 @@ import { v4 as uuidv4 } from "uuid";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
-import TimestampMethodDropdown from "@foxglove/studio-base/components/TimestampMethodDropdown";
 import { useHoverValue } from "@foxglove/studio-base/context/HoverValueContext";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
-import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import PathSettingsModal from "./PathSettingsModal";
 import { PlotPath, isReferenceLinePlotPathType } from "./internalTypes";
@@ -166,12 +164,6 @@ export default function PlotLegendRow({
   const classes = useStyles();
 
   const isReferenceLinePlotPath = isReferenceLinePlotPathType(path);
-  let timestampMethod;
-  // Only allow chosing the timestamp method if it is applicable (not a reference line) and there is at least
-  // one character typed.
-  if (!isReferenceLinePlotPath && path.value.length > 0) {
-    timestampMethod = path.timestampMethod;
-  }
 
   const onInputChange = useCallback(
     (value: string, idx?: number) => {
@@ -188,18 +180,6 @@ export default function PlotLegendRow({
     [paths, saveConfig],
   );
 
-  const onInputTimestampMethodChange = useCallback(
-    (value: TimestampMethod) => {
-      const newPaths = paths.slice();
-      const newPath = newPaths[index];
-      if (newPath) {
-        newPaths[index] = { ...newPath, timestampMethod: value };
-      }
-      saveConfig({ paths: newPaths });
-    },
-    [paths, index, saveConfig],
-  );
-
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
 
   return (
@@ -207,6 +187,7 @@ export default function PlotLegendRow({
       <div style={{ position: "absolute" }}>
         {settingsModalOpen && (
           <PathSettingsModal
+            xAxisVal={xAxisVal}
             path={path}
             paths={paths}
             index={index}
@@ -244,7 +225,6 @@ export default function PlotLegendRow({
           autoSize
           disableAutocomplete={isReferenceLinePlotPath}
           inputStyle={{ textDecoration: !path.enabled ? "line-through" : undefined }}
-          {...(xAxisVal === "timestamp" ? { timestampMethod } : undefined)}
         />
         {hasMismatchedDataLength && (
           <Tooltip
@@ -271,13 +251,6 @@ export default function PlotLegendRow({
         >
           <MoreVertIcon fontSize="small" />
         </IconButton>
-        <TimestampMethodDropdown
-          path={path.value}
-          onTimestampMethodChange={onInputTimestampMethodChange}
-          index={index}
-          iconButtonProps={{ disabled: !path.value }}
-          timestampMethod={xAxisVal === "timestamp" ? timestampMethod : undefined}
-        />
         <IconButton
           className={classes.actionButton}
           size="small"


### PR DESCRIPTION
**User-Facing Changes**
Moved Plot panel setting for receive-time/header-stamp ordering into the new per-series settings dialog.

**Description**
<img width="243" alt="image" src="https://user-images.githubusercontent.com/14237/157549188-9148b72f-c81c-43ff-ade6-f1c8190bb3bf.png">

<img width="529" alt="Screen Shot 2022-03-09 at 2 17 54 PM" src="https://user-images.githubusercontent.com/14237/157547785-780eb317-c5ad-484a-b80c-7bffafc619e9.png">

<img width="528" alt="Screen Shot 2022-03-09 at 2 17 59 PM" src="https://user-images.githubusercontent.com/14237/157547762-6cdfebb5-46fe-42f0-bd9d-3835c7c066d2.png">

