### PR TITLE
update rosbag2 and rosmsg-msgs-common for adding velodyne msgs

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -43,7 +43,7 @@
     "@foxglove/rosbag": "0.2.1",
     "@foxglove/rosbag2-web": "4.0.3",
     "@foxglove/rosmsg": "3.0.0",
-    "@foxglove/rosmsg-msgs-common": "1.0.4",
+    "@foxglove/rosmsg-msgs-common": "1.1.0",
     "@foxglove/rosmsg-msgs-foxglove": "2.0.3",
     "@foxglove/rosmsg-serialization": "1.3.0",
     "@foxglove/rosmsg2-serialization": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,15 +2397,15 @@ __metadata:
   linkType: hard
 
 "@foxglove/rosbag2@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@foxglove/rosbag2@npm:4.1.0"
+  version: 4.1.1
+  resolution: "@foxglove/rosbag2@npm:4.1.1"
   dependencies:
-    "@foxglove/rosmsg-msgs-common": ^1.0.4
+    "@foxglove/rosmsg-msgs-common": ^1.1.0
     "@foxglove/rosmsg-msgs-foxglove": ^2.0.3
     "@foxglove/rosmsg2-serialization": ^1.0.5
     "@foxglove/rostime": ^1.1.1
     js-yaml: ^4.1.0
-  checksum: 9f80aeb4f0784d50963a76dc2de1861cc7a9ce711551056159750ec18cd37f8313f11d00b2a06122ad3b114849f733eeb40a3e920f5ed6f0da2cb1586e03f0f4
+  checksum: b984f215a08cef0446ffb82f8b94a2747f29bd0fc82be0ab4b57ea6d63082024732048db1f008fab44056d66c3b8e8abe41e75fee3b37990893aabc5bb3911f6
   languageName: node
   linkType: hard
 
@@ -2421,12 +2421,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-msgs-common@npm:1.0.4, @foxglove/rosmsg-msgs-common@npm:^1.0.4":
+"@foxglove/rosmsg-msgs-common@npm:1.0.4":
   version: 1.0.4
   resolution: "@foxglove/rosmsg-msgs-common@npm:1.0.4"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
   checksum: efcec07360eada4c06dfcbe7a4f73c979b89278285e0c7d7411ed979de964c7be9fe3a3a19ed19e936c5185bb6cbcbc6d98b000c88c526c01bb873add05df861
+  languageName: node
+  linkType: hard
+
+"@foxglove/rosmsg-msgs-common@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@foxglove/rosmsg-msgs-common@npm:1.1.0"
+  dependencies:
+    "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
+  checksum: 1b5df8387de0afaa4ca9ce6ddae50fe69fcabfbbe2f6032fe0d85708be91fcac803338571201e9a756b263c48f6a467a2c7e8eb96454ee2a4e5a38a6b3e5494a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,16 +2421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-msgs-common@npm:1.0.4":
-  version: 1.0.4
-  resolution: "@foxglove/rosmsg-msgs-common@npm:1.0.4"
-  dependencies:
-    "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
-  checksum: efcec07360eada4c06dfcbe7a4f73c979b89278285e0c7d7411ed979de964c7be9fe3a3a19ed19e936c5185bb6cbcbc6d98b000c88c526c01bb873add05df861
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg-msgs-common@npm:^1.1.0":
+"@foxglove/rosmsg-msgs-common@npm:1.1.0, @foxglove/rosmsg-msgs-common@npm:^1.1.0":
   version: 1.1.0
   resolution: "@foxglove/rosmsg-msgs-common@npm:1.1.0"
   dependencies:
@@ -2525,7 +2516,7 @@ __metadata:
     "@foxglove/rosbag": 0.2.1
     "@foxglove/rosbag2-web": 4.0.3
     "@foxglove/rosmsg": 3.0.0
-    "@foxglove/rosmsg-msgs-common": 1.0.4
+    "@foxglove/rosmsg-msgs-common": 1.1.0
     "@foxglove/rosmsg-msgs-foxglove": 2.0.3
     "@foxglove/rosmsg-serialization": 1.3.0
     "@foxglove/rosmsg2-serialization": 1.0.5


### PR DESCRIPTION
**User-Facing Changes**
Adds velodyne_msgs/VelodyneScan and velodyne_msgs/VelodynePacket to the set of built-in message definitions


**Description**
update version of rosbag2 and rosmsg-msgs-commonfor velodyne msgs

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
https://github.com/foxglove/rosbag2/pull/7

