### PR TITLE
Fix sensor_msgs/LaserScan hasIntensity check for typed arrays

### DIFF
--- a/packages/studio-base/src/panels/ImageView/lib/PinholeCameraModel.ts
+++ b/packages/studio-base/src/panels/ImageView/lib/PinholeCameraModel.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { CameraInfo, Point2D } from "@foxglove/studio-base/types/Messages";
+import { CameraInfo, FloatArray, Point2D } from "@foxglove/studio-base/types/Messages";
 
 const DISTORTION_STATE = {
   NONE: "NONE",
@@ -26,10 +26,10 @@ type DistortionState = typeof DISTORTION_STATE[keyof typeof DISTORTION_STATE];
 // http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html
 export default class PinholeCameraModel {
   private _distortionState: DistortionState = DISTORTION_STATE.NONE;
-  D: readonly number[] = [];
-  K: readonly number[] = [];
-  P: readonly number[] = [];
-  R: readonly number[] = [];
+  D: FloatArray = [];
+  K: FloatArray = [];
+  P: FloatArray = [];
+  R: FloatArray = [];
 
   // Mostly copied from `fromCameraInfo`
   // http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html#l00062

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -625,7 +625,9 @@ export default class SceneBuilder implements MarkerProvider {
 
   private _consumeLaserScan = (topic: string, msg: MessageEvent<LaserScan>): void => {
     const scan = msg.message;
-    const hasIntensity = Array.isArray(scan.intensities) && scan.intensities.length > 0;
+    const hasIntensity =
+      (ArrayBuffer.isView(scan.intensities) || Array.isArray(scan.intensities)) &&
+      scan.intensities.length > 0;
     const pointStep = hasIntensity ? 48 : 40;
 
     const data = new Uint8Array(pointStep * scan.ranges.length);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -635,7 +635,7 @@ export default class SceneBuilder implements MarkerProvider {
     for (let i = 0; i < scan.ranges.length; i++) {
       const offset = i * pointStep;
       const distance = Math.min(scan.range_max, Math.max(scan.range_min, scan.ranges[i] ?? 0));
-      const intensity = scan.intensities[i] ?? Number.NaN;
+      const intensity = (scan.intensities[i] ?? Number.NaN) as number;
       const angle = Math.min(scan.angle_max, scan.angle_min + i * scan.angle_increment);
       const x = distance * Math.cos(angle);
       const y = distance * Math.sin(angle);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.stories.tsx
@@ -1627,6 +1627,7 @@ SensorMsgs_LaserScan.parameters = { colorScheme: "dark" };
 export function SensorMsgs_LaserScan(): JSX.Element {
   const topics: Topic[] = [
     { name: "/laserscan", datatype: "sensor_msgs/LaserScan" },
+    { name: "/laserscan/nointensity", datatype: "sensor_msgs/LaserScan" },
     { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
   ];
   const tf1: MessageEvent<TF> = {
@@ -1674,11 +1675,30 @@ export function SensorMsgs_LaserScan(): JSX.Element {
     sizeInBytes: 0,
   };
 
+  const laserScanNoIntensity: MessageEvent<LaserScan> = {
+    topic: "/laserscan/nointensity",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      angle_min: 0,
+      angle_max: 2 * Math.PI,
+      angle_increment: (1 / 360) * 2 * Math.PI,
+      time_increment: 1 / 360,
+      scan_time: 1,
+      range_min: 0.001,
+      range_max: 10,
+      ranges: [...Array(360)].map((_, i) => 1 + (1 + Math.sin(i / 2)) / 2),
+      intensities: [],
+    },
+    sizeInBytes: 0,
+  };
+
   const fixture = useDelayedFixture({
     datatypes,
     topics,
     frame: {
       "/laserscan": [laserScan],
+      "/laserscan/nointensity": [laserScanNoIntensity],
       "/tf": [tf1, tf2],
     },
     capabilities: [],
@@ -1692,8 +1712,20 @@ export function SensorMsgs_LaserScan(): JSX.Element {
       <ThreeDimensionalViz
         overrideConfig={{
           ...ThreeDimensionalViz.defaultConfig,
-          checkedKeys: ["name:Topics", "t:/tf", "t:/laserscan", `t:${FOXGLOVE_GRID_TOPIC}`],
-          expandedKeys: ["name:Topics", "t:/tf", "t:/laserscan", `t:${FOXGLOVE_GRID_TOPIC}`],
+          checkedKeys: [
+            "name:Topics",
+            "t:/tf",
+            "t:/laserscan",
+            "t:/laserscan/nointensity",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
+          expandedKeys: [
+            "name:Topics",
+            "t:/tf",
+            "t:/laserscan",
+            "t:/laserscan/nointensity",
+            `t:${FOXGLOVE_GRID_TOPIC}`,
+          ],
           followTf: "base_link",
           cameraState: {
             distance: 13.5,

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -88,7 +88,7 @@ export type Polygon = Readonly<{
   points: Points;
 }>;
 
-type FloatArray = ReadonlyArray<number> | Readonly<Float32Array> | Readonly<Float64Array>;
+export type FloatArray = ReadonlyArray<number> | Readonly<Float32Array> | Readonly<Float64Array>;
 
 export type LaserScan = Readonly<{
   header: Header;

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -88,15 +88,17 @@ export type Polygon = Readonly<{
   points: Points;
 }>;
 
+type FloatArray = ReadonlyArray<number> | Readonly<Float32Array> | Readonly<Float64Array>;
+
 export type LaserScan = Readonly<{
   header: Header;
   angle_increment: number;
   angle_max: number;
   angle_min: number;
-  intensities: readonly number[];
+  intensities: FloatArray;
   range_max: number;
   range_min: number;
-  ranges: readonly number[];
+  ranges: FloatArray;
   scan_time?: number;
   time_increment?: number;
 }>;
@@ -236,7 +238,7 @@ type NavMsgs$MapMetaData = Readonly<{
 export type NavMsgs$OccupancyGrid = Readonly<{
   header: Header;
   info: NavMsgs$MapMetaData;
-  data: number[] | Int8Array;
+  data: ReadonlyArray<number> | Readonly<Int8Array>;
 }>;
 
 export type NavMsgs$Path = Readonly<{
@@ -251,7 +253,7 @@ export type OccupancyGridMessage = Readonly<{
   alpha?: number;
   info: NavMsgs$MapMetaData;
   pose: MutablePose;
-  data: readonly number[];
+  data: ReadonlyArray<number> | Readonly<Int8Array>;
 }>;
 
 export type TriangleListMarker = Readonly<
@@ -297,19 +299,6 @@ export type Marker =
 export type MarkerArray = Readonly<{
   markers: readonly Marker[];
 }>;
-
-type ChannelFloat = Readonly<{
-  name: string;
-  values: readonly number[];
-}>;
-
-type PointCloud1 = Readonly<
-  StampedMessage & {
-    points: Points;
-    channels: readonly ChannelFloat[];
-    type: "PointCloud1";
-  }
->;
 
 export type PointField = Readonly<{
   name: string;
@@ -368,7 +357,7 @@ export type VelodyneScanDecoded = Readonly<
   }
 >;
 
-export type PointCloud = PointCloud1 | PointCloud2 | VelodyneScanDecoded;
+export type PointCloud = PointCloud2 | VelodyneScanDecoded;
 
 type Transform = Readonly<{
   rotation: Orientation;
@@ -439,16 +428,16 @@ export type CameraInfo = Readonly<{
   binning_y: number;
   roi: Roi;
   distortion_model: DistortionModel;
-  D: readonly number[];
-  K: readonly number[];
-  P: readonly number[];
-  R: readonly number[];
+  D: FloatArray;
+  K: FloatArray;
+  P: FloatArray;
+  R: FloatArray;
 }>;
 
 export type JointState = Readonly<{
   header: Header;
   name: string[];
-  position: number[];
-  velocity: number[];
-  effort: number[];
+  position: FloatArray;
+  velocity: FloatArray;
+  effort: FloatArray;
 }>;


### PR DESCRIPTION
**User-Facing Changes**

- Fixed a bug where `sensor_msgs/LaserScan` messages with intensities would sometimes not allow coloring by intensity

**Description**

```
> Array.isArray(new Float32Buffer())
false
> ArrayBuffer.isView(new Float32Buffer())
true
```
