### PR TITLE
Add links for contacting Foxglove and scheduling a demo

### DIFF
--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -30,7 +30,7 @@ const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 const closeMenuItem: MenuItemConstructorOptions = isMac ? { role: "close" } : { role: "quit" };
 const log = Logger.getLogger(__filename);
 
-type SectionKey = "app" | "panels" | "resources" | "products" | "legal";
+type SectionKey = "app" | "panels" | "resources" | "products" | "contact" | "legal";
 type HelpInfo = {
   title: string;
   content?: React.ReactNode;
@@ -42,7 +42,7 @@ const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> =
     {
       subheader: "External resources",
       links: [
-        { title: "Read docs", url: "https://foxglove.dev/docs" },
+        { title: "Browse docs", url: "https://foxglove.dev/docs" },
         { title: "Join our community", url: "https://foxglove.dev/community" },
       ],
     },
@@ -54,6 +54,16 @@ const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> =
       links: [
         { title: "Foxglove Studio", url: "https://foxglove.dev/studio" },
         { title: "Foxglove Data Platform", url: "https://foxglove.dev/data-platform" },
+      ],
+    },
+  ],
+  [
+    "contact",
+    {
+      subheader: "Contact",
+      links: [
+        { title: "Give feedback", url: "https://foxglove.dev/contact" },
+        { title: "Schedule a demo", url: "https://foxglove.dev/demo" },
       ],
     },
   ],

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -329,7 +329,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
     role: "help",
     submenu: [
       {
-        label: "Explore sample data",
+        label: "Explore Sample Data",
         click: () => browserWindow.webContents.send("open-sample-data"),
       },
       { type: "separator" },

--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -23,7 +23,7 @@ export const MESSAGE_PATH_SYNTAX_HELP_INFO = {
   content: MesssagePathSyntaxHelp,
 };
 
-type SectionKey = "app" | "panels" | "resources" | "products" | "legal";
+type SectionKey = "app" | "panels" | "resources" | "products" | "contact" | "legal";
 const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> = new Map([
   [
     "resources",
@@ -31,7 +31,7 @@ const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> =
       subheader: "External resources",
       links: [
         ...(isDesktopApp() ? [] : [{ title: "Desktop app", url: "https://foxglove.dev/download" }]),
-        { title: "Read docs", url: "https://foxglove.dev/docs" },
+        { title: "Browse docs", url: "https://foxglove.dev/docs" },
         { title: "Join our community", url: "https://foxglove.dev/community" },
       ],
     },
@@ -43,6 +43,16 @@ const helpMenuItems: Map<SectionKey, { subheader: string; links: HelpInfo[] }> =
       links: [
         { title: "Foxglove Studio", url: "https://foxglove.dev/studio" },
         { title: "Foxglove Data Platform", url: "https://foxglove.dev/data-platform" },
+      ],
+    },
+  ],
+  [
+    "contact",
+    {
+      subheader: "Contact",
+      links: [
+        { title: "Give feedback", url: "https://foxglove.dev/contact" },
+        { title: "Schedule a demo", url: "https://foxglove.dev/demo" },
       ],
     },
   ],
@@ -120,6 +130,7 @@ export default function HelpSidebar({
         ["panels", { subheader: "Panels", links: sortedPanelLinks }],
         ["resources", helpMenuItems.get("resources")],
         ["products", helpMenuItems.get("products")],
+        ["contact", helpMenuItems.get("contact")],
         ["legal", helpMenuItems.get("legal")],
       ]),
     [sortedPanelLinks],

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -119,7 +119,7 @@ export default function Start(props: IStartProps): JSX.Element {
       },
       {
         id: "sample-data",
-        children: "Explore sample data",
+        children: "Explore Sample Data",
         secondaryText: "New to Foxglove Studio? Start here!",
         iconProps: { iconName: "BookStar" },
         onClick: () => onSelectView("demo"),

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -25,13 +25,28 @@ const HELP_ITEMS: IButtonProps[] = [
     id: "docs",
     href: "https://foxglove.dev/docs?utm_source=studio&utm_medium=open-dialog",
     target: "_blank",
-    children: "Browse the documentation",
+    children: "Browse docs",
   },
   {
     id: "github",
     href: "https://github.com/foxglove/studio/issues/",
     target: "_blank",
     children: "Report a bug or request a feature",
+  },
+];
+
+const CONTACT_ITEMS = [
+  {
+    id: "feedback",
+    href: "https://foxglove.dev/contact/",
+    target: "_blank",
+    children: "Give feedback",
+  },
+  {
+    id: "demo",
+    href: "https://foxglove.dev/demo/",
+    target: "_blank",
+    children: "Schedule a demo",
   },
 ];
 
@@ -174,6 +189,7 @@ export default function Start(props: IStartProps): JSX.Element {
         <Stack flexGrow={1} minWidth={0} spacing={2.5}>
           {recentItems.length > 0 && <ActionList title="Recent" items={recentItems} />}
           <ActionList title="Help" items={HELP_ITEMS} />
+          <ActionList title="Contact" items={CONTACT_ITEMS} />
         </Stack>
       </Stack>
       <Checkbox

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -119,7 +119,7 @@ export default function Start(props: IStartProps): JSX.Element {
       },
       {
         id: "sample-data",
-        children: "Explore Sample Data",
+        children: "Explore sample data",
         secondaryText: "New to Foxglove Studio? Start here!",
         iconProps: { iconName: "BookStar" },
         onClick: () => onSelectView("demo"),


### PR DESCRIPTION
**User-Facing Changes**
Added links for contacting Foxglove and scheduling a demo to: 
- Sidebar, under new Contact section
- Data source dialog, under new Contact section
- App menu, under new Contact section


![image](https://user-images.githubusercontent.com/6993359/158690502-b72f420e-53fe-4854-b6e1-ebd563cbe3f0.png)
![image](https://user-images.githubusercontent.com/6993359/158690480-3724f599-ebee-4d6b-9ba0-bb220dfe0c83.png)
<img width="546" alt="Screen Shot 2022-03-16 at 2 03 55 PM" src="https://user-images.githubusercontent.com/6993359/158690611-83e9bc93-aa80-4f4a-b488-4fb92f11f67c.png">


Additional work on already-closed issue: https://github.com/foxglove/studio/issues/1414
