### PR TITLE
Generate the CSP header once instead of per-request

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -249,6 +249,9 @@ function main() {
       "font-src": "'self' data:",
       "img-src": "'self' data: https: package: x-foxglove-converted-tiff:",
     };
+    const cspHeader = Object.entries(contentSecurityPolicy)
+      .map(([key, val]) => `${key} ${val}`)
+      .join("; ");
 
     // Set default http headers
     session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
@@ -257,11 +260,7 @@ function main() {
 
       // don't set CSP for internal URLs
       if (!["chrome-extension:", "devtools:", "data:"].includes(url.protocol)) {
-        responseHeaders["Content-Security-Policy"] = [
-          Object.entries(contentSecurityPolicy)
-            .map(([key, val]) => `${key} ${val}`)
-            .join("; "),
-        ];
+        responseHeaders["Content-Security-Policy"] = [cspHeader];
       }
 
       callback({ responseHeaders });


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

The `contentSecurityPolicy` object is collapsed down into a single string header. Do this once instead of per-request.
