### PR TITLE
Wait until player is ready to seek to url time

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -127,7 +127,7 @@ describe("IterablePlayer", () => {
       // before initialize
       baseState,
       // start delay
-      { ...baseState, presence: PlayerPresence.PRESENT },
+      baseState,
       // startPlay
       { ...baseState, presence: PlayerPresence.PRESENT },
       // idle

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -239,7 +239,6 @@ export class IterablePlayer implements Player {
       this._setError(`Error initializing: ${error.message}`, error);
     }
 
-    this._presence = PlayerPresence.PRESENT;
     await this._emitState();
     if (!this._hasError) {
       this._setState("start-delay");
@@ -303,6 +302,7 @@ export class IterablePlayer implements Player {
 
     this._currentTime = stopTime;
     this._messages = messageEvents;
+    this._presence = PlayerPresence.PRESENT;
     await this._emitState();
     if (this._nextState) {
       return;


### PR DESCRIPTION
**User-Facing Changes**
This fixes seeking and url times for the experimental data platform player.

**Description**
Currently we try to seek to the time specified in the url before the new data platform player is ready and the seek is just discarded. The new logic here waits until the player is ready before seeking. This also requires changing the new player to not report presence of `PRESENT` until it enters the `start-play` state.

In general the order of operations on starting up a new instance of studio is complex. Maybe player presence is too coarse a tool to handle this correctly?

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3178 