### PR TITLE
Add sign.ts to handle windows codesigning

### DIFF
--- a/desktop/sign.ts
+++ b/desktop/sign.ts
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { exec } from "@actions/exec";
+import { log } from "builder-util";
+import type { WindowsSignOptions } from "electron-builder";
+import { rename, mkdtemp } from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+
+exports.default = async function (context: WindowsSignOptions) {
+  const USER_NAME = process.env.WINDOWS_SIGN_USER_NAME;
+  const USER_PASSWORD = process.env.WINDOWS_SIGN_USER_PASSWORD;
+  const CREDENTIAL_ID = process.env.WINDOWS_SIGN_CREDENTIAL_ID;
+  const USER_TOTP = process.env.WINDOWS_SIGN_USER_TOTP;
+
+  // skip signing temp paths like dist/__uninstaller-nsis-foxglove-studio.exe and -unpacked
+  if (context.path.includes("-unpacked") || context.path.includes("__uninstaller")) {
+    return;
+  }
+
+  if (!USER_NAME || !USER_PASSWORD || !CREDENTIAL_ID || !USER_TOTP) {
+    log.info("Skipping signing");
+    return;
+  }
+
+  const { base } = path.parse(context.path);
+
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "signing-"));
+  const tmpPath = path.join(tmpDir, base);
+
+  log.info(`Signing: ${context.path}`);
+  await exec(
+    "./CodeSignTool.bat",
+    [
+      "sign",
+      "-input_file_path",
+      context.path,
+      "-output_dir_path",
+      tmpDir,
+      "-credential_id",
+      CREDENTIAL_ID,
+      "-username",
+      USER_NAME,
+      "-password",
+      USER_PASSWORD,
+      "-totp_secret",
+      USER_TOTP,
+    ],
+    {
+      cwd: "./CodeSignTool",
+    },
+  );
+
+  log.info(`Moving: ${tmpPath} -> ${context.path}`);
+  await rename(tmpPath, context.path);
+};

--- a/desktop/sign.ts
+++ b/desktop/sign.ts
@@ -5,7 +5,7 @@
 import { exec } from "@actions/exec";
 import { log } from "builder-util";
 import type { WindowsSignOptions } from "electron-builder";
-import { rename, mkdtemp } from "fs/promises";
+import { copyFile, mkdtemp } from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 
@@ -53,6 +53,8 @@ exports.default = async function (context: WindowsSignOptions) {
     },
   );
 
-  log.info(`Moving: ${tmpPath} -> ${context.path}`);
-  await rename(tmpPath, context.path);
+  // Copy the file because src and dest might be on different devices
+  // "rename" does not work across devices
+  log.info(`Copy: ${tmpPath} -> ${context.path}`);
+  await copyFile(tmpPath, context.path);
 };

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -53,6 +53,8 @@
     ]
   },
   "win": {
+    "sign": "desktop/sign.ts",
+    "signingHashAlgorithms": ["sha256"],
     "target": [
       {
         "target": "nsis",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add a sign.ts script which executes the SSL.com CodeSignTool to sign our windows binaries.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
