### PR TITLE
Convert diagnostic summary panel to new settings UI

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import SchemaEditor from "@foxglove/studio-base/components/PanelSettings/SchemaEditor";
+
 import DiagnosticSummary from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary";
 import {
   DiagnosticStatusArrayMsg,
@@ -161,15 +161,5 @@ export function FilteredByHardwareIdAndLevel(): JSX.Element {
         }}
       />
     </PanelSetup>
-  );
-}
-
-export function Settings(): JSX.Element {
-  return (
-    <SchemaEditor
-      configSchema={DiagnosticSummary.configSchema!}
-      config={DiagnosticSummary.defaultConfig}
-      saveConfig={() => {}}
-    />
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
This converts the diagnostic summary panel to use the new settings UI.

**Description**
This panel just has a single boolean setting so the conversion is simple.

<img width="473" alt="Screen Shot 2022-04-22 at 7 19 59 AM" src="https://user-images.githubusercontent.com/93935560/164713147-f0ee153b-c61c-45d4-9d5a-3553b167edb6.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
