### PR TITLE
Fix url state and recents update issue

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -29,6 +29,7 @@ import {
   PublishPayload,
   SubscribePayload,
   Topic,
+  PlayerURLState,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import naturalSort from "@foxglove/studio-base/util/naturalSort";
@@ -64,6 +65,7 @@ export default function MockMessagePipelineProvider(props: {
   playerId?: string;
   requestBackfill?: () => void;
   progress?: Progress;
+  urlState?: PlayerURLState;
 }): React.ReactElement {
   const startTime = useRef<Time | undefined>();
   let currentTime = props.currentTime;
@@ -114,6 +116,7 @@ export default function MockMessagePipelineProvider(props: {
       progress: props.progress ?? {},
       capabilities,
       problems: props.problems,
+      urlState: props.urlState,
       activeData:
         props.noActiveData === true
           ? undefined
@@ -145,6 +148,7 @@ export default function MockMessagePipelineProvider(props: {
       props.isPlaying,
       props.activeData,
       props.problems,
+      props.urlState,
       capabilities,
       currentTime,
     ],

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { renderHook } from "@testing-library/react-hooks";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import PlayerSelectionContext, {
+  PlayerSelection,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { useStateToURLSynchronization } from "@foxglove/studio-base/hooks/useStateToURLSynchronization";
+import { PlayerPresence } from "@foxglove/studio-base/players/types";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+
+// useLayoutEffect doesn't work in headless tests.
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useLayoutEffect: jest.requireActual("react").useEffect,
+}));
+
+function makePlayerSelection(options: Partial<PlayerSelection>): PlayerSelection {
+  return {
+    selectSource: () => {},
+    selectRecent: () => {},
+    availableSources: [],
+    recentSources: [],
+    selectedSource: undefined,
+    ...options,
+  };
+}
+
+describe("useStateToURLSynchronization", () => {
+  it("updates the url with a stable source & player state", () => {
+    const emptyPlayerSelection = makePlayerSelection({});
+
+    const selectedPlayerSelection = makePlayerSelection({
+      selectedSource: {
+        id: "test1",
+        type: "connection",
+        displayName: "test",
+        initialize: () => undefined,
+      },
+    });
+
+    const replaceState = jest.fn();
+
+    // eslint-disable-next-line id-denylist
+    (global as unknown as any).window = {
+      history: { replaceState },
+      location: new URL("http://localhost"),
+    };
+
+    const { rerender } = renderHook(useStateToURLSynchronization, {
+      initialProps: { presence: PlayerPresence.NOT_PRESENT, playerSelection: emptyPlayerSelection },
+      wrapper: ({ children, presence, playerSelection }) => {
+        return (
+          <MockMessagePipelineProvider
+            topics={[]}
+            presence={presence}
+            datatypes={new Map()}
+            capabilities={["hello"]}
+            messages={[]}
+            urlState={{ url: "testurl", param: "one" }}
+            startTime={{ sec: 0, nsec: 1 }}
+          >
+            <PlayerSelectionContext.Provider value={playerSelection}>
+              <MockCurrentLayoutProvider>{children}</MockCurrentLayoutProvider>
+            </PlayerSelectionContext.Provider>
+          </MockMessagePipelineProvider>
+        );
+      },
+    });
+
+    expect(replaceState).not.toHaveBeenCalled();
+
+    rerender({ presence: PlayerPresence.NOT_PRESENT, playerSelection: selectedPlayerSelection });
+
+    expect(replaceState).not.toHaveBeenCalled();
+
+    rerender({ presence: PlayerPresence.PRESENT, playerSelection: selectedPlayerSelection });
+
+    expect(replaceState).toHaveBeenCalledWith(
+      undefined,
+      "",
+      "http://localhost/?ds=test1&ds.param=one&ds.url=testurl&layoutId=mock-layout",
+    );
+  });
+});

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -15,7 +15,7 @@ import {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
-import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
+import { PlayerCapabilities, PlayerPresence } from "@foxglove/studio-base/players/types";
 import {
   AppURLState,
   encodeAppURLState,
@@ -28,6 +28,7 @@ const selectCanSeek = (ctx: MessagePipelineContext) =>
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
+const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
@@ -35,10 +36,13 @@ const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?
 export function useStateToURLSynchronization(): void {
   const canSeek = useMessagePipeline(selectCanSeek);
   const currentTime = useMessagePipeline(selectCurrentTime);
-  const urlState = useMessagePipeline(selectUrlState);
+  const playerUrlState = useMessagePipeline(selectUrlState);
   const layoutId = useCurrentLayoutSelector(selectLayoutId);
-  const stableUrlState = useDeepMemo(urlState);
+  const stablePlayerUrlState = useDeepMemo(playerUrlState);
+  const playerPresence = useMessagePipeline(selectPlayerPresence);
   const { selectedSource } = usePlayerSelection();
+
+  const stablePlayerRef = useRef(false);
 
   // unsavedAppStateRef contains the app state that will be saved to the url
   // It starts out as the current url state values
@@ -67,14 +71,17 @@ export function useStateToURLSynchronization(): void {
     maxWait: 500,
   });
 
-  // During startup, many of the values (selectedSource, layoutId, etc) start out undefined.
-  // We don't want their initial undefined state to clear the url state only to add it back
-  // immediately. Conversely, if a value goes from being defined to undefined, we want to clear
-  // the url state value.
-  //
-  // referenceAppStateRef lets us accomplish this. We start with an empty state and as the values
-  // differ from our reference values, we update the unsavedAppState
-  const referenceAppStateRef = useRef<AppURLState>({});
+  // Mark our player state as unstable when a new source is selected.
+  useEffect(() => {
+    stablePlayerRef.current = false;
+  }, [selectedSource]);
+
+  // Wait until the player is present to switch player state back to stable.
+  useEffect(() => {
+    if (playerPresence === PlayerPresence.PRESENT) {
+      stablePlayerRef.current = true;
+    }
+  }, [playerPresence]);
 
   useEffect(() => {
     // Electron has its own concept of what the app URL is. If we want to do anything
@@ -84,32 +91,25 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
+    // Don't update url unless we have a stable player state.
+    if (!stablePlayerRef.current) {
+      return;
+    }
+
     const unsavedAppState = getUnsavedAppState();
-
-    if (referenceAppStateRef.current.layoutId !== layoutId) {
-      unsavedAppState.layoutId = layoutId;
-    }
-
-    if (referenceAppStateRef.current.ds !== selectedSource?.id) {
-      unsavedAppState.ds = selectedSource?.id;
-    }
-
-    if (referenceAppStateRef.current.dsParams !== stableUrlState) {
-      unsavedAppState.dsParams = stableUrlState;
-    }
-
-    const time = canSeek ? currentTime : undefined;
-    if (referenceAppStateRef.current.time !== time) {
-      unsavedAppState.time = time;
-    }
-
-    referenceAppStateRef.current = {
-      layoutId,
-      ds: selectedSource?.id,
-      dsParams: stableUrlState,
-      time,
-    };
+    unsavedAppState.layoutId = layoutId;
+    unsavedAppState.ds = selectedSource?.id;
+    unsavedAppState.dsParams = stablePlayerUrlState;
+    unsavedAppState.time = canSeek ? currentTime : undefined;
 
     queueUpdateUrl();
-  }, [canSeek, currentTime, layoutId, queueUpdateUrl, selectedSource, stableUrlState]);
+  }, [
+    canSeek,
+    currentTime,
+    layoutId,
+    playerPresence,
+    queueUpdateUrl,
+    selectedSource,
+    stablePlayerUrlState,
+  ]);
 }

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import {
@@ -26,6 +26,12 @@ const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState
 const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 
+// Write the unsaved app state to the url
+function writeStateToUrl(state: AppURLState) {
+  const url = encodeAppURLState(new URL(window.location.href), state);
+  window.history.replaceState(undefined, "", url.href);
+}
+
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
  */
@@ -41,29 +47,23 @@ export function useStateToURLSynchronization(): void {
   // This ref tracks the state of our player. Because the selected source and the active player
   // are in different contexts we have to do some extra work to act on the state of both of
   // them correctly.
-  const stablePlayerRef = useRef(false);
-
-  // Write the unsaved app state to the url
-  const updateUrl = useCallback((state: AppURLState) => {
-    const url = encodeAppURLState(new URL(window.location.href), state);
-    window.history.replaceState(undefined, "", url.href);
-  }, []);
+  const playerIsStableRef = useRef(false);
 
   // Debounce url updates to prevent thrashing when currentTime updates tne unsaved state
-  const queueUpdateUrl = useDebouncedCallback(updateUrl, 500, {
+  const queueUpdateUrl = useDebouncedCallback(writeStateToUrl, 500, {
     leading: true,
     maxWait: 500,
   });
 
   // Mark our player state as unstable when a new source is selected.
   useEffect(() => {
-    stablePlayerRef.current = false;
+    playerIsStableRef.current = false;
   }, [selectedSource]);
 
   // Wait until the player is present to switch player state back to stable.
   useEffect(() => {
     if (playerPresence === PlayerPresence.PRESENT) {
-      stablePlayerRef.current = true;
+      playerIsStableRef.current = true;
     }
   }, [playerPresence]);
 
@@ -76,7 +76,7 @@ export function useStateToURLSynchronization(): void {
     }
 
     // Don't update url unless we have a stable player state and a selected source.
-    if (!stablePlayerRef.current || !selectedSource) {
+    if (!playerIsStableRef.current || !selectedSource) {
       return;
     }
 

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -16,11 +16,7 @@ import {
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { PlayerCapabilities, PlayerPresence } from "@foxglove/studio-base/players/types";
-import {
-  AppURLState,
-  encodeAppURLState,
-  parseAppURLState,
-} from "@foxglove/studio-base/util/appURLState";
+import { AppURLState, encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectCanSeek = (ctx: MessagePipelineContext) =>
@@ -42,26 +38,14 @@ export function useStateToURLSynchronization(): void {
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const { selectedSource } = usePlayerSelection();
 
+  // This ref tracks the state of our player. Because the selected source and the active player
+  // are in different contexts we have to do some extra work to act on the state of both of
+  // them correctly.
   const stablePlayerRef = useRef(false);
 
-  // unsavedAppStateRef contains the app state that will be saved to the url
-  // It starts out as the current url state values
-  const unusavedAppStateRef = useRef<AppURLState>();
-  function getUnsavedAppState(): AppURLState {
-    return (unusavedAppStateRef.current ??= parseAppURLState(new URL(window.location.href)) ?? {});
-  }
-
   // Write the unsaved app state to the url
-  const updateUrl = useCallback(() => {
-    const unsavedAppState = getUnsavedAppState();
-
-    const url = encodeAppURLState(new URL(window.location.href), {
-      ds: unsavedAppState.ds,
-      layoutId: unsavedAppState.layoutId,
-      time: unsavedAppState.time,
-      dsParams: unsavedAppState.dsParams,
-    });
-
+  const updateUrl = useCallback((state: AppURLState) => {
+    const url = encodeAppURLState(new URL(window.location.href), state);
     window.history.replaceState(undefined, "", url.href);
   }, []);
 
@@ -91,18 +75,17 @@ export function useStateToURLSynchronization(): void {
       return;
     }
 
-    // Don't update url unless we have a stable player state.
-    if (!stablePlayerRef.current) {
+    // Don't update url unless we have a stable player state and a selected source.
+    if (!stablePlayerRef.current || !selectedSource) {
       return;
     }
 
-    const unsavedAppState = getUnsavedAppState();
-    unsavedAppState.layoutId = layoutId;
-    unsavedAppState.ds = selectedSource?.id;
-    unsavedAppState.dsParams = stablePlayerUrlState;
-    unsavedAppState.time = canSeek ? currentTime : undefined;
-
-    queueUpdateUrl();
+    queueUpdateUrl({
+      layoutId,
+      ds: selectedSource.id,
+      dsParams: stablePlayerUrlState,
+      time: canSeek ? currentTime : undefined,
+    });
   }, [
     canSeek,
     currentTime,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with updates to the state url and the recents list.

**Description**
Existing logic for updating the URL and the recents list doesn't take the current state of the player into consideration and can in some cases garble state from two different sources. The solution here is to defer updating the URL until a newly selected source has successfully been loaded. This is a bit tricky since we need state from two different contexts to do this so some sequential `useEffect` steps are needed.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2944 