### PR TITLE
Parse URL state containing only a layoutId

### DIFF
--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -30,6 +30,12 @@ describe("app state url parser", () => {
       expect(parseAppURLState(urlBuilder())).toBeUndefined();
     });
 
+    it("parses urls with only a layoutId", () => {
+      const url = urlBuilder();
+      url.searchParams.append("layoutId", "1234");
+      expect(parseAppURLState(url)?.layoutId).toBe("1234");
+    });
+
     it("parses rosbag data state urls", () => {
       const url = urlBuilder();
       url.searchParams.append("ds", "ros1-remote-bagfile");


### PR DESCRIPTION
**User-Facing Changes**
This improves url state handling.

**Description**
This improves url state handling to respect the `layoutId` parameter even if no other url state parameters are specified.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
