### PR TITLE
Add topic warning when nav_msgs/Path has inconsistent frame_ids

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -638,6 +638,12 @@ export default class SceneBuilder implements MarkerProvider {
     if (message.poses.length === 0) {
       return;
     }
+    for (const pose of message.poses) {
+      if (pose.header.frame_id !== message.header.frame_id) {
+        this._setTopicError(topic, "Path poses must all have the same frame_id");
+        return;
+      }
+    }
     const newMessage = {
       header: message.header,
       // Future: display orientation of the poses in the path


### PR DESCRIPTION
**User-Facing Changes**

* A topic warning is shown when `nav_msgs/Path` poses have different frame_ids

**Description**

An interesting side note, 100% of this PR was written by GitHub Copilot. The only prompt was a newline.