### PR TITLE
Add currentTime to extension API RenderState

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.stories.tsx
@@ -5,7 +5,8 @@
 import { ReactElement, useLayoutEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
-import { PanelExtensionContext, ParameterValue, RenderState } from "@foxglove/studio";
+import { toSec } from "@foxglove/rostime";
+import { PanelExtensionContext, ParameterValue, RenderState, Time } from "@foxglove/studio";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -51,11 +52,14 @@ export const CatchRenderError = (): JSX.Element => {
 };
 
 function SimplePanel({ context }: { context: PanelExtensionContext }) {
+  const [currentTime, setCurrentTime] = useState<Time | undefined>(undefined);
   const [parameters, setParameters] = useState<ReadonlyMap<string, ParameterValue>>(new Map());
 
   useLayoutEffect(() => {
+    context.watch("currentTime");
     context.watch("parameters");
     context.onRender = (renderState: RenderState, done) => {
+      setCurrentTime(renderState.currentTime);
       if (renderState.parameters != undefined) {
         setParameters(renderState.parameters);
       }
@@ -66,6 +70,8 @@ function SimplePanel({ context }: { context: PanelExtensionContext }) {
   return (
     <div>
       <h2>Simple Panel</h2>
+      <h3>Current Time</h3>
+      <div>{currentTime ? toSec(currentTime) : "-"}</div>
       <h3>Parameters</h3>
       <div>{JSON.stringify(Array.from(parameters))}</div>
     </div>
@@ -83,6 +89,7 @@ export const SimplePanelRender = (): ReactElement => {
         datatypes: new Map(),
         frame: {},
         activeData: {
+          currentTime: { sec: 1, nsec: 2 },
           parameters: new Map([
             ["param1", "value1"],
             ["param2", "value2"],

--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -226,6 +226,20 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       prevBlocksRef.current = newBlocks;
     }
 
+    if (watchedFieldsRef.current.has("currentTime")) {
+      const currentTime = playerState?.activeData?.currentTime;
+
+      if (currentTime != undefined && currentTime !== renderState.currentTime) {
+        shouldRender = true;
+        renderState.currentTime = currentTime;
+      } else {
+        if (renderState.currentTime != undefined) {
+          shouldRender = true;
+        }
+        renderState.currentTime = undefined;
+      }
+    }
+
     if (watchedFieldsRef.current.has("previewTime")) {
       const startTime = playerState?.activeData?.startTime;
       const hoverVal = hoverValueRef.current?.value;

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -96,6 +96,11 @@ declare module "@foxglove/studio" {
     topics?: readonly Topic[];
 
     /**
+     * A timestamp value indicating the current playback time.
+     */
+    currentTime?: Time;
+
+    /**
      * A seconds value indicating a preview time. The preview time is set when a user hovers
      * over the seek bar or when a panel sets the preview time explicitly. The preview time
      * is a seconds value within the playback range.


### PR DESCRIPTION
**User-Facing Changes**

- Adds RenderState.currentTime and context.watch("currentTime") to the extension API
