### PR TITLE
Don't depend on topic name to control marker transforms

### DIFF
--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -109,8 +109,6 @@ const BottomBar = ({ children }: { children?: React.ReactNode }) => {
   );
 };
 
-const canTransformMarkersByTopic = (topic: string) => !topic.includes("rect");
-
 function ImageView(props: Props) {
   const classes = useStyles();
   const { config, saveConfig } = props;
@@ -163,11 +161,10 @@ function ImageView(props: Props) {
 
       saveConfig({
         cameraTopic: newCameraTopic,
-        transformMarkers: canTransformMarkersByTopic(newCameraTopic),
         enabledMarkerTopics: newEnabledMarkerTopics,
       });
     },
-    [topics, enabledMarkerTopics, saveConfig],
+    [enabledMarkerTopics, saveConfig, topics],
   );
   const imageTopicDropdown = useMemo(() => {
     const items = allImageTopics.map((topic) => {
@@ -282,18 +279,12 @@ function ImageView(props: Props) {
   }, [cameraTopic, classes.controls, imageTopicDropdown, markerDropdown]);
 
   const renderBottomBar = () => {
-    const canTransformMarkers = canTransformMarkersByTopic(cameraTopic);
-
     const topicTimestamp = (
       <TopicTimestamp
         style={{ padding: "8px 8px 0px 0px" }}
         text={image ? formatTimeRaw(image.stamp) : ""}
       />
     );
-
-    if (!canTransformMarkers) {
-      return <BottomBar>{topicTimestamp}</BottomBar>;
-    }
 
     return (
       <BottomBar>


### PR DESCRIPTION
**User-Facing Changes**
This improves our handling of image marker transforms.

**Description**
Currently the image view depends on the presence of "rect" in the topic name to determine whether or not to enable transforms on image markers. This causes markers to completely disappear when changing image topics if the topic names don't contain "rect".

The solution is depends on two changes:
1. Transforms are off by default on newly created image panels.
2. The user can always turn them on and the setting persists when a new image topic is selected in an existing panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3010 