### PR TITLE
Add backfill method to IIterableSource, remove reverse param from mesageIterator

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -41,7 +41,14 @@ export default async function* streamMessages({
   signal?: AbortSignal;
 
   /** Parameters indicating the time range to stream. */
-  params: { deviceId: string; start: Time; end: Time; topics: readonly string[] };
+  params: {
+    deviceId: string;
+    start: Time;
+    end: Time;
+    topics: readonly string[];
+    replayPolicy?: "lastPerChannel" | "";
+    replayLookbackSeconds?: number;
+  };
 
   /**
    * Message readers are initialized out of band so we can parse message definitions only once.
@@ -66,6 +73,8 @@ export default async function* streamMessages({
     end: toRFC3339String(params.end),
     topics: params.topics,
     outputFormat: "mcap0",
+    replayPolicy: params.replayPolicy,
+    replayLookbackSeconds: params.replayLookbackSeconds,
   });
   if (controller.signal.aborted) {
     return;

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -186,6 +186,9 @@ export default async function* streamMessages({
     for (let result; (result = await streamReader.read()), !result.done; ) {
       reader.append(result.value);
       for (let record; (record = reader.nextRecord()); ) {
+        if (record.type === "DataEnd") {
+          break;
+        }
         processRecord(record);
       }
       if (messages.length > 0) {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -181,13 +181,15 @@ export default async function* streamMessages({
     }
   }
 
-  try {
+  let normalReturn = false;
+  parseLoop: try {
     const reader = new Mcap0StreamReader({ decompressHandlers });
     for (let result; (result = await streamReader.read()), !result.done; ) {
       reader.append(result.value);
       for (let record; (record = reader.nextRecord()); ) {
         if (record.type === "DataEnd") {
-          break;
+          normalReturn = true;
+          break parseLoop;
         }
         processRecord(record);
       }
@@ -199,9 +201,12 @@ export default async function* streamMessages({
     if (!reader.done()) {
       throw new Error("Incomplete mcap file");
     }
+    normalReturn = true;
   } finally {
-    // If the caller called generator.return() in between body chunks, automatically cancel the request.
-    log.debug("Automatic abort of streamMessages", params);
+    if (!normalReturn) {
+      // If the caller called generator.return() in between body chunks, automatically cancel the request.
+      log.debug("Automatic abort of streamMessages", params);
+    }
     controller.abort();
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -8,8 +8,9 @@ import { Bag, Filelike } from "@foxglove/rosbag";
 import { BlobReader } from "@foxglove/rosbag/web";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
+import { compare } from "@foxglove/rostime";
 import { Topic } from "@foxglove/studio";
-import { PlayerProblem } from "@foxglove/studio-base/players/types";
+import { PlayerProblem, MessageEvent } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import BrowserHttpReader from "@foxglove/studio-base/util/BrowserHttpReader";
 import CachedFilelike from "@foxglove/studio-base/util/CachedFilelike";
@@ -21,6 +22,7 @@ import {
   IteratorResult,
   Initalization,
   MessageIteratorArgs,
+  BackfillMessagesArgs,
 } from "./IIterableSource";
 
 type BagSource = { type: "file"; file: File } | { type: "remote"; url: string };
@@ -141,7 +143,9 @@ export class BagIterableSource implements IIterableSource {
     };
   }
 
-  async *messageIterator(opt: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>> {
+  async *messageIterator(
+    opt: MessageIteratorArgs & { reverse?: boolean },
+  ): AsyncGenerator<Readonly<IteratorResult>> {
     if (!this._bag) {
       throw new Error("Invariant: uninitialized");
     }
@@ -181,5 +185,26 @@ export class BagIterableSource implements IIterableSource {
         };
       }
     }
+  }
+
+  async backfillMessages({ topics, time }: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
+    const messages: MessageEvent<unknown>[] = [];
+    for (const topic of topics) {
+      // NOTE: An iterator is made for each topic to get the latest message on that topic.
+      // An single iterator for all the topics could result in iterating through many
+      // irrelevant messages to get to an older message on a topic.
+      for await (const result of this.messageIterator({
+        topics: [topic],
+        start: time,
+        reverse: true,
+      })) {
+        if (result.msgEvent) {
+          messages.push(result.msgEvent);
+        }
+        break;
+      }
+    }
+    messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
+    return messages;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -22,7 +22,7 @@ import {
   IteratorResult,
   Initalization,
   MessageIteratorArgs,
-  BackfillMessagesArgs,
+  GetBackfillMessagesArgs,
 } from "./IIterableSource";
 
 type BagSource = { type: "file"; file: File } | { type: "remote"; url: string };
@@ -143,8 +143,12 @@ export class BagIterableSource implements IIterableSource {
     };
   }
 
-  async *messageIterator(
-    opt: MessageIteratorArgs & { reverse?: boolean },
+  async *messageIterator(opt: MessageIteratorArgs): AsyncGenerator<Readonly<IteratorResult>> {
+    yield* this._messageIterator({ ...opt, reverse: false });
+  }
+
+  private async *_messageIterator(
+    opt: MessageIteratorArgs & { reverse: boolean },
   ): AsyncGenerator<Readonly<IteratorResult>> {
     if (!this._bag) {
       throw new Error("Invariant: uninitialized");
@@ -187,13 +191,16 @@ export class BagIterableSource implements IIterableSource {
     }
   }
 
-  async backfillMessages({ topics, time }: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
+  async getBackfillMessages({
+    topics,
+    time,
+  }: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
     const messages: MessageEvent<unknown>[] = [];
     for (const topic of topics) {
       // NOTE: An iterator is made for each topic to get the latest message on that topic.
       // An single iterator for all the topics could result in iterating through many
       // irrelevant messages to get to an older message on a topic.
-      for await (const result of this.messageIterator({
+      for await (const result of this._messageIterator({
         topics: [topic],
         start: time,
         reverse: true,

--- a/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
@@ -30,6 +30,7 @@ import {
   Initalization,
   MessageIteratorArgs,
   IteratorResult,
+  BackfillMessagesArgs,
 } from "./IIterableSource";
 
 const log = Logger.getLogger(__filename);
@@ -154,9 +155,6 @@ export class DataPlatformIterableSource implements IIterableSource {
   }
 
   async *messageIterator(args: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>> {
-    if (args.reverse === true) {
-      return;
-    }
     const api = this._consoleApi;
     const deviceId = this._deviceId;
     const parsedChannelsByTopic = this._parsedChannelsByTopic;
@@ -198,5 +196,23 @@ export class DataPlatformIterableSource implements IIterableSource {
         this._end,
       );
     }
+  }
+
+  async backfillMessages({ topics, time }: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
+    const messages: MessageEvent<unknown>[] = [];
+    for await (const block of streamMessages({
+      api: this._consoleApi,
+      parsedChannelsByTopic: this._parsedChannelsByTopic,
+      params: {
+        deviceId: this._deviceId,
+        start: time,
+        end: time,
+        topics,
+        replayPolicy: "lastPerChannel",
+      },
+    })) {
+      messages.push(...block);
+    }
+    return messages;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
@@ -30,7 +30,7 @@ import {
   Initalization,
   MessageIteratorArgs,
   IteratorResult,
-  BackfillMessagesArgs,
+  GetBackfillMessagesArgs,
 } from "./IIterableSource";
 
 const log = Logger.getLogger(__filename);
@@ -198,7 +198,10 @@ export class DataPlatformIterableSource implements IIterableSource {
     }
   }
 
-  async backfillMessages({ topics, time }: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
+  async getBackfillMessages({
+    topics,
+    time,
+  }: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
     const messages: MessageEvent<unknown>[] = [];
     for await (const block of streamMessages({
       api: this._consoleApi,
@@ -209,6 +212,7 @@ export class DataPlatformIterableSource implements IIterableSource {
         end: time,
         topics,
         replayPolicy: "lastPerChannel",
+        replayLookbackSeconds: 30 * 60,
       },
     })) {
       messages.push(...block);

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -23,7 +23,6 @@ export type Initalization = {
 export type MessageIteratorArgs = {
   topics: string[];
   start?: Time;
-  reverse?: boolean;
 };
 
 export type IteratorResult =
@@ -37,6 +36,11 @@ export type IteratorResult =
       msgEvent: undefined;
       problem: PlayerProblem;
     };
+
+export type BackfillMessagesArgs = {
+  topics: string[];
+  time: Time;
+};
 
 /**
  * IIterableSource specifies an interface initializing and accessing messages.
@@ -62,4 +66,10 @@ export interface IIterableSource {
    * finishes or is canceled.
    */
   messageIterator(args: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>>;
+
+  /**
+   * Load the most recent messages per topic that occurred before or at the target time, if
+   * available.
+   */
+  backfillMessages(args: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]>;
 }

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -37,7 +37,7 @@ export type IteratorResult =
       problem: PlayerProblem;
     };
 
-export type BackfillMessagesArgs = {
+export type GetBackfillMessagesArgs = {
   topics: string[];
   time: Time;
 };
@@ -71,5 +71,5 @@ export interface IIterableSource {
    * Load the most recent messages per topic that occurred before or at the target time, if
    * available.
    */
-  backfillMessages(args: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]>;
+  getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]>;
 }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -15,7 +15,7 @@ import {
   Initalization,
   MessageIteratorArgs,
   IteratorResult,
-  BackfillMessagesArgs,
+  GetBackfillMessagesArgs,
 } from "./IIterableSource";
 import { IterablePlayer } from "./IterablePlayer";
 
@@ -33,7 +33,7 @@ class TestSource implements IIterableSource {
 
   async *messageIterator(_args: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>> {}
 
-  async backfillMessages(_args: BackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
+  async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
     return [];
   }
 }
@@ -153,10 +153,10 @@ describe("IterablePlayer", () => {
     // replace the message iterator with our own implementation
     // This implementation performs a seekPlayback during backfill.
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalMethod = source.backfillMessages;
-    source.backfillMessages = async function (_args: BackfillMessagesArgs) {
+    const originalMethod = source.getBackfillMessages;
+    source.getBackfillMessages = async function (_args: GetBackfillMessagesArgs) {
       player.seekPlayback({ sec: 0, nsec: 0 });
-      source.backfillMessages = originalMethod;
+      source.getBackfillMessages = originalMethod;
       return [
         {
           topic: "foo",

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -311,41 +311,13 @@ export class IterablePlayer implements Player {
     this._lastMessage = undefined;
     this._seekTarget = undefined;
 
-    const topics = new Set(this._subscriptions.map((subscription) => subscription.topic));
+    const topics = Array.from(
+      new Set(this._subscriptions.map((subscription) => subscription.topic)),
+    );
 
-    const messages: MessageEvent<unknown>[] = [];
-    for (const topic of topics) {
-      // NOTE: An iterator is made for each topic to get the latest message on that topic.
-      // An single iterator for all the topics could result in iterating through many
-      // irrelevant messages to get to an older message on a topic.
-      const topicIterator = this._iterableSource.messageIterator({
-        topics: [topic],
-        start: targetTime,
-        reverse: true,
-      });
-      for (;;) {
-        const result = await topicIterator.next();
-        if (result.done === true) {
-          break;
-        }
-        // NOTE: Even if _nextState is set, we finish the backfill
-        // This is to support continuous scrubbing. As the user scrubbs, we
-        // continue to backfill and emit state so they can see updates as they scrub.
+    const messages = await this._iterableSource.backfillMessages({ topics, time: targetTime });
 
-        if (result.value.problem) {
-          this._problemManager.addProblem(
-            `connid-${result.value.connectionId}`,
-            result.value.problem,
-          );
-          continue;
-        }
-
-        messages.push(result.value.msgEvent);
-        break;
-      }
-    }
-
-    // Our reverse iterators loaded the messages inclusive of the seek time, thus the next messages
+    // Our backfill loaded the messages inclusive of the seek time, thus the next messages
     // we read should be _after_ the seek time.
     const forwardPosition = add(targetTime, { sec: 0, nsec: 1 });
     await this._forwardIterator?.return?.();
@@ -353,10 +325,6 @@ export class IterablePlayer implements Player {
       topics: Array.from(topics),
       start: forwardPosition,
     });
-
-    // Our iterator reads messages in reverse, but the studio message pipeline assumes
-    // messages are delivered in increasing receiveTime order
-    messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
 
     this._messages = messages;
     this._currentTime = targetTime;

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -315,7 +315,7 @@ export class IterablePlayer implements Player {
       new Set(this._subscriptions.map((subscription) => subscription.topic)),
     );
 
-    const messages = await this._iterableSource.backfillMessages({ topics, time: targetTime });
+    const messages = await this._iterableSource.getBackfillMessages({ topics, time: targetTime });
 
     // Our backfill loaded the messages inclusive of the seek time, thus the next messages
     // we read should be _after_ the seek time.

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -290,6 +290,8 @@ class ConsoleApi {
     end: string;
     topics: readonly string[];
     outputFormat?: "bag1" | "mcap0";
+    replayPolicy?: "lastPerChannel" | "";
+    replayLookbackSeconds?: number;
   }): Promise<{ link: string }> {
     return await this.post<{ link: string }>("/v1/data/stream", params);
   }


### PR DESCRIPTION
**User-Facing Changes**
None - feature flagged

**Description**
Relates to https://github.com/foxglove/studio/issues/2899 for the experimental player.
The iterating-in-reverse logic is moved into BagIterableSource. The DataPlatformIterableSource implements backfill by passing a `replayPolicy` param.