### PR TITLE
Fix support for protobuf enums in message paths and plots

### DIFF
--- a/packages/mcap-support/src/protobufDefinitionsToDatatypes.ts
+++ b/packages/mcap-support/src/protobufDefinitionsToDatatypes.ts
@@ -52,6 +52,7 @@ export function protobufDefinitionsToDatatypes(
         // https://github.com/foxglove/studio/issues/2214
         definitions.push({ name, type: "int32", isConstant: true, value });
       }
+      definitions.push({ type: "int32", name: field.name });
     } else if (field.resolvedType) {
       definitions.push({
         type: stripLeadingDot(field.resolvedType.fullName),


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where `enum`-valued fields in Protobuf schemas were not usable in plots or via message path syntax.

**Description**

Closes https://github.com/foxglove/studio/issues/3126

```proto
syntax = "proto3";

enum MyEnum {
  ZERO = 0;
  ONE = 1;
  TWO = 2;
}

message ExampleMsg {
  string msg = 1;
  int32 count = 2;
  MyEnum val = 3;
}
```

<img width="324" alt="image" src="https://user-images.githubusercontent.com/14237/161169870-818c99ba-08a9-4e3d-a804-03ae343bf8de.png">