### PR TITLE
Convert the map panel to the new settings interface.

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -157,6 +157,22 @@ export default function PanelSettings({
     <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
+        {panelInfo.help != undefined && (
+          <Stack paddingX={isSettingsTree ? 2 : 0}>
+            <Typography color="text.secondary">
+              See docs{" "}
+              <Link
+                onClick={() => {
+                  setHelpInfo({ title: panelInfo.type, content: panelInfo.help });
+                  openHelp();
+                }}
+              >
+                here
+              </Link>
+              .
+            </Typography>
+          </Stack>
+        )}
         <div>
           {settingsTree && <SettingsEditor settings={settingsTree} />}
           {!settingsTree && schema && (

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -157,22 +157,6 @@ export default function PanelSettings({
     <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
-        {panelInfo.help != undefined && (
-          <Stack paddingX={isSettingsTree ? 2 : 0}>
-            <Typography color="text.secondary">
-              See docs{" "}
-              <Link
-                onClick={() => {
-                  setHelpInfo({ title: panelInfo.type, content: panelInfo.help });
-                  openHelp();
-                }}
-              >
-                here
-              </Link>
-              .
-            </Typography>
-          </Stack>
-        )}
         <div>
           {settingsTree && <SettingsEditor settings={settingsTree} />}
           {!settingsTree && schema && (

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -19,6 +19,10 @@ export default {
 };
 
 const DefaultSettings: SettingsTreeNode = {
+  fields: {
+    firstRootField: { input: "string", label: "First Root Field" },
+    secondRootField: { input: "string", label: "Second Root Field" },
+  },
   children: {
     complex_inputs: {
       label: "Complex Inputs",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -32,28 +32,30 @@ export default function SettingsTreeEditor({
 
   return (
     <Stack fullHeight>
-      <StyledAppBar position="sticky" color="default" elevation={0}>
-        <TextField
-          onChange={(event) => setFilterText(event.target.value)}
-          value={filterText}
-          variant="filled"
-          fullWidth
-          placeholder="Filter by layer name"
-          InputProps={{
-            startAdornment: <SearchIcon fontSize="small" />,
-            endAdornment: filterText && (
-              <IconButton
-                size="small"
-                title="Clear search"
-                onClick={() => setFilterText("")}
-                edge="end"
-              >
-                <ClearIcon fontSize="small" />
-              </IconButton>
-            ),
-          }}
-        />
-      </StyledAppBar>
+      {settings.disableFilter !== true && (
+        <StyledAppBar position="sticky" color="default" elevation={0}>
+          <TextField
+            onChange={(event) => setFilterText(event.target.value)}
+            value={filterText}
+            variant="filled"
+            fullWidth
+            placeholder="Filter"
+            InputProps={{
+              startAdornment: <SearchIcon fontSize="small" />,
+              endAdornment: filterText && (
+                <IconButton
+                  size="small"
+                  title="Clear search"
+                  onClick={() => setFilterText("")}
+                  edge="end"
+                >
+                  <ClearIcon fontSize="small" />
+                </IconButton>
+              ),
+            }}
+          />
+        </StyledAppBar>
+      )}
       <List dense disablePadding>
         <NodeEditor path={ROOT_PATH} settings={settings.settings} actionHandler={actionHandler} />
       </List>

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -51,6 +51,19 @@ export type SettingsTreeAction = {
  * a default user interface in Studio.
  */
 export type SettingsTree = {
+  /**
+   * Handler to process all actions on the settings tree initiated by the UI.
+   */
   actionHandler: (action: SettingsTreeAction) => void;
+
+  /**
+   * True if the editor should not show the filter control.
+   */
+  disableFilter?: boolean;
+
+  /**
+   * The actual settings tree. Updates to this will automatically be reflected in the
+   * editor UI.
+   */
   settings: SettingsTreeNode;
 };

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -2,28 +2,29 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import escapeHTML from "escape-html";
 import {
   Map as LeafMap,
   TileLayer,
-  Control,
   LatLngBounds,
   CircleMarker,
   FeatureGroup,
-  LayersControlEvent,
   LayerGroup,
   geoJSON,
   Layer,
 } from "leaflet";
-import { minBy, partition } from "lodash";
+import { difference, minBy, partition, transform, xor } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
-import { useLatest } from "react-use";
 import { useDebouncedCallback } from "use-debounce";
 
 import { toSec } from "@foxglove/rostime";
 import { PanelExtensionContext, MessageEvent } from "@foxglove/studio";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import {
+  SettingsTreeAction,
+  SettingsTreeFields,
+  SettingsTreeNode,
+} from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import FilteredPointLayer, {
   POINT_MARKER_RADIUS,
 } from "@foxglove/studio-base/panels/Map/FilteredPointLayer";
@@ -36,8 +37,9 @@ import { MapPanelMessage, Point } from "./types";
 
 // Persisted panel state
 type Config = {
+  disabledTopics: string[];
+  layer: string;
   zoomLevel?: number;
-  disabledTopics?: [];
 };
 
 type MapPanelProps = {
@@ -52,6 +54,38 @@ function isGeoJSONMessage(
     message.message != undefined &&
     "geojson" in message.message
   );
+}
+
+function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTreeNode {
+  const topics: SettingsTreeFields = transform(
+    eligibleTopics,
+    (result, topic) => {
+      result[topic] = {
+        label: topic,
+        input: "boolean",
+        value: !config.disabledTopics.includes(topic),
+      };
+    },
+    {} as SettingsTreeFields,
+  );
+
+  return {
+    label: "General",
+    fields: {
+      layer: {
+        label: "Layer",
+        input: "select",
+        value: config.layer,
+        options: ["map", "satellite"],
+      },
+    },
+    children: {
+      topics: {
+        label: "Topics",
+        fields: topics,
+      },
+    },
+  };
 }
 
 function topicMessageType(topic: Topic) {
@@ -76,7 +110,32 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const mapContainerRef = useRef<HTMLDivElement>(ReactNull);
 
-  const [config] = useState<Config>(props.context.initialState as Config);
+  const [config, setConfig] = useState<Config>(() => {
+    const initialConfig = props.context.initialState as Partial<Config>;
+    initialConfig.disabledTopics = initialConfig.disabledTopics ?? [];
+    initialConfig.layer = initialConfig.layer ?? "map";
+    return initialConfig as Config;
+  });
+
+  const [tileLayer] = useState(
+    new TileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+      maxNativeZoom: 18,
+      maxZoom: 24,
+    }),
+  );
+
+  const [satelliteLayer] = useState(
+    new TileLayer(
+      "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      {
+        attribution:
+          "&copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+        maxNativeZoom: 18,
+        maxZoom: 24,
+      },
+    ),
+  );
 
   // Panel state management to update our set of messages
   // We use state to trigger a render on the panel
@@ -95,12 +154,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   // Panel state management to track the list of available topics
   const [topics, setTopics] = useState<readonly Topic[]>([]);
-
-  // Disabled topics is the set of topics the user has unchecked in the layer control
-  // Track disabled topics rather than enabled so any new topics display by default
-  const [disabledTopics, setDisabledTopics] = useState(
-    () => new Set<string>(config.disabledTopics),
-  );
 
   // Panel state management to track the current preview time
   const [previewTime, setPreviewTime] = useState<number | undefined>();
@@ -128,14 +181,49 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     return topics.filter(topicMessageType).map((topic) => topic.name);
   }, [topics]);
 
+  const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.payload.path[0] === "topics") {
+      const topic = action.payload.path[1];
+      if (topic) {
+        setConfig((oldConfig) => {
+          return { ...oldConfig, disabledTopics: xor(oldConfig.disabledTopics, [topic]) };
+        });
+      }
+    }
+    if (action.payload.path[0] === "layer") {
+      setConfig((oldConfig) => {
+        return { ...oldConfig, layer: String(action.payload.value ?? "map") };
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (config.layer === "map") {
+      currentMap?.addLayer(tileLayer);
+      currentMap?.removeLayer(satelliteLayer);
+    } else {
+      currentMap?.addLayer(satelliteLayer);
+      currentMap?.removeLayer(tileLayer);
+    }
+  }, [config.layer, currentMap, satelliteLayer, tileLayer]);
+
   // Subscribe to eligible and enabled topics
   useEffect(() => {
-    const eligibleEnabled = eligibleTopics.filter((topic) => !disabledTopics.has(topic));
+    const eligibleEnabled = difference(eligibleTopics, config.disabledTopics);
     context.subscribe(eligibleEnabled);
+
+    const tree = buildSettingsTree(config, eligibleTopics);
+    // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
+    (context as unknown as any).__updatePanelSettingsTree({
+      actionHandler: settingsActionHandler,
+      disableFilter: true,
+      settings: tree,
+    });
+
     return () => {
       context.unsubscribeAll();
     };
-  }, [context, disabledTopics, eligibleTopics]);
+  }, [config, context, eligibleTopics, settingsActionHandler]);
 
   type TopicGroups = {
     baseColor: string;
@@ -164,12 +252,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     return topicLayerMap;
   }, [eligibleTopics]);
 
-  // layer controls for user selection between map, satellite and topics
-  const layerControl = useMemo(() => new Control.Layers(), []);
-
-  // toggling layers changes the disabledTopics list, but we don't want to re-run this effect
-  // because the layer controls have already updated the map with active/inactive layers
-  const disabledTopicsLatest = useLatest(disabledTopics);
   useLayoutEffect(() => {
     if (!currentMap) {
       return;
@@ -177,24 +259,18 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
     const topicLayerEntries = [...topicLayers.entries()];
     for (const [topic, featureGroups] of topicLayerEntries) {
-      layerControl.addOverlay(
-        featureGroups.topicGroup,
-        `<span style="color: ${featureGroups.baseColor}">${escapeHTML(topic)}</span>`,
-      );
-
       // if the topic does not appear in the disabled topics list, add to map so it displays
-      if (!disabledTopicsLatest.current.has(topic)) {
+      if (!config.disabledTopics.includes(topic)) {
         currentMap.addLayer(featureGroups.topicGroup);
       }
     }
 
     return () => {
       for (const [_topic, featureGroups] of topicLayerEntries) {
-        layerControl.removeLayer(featureGroups.topicGroup);
         currentMap.removeLayer(featureGroups.topicGroup);
       }
     };
-  }, [currentMap, disabledTopicsLatest, layerControl, topicLayers]);
+  }, [config.disabledTopics, currentMap, topicLayers]);
 
   // During the initial mount we setup our context render handler
   useLayoutEffect(() => {
@@ -202,35 +278,10 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       return;
     }
 
-    const tileLayer = new TileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-      maxNativeZoom: 18,
-      maxZoom: 24,
-    });
-
-    const satelliteLayer = new TileLayer(
-      "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
-      {
-        attribution:
-          "&copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
-        maxNativeZoom: 18,
-        maxZoom: 24,
-      },
-    );
-
-    const map = new LeafMap(mapContainerRef.current, {
-      // sets the tile layer as the default
-      layers: [tileLayer],
-    });
+    const map = new LeafMap(mapContainerRef.current);
 
     // the map must be initialized with some view before other features work
     map.setView([0, 0], 10);
-
-    // layer controls for user selection between satellite and map
-    layerControl.addBaseLayer(tileLayer, "map");
-    layerControl.addBaseLayer(satelliteLayer, "satellite");
-    layerControl.setPosition("topleft");
-    layerControl.addTo(map);
 
     setCurrentMap(map);
 
@@ -239,30 +290,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     context.watch("currentFrame");
     context.watch("allFrames");
     context.watch("previewTime");
-
-    // layer is added (checked) - remove from disabled list
-    map.on("overlayadd", (ev: LayersControlEvent) => {
-      const topic = ev.name;
-      setDisabledTopics((prevDisabled) => {
-        if (!prevDisabled.has(topic)) {
-          return prevDisabled;
-        }
-        prevDisabled.delete(topic);
-        return new Set(prevDisabled);
-      });
-    });
-
-    // layer is removed (unckecked) - add to disabled topics list
-    map.on("overlayremove", (ev: LayersControlEvent) => {
-      const topic = ev.name;
-      setDisabledTopics((prevDisabled) => {
-        if (prevDisabled.has(topic)) {
-          return prevDisabled;
-        }
-        prevDisabled.add(topic);
-        return new Set(prevDisabled);
-      });
-    });
 
     // The render event handler updates the state for our messages an triggers a component render
     //
@@ -290,7 +317,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       map.remove();
       context.onRender = undefined;
     };
-  }, [context, layerControl]);
+  }, [context]);
 
   const onHover = useCallback(
     (messageEvent?: MessageEvent<unknown>) => {
@@ -490,10 +517,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   }, [context, currentMap]);
 
   useEffect(() => {
-    context.saveState({
-      disabledTopics: Array.from(disabledTopics),
-    });
-  }, [context, disabledTopics]);
+    context.saveState(config);
+  }, [context, config]);
 
   // we don't want to invoke filtering on every user map move so we rate limit to 100ms
   const moveHandler = useDebouncedCallback(

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -12,7 +12,7 @@ import {
   geoJSON,
   Layer,
 } from "leaflet";
-import { difference, minBy, partition, transform, xor } from "lodash";
+import { difference, minBy, partition, transform, union } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useDebouncedCallback } from "use-debounce";
@@ -182,17 +182,26 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   }, [topics]);
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
-    if (action.payload.path[0] === "topics") {
-      const topic = action.payload.path[1];
+    const { path, input, value } = action.payload;
+
+    if (path[0] === "topics" && input === "boolean") {
+      const topic = path[1];
       if (topic) {
         setConfig((oldConfig) => {
-          return { ...oldConfig, disabledTopics: xor(oldConfig.disabledTopics, [topic]) };
+          return {
+            ...oldConfig,
+            disabledTopics:
+              value === true
+                ? difference(oldConfig.disabledTopics, [topic])
+                : union(oldConfig.disabledTopics, [topic]),
+          };
         });
       }
     }
-    if (action.payload.path[0] === "layer") {
+
+    if (path[0] === "layer" && input === "select") {
       setConfig((oldConfig) => {
-        return { ...oldConfig, layer: String(action.payload.value ?? "map") };
+        return { ...oldConfig, layer: value ?? "map" };
       });
     }
   }, []);

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -41,6 +41,7 @@ type Config = {
 
 function buildSettingsTree(config: Config, topics: readonly Topic[]): SettingsTreeNode {
   return {
+    label: "General",
     fields: {
       publishRate: { label: "Publish Rate", input: "number", value: config.publishRate },
       topic: {
@@ -181,8 +182,9 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
     const tree = buildSettingsTree(config, topics);
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
-      settings: tree,
       actionHandler: settingsActionHandler,
+      disableFilter: true,
+      settings: tree,
     });
     saveState(config);
   }, [config, context, saveState, settingsActionHandler, topics]);


### PR DESCRIPTION
**User-Facing Changes**
Converts the map panel to the new settings interface.

**Description**
This replaces the custom layers and topics control in the map panel with our new settings UI. Things like map vs satellite view and enabled and disabled topics are now controlled in our standard settings UI in the panel settings sidebar.

<img width="680" alt="Screen Shot 2022-04-20 at 12 37 01 PM" src="https://user-images.githubusercontent.com/93935560/164289973-e35ac588-e0d7-4d1d-8b7e-32c317fc4212.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
