### PR TITLE
Automatically select single panel layouts when opening the settings sidebar

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -25,11 +25,16 @@ import {
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
-import { getAllPanelIds, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
+import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import SchemaEditor from "./SchemaEditor";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+
+const singlePanelIdSelector = (state: LayoutState) =>
+  typeof state.selectedLayout?.data?.layout === "string"
+    ? state.selectedLayout.data.layout
+    : undefined;
 
 export default function PanelSettings({
   selectedPanelIdsForTests,
@@ -37,12 +42,7 @@ export default function PanelSettings({
   selectedPanelIdsForTests?: readonly string[];
 }>): JSX.Element {
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
-  const { getCurrentLayoutState } = useCurrentLayoutActions();
-  const savedProps = getCurrentLayoutState().selectedLayout?.data?.configById;
-  const allPanelIds = useMemo(
-    () => (selectedLayoutId && savedProps ? getAllPanelIds(selectedLayoutId, savedProps) : []),
-    [savedProps, selectedLayoutId],
-  );
+  const singlePanelId = useCurrentLayoutSelector(singlePanelIdSelector);
   const {
     selectedPanelIds: originalSelectedPanelIds,
     setSelectedPanelIds,
@@ -52,10 +52,10 @@ export default function PanelSettings({
 
   // If no panel is selected and there is only one panel in the layout, select it
   useEffect(() => {
-    if (selectedPanelIds.length === 0 && allPanelIds.length === 1) {
+    if (selectedPanelIds.length === 0 && singlePanelId != undefined) {
       selectAllPanels();
     }
-  }, [allPanelIds, selectedPanelIds, selectAllPanels]);
+  }, [selectAllPanels, selectedPanelIds, singlePanelId]);
 
   const { openLayoutBrowser } = useWorkspace();
   const selectedPanelId = useMemo(

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -25,7 +25,7 @@ import {
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
-import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
+import { getAllPanelIds, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import SchemaEditor from "./SchemaEditor";
 
@@ -37,8 +37,26 @@ export default function PanelSettings({
   selectedPanelIdsForTests?: readonly string[];
 }>): JSX.Element {
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
-  const { selectedPanelIds: originalSelectedPanelIds, setSelectedPanelIds } = useSelectedPanels();
+  const { getCurrentLayoutState } = useCurrentLayoutActions();
+  const savedProps = getCurrentLayoutState().selectedLayout?.data?.configById;
+  const allPanelIds = useMemo(
+    () => (selectedLayoutId && savedProps ? getAllPanelIds(selectedLayoutId, savedProps) : []),
+    [savedProps, selectedLayoutId],
+  );
+  const {
+    selectedPanelIds: originalSelectedPanelIds,
+    setSelectedPanelIds,
+    selectAllPanels,
+  } = useSelectedPanels();
   const selectedPanelIds = selectedPanelIdsForTests ?? originalSelectedPanelIds;
+
+  // If no panel is selected and there is only one panel in the layout, select it
+  useEffect(() => {
+    if (selectedPanelIds.length === 0 && allPanelIds.length === 1) {
+      selectAllPanels();
+    }
+  }, [allPanelIds, selectedPanelIds, selectAllPanels]);
+
   const { openLayoutBrowser } = useWorkspace();
   const selectedPanelId = useMemo(
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -62,8 +62,9 @@ export default function PanelSettings({
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),
     [selectedPanelIds],
   );
+
+  // Automatically deselect the panel we were editing when the settings sidebar closes
   useUnmount(() => {
-    // Automatically deselect the panel we were editing when the settings sidebar closes
     if (selectedPanelId != undefined) {
       setSelectedPanelIds([]);
     }

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -117,7 +117,7 @@ export default function MockCurrentLayoutProvider({
     mosaicId: "mockMosaicId",
     getSelectedPanelIds: useCallback(() => [], []),
     setSelectedPanelIds: useCallback(() => {
-      throw new Error("Not implemented in MockCurrentLayoutProvider");
+      // no-op
     }, []),
     actions,
   });


### PR DESCRIPTION
**User-Facing Changes**

* The settings sidebar works without interaction for single panel layouts

**Description**

If a layout only contains one panel, that panel is auto-selected when opening the settings sidebar.
