### PR TITLE
Convert variable slider panel to new settings UI and MUI

### DIFF
--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.stories.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
 import GlobalVariableSliderPanel from "@foxglove/studio-base/panels/GlobalVariableSlider/index";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.stories.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.stories.tsx
@@ -49,13 +49,3 @@ export function NarrowLayout(): JSX.Element {
     </PanelSetup>
   );
 }
-
-export function Settings(): JSX.Element {
-  return (
-    <SchemaEditor
-      configSchema={GlobalVariableSliderPanel.configSchema!}
-      config={GlobalVariableSliderPanel.defaultConfig}
-      saveConfig={() => {}}
-    />
-  );
-}

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -11,8 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Slider } from "@fluentui/react";
-import { useTheme } from "@mui/material";
+import { Slider, Typography, useTheme } from "@mui/material";
 import produce from "immer";
 import { set } from "lodash";
 import { useCallback, useContext, useEffect } from "react";
@@ -24,6 +23,7 @@ import {
   SettingsTreeAction,
   SettingsTreeNode,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { PanelSettingsEditorContext } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 
@@ -100,51 +100,32 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
     });
   }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
 
-  const sliderOnChange = (value: number) => {
+  const sliderOnChange = (_event: Event, value: number | number[]) => {
     if (value !== globalVariableValue) {
       setGlobalVariables({ [globalVariableName]: value });
     }
   };
 
+  const marks = [
+    { value: sliderProps.min, label: String(sliderProps.min) },
+    { value: sliderProps.max, label: String(sliderProps.max) },
+  ];
+
   return (
-    <div style={{ padding: theme.spacing(2, 0.5) }}>
+    <Stack direction="row" alignItems="center" fullHeight gap={2} paddingY={2} paddingX={3}>
       <PanelToolbar helpContent={helpContent} floating />
       <Slider
         min={sliderProps.min}
         max={sliderProps.max}
         step={sliderProps.step}
-        showValue
-        snapToStep
+        marks={marks}
         value={typeof globalVariableValue === "number" ? globalVariableValue : 0}
         onChange={sliderOnChange}
-        styles={{
-          // render min/max labels under the slider
-          slideBox: {
-            "::after": {
-              position: "absolute",
-              bottom: "-60%",
-              left: 0,
-              paddingLeft: "8px",
-              fontSize: "0.75em",
-              width: "100%",
-              mixBlendMode: "difference",
-              content: `'${sliderProps.min}'`,
-            },
-            "::before": {
-              position: "absolute",
-              bottom: "-60%",
-              left: 0,
-              fontSize: "0.75em",
-              paddingRight: "8px",
-              textAlign: "right",
-              width: "100%",
-              mixBlendMode: "difference",
-              content: `'${sliderProps.max}'`,
-            },
-          },
-        }}
       />
-    </div>
+      <Typography variant="h5" style={{ marginTop: theme.spacing(-2.5) }}>
+        {typeof globalVariableValue === "number" ? globalVariableValue : 0}
+      </Typography>
+    </Stack>
   );
 }
 

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -12,11 +12,20 @@
 //   You may not use this file except in compliance with the License.
 
 import { Slider } from "@fluentui/react";
+import { useTheme } from "@mui/material";
+import produce from "immer";
+import { set } from "lodash";
+import { useCallback, useContext, useEffect } from "react";
 
 import Panel from "@foxglove/studio-base/components/Panel";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import {
+  SettingsTreeAction,
+  SettingsTreeNode,
+} from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { PanelSettingsEditorContext } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
-import { PanelConfigSchema } from "@foxglove/studio-base/types/panels";
 
 import helpContent from "./index.help.md";
 
@@ -31,6 +40,21 @@ export type GlobalVariableSliderConfig = {
   globalVariableName: string;
 };
 
+function buildSettingsTree(config: GlobalVariableSliderConfig): SettingsTreeNode {
+  return {
+    fields: {
+      min: { label: "Min", input: "number", value: config.sliderProps.min },
+      max: { label: "Max", input: "number", value: config.sliderProps.max },
+      step: { label: "Step", input: "number", value: config.sliderProps.step },
+      globalVariableName: {
+        label: "Global Variable Name",
+        input: "string",
+        value: config.globalVariableName,
+      },
+    },
+  };
+}
+
 type Props = {
   config: GlobalVariableSliderConfig;
 };
@@ -41,6 +65,41 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
 
   const globalVariableValue = globalVariables[globalVariableName];
 
+  const { id: panelId, saveConfig } = usePanelContext();
+  const { updatePanelSettingsTree } = useContext(PanelSettingsEditorContext);
+
+  const theme = useTheme();
+
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      saveConfig(
+        produce(props.config, (draft) => {
+          if (["min", "max"].includes(action.payload.path[0] ?? "")) {
+            set(draft, ["sliderProps", ...action.payload.path], action.payload.value);
+          } else if (
+            action.payload.path[0] === "step" &&
+            action.payload.input === "number" &&
+            action.payload.value != undefined &&
+            action.payload.value > 0
+          ) {
+            set(draft, ["sliderProps", "step"], action.payload.value);
+          } else {
+            set(draft, action.payload.path, action.payload.value);
+          }
+        }),
+      );
+    },
+    [props.config, saveConfig],
+  );
+
+  useEffect(() => {
+    updatePanelSettingsTree(panelId, {
+      actionHandler,
+      disableFilter: true,
+      settings: buildSettingsTree(props.config),
+    });
+  }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
+
   const sliderOnChange = (value: number) => {
     if (value !== globalVariableValue) {
       setGlobalVariables({ [globalVariableName]: value });
@@ -48,7 +107,7 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
   };
 
   return (
-    <div style={{ padding: "25px 4px 4px" }}>
+    <div style={{ padding: theme.spacing(2, 0.5) }}>
       <PanelToolbar helpContent={helpContent} floating />
       <Slider
         min={sliderProps.min}
@@ -89,13 +148,6 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
   );
 }
 
-const configSchema: PanelConfigSchema<GlobalVariableSliderConfig> = [
-  { key: "globalVariableName", type: "text", title: "Variable name" },
-  { key: "sliderProps.min", type: "number", title: "Min" },
-  { key: "sliderProps.max", type: "number", title: "Max" },
-  { key: "sliderProps.step", type: "number", title: "Step", validate: (x) => (x <= 0 ? 1 : x) },
-];
-
 export default Panel(
   Object.assign(GlobalVariableSliderPanel, {
     panelType: "GlobalVariableSliderPanel",
@@ -103,6 +155,5 @@ export default Panel(
       sliderProps: { min: 0, max: 10, step: 1 },
       globalVariableName: "globalVariable",
     },
-    configSchema,
   }),
 );

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -47,7 +47,7 @@ function buildSettingsTree(config: GlobalVariableSliderConfig): SettingsTreeNode
       max: { label: "Max", input: "number", value: config.sliderProps.max },
       step: { label: "Step", input: "number", value: config.sliderProps.step },
       globalVariableName: {
-        label: "Variable Slider",
+        label: "Variable name",
         input: "string",
         value: config.globalVariableName,
       },

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -47,7 +47,7 @@ function buildSettingsTree(config: GlobalVariableSliderConfig): SettingsTreeNode
       max: { label: "Max", input: "number", value: config.sliderProps.max },
       step: { label: "Step", input: "number", value: config.sliderProps.step },
       globalVariableName: {
-        label: "Global Variable Name",
+        label: "Variable Slider",
         input: "string",
         value: config.globalVariableName,
       },


### PR DESCRIPTION
**User-Facing Changes**
This converts the global variable slider panel to the new settings UI and to MUI. 

**Description**
This is a straightforward change to the new settings UI and also to a MUI slider with a slightly improved layout that centers the slider vertically so it doesn't overlap with the toolbar..

<img width="1077" alt="Screen Shot 2022-04-22 at 7 03 19 AM" src="https://user-images.githubusercontent.com/93935560/164710868-4ae33aad-f938-415c-a275-fbc994f392f7.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
