### PR TITLE
Fix destructing an undefined value for occupancy grids

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -584,7 +584,7 @@ export default class SceneBuilder implements MarkerProvider {
     const type = 101;
     const name = `${topic}/${type}`;
 
-    const { frameLocked } = this._settingsByKey[`t:${topic}`] as { frameLocked?: boolean };
+    const { frameLocked } = (this._settingsByKey[`t:${topic}`] ?? {}) as { frameLocked?: boolean };
 
     const { header, info, data } = message;
     if (info.width * info.height !== data.length) {


### PR DESCRIPTION


**User-Facing Changes**
Fixes _cannot destructure_ error in 3d panel when using OccupancyGrid topics

**Description**
Bug introduced in https://github.com/foxglove/studio/pull/3024

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
