### PR TITLE
Stabilize selector in topic list

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
@@ -102,13 +102,15 @@ const StyledListItem = muiStyled(ListItem, { skipSx: true })(({ theme }) => ({
   },
 }));
 
+const EMPTY_TOPICS: Topic[] = [];
+
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
 
 export function TopicList(): JSX.Element {
   const [filterText, setFilterText] = useState<string>("");
 
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const topics = useMessagePipeline((ctx) => ctx.playerState.activeData?.topics ?? []);
+  const topics = useMessagePipeline((ctx) => ctx.playerState.activeData?.topics ?? EMPTY_TOPICS);
 
   const filteredTopics: FzfResultItem<Topic>[] = useMemo(
     () =>

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
@@ -106,11 +106,14 @@ const EMPTY_TOPICS: Topic[] = [];
 
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
 
+const selectTopics = (ctx: MessagePipelineContext) =>
+  ctx.playerState.activeData?.topics ?? EMPTY_TOPICS;
+
 export function TopicList(): JSX.Element {
   const [filterText, setFilterText] = useState<string>("");
 
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const topics = useMessagePipeline((ctx) => ctx.playerState.activeData?.topics ?? EMPTY_TOPICS);
+  const topics = useMessagePipeline(selectTopics);
 
   const filteredTopics: FzfResultItem<Topic>[] = useMemo(
     () =>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This stabilizes the message pipeline selector used in the `TopicList` component to silence warnings and avoid unnecessary rerenders.

<img width="534" alt="Screen Shot 2022-04-04 at 9 34 50 AM" src="https://user-images.githubusercontent.com/93935560/161567244-5ecedb04-23ab-47bb-a4f6-d37c1d9edeaf.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
