### PR TITLE
Fix jumping dropdown menu in Diagnostic panels

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -14,8 +14,7 @@
 import DatabaseIcon from "@mdi/svg/svg/database.svg";
 import { Autocomplete, Menu, MenuItem, TextField } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { sortBy } from "lodash";
-import { uniq } from "lodash";
+import { sortBy, uniq } from "lodash";
 import { useCallback, useMemo, useRef, useState, MouseEvent } from "react";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -11,17 +11,19 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Autocomplete, TextField } from "@mui/material";
+import DatabaseIcon from "@mdi/svg/svg/database.svg";
+import { Autocomplete, Menu, MenuItem, TextField } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { sortBy } from "lodash";
-import { useMemo } from "react";
+import { uniq } from "lodash";
+import { useCallback, useMemo, useRef, useState, MouseEvent } from "react";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import Icon from "@foxglove/studio-base/components/Icon";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import TopicToRenderMenu from "@foxglove/studio-base/components/TopicToRenderMenu";
 import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 
 import DiagnosticStatus from "./DiagnosticStatus";
@@ -58,6 +60,12 @@ const useStyles = makeStyles({
   },
 });
 
+const ALLOWED_DATATYPES: string[] = [
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+  "ros.diagnostic_msgs.DiagnosticArray",
+];
+
 // component to display a single diagnostic status from list
 function DiagnosticStatusPanel(props: Props) {
   const classes = useStyles();
@@ -72,18 +80,44 @@ function DiagnosticStatusPanel(props: Props) {
     collapsedSections = [],
   } = config;
 
-  const topicToRenderMenu = (
-    <TopicToRenderMenu
-      topicToRender={topicToRender}
-      onChange={(newTopicToRender) => saveConfig({ topicToRender: newTopicToRender })}
-      topics={topics}
-      allowedDatatypes={[
-        "diagnostic_msgs/DiagnosticArray",
-        "diagnostic_msgs/msg/DiagnosticArray",
-        "ros.diagnostic_msgs.DiagnosticArray",
-      ]}
-      defaultTopicToRender={DIAGNOSTIC_TOPIC}
-    />
+  const menuRef = useRef<HTMLDivElement>(ReactNull);
+  const [topicMenuOpen, setTopicMenuOpen] = useState(false);
+
+  // Filter down all topics to those that conform to our supported datatypes
+  const availableTopics = useMemo(() => {
+    const filtered = topics
+      .filter((topic) => ALLOWED_DATATYPES.includes(topic.datatype))
+      .map((topic) => topic.name);
+
+    // Keeps only the first occurrence of each topic.
+    return uniq([DIAGNOSTIC_TOPIC, ...filtered, topicToRender]);
+  }, [topics, topicToRender]);
+
+  const changeTopicToRender = useCallback(
+    (newTopicToRender: string) => {
+      saveConfig({ topicToRender: newTopicToRender });
+      setTopicMenuOpen(false);
+    },
+    [saveConfig],
+  );
+
+  const toggleTopicMenuAction = useCallback((ev: MouseEvent<HTMLElement>) => {
+    // To accurately position the topic dropdown menu we set the location of our menu ref to the
+    // click location
+    menuRef.current!.style.left = `${ev.clientX}px`;
+    setTopicMenuOpen((isOpen) => !isOpen);
+  }, []);
+
+  const topicMenuIcon = (
+    <Icon
+      fade
+      tooltip={`Supported datatypes: ${ALLOWED_DATATYPES.join(", ")}`}
+      tooltipProps={{ placement: "top" }}
+      dataTest={"topic-set"}
+      onClick={toggleTopicMenuAction}
+    >
+      <DatabaseIcon />
+    </Icon>
   );
 
   const availableDiagnostics = useAvailableDiagnostics(topicToRender);
@@ -146,7 +180,8 @@ function DiagnosticStatusPanel(props: Props) {
 
   return (
     <div className={classes.root}>
-      <PanelToolbar floating helpContent={helpContent} additionalIcons={topicToRenderMenu}>
+      <div ref={menuRef} style={{ position: "absolute" }}></div>
+      <PanelToolbar floating helpContent={helpContent} additionalIcons={topicMenuIcon}>
         <Autocomplete
           disablePortal
           blurOnSelect={true}
@@ -179,6 +214,21 @@ function DiagnosticStatusPanel(props: Props) {
             />
           )}
         />
+        <Menu
+          anchorEl={menuRef.current}
+          open={topicMenuOpen}
+          onClose={() => setTopicMenuOpen(false)}
+        >
+          {availableTopics.map((topic) => (
+            <MenuItem
+              key={topic}
+              onClick={() => changeTopicToRender(topic)}
+              selected={topicToRender === topic}
+            >
+              {topic}
+            </MenuItem>
+          ))}
+        </Menu>
       </PanelToolbar>
       {filteredDiagnostics.length > 0 ? (
         <div className={classes.content}>

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -23,8 +23,7 @@ import PinIcon from "@mdi/svg/svg/pin.svg";
 import { Stack, Theme, Menu, MenuItem } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
-import { compact } from "lodash";
-import { uniq } from "lodash";
+import { compact, uniq } from "lodash";
 import { useCallback, useMemo, useRef, useState, MouseEvent } from "react";
 import { List, AutoSizer, ListRowProps } from "react-virtualized";
 

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -18,12 +18,14 @@ import {
   ISelectableOption,
   useTheme,
 } from "@fluentui/react";
+import DatabaseIcon from "@mdi/svg/svg/database.svg";
 import PinIcon from "@mdi/svg/svg/pin.svg";
-import { Stack, Theme } from "@mui/material";
+import { Stack, Theme, Menu, MenuItem } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import { compact } from "lodash";
-import { useCallback, useMemo } from "react";
+import { uniq } from "lodash";
+import { useCallback, useMemo, useRef, useState, MouseEvent } from "react";
 import { List, AutoSizer, ListRowProps } from "react-virtualized";
 
 import { filterMap } from "@foxglove/den/collection";
@@ -34,7 +36,6 @@ import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledCompon
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import TopicToRenderMenu from "@foxglove/studio-base/components/TopicToRenderMenu";
 import { Config as DiagnosticStatusConfig } from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.help.md";
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
@@ -153,6 +154,12 @@ type Props = {
   saveConfig: (arg0: Partial<Config>) => void;
 };
 
+const ALLOWED_DATATYPES: string[] = [
+  "diagnostic_msgs/DiagnosticArray",
+  "diagnostic_msgs/msg/DiagnosticArray",
+  "ros.diagnostic_msgs.DiagnosticArray",
+];
+
 function DiagnosticSummary(props: Props): JSX.Element {
   const theme = useTheme();
   const classes = useStyles();
@@ -251,18 +258,44 @@ function DiagnosticSummary(props: Props): JSX.Element {
     />
   );
 
-  const topicToRenderMenu = (
-    <TopicToRenderMenu
-      topicToRender={topicToRender}
-      onChange={(newTopicToRender) => saveConfig({ topicToRender: newTopicToRender })}
-      topics={topics}
-      allowedDatatypes={[
-        "diagnostic_msgs/DiagnosticArray",
-        "diagnostic_msgs/msg/DiagnosticArray",
-        "ros.diagnostic_msgs.DiagnosticArray",
-      ]}
-      defaultTopicToRender={DIAGNOSTIC_TOPIC}
-    />
+  const menuRef = useRef<HTMLDivElement>(ReactNull);
+  const [topicMenuOpen, setTopicMenuOpen] = useState(false);
+
+  // Filter down all topics to those that conform to our supported datatypes
+  const availableTopics = useMemo(() => {
+    const filtered = topics
+      .filter((topic) => ALLOWED_DATATYPES.includes(topic.datatype))
+      .map((topic) => topic.name);
+
+    // Keeps only the first occurrence of each topic.
+    return uniq([DIAGNOSTIC_TOPIC, ...filtered, topicToRender]);
+  }, [topics, topicToRender]);
+
+  const changeTopicToRender = useCallback(
+    (newTopicToRender: string) => {
+      saveConfig({ topicToRender: newTopicToRender });
+      setTopicMenuOpen(false);
+    },
+    [saveConfig],
+  );
+
+  const toggleTopicMenuAction = useCallback((ev: MouseEvent<HTMLElement>) => {
+    // To accurately position the topic dropdown menu we set the location of our menu ref to the
+    // click location
+    menuRef.current!.style.left = `${ev.clientX}px`;
+    setTopicMenuOpen((isOpen) => !isOpen);
+  }, []);
+
+  const topicMenuIcon = (
+    <Icon
+      fade
+      tooltip={`Supported datatypes: ${ALLOWED_DATATYPES.join(", ")}`}
+      tooltipProps={{ placement: "top" }}
+      dataTest={"topic-set"}
+      onClick={toggleTopicMenuAction}
+    >
+      <DatabaseIcon />
+    </Icon>
   );
 
   const diagnostics = useDiagnostics(topicToRender);
@@ -338,7 +371,8 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   return (
     <Stack flex="auto">
-      <PanelToolbar helpContent={helpContent} additionalIcons={topicToRenderMenu}>
+      <div ref={menuRef} style={{ position: "absolute" }}></div>
+      <PanelToolbar helpContent={helpContent} additionalIcons={topicMenuIcon}>
         <Dropdown
           styles={dropdownStyles}
           onRenderOption={renderOption}
@@ -354,6 +388,21 @@ function DiagnosticSummary(props: Props): JSX.Element {
           selectedKey={minLevel}
         />
         {hardwareFilter}
+        <Menu
+          anchorEl={menuRef.current}
+          open={topicMenuOpen}
+          onClose={() => setTopicMenuOpen(false)}
+        >
+          {availableTopics.map((topic) => (
+            <MenuItem
+              key={topic}
+              onClick={() => changeTopicToRender(topic)}
+              selected={topicToRender === topic}
+            >
+              {topic}
+            </MenuItem>
+          ))}
+        </Menu>
       </PanelToolbar>
       <Stack flex="auto">{summary}</Stack>
     </Stack>


### PR DESCRIPTION


**User-Facing Changes**
The topic selection menu no longer jumps around in the Diagnostic panels.

**Description**
When using the topic selection menu in the Diagnostic panels (detail and summary), the context menu would jump around on the screen during playback or new messages.

The panel toolbar disappears when the user mouses away from the panel. Since a context menu is considered "outside" the panel the disappearing toolbar removes the icon from acting as the anchor point.

This change fixes the jumping behavior by using a static anchor for the menu that is outside of the disappearing panel toolbar.

Fixes: #3097

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
