### PR TITLE
Remove sendNotification from MessageOrderTracker

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
@@ -12,7 +12,6 @@
 //   You may not use this file except in compliance with the License.
 
 import { MessageEvent, PlayerPresence, PlayerState } from "@foxglove/studio-base/players/types";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
 
 import MessageOrderTracker from "./MessageOrderTracker";
 
@@ -62,61 +61,145 @@ const message = (
   sizeInBytes: 0,
 });
 
-describe("MessagePipeline/warnOnOutOfSyncMessages", () => {
+describe("MessagePipeline/MessageOrderTracker", () => {
   describe("when expecting messages ordered by receive time", () => {
-    it("calls report error when messages are out of order", () => {
+    it("report error when messages are out of order", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(7, 10), message(8, 9)], "receiveTime"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(7, 10), message(8, 9)], "receiveTime"),
+      );
+
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Processed a message on /foo at 9.000000001 which is earlier than last processed message on /foo at 10.000000001.",
+          ),
+          message: "Data went back in time",
+          severity: "warn",
+        },
+      ]);
+    });
+
+    it("preserves original problems when reporting new problems", () => {
+      const orderTracker = new MessageOrderTracker();
+      const playerState = playerStateWithMessages([message(7, 10), message(8, 9)], "receiveTime");
+      playerState.problems = [{ severity: "error", message: "Original problem" }];
+      const state = orderTracker.update(playerState);
+
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Processed a message on /foo at 9.000000001 which is earlier than last processed message on /foo at 10.000000001.",
+          ),
+          message: "Data went back in time",
+          severity: "warn",
+        },
+        {
+          severity: "error",
+          message: "Original problem",
+        },
+      ]);
     });
 
     it("does not report an error when messages are in order", () => {
-      expect.assertions(0);
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(8, 9), message(7, 10)], "receiveTime"));
+      const playerState = playerStateWithMessages([message(8, 9), message(7, 10)], "receiveTime");
+      const state = orderTracker.update(playerState);
+      expect(state.problems).toEqual(playerState.problems);
     });
 
     it("reports an error when given a message with no receive time", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(7, undefined)], "receiveTime"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(7, undefined)], "receiveTime"),
+      );
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Received a message on topic /foo around 1.000000011 with no receiveTime.",
+          ),
+          message: "Unsortable message",
+          severity: "warn",
+        },
+      ]);
     });
 
     it("reports an error when given a message with no timestamps at all", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(undefined, undefined)], "receiveTime"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(undefined, undefined)], "receiveTime"),
+      );
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Received a message on topic /foo around 1.000000011 with no receiveTime.",
+          ),
+          message: "Unsortable message",
+          severity: "warn",
+        },
+      ]);
     });
   });
 
   describe("when expecting messages ordered by header stamp", () => {
     it("calls report error when messages are out of order", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(8, 9), message(7, 10)], "headerStamp"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(8, 9), message(7, 10)], "headerStamp"),
+      );
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Processed a message on /foo at 7.000000001 which is earlier than last processed message on /foo at 8.000000001.",
+          ),
+          message: "Data went back in time",
+          severity: "warn",
+        },
+      ]);
     });
 
     it("does not report an error when messages are in order", () => {
-      expect.assertions(0);
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(7, 10), message(8, 9)], "headerStamp"));
+      const playerState = playerStateWithMessages([message(7, 10), message(8, 9)], "headerStamp");
+      const state = orderTracker.update(playerState);
+      expect(state.problems).toEqual(playerState.problems);
     });
 
     it("reports an error when given a message with no header stamp", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(undefined, 10)], "headerStamp"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(undefined, 10)], "headerStamp"),
+      );
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Received a message on topic /foo around 1.000000011 with no headerStamp.",
+          ),
+          message: "Unsortable message",
+          severity: "warn",
+        },
+      ]);
     });
 
     it("reports an error when given a message with no timestamps at all", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(playerStateWithMessages([message(undefined, undefined)], "headerStamp"));
-      sendNotification.expectCalledDuringTest();
+      const state = orderTracker.update(
+        playerStateWithMessages([message(undefined, undefined)], "headerStamp"),
+      );
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Received a message on topic /foo around 1.000000011 with no headerStamp.",
+          ),
+          message: "Unsortable message",
+          severity: "warn",
+        },
+      ]);
     });
 
     it("forgives a timestamp-backtracking after a missing header stamp", () => {
       const orderTracker = new MessageOrderTracker();
-      orderTracker.update(
+      const state = orderTracker.update(
         playerStateWithMessages(
           [
             message(8, 9),
@@ -126,8 +209,15 @@ describe("MessagePipeline/warnOnOutOfSyncMessages", () => {
           "headerStamp",
         ),
       );
-      expect((sendNotification as any).mock.calls.length).toBe(1);
-      sendNotification.expectCalledDuringTest();
+      expect(state.problems).toEqual([
+        {
+          error: new Error(
+            "Received a message on topic /foo around 1.000000011 with no headerStamp.",
+          ),
+          message: "Unsortable message",
+          severity: "warn",
+        },
+      ]);
     });
   });
 });

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.test.ts
@@ -65,38 +65,17 @@ describe("MessagePipeline/MessageOrderTracker", () => {
   describe("when expecting messages ordered by receive time", () => {
     it("report error when messages are out of order", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(7, 10), message(8, 9)], "receiveTime"),
       );
 
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Processed a message on /foo at 9.000000001 which is earlier than last processed message on /foo at 10.000000001.",
           ),
           message: "Data went back in time",
           severity: "warn",
-        },
-      ]);
-    });
-
-    it("preserves original problems when reporting new problems", () => {
-      const orderTracker = new MessageOrderTracker();
-      const playerState = playerStateWithMessages([message(7, 10), message(8, 9)], "receiveTime");
-      playerState.problems = [{ severity: "error", message: "Original problem" }];
-      const state = orderTracker.update(playerState);
-
-      expect(state.problems).toEqual([
-        {
-          error: new Error(
-            "Processed a message on /foo at 9.000000001 which is earlier than last processed message on /foo at 10.000000001.",
-          ),
-          message: "Data went back in time",
-          severity: "warn",
-        },
-        {
-          severity: "error",
-          message: "Original problem",
         },
       ]);
     });
@@ -104,16 +83,16 @@ describe("MessagePipeline/MessageOrderTracker", () => {
     it("does not report an error when messages are in order", () => {
       const orderTracker = new MessageOrderTracker();
       const playerState = playerStateWithMessages([message(8, 9), message(7, 10)], "receiveTime");
-      const state = orderTracker.update(playerState);
-      expect(state.problems).toEqual(playerState.problems);
+      const problems = orderTracker.update(playerState);
+      expect(problems).toEqual([]);
     });
 
     it("reports an error when given a message with no receive time", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(7, undefined)], "receiveTime"),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Received a message on topic /foo around 1.000000011 with no receiveTime.",
@@ -126,10 +105,10 @@ describe("MessagePipeline/MessageOrderTracker", () => {
 
     it("reports an error when given a message with no timestamps at all", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(undefined, undefined)], "receiveTime"),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Received a message on topic /foo around 1.000000011 with no receiveTime.",
@@ -144,10 +123,10 @@ describe("MessagePipeline/MessageOrderTracker", () => {
   describe("when expecting messages ordered by header stamp", () => {
     it("calls report error when messages are out of order", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(8, 9), message(7, 10)], "headerStamp"),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Processed a message on /foo at 7.000000001 which is earlier than last processed message on /foo at 8.000000001.",
@@ -161,16 +140,16 @@ describe("MessagePipeline/MessageOrderTracker", () => {
     it("does not report an error when messages are in order", () => {
       const orderTracker = new MessageOrderTracker();
       const playerState = playerStateWithMessages([message(7, 10), message(8, 9)], "headerStamp");
-      const state = orderTracker.update(playerState);
-      expect(state.problems).toEqual(playerState.problems);
+      const problems = orderTracker.update(playerState);
+      expect(problems).toEqual([]);
     });
 
     it("reports an error when given a message with no header stamp", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(undefined, 10)], "headerStamp"),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Received a message on topic /foo around 1.000000011 with no headerStamp.",
@@ -183,10 +162,10 @@ describe("MessagePipeline/MessageOrderTracker", () => {
 
     it("reports an error when given a message with no timestamps at all", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages([message(undefined, undefined)], "headerStamp"),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Received a message on topic /foo around 1.000000011 with no headerStamp.",
@@ -199,7 +178,7 @@ describe("MessagePipeline/MessageOrderTracker", () => {
 
     it("forgives a timestamp-backtracking after a missing header stamp", () => {
       const orderTracker = new MessageOrderTracker();
-      const state = orderTracker.update(
+      const problems = orderTracker.update(
         playerStateWithMessages(
           [
             message(8, 9),
@@ -209,7 +188,7 @@ describe("MessagePipeline/MessageOrderTracker", () => {
           "headerStamp",
         ),
       );
-      expect(state.problems).toEqual([
+      expect(problems).toEqual([
         {
           error: new Error(
             "Received a message on topic /foo around 1.000000011 with no headerStamp.",

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -13,8 +13,7 @@
 
 import Logger from "@foxglove/log";
 import { Time, isLessThan, subtract as subtractTimes, toSec } from "@foxglove/rostime";
-import { PlayerState, MessageEvent } from "@foxglove/studio-base/players/types";
-import sendNotification from "@foxglove/studio-base/util/sendNotification";
+import { PlayerState, MessageEvent, PlayerProblem } from "@foxglove/studio-base/players/types";
 import { formatFrame, getTimestampForMessageEvent } from "@foxglove/studio-base/util/time";
 
 const DRIFT_THRESHOLD_SEC = 1; // Maximum amount of drift allowed.
@@ -45,10 +44,13 @@ class MessageOrderTracker {
 
   private incorrectMessages: MessageEvent<unknown>[] = [];
 
-  update(playerState: PlayerState): void {
+  update(playerState: PlayerState): PlayerState {
     if (!playerState.activeData) {
-      return;
+      return playerState;
     }
+
+    const problems: PlayerProblem[] = [];
+
     const { messages, messageOrder, currentTime, lastSeekTime } = playerState.activeData;
     let didSeek = false;
 
@@ -69,14 +71,16 @@ class MessageOrderTracker {
       for (const message of messages) {
         const messageTime = getTimestampForMessageEvent(message, messageOrder);
         if (!messageTime) {
-          sendNotification(
-            `Message has no ${messageOrder}`,
-            `Received a message on topic ${message.topic} around ${formatFrame(
-              currentTime,
-            )} with ` + `no ${messageOrder} when sorting by that method.`,
-            "app",
-            "warn",
-          );
+          const formattedTime = formatFrame(currentTime);
+          const msg =
+            `Received a message on topic ${message.topic} around ${formattedTime} with ` +
+            `no ${messageOrder}.`;
+          problems.push({
+            severity: "warn",
+            error: new Error(msg),
+            message: "Unsortable message",
+          });
+
           this.lastMessageTopic = message.topic;
           this.lastMessageTime = undefined;
           continue;
@@ -121,23 +125,31 @@ class MessageOrderTracker {
           this.lastMessageTopic != undefined &&
           isLessThan(messageTime, this.lastMessageTime)
         ) {
-          sendNotification(
-            "Data went back in time",
-            `Processed a message on ${message.topic} at ${formatFrame(
-              messageTime,
-            )} which is earlier than ` +
-              `last processed message on ${this.lastMessageTopic} at ${formatFrame(
-                this.lastMessageTime,
-              )}. ` +
-              `Data source may be corrupted on these or other topics.`,
-            "user",
-            "warn",
-          );
+          const formattedTime = formatFrame(messageTime);
+          const lastMessageTime = formatFrame(this.lastMessageTime);
+          const errorMessage =
+            `Processed a message on ${message.topic} at ${formattedTime} which is earlier than ` +
+            `last processed message on ${this.lastMessageTopic} at ${lastMessageTime}.`;
+
+          problems.push({
+            severity: "warn",
+            message: "Data went back in time",
+            error: new Error(errorMessage),
+          });
         }
         this.lastMessageTopic = message.topic;
         this.lastMessageTime = messageTime;
       }
     }
+
+    if (problems.length === 0) {
+      return playerState;
+    }
+
+    return {
+      ...playerState,
+      problems: problems.concat(playerState.problems ?? []),
+    };
   }
 }
 

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -44,9 +44,9 @@ class MessageOrderTracker {
 
   private incorrectMessages: MessageEvent<unknown>[] = [];
 
-  update(playerState: PlayerState): PlayerState {
+  update(playerState: PlayerState): PlayerProblem[] {
     if (!playerState.activeData) {
-      return playerState;
+      return [];
     }
 
     const problems: PlayerProblem[] = [];
@@ -142,14 +142,7 @@ class MessageOrderTracker {
       }
     }
 
-    if (problems.length === 0) {
-      return playerState;
-    }
-
-    return {
-      ...playerState,
-      problems: problems.concat(playerState.problems ?? []),
-    };
+    return problems;
   }
 }
 

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -292,7 +292,7 @@ function createPlayerListener(args: {
   const messageOrderTracker = new MessageOrderTracker();
   let closed = false;
   let resolveFn: undefined | (() => void);
-  const listener = async (newPlayerState: PlayerState) => {
+  const listener = async (listenerPlayerState: PlayerState) => {
     if (closed) {
       return;
     }
@@ -302,7 +302,7 @@ function createPlayerListener(args: {
     }
 
     // check for any out-of-order or out-of-sync messages
-    messageOrderTracker.update(newPlayerState);
+    const newPlayerState = messageOrderTracker.update(listenerPlayerState);
 
     const promise = new Promise<void>((resolve) => {
       resolveFn = () => {

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -27,6 +27,7 @@ import {
   Player,
   PlayerCapabilities,
   PlayerPresence,
+  PlayerProblem,
   PlayerState,
   PublishPayload,
   SubscribePayload,
@@ -257,6 +258,18 @@ export function MessagePipelineProvider({
   );
 }
 
+// Given a PlayerState and a PlayerProblem array, add the problems to any existing player problems
+function concatProblems(origState: PlayerState, problems: PlayerProblem[]): PlayerState {
+  if (problems.length === 0) {
+    return origState;
+  }
+
+  return {
+    ...origState,
+    problems: problems.concat(origState.problems ?? []),
+  };
+}
+
 /**
  * The creation of the player listener is extracted as a separate function to prevent memory leaks.
  * When multiple closures are created inside of an outer function, V8 allocates one "context" object
@@ -302,7 +315,8 @@ function createPlayerListener(args: {
     }
 
     // check for any out-of-order or out-of-sync messages
-    const newPlayerState = messageOrderTracker.update(listenerPlayerState);
+    const problems = messageOrderTracker.update(listenerPlayerState);
+    const newPlayerState = concatProblems(listenerPlayerState, problems);
 
     const promise = new Promise<void>((resolve) => {
       resolveFn = () => {


### PR DESCRIPTION
**User-Facing Changes**
When encountering message order warnings the user is no longer bombarded with toast noticiations. Instead, the warnings are added to player problems and displayed alongside the existing player problems display (currently in the Data Source sidebar).

**Description**
Rather than emitting a notification for each message order violation, the MessageOrderTracker builds up an array of player problems. These player problems are added to the existing player problems. Downstream consumers of the playerState are responsible for the display of the problems.

Fixes: #2824


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
