### PR TITLE
Fix URL state for experimental data platform player

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { fromRFC3339String } from "@foxglove/rostime";
+import { fromRFC3339String, toRFC3339String } from "@foxglove/rostime";
 import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
@@ -53,6 +53,11 @@ class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
       return new IterablePlayer({
         metricsCollector: args.metricsCollector,
         source,
+        urlParams: {
+          deviceId,
+          start: toRFC3339String(startTime),
+          end: toRFC3339String(endTime),
+        },
         name: `${deviceId}, ${formatTimeRaw(startTime)} to ${formatTimeRaw(endTime)}`,
       });
     }


### PR DESCRIPTION
**User-Facing Changes**
This fixes url state updates for the experimental data platform player.

**Description**
The player factory wasn't passing `urlParams` to the player so once the player reached the `PRESENT` state it wiped out the url state.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3062 