### PR TITLE
Improve message path autocomplete logic

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -398,17 +398,17 @@ describe("messagePathsForDatatype", () => {
     expect(messagePathsForDatatype("tf/tfMessage", datatypes)).toEqual([
       "",
       ".transforms",
-      ".transforms[:]{child_frame_id==0}",
-      ".transforms[:]{child_frame_id==0}.child_frame_id",
-      ".transforms[:]{child_frame_id==0}.header",
-      ".transforms[:]{child_frame_id==0}.header.frame_id",
-      ".transforms[:]{child_frame_id==0}.header.seq",
-      ".transforms[:]{child_frame_id==0}.header.stamp",
-      ".transforms[:]{child_frame_id==0}.header.stamp.nsec",
-      ".transforms[:]{child_frame_id==0}.header.stamp.sec",
-      ".transforms[:]{child_frame_id==0}.transform",
-      ".transforms[:]{child_frame_id==0}.transform.rotation",
-      ".transforms[:]{child_frame_id==0}.transform.translation",
+      ".transforms[0]",
+      ".transforms[0].child_frame_id",
+      ".transforms[0].header",
+      ".transforms[0].header.frame_id",
+      ".transforms[0].header.seq",
+      ".transforms[0].header.stamp",
+      ".transforms[0].header.stamp.nsec",
+      ".transforms[0].header.stamp.sec",
+      ".transforms[0].transform",
+      ".transforms[0].transform.rotation",
+      ".transforms[0].transform.translation",
     ]);
   });
 

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -51,12 +51,103 @@ const datatypes: RosDatatypes = new Map(
         { name: "myJson", type: "json", isArray: false },
       ],
     },
+    "geometry_msgs/Transform": {
+      definitions: [
+        { name: "rotation", type: "float64", isArray: false },
+        { name: "translation", type: "float64", isArray: false },
+      ],
+    },
+    "geometry_msgs/TransformStamped": {
+      definitions: [
+        { name: "child_frame_id", type: "string", isArray: false },
+        { name: "header", type: "std_msgs/Header", isArray: false },
+        { name: "transform", type: "geometry_msgs/Transform", isArray: false },
+      ],
+    },
+    "tf/tfMessage": {
+      definitions: [{ name: "transforms", type: "geometry_msgs/TransformStamped", isArray: true }],
+    },
   }),
 );
 
 describe("messagePathStructures", () => {
   it("parses datatypes into a flat structure", () => {
     expect(messagePathStructures(datatypes)).toEqual({
+      "geometry_msgs/Transform": {
+        datatype: "geometry_msgs/Transform",
+        nextByName: {
+          rotation: {
+            datatype: "geometry_msgs/Transform",
+            primitiveType: "float64",
+            structureType: "primitive",
+          },
+          translation: {
+            datatype: "geometry_msgs/Transform",
+            primitiveType: "float64",
+            structureType: "primitive",
+          },
+        },
+        structureType: "message",
+      },
+      "geometry_msgs/TransformStamped": {
+        datatype: "geometry_msgs/TransformStamped",
+        nextByName: {
+          child_frame_id: {
+            datatype: "geometry_msgs/TransformStamped",
+            primitiveType: "string",
+            structureType: "primitive",
+          },
+          header: {
+            datatype: "std_msgs/Header",
+            nextByName: {
+              frame_id: {
+                datatype: "std_msgs/Header",
+                primitiveType: "string",
+                structureType: "primitive",
+              },
+              seq: {
+                datatype: "std_msgs/Header",
+                primitiveType: "uint32",
+                structureType: "primitive",
+              },
+              stamp: {
+                datatype: "time",
+                nextByName: {
+                  nsec: {
+                    datatype: "",
+                    primitiveType: "uint32",
+                    structureType: "primitive",
+                  },
+                  sec: {
+                    datatype: "",
+                    primitiveType: "uint32",
+                    structureType: "primitive",
+                  },
+                },
+                structureType: "message",
+              },
+            },
+            structureType: "message",
+          },
+          transform: {
+            datatype: "geometry_msgs/Transform",
+            nextByName: {
+              rotation: {
+                datatype: "geometry_msgs/Transform",
+                primitiveType: "float64",
+                structureType: "primitive",
+              },
+              translation: {
+                datatype: "geometry_msgs/Transform",
+                primitiveType: "float64",
+                structureType: "primitive",
+              },
+            },
+            structureType: "message",
+          },
+        },
+        structureType: "message",
+      },
       "pose_msgs/SomePose": {
         nextByName: {
           dummy_array: {
@@ -203,6 +294,75 @@ describe("messagePathStructures", () => {
         structureType: "message",
         datatype: "msgs/Log",
       },
+      "tf/tfMessage": {
+        datatype: "tf/tfMessage",
+        nextByName: {
+          transforms: {
+            datatype: "tf/tfMessage",
+            next: {
+              datatype: "geometry_msgs/TransformStamped",
+              nextByName: {
+                child_frame_id: {
+                  datatype: "geometry_msgs/TransformStamped",
+                  primitiveType: "string",
+                  structureType: "primitive",
+                },
+                header: {
+                  datatype: "std_msgs/Header",
+                  nextByName: {
+                    frame_id: {
+                      datatype: "std_msgs/Header",
+                      primitiveType: "string",
+                      structureType: "primitive",
+                    },
+                    seq: {
+                      datatype: "std_msgs/Header",
+                      primitiveType: "uint32",
+                      structureType: "primitive",
+                    },
+                    stamp: {
+                      datatype: "time",
+                      nextByName: {
+                        nsec: {
+                          datatype: "",
+                          primitiveType: "uint32",
+                          structureType: "primitive",
+                        },
+                        sec: {
+                          datatype: "",
+                          primitiveType: "uint32",
+                          structureType: "primitive",
+                        },
+                      },
+                      structureType: "message",
+                    },
+                  },
+                  structureType: "message",
+                },
+                transform: {
+                  datatype: "geometry_msgs/Transform",
+                  nextByName: {
+                    rotation: {
+                      datatype: "geometry_msgs/Transform",
+                      primitiveType: "float64",
+                      structureType: "primitive",
+                    },
+                    translation: {
+                      datatype: "geometry_msgs/Transform",
+                      primitiveType: "float64",
+                      structureType: "primitive",
+                    },
+                  },
+                  structureType: "message",
+                },
+              },
+              structureType: "message",
+            },
+            structureType: "array",
+          },
+        },
+        structureType: "message",
+      },
     });
   });
 
@@ -234,6 +394,22 @@ describe("messagePathsForDatatype", () => {
       ".some_pose.x",
     ]);
     expect(messagePathsForDatatype("msgs/Log", datatypes)).toEqual(["", ".id", ".myJson"]);
+
+    expect(messagePathsForDatatype("tf/tfMessage", datatypes)).toEqual([
+      "",
+      ".transforms",
+      ".transforms[:]{child_frame_id==0}",
+      ".transforms[:]{child_frame_id==0}.child_frame_id",
+      ".transforms[:]{child_frame_id==0}.header",
+      ".transforms[:]{child_frame_id==0}.header.frame_id",
+      ".transforms[:]{child_frame_id==0}.header.seq",
+      ".transforms[:]{child_frame_id==0}.header.stamp",
+      ".transforms[:]{child_frame_id==0}.header.stamp.nsec",
+      ".transforms[:]{child_frame_id==0}.header.stamp.sec",
+      ".transforms[:]{child_frame_id==0}.transform",
+      ".transforms[:]{child_frame_id==0}.transform.rotation",
+      ".transforms[:]{child_frame_id==0}.transform.translation",
+    ]);
   });
 
   it("returns an array of possible message paths for the given `validTypes`", () => {

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -29,8 +29,23 @@ import {
   MessagePathStructureItemMessage,
 } from "./constants";
 
+const STRUCTURE_ITEM_INTEGER_TYPES = [
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "int64",
+  "uint64",
+];
+
 function isRosPrimitive(type: string): type is RosPrimitive {
   return rosPrimitives.includes(type as RosPrimitive);
+}
+
+function structureItemIsIntegerPrimitive(item: MessagePathStructureItem) {
+  return item.structureType === "primitive" && STRUCTURE_ITEM_INTEGER_TYPES.includes(item.datatype);
 }
 
 // Generate an easily navigable flat structure given some `datatypes`. We cache
@@ -164,29 +179,33 @@ export function messagePathsForDatatype(
         // When we have an array of messages, you probably want to filter on
         // some field, like `/topic.object{some_id=123}`. If we can't find a
         // typical filter name, fall back to `/topic.object[0]`.
-        const typicalFilterName = Object.keys(structureItem.next.nextByName).find((key) =>
-          isTypicalFilterName(key),
+        const typicalFilterItem = Object.entries(structureItem.next.nextByName).find(([name]) =>
+          isTypicalFilterName(name),
         );
-        if (typicalFilterName != undefined) {
+        if (typicalFilterItem) {
+          const [typicalFilterName, typicalFilterValue] = typicalFilterItem;
+
           // Find matching filter from clonedMessagePath
           const matchingFilterPart = clonedMessagePath.find(
             (pathPart): pathPart is MessagePathFilter =>
               pathPart.type === "filter" && pathPart.path[0] === typicalFilterName,
           );
 
-          // Remove the matching filter from clonedMessagePath, for future searches
-          clonedMessagePath = clonedMessagePath.filter(
-            (pathPart) => pathPart !== matchingFilterPart,
-          );
-
           // Format the displayed filter value
-          const filterVal = matchingFilterPart?.value ?? 0;
-          traverse(
-            structureItem.next,
-            `${builtString}[:]{${typicalFilterName}==${
-              typeof filterVal === "object" ? `$${filterVal.variableName}` : filterVal
-            }}`,
-          );
+          if (matchingFilterPart) {
+            // Remove the matching filter from clonedMessagePath, for future searches
+            clonedMessagePath = clonedMessagePath.filter(
+              (pathPart) => pathPart !== matchingFilterPart,
+            );
+            traverse(
+              structureItem.next,
+              `${builtString}[:]{${typicalFilterName}==${matchingFilterPart.value}}`,
+            );
+          } else if (structureItemIsIntegerPrimitive(typicalFilterValue)) {
+            traverse(structureItem.next, `${builtString}[:]{${typicalFilterName}==0}`);
+          } else {
+            traverse(structureItem.next, `${builtString}[0]`);
+          }
         } else {
           traverse(structureItem.next, `${builtString}[0]`);
         }

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -14,6 +14,7 @@
 import { memoize } from "lodash";
 import memoizeWeak from "memoize-weak";
 
+import { MessagePathFilter } from "@foxglove/studio-base/components/MessagePathSyntax/constants";
 import { isTypicalFilterName } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
 import { quoteFieldNameIfNeeded } from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
@@ -169,7 +170,8 @@ export function messagePathsForDatatype(
         if (typicalFilterName != undefined) {
           // Find matching filter from clonedMessagePath
           const matchingFilterPart = clonedMessagePath.find(
-            (pathPart) => pathPart.type === "filter" && pathPart.path[0] === typicalFilterName,
+            (pathPart): pathPart is MessagePathFilter =>
+              pathPart.type === "filter" && pathPart.path[0] === typicalFilterName,
           );
 
           // Remove the matching filter from clonedMessagePath, for future searches
@@ -178,12 +180,7 @@ export function messagePathsForDatatype(
           );
 
           // Format the displayed filter value
-          const filterVal =
-            matchingFilterPart &&
-            matchingFilterPart.type === "filter" &&
-            matchingFilterPart.value != undefined
-              ? matchingFilterPart.value
-              : 0;
+          const filterVal = matchingFilterPart?.value ?? 0;
           traverse(
             structureItem.next,
             `${builtString}[:]{${typicalFilterName}==${

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -199,7 +199,11 @@ export function messagePathsForDatatype(
             );
             traverse(
               structureItem.next,
-              `${builtString}[:]{${typicalFilterName}==${matchingFilterPart.value}}`,
+              `${builtString}[:]{${typicalFilterName}==${
+                typeof matchingFilterPart.value === "object"
+                  ? `$${matchingFilterPart.value.variableName}`
+                  : matchingFilterPart.value
+              }}`,
             );
           } else if (structureItemIsIntegerPrimitive(typicalFilterValue)) {
             traverse(structureItem.next, `${builtString}[:]{${typicalFilterName}==0}`);


### PR DESCRIPTION
**User-Facing Changes**
This improves message path autocomplete suggestions.

**Description**
Currently we offer unhelpful message path autocomplete suggestions across arrays of message objects when they contain fields that we mistakenly identify as numeric ids. For example trying to treat the `child_frame_id` field of a transform as a numeric id. The solution in this PR is to check the datatype of that `*_id` field and only offer autocomplete values of `*_id==0` if `*_id` is a primitive integer type.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2997 