### PR TITLE
Fix some extraneous calls to saveConfig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "jest.autoRun": { "watch": false, "onSave": "test-file" }
+  "jest.autoRun": { "watch": false, "onSave": "test-file" },
+  "jest.jestCommandLine": "yarn test"
 }

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -26,7 +26,11 @@ import panelsReducer from "./reducers";
 export default function MockCurrentLayoutProvider({
   children,
   initialState,
-}: React.PropsWithChildren<{ initialState?: Partial<PanelsState> }>): JSX.Element {
+  onAction,
+}: React.PropsWithChildren<{
+  initialState?: Partial<PanelsState>;
+  onAction?: (action: PanelsActions) => void;
+}>): JSX.Element {
   const layoutStateListeners = useRef(new Set<(_: LayoutState) => void>());
   const addLayoutStateListener = useCallback((listener: (_: LayoutState) => void) => {
     layoutStateListeners.current.add(listener);
@@ -62,6 +66,7 @@ export default function MockCurrentLayoutProvider({
 
   const performAction = useCallback(
     (action: PanelsActions) => {
+      onAction?.(action);
       setLayoutState({
         ...layoutStateRef.current,
         selectedLayout: {
@@ -70,7 +75,7 @@ export default function MockCurrentLayoutProvider({
         },
       });
     },
-    [setLayoutState],
+    [onAction, setLayoutState],
   );
 
   const actions: ICurrentLayout["actions"] = useMemo(

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -167,6 +167,7 @@ export default function CurrentLayoutProvider({
 
       // the panel state did not change, so no need to perform layout state updates or layout manager updates
       if (isEqual(oldData, newData)) {
+        log.warn("Panel action resulted in identical config:", action);
         return;
       }
 

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -27,6 +27,7 @@ import {
   useCurrentLayoutActions,
   useSelectedPanels,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { PanelsActions } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { HoverValueProvider } from "@foxglove/studio-base/context/HoverValueContext";
 import PanelCatalogContext, {
   PanelCatalog,
@@ -76,7 +77,7 @@ export type Fixture = {
   setSubscriptions?: ComponentProps<typeof MockMessagePipelineProvider>["setSubscriptions"];
 };
 
-type Props = {
+type UnconnectedProps = {
   children: React.ReactNode;
   fixture?: Fixture;
   panelCatalog?: PanelCatalog;
@@ -156,7 +157,7 @@ class MockPanelCatalog implements PanelCatalog {
   }
 }
 
-function UnconnectedPanelSetup(props: Props): JSX.Element | ReactNull {
+function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull {
   const [mockPanelCatalog] = useState(() => props.panelCatalog ?? new MockPanelCatalog());
   const [mockAppConfiguration] = useState(() => ({
     get() {
@@ -290,11 +291,14 @@ function UnconnectedPanelSetup(props: Props): JSX.Element | ReactNull {
   return omitDragAndDrop ? inner : <MosaicWrapper>{inner}</MosaicWrapper>;
 }
 
+type Props = UnconnectedProps & {
+  onLayoutAction?: (action: PanelsActions) => void;
+};
 export default function PanelSetup(props: Props): JSX.Element {
   return (
     <UserNodeStateProvider>
       <HoverValueProvider>
-        <MockCurrentLayoutProvider>
+        <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
           <HelpInfoProvider>
             <UnconnectedPanelSetup {...props} />
           </HelpInfoProvider>


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where loading a layout that contained a Plot panel would cause the layout to appear modified immediately.

**Description**
Fixes https://github.com/foxglove/nvidia-issue-tracker/issues/42. Does not include https://github.com/foxglove/studio/issues/2068, may tackle that separately.

In https://github.com/foxglove/studio/pull/2738, we started saving configs automatically when the defaultConfig's keys did not match the savedConfig's keys. Two issues arose with this approach:
1. When defaultConfig had an undefined value (such as Plot's `title: undefined`), the logic would always be triggered because the save action would not properly take effect (at least after an app reload), because JSON.stringify ignores undefined values.
2. If keys were _removed_ from defaultConfig in a future app update, the save logic would always be triggered because the key sets would never become equal.

This PR fixes the issue by only saving if there are keys in defaultConfig (with non-undefined values) which are not present in savedConfig. It also adds some tests, more defensive logic, and a warning console message for extraneous saves.