### PR TITLE
Fix validateDOMNesting error

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -42,7 +42,7 @@ function DataSourceInfo(): JSX.Element {
         ) : playerPresence === PlayerPresence.RECONNECTING ? (
           <Typography variant="inherit">Waiting for connection…</Typography>
         ) : playerName ? (
-          <Typography variant="inherit" component={"span"}>
+          <Typography variant="inherit" component="span">
             <MultilineMiddleTruncate text={playerName} />
           </Typography>
         ) : (

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -42,7 +42,7 @@ function DataSourceInfo(): JSX.Element {
         ) : playerPresence === PlayerPresence.RECONNECTING ? (
           <Typography variant="inherit">Waiting for connection…</Typography>
         ) : playerName ? (
-          <Typography variant="inherit">
+          <Typography variant="inherit" component={"span"}>
             <MultilineMiddleTruncate text={playerName} />
           </Typography>
         ) : (


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes a DOM nesting validation error in the `DataSourceInfo` component. The MUI `Typography` component is defaulting to a `<p>` element here which doesn't allow nesting.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<img width="545" alt="Screen Shot 2022-04-04 at 9 49 27 AM" src="https://user-images.githubusercontent.com/93935560/161570314-45c27633-004f-4bee-b5eb-1b28375d5ac9.png">
