### PR TITLE
Add sidebar UI for Studio updates

### DIFF
--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -4,6 +4,7 @@
 
 // Events that are forwarded from the main process
 export type ForwardedMenuEvent =
+  // Menu items
   | "open-file"
   | "open-remote-file"
   | "open-sample-data"
@@ -14,7 +15,13 @@ export type ForwardedMenuEvent =
   | "open-variables"
   | "open-extensions"
   | "open-help"
-  | "open-account";
+  | "open-account"
+  // StudioAppUpdater events
+  | "checking-for-update"
+  | "update-available"
+  | "update-not-available"
+  | "update-downloaded"
+  | "update-error";
 
 interface NativeMenuBridge {
   // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.

--- a/packages/studio-base/src/components/UpdaterSidebar.tsx
+++ b/packages/studio-base/src/components/UpdaterSidebar.tsx
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Stack } from "@mui/material";
+
+import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+
+export default function UpdaterSidebar(_props: React.PropsWithChildren<unknown>): JSX.Element {
+  return (
+    <SidebarContent title="Update">
+      <Stack spacing={3.75}>
+        <div>
+          <Stack spacing={1}>
+            <div>Say something here</div>
+          </Stack>
+        </div>
+      </Stack>
+    </SidebarContent>
+  );
+}

--- a/packages/studio-base/src/context/NativeAppMenuContext.ts
+++ b/packages/studio-base/src/context/NativeAppMenuContext.ts
@@ -5,9 +5,11 @@
 import { createContext, useContext } from "react";
 
 export type NativeAppMenuEvent =
+  // Menu items
   | "open-file"
   | "open-remote-file"
   | "open-sample-data"
+  | "open-preferences"
   | "open-layouts"
   | "open-add-panel"
   | "open-panel-settings"
@@ -15,7 +17,12 @@ export type NativeAppMenuEvent =
   | "open-extensions"
   | "open-help"
   | "open-account"
-  | "open-preferences";
+  // StudioAppUpdater events
+  | "checking-for-update"
+  | "update-available"
+  | "update-not-available"
+  | "update-downloaded"
+  | "update-error";
 
 type Handler = () => void;
 


### PR DESCRIPTION
**User-Facing Changes**

Displays a sidebar icon when a new Studio update is available, has been downloaded, or the update check failed

**Description**

The electron-updater events are plumbed through to the Workspace component and used to conditionally add a new sidebar entry when there is app update activity. This could be extended to notify Linux .deb users when a new update is available as well.

**TODO**

- [ ] Finish the UpdaterSidebar component
- [ ] UpdaterSidebar storybook
- [ ] Finalize icon selection for the different states
- [ ] Test the various update events (does this need to be mocked?)
- [ ] Manually check for updates on Linux desktop, where electron-updater cannot auto-update
