### PR TITLE
Allow number or string for foxglove Image message timestamp

### DIFF
--- a/packages/studio-base/src/panels/ImageView/lib/normalizeMessage.ts
+++ b/packages/studio-base/src/panels/ImageView/lib/normalizeMessage.ts
@@ -23,6 +23,15 @@ export const NORMALIZABLE_IMAGE_DATATYPES = [
   "foxglove.CompressedImage",
 ];
 
+function asBigint(val: bigint | string | number): bigint {
+  if (typeof val === "string") {
+    return BigInt(val);
+  } else if (typeof val === "number") {
+    return BigInt(val);
+  }
+  return val;
+}
+
 /**
  * Convert a message based on datatype to a NormalizedImageMessage
  * A NormalizedImageMessage defines consistent semantics across different frameworks
@@ -34,7 +43,7 @@ export function normalizeImageMessage(
   switch (datatype) {
     case "foxglove.RawImage": {
       const typedMessage = message as FoxgloveRawImageMessage;
-      const stamp = fromNanoSec(typedMessage.timestamp);
+      const stamp = fromNanoSec(asBigint(typedMessage.timestamp));
       return {
         type: "raw",
         stamp,
@@ -74,7 +83,7 @@ export function normalizeImageMessage(
     }
     case "foxglove.CompressedImage": {
       const typedMessage = message as FoxgloveCompressedImageMessage;
-      const stamp = fromNanoSec(typedMessage.timestamp);
+      const stamp = fromNanoSec(asBigint(typedMessage.timestamp));
       return {
         type: "compressed",
         stamp,

--- a/packages/studio-base/src/panels/ImageView/types.ts
+++ b/packages/studio-base/src/panels/ImageView/types.ts
@@ -178,7 +178,7 @@ export type CompressedImageMessage = {
 };
 
 export type FoxgloveRawImageMessage = {
-  timestamp: bigint;
+  timestamp: bigint | string | number;
   width: number;
   height: number;
   encoding: string;
@@ -188,7 +188,7 @@ export type FoxgloveRawImageMessage = {
 
 export type FoxgloveCompressedImageMessage = {
   type: "compressed";
-  timestamp: bigint;
+  timestamp: bigint | string | number;
   format: string;
   data: Uint8Array;
 };


### PR DESCRIPTION
**User-Facing Changes**


**Description**
When loading JSON data (via mcap), using `(u)int64` fields is awkward since there is no way to specify bigint types with JSONSchema. As a workaround, we allow the timestamp field to be a string or number and convert those to bigint within the image panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
