### PR TITLE
Add abort signal to getBackfillMessages

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -8,7 +8,7 @@ import { isEqual } from "lodash";
 import Logger from "@foxglove/log";
 import { Mcap0StreamReader, Mcap0Types } from "@foxglove/mcap";
 import { loadDecompressHandlers, parseChannel, ParsedChannel } from "@foxglove/mcap-support";
-import { fromNanoSec, isTimeInRangeInclusive, Time, toRFC3339String } from "@foxglove/rostime";
+import { fromNanoSec, Time, toRFC3339String } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 
@@ -79,7 +79,8 @@ export default async function* streamMessages({
   if (controller.signal.aborted) {
     return;
   }
-  const response = await fetch(mcapUrl, { signal: controller.signal });
+
+  const response = await fetch(mcapUrl, { signal: controller.signal, cache: "no-cache" });
   if (response.status === 404) {
     return;
   } else if (response.status !== 200) {
@@ -167,15 +168,13 @@ export default async function* streamMessages({
           throw new Error(`message for channel ${record.channelId} with no prior channel/schema`);
         }
         const receiveTime = fromNanoSec(record.logTime);
-        if (isTimeInRangeInclusive(receiveTime, params.start, params.end)) {
-          totalMessages++;
-          messages.push({
-            topic: info.channel.topic,
-            receiveTime,
-            message: info.parsedChannel.deserializer(record.data),
-            sizeInBytes: record.data.byteLength,
-          });
-        }
+        totalMessages++;
+        messages.push({
+          topic: info.channel.topic,
+          receiveTime,
+          message: info.parsedChannel.deserializer(record.data),
+          sizeInBytes: record.data.byteLength,
+        });
         return;
       }
     }
@@ -189,13 +188,17 @@ export default async function* streamMessages({
       for (let record; (record = reader.nextRecord()); ) {
         if (record.type === "DataEnd") {
           normalReturn = true;
-          break parseLoop;
+          break;
         }
         processRecord(record);
       }
       if (messages.length > 0) {
         yield messages;
         messages = [];
+      }
+
+      if (normalReturn) {
+        break parseLoop;
       }
     }
     if (!reader.done()) {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -80,6 +80,7 @@ export default async function* streamMessages({
     return;
   }
 
+  // Since every request is signed with a new token, there's no benefit to caching.
   const response = await fetch(mcapUrl, { signal: controller.signal, cache: "no-cache" });
   if (response.status === 404) {
     return;

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -40,6 +40,8 @@ export type IteratorResult =
 export type GetBackfillMessagesArgs = {
   topics: string[];
   time: Time;
+
+  abortSignal?: AbortSignal;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -324,13 +324,25 @@ export class IterablePlayer implements Player {
 
     const topics = Array.from(this._allTopics);
 
-    this._abort = new AbortController();
-    const messages = await this._iterableSource.getBackfillMessages({
-      topics,
-      time: targetTime,
-      abortSignal: this._abort.signal,
-    });
-    this._abort = undefined;
+    try {
+      this._abort = new AbortController();
+      const messages = await this._iterableSource.getBackfillMessages({
+        topics,
+        time: targetTime,
+        abortSignal: this._abort.signal,
+      });
+      this._messages = messages;
+    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
+      if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
+        log.debug("Aborted backfill");
+      } else {
+        throw err;
+      }
+    } finally {
+      this._abort = undefined;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
     if (this._nextState) {
       return;
@@ -350,7 +362,6 @@ export class IterablePlayer implements Player {
       start: forwardPosition,
     });
 
-    this._messages = messages;
     this._currentTime = targetTime;
     this._lastSeekEmitTime = Date.now();
     await this._emitState();
@@ -403,12 +414,7 @@ export class IterablePlayer implements Player {
             break;
           case "seek-backfill":
             // We allow aborting requests when moving on to the next state
-            await this._stateSeekBackfill().catch((err) => {
-              if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
-                return;
-              }
-              throw err;
-            });
+            await this._stateSeekBackfill();
             break;
           case "play": {
             await this._statePlay();

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { simplify } from "intervals-fn";
+import { isEqual } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { filterMap } from "@foxglove/den/collection";
@@ -118,6 +119,8 @@ export class IterablePlayer implements Player {
   ];
   private _metricsCollector: PlayerMetricsCollectorInterface;
   private _subscriptions: SubscribePayload[] = [];
+  private _allTopics: Set<string> = new Set();
+  private _partialTopics: Set<string> = new Set();
 
   private _progress: Progress = {};
   private _id: string = uuidv4();
@@ -130,6 +133,7 @@ export class IterablePlayer implements Player {
   private _lastMessage?: MessageEvent<unknown>;
   private _publishedTopics = new Map<string, Set<string>>();
   private _seekTarget?: Time;
+  private _abort?: AbortController;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
@@ -251,10 +255,9 @@ export class IterablePlayer implements Player {
   }
 
   private async _stateStartPlay() {
-    const topics = new Set(this._subscriptions.map((subscription) => subscription.topic));
-
+    const allTopics = this._allTopics;
     this._forwardIterator = this._iterableSource.messageIterator({
-      topics: Array.from(topics),
+      topics: Array.from(allTopics),
     });
 
     const stopTime = clampTime(
@@ -311,18 +314,39 @@ export class IterablePlayer implements Player {
     this._lastMessage = undefined;
     this._seekTarget = undefined;
 
-    const topics = Array.from(
-      new Set(this._subscriptions.map((subscription) => subscription.topic)),
-    );
+    this._messages = [];
+    this._currentTime = targetTime;
+    this._lastSeekEmitTime = Date.now();
+    await this._emitState();
+    if (this._nextState) {
+      return;
+    }
 
-    const messages = await this._iterableSource.getBackfillMessages({ topics, time: targetTime });
+    const topics = Array.from(this._allTopics);
+
+    this._abort = new AbortController();
+    const messages = await this._iterableSource.getBackfillMessages({
+      topics,
+      time: targetTime,
+      abortSignal: this._abort.signal,
+    });
+    this._abort = undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
+    if (this._nextState) {
+      return;
+    }
 
     // Our backfill loaded the messages inclusive of the seek time, thus the next messages
     // we read should be _after_ the seek time.
     const forwardPosition = add(targetTime, { sec: 0, nsec: 1 });
     await this._forwardIterator?.return?.();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
+    if (this._nextState) {
+      return;
+    }
+
     this._forwardIterator = this._iterableSource.messageIterator({
-      topics: Array.from(topics),
+      topics,
       start: forwardPosition,
     });
 
@@ -330,6 +354,7 @@ export class IterablePlayer implements Player {
     this._currentTime = targetTime;
     this._lastSeekEmitTime = Date.now();
     await this._emitState();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
     if (this._nextState) {
       return;
     }
@@ -339,6 +364,11 @@ export class IterablePlayer implements Player {
   private _setState(newState: IterablePlayerState) {
     log.debug(`Set next state: ${newState}`);
     this._nextState = newState;
+    if (this._abort) {
+      this._abort.abort();
+      this._abort = undefined;
+    }
+
     void this._runState();
   }
 
@@ -372,7 +402,13 @@ export class IterablePlayer implements Player {
             await this._stateIdle();
             break;
           case "seek-backfill":
-            await this._stateSeekBackfill();
+            // We allow aborting requests when moving on to the next state
+            await this._stateSeekBackfill().catch((err) => {
+              if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
+                return;
+              }
+              throw err;
+            });
             break;
           case "play": {
             await this._statePlay();
@@ -406,6 +442,7 @@ export class IterablePlayer implements Player {
         playerId: this._id,
         activeData: undefined,
         problems: this._problemManager.problems(),
+        urlState: this._urlParams,
       });
     }
 
@@ -547,7 +584,7 @@ export class IterablePlayer implements Player {
     if (!this._currentTime) {
       throw new Error("Invariant: currentTime not set before statePlay");
     }
-    const subscriptions = this._subscriptions;
+    let allTopics = this._allTopics;
 
     const blockLoading = this.loadBlocks(this._currentTime, { emit: false });
     try {
@@ -556,16 +593,16 @@ export class IterablePlayer implements Player {
         await this._tick();
 
         // If subscriptions changed, update to the new subscriptions
-        if (this._subscriptions !== subscriptions) {
+        if (this._allTopics !== allTopics) {
           // Discard any last message event since the new iterator will repeat it
           this._lastMessage = undefined;
 
-          const topics = new Set(this._subscriptions.map((sub) => sub.topic));
           await this._forwardIterator?.return?.();
           this._forwardIterator = this._iterableSource.messageIterator({
-            topics: Array.from(topics),
+            topics: Array.from(this._allTopics),
             start: this._currentTime,
           });
+          allTopics = this._allTopics;
         }
 
         // Eslint doesn't understand that this._nextState could change
@@ -602,10 +639,7 @@ export class IterablePlayer implements Player {
 
     log.info("Start block load", time);
 
-    const topics = this._subscriptions
-      .filter((sub) => sub.preloadType !== "partial")
-      .map((sub) => sub.topic);
-
+    const topics = this._partialTopics;
     const timeNanos = Number(toNanoSec(subtractTimes(time, this._start)));
 
     const startBlockId = Math.floor(timeNanos / this._blockDurationNanos);
@@ -859,6 +893,18 @@ export class IterablePlayer implements Player {
   setSubscriptions(newSubscriptions: SubscribePayload[]): void {
     this._subscriptions = newSubscriptions;
     this._metricsCollector.setSubscriptions(newSubscriptions);
+
+    const allTopics = new Set(this._subscriptions.map((subscription) => subscription.topic));
+    const partialTopics = new Set(
+      this._subscriptions.filter((sub) => sub.preloadType !== "partial").map((sub) => sub.topic),
+    );
+
+    if (isEqual(allTopics, this._allTopics) && isEqual(partialTopics, this._partialTopics)) {
+      return;
+    }
+
+    this._allTopics = allTopics;
+    this._partialTopics = partialTopics;
 
     // Once we are in an active state (i.e. done initializing), we use seeking to indicate
     // that subscriptions have changed so restart our loading


### PR DESCRIPTION

**User-Facing Changes**
For users on Experimental Data Platform player, seeking behavior is improved.

**Description**
When in backfill mode and the user clicks to seek elsewhere, we need to abort the current request
and start a new backfill. This adds an abort controller to signal the abort for the fetch request.

This also adds an emitState prior to any backfill to give immediate feedback in the UI for the new
seek location even if the player needs to buffer some before it can play.

Fixes: #3064 #3063


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
