### PR TITLE
Turn on experimental bag player in development

### DIFF
--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -55,6 +55,8 @@ if (!rootEl) {
   throw new Error("missing #root element");
 }
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
 async function main() {
   // Initialize the RPC channel for electron-socket. This method is called first
   // since the window.onmessage handler needs to be installed before
@@ -66,7 +68,13 @@ async function main() {
 
   const appConfiguration = await NativeStorageAppConfiguration.Initialize(
     (global as { storageBridge?: Storage }).storageBridge!,
-    { defaults: { [AppSetting.OPEN_DIALOG]: true, [AppSetting.ENABLE_REACT_STRICT_MODE]: true } },
+    {
+      defaults: {
+        [AppSetting.OPEN_DIALOG]: true,
+        [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
+        [AppSetting.EXPERIMENTAL_BAG_PLAYER]: isDevelopment,
+      },
+    },
   );
 
   const enableStrictMode = appConfiguration.get(AppSetting.ENABLE_REACT_STRICT_MODE) as boolean;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -39,6 +39,8 @@ if (!rootEl) {
   throw new Error("missing #root element");
 }
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
 async function main() {
   const chromeMatch = navigator.userAgent.match(/Chrome\/(\d+)\./);
   const chromeVersion = chromeMatch ? parseInt(chromeMatch[1] ?? "", 10) : 0;
@@ -73,7 +75,11 @@ async function main() {
   const { Root } = await import("./Root");
 
   const appConfiguration = new LocalStorageAppConfiguration({
-    defaults: { [AppSetting.OPEN_DIALOG]: true, [AppSetting.ENABLE_REACT_STRICT_MODE]: true },
+    defaults: {
+      [AppSetting.OPEN_DIALOG]: true,
+      [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
+      [AppSetting.EXPERIMENTAL_BAG_PLAYER]: isDevelopment,
+    },
   });
   const enableStrictMode = appConfiguration.get(AppSetting.ENABLE_REACT_STRICT_MODE) as boolean;
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
To help test the new experimental player, this change enables it by default in development. Since we tend to open bag during development this should give this player more use to surface bugs.

Fixes: #3011

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
