### PR TITLE
Use dialog auth for local development

### DIFF
--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -61,8 +61,13 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
   const extensionLoader = useMemo(() => new NoopExtensionLoader(), []);
   const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL!), []);
 
+  // Enable dialog auth in development since using cookie auth does not work between
+  // localhost and the hosted dev deployment due to browser cookie/host security.
+  const enableDialogAuth = process.env.NODE_ENV === "development";
+
   return (
     <App
+      enableDialogAuth={enableDialogAuth}
       enableLaunchPreferenceScreen
       deepLinks={[window.location.href]}
       dataSources={dataSources}


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
When trying to signin using cookie auth, our deployed api service limits the cookie use to foxglove domains for security. This prevents localhost domains from making api requests and including the cookie.

To make the local development experience more plasant for testing against our dev api deployment, we use the dialog auth during development. The dialog auth stores the session credential locally and sends it in the header for api requests.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
