### PR TITLE
Add name to Ros1LocalBagDataSourceFactory for IterablePlayer

### DIFF
--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
@@ -38,6 +38,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       return new IterablePlayer({
         metricsCollector: args.metricsCollector,
         source: bagSource,
+        name: file.name,
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "file", file });

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -38,7 +38,7 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
       return new IterablePlayer({
         source: bagSource,
         isSampleDataSource: true,
-        name: "Adapted from nuScenes dataset.\nCopyright © 2020 nuScenes.\nhttps://www.nuscenes.org/terms-of-use",
+        name: url,
         metricsCollector: args.metricsCollector,
         // Use blank url params so the data source is set in the url
         urlParams: {


### PR DESCRIPTION


**User-Facing Changes**
When loading a file with the experimental bag player, the "Current Source" item in the data source sidebar displays the filename.

**Description**

The name field is displayed to the user in the data source sidebar under "Current Source". I forgot to include the name option when adding the codepath for the IterablePlayer.

Fixes the name field for Ros1RemoteBagDataSourceFactory.

Fixes: #3020
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
