### PR TITLE
Remove "ROS" time label from Raw Message panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -53,12 +53,12 @@ export default function Metadata({
           {datatype}
         </Link>
       )}
-      {diffMessage ? " base" : ""} @ {formatTimeRaw(message.receiveTime)} ROS{" "}
+      {diffMessage ? " base" : ""} @ {formatTimeRaw(message.receiveTime)} sec{" "}
       <CopyMessageButton data={data} text="Copy msg" />
       {diffMessage?.receiveTime && (
         <>
           <div>
-            {`diff @ ${formatTimeRaw(diffMessage.receiveTime)} ROS `}
+            {`diff @ ${formatTimeRaw(diffMessage.receiveTime)} sec `}
             <CopyMessageButton data={diffData} text="Copy msg" />
           </div>
           <CopyMessageButton data={diff} text="Copy diff of msgs" />


### PR DESCRIPTION
**User-Facing Changes**
Not significant enough to put in release notes

**Description**
Change "ROS" label to "sec" in Raw Message panel.