### PR TITLE
Fix ros2 message parsing crash

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useFrame.ts
@@ -61,8 +61,8 @@ const useFrame = (topics: string[]): FrameState => {
           // ThreeDimensionalViz panel fully parses all of the messages it
           // consumes, and sometimes repeatedly so via lastSeenMessages. All
           // incoming lazy messages are converted into fully parsed messages here
-          const maybeLazy = messageEvent as { message: { toJSON?: () => unknown } };
-          if ("toJSON" in maybeLazy.message) {
+          const maybeLazy = messageEvent as { message: undefined | { toJSON?: () => unknown } };
+          if (maybeLazy.message && "toJSON" in maybeLazy.message) {
             (maybeLazy.message as unknown) = maybeLazy.message.toJSON!();
           }
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -30,7 +30,6 @@ import {
 import { MessageEvent, Topic } from "@foxglove/studio-base/players/types";
 import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 import { MarkerArray, StampedMessage, TF } from "@foxglove/studio-base/types/Messages";
-import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
 import { TransformLink } from "./types";
 import { Frame } from "./useFrame";


### PR DESCRIPTION
**User-Facing Changes**
This fixes a crash in the 3d panel when trying to visualize ros2 turtle sim data.

**Description**
Looks like the message is being parsed without any data in the `message` field. This just adds some more checks around that logic. I'm not sure what the root cause of this issue is though.

<img width="564" alt="Screen Shot 2022-04-18 at 7 58 41 AM" src="https://user-images.githubusercontent.com/93935560/163812228-00419133-b29a-4dbf-a42d-a7bfd7ff0538.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3199 