### PR TITLE
Always show panel settings menu item in panel actions dropdown

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -97,6 +97,7 @@ export default function PanelSettings({
 
   useEffect(() => {
     if (selectedPanelId) {
+      setSettingsTree(undefined);
       addUpdateSubscriber(selectedPanelId, updateSubscriber);
       return () => removeUpdateSubscriber(selectedPanelId, updateSubscriber);
     } else {

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -127,7 +127,6 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         text: "Panel settings",
         onClick: openSettings,
         iconProps: { iconName: "SingleColumnEdit" },
-        disabled: !(panelContext?.hasSettings ?? false),
       },
       {
         key: "change-panel",


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the `panel settings` menu item in the panel actions dropdown.

**Description**
Currently we disable this menu item if we think the panel has no settings to offer. We don't offer any mechanism for extension panels to control this though and since we expect most panels will have some kind of settings to expose in the panel settings panel it makes sense to just enable this by default and have a a reasonable "no settings" state for the settings sidebar.

This also fixes an issue with clearing settings state on changing panel selection.

<img width="219" alt="Screen Shot 2022-04-19 at 7 51 46 AM" src="https://user-images.githubusercontent.com/93935560/164008187-1ddc4691-90cb-40ba-9e51-e79abf91ab91.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3192 