### PR TITLE
Fix rosbridge player topic initialization

### DIFF
--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -610,23 +610,20 @@ export default class RosbridgePlayer implements Player {
 
     return await new Promise((outerResolve, outerReject) => {
       this._rosClient?.getNodes(async (nodes) => {
-        await Promise.all(
-          nodes.map(async (node) => {
-            return await new Promise((innerResolve, innerReject) => {
-              this._rosClient?.getNodeDetails(
-                node,
-                (subscriptions, publications, services) => {
-                  publications.forEach((pub) => addEntry(output.publishers, pub, node));
-                  subscriptions.forEach((sub) => addEntry(output.subscribers, sub, node));
-                  services.forEach((srv) => addEntry(output.services, srv, node));
-                  innerResolve(undefined);
-                },
-                innerReject,
-              );
-            });
-          }),
-        );
-
+        for (const node of nodes) {
+          await new Promise((innerResolve, innerReject) => {
+            this._rosClient?.getNodeDetails(
+              node,
+              (subscriptions, publications, services) => {
+                publications.forEach((pub) => addEntry(output.publishers, pub, node));
+                subscriptions.forEach((sub) => addEntry(output.subscribers, sub, node));
+                services.forEach((srv) => addEntry(output.services, srv, node));
+                innerResolve(undefined);
+              },
+              innerReject,
+            );
+          });
+        }
         outerResolve(output);
       }, outerReject);
     });

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -608,24 +608,27 @@ export default class RosbridgePlayer implements Player {
       entries.add(value);
     };
 
-    return await new Promise((resolve, reject) => {
+    return await new Promise((outerResolve, outerReject) => {
       this._rosClient?.getNodes(async (nodes) => {
         await Promise.all(
-          nodes.map((node) => {
-            this._rosClient?.getNodeDetails(
-              node,
-              (subscriptions, publications, services) => {
-                publications.forEach((pub) => addEntry(output.publishers, pub, node));
-                subscriptions.forEach((sub) => addEntry(output.subscribers, sub, node));
-                services.forEach((srv) => addEntry(output.services, srv, node));
-              },
-              reject,
-            );
+          nodes.map(async (node) => {
+            return await new Promise((innerResolve, innerReject) => {
+              this._rosClient?.getNodeDetails(
+                node,
+                (subscriptions, publications, services) => {
+                  publications.forEach((pub) => addEntry(output.publishers, pub, node));
+                  subscriptions.forEach((sub) => addEntry(output.subscribers, sub, node));
+                  services.forEach((srv) => addEntry(output.services, srv, node));
+                  innerResolve(undefined);
+                },
+                innerReject,
+              );
+            });
           }),
         );
 
-        resolve(output);
-      }, reject);
+        outerResolve(output);
+      }, outerReject);
     });
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the topic graph panel on startup.

**Description**
Fetching the published topics list from the rosbridge requires a set of nested callbacks. We need to convert both the outer and inner callbacks into promises or else we prematurely return an empty set of published topics before the callbacks are complete.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3176 