### PR TITLE
Add a validate property to IDataSourceFactory formConfig fields

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/FormField.tsx
+++ b/packages/studio-base/src/components/OpenDialog/FormField.tsx
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { TextField } from "@fluentui/react";
+import { useState } from "react";
+
+import { Field } from "@foxglove/studio-base/context/PlayerSelectionContext";
+
+type Props = {
+  disabled: boolean;
+  field: Field;
+  onChange: (newValue: string | undefined) => void;
+  onError: (message: string) => void;
+};
+
+export function FormField(props: Props): JSX.Element {
+  const [error, setError] = useState<string | undefined>();
+  const field = props.field;
+
+  const onChange = (_: unknown, newValue: string | undefined) => {
+    setError(undefined);
+
+    if (newValue != undefined) {
+      const maybeError = field.validate?.(newValue);
+      if (maybeError instanceof Error) {
+        setError(maybeError.message);
+        props.onError(maybeError.message);
+        return;
+      }
+    }
+
+    props.onChange(newValue ?? field.defaultValue);
+  };
+
+  return (
+    <TextField
+      disabled={props.disabled}
+      key={field.label}
+      label={field.label}
+      errorMessage={error}
+      description={field.description}
+      placeholder={field.placeholder}
+      defaultValue={field.defaultValue}
+      onChange={onChange}
+    />
+  );
+}

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -20,6 +20,22 @@ export type DataSourceFactoryInitializeArgs = {
 
 export type DataSourceFactoryType = "file" | "remote-file" | "connection" | "sample";
 
+export type Field = {
+  id: string;
+  label: string;
+  defaultValue?: string;
+  placeholder?: string;
+  description?: string;
+
+  /**
+   * Optional validate function
+   *
+   * The function is called with a value and can return an Error if the value should
+   * be rejected. If the function returns `undefined`, then the value is accepted.
+   */
+  validate?: (value: string) => Error | undefined;
+};
+
 export interface IDataSourceFactory {
   id: string;
   type: DataSourceFactoryType;
@@ -35,13 +51,7 @@ export interface IDataSourceFactory {
 
   formConfig?: {
     // Initialization args are populated with keys of the _id_ field
-    fields: {
-      id: string;
-      label: string;
-      defaultValue?: string;
-      placeholder?: string;
-      description?: string;
-    }[];
+    fields: Field[];
   };
 
   // If data source initialization supports "Open File" workflow, this property lists the supported

--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -19,7 +19,24 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   docsLink = "https://foxglove.dev/docs/studio/connection/foxglove-websocket";
 
   formConfig = {
-    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:8765" }],
+    fields: [
+      {
+        id: "url",
+        label: "WebSocket URL",
+        defaultValue: "ws://localhost:8765",
+        validate: (newValue: string): Error | undefined => {
+          try {
+            const url = new URL(newValue);
+            if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+              return new Error(`Invalid protocol: ${url.protocol}`);
+            }
+            return undefined;
+          } catch (err) {
+            return new Error("Enter a valid url");
+          }
+        },
+      },
+    ],
   };
 
   initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {

--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -19,7 +19,24 @@ class RosbridgeDataSourceFactory implements IDataSourceFactory {
     "Connect to a running ROS 1 or ROS 2 system over WebSockets using the rosbridge_suite package.";
 
   formConfig = {
-    fields: [{ id: "url", label: "WebSocket URL", defaultValue: "ws://localhost:9090" }],
+    fields: [
+      {
+        id: "url",
+        label: "WebSocket URL",
+        defaultValue: "ws://localhost:9090",
+        validate: (newValue: string): Error | undefined => {
+          try {
+            const url = new URL(newValue);
+            if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+              return new Error(`Invalid protocol: ${url.protocol}`);
+            }
+            return undefined;
+          } catch (err) {
+            return new Error("Enter a valid url");
+          }
+        },
+      },
+    ],
   };
 
   initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {


### PR DESCRIPTION

**User-Facing Changes**

Rather than receive errors for an invalid url format after clicking "open" in the connection dialog, the user is shown an error under the text field and prevented from clicking "open" until they resolve the issue.

<img width="818" alt="Screen Shot 2022-04-20 at 1 49 27 PM" src="https://user-images.githubusercontent.com/84792/164320468-7205a596-7f3e-46b4-bc95-fdd0443a885a.png">
<img width="816" alt="Screen Shot 2022-04-20 at 1 49 17 PM" src="https://user-images.githubusercontent.com/84792/164320474-e3b11f42-09ea-466a-94fe-9f8674f58633.png">
<img width="828" alt="Screen Shot 2022-04-20 at 1 49 08 PM" src="https://user-images.githubusercontent.com/84792/164320477-552dce34-ff81-4d8f-9cc0-250508fc7703.png">



**Description**
A data source factory can provide a validate function for each field. The validate function allows the factory to intercept new values and return an error if the value for the field is not valid. The open dialog uses this to determine whether to show an error for the field or allow the user to click the "open" button.

Fixes: #3203

----

Not sold on my approach with `setFieldErrors` and `setFieldValues` but maybe this is an ok solution for now since it is internal. The `validate` property for formConfig fields is arbitrary but served this specific goal.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
