### PR TITLE
Add production endpoint tip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ $ yarn storybook
 # Advanced usage: running webpack and electron on different computers (or VMs) on the same network
 $ yarn serve --host 192.168.xxx.yyy         # the address where electron can reach the webpack dev server
 $ yarn dlx electron@13.0.0-beta.13 .webpack # launch the version of electron for the current computer's platform
+
+# To launch the desktop app using production API endpoints
+$ yarn serve --env FOXGLOVE_BACKEND=production
+$ yarn start
+
+# NOTE: yarn web:serve does not support connecting to the production endpoints
 ```
 
 A [Dockerfile](/Dockerfile) to self-host the browser app is also available.


### PR DESCRIPTION


**User-Facing Changes**
None

README notes for devx.

**Description**
The app defaults to using dev api endpoints. This note shows how to connect to the production endpoints using the desktop app.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
