### PR TITLE
Enable Experimental bag player as the default

### DIFF
--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -78,7 +78,7 @@ async function main() {
       defaults: {
         [AppSetting.OPEN_DIALOG]: true,
         [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
-        [AppSetting.EXPERIMENTAL_BAG_PLAYER]: isDevelopment,
+        [AppSetting.EXPERIMENTAL_BAG_PLAYER]: true,
       },
     },
   );

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -84,7 +84,7 @@ async function main() {
     defaults: {
       [AppSetting.OPEN_DIALOG]: true,
       [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
-      [AppSetting.EXPERIMENTAL_BAG_PLAYER]: isDevelopment,
+      [AppSetting.EXPERIMENTAL_BAG_PLAYER]: true,
     },
   });
   const enableStrictMode = appConfiguration.get(AppSetting.ENABLE_REACT_STRICT_MODE) as boolean;


### PR DESCRIPTION
**User-Facing Changes**
When viewing bag files (local or remote), users will experience better backfill behavior for infrequently published topics. After a seek, panels will receive (and usually display), the last message on all their subscribed topics.

Some specific benefits:

- 3d panel will always get the last /tf_static message so markers that leverage static transforms will display
- Image panel will get the last image even if it happened some time ago
- Raw message panel will display the last message even if it happened some time ago

This change keeps the `Experimental bag player` application setting so users can turn it off if we find cases where the new player does not yet meet their needs. This gives us time to fix the issue without blocking the user.

**Description**
The experimental bag player is ready to graduate to the default. With this player users get better
seek behavior. When a user seeks, the player will backfill the last message on every topic. This
results in a better experience for panels which rely on having the last message on topics to display
useful info (which is basically every panel).

The previous bag player would backfill messages within a certain small window prior to the seek position.
If a message was outside that window it would not get backfilled. This meant some topics with infrequent publishing
would not be backfilled and some panels would not show any data for such topics on a seek. This behavior is different
to what the panel would show had the user played the data forward from the start to the seek time.

Fixes: #2906


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
