### PR TITLE
Fix chart auto-y scaling

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.test.ts
@@ -94,7 +94,10 @@ describe("downsampleScatter", () => {
       bounds,
     );
     expect(result).toEqual({
-      data: [],
+      data: [
+        { x: 0, y: -1 },
+        { x: 0, y: 200 },
+      ],
     });
   });
 

--- a/packages/studio-base/src/components/TimeBasedChart/downsample.ts
+++ b/packages/studio-base/src/components/TimeBasedChart/downsample.ts
@@ -172,13 +172,10 @@ export function downsampleScatter(dataset: DataSet, bounds: DownsampleBounds): D
       continue;
     }
 
-    // out-of-bounds scatter points are ignored
-    if (
-      datum.x > bounds.x.max ||
-      datum.x < bounds.x.min ||
-      datum.y < bounds.y.min ||
-      datum.y > bounds.y.max
-    ) {
+    // Out-of-bounds scatter points are ignored. We don't filter on y
+    // because y values are needed to allow chart to auto scale to the correct
+    // height.
+    if (datum.x > bounds.x.max || datum.x < bounds.x.min) {
       continue;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with plot auto-scaling on the Y axis.

**Description**
The issue is that the downsampling logic was also discarding points outside the current Y axis scale but this was preventing the chart from autoscaling as new data arrives.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fix #3168 