### PR TITLE
Fix table panel auto-collapse on data change

### DIFF
--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -153,6 +153,7 @@ export default function Table({
     {
       columns,
       data,
+      autoResetExpanded: false,
       initialState: { pageSize: 30 },
     },
     useSortBy,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the table panel collapsing when it receives new data.

**Description**
This just sets the `autoResetExpanded` flag on the table to false so it doesn't collapse automatically when data changes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3008 