### PR TITLE
Fix stale messages in raw messages panel

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
@@ -191,6 +191,45 @@ describe("useMessageDataItem", () => {
     ]);
   });
 
+  it("clears previous messages on topic change", async () => {
+    const { result, rerender } = renderHook(
+      ({ path }) => useMessageDataItem(path, { historySize: 2 }),
+      {
+        initialProps: { path: "/topic.value" },
+        wrapper({ children }) {
+          return (
+            <MockCurrentLayoutProvider>
+              <MockMessagePipelineProvider
+                messages={fixtureMessages}
+                topics={topics}
+                datatypes={datatypes}
+              >
+                {children}
+              </MockMessagePipelineProvider>
+            </MockCurrentLayoutProvider>
+          );
+        },
+      },
+    );
+    expect(result.all).toEqual([
+      [],
+      [
+        {
+          messageEvent: fixtureMessages[1],
+          queriedData: [{ path: "/topic.value", value: 1 }],
+        },
+        {
+          messageEvent: fixtureMessages[2],
+          queriedData: [{ path: "/topic.value", value: 2 }],
+        },
+      ],
+    ]);
+
+    rerender({ path: "/other_topic" });
+
+    expect(result.current).toEqual([]);
+  });
+
   it("keeps a history", async () => {
     const { result } = renderHook(({ path }) => useMessageDataItem(path, { historySize: 2 }), {
       initialProps: { path: "/topic.value" },

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
@@ -32,6 +32,9 @@ type ReducedValue = {
 
   // The latest set of message events recevied to addMessages
   messageEvents: readonly Readonly<MessageEvent<unknown>>[];
+
+  // The path used to match these messages.
+  path: string;
 };
 
 /**
@@ -73,6 +76,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
         return {
           matches: reversed,
           messageEvents,
+          path,
         };
       }
 
@@ -80,6 +84,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
       return {
         matches: prevMatches.concat(reversed).slice(-historySize),
         messageEvents,
+        path,
       };
     },
     [cachedGetMessagePathDataItems, historySize, path],
@@ -91,6 +96,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
         return {
           matches: [],
           messageEvents: [],
+          path,
         };
       }
 
@@ -103,10 +109,13 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
         }
       }
 
-      if (newMatches.length > 0) {
+      // Return a new message set if we have new messages or this is a different path
+      // than the path used to fetch the previous set of messages.
+      if (newMatches.length > 0 || path !== prevValue.path) {
         return {
           matches: newMatches.slice(-historySize),
           messageEvents: prevValue.messageEvents,
+          path,
         };
       }
 

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
@@ -109,7 +109,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
         }
       }
 
-      // Return a new message set if we have new messages or this is a different path
+      // Return a new message set if we have matching messages or this is a different path
       // than the path used to fetch the previous set of messages.
       if (newMatches.length > 0 || path !== prevValue.path) {
         return {


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with stale messages being shown in the raw messages panel.

**Description**
The existing logic holds on to previous messages in the message reducer if it can't find any new messages but it doesn't check to see if those older messages correspond to the current topic. This adds some extra logic to store and compare paths and only use cached messages if the topic is the same.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3151 