### PR TITLE
Set ROS2 subscription QoS using the same rules as rosbag2

### DIFF
--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -12,7 +12,7 @@ import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { definitions as foxgloveDefs } from "@foxglove/rosmsg-msgs-foxglove";
 import { Time, fromMillis, toSec } from "@foxglove/rostime";
-import { Reliability } from "@foxglove/rtps";
+import { Durability, Reliability } from "@foxglove/rtps";
 import { ParameterValue } from "@foxglove/studio";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
@@ -389,12 +389,30 @@ export default class Ros2Player implements Player {
         });
       }
 
+      // Pick the best but lowest common denominator QoS profile for this topic
+      const topicEndpoints = publishedTopics.get(topicName) ?? [];
+      const reliableCount = topicEndpoints.reduce(
+        (sum, pub) => sum + (pub.reliability.kind === Reliability.Reliable ? 1 : 0),
+        0,
+      );
+      const transientLocalCount = topicEndpoints.reduce(
+        (sum, pub) => sum + (pub.durability === Durability.TransientLocal ? 1 : 0),
+        0,
+      );
+      const endpointCount = topicEndpoints.length;
+      const durability =
+        transientLocalCount === endpointCount ? Durability.TransientLocal : Durability.Volatile;
+      const reliability = {
+        kind: reliableCount === endpointCount ? Reliability.Reliable : Reliability.BestEffort,
+        maxBlockingTime: rosEndpoint.reliability.maxBlockingTime,
+      };
+
       const subscription = this._rosNode.subscribe({
         topic: topicName,
         dataType,
-        durability: rosEndpoint.durability,
+        durability,
         history: rosEndpoint.history,
-        reliability: rosEndpoint.reliability,
+        reliability,
         msgDefinition,
       });
 

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -361,15 +361,13 @@ export default class Ros2Player implements Player {
       }
       const dataType = availableTopic.datatype;
 
-      // Find the first reliable publisher for this topic to mimic its QoS profile
-      const rosEndpoint = publishedTopics
-        .get(topicName)
-        ?.find((pub) => pub.reliability.kind === Reliability.Reliable);
+      // Find the first publisher for this topic to mimic its QoS history settings
+      const rosEndpoint = publishedTopics.get(topicName)?.[0];
       if (!rosEndpoint) {
         this._problems.addProblem(`subscription:${topicName}`, {
           severity: "warn",
-          message: `No reliable publisher for "${topicName}"`,
-          tip: `Best-effort subscriptions are not supported yet`,
+          message: `No publisher for "${topicName}"`,
+          tip: `Publish "${topicName}"`,
         });
         continue;
       } else {


### PR DESCRIPTION
**User-Facing Changes**

- Fixed ROS2 native subscriptions to multiple publishers with different QoS profiles

**Description**

Credit to @wep21 for the original PR (https://github.com/foxglove/studio/pull/3112).

Handle qos like rosbag2 implementation in ros2 player
https://github.com/ros2/rosbag2/blob/e156eb9e38c377df33e5075ab7fa48f3b52eaa12/rosbag2_transport/src/rosbag2_transport/qos.cpp#L106-L173

If all publishing endpoints for a topic have Reliable reliability, the subscriber uses Reliable, else subscriber uses BestEffort. If all endpoints have TransientLocal durability, the subscriber uses TransientLocal, else subscriber uses Volatile.