### PR TITLE
Convert the image panel to use the new settings editor

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -17,7 +17,6 @@ import {
   useCurrentLayoutSelector,
   useSelectedPanels,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useHelpInfo } from "@foxglove/studio-base/context/HelpInfoContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import {
   ImmutableSettingsTree,
@@ -40,7 +39,7 @@ export default function PanelSettings({
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
   const { selectedPanelIds: originalSelectedPanelIds, setSelectedPanelIds } = useSelectedPanels();
   const selectedPanelIds = selectedPanelIdsForTests ?? originalSelectedPanelIds;
-  const { openLayoutBrowser, openHelp } = useWorkspace();
+  const { openLayoutBrowser } = useWorkspace();
   const selectedPanelId = useMemo(
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),
     [selectedPanelIds],
@@ -62,7 +61,6 @@ export default function PanelSettings({
     () => (panelType != undefined ? panelCatalog.getPanelByType(panelType) : undefined),
     [panelCatalog, panelType],
   );
-  const { setHelpInfo } = useHelpInfo();
 
   const [showShareModal, setShowShareModal] = useState(false);
   const shareModal = useMemo(() => {
@@ -157,22 +155,6 @@ export default function PanelSettings({
     <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
-        {panelInfo.help != undefined && (
-          <Stack paddingX={isSettingsTree ? 2 : 0}>
-            <Typography color="text.secondary">
-              See docs{" "}
-              <Link
-                onClick={() => {
-                  setHelpInfo({ title: panelInfo.type, content: panelInfo.help });
-                  openHelp();
-                }}
-              >
-                here
-              </Link>
-              .
-            </Typography>
-          </Stack>
-        )}
         <div>
           {settingsTree && <SettingsEditor settings={settingsTree} />}
           {!settingsTree && schema && (

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -157,6 +157,22 @@ export default function PanelSettings({
     <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
+        {panelInfo.help != undefined && (
+          <Stack paddingX={isSettingsTree ? 2 : 0}>
+            <Typography color="text.secondary">
+              See docs{" "}
+              <Link
+                onClick={() => {
+                  setHelpInfo({ title: panelInfo.type, content: panelInfo.help });
+                  openHelp();
+                }}
+              >
+                here
+              </Link>
+              .
+            </Typography>
+          </Stack>
+        )}
         <div>
           {settingsTree && <SettingsEditor settings={settingsTree} />}
           {!settingsTree && schema && (

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -157,22 +157,6 @@ export default function PanelSettings({
     <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
-        {panelInfo.help != undefined && (
-          <Stack paddingX={isSettingsTree ? 2 : 0}>
-            <Typography color="text.secondary">
-              See docs{" "}
-              <Link
-                onClick={() => {
-                  setHelpInfo({ title: panelInfo.type, content: panelInfo.help });
-                  openHelp();
-                }}
-              >
-                here
-              </Link>
-              .
-            </Typography>
-          </Stack>
-        )}
         <div>
           {settingsTree && <SettingsEditor settings={settingsTree} />}
           {!settingsTree && schema && (

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -284,10 +284,12 @@ function FieldEditorComponent({
   field: DeepReadonly<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
+  const indent = Math.min(path.length, 4);
+
   return (
     <>
-      <div /> {/* Spacer for left column */}
-      <Stack direction="row" alignItems="center">
+      <div style={{ gridColumn: `span ${indent}` }} />
+      <Stack direction="row" alignItems="center" style={{ gridColumn: `span ${9 - indent}` }}>
         <Typography
           title={field.label}
           variant="subtitle2"

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -17,6 +17,7 @@ import {
   TextField,
   IconButton,
   ListProps,
+  useTheme,
 } from "@mui/material";
 import { DeepReadonly } from "ts-essentials";
 
@@ -284,12 +285,16 @@ function FieldEditorComponent({
   field: DeepReadonly<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
+  const theme = useTheme();
   const indent = Math.min(path.length, 4);
 
   return (
     <>
-      <div style={{ gridColumn: `span ${indent}` }} />
-      <Stack direction="row" alignItems="center" style={{ gridColumn: `span ${9 - indent}` }}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        style={{ paddingLeft: theme.spacing(2 * Math.max(2, indent)) }}
+      >
         <Typography
           title={field.label}
           variant="subtitle2"
@@ -305,7 +310,7 @@ function FieldEditorComponent({
           </IconButton>
         )}
       </Stack>
-      <div>
+      <div style={{ paddingRight: theme.spacing(2) }}>
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
       </div>
     </>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -262,9 +262,9 @@ function FieldInput({
           }
           MenuProps={{ MenuListProps: { dense: true } }}
         >
-          {field.options.map((opt) => (
-            <MenuItem key={opt} value={opt}>
-              {opt}
+          {field.options.map(({ label, value }) => (
+            <MenuItem key={value} value={value}>
+              {label}
             </MenuItem>
           ))}
         </Select>
@@ -287,14 +287,11 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
+  const paddingLeft = theme.spacing(2 + 2 * Math.max(0, indent - 1));
 
   return (
     <>
-      <Stack
-        direction="row"
-        alignItems="center"
-        style={{ paddingLeft: theme.spacing(2 * Math.max(2, indent)) }}
-      >
+      <Stack direction="row" alignItems="center" style={{ paddingLeft }}>
         <Typography
           title={field.label}
           variant="subtitle2"

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -6,21 +6,9 @@ import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import LayerIcon from "@mui/icons-material/Layers";
 import SettingsIcon from "@mui/icons-material/Settings";
-import {
-  Collapse,
-  Divider,
-  ListItem,
-  ListItemButton,
-  ListItemButtonProps,
-  ListItemIcon,
-  ListItemProps,
-  ListItemText,
-  styled as muiStyled,
-} from "@mui/material";
+import { Collapse, Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
 import { ChangeEvent, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
-
-import Stack from "@foxglove/studio-base/components/Stack";
 
 import { FieldEditor } from "./FieldEditor";
 import { VisibilityToggle } from "./VisibilityToggle";
@@ -33,83 +21,47 @@ export type NodeEditorProps = {
   divider?: ListItemProps["divider"];
   group?: string;
   icon?: JSX.Element;
-  onClick?: ListItemButtonProps["onClick"];
   path: readonly string[];
-  secondaryAction?: ListItemProps["secondaryAction"];
   settings?: DeepReadonly<SettingsTreeNode>;
   updateSettings?: (path: readonly string[], value: unknown) => void;
 };
 
-const StyledListItem = muiStyled(ListItem, {
-  shouldForwardProp: (prop) => prop !== "visible" && prop !== "indent",
-})<{
-  visible: boolean;
-  indent: number;
-}>(({ theme, visible, indent = 0 }) => ({
-  ".MuiListItemButton-root": {
-    paddingLeft: indent === 3 ? theme.spacing(3.5) : theme.spacing(0.5),
-    gap: theme.spacing(1),
-  },
-  ".MuiListItemIcon-root": {
-    minWidth: theme.spacing(5),
-    opacity: visible ? 0.6 : 0.3,
-    display: "flex",
-    justifyContent: "flex-end",
-  },
-  "&:hover": {
-    outline: `1px solid ${theme.palette.primary.main}`,
-    outlineOffset: -1,
-
-    ".MuiListItemIcon-root": {
-      opacity: visible ? 1 : 0.8,
-    },
-  },
-  ...(visible && {
-    "@media (pointer: fine)": {
-      ".MuiListItemSecondaryAction-root": {
-        visibility: "hidden",
-      },
-      "&:hover": {
-        ".MuiListItemSecondaryAction-root": {
-          visibility: "visible",
-        },
-      },
-    },
-  }),
-}));
-
+// We use a 20 cell CSS grid to layout elements. The outer two cells create
+// padding and the inner cells are used to indent nodes at various depths
+// in the tree.
 const LayerOptions = muiStyled("div", {
   shouldForwardProp: (prop) => prop !== "visible" && prop !== "indent",
 })<{
   visible: boolean;
   indent: number;
-}>(({ theme, visible, indent = 0 }) => ({
+}>(({ theme, visible }) => ({
   display: "grid",
-  gridTemplateColumns: [
-    `minmax(0, ${(indent === 3 && theme.spacing(9)) || theme.spacing(6)})`,
-    "minmax(128px, 1fr)",
-    "minmax(128px, 1fr)",
-  ].join(" "),
-  // gridAutoRows: 30,
-  padding: theme.spacing(0.5, 1.5, 1, 0.5),
+  gridTemplateColumns: `${theme.spacing(
+    1,
+  )} repeat(8, minmax(0, 1fr)) minmax(0, 10fr) ${theme.spacing(1)}`,
+  padding: theme.spacing(1, 0, 1, 0),
   columnGap: theme.spacing(0.5),
   rowGap: theme.spacing(0.25),
   alignItems: "center",
   opacity: visible ? 1 : 0.6,
 }));
 
+const NodeHeader = muiStyled("div")(({ theme }) => {
+  return {
+    display: "grid",
+    gridTemplateColumns: `${theme.spacing(1)} repeat(18, minmax(0, 1fr)) ${theme.spacing(1)}`,
+    "&:hover": {
+      outline: `1px solid ${theme.palette.primary.main}`,
+      outlineOffset: -1,
+    },
+    paddingRight: theme.spacing(1.5),
+  };
+});
+
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
-  const {
-    actionHandler,
-    defaultOpen = true,
-    disableIcon = false,
-    icon,
-    onClick = () => {},
-    secondaryAction,
-    settings = {},
-  } = props;
-  const [open, setOpen] = useState<boolean>(defaultOpen);
-  const [visible, setVisiblity] = useState<boolean>(true);
+  const { actionHandler, defaultOpen = true, disableIcon = false, icon, settings = {} } = props;
+  const [open, setOpen] = useState(defaultOpen);
+  const [visible, setVisiblity] = useState(true);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setVisiblity(event.target.checked);
@@ -142,52 +94,44 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
-  const indent: number = props.path.length;
+  const indent = props.path.length;
 
   return (
     <>
-      {(indent > 0 || fieldEditors.length > 0) && (
-        <StyledListItem
-          indent={indent}
-          visible={visible}
-          secondaryAction={
-            <Stack direction="row" gap={0.5} alignItems="center">
-              {secondaryAction}
-              <VisibilityToggle edge="end" size="small" checked={visible} onChange={handleChange} />
-            </Stack>
-          }
-          disablePadding
-        >
-          <ListItemButton
-            onClick={(event) => {
-              if (hasProperties) {
-                setOpen(!open);
-              } else {
-                onClick(event);
-              }
+      {indent > 0 && (
+        <NodeHeader>
+          <div style={{ gridColumn: `span ${indent}` }} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              cursor: "pointer",
+              gridColumn: `span ${18 - indent}`,
+              userSelect: "none",
             }}
+            onClick={() => setOpen((oldOpen) => !oldOpen)}
           >
-            <ListItemIcon>
+            <div
+              style={{
+                display: "inline-flex",
+                opacity: visible ? 0.6 : 0.3,
+                marginRight: "0.25rem",
+              }}
+            >
               {hasProperties && <>{open ? <ArrowDownIcon /> : <ArrowRightIcon />}</>}
               {!disableIcon &&
-                (icon != undefined ? (
-                  icon
-                ) : props.path.length > 0 ? (
-                  <LayerIcon />
-                ) : (
-                  <SettingsIcon />
-                ))}
-            </ListItemIcon>
-            <ListItemText
-              primary={settings.label ?? "Settings"}
-              primaryTypographyProps={{
-                noWrap: true,
-                variant: "subtitle2",
-                color: visible ? "text.primary" : "text.disabled",
-              }}
-            />
-          </ListItemButton>
-        </StyledListItem>
+                (icon != undefined ? icon : indent > 0 ? <LayerIcon /> : <SettingsIcon />)}
+            </div>
+            <Typography
+              noWrap={true}
+              variant="subtitle2"
+              color={visible ? "text.primary" : "text.disabled"}
+            >
+              {settings.label ?? "Settings"}
+            </Typography>
+          </div>
+          <VisibilityToggle edge="end" size="small" checked={visible} onChange={handleChange} />
+        </NodeHeader>
       )}
       <Collapse in={open}>
         {fieldEditors.length > 0 && (
@@ -195,9 +139,8 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
             {fieldEditors}
           </LayerOptions>
         )}
-        {indent !== 0 && childNodes}
+        {childNodes}
       </Collapse>
-      {indent === 0 && childNodes}
       {indent === 1 && <Divider />}
     </>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -7,6 +7,7 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import LayerIcon from "@mui/icons-material/Layers";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { Collapse, Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
+import { useTheme } from "@mui/material";
 import { ChangeEvent, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
@@ -26,19 +27,13 @@ export type NodeEditorProps = {
   updateSettings?: (path: readonly string[], value: unknown) => void;
 };
 
-// We use a 20 cell CSS grid to layout elements. The outer two cells create
-// padding and the inner cells are used to indent nodes at various depths
-// in the tree.
 const LayerOptions = muiStyled("div", {
   shouldForwardProp: (prop) => prop !== "visible" && prop !== "indent",
 })<{
   visible: boolean;
-  indent: number;
 }>(({ theme, visible }) => ({
   display: "grid",
-  gridTemplateColumns: `${theme.spacing(
-    1,
-  )} repeat(8, minmax(0, 1fr)) minmax(0, 10fr) ${theme.spacing(1)}`,
+  gridTemplateColumns: "minmax(0, 1fr)  minmax(0, 1.2fr)",
   padding: theme.spacing(1, 0, 1, 0),
   columnGap: theme.spacing(0.5),
   rowGap: theme.spacing(0.25),
@@ -48,13 +43,12 @@ const LayerOptions = muiStyled("div", {
 
 const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
-    display: "grid",
-    gridTemplateColumns: `${theme.spacing(1)} repeat(18, minmax(0, 1fr)) ${theme.spacing(1)}`,
+    display: "flex",
     "&:hover": {
       outline: `1px solid ${theme.palette.primary.main}`,
       outlineOffset: -1,
     },
-    paddingRight: theme.spacing(1.5),
+    paddingRight: theme.spacing(2.25),
   };
 });
 
@@ -94,20 +88,23 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
+  const theme = useTheme();
+
   const indent = props.path.length;
 
   return (
     <>
       {indent > 0 && (
         <NodeHeader>
-          <div style={{ gridColumn: `span ${indent}` }} />
+          <div />
           <div
             style={{
               display: "flex",
               alignItems: "center",
               cursor: "pointer",
-              gridColumn: `span ${18 - indent}`,
+              paddingLeft: theme.spacing(2 * Math.max(0.25, indent - 1)),
               userSelect: "none",
+              width: "100%",
             }}
             onClick={() => setOpen((oldOpen) => !oldOpen)}
           >
@@ -134,11 +131,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
         </NodeHeader>
       )}
       <Collapse in={open}>
-        {fieldEditors.length > 0 && (
-          <LayerOptions indent={indent} visible={visible}>
-            {fieldEditors}
-          </LayerOptions>
-        )}
+        {fieldEditors.length > 0 && <LayerOptions visible={visible}>{fieldEditors}</LayerOptions>}
         {childNodes}
       </Collapse>
       {indent === 1 && <Divider />}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -7,7 +7,6 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import LayerIcon from "@mui/icons-material/Layers";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { Collapse, Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
-import { useTheme } from "@mui/material";
 import { ChangeEvent, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
@@ -35,7 +34,7 @@ const LayerOptions = muiStyled("div", {
   display: "grid",
   gridTemplateColumns: "minmax(0, 1fr)  minmax(0, 1.2fr)",
   padding: theme.spacing(1, 0, 1, 0),
-  columnGap: theme.spacing(0.5),
+  columnGap: theme.spacing(1),
   rowGap: theme.spacing(0.25),
   alignItems: "center",
   opacity: visible ? 1 : 0.6,
@@ -49,6 +48,17 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
       outlineOffset: -1,
     },
     paddingRight: theme.spacing(2.25),
+  };
+});
+
+const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }) => {
+  return {
+    display: "flex",
+    alignItems: "center",
+    cursor: "pointer",
+    paddingLeft: theme.spacing(1.25 + 2 * Math.max(0, indent - 1)),
+    userSelect: "none",
+    width: "100%",
   };
 });
 
@@ -88,26 +98,13 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
-  const theme = useTheme();
-
   const indent = props.path.length;
 
   return (
     <>
       {indent > 0 && (
         <NodeHeader>
-          <div />
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              cursor: "pointer",
-              paddingLeft: theme.spacing(2 * Math.max(0.25, indent - 1)),
-              userSelect: "none",
-              width: "100%",
-            }}
-            onClick={() => setOpen((oldOpen) => !oldOpen)}
-          >
+          <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
             <div
               style={{
                 display: "inline-flex",
@@ -126,7 +123,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
             >
               {settings.label ?? "Settings"}
             </Typography>
-          </div>
+          </NodeHeaderToggle>
           <VisibilityToggle edge="end" size="small" checked={visible} onChange={handleChange} />
         </NodeHeader>
       )}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -76,10 +76,16 @@ For ROS users, we also support package:// URLs
           value: "Open Street Maps",
           input: "select",
           options: [
-            "Open Street Maps",
-            "Stadia Maps (Adelaide Smooth Light)",
-            "Stadia Maps (Adelaide Smooth Dark)",
-            "Custom",
+            { label: "Open Street Maps", value: "Open Street Maps" },
+            {
+              label: "Stadia Maps (Adelaide Smooth Light)",
+              value: "Stadia Maps (Adelaide Smooth Light)",
+            },
+            {
+              label: "Stadia Maps (Adelaide Smooth Dark)",
+              value: "Stadia Maps (Adelaide Smooth Dark)",
+            },
+            { label: "Custom", value: "Custom" },
           ],
         },
         api_key: {
@@ -162,7 +168,10 @@ For ROS users, we also support package:// URLs
               label: "Selection mode",
               value: "Line",
               input: "select",
-              options: ["Line", "Enclosed polygons"],
+              options: [
+                { value: "Line", label: "Line" },
+                { value: "Enclosed polygons", label: "Enclosed polygons" },
+              ],
               help: `Treating line markers as polygons. Clicking inside the lines in the
                 marker selects the marker. The default behavior for line markers requires the
                 user to click exactly on the line to select the line marker.

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -9,7 +9,11 @@ export type SettingsTreeFieldValue =
   | { input: "gradient"; value?: string }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
   | { input: "number"; value?: number; step?: number }
-  | { input: "select"; value?: string; options: Array<{ label: string; value: string }> }
+  | {
+      input: "select";
+      value?: string | number;
+      options: Array<{ label: string; value: string | number | undefined }>;
+    }
   | { input: "string"; value?: string }
   | { input: "toggle"; value?: string; options: string[] };
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -9,23 +9,24 @@ export type SettingsTreeFieldValue =
   | { input: "gradient"; value?: string }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
   | { input: "number"; value?: number; step?: number }
-  | { input: "select"; value?: string; options: string[] }
+  | { input: "select"; value?: string; options: Array<{ label: string; value: string }> }
   | { input: "string"; value?: string }
   | { input: "toggle"; value?: string; options: string[] };
 
 export type SettingsTreeField = SettingsTreeFieldValue & {
-  label: string;
   help?: string;
+  label: string;
   placeholder?: string;
 };
 
 export type SettingsTreeFields = Record<string, SettingsTreeField>;
+
 export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
 
 export type SettingsTreeNode = {
-  label?: string;
-  fields?: SettingsTreeFields;
   children?: SettingsTreeChildren;
+  fields?: SettingsTreeFields;
+  label?: string;
 };
 
 /**

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -11,8 +11,13 @@ export type SettingsTreeFieldValue =
   | { input: "number"; value?: number; step?: number }
   | {
       input: "select";
-      value?: string | number;
-      options: Array<{ label: string; value: string | number | undefined }>;
+      value?: number | readonly number[];
+      options: Array<{ label: string; value: undefined | number }>;
+    }
+  | {
+      input: "select";
+      value?: string | readonly string[];
+      options: Array<{ label: string; value: undefined | string }>;
     }
   | { input: "string"; value?: string }
   | { input: "toggle"; value?: string; options: string[] };

--- a/packages/studio-base/src/panels/ImageView/index.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.stories.tsx
@@ -5,7 +5,6 @@
 import { useRef } from "react";
 import TestUtils from "react-dom/test-utils";
 
-import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ImageView from "./index";
@@ -58,13 +57,3 @@ export const TopicButNoDataSourceHoveredLight = Object.assign(
   TopicButNoDataSourceHovered.bind(undefined),
   { parameters: { colorScheme: "light" } },
 );
-
-export function Settings(): JSX.Element {
-  return (
-    <SchemaEditor
-      configSchema={ImageView.configSchema!}
-      config={ImageView.defaultConfig}
-      saveConfig={() => {}}
-    />
-  );
-}

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -130,7 +130,7 @@ function buildSettingsTree(config: Config): SettingsTreeNode {
       rotation: {
         input: "select",
         label: "Rotation",
-        value: String(config.rotation ?? 0),
+        value: config.rotation ?? 0,
         options: [
           { label: "0°", value: 0 },
           { label: "90°", value: 90 },

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -16,15 +16,21 @@ import WavesIcon from "@mdi/svg/svg/waves.svg";
 import { Stack, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
-import { useEffect, useState, useMemo, useCallback, useRef } from "react";
+import { set } from "lodash";
+import { useEffect, useState, useMemo, useCallback, useRef, useContext } from "react";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import Icon from "@foxglove/studio-base/components/Icon";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import {
+  SettingsTreeAction,
+  SettingsTreeNode,
+} from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { PanelSettingsEditorContext } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
-import { PanelConfigSchema } from "@foxglove/studio-base/types/panels";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
@@ -96,6 +102,57 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+function buildSettingsTree(config: Config): SettingsTreeNode {
+  return {
+    label: "General",
+    fields: {
+      transformMarkers: {
+        input: "boolean",
+        label: "Synchronize Markers",
+        value: config.transformMarkers,
+      },
+      smooth: {
+        input: "boolean",
+        label: "Bilinear Smoothing",
+        value: config.smooth ?? false,
+      },
+      flipHorizontal: {
+        input: "boolean",
+        label: "Flip Horizontal",
+        value: config.flipHorizontal ?? false,
+      },
+      flipVertical: {
+        input: "boolean",
+        label: "Flip Vertical",
+        value: config.flipVertical ?? false,
+      },
+      rotation: {
+        input: "select",
+        label: "Rotation",
+        value: String(config.rotation ?? 0),
+        options: [
+          { label: "0°", value: "0" },
+          { label: "90°", value: "90" },
+          { label: "180°", value: "180" },
+          { label: "270°", value: "270" },
+        ],
+      },
+      minValue: {
+        input: "number",
+        label: "Minimum Value (depth images)",
+        placeholder: "0",
+        value: config.minValue,
+      },
+      maxValue: {
+        input: "number",
+        label: "Maximum Value (depth images)",
+        placeholder: "10000",
+        value: config.maxValue,
+      },
+    },
+  };
+}
+
 const BottomBar = ({ children }: { children?: React.ReactNode }) => {
   const classes = useStyles();
   return (
@@ -120,6 +177,8 @@ function ImageView(props: Props) {
     [cameraTopic, topics],
   );
   const [activePixelData, setActivePixelData] = useState<PixelData | undefined>();
+  const { updatePanelSettingsTree } = useContext(PanelSettingsEditorContext);
+  const { id: panelId } = usePanelContext();
 
   const allImageTopics = useMemo(() => {
     return topics.filter(({ datatype }) => NORMALIZABLE_IMAGE_DATATYPES.includes(datatype));
@@ -134,6 +193,23 @@ function ImageView(props: Props) {
       }
     }
   }, [allImageTopics, config, saveConfig]);
+
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      const newConfig = { ...config };
+      set(newConfig, action.payload.path, action.payload.value);
+      saveConfig(newConfig);
+    },
+    [config, saveConfig],
+  );
+
+  useEffect(() => {
+    updatePanelSettingsTree(panelId, {
+      actionHandler,
+      disableFilter: true,
+      settings: buildSettingsTree(config),
+    });
+  }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 
   const relatedAnnotationTopics = useMemo(
     () => getMarkerOptions(cameraTopic, topics, ANNOTATION_DATATYPES),
@@ -366,54 +442,9 @@ const defaultConfig: Config = {
   zoom: 1,
 };
 
-const configSchema: PanelConfigSchema<Config> = [
-  { key: "synchronize", type: "toggle", title: "Synchronize images and markers" },
-  {
-    key: "smooth",
-    type: "toggle",
-    title: "Bilinear smoothing",
-  },
-  {
-    key: "flipHorizontal",
-    type: "toggle",
-    title: "Flip horizontally",
-  },
-  {
-    key: "flipVertical",
-    type: "toggle",
-    title: "Flip vertically",
-  },
-  {
-    key: "rotation",
-    type: "dropdown",
-    title: "Rotation",
-    options: [
-      { value: 0, text: "0°" },
-      { value: 90, text: "90°" },
-      { value: 180, text: "180°" },
-      { value: 270, text: "270°" },
-    ],
-  },
-  {
-    key: "minValue",
-    type: "number",
-    title: "Minimum value (depth images)",
-    placeholder: "0",
-    allowEmpty: true,
-  },
-  {
-    key: "maxValue",
-    type: "number",
-    title: "Maximum value (depth images)",
-    placeholder: "10000",
-    allowEmpty: true,
-  },
-];
-
 export default Panel(
   Object.assign(ImageView, {
     panelType: "ImageViewPanel",
     defaultConfig,
-    configSchema,
   }),
 );

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -132,10 +132,10 @@ function buildSettingsTree(config: Config): SettingsTreeNode {
         label: "Rotation",
         value: String(config.rotation ?? 0),
         options: [
-          { label: "0°", value: "0" },
-          { label: "90°", value: "90" },
-          { label: "180°", value: "180" },
-          { label: "270°", value: "270" },
+          { label: "0°", value: 0 },
+          { label: "90°", value: 90 },
+          { label: "180°", value: 180 },
+          { label: "270°", value: 270 },
         ],
       },
       minValue: {
@@ -199,11 +199,7 @@ function ImageView(props: Props) {
     (action: SettingsTreeAction) => {
       saveConfig(
         produce(config, (draft) => {
-          const value =
-            action.payload.path[0] === "rotation"
-              ? Number(action.payload.value)
-              : action.payload.value;
-          set(draft, action.payload.path, value);
+          set(draft, action.payload.path, action.payload.value);
         }),
       );
     },

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -16,6 +16,7 @@ import WavesIcon from "@mdi/svg/svg/waves.svg";
 import { Stack, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
+import produce from "immer";
 import { set } from "lodash";
 import { useEffect, useState, useMemo, useCallback, useRef, useContext } from "react";
 
@@ -196,9 +197,15 @@ function ImageView(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
-      const newConfig = { ...config };
-      set(newConfig, action.payload.path, action.payload.value);
-      saveConfig(newConfig);
+      saveConfig(
+        produce(config, (draft) => {
+          const value =
+            action.payload.path[0] === "rotation"
+              ? Number(action.payload.value)
+              : action.payload.value;
+          set(draft, action.payload.path, value);
+        }),
+      );
     },
     [config, saveConfig],
   );

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -76,7 +76,10 @@ function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTr
         label: "Layer",
         input: "select",
         value: config.layer,
-        options: ["map", "satellite"],
+        options: [
+          { label: "Map", value: "map" },
+          { label: "Satellite", value: "satellite" },
+        ],
       },
     },
     children: {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -204,7 +204,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
     if (path[0] === "layer" && input === "select") {
       setConfig((oldConfig) => {
-        return { ...oldConfig, layer: value ?? "map" };
+        return { ...oldConfig, layer: String(value) };
       });
     }
   }, []);

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -22,12 +22,12 @@ type TeleopPanelProps = {
 };
 
 const geometryMsgOptions = [
-  "linear-x",
-  "linear-y",
-  "linear-z",
-  "angular-x",
-  "angular-y",
-  "angular-z",
+  { label: "linear-x", value: "linear-x" },
+  { label: "linear-y", value: "linear-y" },
+  { label: "linear-z", value: "linear-z" },
+  { label: "angular-x", value: "angular-x" },
+  { label: "angular-y", value: "angular-y" },
+  { label: "angular-z", value: "angular-z" },
 ];
 
 type Config = {


### PR DESCRIPTION
**User-Facing Changes**
This converts the image panel to the new settings editor.

**Description**
This converts the existing image panel properties to use the new settings editor. 

<img width="473" alt="Screen Shot 2022-04-21 at 2 07 26 PM" src="https://user-images.githubusercontent.com/93935560/164535292-949377c9-17de-42b2-95a9-03f76b4506e1.png">

It also improves the resize behavior of the settings editor to work better at smaller widths.

### Before:
<img width="248" alt="Screen Shot 2022-04-21 at 2 06 52 PM" src="https://user-images.githubusercontent.com/93935560/164535167-8062be0f-98e2-4d08-8755-47cba28622b4.png">

### After:
<img width="289" alt="Screen Shot 2022-04-21 at 2 07 07 PM" src="https://user-images.githubusercontent.com/93935560/164535358-8b7e4c57-0548-44c8-8667-c88da4c07372.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
