### PR TITLE
Make all builtin datatypes available from node playground

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -277,7 +277,11 @@ export default class UserNodePlayer implements Player {
     // Pass all the nodes a set of basic datatypes that we know how to render.
     // These could be overwritten later by bag datatypes, but these datatype definitions should be very stable.
     const { topics = [], datatypes = new Map() } = this._lastPlayerStateActiveData ?? {};
-    const nodeDatatypes: RosDatatypes = new Map([...basicDatatypes, ...datatypes]);
+    const nodeDatatypes: RosDatatypes = new Map([
+      ...basicDatatypes,
+      ...foxgloveDatatypes,
+      ...datatypes,
+    ]);
 
     const rosLib = await this._getRosLib();
     const typesLib = await this._getTypesLib();

--- a/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
@@ -107,7 +107,6 @@ export const registerNode = ({
     }
     userNodeLogs.push(...args.map((value) => ({ source: "registerNode" as const, value })));
   };
-  // TODO: Blacklist global methods.
   try {
     const nodeExports: { default?: typeof nodeCallback } = {};
 
@@ -156,9 +155,8 @@ export const processMessage = ({
   try {
     const newMessage = nodeCallback(message, globalVariables);
     return { message: newMessage, error: undefined, userNodeLogs, userNodeDiagnostics };
-  } catch (e) {
-    // TODO: Be able to map line numbers from errors.
-    const error: string = e.toString();
+  } catch (err) {
+    const error: string = err.toString();
     return {
       message: undefined,
       error: error.length > 0 ? error : "Unknown error encountered running this node.",

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
@@ -377,6 +377,7 @@ export const extractDatatypes = (nodeData: NodeData): NodeData => {
       typeNode,
       name,
       messageDefinitionMap,
+      sourceDatatypes,
     );
     return { ...nodeData, datatypes, outputDatatype };
   } catch (error) {

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -37,7 +37,6 @@ import {
   Diagnostic,
 } from "@foxglove/studio-base/players/UserNodePlayer/types";
 import type { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
-import { basicDatatypes } from "@foxglove/studio-base/util/datatypes";
 
 type TypeParam = {
   parent?: TypeParam;
@@ -256,6 +255,7 @@ export const constructDatatypes = (
   node: ts.TypeLiteralNode | ts.InterfaceDeclaration,
   currentDatatype: string,
   messageDefinitionMap: { [formattedDatatype: string]: string },
+  sourceDatatypes: RosDatatypes,
   depth: number = 1,
   currentTypeParamMap: TypeMap = {},
 ): { outputDatatype: string; datatypes: RosDatatypes } => {
@@ -272,7 +272,7 @@ export const constructDatatypes = (
   if (isNodeFromRosModule(node) && messageDef != undefined) {
     return {
       outputDatatype: messageDef,
-      datatypes: basicDatatypes,
+      datatypes: sourceDatatypes,
     };
   }
 
@@ -284,7 +284,7 @@ export const constructDatatypes = (
       const datatype = node.parent.name.text;
       return {
         outputDatatype: datatype,
-        datatypes: basicDatatypes,
+        datatypes: sourceDatatypes,
       };
     }
   }
@@ -328,6 +328,7 @@ export const constructDatatypes = (
           typeLiteral,
           nestedType,
           messageDefinitionMap,
+          sourceDatatypes,
           depth + 1,
           typeParamMap,
         );


### PR DESCRIPTION


**User-Facing Changes**
Users can write node playground scripts that output builtin Foxglove datatypes without their dataset having those datatypes.

**Description**
When detecting the output datatype, node playground has logic to see that the type comes from the generatedTypes.ts file. When detecting this, it would return the available datatypes as the _basicDatatypes_ which did not include the foxglove datatypes. This change fixes the datatype return logic to include all the datatypes that went into building the generatedTypes.ts file.

Fixes: #3046

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
