### PR TITLE
Improve error messages for console/DP API auth errors

### DIFF
--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -193,12 +193,18 @@ class ConsoleApi {
     const res = await fetch(fullUrl, fullConfig);
     this._responseObserver?.(res);
     if (res.status !== 200 && !allowedStatuses.includes(res.status)) {
+      if (res.status === 401) {
+        throw new Error("Not logged in. Log in to your Foxglove account and try again.");
+      } else if (res.status === 403) {
+        throw new Error(
+          "Unauthorized. Check that you are logged in to the correct Foxglove organization.",
+        );
+      }
       const json = (await res.json().catch((err) => {
         throw new Error(`Status ${res.status}: ${err.message}`);
-      })) as { message?: string };
-      throw new Error(
-        `Status ${res.status}${json.message != undefined ? `: ${json.message}` : ""}`,
-      );
+      })) as { message?: string; error?: string };
+      const message = json.message ?? json.error;
+      throw new Error(`Status ${res.status}${message != undefined ? `: ${message}` : ""}`);
     }
 
     try {


### PR DESCRIPTION
**User-Facing Changes**
Improved error messages when attempting to access data from Data Platform when not logged in or logged in to the wrong organization.

**Description**
Fixes #3079

Added a custom human-readable message to 401/403 errors.

<img width="364" alt="Screen Shot 2022-03-29 at 10 39 10 AM" src="https://user-images.githubusercontent.com/14237/160673949-37737d63-254b-4b9a-8e2f-ef6b57e0747f.png">

Pipe through the `{"error":"..."}` message from the error response in other cases (we were already passing through a `message` field, but not an `error` field).

<img width="338" alt="Screen Shot 2022-03-29 at 10 44 06 AM" src="https://user-images.githubusercontent.com/14237/160673934-19752d60-067b-4f5c-9258-e815992fd132.png">
