### PR TITLE
Fix CachedFilelike reading past end of underlying FileReader

### DIFF
--- a/packages/studio-base/src/util/CachedFilelike.test.ts
+++ b/packages/studio-base/src/util/CachedFilelike.test.ts
@@ -27,6 +27,11 @@ class InMemoryFileReader implements FileReader {
   }
 
   fetch(offset: number, length: number): FileStream {
+    if (offset + length > this._buffer.byteLength) {
+      throw new Error(
+        `Read offset=${offset} length=${length} past buffer length ${this._buffer.byteLength}`,
+      );
+    }
     return {
       on: (type: "data" | "error", callback: ((_: Uint8Array) => void) & ((_: Error) => void)) => {
         if (type === "data") {
@@ -69,6 +74,7 @@ describe("CachedFilelike", () => {
       const fileReader = new InMemoryFileReader(new Uint8Array([0, 1, 2, 3]));
       const cachedFileReader = new CachedFilelike({ fileReader, log });
       await expect(cachedFileReader.read(1, 2)).resolves.toEqual(new Uint8Array([1, 2]));
+      await expect(cachedFileReader.read(2, 2)).resolves.toEqual(new Uint8Array([2, 3]));
     });
 
     it("returns an error in the callback if the FileReader keeps returning errors", async () => {

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -233,7 +233,7 @@ export default class CachedFilelike implements Filelike {
     }
 
     // Start the stream, and update the current connection state.
-    const stream = this._fileReader.fetch(range.start, range.end);
+    const stream = this._fileReader.fetch(range.start, range.end - range.start);
     this._currentConnection = { stream, remainingRange: range };
 
     stream.on("error", (error: Error) => {

--- a/packages/studio-base/src/util/ranges.ts
+++ b/packages/studio-base/src/util/ranges.ts
@@ -20,8 +20,9 @@ import {
 } from "intervals-fn";
 
 export type Range = {
+  /** inclusive */
   start: number;
-  /* inclusive */
+  /** exclusive */
   end: number;
 };
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed incorrect fetching behavior for remote bag/mcap file sources, where the app would make HTTP Range requests that were too large and beyond the end of the file.

**Description**
Thanks to @jameskuszmaul-brt for the bug report.

Update incorrectly-ported inclusive/exclusive comments on the Range type: https://github.com/cruise-automation/webviz/blob/d82468c05fb2d3aeca670ff37999faeafa4d7ffc/packages/webviz-core/src/util/ranges.js#L10