### PR TITLE
Remove dataset iteration from PlotLegendRow

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -347,6 +347,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
           y: canvasRect.top + mouseYRef.current,
           data: tooltipItems.map((item) => item.item),
         });
+
+        // fixme - call a prop to provide the hovered data
       }
     },
     [tooltipLookup],

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
@@ -22,10 +22,9 @@ export function DefaultIndex0(): JSX.Element {
     <PathSettingsModal
       xAxisVal="timestamp"
       path={paths[index]!}
-      paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      onChange={action("onChange")}
     />
   );
 }
@@ -40,10 +39,9 @@ export function DefaultIndex1(): JSX.Element {
     <PathSettingsModal
       xAxisVal="timestamp"
       path={paths[index]!}
-      paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      onChange={action("onChange")}
     />
   );
 }
@@ -58,10 +56,9 @@ export function CustomColor(): JSX.Element {
     <PathSettingsModal
       xAxisVal="timestamp"
       path={paths[index]!}
-      paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      onChange={action("onChange")}
     />
   );
 }
@@ -75,10 +72,9 @@ export function CustomXAxis(): JSX.Element {
     <PathSettingsModal
       xAxisVal="custom"
       path={paths[index]!}
-      paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      onChange={action("onChange")}
     />
   );
 }
@@ -90,10 +86,9 @@ export function ReferenceLine(): JSX.Element {
     <PathSettingsModal
       xAxisVal="timestamp"
       path={paths[index]!}
-      paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      onChange={action("onChange")}
     />
   );
 }

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
@@ -14,14 +14,12 @@ import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import { isReferenceLinePlotPathType, PlotPath } from "./internalTypes";
-import { PlotConfig, PlotXAxisVal } from "./types";
+import { PlotXAxisVal } from "./types";
 
 type PathSettingsModalProps = {
   xAxisVal: PlotXAxisVal;
   path: PlotPath;
-  paths: PlotPath[];
   index: number;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
   onDismiss: () => void;
 };
 
@@ -36,25 +34,22 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function PathSettingsModal({
   xAxisVal,
   path,
-  paths,
   index,
-  saveConfig,
   onDismiss,
 }: PathSettingsModalProps): JSX.Element {
   const classes = useStyles();
   const hostId = useDialogHostId();
 
-  const savePathConfig = useCallback(
-    (newConfig: Partial<PlotPath>) => {
+  const savePathConfig = useCallback((newConfig: Partial<PlotPath>) => {
+    /*
       const newPaths = paths.slice();
       const newPath = newPaths[index];
       if (newPath) {
         newPaths[index] = { ...newPath, ...newConfig };
       }
       saveConfig({ paths: newPaths });
-    },
-    [paths, index, saveConfig],
-  );
+      */
+  }, []);
 
   const resetToDefaults = useCallback(() => {
     savePathConfig({ color: undefined });

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
@@ -20,6 +20,7 @@ type PathSettingsModalProps = {
   xAxisVal: PlotXAxisVal;
   path: PlotPath;
   index: number;
+  onChange: (index: number, newConfig: PlotPath) => void;
   onDismiss: () => void;
 };
 
@@ -35,21 +36,18 @@ export default function PathSettingsModal({
   xAxisVal,
   path,
   index,
+  onChange,
   onDismiss,
 }: PathSettingsModalProps): JSX.Element {
   const classes = useStyles();
   const hostId = useDialogHostId();
 
-  const savePathConfig = useCallback((newConfig: Partial<PlotPath>) => {
-    /*
-      const newPaths = paths.slice();
-      const newPath = newPaths[index];
-      if (newPath) {
-        newPaths[index] = { ...newPath, ...newConfig };
-      }
-      saveConfig({ paths: newPaths });
-      */
-  }, []);
+  const savePathConfig = useCallback(
+    (newConfig: Partial<PlotPath>) => {
+      onChange(index, { ...path, ...newConfig });
+    },
+    [index, onChange, path],
+  );
 
   const resetToDefaults = useCallback(() => {
     savePathConfig({ color: undefined });

--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -25,8 +25,8 @@ import TimeBasedChart, {
 } from "@foxglove/studio-base/components/TimeBasedChart";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 
-import { PlotXAxisVal } from "./index";
 import { PlotPath, isReferenceLinePlotPathType } from "./internalTypes";
+import { PlotXAxisVal } from "./types";
 
 // A "reference line" plot path is a numeric value. It creates a horizontal line on the plot at the specified value.
 function getAnnotationFromReferenceLine(path: PlotPath, index: number): AnnotationOptions {
@@ -67,7 +67,9 @@ type PlotChartProps = {
   xAxisVal: PlotXAxisVal;
   currentTime?: number;
   defaultView?: ChartDefaultView;
+  showTooltips?: boolean;
   onClick?: TimeBasedChartProps["onClick"];
+  onHover?: TimeBasedChartProps["onHover"];
 };
 export default function PlotChart(props: PlotChartProps): JSX.Element {
   const theme = useTheme();
@@ -80,10 +82,12 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
     minYValue,
     maxYValue,
     datasets,
+    showTooltips,
     onClick,
     isSynced,
     tooltips,
     xAxisVal,
+    onHover,
   } = props;
 
   const annotations = useMemo(() => getAnnotations(paths), [paths]);
@@ -130,6 +134,7 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
         height={height ?? 0}
         data={data}
         tooltips={tooltips}
+        showTooltips={showTooltips}
         annotations={annotations}
         type="scatter"
         yAxes={yAxes}
@@ -138,6 +143,7 @@ export default function PlotChart(props: PlotChartProps): JSX.Element {
         currentTime={currentTime}
         defaultView={defaultView}
         onClick={onClick}
+        onHover={onHover}
       />
     </div>
   );

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -30,6 +30,7 @@ export const Default: Story = () => {
           { value: "foo.baz", enabled: false, timestampMethod: "receiveTime" },
         ]}
         pathValues={{}}
+        hoveredPathValues={{}}
         xAxisVal="timestamp"
         pathsWithMismatchedDataLengths={[]}
         legendDisplay={"floating"}
@@ -52,6 +53,7 @@ export const WithValues: Story = () => {
         pathValues={{
           "foo.bar": 12.3212,
         }}
+        hoveredPathValues={{}}
         xAxisVal="timestamp"
         pathsWithMismatchedDataLengths={[]}
         legendDisplay={"floating"}

--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Story } from "@storybook/react";
+import { PropsWithChildren } from "react";
+
+import PlotLegend from "@foxglove/studio-base/panels/Plot/PlotLegend";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+export default {
+  title: "panels/Plot/PlotLegend",
+  component: PlotLegend,
+};
+
+function StoryWrapper(props: PropsWithChildren<unknown>) {
+  return (
+    <div style={{ height: "100vh" }}>
+      <PanelSetup>{props.children}</PanelSetup>
+    </div>
+  );
+}
+
+export const Default: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegend
+        paths={[
+          { value: "foo.bar", enabled: false, timestampMethod: "receiveTime" },
+          { value: "foo.baz", enabled: false, timestampMethod: "receiveTime" },
+        ]}
+        pathValues={{}}
+        xAxisVal="timestamp"
+        pathsWithMismatchedDataLengths={[]}
+        legendDisplay={"floating"}
+        showLegend={true}
+        saveConfig={() => {}}
+        sidebarDimension={240}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const WithValues: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegend
+        paths={[
+          { value: "foo.bar", enabled: false, timestampMethod: "receiveTime" },
+          { value: "foo.baz", enabled: false, timestampMethod: "receiveTime" },
+        ]}
+        pathValues={{
+          "foo.bar": 12.3212,
+        }}
+        xAxisVal="timestamp"
+        pathsWithMismatchedDataLengths={[]}
+        legendDisplay={"floating"}
+        showLegend={true}
+        saveConfig={() => {}}
+        sidebarDimension={240}
+      />
+    </StoryWrapper>
+  );
+};

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -31,15 +31,16 @@ import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax
 import PlotLegendRow from "@foxglove/studio-base/panels/Plot/PlotLegendRow";
 
 import { PlotPath, BasePlotPath, isReferenceLinePlotPathType } from "./internalTypes";
-import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
+import { plotableRosTypes, PlotConfig, PlotXAxisVal, PathValue } from "./types";
 
 const minLegendWidth = 25;
 const maxLegendWidth = 800;
 
 type PlotLegendProps = {
   paths: PlotPath[];
-  pathValues: { [path: string]: number };
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
+  pathValues: { [path: string]: PathValue };
+  hoveredPathValues: { [path: string]: PathValue };
+  saveConfig: (partialConfig: Partial<PlotConfig>) => void;
   showLegend: boolean;
   xAxisVal: PlotXAxisVal;
   xAxisPath?: BasePlotPath;
@@ -229,6 +230,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
     sidebarDimension,
     legendDisplay,
     pathValues,
+    hoveredPathValues,
   } = props;
   const lastPath = last(paths);
   const classes = useStyles({
@@ -321,7 +323,21 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
               xAxisVal={xAxisVal}
               path={path}
               value={pathValues[path.value]}
+              hoverValue={hoveredPathValues[path.value]}
               hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
+              onChange={(idx, value) => {
+                const newPaths = paths.slice();
+                const newPath = newPaths[idx];
+                if (newPath) {
+                  newPaths[idx] = value;
+                }
+                saveConfig({ paths: newPaths });
+              }}
+              onRemove={(idx) => {
+                const newPaths = paths.slice();
+                newPaths.splice(idx, 1);
+                saveConfig({ paths: newPaths });
+              }}
             />
           ))}
         </div>
@@ -359,6 +375,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
       pathValues,
       pathsWithMismatchedDataLengths,
       lastPath,
+      hoveredPathValues,
     ],
   );
 

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -23,12 +23,11 @@ import { Button, IconButton, Theme, alpha } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import { last } from "lodash";
-import { ComponentProps, useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
 import DropdownItem from "@foxglove/studio-base/components/Dropdown/DropdownItem";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
-import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import PlotLegendRow from "@foxglove/studio-base/panels/Plot/PlotLegendRow";
 
 import { PlotPath, BasePlotPath, isReferenceLinePlotPathType } from "./internalTypes";
@@ -39,8 +38,7 @@ const maxLegendWidth = 800;
 
 type PlotLegendProps = {
   paths: PlotPath[];
-  datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
-  currentTime?: number;
+  pathValues: { [path: string]: number };
   saveConfig: (arg0: Partial<PlotConfig>) => void;
   showLegend: boolean;
   xAxisVal: PlotXAxisVal;
@@ -48,7 +46,6 @@ type PlotLegendProps = {
   pathsWithMismatchedDataLengths: string[];
   sidebarDimension: number;
   legendDisplay: "floating" | "top" | "left";
-  showPlotValuesInLegend: boolean;
 };
 
 const shortXAxisLabel = (path: PlotXAxisVal): string => {
@@ -68,7 +65,6 @@ const shortXAxisLabel = (path: PlotXAxisVal): string => {
 type StyleProps = {
   legendDisplay: PlotLegendProps["legendDisplay"];
   showLegend: PlotLegendProps["showLegend"];
-  showPlotValuesInLegend?: PlotLegendProps["showPlotValuesInLegend"];
   sidebarDimension: PlotLegendProps["sidebarDimension"];
 };
 
@@ -129,15 +125,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: "stretch",
     position: "relative",
     display: "grid",
-    gridTemplateColumns: ({ showPlotValuesInLegend = false }: StyleProps) =>
-      [
-        "auto",
-        "minmax(max-content, 1fr)",
-        showPlotValuesInLegend && "minmax(max-content, 1fr)",
-        "auto",
-      ]
-        .filter(Boolean)
-        .join(" "),
+    gridTemplateColumns: [
+      "auto",
+      "minmax(max-content, 1fr)",
+      "minmax(max-content, 1fr)",
+      "auto",
+    ].join(" "),
   },
   header: {
     display: "flex",
@@ -228,8 +221,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function PlotLegend(props: PlotLegendProps): JSX.Element {
   const {
     paths,
-    datasets,
-    currentTime,
     saveConfig,
     showLegend,
     xAxisVal,
@@ -237,14 +228,13 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
     pathsWithMismatchedDataLengths,
     sidebarDimension,
     legendDisplay,
-    showPlotValuesInLegend,
+    pathValues,
   } = props;
   const lastPath = last(paths);
   const classes = useStyles({
     legendDisplay,
     sidebarDimension,
     showLegend,
-    showPlotValuesInLegend,
   });
 
   const toggleLegend = useCallback(
@@ -330,12 +320,8 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
               index={index}
               xAxisVal={xAxisVal}
               path={path}
-              paths={paths}
+              value={pathValues[path.value]}
               hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
-              datasets={datasets}
-              currentTime={currentTime}
-              saveConfig={saveConfig}
-              showPlotValuesInLegend={showPlotValuesInLegend}
             />
           ))}
         </div>
@@ -365,21 +351,13 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
       </div>
     ),
     [
-      classes.legendContent,
-      classes.header,
-      classes.dropdownWrapper,
-      classes.dropdown,
-      classes.grid,
-      classes.footer,
-      classes.addButton,
+      classes,
       xAxisVal,
       xAxisPath,
       paths,
       saveConfig,
+      pathValues,
       pathsWithMismatchedDataLengths,
-      datasets,
-      currentTime,
-      showPlotValuesInLegend,
       lastPath,
     ],
   );

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.stories.tsx
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Story } from "@storybook/react";
+import { PropsWithChildren } from "react";
+
+import PlotLegendRow from "@foxglove/studio-base/panels/Plot/PlotLegendRow";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+export default {
+  title: "panels/Plot/PlotLegendRow",
+  component: PlotLegendRow,
+};
+
+function StoryWrapper(props: PropsWithChildren<unknown>) {
+  return (
+    <div style={{ height: 30 }}>
+      <PanelSetup>{props.children}</PanelSetup>
+    </div>
+  );
+}
+
+export const Default: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegendRow
+        path={{ value: "foo.bar", enabled: false, timestampMethod: "receiveTime" }}
+        index={0}
+        xAxisVal="timestamp"
+        hasMismatchedDataLength={false}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const HasMismatchedDataLength: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegendRow
+        path={{ value: "foo.bar", enabled: false, timestampMethod: "receiveTime" }}
+        index={0}
+        xAxisVal="timestamp"
+        hasMismatchedDataLength={true}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const WithValue: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegendRow
+        path={{ value: "foo.bar", enabled: false, timestampMethod: "receiveTime" }}
+        index={0}
+        value={33.44423}
+        xAxisVal="timestamp"
+        hasMismatchedDataLength={false}
+      />
+    </StoryWrapper>
+  );
+};

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.stories.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { action } from "@storybook/addon-actions";
 import { Story } from "@storybook/react";
 import { PropsWithChildren } from "react";
 
@@ -29,6 +30,8 @@ export const Default: Story = () => {
         index={0}
         xAxisVal="timestamp"
         hasMismatchedDataLength={false}
+        onChange={action("onChange")}
+        onRemove={action("onRemove")}
       />
     </StoryWrapper>
   );
@@ -42,6 +45,8 @@ export const HasMismatchedDataLength: Story = () => {
         index={0}
         xAxisVal="timestamp"
         hasMismatchedDataLength={true}
+        onChange={action("onChange")}
+        onRemove={action("onRemove")}
       />
     </StoryWrapper>
   );
@@ -56,6 +61,25 @@ export const WithValue: Story = () => {
         value={33.44423}
         xAxisVal="timestamp"
         hasMismatchedDataLength={false}
+        onChange={action("onChange")}
+        onRemove={action("onRemove")}
+      />
+    </StoryWrapper>
+  );
+};
+
+export const WithHoveredValue: Story = () => {
+  return (
+    <StoryWrapper>
+      <PlotLegendRow
+        path={{ value: "foo.bar", enabled: false, timestampMethod: "receiveTime" }}
+        index={0}
+        value={33.44423}
+        hoverValue={40.3242}
+        xAxisVal="timestamp"
+        hasMismatchedDataLength={false}
+        onChange={action("onChange")}
+        onRemove={action("onRemove")}
       />
     </StoryWrapper>
   );

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -11,28 +11,21 @@ import {
 } from "@mui/icons-material";
 import { IconButton, Theme, Tooltip, Typography, useTheme } from "@mui/material";
 import { createStyles, makeStyles } from "@mui/styles";
-import { ComponentProps, useCallback, useMemo, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
+import { useCallback, useState } from "react";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
-import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
-import { useHoverValue } from "@foxglove/studio-base/context/HoverValueContext";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 
 import PathSettingsModal from "./PathSettingsModal";
 import { PlotPath, isReferenceLinePlotPathType } from "./internalTypes";
-import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
+import { plotableRosTypes, PlotXAxisVal } from "./types";
 
 type PlotLegendRowProps = {
   index: number;
   xAxisVal: PlotXAxisVal;
   path: PlotPath;
-  paths: PlotPath[];
+  value?: number;
   hasMismatchedDataLength: boolean;
-  datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
-  currentTime?: number;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
-  showPlotValuesInLegend: boolean;
 };
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -72,6 +65,7 @@ const useStyles = makeStyles((theme: Theme) =>
     plotValue: {
       display: "flex",
       alignItems: "center",
+      justifyContent: "right",
       padding: theme.spacing(0.25),
     },
     actionButton: {
@@ -106,31 +100,15 @@ export default function PlotLegendRow({
   index,
   xAxisVal,
   path,
-  paths,
+  value,
   hasMismatchedDataLength,
-  datasets,
-  currentTime,
-  saveConfig,
-  showPlotValuesInLegend,
 }: PlotLegendRowProps): JSX.Element {
-  const correspondingData = useMemo(() => {
-    if (!showPlotValuesInLegend) {
-      return [];
-    }
-    return datasets.find((set) => set.label === path.value)?.data ?? [];
-  }, [datasets, path.value, showPlotValuesInLegend]);
-
-  const [hoverComponentId] = useState<string>(() => uuidv4());
-  const hoverValue = useHoverValue({
-    componentId: hoverComponentId,
-    isTimestampScale: true,
-  });
-
-  const fluentUITheme = useFluentUITheme();
+  // const fluentUITheme = useFluentUITheme();
   const theme = useTheme();
 
+  /*
   const currentDisplay = useMemo(() => {
-    if (!showPlotValuesInLegend) {
+    if (value == undefined) {
       return {
         value: undefined,
         color: "inherit",
@@ -150,12 +128,12 @@ export default function PlotLegendRow({
       color: hoverValue?.value != undefined ? fluentUITheme.palette.yellowDark : "inherit",
     };
   }, [
-    showPlotValuesInLegend,
     hoverValue?.value,
     currentTime,
     fluentUITheme.palette.yellowDark,
     correspondingData,
   ]);
+  */
 
   const legendIconColor = path.enabled
     ? getLineColor(path.color, index)
@@ -165,20 +143,20 @@ export default function PlotLegendRow({
 
   const isReferenceLinePlotPath = isReferenceLinePlotPathType(path);
 
-  const onInputChange = useCallback(
-    (value: string, idx?: number) => {
+  const onInputChange = useCallback((inputValue: string, idx?: number) => {
+    console.log("input change", value, idx);
+    /*
       if (idx == undefined) {
         throw new Error("index not set");
       }
       const newPaths = paths.slice();
       const newPath = newPaths[idx];
       if (newPath) {
-        newPaths[idx] = { ...newPath, value: value.trim() };
+        newPaths[idx] = { ...newPath, value: inputValue.trim() };
       }
       saveConfig({ paths: newPaths });
-    },
-    [paths, saveConfig],
-  );
+      */
+  }, []);
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
 
@@ -189,9 +167,7 @@ export default function PlotLegendRow({
           <PathSettingsModal
             xAxisVal={xAxisVal}
             path={path}
-            paths={paths}
             index={index}
-            saveConfig={saveConfig}
             onDismiss={() => setSettingsModalOpen(false)}
           />
         )}
@@ -203,12 +179,14 @@ export default function PlotLegendRow({
           size="small"
           title="Toggle visibility"
           onClick={() => {
+            /*
             const newPaths = paths.slice();
             const newPath = newPaths[index];
             if (newPath) {
               newPaths[index] = { ...newPath, enabled: !newPath.enabled };
             }
             saveConfig({ paths: newPaths });
+            */
           }}
         >
           <RemoveIcon style={{ color: legendIconColor }} color="inherit" />
@@ -235,13 +213,14 @@ export default function PlotLegendRow({
           </Tooltip>
         )}
       </div>
-      {showPlotValuesInLegend && (
-        <div className={classes.plotValue} style={{ color: currentDisplay.color }}>
+      {value != undefined && (
+        <div className={classes.plotValue}>
           <Typography component="div" variant="body2" align="right" color="inherit">
-            {currentDisplay.value ?? ""}
+            {value}
           </Typography>
         </div>
       )}
+      {value == undefined && <div></div>}
       <div className={classes.actions}>
         <IconButton
           className={classes.actionButton}
@@ -256,9 +235,11 @@ export default function PlotLegendRow({
           size="small"
           title={`Remove ${path.value}`}
           onClick={() => {
+            /*
             const newPaths = paths.slice();
             newPaths.splice(index, 1);
             saveConfig({ paths: newPaths });
+            */
           }}
         >
           <CloseIcon fontSize="small" />

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -10,7 +10,6 @@ import { format } from "@foxglove/studio-base/util/formatTime";
 import { darkColor, getLineColor, lightColor } from "@foxglove/studio-base/util/plotColors";
 import { formatTimeRaw, TimestampMethod } from "@foxglove/studio-base/util/time";
 
-import { PlotXAxisVal } from "./index";
 import {
   BasePlotPath,
   DataSet,
@@ -21,6 +20,7 @@ import {
   Datum,
 } from "./internalTypes";
 import { derivative, applyToDatum, mathFunctions, MathFunction } from "./transformPlotRange";
+import { PlotXAxisVal } from "./types";
 
 const isCustomScale = (xAxisVal: PlotXAxisVal): boolean =>
   xAxisVal === "custom" || xAxisVal === "currentCustom";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -17,11 +17,13 @@ import { useCallback, useRef } from "react";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { fromSec } from "@foxglove/rostime";
 import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
-import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
+import Plot from "@foxglove/studio-base/panels/Plot";
 import { BlockCache } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+
+import { PlotConfig } from "./types";
 
 const float64StampedDefinition = `std_msgs/Header header
 float64 data

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -380,6 +380,21 @@ LineGraph.parameters = {
   useReadySignal: true,
 };
 
+export function LineGraphWithValuesInLegend(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  return (
+    <PlotWrapper
+      pauseFrame={pauseFrame}
+      config={{ ...exampleConfig, showPlotValuesInLegend: true }}
+    />
+  );
+}
+LineGraphWithValuesInLegend.parameters = {
+  colorScheme: "light",
+  useReadySignal: true,
+};
+
 LineGraphWithLegendsHidden.storyName = "line graph with legends hidden";
 export function LineGraphWithLegendsHidden(): JSX.Element {
   const readySignal = useReadySignal({ count: 3 });

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -49,3 +49,5 @@ export const plotableRosTypes = [
   "string",
   "json",
 ];
+
+export type PathValue = string | number | bigint | boolean;


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
The Plot panel has a feature to display current and hovered values in the legend. This feature was implemented in https://github.com/foxglove/studio/pull/2484.

The logic for the feature computed the value by iterating through the dataset within the PlotLegendRow. This iteration would happen on every tick or during hovering. For large datasets, this iteration slows down rendering.

This change removes dataset iteration from the PlotLegendRow and uses the messages reducer already present in the plot panel to capture the latest value for each path.

Fixes: #2920

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
