### PR TITLE
Fix open dialog checkbox cutoff

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -170,9 +170,9 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
           content: {
             overflow: "hidden",
             // Keep a consistent height for the dialog so changing views does not change the height
-            height: 520,
             display: "flex",
             flexDirection: "column",
+            minHeight: 520,
             padding: theme.spacing.l1,
 
             "@media (max-height: 552px)": { overflowY: "auto" },


### PR DESCRIPTION
**User-Facing Changes**
This fixes an overflow issue in the open data source dialog.

**Description**
Currently we have a hardcoded height of 520 pixels for this dialog which is not enough to accommodate the content. Rather than set a fixed height, which is fragile. I think we can accomplish the same goal of having a visually stable layout through the steps of the dialog with a min-height.

<img width="807" alt="Screen Shot 2022-04-19 at 7 28 03 AM" src="https://user-images.githubusercontent.com/93935560/164003632-cebba7f4-2801-4be3-a6a9-2957870426e8.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3074 