### PR TITLE
Add just-in-time reader creation for data platform player

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { captureException } from "@sentry/core";
 import { isEqual } from "lodash";
 
 import Logger from "@foxglove/log";
@@ -44,6 +45,9 @@ export default async function* streamMessages({
 
   /**
    * Message readers are initialized out of band so we can parse message definitions only once.
+   *
+   * NOTE: If we encounter a channel/schema pair that is not pre-initialized, we will add it to
+   * parsedChannelsByTopic (thus mutating parsedChannelsByTopic).
    */
   parsedChannelsByTopic: Map<string, ParsedChannelAndEncodings[]>;
 }): AsyncIterable<MessageEvent<unknown>[]> {
@@ -132,12 +136,14 @@ export default async function* streamMessages({
           parsedChannel,
         });
 
-        // This is tragic because we are mutating parsedChannelsByTopic which is an input
-        // To avoid mutating the input the overall flow needs reworking.
         parsedChannelsByTopic.set(record.topic, parsedChannels);
 
         channelInfoById.set(record.id, { channel: record, parsedChannel });
-        log.warn("No pre-initialized reader for", record);
+
+        const err = new Error(
+          `No pre-initialized reader for ${record.topic} (message encoding ${record.messageEncoding}, schema encoding ${schema.encoding}, schema name ${schema.name})`,
+        );
+        captureException(err);
         return;
       }
 

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -132,6 +132,10 @@ export default async function* streamMessages({
           parsedChannel,
         });
 
+        // This is tragic because we are mutating parsedChannelsByTopic which is an input
+        // To avoid mutating the input the overall flow needs reworking.
+        parsedChannelsByTopic.set(record.topic, parsedChannels);
+
         channelInfoById.set(record.id, { channel: record, parsedChannel });
         log.warn("No pre-initialized reader for", record);
         return;

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -6,7 +6,7 @@ import { isEqual } from "lodash";
 
 import Logger from "@foxglove/log";
 import { Mcap0StreamReader, Mcap0Types } from "@foxglove/mcap";
-import { loadDecompressHandlers, ParsedChannel } from "@foxglove/mcap-support";
+import { loadDecompressHandlers, parseChannel, ParsedChannel } from "@foxglove/mcap-support";
 import { fromNanoSec, isTimeInRangeInclusive, Time, toRFC3339String } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
@@ -117,17 +117,24 @@ export default async function* streamMessages({
             return;
           }
         }
-        // Throw an error for now, although we could fall back to just-in-time parsing:
-        // https://github.com/foxglove/studio/issues/2303
-        log.error(
-          "No pre-initialized reader for",
-          record,
-          "available readers are:",
-          parsedChannels,
-        );
-        throw new Error(
-          `No pre-initialized reader for ${record.topic} (message encoding ${record.messageEncoding}, schema encoding ${schema.encoding}, schema name ${schema.name})`,
-        );
+
+        // We've not found a previously parsed channel with matching schema
+        // Create one here just-in-time
+        const parsedChannel = parseChannel({
+          messageEncoding: record.messageEncoding,
+          schema,
+        });
+
+        parsedChannels.push({
+          messageEncoding: record.messageEncoding,
+          schemaEncoding: schema.encoding,
+          schema: schema.data,
+          parsedChannel,
+        });
+
+        channelInfoById.set(record.id, { channel: record, parsedChannel });
+        log.warn("No pre-initialized reader for", record);
+        return;
       }
 
       case "Message": {


### PR DESCRIPTION


**User-Facing Changes**
Users playing data from data platform no longer see errors if they encounter previously unseen schema/channel combinations. This is an implementation detail that prevented the vieweing of their data.

**Description**
When data platform streaming encounters a previously unknown channel/schema combination, it creates a parser and stores it alongside the other pre-initialized parsers. This makes message streaming more resilient to to encountering semantically identical schemas (same serialization format), but physically different schema data (i.e. comments or other extraneous artifacts with no impact on serialization).

Fixes: #2303

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
