### PR TITLE
Explicitly track player presence in IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/DataPlatformIterableSource.ts
@@ -98,7 +98,7 @@ export class DataPlatformIterableSource implements IIterableSource {
       );
     }
     if (isLessThan(this._start, coverageStartTime)) {
-      log.debug("Increased start time from", this._start, "to", coverageStart);
+      log.debug("Increased start time from", this._start, "to", coverageStartTime);
       this._start = coverageStartTime;
     }
     if (isGreaterThan(this._end, coverageEndTime)) {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -127,7 +127,7 @@ describe("IterablePlayer", () => {
       // before initialize
       baseState,
       // start delay
-      { ...baseState, presence: PlayerPresence.INITIALIZING },
+      { ...baseState, presence: PlayerPresence.PRESENT },
       // startPlay
       { ...baseState, presence: PlayerPresence.PRESENT },
       // idle


### PR DESCRIPTION


**User-Facing Changes**
More accurate player presence when using the Experimental players.

**Description**
At the end of the initialize state the player is initialized and the emitState should indicate this. Previously it did not because it use the current state which was not yet set to the next state.

Fixes: #3135

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
