### PR TITLE
Fix start/end time from coverage calculation in data platform player

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -163,9 +163,9 @@ export default class FoxgloveDataPlatformPlayer implements Player {
 
     // Truncate start/end time to coverage range
     const coverageStart = minBy(coverage, (c) => c.start);
-    const converageEnd = maxBy(coverage, (c) => c.end);
-    const coverageStartTime = fromRFC3339String(coverageStart!.start);
-    const coverageEndTime = fromRFC3339String(converageEnd!.end);
+    const coverageEnd = maxBy(coverage, (c) => c.end);
+    const coverageStartTime = coverageStart ? fromRFC3339String(coverageStart.start) : undefined;
+    const coverageEndTime = coverageEnd ? fromRFC3339String(coverageEnd.end) : undefined;
     if (!coverageStartTime || !coverageEndTime) {
       throw new Error(
         `Invalid coverage response, start: ${coverage[0]!.start}, end: ${

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { captureException } from "@sentry/core";
-import { isEqual, partition, uniq } from "lodash";
+import { isEqual, maxBy, minBy, partition, uniq } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { signal, Signal } from "@foxglove/den/async";
@@ -162,22 +162,24 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     }
 
     // Truncate start/end time to coverage range
-    const coverageStart = fromRFC3339String(coverage[0]!.start);
-    const coverageEnd = fromRFC3339String(coverage[coverage.length - 1]!.end);
-    if (!coverageStart || !coverageEnd) {
+    const coverageStart = minBy(coverage, (c) => c.start);
+    const converageEnd = maxBy(coverage, (c) => c.end);
+    const coverageStartTime = fromRFC3339String(coverageStart!.start);
+    const coverageEndTime = fromRFC3339String(converageEnd!.end);
+    if (!coverageStartTime || !coverageEndTime) {
       throw new Error(
         `Invalid coverage response, start: ${coverage[0]!.start}, end: ${
           coverage[coverage.length - 1]!.end
         }`,
       );
     }
-    if (isLessThan(this._start, coverageStart)) {
-      log.debug("Reduced start time from", this._start, "to", coverageStart);
-      this._start = coverageStart;
+    if (isLessThan(this._start, coverageStartTime)) {
+      log.debug("Increased start time from", this._start, "to", coverageStartTime);
+      this._start = coverageStartTime;
     }
-    if (isGreaterThan(this._end, coverageEnd)) {
-      log.debug("Reduced end time from", this._end, "to", coverageEnd);
-      this._end = coverageEnd;
+    if (isGreaterThan(this._end, coverageEndTime)) {
+      log.debug("Reduced end time from", this._end, "to", coverageEndTime);
+      this._end = coverageEndTime;
     }
 
     // During startup, seekPlayback might get called to set the currentTime. This might change the

--- a/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
@@ -87,9 +87,9 @@ export class DataPlatformIterableSource implements IIterableSource {
 
     // Truncate start/end time to coverage range
     const coverageStart = minBy(coverage, (c) => c.start);
-    const converageEnd = maxBy(coverage, (c) => c.end);
-    const coverageStartTime = fromRFC3339String(coverageStart!.start);
-    const coverageEndTime = fromRFC3339String(converageEnd!.end);
+    const coverageEnd = maxBy(coverage, (c) => c.end);
+    const coverageStartTime = coverageStart ? fromRFC3339String(coverageStart.start) : undefined;
+    const coverageEndTime = coverageEnd ? fromRFC3339String(coverageEnd.end) : undefined;
     if (!coverageStartTime || !coverageEndTime) {
       throw new Error(
         `Invalid coverage response, start: ${coverage[0]!.start}, end: ${

--- a/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { isEqual } from "lodash";
+import { isEqual, maxBy, minBy } from "lodash";
 
 import Logger from "@foxglove/log";
 import { parseChannel } from "@foxglove/mcap-support";
@@ -86,22 +86,24 @@ export class DataPlatformIterableSource implements IIterableSource {
     }
 
     // Truncate start/end time to coverage range
-    const coverageStart = fromRFC3339String(coverage[0]!.start);
-    const coverageEnd = fromRFC3339String(coverage[coverage.length - 1]!.end);
-    if (!coverageStart || !coverageEnd) {
+    const coverageStart = minBy(coverage, (c) => c.start);
+    const converageEnd = maxBy(coverage, (c) => c.end);
+    const coverageStartTime = fromRFC3339String(coverageStart!.start);
+    const coverageEndTime = fromRFC3339String(converageEnd!.end);
+    if (!coverageStartTime || !coverageEndTime) {
       throw new Error(
         `Invalid coverage response, start: ${coverage[0]!.start}, end: ${
           coverage[coverage.length - 1]!.end
         }`,
       );
     }
-    if (isLessThan(this._start, coverageStart)) {
-      log.debug("Reduced start time from", this._start, "to", coverageStart);
-      this._start = coverageStart;
+    if (isLessThan(this._start, coverageStartTime)) {
+      log.debug("Increased start time from", this._start, "to", coverageStart);
+      this._start = coverageStartTime;
     }
-    if (isGreaterThan(this._end, coverageEnd)) {
-      log.debug("Reduced end time from", this._end, "to", coverageEnd);
-      this._end = coverageEnd;
+    if (isGreaterThan(this._end, coverageEndTime)) {
+      log.debug("Reduced end time from", this._end, "to", coverageEndTime);
+      this._end = coverageEndTime;
     }
 
     const topics: Topic[] = [];


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue in the data platform player start & end time calculation.

**Description**
This calculation was assuming that the coverage data coming from the API was sorted but it is in fact in random order.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
