### PR TITLE
Recursively search ROS_PACKAGE_PATH in findRosPackage

### DIFF
--- a/desktop/main/fixtures/packages/nested/child/package.xml
+++ b/desktop/main/fixtures/packages/nested/child/package.xml
@@ -1,8 +1,8 @@
 <package format="2">
-  <name>foo</name>
-  <version>1.2.3</version>
+  <name>nested-child</name>
+  <version>3.2.1</version>
   <description>
-    This package provides foo capability.
+    This package provides nested-child capability.
   </description>
   <maintainer email="john@example.com">John Doe</maintainer>
   <license>MIT</license>

--- a/desktop/main/rosPackageResources.test.ts
+++ b/desktop/main/rosPackageResources.test.ts
@@ -4,7 +4,7 @@
 
 import path from "path";
 
-import { findRosPackageRoot, rosPackageNameAtPath } from "./rosPackageResources";
+import { findRosPackage, rosPackageNameAtPath } from "./rosPackageResources";
 
 const FIXTURES_ROOT = path.join(__dirname, "./fixtures");
 const PACKAGES_ROOT = path.join(FIXTURES_ROOT, "./packages");
@@ -17,14 +17,14 @@ describe("rosPackageResources", () => {
     });
   });
 
-  describe("findRosPackageRoot", () => {
+  describe("findRosPackage", () => {
     it("should find package within rosPackagePath", async () => {
-      const packagePath = await findRosPackageRoot("foo", { rosPackagePath: PACKAGES_ROOT });
+      const packagePath = await findRosPackage("foo", { rosPackagePath: PACKAGES_ROOT });
       expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
     });
 
     it("should find package within multiple rosPackagePaths", async () => {
-      const packagePath = await findRosPackageRoot("foo", {
+      const packagePath = await findRosPackage("foo", {
         rosPackagePath: `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`,
       });
       expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
@@ -33,7 +33,7 @@ describe("rosPackageResources", () => {
     it("should find package within process.env.ROS_PACKAGE_PATH", async () => {
       process.env.ROS_PACKAGE_PATH = `${FIXTURES_ROOT}${path.delimiter}${PACKAGES_ROOT}`;
       try {
-        const packagePath = await findRosPackageRoot("foo");
+        const packagePath = await findRosPackage("foo");
         expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "./foo"));
       } finally {
         process.env.ROS_PACKAGE_PATH = undefined;
@@ -41,7 +41,7 @@ describe("rosPackageResources", () => {
     });
 
     it("should find packages recursively within rosPackagePath", async () => {
-      const packagePath = await findRosPackageRoot("nested-child", {
+      const packagePath = await findRosPackage("nested-child", {
         rosPackagePath: PACKAGES_ROOT,
       });
       expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "nested", "child"));

--- a/desktop/main/rosPackageResources.test.ts
+++ b/desktop/main/rosPackageResources.test.ts
@@ -39,5 +39,12 @@ describe("rosPackageResources", () => {
         process.env.ROS_PACKAGE_PATH = undefined;
       }
     });
+
+    it("should find packages recursively within rosPackagePath", async () => {
+      const packagePath = await findRosPackageRoot("nested-child", {
+        rosPackagePath: PACKAGES_ROOT,
+      });
+      expect(packagePath).toEqual(path.join(PACKAGES_ROOT, "nested", "child"));
+    });
   });
 });

--- a/desktop/main/rosPackageResources.ts
+++ b/desktop/main/rosPackageResources.ts
@@ -40,30 +40,39 @@ export async function rosPackageNameAtPath(packagePath: string): Promise<string 
 }
 
 /**
- * Return a map of ROS package names to their absolute paths.
+ * Find ROS package named `pkg` within the `rootPath`
  *
- * rootPath is searched recursively to find all packages below the path
+ * rootPath is searched recursively
  */
-async function listRosPackages(rootPath: string): Promise<Map<string, string>> {
+export async function findRosPackageInRoot(
+  pkg: string,
+  rootPath: string,
+): Promise<string | undefined> {
   const packagePaths = await fs.readdir(rootPath, { withFileTypes: true });
   log.debug(`searching ${rootPath} for packages`);
 
-  const packages = new Map<string, string>();
-  for (const packagePath of packagePaths) {
+  const directories = packagePaths.filter((pkgPath) => pkgPath.isDirectory());
+
+  // Check any of our immediate folders for the package
+  for (const packagePath of directories) {
     const absolutePath = path.join(rootPath, packagePath.name);
 
     const packageName = await rosPackageNameAtPath(absolutePath);
-    if (packageName) {
-      packages.set(packageName, absolutePath);
-    } else if (packagePath.isDirectory()) {
-      const nestedPackages = await listRosPackages(absolutePath);
-      for (const [key, value] of nestedPackages) {
-        packages.set(key, value);
-      }
+    if (packageName === pkg) {
+      return absolutePath;
     }
   }
 
-  return packages;
+  // Recurse into all directories
+  for (const packagePath of directories) {
+    const absolutePath = path.join(rootPath, packagePath.name);
+    const foundPath = await findRosPackageInRoot(pkg, absolutePath);
+    if (foundPath) {
+      return foundPath;
+    }
+  }
+
+  return;
 }
 
 /**
@@ -71,36 +80,16 @@ async function listRosPackages(rootPath: string): Promise<Map<string, string>> {
  *
  * The search algorithm attempts to find the package in this order. It stops as soon as the package
  * is found:
- * - If options.searchPath is set, this folder and all of its parents are searched for the package
- * - If options.rosPackagePath is set, this folder(s) are searched
- * - If env.ROS_PACKAGE_PATH is available, this folder(s) are searched
+ * - If options.rosPackagePath is set, this folder(s) are searched recursively
+ * - If env.ROS_PACKAGE_PATH is available, this folder(s) are searched recursively
  *
  * https://wiki.ros.org/ROS/EnvironmentVariables#ROS_PACKAGE_PATH
  */
-export async function findRosPackageRoot(
+export async function findRosPackage(
   pkg: string,
-  options?: { rosPackagePath?: string; searchPath?: string },
+  options?: { rosPackagePath?: string },
 ): Promise<string | undefined> {
-  const { searchPath } = options ?? {};
-  // log.debug(`findRosPackageRoot(${pkg}, ${rosPackagePath}, ${searchPath})`);
-
-  const triedPaths: string[] = [];
-
-  // Search searchPath and all parent paths
-  if (searchPath != undefined) {
-    let currentPath = searchPath;
-    for (;;) {
-      triedPaths.push(currentPath);
-      if ((await rosPackageNameAtPath(currentPath)) === pkg) {
-        // log.debug(`Found ROS package ${pkg} at ${currentPath} (searched relative to ${searchPath})`);
-        return currentPath;
-      }
-      if (path.dirname(currentPath) === currentPath) {
-        break;
-      }
-      currentPath = path.dirname(currentPath);
-    }
-  }
+  // log.debug(`findRosPackage(${pkg}, ${rosPackagePath}, ${searchPath})`);
 
   const rosPackagePaths: string[] = [];
 
@@ -115,16 +104,14 @@ export async function findRosPackageRoot(
   }
 
   for (const rosPackagePath of rosPackagePaths) {
-    triedPaths.push(rosPackagePath);
-    const packages = await listRosPackages(rosPackagePath);
-    const packagePath = packages.get(pkg);
+    const packagePath = await findRosPackageInRoot(pkg, rosPackagePath);
     if (packagePath) {
       // log.info(`Found ROS package "${pkg}" at "${packagePath}" (in ROS_PACKAGE_PATH "${ROS_PACKAGE_PATH}")`);
       return packagePath;
     }
   }
 
-  log.warn(`Could not find ROS package "${pkg}" in: ${triedPaths.join(path.delimiter)}`);
+  log.warn(`Could not find ROS package "${pkg}" in: ${rosPackagePaths.join(path.delimiter)}`);
   return undefined;
 }
 
@@ -154,7 +141,7 @@ export function registerRosPackageProtocolHandlers(): void {
       const targetPkg = url.host;
       const relPath = url.pathname;
 
-      const pkgRoot = await findRosPackageRoot(targetPkg, {
+      const pkgRoot = await findRosPackage(targetPkg, {
         rosPackagePath,
       });
 
@@ -194,7 +181,7 @@ export function registerRosPackageProtocolHandlers(): void {
       const targetPkg = url.host;
       const relPath = url.pathname;
 
-      const pkgRoot = await findRosPackageRoot(targetPkg, {
+      const pkgRoot = await findRosPackage(targetPkg, {
         rosPackagePath,
       });
 

--- a/desktop/main/rosPackageResources.ts
+++ b/desktop/main/rosPackageResources.ts
@@ -41,29 +41,28 @@ export async function rosPackageNameAtPath(packagePath: string): Promise<string 
 
 /**
  * Return a map of ROS package names to their absolute paths.
+ *
+ * rootPath is searched recursively to find all packages below the path
  */
 async function listRosPackages(rootPath: string): Promise<Map<string, string>> {
   const packagePaths = await fs.readdir(rootPath, { withFileTypes: true });
-  const packagesArray: { name: string | undefined; absolutePath: string }[] = await Promise.all(
-    packagePaths.map(async (packagePath) => {
-      const absolutePath = path.join(rootPath, packagePath.name);
-      try {
-        const name = packagePath.isDirectory()
-          ? await rosPackageNameAtPath(absolutePath)
-          : undefined;
-        return { name, absolutePath };
-      } catch (err) {
-        return { name: undefined, absolutePath };
-      }
-    }),
-  );
+  log.debug(`searching ${rootPath} for packages`);
 
   const packages = new Map<string, string>();
-  for (const { name, absolutePath } of packagesArray) {
-    if (name != undefined) {
-      packages.set(name, absolutePath);
+  for (const packagePath of packagePaths) {
+    const absolutePath = path.join(rootPath, packagePath.name);
+
+    const packageName = await rosPackageNameAtPath(absolutePath);
+    if (packageName) {
+      packages.set(packageName, absolutePath);
+    } else if (packagePath.isDirectory()) {
+      const nestedPackages = await listRosPackages(absolutePath);
+      for (const [key, value] of nestedPackages) {
+        packages.set(key, value);
+      }
     }
   }
+
   return packages;
 }
 
@@ -103,31 +102,25 @@ export async function findRosPackageRoot(
     }
   }
 
+  const rosPackagePaths: string[] = [];
+
   // Search options.rosPackagePath
   if (options?.rosPackagePath) {
-    const rosPackagePaths = options.rosPackagePath.split(path.delimiter);
-    for (const rosPackagePath of rosPackagePaths) {
-      triedPaths.push(rosPackagePath);
-      const packages = await listRosPackages(rosPackagePath);
-      const packagePath = packages.get(pkg);
-      if (packagePath) {
-        // log.info(`Found ROS package "${pkg}" at "${packagePath}" (in ROS_PACKAGE_PATH "${ROS_PACKAGE_PATH}")`);
-        return packagePath;
-      }
-    }
+    rosPackagePaths.push(...options.rosPackagePath.split(path.delimiter));
   }
 
   // Search env.ROS_PACKAGE_PATH
   if (process.env.ROS_PACKAGE_PATH) {
-    const rosPackagePaths = process.env.ROS_PACKAGE_PATH.split(path.delimiter);
-    for (const rosPackagePath of rosPackagePaths) {
-      triedPaths.push(rosPackagePath);
-      const packages = await listRosPackages(rosPackagePath);
-      const packagePath = packages.get(pkg);
-      if (packagePath) {
-        // log.info(`Found ROS package "${pkg}" at "${packagePath}" (in ROS_PACKAGE_PATH "${ROS_PACKAGE_PATH}")`);
-        return packagePath;
-      }
+    rosPackagePaths.push(...process.env.ROS_PACKAGE_PATH.split(path.delimiter));
+  }
+
+  for (const rosPackagePath of rosPackagePaths) {
+    triedPaths.push(rosPackagePath);
+    const packages = await listRosPackages(rosPackagePath);
+    const packagePath = packages.get(pkg);
+    if (packagePath) {
+      // log.info(`Found ROS package "${pkg}" at "${packagePath}" (in ROS_PACKAGE_PATH "${ROS_PACKAGE_PATH}")`);
+      return packagePath;
     }
   }
 


### PR DESCRIPTION

**User-Facing Changes**
Users can follow ROS conventions and set the ROS_PACKAGE_PATH to the root of their workspace. Studio (desktop only) will traverse this path to find all packages within it when resolving `package://` urls.

**Description**
ROS package:// urls follow the convention of `package://<package name>/<path to file>`. In ROS projects, it is common to have a monorepo with several packages folders. This folder would be in the ROS workspace. When setting the ROS_PACKAGE_PATH environment variable or app setting to point to the workspace, the correct behavior for finding packages is to look recursively at the ROS_PACKAGE_PATH location and any locations below it to find the package.

This change updates our package lookup logic to use a recursive search on the ROS_PACKAGE_PATH. This allows finding packages which are within parent folders under the ROS_PACKAGE_PATH.

Fixes: #3088


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
