### PR TITLE
Fix geojson marker images

### DIFF
--- a/packages/studio-base/src/panels/Map/index.tsx
+++ b/packages/studio-base/src/panels/Map/index.tsx
@@ -2,6 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import L from "leaflet";
+import LeafletRetinaIconUrl from "leaflet/dist/images/marker-icon-2x.png";
+import LeafletIconUrl from "leaflet/dist/images/marker-icon.png";
+import LeafletShadowIconUrl from "leaflet/dist/images/marker-shadow.png";
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
@@ -15,6 +19,19 @@ import MapPanel from "./MapPanel";
 import helpContent from "./index.help.md";
 
 import "leaflet/dist/leaflet.css";
+
+// Webpack and leaflet don't work well out of the box without manually
+// overriding the default icon and its asset paths.
+L.Marker.prototype.options.icon = L.icon({
+  iconUrl: LeafletIconUrl,
+  iconRetinaUrl: LeafletRetinaIconUrl,
+  shadowUrl: LeafletShadowIconUrl,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  tooltipAnchor: [16, -28],
+  shadowSize: [41, 41],
+});
 
 function initPanel(context: PanelExtensionContext) {
   ReactDOM.render(


### PR DESCRIPTION
**User-Facing Changes**
This fixes the missing marker images in GeoJSON layers on the map panel.

**Description**
Leaflet asset location and Webpack do not work well out of the box. We have to override the default leaflet icon to use the correct asset paths to our images.

See https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-264311098

<img width="512" alt="Screen Shot 2022-04-25 at 8 26 41 AM" src="https://user-images.githubusercontent.com/93935560/165098666-20b0c313-b010-43f0-82a9-b598d8891374.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3248 