### PR TITLE
Use the basename from node playground scripts in the editor

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/Editor.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Editor.tsx
@@ -15,6 +15,7 @@ import { useTheme } from "@fluentui/react";
 import * as monacoApi from "monaco-editor/esm/vs/editor/editor.api";
 // @ts-expect-error StaticServices does not have type information in the monaco-editor package
 import { StaticServices } from "monaco-editor/esm/vs/editor/standalone/browser/standaloneServices";
+import * as path from "path";
 import { ReactElement, useCallback, useRef } from "react";
 import MonacoEditor, { EditorDidMount, EditorWillMount } from "react-monaco-editor";
 import { useResizeDetector } from "react-resize-detector";
@@ -23,6 +24,7 @@ import getPrettifiedCode from "@foxglove/studio-base/panels/NodePlayground/getPr
 import { Script } from "@foxglove/studio-base/panels/NodePlayground/script";
 import { getNodeProjectConfig } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/projectConfig";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
+import { DEFAULT_STUDIO_NODE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
 import { themes } from "./theme";
@@ -148,7 +150,13 @@ const Editor = ({
     if (!editor || !script) {
       return;
     }
-    const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
+
+    // For nodes, the name becomes the filePath.
+    // For the editor to resolve relative imports of the utilities (i.e. ./types), we need the
+    // user's code to be in a file next to the utility files. For this we grab the basename
+    // of the user's entered node name to remove any path-like sections.
+    const basename = path.basename(script.filePath);
+    const filePath = monacoApi.Uri.parse(`file://${DEFAULT_STUDIO_NODE_PREFIX}${basename}`);
     const model =
       monacoApi.editor.getModel(filePath) ??
       monacoApi.editor.createModel(script.code, "typescript", filePath);
@@ -231,7 +239,12 @@ const Editor = ({
         model.updateOptions({ tabSize: 2 });
       });
 
-      const filePath = monacoApi.Uri.parse(`file://${script.filePath}`);
+      // For nodes, the name becomes the filePath.
+      // For the editor to resolve relative imports of the utilities (i.e. ./types), we need the
+      // user's code to be in a file next to the utility files. For this we grab the basename
+      // of the user's entered node name to remove any path-like sections.
+      const basename = path.basename(script.filePath);
+      const filePath = monacoApi.Uri.parse(`file://${DEFAULT_STUDIO_NODE_PREFIX}${basename}`);
       const model =
         monaco.editor.getModel(filePath) ??
         monaco.editor.createModel(script.code, "typescript", filePath);

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -36,7 +36,6 @@ import BottomBar from "@foxglove/studio-base/panels/NodePlayground/BottomBar";
 import Sidebar from "@foxglove/studio-base/panels/NodePlayground/Sidebar";
 import Playground from "@foxglove/studio-base/panels/NodePlayground/playground-icon.svg";
 import { PanelConfigSchema, UserNodes } from "@foxglove/studio-base/types/panels";
-import { DEFAULT_STUDIO_NODE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import Config from "./Config";
@@ -217,7 +216,7 @@ function NodePlayground(props: Props) {
       setUserNodes({
         [newNodeId]: {
           sourceCode,
-          name: `${DEFAULT_STUDIO_NODE_PREFIX}${newNodeId.split("-")[0]}`,
+          name: `${newNodeId.split("-")[0]}`,
         },
       });
       saveConfig({ selectedNodeId: newNodeId });


### PR DESCRIPTION


**User-Facing Changes**
User can name their node playground nodes whatever they want; they no longer need to keep the `/studio_node/` prefix in their name.

**Description**
The editor uses the script filePath to resolve additional imports. When a user renames their node and removes the /studio_node/ prefix, it causes the relative path of the file to change.

To allow users to name their node whatever they want, we use only the basename of the path and manually prefix the /studio_node/ path since this is an internal implementation detail.

This change also removes the /studio_node/ prefix from new node names since it is no longer a requirement to have this prefix.

Fixes: #3148

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
