### PR TITLE
Adjust demo pose shaft

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -62,9 +62,10 @@
       "settingsByKey": {
         "t:/pose": {
           "size": {
-            "headLength": 0.5,
+            "headLength": 0.75,
             "headWidth": 2,
-            "shaftWidth": 2
+            "shaftLength": 1.5,
+            "shaftWidth": 1.5
           }
         }
       },


### PR DESCRIPTION
**User-Facing Changes**
We seem to have a new `shaftLength` setting so I added it to the nuscenes demo.

Before:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/637671/159351334-739f4314-c936-4558-a5ed-9dfaa3f1d798.png">

After:
<img width="296" alt="image" src="https://user-images.githubusercontent.com/637671/159351483-a5231f57-2c6d-4c25-be9b-0533fc33a5c2.png">
