### PR TITLE
Expose the new 3d panel's camera settings in the new settings UI

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -27,7 +27,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { useHelpInfo } from "@foxglove/studio-base/context/HelpInfoContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 
-import { ColorPickerInput, ColorScalePicker, NumberInput } from "./inputs";
+import { ColorPickerInput, ColorScalePicker, NumberInput, Vec3Input } from "./inputs";
 import { SettingsTreeAction, SettingsTreeField } from "./types";
 
 const StyledToggleButtonGroup = muiStyled(ToggleButtonGroup)(({ theme }) => ({
@@ -273,6 +273,78 @@ function FieldInput({
     case "gradient": {
       return <ColorScalePicker color="inherit" size="small" />;
     }
+    case "vec3": {
+      return (
+        <Vec3Input
+          value={field.value}
+          onChange={(value) =>
+            actionHandler({ action: "update", payload: { path, input: "vec3", value } })
+          }
+        />
+      );
+    }
+  }
+}
+
+function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.Element {
+  if (field.input === "vec3") {
+    const labels = field.labels ?? ["X", "Y", "Z"];
+    return (
+      <>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            columnGap: "0.5rem",
+            height: "100%",
+            width: "100%",
+            alignItems: "center",
+          }}
+        >
+          <Typography
+            title={field.label}
+            variant="subtitle2"
+            color="text.secondary"
+            noWrap
+            flex="auto"
+          >
+            {field.label}
+          </Typography>
+          {labels.map((label, index) => (
+            <Typography
+              key={label}
+              title={field.label}
+              variant="subtitle2"
+              color="text.secondary"
+              noWrap
+              style={{ gridColumn: index === 0 ? "span 1" : "2 / span 1" }}
+              flex="auto"
+            >
+              {label}
+            </Typography>
+          ))}
+        </div>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <Typography
+          title={field.label}
+          variant="subtitle2"
+          color="text.secondary"
+          noWrap
+          flex="auto"
+        >
+          {field.label}
+        </Typography>
+        {field.help && (
+          <IconButton size="small" color="secondary" title={field.help}>
+            <HelpOutlineIcon fontSize="inherit" />
+          </IconButton>
+        )}
+      </>
+    );
   }
 }
 
@@ -291,21 +363,8 @@ function FieldEditorComponent({
 
   return (
     <>
-      <Stack direction="row" alignItems="center" style={{ paddingLeft }}>
-        <Typography
-          title={field.label}
-          variant="subtitle2"
-          color="text.secondary"
-          noWrap
-          flex="auto"
-        >
-          {field.label}
-        </Typography>
-        {field.help && (
-          <IconButton size="small" color="secondary" title={field.help}>
-            <HelpOutlineIcon fontSize="inherit" />
-          </IconButton>
-        )}
+      <Stack direction="row" alignItems="center" style={{ paddingLeft }} fullHeight>
+        <FieldLabel field={field} />
       </Stack>
       <div style={{ paddingRight: theme.spacing(2) }}>
         <FieldInput actionHandler={actionHandler} field={field} path={path} />

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -287,6 +287,8 @@ function FieldInput({
 }
 
 function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.Element {
+  const theme = useTheme();
+
   if (field.input === "vec3") {
     const labels = field.labels ?? ["X", "Y", "Z"];
     return (
@@ -295,7 +297,7 @@ function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.
           style={{
             display: "grid",
             gridTemplateColumns: "1fr auto",
-            columnGap: "0.5rem",
+            columnGap: theme.spacing(0.5),
             height: "100%",
             width: "100%",
             alignItems: "center",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -36,6 +36,12 @@ const DefaultSettings: SettingsTreeNode = {
           input: "autocomplete",
           items: ["topic1", "topic2", "topic3"],
         },
+        vec3: {
+          label: "Vec3",
+          input: "vec3",
+          labels: ["U", "V", "W"],
+          value: [1, 2, 3],
+        },
       },
     },
     background: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useCallback } from "react";
+
+import Stack from "@foxglove/studio-base/components/Stack";
+
+import { NumberInput } from "./NumberInput";
+
+export function Vec3Input({
+  onChange,
+  value,
+}: {
+  onChange: (
+    value: undefined | readonly [undefined | number, undefined | number, undefined | number],
+  ) => void;
+  value: undefined | readonly [undefined | number, undefined | number, undefined | number];
+}): JSX.Element {
+  const onChangeCallback = useCallback(
+    (position: number, inputValue: undefined | number) => {
+      const newValue: [undefined | number, undefined | number, undefined | number] = [
+        ...(value ?? [0, 0, 0]),
+      ];
+      newValue[position] = inputValue;
+      onChange(newValue);
+    },
+    [onChange, value],
+  );
+
+  if (value == undefined) {
+    return <div />;
+  }
+
+  return (
+    <Stack gap={0.25}>
+      {value.map((pval, position) => (
+        <NumberInput
+          key={position}
+          size="small"
+          variant="filled"
+          fullWidth
+          value={pval}
+          onChange={(newValue) => onChangeCallback(position, newValue)}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
@@ -5,3 +5,4 @@
 export * from "./ColorPickerInput";
 export * from "./ColorScalePicker";
 export * from "./NumberInput";
+export * from "./Vec3Input";

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -20,7 +20,12 @@ export type SettingsTreeFieldValue =
       options: Array<{ label: string; value: undefined | string }>;
     }
   | { input: "string"; value?: string }
-  | { input: "toggle"; value?: string; options: string[] };
+  | { input: "toggle"; value?: string; options: string[] }
+  | {
+      input: "vec3";
+      value?: readonly [undefined | number, undefined | number, undefined | number];
+      labels?: [string, string, string];
+    };
 
 export type SettingsTreeField = SettingsTreeFieldValue & {
   help?: string;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -43,7 +43,6 @@ import {
   OCCUPANCY_GRID_DATATYPES,
 } from "./ros";
 
-const SHOW_STATS = true;
 const SHOW_DEBUG = false;
 
 const SUPPORTED_DATATYPES = new Set<string>();
@@ -56,6 +55,7 @@ mergeSetInto(SUPPORTED_DATATYPES, POINTCLOUD_DATATYPES);
 
 type Config = {
   cameraState: CameraState;
+  enableStats: boolean;
   followTf?: string;
 };
 
@@ -75,6 +75,9 @@ const labelDark = css`
 
 function buildSettingsTree(config: Config): SettingsTreeNode {
   return {
+    fields: {
+      enableStats: { label: "Enable Stats", input: "boolean", value: config.enableStats },
+    },
     children: {
       cameraState: {
         label: "Camera",
@@ -127,7 +130,10 @@ function buildSettingsTree(config: Config): SettingsTreeNode {
   };
 }
 
-function RendererOverlay(props: { colorScheme: "dark" | "light" | undefined }): JSX.Element {
+function RendererOverlay(props: {
+  colorScheme: "dark" | "light" | undefined;
+  enableStats: boolean;
+}): JSX.Element {
   const colorScheme = props.colorScheme;
   const [_selectedRenderable, setSelectedRenderable] = useState<THREE.Object3D | undefined>(
     undefined,
@@ -202,7 +208,7 @@ function RendererOverlay(props: { colorScheme: "dark" | "light" | undefined }): 
   );
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const stats = SHOW_STATS ? (
+  const stats = props.enableStats ? (
     <div id="stats" style={{ position: "absolute", top: 0 }}>
       <Stats />
     </div>
@@ -237,6 +243,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
     return {
       cameraState,
+      enableStats: partialConfig?.enableStats ?? true,
       followTf: partialConfig?.followTf,
     };
   });
@@ -475,7 +482,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         <canvas ref={setCanvas} style={{ position: "absolute", top: 0, left: 0 }} />
       </CameraListener>
       <RendererContext.Provider value={renderer}>
-        <RendererOverlay colorScheme={colorScheme} />
+        <RendererOverlay colorScheme={colorScheme} enableStats={config.enableStats} />
       </RendererContext.Provider>
     </div>
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -97,32 +97,11 @@ function buildSettingsTree(config: Config): SettingsTreeNode {
           fovy: { label: "Fovy", input: "number", value: config.cameraState.fovy },
           near: { label: "Near", input: "number", value: config.cameraState.near },
           far: { label: "Far", input: "number", value: config.cameraState.far },
-        },
-        children: {
-          target: {
-            label: "Target",
-            fields: {
-              0: { label: "X", input: "number", value: config.cameraState.target[0] },
-              1: { label: "Y", input: "number", value: config.cameraState.target[1] },
-              2: { label: "Z", input: "number", value: config.cameraState.target[2] },
-            },
-          },
+          target: { label: "Target", input: "vec3", value: config.cameraState.target },
           targetOffset: {
             label: "Target Offset",
-            fields: {
-              0: { label: "X", input: "number", value: config.cameraState.targetOffset[0] },
-              1: { label: "Y", input: "number", value: config.cameraState.targetOffset[1] },
-              2: { label: "Z", input: "number", value: config.cameraState.targetOffset[2] },
-            },
-          },
-          targetOrientation: {
-            label: "Target Orientation",
-            fields: {
-              0: { label: "X", input: "number", value: config.cameraState.targetOrientation[0] },
-              1: { label: "Y", input: "number", value: config.cameraState.targetOrientation[1] },
-              2: { label: "Z", input: "number", value: config.cameraState.targetOrientation[2] },
-              3: { label: "W", input: "number", value: config.cameraState.targetOrientation[3] },
-            },
+            input: "vec3",
+            value: config.cameraState.targetOffset,
           },
         },
       },

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -43,7 +43,7 @@ import {
   OCCUPANCY_GRID_DATATYPES,
 } from "./ros";
 
-const SHOW_DEBUG = false;
+const SHOW_DEBUG: true | false = false;
 
 const SUPPORTED_DATATYPES = new Set<string>();
 mergeSetInto(SUPPORTED_DATATYPES, TRANSFORM_STAMPED_DATATYPES);
@@ -186,14 +186,12 @@ function RendererOverlay(props: {
     </div>
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const stats = props.enableStats ? (
     <div id="stats" style={{ position: "absolute", top: 0 }}>
       <Stats />
     </div>
   ) : undefined;
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const debug = SHOW_DEBUG ? (
     <div id="debug" style={{ position: "absolute", top: 60 }}>
       <DebugGui />

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.stories.tsx
@@ -400,6 +400,7 @@ export function Markers(): JSX.Element {
       <ThreeDeeRender
         overrideConfig={{
           ...ThreeDeeRender.defaultConfig,
+          enableStats: false,
           followTf: "base_link",
           cameraState: {
             distance: 5.5,
@@ -537,6 +538,7 @@ export function ArrowMarkers(): JSX.Element {
       <ThreeDeeRender
         overrideConfig={{
           ...ThreeDeeRender.defaultConfig,
+          enableStats: false,
           followTf: "base_link",
           cameraState: {
             distance: 4,


### PR DESCRIPTION
**User-Facing Changes**
This exposes the camera settings for the new 3d panel in the new settings UI.

**Description**
This takes the naive/brute force approach and just rebuilds the whole tree on each update. Performance seems ok for me but we may need to revisit this as we add more fields.

This also adds a vec3 input.
<img width="520" alt="Screen Shot 2022-04-22 at 12 55 07 PM" src="https://user-images.githubusercontent.com/93935560/164769089-8a56871f-b63a-4c65-9ee5-ece23685300c.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
