### PR TITLE
Data platform player: don't continue trying to preload data if an error is encountered

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -367,6 +367,10 @@ export default class FoxgloveDataPlatformPlayer implements Player {
             lastTickEndTime = undefined;
             continue mainLoop;
           }
+          if (this._presence === PlayerPresence.ERROR) {
+            // Avoid persistently re-requesting data if we encountered a parsing error
+            return;
+          }
         }
         lastTickEndTime = performance.now();
         this._nextFrame = messages;
@@ -472,6 +476,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
         if (error.name === "AbortError") {
           return;
         }
+        this._presence = PlayerPresence.ERROR;
         log.error(error);
         captureException(error);
         this._addProblem("stream-error", { message: error.message, error, severity: "error" });


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where errors loading data from Data Platform could lead to the app repeatedly requesting the same data.

**Description**
Put the player in a hard error state and break the playback loop that continued triggering preloading.

Fixes https://github.com/foxglove/studio/issues/3239