### PR TITLE
Set MessageEvent.publishTime, ROS2 /clock support

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -88,7 +88,7 @@ export default class Ros1Player implements Player {
     this._metricsCollector = metricsCollector;
     this._url = url;
     this._hostname = hostname;
-    this._start = fromMillis(Date.now());
+    this._start = this._getCurrentTime();
     this._metricsCollector.playerConstructed();
     void this._open();
   }

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
@@ -125,6 +125,7 @@ export default class Mcap0IndexedDataProvider implements RandomAccessDataProvide
         parsedMessages.push({
           topic: channelInfo.channel.topic,
           receiveTime: fromNanoSec(message.logTime),
+          publishTime: fromNanoSec(message.publishTime),
           message: channelInfo.parsedChannel.deserializer(message.data),
           sizeInBytes: message.data.byteLength,
         });

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
@@ -114,6 +114,7 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
           messages.push({
             topic: channelInfo.channel.topic,
             receiveTime,
+            publishTime: fromNanoSec(record.publishTime),
             message: channelInfo.parsedChannel.deserializer(record.data),
             sizeInBytes: record.data.byteLength,
           });

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -39,14 +39,19 @@ declare module "@foxglove/studio" {
     /** The topic name this message was received on, i.e. "/some/topic" */
     topic: string;
     /**
-     * The time this message was received. This may be set by the local system
-     * clock or the data source, depending on the data source used and whether
-     * time is simulated via a /clock topic or similar mechanism.
+     * The time in nanoseconds this message was received. This may be set by the
+     * local system clock or the data source, depending on the data source used
+     * and whether time is simulated via a /clock topic or similar mechanism.
+     * The timestamp is often nanoseconds since the UNIX epoch, but may be
+     * relative to another event such as system boot time or simulation start
+     * time depending on the context.
      */
     receiveTime: Time;
     /**
-     * The time this message was originally published. This is only available
-     * for some data sources.
+     * The time in nanoseconds this message was originally published. This is
+     * only available for some data sources. The timestamp is often nanoseconds
+     * since the UNIX epoch, but may be relative to another event such as system
+     * boot time or simulation start time depending on the context.
      */
     publishTime?: Time;
     /** The deserialized message as a JavaScript object. */

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -36,9 +36,25 @@ declare module "@foxglove/studio" {
    * A message event frames message data with the topic and receive time
    */
   export type MessageEvent<T> = Readonly<{
+    /** The topic name this message was received on, i.e. "/some/topic" */
     topic: string;
+    /**
+     * The time this message was received. This may be set by the local system
+     * clock or the data source, depending on the data source used and whether
+     * time is simulated via a /clock topic or similar mechanism.
+     */
     receiveTime: Time;
+    /**
+     * The time this message was originally published. This is only available
+     * for some data sources.
+     */
+    publishTime?: Time;
+    /** The deserialized message as a JavaScript object. */
     message: T;
+    /**
+     * The approximate size of this message in its serialized form. This can be
+     * useful for statistics tracking and cache eviction.
+     */
     sizeInBytes: number;
   }>;
 


### PR DESCRIPTION
**User-Facing Changes**

* ROS2 data source supports the /clock topic
* `MessageEvent.publishTime` is populated for ROS2 and MCAP data sources

**Description**

ROS2 and MCAP data sources now set the publishTime field for MessageEvents. This field is not used internally by Studio yet, but extensions can access it. In the future this could be a third option for the plot X-axis, incoming message sort order, and/or displayed in the Raw Message panel or elsewhere.
