### PR TITLE
MemoryCacheDataProvider: remove check for request range > readAheadBlocks

### DIFF
--- a/packages/studio-base/src/util/getNewConnection.ts
+++ b/packages/studio-base/src/util/getNewConnection.ts
@@ -54,12 +54,6 @@ function getNewConnectionWithExistingReadRequest({
   fileSize: number;
   continueDownloadingThreshold: number;
 }): Range | undefined {
-  // We have a requested range that we're trying to download.
-  if (readRequestRange.end - readRequestRange.start > cacheSize) {
-    // This should have been caught way earlier, but just as a sanity check.
-    throw new Error("Range exceeds cache size");
-  }
-
   // Get the parts of the requested range that have not been downloaded yet.
   const notDownloadedRanges = missingRanges(readRequestRange, downloadedRanges);
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where seeking in large files would occasionally crash.

**Description**
Fixes https://github.com/foxglove/studio/issues/3099

After some debugging, we believe this check to be incorrect. Some confusion results from the naming of the `cacheSize` variable, which in the case of MemoryCacheDataProvider is not a hard limit on the cache size, but a hint as to how much data to load with each request (the `cacheSize` variable ultimately comes from the MemoryCacheDataProvider's `_readAheadBlocks`). When the block sizes are large enough (for large files), `_readAheadBlocks` may be 1. However, depending on the data range requested by the player during `_tick()`, it is always possible for the request range to span 2 blocks if it falls near a block boundary.

This logic was also used in CachedFilelike, but that code path has a check that the read request length does not exceed its `_cacheSizeInBytes`.