### PR TITLE
Use a stable anchor point for image annotations dropdown

### DIFF
--- a/packages/studio-base/src/panels/ImageView/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/ImageView/components/TopicDropdown.tsx
@@ -25,6 +25,7 @@ type Props = {
   multiple: boolean;
   size?: SelectProps["size"];
   open?: boolean;
+  anchorEl?: Element | ReactNull;
 
   onChange: (activeTopics: string[]) => void;
 };
@@ -56,7 +57,7 @@ export function TopicDropdown(props: Props): JSX.Element {
         multiple={multiple}
         open={props.open}
         MenuProps={{
-          contentEditable: multiple,
+          anchorEl: props.anchorEl,
           MenuListProps: {
             dense: true,
             subheader: multiple ? <ListSubheader>Select multiple topics</ListSubheader> : undefined,

--- a/packages/studio-base/src/panels/ImageView/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/ImageView/components/TopicDropdown.tsx
@@ -11,6 +11,7 @@ import {
   Radio,
   ListSubheader,
   SelectProps,
+  MenuProps,
 } from "@mui/material";
 import { useMemo } from "react";
 
@@ -44,6 +45,20 @@ export function TopicDropdown(props: Props): JSX.Element {
     onChange(typeof value === "string" ? [value] : value);
   };
 
+  const menuProps: Partial<MenuProps> = {
+    MenuListProps: {
+      dense: true,
+      subheader: multiple ? <ListSubheader>Select multiple topics</ListSubheader> : undefined,
+    },
+  };
+
+  // We avoid setting the anchorEl property unless it is specified.
+  // The underlying menu component treats the presence of the property (even if undefined or null)
+  // as a value.
+  if ("anchorEl" in props) {
+    menuProps.anchorEl = props.anchorEl;
+  }
+
   return (
     <>
       <Select
@@ -56,13 +71,7 @@ export function TopicDropdown(props: Props): JSX.Element {
         onChange={handleChange}
         multiple={multiple}
         open={props.open}
-        MenuProps={{
-          anchorEl: props.anchorEl,
-          MenuListProps: {
-            dense: true,
-            subheader: multiple ? <ListSubheader>Select multiple topics</ListSubheader> : undefined,
-          },
-        }}
+        MenuProps={menuProps}
       >
         {items.length === 0 && (
           <MenuItem disabled value="">

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -200,7 +200,9 @@ function ImageView(props: Props) {
     synchronize: shouldSynchronize,
   });
 
-  const markerDropdown = useMemo(() => {
+  const rootRef = useRef<HTMLDivElement>(ReactNull);
+
+  const annotationDropdown = useMemo(() => {
     const allSet = new Set(allAnnotationTopics);
     const enabledAnnotationTopics = new Set(enabledMarkerTopics);
 
@@ -232,6 +234,7 @@ function ImageView(props: Props) {
 
     return (
       <TopicDropdown
+        anchorEl={rootRef.current}
         multiple={true}
         title="Annotations"
         items={dropdownTopics}
@@ -266,17 +269,6 @@ function ImageView(props: Props) {
       cameraInfo,
     };
   }, [annotations, cameraInfo, transformMarkers]);
-
-  const toolbar = useMemo(() => {
-    return (
-      <PanelToolbar floating={cameraTopic !== ""} helpContent={helpContent}>
-        <div className={classes.controls}>
-          {imageTopicDropdown}
-          {markerDropdown}
-        </div>
-      </PanelToolbar>
-    );
-  }, [cameraTopic, classes.controls, imageTopicDropdown, markerDropdown]);
 
   const renderBottomBar = () => {
     const topicTimestamp = (
@@ -315,7 +307,24 @@ function ImageView(props: Props) {
 
   return (
     <Stack flex="auto" overflow="hidden" position="relative">
-      {toolbar}
+      {/*
+      HACK:
+      When the floating panel toolbar disappears, it also removes the anchor elements for
+      the dropdown menus. When the anchor element is removed, the dropdown menu re-positions to a
+      different part of the screen. To prevent the re-positioning of the open menu, we use an empty
+      div as the anchor for our annotation dropdown. This keeps the annotation dropdown stable even
+      when the toolbar goes away.
+
+      The image topic dropdown does not need the anchor because it closes after an image is selected.
+      The annotation dropdown allows multiple selection and remains open.
+      */}
+      <div ref={rootRef}></div>
+      <PanelToolbar floating={cameraTopic !== ""} helpContent={helpContent}>
+        <div className={classes.controls}>
+          {imageTopicDropdown}
+          {annotationDropdown}
+        </div>
+      </PanelToolbar>
       <Stack width="100%" height="100%">
         {/* Always render the ImageCanvas because it's expensive to unmount and start up. */}
         {imageMessageToRender && (


### PR DESCRIPTION


**User-Facing Changes**
When selecting image annotations, the dropdown does not jump around between selections.

**Description**
When opening the image annotations dropdown, the floating panel toolbar disappears
because it detects the cursor is no longer hovering the panel and is instead hovering
the context menu which is outside the panel.

When the toolbar disappears, it also removes the anchor element for the menu. This
causes the menu to jump screen locations between selection. This change works around this
behavior by using an empty div to anchor the annotations dropdown. The empty div is
always present and keeps the dropdown location stable.

Fixes: #3039

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
