### PR TITLE
[New3D] OccupancyGrid, axis arrows and lines

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/DetailLevel.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DetailLevel.ts
@@ -1,9 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-
-export enum DetailLevel {
-  Low,
-  Medium,
-  High,
-}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -15,8 +15,9 @@ import { MaterialCache } from "./MaterialCache";
 import { ModelCache } from "./ModelCache";
 import { FrameAxes } from "./renderables/FrameAxes";
 import { Markers } from "./renderables/Markers";
+import { OccupancyGrids } from "./renderables/OccupancyGrids";
 import { PointClouds } from "./renderables/PointClouds";
-import { Marker, PointCloud2, TF } from "./ros";
+import { Marker, OccupancyGrid, PointCloud2, TF } from "./ros";
 import { TransformTree } from "./transforms/TransformTree";
 
 const log = Logger.getLogger(__filename);
@@ -57,6 +58,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   renderFrameId: string | undefined;
 
   frameAxes = new FrameAxes(this);
+  occupancyGrids = new OccupancyGrids(this);
   pointClouds = new PointClouds(this);
   markers = new Markers(this);
 
@@ -98,6 +100,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.scene = new THREE.Scene();
     this.scene.add(this.frameAxes);
+    this.scene.add(this.occupancyGrids);
     this.scene.add(this.pointClouds);
     this.scene.add(this.markers);
 
@@ -133,6 +136,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   dispose(): void {
     this.frameAxes.dispose();
+    this.occupancyGrids.dispose();
     this.pointClouds.dispose();
     this.markers.dispose();
     this.gl.dispose();
@@ -147,6 +151,10 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   addTransformMessage(tf: TF): void {
     this.frameAxes.addTransformMessage(tf);
+  }
+
+  addOccupancyGridMessage(topic: string, occupancyGrid: OccupancyGrid): void {
+    this.occupancyGrids.addOccupancyGridMessage(topic, occupancyGrid);
   }
 
   addPointCloud2Message(topic: string, pointCloud: PointCloud2): void {
@@ -189,6 +197,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.materialCache.update(this.input.canvasSize);
 
     this.frameAxes.startFrame(currentTime);
+    this.occupancyGrids.startFrame(currentTime);
     this.pointClouds.startFrame(currentTime);
     this.markers.startFrame(currentTime);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -25,6 +25,7 @@ const log = Logger.getLogger(__filename);
 export type RendererEvents = {
   startFrame: (currentTime: bigint, renderer: Renderer) => void;
   endFrame: (currentTime: bigint, renderer: Renderer) => void;
+  cameraMove: (renderer: Renderer) => void;
   renderableSelected: (renderable: THREE.Object3D, renderer: Renderer) => void;
   transformTreeUpdated: (renderer: Renderer) => void;
   showLabel: (labelId: string, labelMarker: Marker, renderer: Renderer) => void;
@@ -132,8 +133,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.camera.lookAt(new THREE.Vector3(0, 0, 0));
 
     this.controls = new OrbitControls(this.camera, this.gl.domElement);
+    this.controls.addEventListener("change", () => this.emit("cameraMove", this));
 
-    this.animationFrame(performance.now());
+    this.animationFrame();
   }
 
   dispose(): void {
@@ -180,11 +182,10 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   // Callback handlers
 
-  animationFrame = (_wallTime: DOMHighResTimeStamp): void => {
+  animationFrame = (): void => {
     if (this.currentTime != undefined) {
       this.frameHandler(this.currentTime);
     }
-    requestAnimationFrame(this.animationFrame);
   };
 
   frameHandler = (currentTime: bigint): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -214,11 +214,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   resizeHandler = (size: THREE.Vector2): void => {
     log.debug(`Resizing to ${size.width}x${size.height}`);
-    this.camera.aspect = size.width / size.height;
-    this.camera.updateProjectionMatrix();
-
     this.gl.setPixelRatio(window.devicePixelRatio);
     this.gl.setSize(size.width, size.height);
+    this.camera.aspect = size.width / size.height;
+    this.camera.updateProjectionMatrix();
+    this.emit("cameraMove", this);
   };
 
   clickHandler = (_cursorCoords: THREE.Vector2): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -47,7 +47,7 @@ const tempVec = new THREE.Vector3();
 export class Renderer extends EventEmitter<RendererEvents> {
   canvas: HTMLCanvasElement;
   gl: THREE.WebGLRenderer;
-  lod = DetailLevel.High;
+  maxLod = DetailLevel.High;
   scene: THREE.Scene;
   dirLight: THREE.DirectionalLight;
   hemiLight: THREE.HemisphereLight;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -8,11 +8,11 @@ import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 
 import Logger from "@foxglove/log";
 
-import { DetailLevel } from "./DetailLevel";
 import { Input } from "./Input";
 import { LayerErrors } from "./LayerErrors";
 import { MaterialCache } from "./MaterialCache";
 import { ModelCache } from "./ModelCache";
+import { DetailLevel } from "./lod";
 import { FrameAxes } from "./renderables/FrameAxes";
 import { Markers } from "./renderables/Markers";
 import { OccupancyGrids } from "./renderables/OccupancyGrids";

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -40,7 +40,7 @@ const DARK_BACKDROP = new THREE.Color(0x121217);
 const LIGHT_OUTLINE = new THREE.Color(0x000000);
 const DARK_OUTLINE = new THREE.Color(0xffffff);
 
-const TRANSFORM_STORAGE_TIME = 60n * BigInt(1e9);
+const TRANSFORM_STORAGE_TIME_NS = 60n * BigInt(1e9);
 
 const tempVec = new THREE.Vector3();
 
@@ -50,6 +50,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   lod = DetailLevel.High;
   scene: THREE.Scene;
   dirLight: THREE.DirectionalLight;
+  hemiLight: THREE.HemisphereLight;
   input: Input;
   camera: THREE.PerspectiveCamera;
   controls: OrbitControls;
@@ -58,7 +59,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   colorScheme: "dark" | "light" | undefined;
   modelCache: ModelCache;
   renderables = new Map<string, THREE.Object3D>();
-  transformTree = new TransformTree(TRANSFORM_STORAGE_TIME);
+  transformTree = new TransformTree(TRANSFORM_STORAGE_TIME_NS);
   currentTime: bigint | undefined;
   fixedFrameId: string | undefined;
   renderFrameId: string | undefined;
@@ -120,14 +121,16 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.dirLight.shadow.camera.far = 500;
     this.dirLight.shadow.bias = -0.00001;
 
+    this.hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, 0.5);
+
     this.scene.add(this.dirLight);
-    this.scene.add(new THREE.HemisphereLight(0xffffff, 0xffffff, 0.5));
+    this.scene.add(this.hemiLight);
 
     this.input = new Input(canvas);
     this.input.on("resize", (size) => this.resizeHandler(size));
     this.input.on("click", (cursorCoords) => this.clickHandler(cursorCoords));
 
-    const fov = 50;
+    const fov = 79;
     const near = 0.01; // 1cm
     const far = 10_000; // 10km
     this.camera = new THREE.PerspectiveCamera(fov, width / height, near, far);
@@ -147,7 +150,6 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.pointClouds.dispose();
     this.markers.dispose();
     this.gl.dispose();
-    // this.gl.forceContextLoss();
   }
 
   setColorScheme(colorScheme: "dark" | "light"): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -36,6 +36,8 @@ export type RendererEvents = {
 const LIGHT_BACKDROP = new THREE.Color(0xececec);
 const DARK_BACKDROP = new THREE.Color(0x121217);
 
+const TRANSFORM_STORAGE_TIME = 60n * BigInt(1e9);
+
 const tempVec = new THREE.Vector3();
 
 export class Renderer extends EventEmitter<RendererEvents> {
@@ -52,7 +54,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   colorScheme: "dark" | "light" | undefined;
   modelCache: ModelCache;
   renderables = new Map<string, THREE.Object3D>();
-  transformTree = new TransformTree();
+  transformTree = new TransformTree(TRANSFORM_STORAGE_TIME);
   currentTime: bigint | undefined;
   fixedFrameId: string | undefined;
   renderFrameId: string | undefined;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -37,6 +37,9 @@ export type RendererEvents = {
 const LIGHT_BACKDROP = new THREE.Color(0xececec);
 const DARK_BACKDROP = new THREE.Color(0x121217);
 
+const LIGHT_OUTLINE = new THREE.Color(0x000000);
+const DARK_OUTLINE = new THREE.Color(0xffffff);
+
 const TRANSFORM_STORAGE_TIME = 60n * BigInt(1e9);
 
 const tempVec = new THREE.Vector3();
@@ -151,6 +154,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
     log.debug(`Setting color scheme to "${colorScheme}"`);
     this.colorScheme = colorScheme;
     this.gl.setClearColor(colorScheme === "dark" ? DARK_BACKDROP : LIGHT_BACKDROP, 1);
+    this.materialCache.outlineMaterial.color =
+      colorScheme === "dark" ? DARK_OUTLINE : LIGHT_OUTLINE;
+    this.materialCache.outlineMaterial.needsUpdate = true;
   }
 
   addTransformMessage(tf: TF): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -85,7 +85,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.gl.toneMapping = THREE.NoToneMapping;
     this.gl.autoClear = false;
     this.gl.info.autoReset = false;
-    this.gl.shadowMap.enabled = true;
+    this.gl.shadowMap.enabled = false;
     this.gl.shadowMap.type = THREE.VSMShadowMap;
     this.gl.setPixelRatio(window.devicePixelRatio);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -140,7 +140,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.pointClouds.dispose();
     this.markers.dispose();
     this.gl.dispose();
-    this.gl.forceContextLoss();
+    // this.gl.forceContextLoss();
   }
 
   setColorScheme(colorScheme: "dark" | "light"): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
@@ -3,16 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useEffect, useState } from "react";
-import THREEStats from "three/examples/jsm/libs/stats.module";
 
 import { Renderer } from "./Renderer";
 import { useRenderer, useRendererEvent } from "./RendererContext";
 
 let stats: THREEStats | undefined;
-let drawCallsPanel: THREEStats.Panel | undefined;
-let trianglesPanel: THREEStats.Panel | undefined;
-let texturesPanel: THREEStats.Panel | undefined;
-let geometriesPanel: THREEStats.Panel | undefined;
+let drawCallsPanel: Panel | undefined;
+let trianglesPanel: Panel | undefined;
+let texturesPanel: Panel | undefined;
+let geometriesPanel: Panel | undefined;
 let maxDrawCalls = 0;
 let maxTriangles = 0;
 let maxTextures = 0;
@@ -42,13 +41,13 @@ export function Stats(): JSX.Element {
       return;
     }
 
-    stats = THREEStats();
+    stats = new THREEStats();
     stats.dom.style.position = "relative";
     stats.dom.style.zIndex = "auto";
-    drawCallsPanel = THREEStats.Panel("draws", "red", "black");
-    trianglesPanel = THREEStats.Panel("tris", "cyan", "black");
-    texturesPanel = THREEStats.Panel("textures", "yellow", "black");
-    geometriesPanel = THREEStats.Panel("geometries", "green", "black");
+    drawCallsPanel = new Panel("draws", "red", "black");
+    trianglesPanel = new Panel("tris", "cyan", "black");
+    texturesPanel = new Panel("textures", "yellow", "black");
+    geometriesPanel = new Panel("geometries", "green", "black");
     stats.addPanel(drawCallsPanel);
     stats.addPanel(trianglesPanel);
     stats.addPanel(texturesPanel);
@@ -59,4 +58,180 @@ export function Stats(): JSX.Element {
   }, [div]);
 
   return <div ref={setDiv} />;
+}
+
+class THREEStats {
+  mode = 0;
+  container: HTMLDivElement;
+  dom: HTMLDivElement;
+  beginTime: number;
+  prevTime: number;
+  frames = 0;
+  msPanel: Panel;
+  fpsPanel: Panel;
+  memPanel: Panel;
+
+  constructor() {
+    this.container = document.createElement("div");
+    this.container.style.cssText =
+      "position:fixed;top:0;left:0;cursor:pointer;opacity:0.9;z-index:10000";
+    this.container.addEventListener(
+      "click",
+      (event) => {
+        event.preventDefault();
+        this.showPanel(++this.mode % this.container.children.length);
+      },
+      false,
+    );
+    this.dom = this.container;
+
+    this.beginTime = performance.now();
+    this.prevTime = this.beginTime;
+
+    this.msPanel = this.addPanel(new Panel("MS", "#0f0", "#020"));
+    this.fpsPanel = this.addPanel(new Panel("FPS", "#0ff", "#002"));
+    this.memPanel = this.addPanel(new Panel("MB", "#f08", "#201"));
+
+    this.showPanel(0);
+  }
+
+  addPanel(panel: Panel) {
+    this.container.appendChild(panel.dom);
+    return panel;
+  }
+
+  showPanel(id: number) {
+    for (let i = 0; i < this.container.children.length; i++) {
+      const child = this.container.children[i] as HTMLElement;
+      child.style.display = i === id ? "block" : "none";
+    }
+
+    this.mode = id;
+  }
+
+  begin = () => {
+    this.beginTime = performance.now();
+  };
+
+  end = () => {
+    this.frames++;
+
+    const time = performance.now();
+
+    this.msPanel.update(time - this.beginTime, 20);
+
+    if (time >= this.prevTime + 1000) {
+      this.fpsPanel.update((this.frames * 1000) / (time - this.prevTime), 100);
+
+      this.prevTime = time;
+      this.frames = 0;
+
+      const memory = (
+        performance as unknown as { memory: { usedJSHeapSize: number; jsHeapSizeLimit: number } }
+      ).memory;
+      this.memPanel.update(memory.usedJSHeapSize / 1048576, memory.jsHeapSizeLimit / 1048576);
+    }
+
+    return time;
+  };
+
+  update = () => {
+    this.beginTime = this.end();
+  };
+}
+
+class Panel {
+  dom: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  min = Infinity;
+  max = 0;
+  name: string;
+  fg: string;
+  bg: string;
+
+  constructor(name: string, fg: string, bg: string) {
+    this.name = name;
+    this.fg = fg;
+    this.bg = bg;
+
+    const PR = Math.round(window.devicePixelRatio);
+    const WIDTH = 80 * PR,
+      HEIGHT = 48 * PR,
+      TEXT_X = 3 * PR,
+      TEXT_Y = 2 * PR,
+      GRAPH_X = 3 * PR,
+      GRAPH_Y = 15 * PR,
+      GRAPH_WIDTH = 74 * PR,
+      GRAPH_HEIGHT = 30 * PR;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = WIDTH;
+    canvas.height = HEIGHT;
+    canvas.style.cssText = "width:80px;height:48px";
+
+    const context = canvas.getContext("2d")!;
+    context.font = `bold ${9 * PR}px Helvetica,Arial,sans-serif`;
+    context.textBaseline = "top";
+
+    context.fillStyle = bg;
+    context.fillRect(0, 0, WIDTH, HEIGHT);
+
+    context.fillStyle = fg;
+    context.fillText(name, TEXT_X, TEXT_Y);
+    context.fillRect(GRAPH_X, GRAPH_Y, GRAPH_WIDTH, GRAPH_HEIGHT);
+
+    context.fillStyle = bg;
+    context.globalAlpha = 0.9;
+    context.fillRect(GRAPH_X, GRAPH_Y, GRAPH_WIDTH, GRAPH_HEIGHT);
+
+    this.dom = canvas;
+    this.context = context;
+  }
+
+  update(value: number, maxValue: number): void {
+    const PR = Math.round(window.devicePixelRatio);
+    const WIDTH = 80 * PR,
+      TEXT_X = 3 * PR,
+      TEXT_Y = 2 * PR,
+      GRAPH_X = 3 * PR,
+      GRAPH_Y = 15 * PR,
+      GRAPH_WIDTH = 74 * PR,
+      GRAPH_HEIGHT = 30 * PR;
+
+    this.min = Math.min(this.min, value);
+    this.max = Math.max(this.max, value);
+
+    this.context.fillStyle = this.bg;
+    this.context.globalAlpha = 1;
+    this.context.fillRect(0, 0, WIDTH, GRAPH_Y);
+    this.context.fillStyle = this.fg;
+    this.context.fillText(
+      `${Math.round(value)} ${this.name} (${Math.round(this.min)}-${Math.round(this.max)})`,
+      TEXT_X,
+      TEXT_Y,
+    );
+
+    this.context.drawImage(
+      this.dom,
+      GRAPH_X + PR,
+      GRAPH_Y,
+      GRAPH_WIDTH - PR,
+      GRAPH_HEIGHT,
+      GRAPH_X,
+      GRAPH_Y,
+      GRAPH_WIDTH - PR,
+      GRAPH_HEIGHT,
+    );
+
+    this.context.fillRect(GRAPH_X + GRAPH_WIDTH - PR, GRAPH_Y, PR, GRAPH_HEIGHT);
+
+    this.context.fillStyle = this.bg;
+    this.context.globalAlpha = 0.9;
+    this.context.fillRect(
+      GRAPH_X + GRAPH_WIDTH - PR,
+      GRAPH_Y,
+      PR,
+      Math.round((1 - value / maxValue) * GRAPH_HEIGHT),
+    );
+  }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
@@ -54,7 +54,15 @@ export function Stats(): JSX.Element {
     stats.addPanel(geometriesPanel);
     div.appendChild(stats.dom);
     stats.showPanel(0);
-    return () => stats && void div.removeChild(stats.dom);
+    return () => {
+      if (stats) {
+        try {
+          div.removeChild(stats.dom);
+        } catch (ex) {
+          // ignore
+        }
+      }
+    };
   }, [div]);
 
   return <div ref={setDiv} />;
@@ -118,7 +126,7 @@ class THREEStats {
 
     const time = performance.now();
 
-    this.msPanel.update(time - this.beginTime, 20);
+    this.msPanel.update(time - this.beginTime, 1000 / 30);
 
     if (time >= this.prevTime + 1000) {
       this.fpsPanel.update((this.frames * 1000) / (time - this.prevTime), 100);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
@@ -68,6 +68,9 @@ export function Stats(): JSX.Element {
   return <div ref={setDiv} />;
 }
 
+// Adapted from <https://github.com/mrdoob/stats.js/>. The frame time panel is
+// modified to use a maximum value of ~33ms instead of the default 200ms and
+// appear first in the list.
 class THREEStats {
   mode = 0;
   container: HTMLDivElement;
@@ -148,6 +151,7 @@ class THREEStats {
   };
 }
 
+// Adapted from <https://github.com/mrdoob/stats.js/>. License: MIT.
 class Panel {
   dom: HTMLCanvasElement;
   context: CanvasRenderingContext2D;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -80,18 +80,18 @@ function RendererOverlay(props: { colorScheme: "dark" | "light" | undefined }): 
     setLabelsMap(new Map(labelsMap));
   });
 
-  useRendererEvent("endFrame", () => {
-    if (renderer && labelsRef.current) {
+  useRendererEvent("endFrame", (_, curRenderer) => {
+    if (labelsRef.current) {
       for (const labelId of labelsMap.keys()) {
         const labelEl = document.getElementById(`label-${labelId}`);
         if (labelEl) {
-          const worldPosition = renderer.markerWorldPosition(labelId);
+          const worldPosition = curRenderer.markerWorldPosition(labelId);
           if (worldPosition) {
             setOverlayPosition(
               labelEl.style,
               worldPosition,
-              renderer.input.canvasSize,
-              renderer.camera,
+              curRenderer.input.canvasSize,
+              curRenderer.camera,
             );
           }
         }
@@ -159,6 +159,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();
   const [messages, setMessages] = useState<ReadonlyArray<MessageEvent<unknown>> | undefined>();
   const [currentTime, setCurrentTime] = useState<bigint | undefined>();
+  const [cameraVersion, setCameraVersion] = useState<number>(0);
 
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
 
@@ -260,49 +261,62 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     }
   }, [colorScheme, renderer]);
 
-  // Handle messages
+  // Handle camera movements
+  const handleCameraMove = () => setCameraVersion((prev) => prev + 1);
   useEffect(() => {
-    if (!messages || !renderer) {
+    renderer?.addListener("cameraMove", handleCameraMove);
+    return () => void renderer?.removeListener("cameraMove", handleCameraMove);
+  }, [renderer]);
+
+  // Handle messages and render a frame if the camera has moved or new messages
+  // are available
+  useEffect(() => {
+    void cameraVersion;
+    if (!renderer) {
       return;
     }
 
-    for (const message of messages) {
-      const datatype = topicsToDatatypes.get(message.topic);
-      if (!datatype) {
-        continue;
-      }
+    if (messages) {
+      for (const message of messages) {
+        const datatype = topicsToDatatypes.get(message.topic);
+        if (!datatype) {
+          continue;
+        }
 
-      if (TF_DATATYPES.has(datatype)) {
-        // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
-        const tfMessage = message.message as { transforms: TF[] };
-        for (const tf of tfMessage.transforms) {
+        if (TF_DATATYPES.has(datatype)) {
+          // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
+          const tfMessage = message.message as { transforms: TF[] };
+          for (const tf of tfMessage.transforms) {
+            renderer.addTransformMessage(tf);
+          }
+        } else if (TRANSFORM_STAMPED_DATATYPES.has(datatype)) {
+          // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
+          const tf = message.message as TF;
           renderer.addTransformMessage(tf);
-        }
-      } else if (TRANSFORM_STAMPED_DATATYPES.has(datatype)) {
-        // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
-        const tf = message.message as TF;
-        renderer.addTransformMessage(tf);
-      } else if (MARKER_ARRAY_DATATYPES.has(datatype)) {
-        // visualization_msgs/MarkerArray - Ingest the list of markers
-        const markerArray = message.message as { markers: Marker[] };
-        for (const marker of markerArray.markers) {
+        } else if (MARKER_ARRAY_DATATYPES.has(datatype)) {
+          // visualization_msgs/MarkerArray - Ingest the list of markers
+          const markerArray = message.message as { markers: Marker[] };
+          for (const marker of markerArray.markers) {
+            renderer.addMarkerMessage(message.topic, marker);
+          }
+        } else if (MARKER_DATATYPES.has(datatype)) {
+          // visualization_msgs/Marker - Ingest this single marker
+          const marker = message.message as Marker;
           renderer.addMarkerMessage(message.topic, marker);
+        } else if (OCCUPANCY_GRID_DATATYPES.has(datatype)) {
+          // nav_msgs/OccupancyGrid - Ingest this occupancy grid
+          const occupancyGrid = message.message as OccupancyGrid;
+          renderer.addOccupancyGridMessage(message.topic, occupancyGrid);
+        } else if (POINTCLOUD_DATATYPES.has(datatype)) {
+          // sensor_msgs/PointCloud2 - Ingest this point cloud
+          const pointCloud = message.message as PointCloud2;
+          renderer.addPointCloud2Message(message.topic, pointCloud);
         }
-      } else if (MARKER_DATATYPES.has(datatype)) {
-        // visualization_msgs/Marker - Ingest this single marker
-        const marker = message.message as Marker;
-        renderer.addMarkerMessage(message.topic, marker);
-      } else if (OCCUPANCY_GRID_DATATYPES.has(datatype)) {
-        // nav_msgs/OccupancyGrid - Ingest this occupancy grid
-        const occupancyGrid = message.message as OccupancyGrid;
-        renderer.addOccupancyGridMessage(message.topic, occupancyGrid);
-      } else if (POINTCLOUD_DATATYPES.has(datatype)) {
-        // sensor_msgs/PointCloud2 - Ingest this point cloud
-        const pointCloud = message.message as PointCloud2;
-        renderer.addPointCloud2Message(message.topic, pointCloud);
       }
     }
-  }, [messages, renderer, topicsToDatatypes]);
+
+    renderer.animationFrame();
+  }, [cameraVersion, messages, renderer, topicsToDatatypes]);
 
   // Invoke the done callback once the render is complete
   useEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -23,6 +23,8 @@ import {
   Marker,
   PointCloud2,
   POINTCLOUD_DATATYPES,
+  OccupancyGrid,
+  OCCUPANCY_GRID_DATATYPES,
 } from "./ros";
 
 const SHOW_STATS = true;
@@ -33,6 +35,7 @@ mergeSetInto(SUPPORTED_DATATYPES, TRANSFORM_STAMPED_DATATYPES);
 mergeSetInto(SUPPORTED_DATATYPES, TF_DATATYPES);
 mergeSetInto(SUPPORTED_DATATYPES, MARKER_DATATYPES);
 mergeSetInto(SUPPORTED_DATATYPES, MARKER_ARRAY_DATATYPES);
+mergeSetInto(SUPPORTED_DATATYPES, OCCUPANCY_GRID_DATATYPES);
 mergeSetInto(SUPPORTED_DATATYPES, POINTCLOUD_DATATYPES);
 
 const log = Logger.getLogger(__filename);
@@ -284,6 +287,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         // visualization_msgs/Marker - Ingest this single marker
         const marker = message.message as Marker;
         renderer.addMarkerMessage(message.topic, marker);
+      } else if (OCCUPANCY_GRID_DATATYPES.has(datatype)) {
+        // nav_msgs/OccupancyGrid - Ingest this occupancy grid
+        const occupancyGrid = message.message as OccupancyGrid;
+        renderer.addOccupancyGridMessage(message.topic, occupancyGrid);
       } else if (POINTCLOUD_DATATYPES.has(datatype)) {
         // sensor_msgs/PointCloud2 - Ingest this point cloud
         const pointCloud = message.message as PointCloud2;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -285,42 +285,45 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       return;
     }
 
-    if (messages) {
-      for (const message of messages) {
-        const datatype = topicsToDatatypes.get(message.topic);
-        if (!datatype) {
-          continue;
-        }
+    if (!messages) {
+      renderer.animationFrame();
+      return;
+    }
 
-        if (TF_DATATYPES.has(datatype)) {
-          // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
-          const tfMessage = message.message as { transforms: TF[] };
-          for (const tf of tfMessage.transforms) {
-            renderer.addTransformMessage(tf);
-          }
-        } else if (TRANSFORM_STAMPED_DATATYPES.has(datatype)) {
-          // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
-          const tf = message.message as TF;
+    for (const message of messages) {
+      const datatype = topicsToDatatypes.get(message.topic);
+      if (!datatype) {
+        continue;
+      }
+
+      if (TF_DATATYPES.has(datatype)) {
+        // tf2_msgs/TFMessage - Ingest the list of transforms into our TF tree
+        const tfMessage = message.message as { transforms: TF[] };
+        for (const tf of tfMessage.transforms) {
           renderer.addTransformMessage(tf);
-        } else if (MARKER_ARRAY_DATATYPES.has(datatype)) {
-          // visualization_msgs/MarkerArray - Ingest the list of markers
-          const markerArray = message.message as { markers: Marker[] };
-          for (const marker of markerArray.markers) {
-            renderer.addMarkerMessage(message.topic, marker);
-          }
-        } else if (MARKER_DATATYPES.has(datatype)) {
-          // visualization_msgs/Marker - Ingest this single marker
-          const marker = message.message as Marker;
-          renderer.addMarkerMessage(message.topic, marker);
-        } else if (OCCUPANCY_GRID_DATATYPES.has(datatype)) {
-          // nav_msgs/OccupancyGrid - Ingest this occupancy grid
-          const occupancyGrid = message.message as OccupancyGrid;
-          renderer.addOccupancyGridMessage(message.topic, occupancyGrid);
-        } else if (POINTCLOUD_DATATYPES.has(datatype)) {
-          // sensor_msgs/PointCloud2 - Ingest this point cloud
-          const pointCloud = message.message as PointCloud2;
-          renderer.addPointCloud2Message(message.topic, pointCloud);
         }
+      } else if (TRANSFORM_STAMPED_DATATYPES.has(datatype)) {
+        // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
+        const tf = message.message as TF;
+        renderer.addTransformMessage(tf);
+      } else if (MARKER_ARRAY_DATATYPES.has(datatype)) {
+        // visualization_msgs/MarkerArray - Ingest the list of markers
+        const markerArray = message.message as { markers: Marker[] };
+        for (const marker of markerArray.markers) {
+          renderer.addMarkerMessage(message.topic, marker);
+        }
+      } else if (MARKER_DATATYPES.has(datatype)) {
+        // visualization_msgs/Marker - Ingest this single marker
+        const marker = message.message as Marker;
+        renderer.addMarkerMessage(message.topic, marker);
+      } else if (OCCUPANCY_GRID_DATATYPES.has(datatype)) {
+        // nav_msgs/OccupancyGrid - Ingest this occupancy grid
+        const occupancyGrid = message.message as OccupancyGrid;
+        renderer.addOccupancyGridMessage(message.topic, occupancyGrid);
+      } else if (POINTCLOUD_DATATYPES.has(datatype)) {
+        // sensor_msgs/PointCloud2 - Ingest this point cloud
+        const pointCloud = message.message as PointCloud2;
+        renderer.addPointCloud2Message(message.topic, pointCloud);
       }
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -8,6 +8,7 @@ import React, { useRef, useLayoutEffect, useEffect, useState, useMemo } from "re
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
 import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 
 import { DebugGui } from "./DebugGui";
 import { setOverlayPosition } from "./LabelOverlay";
@@ -160,6 +161,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [currentTime, setCurrentTime] = useState<bigint | undefined>();
 
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
+
+  useCleanup(() => {
+    renderer?.dispose();
+  });
 
   // We use a layout effect to setup render handling for our panel. We also setup some topic subscriptions.
   useLayoutEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -196,6 +196,15 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       setTopics(renderState.topics);
 
       // currentFrame has messages on subscribed topics since the last render call
+      if (renderState.currentFrame) {
+        // Fully parse lazy messages
+        for (const messageEvent of renderState.currentFrame) {
+          const maybeLazy = messageEvent.message as { toJSON?: () => unknown };
+          if ("toJSON" in maybeLazy) {
+            (messageEvent as { message: unknown }).message = maybeLazy.toJSON!();
+          }
+        }
+      }
       setMessages(renderState.currentFrame);
     };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/color.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/color.ts
@@ -7,6 +7,10 @@ import { clamp } from "three/src/math/MathUtils";
 import { approxEquals, uint8Equals } from "./math";
 import { ColorRGBA } from "./ros";
 
+export function SRGBToLinear(c: number): number {
+  return c < 0.04045 ? c * 0.0773993808 : Math.pow(c * 0.9478672986 + 0.0521327014, 2.4);
+}
+
 export function rgbaToHexString(color: ColorRGBA): string {
   const rgba =
     (clamp(color.r * 255, 0, 255) << 24) ^

--- a/packages/studio-base/src/panels/ThreeDeeRender/lod.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/lod.ts
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export enum DetailLevel {
+  Low,
+  Medium,
+  High,
+}
+
+export function arrowShaftSubdivisions(lod: DetailLevel): number {
+  switch (lod) {
+    case DetailLevel.Low:
+      return 12;
+    case DetailLevel.Medium:
+      return 20;
+    case DetailLevel.High:
+      return 32;
+  }
+}
+
+export function arrowHeadSubdivisions(lod: DetailLevel): number {
+  switch (lod) {
+    case DetailLevel.Low:
+      return 12;
+    case DetailLevel.Medium:
+      return 20;
+    case DetailLevel.High:
+      return 32;
+  }
+}
+
+export function cylinderSubdivisions(lod: DetailLevel): number {
+  switch (lod) {
+    case DetailLevel.Low:
+      return 12;
+    case DetailLevel.Medium:
+      return 20;
+    case DetailLevel.High:
+      return 32;
+  }
+}
+
+export function sphereSubdivisions(lod: DetailLevel): number {
+  switch (lod) {
+    case DetailLevel.Low:
+      return 10;
+    case DetailLevel.Medium:
+      return 24;
+    case DetailLevel.High:
+      return 32;
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/math.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/math.ts
@@ -60,3 +60,11 @@ export function uint8Equals(a: number, b: number): boolean {
   const bi = Math.trunc(b * 255);
   return ai === bi;
 }
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -171,7 +171,7 @@ export class FrameAxes extends THREE.Object3D {
 
     // Create three arrow shafts
     const arrowMaterial = standardMaterial(this.renderer.materialCache);
-    const shaftGeometry = FrameAxes.ShaftGeometry(this.renderer.lod);
+    const shaftGeometry = FrameAxes.ShaftGeometry(this.renderer.maxLod);
     const shaftInstances = new THREE.InstancedMesh(shaftGeometry, arrowMaterial, 3);
     shaftInstances.castShadow = true;
     shaftInstances.receiveShadow = true;
@@ -186,7 +186,7 @@ export class FrameAxes extends THREE.Object3D {
     shaftInstances.setColorAt(2, BLUE_COLOR);
 
     // Create three arrow heads
-    const headGeometry = FrameAxes.HeadGeometry(this.renderer.lod);
+    const headGeometry = FrameAxes.HeadGeometry(this.renderer.maxLod);
     const headInstances = new THREE.InstancedMesh(headGeometry, arrowMaterial, 3);
     headInstances.castShadow = true;
     headInstances.receiveShadow = true;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -54,6 +54,7 @@ export class FrameAxes extends THREE.Object3D {
       frameAdded = true;
     }
 
+    // Create a new transform and add it to the renderer's TransformTree
     const stamp = rosTimeToNanoSec(tf.header.stamp);
     const t = tf.transform.translation;
     const q = tf.transform.rotation;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -5,8 +5,13 @@
 import * as THREE from "three";
 
 import Logger from "@foxglove/log";
+import {
+  MaterialCache,
+  StandardColor,
+} from "@foxglove/studio-base/panels/ThreeDeeRender/MaterialCache";
 
 import { Renderer } from "../Renderer";
+import { arrowHeadSubdivisions, arrowShaftSubdivisions, DetailLevel } from "../lod";
 import { Pose, rosTimeToNanoSec, TF } from "../ros";
 import { Transform } from "../transforms/Transform";
 import { makePose } from "../transforms/geometry";
@@ -14,6 +19,15 @@ import { updatePose } from "../updatePose";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
 
 const log = Logger.getLogger(__filename);
+
+const SHAFT_LENGTH = 0.154;
+const SHAFT_DIAMETER = 0.02;
+const HEAD_LENGTH = 0.046;
+const HEAD_DIAMETER = 0.05;
+
+const tempMat4 = new THREE.Matrix4();
+const tempVec = new THREE.Vector3();
+const tempColor = new THREE.Color();
 
 type FrameAxisRenderable = THREE.Object3D & {
   userData: {
@@ -23,6 +37,11 @@ type FrameAxisRenderable = THREE.Object3D & {
 };
 
 export class FrameAxes extends THREE.Object3D {
+  private static shaftLod: DetailLevel | undefined;
+  private static headLod: DetailLevel | undefined;
+  private static shaftGeometry: THREE.CylinderGeometry | undefined;
+  private static headGeometry: THREE.ConeGeometry | undefined;
+
   renderer: Renderer;
   axesByFrameId = new Map<string, FrameAxisRenderable>();
 
@@ -101,18 +120,81 @@ export class FrameAxes extends THREE.Object3D {
       return;
     }
 
-    const frame = new THREE.Object3D() as FrameAxisRenderable;
-    frame.name = frameId;
-    frame.userData.frameId = frameId;
-    frame.userData.pose = makePose();
+    const renderable = new THREE.Object3D() as FrameAxisRenderable;
+    renderable.name = frameId;
+    renderable.userData.frameId = frameId;
+    renderable.userData.pose = makePose();
 
-    const AXIS_DEFAULT_LENGTH = 1; // [m]
-    const axes = new THREE.AxesHelper(AXIS_DEFAULT_LENGTH);
-    frame.add(axes);
+    const material = standardMaterial(this.renderer.materialCache);
+    const shaftInstances = new THREE.InstancedMesh(
+      FrameAxes.ShaftGeometry(this.renderer.lod),
+      material,
+      3,
+    );
+    shaftInstances.castShadow = true;
+    shaftInstances.receiveShadow = true;
+    renderable.add(shaftInstances);
+    // Set x, y, and z axis arrow directions
+    tempVec.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
+    shaftInstances.setMatrixAt(0, tempMat4.makeRotationX(Math.PI / 2).scale(tempVec));
+    shaftInstances.setMatrixAt(1, tempMat4.makeRotationY(Math.PI / 2).scale(tempVec));
+    shaftInstances.setMatrixAt(2, tempMat4.makeRotationZ(Math.PI / 2).scale(tempVec));
+    shaftInstances.setColorAt(0, tempColor.setHex(0x9c3948).convertSRGBToLinear());
+    shaftInstances.setColorAt(1, tempColor.setHex(0x88dd04).convertSRGBToLinear());
+    shaftInstances.setColorAt(2, tempColor.setHex(0x2b90fb).convertSRGBToLinear());
+
+    // this.shaftMesh.scale.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
+    // this.headMesh.scale.set(HEAD_LENGTH, HEAD_DIAMETER, HEAD_DIAMETER);
+    // this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
+
+    // const halfShaftLength = SHAFT_LENGTH / 2;
+    // const halfHeadLength = HEAD_LENGTH / 2;
+    // this.shaftMesh.position.set(halfShaftLength, 0, 0);
+    // this.headMesh.position.set(halfShaftLength * 2 + halfHeadLength, 0, 0);
+
+    // const AXIS_DEFAULT_LENGTH = 1; // [m]
+    // const axes = new THREE.AxesHelper(AXIS_DEFAULT_LENGTH);
+    // renderable.add(axes);
 
     // TODO: <div> floating label
 
-    this.add(frame);
-    this.axesByFrameId.set(frameId, frame);
+    this.add(renderable);
+    this.axesByFrameId.set(frameId, renderable);
   }
+
+  static ShaftGeometry(lod: DetailLevel): THREE.CylinderGeometry {
+    if (!FrameAxes.shaftGeometry || lod !== FrameAxes.shaftLod) {
+      const subdivs = arrowShaftSubdivisions(lod);
+      FrameAxes.shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivs, 1, false);
+      FrameAxes.shaftGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.shaftGeometry.computeBoundingSphere();
+      FrameAxes.shaftLod = lod;
+    }
+    return FrameAxes.shaftGeometry;
+  }
+
+  static HeadGeometry(lod: DetailLevel): THREE.ConeGeometry {
+    if (!FrameAxes.headGeometry || lod !== FrameAxes.headLod) {
+      const subdivs = arrowHeadSubdivisions(lod);
+      FrameAxes.headGeometry = new THREE.ConeGeometry(0.5, 1, subdivs, 1, false);
+      FrameAxes.headGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.headGeometry.computeBoundingSphere();
+      FrameAxes.headLod = lod;
+    }
+    return FrameAxes.headGeometry;
+  }
+}
+
+const COLOR_WHITE = { r: 1, g: 1, b: 1, a: 1 };
+
+function standardMaterial(materialCache: MaterialCache): THREE.MeshStandardMaterial {
+  return materialCache.acquire(
+    StandardColor.id(COLOR_WHITE),
+    () => StandardColor.create(COLOR_WHITE),
+    StandardColor.dispose,
+  );
+}
+
+function releaseStandardMaterial(materialCache: MaterialCache): void {
+  materialCache.release(StandardColor.id(COLOR_WHITE));
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -31,8 +31,10 @@ const tempColor = new THREE.Color();
 
 type FrameAxisRenderable = THREE.Object3D & {
   userData: {
-    frameId?: string;
-    pose?: Pose;
+    frameId: string;
+    pose: Pose;
+    shaftMesh: THREE.InstancedMesh;
+    headMesh: THREE.InstancedMesh;
   };
 };
 
@@ -51,12 +53,10 @@ export class FrameAxes extends THREE.Object3D {
   }
 
   dispose(): void {
-    for (const axisRenderable of this.axesByFrameId.values()) {
-      axisRenderable.traverse((obj) => {
-        if (obj instanceof THREE.AxesHelper) {
-          obj.dispose();
-        }
-      });
+    for (const renderable of this.axesByFrameId.values()) {
+      releaseStandardMaterial(this.renderer.materialCache);
+      renderable.userData.shaftMesh.dispose();
+      renderable.userData.headMesh.dispose();
     }
     this.children.length = 0;
     this.axesByFrameId.clear();
@@ -136,12 +136,47 @@ export class FrameAxes extends THREE.Object3D {
     renderable.add(shaftInstances);
     // Set x, y, and z axis arrow directions
     tempVec.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
-    shaftInstances.setMatrixAt(0, tempMat4.makeRotationX(Math.PI / 2).scale(tempVec));
-    shaftInstances.setMatrixAt(1, tempMat4.makeRotationY(Math.PI / 2).scale(tempVec));
-    shaftInstances.setMatrixAt(2, tempMat4.makeRotationZ(Math.PI / 2).scale(tempVec));
+    shaftInstances.setMatrixAt(0, tempMat4.identity().scale(tempVec));
+    shaftInstances.setMatrixAt(1, tempMat4.makeRotationZ(Math.PI / 2).scale(tempVec));
+    shaftInstances.setMatrixAt(2, tempMat4.makeRotationY(-Math.PI / 2).scale(tempVec));
     shaftInstances.setColorAt(0, tempColor.setHex(0x9c3948).convertSRGBToLinear());
     shaftInstances.setColorAt(1, tempColor.setHex(0x88dd04).convertSRGBToLinear());
     shaftInstances.setColorAt(2, tempColor.setHex(0x2b90fb).convertSRGBToLinear());
+
+    const headInstances = new THREE.InstancedMesh(
+      FrameAxes.HeadGeometry(this.renderer.lod),
+      material,
+      3,
+    );
+    headInstances.castShadow = true;
+    headInstances.receiveShadow = true;
+    renderable.add(headInstances);
+    // Set x, y, and z axis arrow directions
+    tempVec.set(HEAD_LENGTH, HEAD_DIAMETER, HEAD_DIAMETER);
+    headInstances.setMatrixAt(
+      0,
+      tempMat4.identity().scale(tempVec).setPosition(SHAFT_LENGTH, 0, 0),
+    );
+    headInstances.setMatrixAt(
+      1,
+      tempMat4
+        .makeRotationZ(Math.PI / 2)
+        .scale(tempVec)
+        .setPosition(0, SHAFT_LENGTH, 0),
+    );
+    headInstances.setMatrixAt(
+      2,
+      tempMat4
+        .makeRotationY(-Math.PI / 2)
+        .scale(tempVec)
+        .setPosition(0, 0, SHAFT_LENGTH),
+    );
+    headInstances.setColorAt(0, tempColor.setHex(0x9c3948).convertSRGBToLinear());
+    headInstances.setColorAt(1, tempColor.setHex(0x88dd04).convertSRGBToLinear());
+    headInstances.setColorAt(2, tempColor.setHex(0x2b90fb).convertSRGBToLinear());
+
+    renderable.userData.shaftMesh = shaftInstances;
+    renderable.userData.headMesh = headInstances;
 
     // this.shaftMesh.scale.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
     // this.headMesh.scale.set(HEAD_LENGTH, HEAD_DIAMETER, HEAD_DIAMETER);
@@ -167,6 +202,7 @@ export class FrameAxes extends THREE.Object3D {
       const subdivs = arrowShaftSubdivisions(lod);
       FrameAxes.shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivs, 1, false);
       FrameAxes.shaftGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.shaftGeometry.translate(0.5, 0, 0);
       FrameAxes.shaftGeometry.computeBoundingSphere();
       FrameAxes.shaftLod = lod;
     }
@@ -178,6 +214,7 @@ export class FrameAxes extends THREE.Object3D {
       const subdivs = arrowHeadSubdivisions(lod);
       FrameAxes.headGeometry = new THREE.ConeGeometry(0.5, 1, subdivs, 1, false);
       FrameAxes.headGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.headGeometry.translate(0.5, 0, 0);
       FrameAxes.headGeometry.computeBoundingSphere();
       FrameAxes.headLod = lod;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -3,6 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as THREE from "three";
+import { Line2 } from "three/examples/jsm/lines/Line2";
+import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
+import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 
 import Logger from "@foxglove/log";
 import {
@@ -25,9 +28,16 @@ const SHAFT_DIAMETER = 0.02;
 const HEAD_LENGTH = 0.046;
 const HEAD_DIAMETER = 0.05;
 
+const RED_COLOR = new THREE.Color(0x9c3948).convertSRGBToLinear();
+const GREEN_COLOR = new THREE.Color(0x88dd04).convertSRGBToLinear();
+const BLUE_COLOR = new THREE.Color(0x2b90fb).convertSRGBToLinear();
+const YELLOW_COLOR = new THREE.Color(0xffff00).convertSRGBToLinear();
+
+const PI_2 = Math.PI / 2;
+
 const tempMat4 = new THREE.Matrix4();
 const tempVec = new THREE.Vector3();
-const tempColor = new THREE.Color();
+const tempVecB = new THREE.Vector3();
 
 type FrameAxisRenderable = THREE.Object3D & {
   userData: {
@@ -35,6 +45,7 @@ type FrameAxisRenderable = THREE.Object3D & {
     pose: Pose;
     shaftMesh: THREE.InstancedMesh;
     headMesh: THREE.InstancedMesh;
+    parentLine?: Line2;
   };
 };
 
@@ -43,13 +54,18 @@ export class FrameAxes extends THREE.Object3D {
   private static headLod: DetailLevel | undefined;
   private static shaftGeometry: THREE.CylinderGeometry | undefined;
   private static headGeometry: THREE.ConeGeometry | undefined;
+  private static lineGeometry: LineGeometry | undefined;
 
   renderer: Renderer;
   axesByFrameId = new Map<string, FrameAxisRenderable>();
+  lineMaterial: LineMaterial;
 
   constructor(renderer: Renderer) {
     super();
     this.renderer = renderer;
+
+    this.lineMaterial = new LineMaterial({ worldUnits: false, linewidth: 2 });
+    this.lineMaterial.color = YELLOW_COLOR;
   }
 
   dispose(): void {
@@ -60,18 +76,12 @@ export class FrameAxes extends THREE.Object3D {
     }
     this.children.length = 0;
     this.axesByFrameId.clear();
+    this.lineMaterial.dispose();
   }
 
   addTransformMessage(tf: TF): void {
-    let frameAdded = false;
-    if (!this.renderer.transformTree.hasFrame(tf.header.frame_id)) {
-      this._addFrameAxis(tf.header.frame_id);
-      frameAdded = true;
-    }
-    if (!this.renderer.transformTree.hasFrame(tf.child_frame_id)) {
-      this._addFrameAxis(tf.child_frame_id);
-      frameAdded = true;
-    }
+    const addParent = !this.renderer.transformTree.hasFrame(tf.header.frame_id);
+    const addChild = !this.renderer.transformTree.hasFrame(tf.child_frame_id);
 
     // Create a new transform and add it to the renderer's TransformTree
     const stamp = rosTimeToNanoSec(tf.header.stamp);
@@ -85,19 +95,29 @@ export class FrameAxes extends THREE.Object3D {
       transform,
     );
 
-    if (frameAdded) {
+    if (addParent) {
+      this._addFrameAxis(tf.header.frame_id);
+    }
+    if (addChild) {
+      this._addFrameAxis(tf.child_frame_id);
+    }
+
+    if (addParent || addChild) {
       log.debug(`Added transform "${tf.header.frame_id}_T_${tf.child_frame_id}"`);
       this.renderer.emit("transformTreeUpdated", this.renderer);
     }
   }
 
   startFrame(currentTime: bigint): void {
+    this.lineMaterial.resolution = this.renderer.input.canvasSize;
+
     const renderFrameId = this.renderer.renderFrameId;
     const fixedFrameId = this.renderer.fixedFrameId;
     if (!renderFrameId || !fixedFrameId) {
       return;
     }
 
+    // Update the arrow poses
     for (const [frameId, renderable] of this.axesByFrameId.entries()) {
       const updated = updatePose(
         renderable,
@@ -108,9 +128,31 @@ export class FrameAxes extends THREE.Object3D {
         currentTime,
         currentTime,
       );
+      renderable.visible = updated;
       if (!updated) {
         const message = missingTransformMessage(renderFrameId, fixedFrameId, frameId);
         this.renderer.layerErrors.addToLayer(`f:${frameId}`, MISSING_TRANSFORM, message);
+      }
+    }
+
+    // Update the lines between coordinate frames
+    for (const [_frameId, childRenderable] of this.axesByFrameId.entries()) {
+      const line = childRenderable.userData.parentLine;
+      if (line) {
+        line.visible = false;
+        const childFrame = this.renderer.transformTree.frame(childRenderable.userData.frameId);
+        const parentFrame = childFrame?.parent();
+        if (parentFrame) {
+          const parentRenderable = this.axesByFrameId.get(parentFrame.id);
+          if (parentRenderable?.visible === true) {
+            parentRenderable.getWorldPosition(tempVec);
+            const dist = tempVec.distanceTo(childRenderable.getWorldPosition(tempVecB));
+            line.lookAt(tempVec);
+            line.rotateY(-PI_2);
+            line.scale.set(dist, 1, 1);
+            line.visible = true;
+          }
+        }
       }
     }
   }
@@ -120,88 +162,97 @@ export class FrameAxes extends THREE.Object3D {
       return;
     }
 
+    // Create a scene graph object to hold the three arrows, a text label, and a
+    // line to the parent frame if it exists
     const renderable = new THREE.Object3D() as FrameAxisRenderable;
     renderable.name = frameId;
     renderable.userData.frameId = frameId;
     renderable.userData.pose = makePose();
 
-    const material = standardMaterial(this.renderer.materialCache);
-    const shaftInstances = new THREE.InstancedMesh(
-      FrameAxes.ShaftGeometry(this.renderer.lod),
-      material,
-      3,
-    );
+    // Create three arrow shafts
+    const arrowMaterial = standardMaterial(this.renderer.materialCache);
+    const shaftGeometry = FrameAxes.ShaftGeometry(this.renderer.lod);
+    const shaftInstances = new THREE.InstancedMesh(shaftGeometry, arrowMaterial, 3);
     shaftInstances.castShadow = true;
     shaftInstances.receiveShadow = true;
     renderable.add(shaftInstances);
-    // Set x, y, and z axis arrow directions
+    // Set x, y, and z axis arrow shaft directions
     tempVec.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
     shaftInstances.setMatrixAt(0, tempMat4.identity().scale(tempVec));
-    shaftInstances.setMatrixAt(1, tempMat4.makeRotationZ(Math.PI / 2).scale(tempVec));
-    shaftInstances.setMatrixAt(2, tempMat4.makeRotationY(-Math.PI / 2).scale(tempVec));
-    shaftInstances.setColorAt(0, tempColor.setHex(0x9c3948).convertSRGBToLinear());
-    shaftInstances.setColorAt(1, tempColor.setHex(0x88dd04).convertSRGBToLinear());
-    shaftInstances.setColorAt(2, tempColor.setHex(0x2b90fb).convertSRGBToLinear());
+    shaftInstances.setMatrixAt(1, tempMat4.makeRotationZ(PI_2).scale(tempVec));
+    shaftInstances.setMatrixAt(2, tempMat4.makeRotationY(-PI_2).scale(tempVec));
+    shaftInstances.setColorAt(0, RED_COLOR);
+    shaftInstances.setColorAt(1, GREEN_COLOR);
+    shaftInstances.setColorAt(2, BLUE_COLOR);
 
-    const headInstances = new THREE.InstancedMesh(
-      FrameAxes.HeadGeometry(this.renderer.lod),
-      material,
-      3,
-    );
+    // Create three arrow heads
+    const headGeometry = FrameAxes.HeadGeometry(this.renderer.lod);
+    const headInstances = new THREE.InstancedMesh(headGeometry, arrowMaterial, 3);
     headInstances.castShadow = true;
     headInstances.receiveShadow = true;
     renderable.add(headInstances);
-    // Set x, y, and z axis arrow directions
+    // Set x, y, and z axis arrow head directions
     tempVec.set(HEAD_LENGTH, HEAD_DIAMETER, HEAD_DIAMETER);
-    headInstances.setMatrixAt(
-      0,
-      tempMat4.identity().scale(tempVec).setPosition(SHAFT_LENGTH, 0, 0),
-    );
-    headInstances.setMatrixAt(
-      1,
-      tempMat4
-        .makeRotationZ(Math.PI / 2)
-        .scale(tempVec)
-        .setPosition(0, SHAFT_LENGTH, 0),
-    );
-    headInstances.setMatrixAt(
-      2,
-      tempMat4
-        .makeRotationY(-Math.PI / 2)
-        .scale(tempVec)
-        .setPosition(0, 0, SHAFT_LENGTH),
-    );
-    headInstances.setColorAt(0, tempColor.setHex(0x9c3948).convertSRGBToLinear());
-    headInstances.setColorAt(1, tempColor.setHex(0x88dd04).convertSRGBToLinear());
-    headInstances.setColorAt(2, tempColor.setHex(0x2b90fb).convertSRGBToLinear());
+    tempMat4.identity().scale(tempVec).setPosition(SHAFT_LENGTH, 0, 0);
+    headInstances.setMatrixAt(0, tempMat4);
+    tempMat4.makeRotationZ(PI_2).scale(tempVec).setPosition(0, SHAFT_LENGTH, 0);
+    headInstances.setMatrixAt(1, tempMat4);
+    tempMat4.makeRotationY(-PI_2).scale(tempVec).setPosition(0, 0, SHAFT_LENGTH);
+    headInstances.setMatrixAt(2, tempMat4);
+    headInstances.setColorAt(0, RED_COLOR);
+    headInstances.setColorAt(1, GREEN_COLOR);
+    headInstances.setColorAt(2, BLUE_COLOR);
 
     renderable.userData.shaftMesh = shaftInstances;
     renderable.userData.headMesh = headInstances;
 
-    // this.shaftMesh.scale.set(SHAFT_LENGTH, SHAFT_DIAMETER, SHAFT_DIAMETER);
-    // this.headMesh.scale.set(HEAD_LENGTH, HEAD_DIAMETER, HEAD_DIAMETER);
-    // this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
-
-    // const halfShaftLength = SHAFT_LENGTH / 2;
-    // const halfHeadLength = HEAD_LENGTH / 2;
-    // this.shaftMesh.position.set(halfShaftLength, 0, 0);
-    // this.headMesh.position.set(halfShaftLength * 2 + halfHeadLength, 0, 0);
-
-    // const AXIS_DEFAULT_LENGTH = 1; // [m]
-    // const axes = new THREE.AxesHelper(AXIS_DEFAULT_LENGTH);
-    // renderable.add(axes);
-
     // TODO: <div> floating label
+
+    const frame = this.renderer.transformTree.frame(frameId);
+    if (!frame) {
+      throw new Error(`CoordinateFrame "${frameId}" was not created`);
+    }
+
+    // Check if this frame's parent exists
+    const parentFrame = frame.parent();
+    if (parentFrame) {
+      const parentRenderable = this.axesByFrameId.get(parentFrame.id);
+      if (parentRenderable) {
+        this._addChildParentLine(renderable);
+      }
+    }
+
+    // Find all children of this frame
+    for (const curFrame of this.renderer.transformTree.frames().values()) {
+      if (curFrame.parent() === frame) {
+        const curRenderable = this.axesByFrameId.get(curFrame.id);
+        if (curRenderable) {
+          this._addChildParentLine(curRenderable);
+        }
+      }
+    }
 
     this.add(renderable);
     this.axesByFrameId.set(frameId, renderable);
+  }
+
+  private _addChildParentLine(renderable: FrameAxisRenderable): void {
+    if (renderable.userData.parentLine) {
+      renderable.remove(renderable.userData.parentLine);
+    }
+    const line = new Line2(FrameAxes.LineGeometry(), this.lineMaterial);
+    line.castShadow = true;
+    line.receiveShadow = false;
+
+    renderable.add(line);
+    renderable.userData.parentLine = line;
   }
 
   static ShaftGeometry(lod: DetailLevel): THREE.CylinderGeometry {
     if (!FrameAxes.shaftGeometry || lod !== FrameAxes.shaftLod) {
       const subdivs = arrowShaftSubdivisions(lod);
       FrameAxes.shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivs, 1, false);
-      FrameAxes.shaftGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.shaftGeometry.rotateZ(-PI_2);
       FrameAxes.shaftGeometry.translate(0.5, 0, 0);
       FrameAxes.shaftGeometry.computeBoundingSphere();
       FrameAxes.shaftLod = lod;
@@ -213,12 +264,20 @@ export class FrameAxes extends THREE.Object3D {
     if (!FrameAxes.headGeometry || lod !== FrameAxes.headLod) {
       const subdivs = arrowHeadSubdivisions(lod);
       FrameAxes.headGeometry = new THREE.ConeGeometry(0.5, 1, subdivs, 1, false);
-      FrameAxes.headGeometry.rotateZ(-Math.PI / 2);
+      FrameAxes.headGeometry.rotateZ(-PI_2);
       FrameAxes.headGeometry.translate(0.5, 0, 0);
       FrameAxes.headGeometry.computeBoundingSphere();
       FrameAxes.headLod = lod;
     }
     return FrameAxes.headGeometry;
+  }
+
+  static LineGeometry(): LineGeometry {
+    if (!FrameAxes.lineGeometry) {
+      FrameAxes.lineGeometry = new LineGeometry();
+      FrameAxes.lineGeometry.setPositions([0, 0, 0, 1, 0, 0]);
+    }
+    return FrameAxes.lineGeometry;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -201,6 +201,7 @@ function updateTexture(
   occupancyGrid: OccupancyGrid,
   settings: OccupancyGridSettings,
 ): void {
+  const size = occupancyGrid.info.width * occupancyGrid.info.height;
   const rgba = texture.image.data;
 
   tempUnknownColor.r = SRGBToLinear(settings.unknownColor.r) * 255;
@@ -223,7 +224,9 @@ function updateTexture(
   tempMaxColor.b = SRGBToLinear(settings.maxColor.b) * 255;
   tempMaxColor.a = settings.maxColor.a * 255;
 
-  occupancyGrid.data.forEach((value, i) => {
+  const data = occupancyGrid.data;
+  for (let i = 0; i < size; i++) {
+    const value = data[i]! | 0;
     const offset = i * 4;
     if (value === -1) {
       // Unknown (-1)
@@ -252,7 +255,7 @@ function updateTexture(
       rgba[offset + 2] = tempInvalidColor.b;
       rgba[offset + 3] = tempInvalidColor.a;
     }
-  });
+  }
 
   texture.needsUpdate = true;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -46,10 +46,10 @@ type OccupancyGridRenderable = THREE.Object3D & {
 };
 
 export class OccupancyGrids extends THREE.Object3D {
+  private static geometry: THREE.PlaneGeometry | undefined;
+
   renderer: Renderer;
   occupancyGridsByTopic = new Map<string, OccupancyGridRenderable>();
-
-  static Geometry = new THREE.PlaneGeometry(1, 1, 1, 1).translate(0.5, 0.5, 0);
 
   constructor(renderer: Renderer) {
     super();
@@ -87,7 +87,7 @@ export class OccupancyGrids extends THREE.Object3D {
 
       const texture = createTexture(occupancyGrid);
       const material = createMaterial(texture, renderable);
-      const mesh = new THREE.Mesh(OccupancyGrids.Geometry, material);
+      const mesh = new THREE.Mesh(OccupancyGrids.Geometry(), material);
       mesh.castShadow = true;
       mesh.receiveShadow = true;
       renderable.userData.texture = texture;
@@ -157,6 +157,15 @@ export class OccupancyGrids extends THREE.Object3D {
     updateTexture(texture, occupancyGrid, renderable.userData.settings);
 
     renderable.scale.set(resolution * width, resolution * height, 1);
+  }
+
+  static Geometry(): THREE.PlaneGeometry {
+    if (!OccupancyGrids.geometry) {
+      OccupancyGrids.geometry = new THREE.PlaneGeometry(1, 1, 1, 1);
+      OccupancyGrids.geometry.translate(0.5, 0.5, 0);
+      OccupancyGrids.geometry.computeBoundingSphere();
+    }
+    return OccupancyGrids.geometry;
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -1,0 +1,282 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { Renderer } from "../Renderer";
+import { SRGBToLinear } from "../color";
+import { Pose, rosTimeToNanoSec, ColorRGBA, OccupancyGrid } from "../ros";
+import { updatePose } from "../updatePose";
+import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
+
+// TODO(jhurliman): Upload the OccupancyGrid data directly as a R8I texture and
+// use a custom ShaderMaterial with an isampler2D uniform to reimplement the
+// updateTexture() logic in a shader
+
+export type OccupancyGridSettings = {
+  minColor: ColorRGBA;
+  maxColor: ColorRGBA;
+  unknownColor: ColorRGBA;
+  invalidColor: ColorRGBA;
+};
+
+// ts-prune-ignore-next
+export type StoredOccupancyGridSettings = Partial<OccupancyGridSettings>;
+
+const INVALID_OCCUPANCY_GRID = "INVALID_OCCUPANCY_GRID";
+
+const DEFAULT_MIN_COLOR = { r: 1, g: 1, b: 1, a: 0.5 }; // white
+const DEFAULT_MAX_COLOR = { r: 0, g: 0, b: 0, a: 0.5 }; // black
+const DEFAULT_UNKNOWN_COLOR = { r: 0.5, g: 0.5, b: 0.5, a: 0.5 }; // gray
+const DEFAULT_INVALID_COLOR = { r: 1, g: 0, b: 1, a: 1 }; // magenta
+
+type OccupancyGridRenderable = THREE.Object3D & {
+  userData: {
+    topic: string;
+    settings: OccupancyGridSettings;
+    occupancyGrid: OccupancyGrid;
+    pose: Pose;
+    srcTime: bigint;
+    mesh: THREE.Mesh;
+    texture: THREE.DataTexture;
+    material: THREE.MeshStandardMaterial | THREE.MeshBasicMaterial;
+  };
+};
+
+export class OccupancyGrids extends THREE.Object3D {
+  renderer: Renderer;
+  occupancyGridsByTopic = new Map<string, OccupancyGridRenderable>();
+
+  static Geometry = new THREE.PlaneGeometry(1, 1, 1, 1).translate(0.5, 0.5, 0);
+
+  constructor(renderer: Renderer) {
+    super();
+    this.renderer = renderer;
+  }
+
+  dispose(): void {
+    for (const renderable of this.occupancyGridsByTopic.values()) {
+      renderable.userData.texture.dispose();
+      renderable.userData.material.dispose();
+    }
+    this.children.length = 0;
+    this.occupancyGridsByTopic.clear();
+  }
+
+  addOccupancyGridMessage(topic: string, occupancyGrid: OccupancyGrid): void {
+    let renderable = this.occupancyGridsByTopic.get(topic);
+    if (!renderable) {
+      renderable = new THREE.Object3D() as OccupancyGridRenderable;
+      renderable.name = topic;
+      renderable.userData.topic = topic;
+
+      // TODO: How do we fetch the stored settings for this topic?
+      renderable.userData.settings = {
+        minColor: DEFAULT_MIN_COLOR,
+        maxColor: DEFAULT_MAX_COLOR,
+        unknownColor: DEFAULT_UNKNOWN_COLOR,
+        invalidColor: DEFAULT_INVALID_COLOR,
+      };
+
+      renderable.userData.occupancyGrid = occupancyGrid;
+      renderable.userData.pose = occupancyGrid.info.origin;
+      renderable.userData.srcTime = rosTimeToNanoSec(occupancyGrid.header.stamp);
+
+      const texture = createTexture(occupancyGrid);
+      const material = createMaterial(texture, renderable);
+      const mesh = new THREE.Mesh(OccupancyGrids.Geometry, material);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      renderable.userData.texture = texture;
+      renderable.userData.material = material;
+      renderable.userData.mesh = mesh;
+      renderable.add(renderable.userData.mesh);
+
+      this.add(renderable);
+      this.occupancyGridsByTopic.set(topic, renderable);
+    }
+
+    this._updateOccupancyGridRenderable(renderable, occupancyGrid);
+  }
+
+  startFrame(currentTime: bigint): void {
+    const renderFrameId = this.renderer.renderFrameId;
+    const fixedFrameId = this.renderer.fixedFrameId;
+    if (!renderFrameId || !fixedFrameId) {
+      return;
+    }
+
+    for (const renderable of this.occupancyGridsByTopic.values()) {
+      const srcTime = renderable.userData.srcTime;
+      const frameId = renderable.userData.occupancyGrid.header.frame_id;
+      const updated = updatePose(
+        renderable,
+        this.renderer.transformTree,
+        renderFrameId,
+        fixedFrameId,
+        frameId,
+        currentTime,
+        srcTime,
+      );
+      if (!updated) {
+        const message = missingTransformMessage(renderFrameId, fixedFrameId, frameId);
+        this.renderer.layerErrors.addToTopic(renderable.userData.topic, MISSING_TRANSFORM, message);
+      }
+    }
+  }
+
+  _updateOccupancyGridRenderable(
+    renderable: OccupancyGridRenderable,
+    occupancyGrid: OccupancyGrid,
+  ): void {
+    const size = occupancyGrid.info.width * occupancyGrid.info.height;
+    if (occupancyGrid.data.length !== size) {
+      const message = `OccupancyGrid data length (${occupancyGrid.data.length}) is not equal to width ${occupancyGrid.info.width} * height ${occupancyGrid.info.height}`;
+      invalidOccupancyGridError(this.renderer, renderable, message);
+      return;
+    }
+
+    let texture = renderable.userData.texture;
+    const width = occupancyGrid.info.width;
+    const height = occupancyGrid.info.height;
+    const resolution = occupancyGrid.info.resolution;
+
+    if (width !== texture.image.width || height !== texture.image.height) {
+      // The image dimensions changed, regenerate the texture
+      texture.dispose();
+      texture = createTexture(occupancyGrid);
+      renderable.userData.texture = texture;
+      renderable.userData.material.map = texture;
+    }
+
+    // Update the occupancy grid texture
+    updateTexture(texture, occupancyGrid, renderable.userData.settings);
+
+    renderable.scale.set(resolution * width, resolution * height, 1);
+  }
+}
+
+function invalidOccupancyGridError(
+  renderer: Renderer,
+  renderable: OccupancyGridRenderable,
+  message: string,
+): void {
+  renderer.layerErrors.addToTopic(renderable.userData.topic, INVALID_OCCUPANCY_GRID, message);
+  renderable.userData.positionAttribute.resize(0);
+  renderable.userData.colorAttribute.resize(0);
+}
+
+function createTexture(occupancyGrid: OccupancyGrid): THREE.DataTexture {
+  const width = occupancyGrid.info.width;
+  const height = occupancyGrid.info.height;
+  const size = width * height;
+  const rgba = new Uint8ClampedArray(size * 4);
+  return new THREE.DataTexture(
+    rgba,
+    width,
+    height,
+    THREE.RGBAFormat,
+    THREE.UnsignedByteType,
+    THREE.UVMapping,
+    THREE.ClampToEdgeWrapping,
+    THREE.ClampToEdgeWrapping,
+    THREE.NearestFilter,
+    THREE.NearestFilter,
+    1,
+    THREE.LinearEncoding,
+  );
+}
+
+const tempUnknownColor = { r: 0, g: 0, b: 0, a: 0 };
+const tempInvalidColor = { r: 0, g: 0, b: 0, a: 0 };
+const tempMinColor = { r: 0, g: 0, b: 0, a: 0 };
+const tempMaxColor = { r: 0, g: 0, b: 0, a: 0 };
+
+function updateTexture(
+  texture: THREE.DataTexture,
+  occupancyGrid: OccupancyGrid,
+  settings: OccupancyGridSettings,
+): void {
+  const rgba = texture.image.data;
+
+  tempUnknownColor.r = SRGBToLinear(settings.unknownColor.r) * 255;
+  tempUnknownColor.g = SRGBToLinear(settings.unknownColor.g) * 255;
+  tempUnknownColor.b = SRGBToLinear(settings.unknownColor.b) * 255;
+  tempUnknownColor.a = settings.unknownColor.a * 255;
+
+  tempInvalidColor.r = SRGBToLinear(settings.invalidColor.r) * 255;
+  tempInvalidColor.g = SRGBToLinear(settings.invalidColor.g) * 255;
+  tempInvalidColor.b = SRGBToLinear(settings.invalidColor.b) * 255;
+  tempInvalidColor.a = settings.invalidColor.a * 255;
+
+  tempMinColor.r = SRGBToLinear(settings.minColor.r) * 255;
+  tempMinColor.g = SRGBToLinear(settings.minColor.g) * 255;
+  tempMinColor.b = SRGBToLinear(settings.minColor.b) * 255;
+  tempMinColor.a = settings.minColor.a * 255;
+
+  tempMaxColor.r = SRGBToLinear(settings.maxColor.r) * 255;
+  tempMaxColor.g = SRGBToLinear(settings.maxColor.g) * 255;
+  tempMaxColor.b = SRGBToLinear(settings.maxColor.b) * 255;
+  tempMaxColor.a = settings.maxColor.a * 255;
+
+  occupancyGrid.data.forEach((value, i) => {
+    const offset = i * 4;
+    if (value === -1) {
+      // Unknown (-1)
+      rgba[offset + 0] = tempUnknownColor.r;
+      rgba[offset + 1] = tempUnknownColor.g;
+      rgba[offset + 2] = tempUnknownColor.b;
+      rgba[offset + 3] = tempUnknownColor.a;
+    } else if (value >= 0 && value <= 100) {
+      // Valid [0-100]
+      const t = value / 100;
+      if (t === 1) {
+        rgba[offset + 0] = 0;
+        rgba[offset + 1] = 0;
+        rgba[offset + 2] = 0;
+        rgba[offset + 3] = 0;
+      } else {
+        rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
+        rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;
+        rgba[offset + 2] = tempMinColor.b + (tempMaxColor.b - tempMinColor.b) * t;
+        rgba[offset + 3] = tempMinColor.a + (tempMaxColor.a - tempMinColor.a) * t;
+      }
+    } else {
+      // Invalid (< -1 or > 100)
+      rgba[offset + 0] = tempInvalidColor.r;
+      rgba[offset + 1] = tempInvalidColor.g;
+      rgba[offset + 2] = tempInvalidColor.b;
+      rgba[offset + 3] = tempInvalidColor.a;
+    }
+  });
+
+  texture.needsUpdate = true;
+}
+
+function createMaterial(
+  texture: THREE.DataTexture,
+  renderable: OccupancyGridRenderable,
+): THREE.MeshStandardMaterial | THREE.MeshBasicMaterial {
+  const transparent = occupancyGridHasTransparency(renderable.userData.settings);
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    side: THREE.DoubleSide,
+    // metalness: 0,
+    // roughness: 1,
+    dithering: true,
+  });
+  material.name = `${renderable.userData.topic}:Material`;
+  material.transparent = transparent;
+  material.depthWrite = !material.transparent;
+  return material;
+}
+
+function occupancyGridHasTransparency(settings: OccupancyGridSettings): boolean {
+  return (
+    settings.minColor.a < 1 ||
+    settings.maxColor.a < 1 ||
+    settings.invalidColor.a < 1 ||
+    settings.unknownColor.a < 1
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -277,9 +277,6 @@ function createMaterial(
   const material = new THREE.MeshBasicMaterial({
     map: texture,
     side: THREE.DoubleSide,
-    // metalness: 0,
-    // roughness: 1,
-    dithering: true,
   });
   material.name = `${renderable.userData.topic}:Material`;
   material.transparent = transparent;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -19,6 +19,7 @@ export type OccupancyGridSettings = {
   maxColor: ColorRGBA;
   unknownColor: ColorRGBA;
   invalidColor: ColorRGBA;
+  frameLocked: boolean;
 };
 
 // ts-prune-ignore-next
@@ -77,6 +78,7 @@ export class OccupancyGrids extends THREE.Object3D {
         maxColor: DEFAULT_MAX_COLOR,
         unknownColor: DEFAULT_UNKNOWN_COLOR,
         invalidColor: DEFAULT_INVALID_COLOR,
+        frameLocked: true,
       };
 
       renderable.userData.occupancyGrid = occupancyGrid;
@@ -108,7 +110,8 @@ export class OccupancyGrids extends THREE.Object3D {
     }
 
     for (const renderable of this.occupancyGridsByTopic.values()) {
-      const srcTime = renderable.userData.srcTime;
+      const frameLocked = renderable.userData.settings.frameLocked;
+      const srcTime = frameLocked ? currentTime : renderable.userData.srcTime;
       const frameId = renderable.userData.occupancyGrid.header.frame_id;
       const updated = updatePose(
         renderable,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
@@ -7,9 +7,9 @@
 import * as THREE from "three";
 import { clamp } from "three/src/math/MathUtils";
 
-import { DetailLevel } from "../../DetailLevel";
 import type { Renderer } from "../../Renderer";
 import { rgbaEqual } from "../../color";
+import { arrowHeadSubdivisions, arrowShaftSubdivisions, DetailLevel } from "../../lod";
 import { getRotationTo } from "../../math";
 import { Marker, Vector3 } from "../../ros";
 import { RenderableMarker } from "./RenderableMarker";
@@ -33,6 +33,8 @@ const tempEnd = new THREE.Vector3();
 const tempDirection = new THREE.Vector3();
 
 export class RenderableArrow extends RenderableMarker {
+  private static _shaftLod: DetailLevel | undefined;
+  private static _headLod: DetailLevel | undefined;
   private static _shaftGeometry: THREE.CylinderGeometry | undefined;
   private static _headGeometry: THREE.ConeGeometry | undefined;
   private static _shaftEdgesGeometry: THREE.EdgesGeometry | undefined;
@@ -131,21 +133,23 @@ export class RenderableArrow extends RenderableMarker {
   }
 
   static shaftGeometry(lod: DetailLevel): THREE.CylinderGeometry {
-    if (!RenderableArrow._shaftGeometry) {
-      const subdivs = shaftSubdivisions(lod);
+    if (!RenderableArrow._shaftGeometry || lod !== RenderableArrow._shaftLod) {
+      const subdivs = arrowShaftSubdivisions(lod);
       RenderableArrow._shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivs, 1, false);
       RenderableArrow._shaftGeometry.rotateZ(-Math.PI / 2);
       RenderableArrow._shaftGeometry.computeBoundingSphere();
+      RenderableArrow._shaftLod = lod;
     }
     return RenderableArrow._shaftGeometry;
   }
 
   static headGeometry(lod: DetailLevel): THREE.ConeGeometry {
-    if (!RenderableArrow._headGeometry) {
-      const subdivs = headSubdivisions(lod);
+    if (!RenderableArrow._headGeometry || lod !== RenderableArrow._headLod) {
+      const subdivs = arrowHeadSubdivisions(lod);
       RenderableArrow._headGeometry = new THREE.ConeGeometry(0.5, 1, subdivs, 1, false);
       RenderableArrow._headGeometry.rotateZ(-Math.PI / 2);
       RenderableArrow._headGeometry.computeBoundingSphere();
+      RenderableArrow._headLod = lod;
     }
     return RenderableArrow._headGeometry;
   }
@@ -173,26 +177,4 @@ function copyPoint(from: Vector3, to: Vector3): void {
   to.x = from.x;
   to.y = from.y;
   to.z = from.z;
-}
-
-function shaftSubdivisions(lod: DetailLevel) {
-  switch (lod) {
-    case DetailLevel.Low:
-      return 12;
-    case DetailLevel.Medium:
-      return 20;
-    case DetailLevel.High:
-      return 32;
-  }
-}
-
-function headSubdivisions(lod: DetailLevel) {
-  switch (lod) {
-    case DetailLevel.Low:
-      return 12;
-    case DetailLevel.Medium:
-      return 20;
-    case DetailLevel.High:
-      return 32;
-  }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableArrow.ts
@@ -50,27 +50,27 @@ export class RenderableArrow extends RenderableMarker {
 
     // Shaft mesh
     const material = standardMaterial(marker, renderer.materialCache);
-    this.shaftMesh = new THREE.Mesh(RenderableArrow.shaftGeometry(renderer.lod), material);
+    this.shaftMesh = new THREE.Mesh(RenderableArrow.shaftGeometry(renderer.maxLod), material);
     this.shaftMesh.castShadow = true;
     this.shaftMesh.receiveShadow = true;
     this.add(this.shaftMesh);
 
     // Head mesh
-    this.headMesh = new THREE.Mesh(RenderableArrow.headGeometry(renderer.lod), material);
+    this.headMesh = new THREE.Mesh(RenderableArrow.headGeometry(renderer.maxLod), material);
     this.headMesh.castShadow = true;
     this.headMesh.receiveShadow = true;
     this.add(this.headMesh);
 
     // Shaft outline
     this.shaftOutline = new THREE.LineSegments(
-      RenderableArrow.shaftEdgesGeometry(renderer.lod),
+      RenderableArrow.shaftEdgesGeometry(renderer.maxLod),
       renderer.materialCache.outlineMaterial,
     );
     this.shaftMesh.add(this.shaftOutline);
 
     // Head outline
     this.headOutline = new THREE.LineSegments(
-      RenderableArrow.headEdgesGeometry(renderer.lod),
+      RenderableArrow.headEdgesGeometry(renderer.maxLod),
       renderer.materialCache.outlineMaterial,
     );
     this.headMesh.add(this.headOutline);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -26,14 +26,14 @@ export class RenderableCylinder extends RenderableMarker {
 
     // Cylinder mesh
     const material = standardMaterial(marker, renderer.materialCache);
-    this.mesh = new THREE.Mesh(RenderableCylinder.geometry(renderer.lod), material);
+    this.mesh = new THREE.Mesh(RenderableCylinder.geometry(renderer.maxLod), material);
     this.mesh.castShadow = true;
     this.mesh.receiveShadow = true;
     this.add(this.mesh);
 
     // Cylinder outline
     this.outline = new THREE.LineSegments(
-      RenderableCylinder.edgesGeometry(renderer.lod),
+      RenderableCylinder.edgesGeometry(renderer.maxLod),
       renderer.materialCache.outlineMaterial,
     );
     this.mesh.add(this.outline);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -6,9 +6,9 @@
 
 import * as THREE from "three";
 
-import { DetailLevel } from "../../DetailLevel";
 import type { Renderer } from "../../Renderer";
 import { rgbaEqual } from "../../color";
+import { cylinderSubdivisions, DetailLevel } from "../../lod";
 import { Marker } from "../../ros";
 import { RenderableMarker } from "./RenderableMarker";
 import { releaseStandardMaterial, standardMaterial } from "./materials";
@@ -75,16 +75,5 @@ export class RenderableCylinder extends RenderableMarker {
       RenderableCylinder._edgesGeometry.computeBoundingSphere();
     }
     return RenderableCylinder._edgesGeometry;
-  }
-}
-
-function cylinderSubdivisions(lod: DetailLevel) {
-  switch (lod) {
-    case DetailLevel.Low:
-      return 12;
-    case DetailLevel.Medium:
-      return 20;
-    case DetailLevel.High:
-      return 32;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -6,9 +6,9 @@
 
 import * as THREE from "three";
 
-import { DetailLevel } from "../../DetailLevel";
 import type { Renderer } from "../../Renderer";
 import { rgbaEqual } from "../../color";
+import { DetailLevel, sphereSubdivisions } from "../../lod";
 import { Marker } from "../../ros";
 import { RenderableMarker } from "./RenderableMarker";
 import { releaseStandardMaterial, standardMaterial } from "./materials";
@@ -56,16 +56,5 @@ export class RenderableSphere extends RenderableMarker {
       RenderableSphere._lod = lod;
     }
     return RenderableSphere._geometry;
-  }
-}
-
-function sphereSubdivisions(lod: DetailLevel) {
-  switch (lod) {
-    case DetailLevel.Low:
-      return 10;
-    case DetailLevel.Medium:
-      return 24;
-    case DetailLevel.High:
-      return 32;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -24,7 +24,7 @@ export class RenderableSphere extends RenderableMarker {
 
     // Sphere mesh
     const material = standardMaterial(marker, renderer.materialCache);
-    this.mesh = new THREE.Mesh(RenderableSphere.geometry(renderer.lod), material);
+    this.mesh = new THREE.Mesh(RenderableSphere.geometry(renderer.maxLod), material);
     this.mesh.castShadow = true;
     this.mesh.receiveShadow = true;
     this.add(this.mesh);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
@@ -24,7 +24,7 @@ export class RenderableSphereList extends RenderableMarker {
     // Sphere instanced mesh
     const material = standardInstancedMaterial(marker, renderer.materialCache);
     this.mesh = new DynamicInstancedMesh(
-      RenderableSphere.geometry(renderer.lod),
+      RenderableSphere.geometry(renderer.maxLod),
       material,
       marker.points.length,
     );

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -61,7 +61,7 @@ export function getColorConverter(
     case PointCloudColorMode.Turbo:
       return (output: ColorRGBA, colorValue: number) => {
         const t = (colorValue - minValue) / valueDelta;
-        turbo(output, t);
+        turboCached(output, t);
       };
   }
 }
@@ -174,5 +174,31 @@ function turbo(output: ColorRGBA, pct: number): void {
   output.r = SRGBToLinear(clamp(v4.dot(kRedVec4) + v2.dot(kRedVec2), 0, 1));
   output.g = SRGBToLinear(clamp(v4.dot(kGreenVec4) + v2.dot(kGreenVec2), 0, 1));
   output.b = SRGBToLinear(clamp(v4.dot(kBlueVec4) + v2.dot(kBlueVec2), 0, 1));
+  output.a = 1;
+}
+
+// A lookup table for the turbo() function
+let TurboLookup: Float32Array | undefined;
+const TURBO_LOOKUP_SIZE = 65535;
+
+// Builds a one-time lookup table for the turbo() function then uses it to
+// convert `pct` to a color
+function turboCached(output: ColorRGBA, pct: number): void {
+  if (!TurboLookup) {
+    TurboLookup = new Float32Array(TURBO_LOOKUP_SIZE * 3);
+    const tempColor = { r: 0, g: 0, b: 0, a: 0 };
+    for (let i = 0; i < TURBO_LOOKUP_SIZE; i++) {
+      turbo(tempColor, i / (TURBO_LOOKUP_SIZE - 1));
+      const offset = i * 3;
+      TurboLookup[offset + 0] = tempColor.r;
+      TurboLookup[offset + 1] = tempColor.g;
+      TurboLookup[offset + 2] = tempColor.b;
+    }
+  }
+
+  const offset = Math.trunc(pct * (TURBO_LOOKUP_SIZE - 1)) * 3;
+  output.r = TurboLookup[offset + 0]!;
+  output.g = TurboLookup[offset + 1]!;
+  output.b = TurboLookup[offset + 2]!;
   output.a = 1;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { SRGBToLinear } from "../../color";
+import { clamp, lerp } from "../../math";
 import { ColorRGBA } from "../../ros";
 import { PointCloudColorMode, PointCloudSettings } from "./settings";
 
@@ -62,10 +64,6 @@ export function getColorConverter(
         turbo(output, t);
       };
   }
-}
-
-export function SRGBToLinear(c: number): number {
-  return c < 0.04045 ? c * 0.0773993808 : Math.pow(c * 0.9478672986 + 0.0521327014, 2.4);
 }
 
 // 0xrrggbb00
@@ -177,12 +175,4 @@ function turbo(output: ColorRGBA, pct: number): void {
   output.g = SRGBToLinear(clamp(v4.dot(kGreenVec4) + v2.dot(kGreenVec2), 0, 1));
   output.b = SRGBToLinear(clamp(v4.dot(kBlueVec4) + v2.dot(kBlueVec2), 0, 1));
   output.a = 1;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
@@ -119,6 +119,20 @@ export type PointCloud2 = {
   is_dense: boolean;
 };
 
+export type MapMetaData = {
+  map_load_time: RosTime;
+  resolution: number;
+  width: number;
+  height: number;
+  origin: Pose;
+};
+
+export type OccupancyGrid = {
+  header: Header;
+  info: MapMetaData;
+  data: Int8Array | number[];
+};
+
 export const TRANSFORM_STAMPED_DATATYPES = new Set<string>();
 addRosDataType(TRANSFORM_STAMPED_DATATYPES, "geometry_msgs/TransformStamped");
 
@@ -131,6 +145,9 @@ addRosDataType(MARKER_DATATYPES, "visualization_msgs/Marker");
 
 export const MARKER_ARRAY_DATATYPES = new Set<string>();
 addRosDataType(MARKER_ARRAY_DATATYPES, "visualization_msgs/MarkerArray");
+
+export const OCCUPANCY_GRID_DATATYPES = new Set<string>();
+addRosDataType(OCCUPANCY_GRID_DATATYPES, "nav_msgs/OccupancyGrid");
 
 export const POINTCLOUD_DATATYPES = new Set<string>();
 addRosDataType(POINTCLOUD_DATATYPES, "sensor_msgs/PointCloud2");

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -16,7 +16,6 @@ import { compareTime, Duration, interpolate, percentOf, Time } from "./time";
 type TimeAndTransform = [time: Time, transform: Transform];
 
 const INFINITE_DURATION: Duration = 4_294_967_295n * BigInt(1e9);
-const DEFAULT_MAX_STORAGE_TIME: Duration = 10n * BigInt(1e9);
 
 const tempLower: TimeAndTransform = [0n, Transform.Identity()];
 const tempUpper: TimeAndTransform = [0n, Transform.Identity()];
@@ -38,11 +37,7 @@ export class CoordinateFrame {
   private _parent?: CoordinateFrame;
   private _transforms: AVLTree<Time, Transform>;
 
-  constructor(
-    id: string,
-    parent: CoordinateFrame | undefined,
-    maxStorageTime: Duration = DEFAULT_MAX_STORAGE_TIME,
-  ) {
+  constructor(id: string, parent: CoordinateFrame | undefined, maxStorageTime: Duration) {
     this.id = id;
     this.maxStorageTime = maxStorageTime;
     this._parent = parent;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -7,12 +7,19 @@ import { Transform } from "./Transform";
 import { Pose } from "./geometry";
 import { Duration, Time } from "./time";
 
+const DEFAULT_MAX_STORAGE_TIME: Duration = 10n * BigInt(1e9);
+
 /**
  * TransformTree is a collection of coordinate frames with convenience methods
  * for getting and creating frames and adding transforms between frames.
  */
 export class TransformTree {
   private _frames = new Map<string, CoordinateFrame>();
+  private _maxStorageTime: Duration;
+
+  constructor(maxStorageTime = DEFAULT_MAX_STORAGE_TIME) {
+    this._maxStorageTime = maxStorageTime;
+  }
 
   addTransform(frameId: string, parentFrameId: string, time: Time, transform: Transform): void {
     const frame = this.getOrCreateFrame(frameId);
@@ -37,7 +44,7 @@ export class TransformTree {
   getOrCreateFrame(id: string): CoordinateFrame {
     let frame = this._frames.get(id);
     if (!frame) {
-      frame = new CoordinateFrame(id, undefined);
+      frame = new CoordinateFrame(id, undefined, this._maxStorageTime);
       this._frames.set(id, frame);
     }
     return frame;
@@ -68,7 +75,8 @@ export class TransformTree {
   }
 
   static Clone(tree: TransformTree): TransformTree {
-    const newTree = new TransformTree();
+    // eslint-disable-next-line no-underscore-dangle
+    const newTree = new TransformTree(tree._maxStorageTime);
     // eslint-disable-next-line no-underscore-dangle
     newTree._frames = tree._frames;
     return newTree;

--- a/packages/studio-base/src/panels/ThreeDeeRender/updatePose.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/updatePose.ts
@@ -19,7 +19,7 @@ export function updatePose(
   dstTime: bigint,
   srcTime: bigint,
 ): boolean {
-  const pose = renderable.userData.pose as Pose | undefined;
+  const pose = renderable.userData.pose as Readonly<Pose> | undefined;
   if (!pose) {
     throw new Error(`Missing userData.pose for ${renderable.name}`);
   }

--- a/packages/studio-base/src/panels/URDFViewer/Renderer.ts
+++ b/packages/studio-base/src/panels/URDFViewer/Renderer.ts
@@ -86,14 +86,16 @@ export class Renderer extends EventEmitter<EventTypes> {
       if (obj instanceof THREE.Mesh) {
         if (Array.isArray(obj.material)) {
           for (const material of obj.material) {
+            const transparent = opacity < 1;
             material.opacity = opacity;
-            material.transparent = opacity < 1;
-            material.depthWrite = !(material.transparent as boolean);
+            material.transparent = transparent;
+            material.depthWrite = !transparent;
           }
         } else if (obj.material != undefined) {
+          const transparent = opacity < 1;
           obj.material.opacity = opacity;
-          obj.material.transparent = opacity < 1;
-          obj.material.depthWrite = !(obj.material.transparent as boolean);
+          obj.material.transparent = transparent;
+          obj.material.depthWrite = !transparent;
         }
       }
     });


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

This implements slow but correct OccupancyGrid rendering for the experimental 3D panel. The Int8Array grid is converted to a UInt8ClampedArray of RGBA values before uploading to the GPU.

This also extends the CoordinateFrame transform buffer to 60 seconds to mitigate the lack of a "reset" / "seek" event in extensions, and only renders the scene when new messages arrive or the camera moves.

<img width="1312" alt="Screen Shot 2022-03-25 at 3 22 57 PM" src="https://user-images.githubusercontent.com/195374/160209886-e86503b5-a219-4721-9e9c-6e6fd7296518.png">
<img width="1129" alt="Screen Shot 2022-03-26 at 2 06 04 PM" src="https://user-images.githubusercontent.com/195374/160257195-6c245494-3031-4186-b0ee-3004cf3ebc30.png">
