### PR TITLE
Set X-Content-Type-Options to nosniff

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,8 @@
       "headers": [
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "origin" },
-        { "key": "Content-Security-Policy", "value": "base-uri 'self';" }
+        { "key": "Content-Security-Policy", "value": "base-uri 'self';" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" }
       ]
     },
     {


### PR DESCRIPTION
This prevents content-type sniffing and enables CORB.

**User-Facing Changes**

None.

**Description**

This adds [X-Content-Type-Options: nosniff](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) to the website headers, which prevents client content sniffing and enables [CORB](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md). Vercel takes care of setting the Content-Type, and [their example configuration includes this header](https://vercel.com/docs/project-configuration). I'm not aware of anything in Studio that would be impacted by this today.