### PR TITLE
Persist desktop app state across refreshes

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 
 import {
   IDataSourceFactory,
@@ -92,13 +92,13 @@ export default function Root({
   // App url state in window.location will represent the user's current session state
   // better than the initial deep link so we prioritize the current window.location
   // url for startup state. This persists state across user-initiated refreshes.
-  const deepLinks = useMemo(() => {
+  const [deepLinks] = useState(() => {
     // We treat presence of the `ds` or `layoutId` params as indicative of active state.
     const windowUrl = new URL(window.location.href);
     const hasActiveURLState =
       windowUrl.searchParams.has("ds") || windowUrl.searchParams.has("layoutId");
     return hasActiveURLState ? [window.location.href] : desktopBridge.getDeepLinks();
-  }, []);
+  });
 
   return (
     <App

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -88,7 +88,17 @@ export default function Root({
   const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL!), []);
   const nativeAppMenu = useMemo(() => new NativeAppMenu(menuBridge), []);
   const nativeWindow = useMemo(() => new NativeWindow(desktopBridge), []);
-  const deepLinks = useMemo(() => desktopBridge.getDeepLinks(), []);
+
+  // App url state in window.location will represent the user's current session state
+  // better than the initial deep link so we prioritize the current window.location
+  // url for startup state. This persists state across user-initiated refreshes.
+  const deepLinks = useMemo(() => {
+    // We treat presence of the `ds` or `layoutId` params as indicative of active state.
+    const windowUrl = new URL(window.location.href);
+    const hasActiveURLState =
+      windowUrl.searchParams.has("ds") || windowUrl.searchParams.has("layoutId");
+    return hasActiveURLState ? [window.location.href] : desktopBridge.getDeepLinks();
+  }, []);
 
   return (
     <App

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -17,7 +17,6 @@ import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectio
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { PlayerCapabilities, PlayerPresence } from "@foxglove/studio-base/players/types";
 import { AppURLState, encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
-import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectCanSeek = (ctx: MessagePipelineContext) =>
   ctx.playerState.capabilities.includes(PlayerCapabilities.playbackControl);
@@ -68,13 +67,6 @@ export function useStateToURLSynchronization(): void {
   }, [playerPresence]);
 
   useEffect(() => {
-    // Electron has its own concept of what the app URL is. If we want to do anything
-    // here for desktop we'll need to find some other method of encoding the state
-    // like perhaps the URL hash.
-    if (isDesktopApp()) {
-      return;
-    }
-
     // Don't update url unless we have a stable player state and a selected source.
     if (!playerIsStableRef.current || !selectedSource) {
       return;

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -6,7 +6,6 @@ import { isEmpty, omitBy } from "lodash";
 
 import { fromRFC3339String, toRFC3339String, Time } from "@foxglove/rostime";
 import { LayoutID } from "@foxglove/studio-base/index";
-import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 export type AppURLState = {
   ds?: string;
@@ -56,10 +55,6 @@ export function encodeAppURLState(url: URL, urlState: AppURLState): URL {
  * @throws Error if URL parsing fails.
  */
 export function parseAppURLState(url: URL): AppURLState | undefined {
-  if (isDesktopApp() && url.protocol !== "foxglove:") {
-    throw Error("Unknown protocol.");
-  }
-
   const ds = url.searchParams.get("ds") ?? undefined;
   const layoutId = url.searchParams.get("layoutId");
   const timeString = url.searchParams.get("time");


### PR DESCRIPTION
**User-Facing Changes**
This improves state handling over refreshes for the desktop app.

**Description**
The approach here is to check on startup if we have parseable state in `window.location` and prioritize that over command line deep links since we will be updating the values in `window.location` dynamically in response to changes in data source, layout etc and thus this state should better represent the user's intentions for the session.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3044 