### PR TITLE
Add new toggle function to SettingsTreeNode

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -7,7 +7,7 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import LayerIcon from "@mui/icons-material/Layers";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { Collapse, Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
-import { ChangeEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
 import { FieldEditor } from "./FieldEditor";
@@ -65,10 +65,9 @@ const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { actionHandler, defaultOpen = true, disableIcon = false, icon, settings = {} } = props;
   const [open, setOpen] = useState(defaultOpen);
-  const [visible, setVisiblity] = useState(true);
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setVisiblity(event.target.checked);
+  const handleChange = () => {
+    actionHandler({ action: "toggle", payload: { path: props.path } });
   };
 
   const { fields, children } = settings;
@@ -99,6 +98,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   });
 
   const indent = props.path.length;
+  const visible = props.settings?.toggled !== true;
 
   return (
     <>
@@ -124,7 +124,14 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               {settings.label ?? "Settings"}
             </Typography>
           </NodeHeaderToggle>
-          <VisibilityToggle edge="end" size="small" checked={visible} onChange={handleChange} />
+          <VisibilityToggle
+            edge="end"
+            size="small"
+            checked={visible}
+            onChange={handleChange}
+            disabled={props.settings?.allowToggle !== true}
+            style={{ opacity: props.settings?.allowToggle === true ? 1 : 0 }}
+          />
         </NodeHeader>
       )}
       <Collapse in={open}>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -280,6 +280,10 @@ export const Default = (): JSX.Element => {
   const [settingsNode, setSettingsNode] = React.useState({ ...DefaultSettings });
 
   const actionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     setSettingsNode((previous) =>
       updateSettingsTreeNode(previous, action.payload.path, action.payload.value),
     );

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -38,9 +38,11 @@ export type SettingsTreeFields = Record<string, SettingsTreeField>;
 export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
 
 export type SettingsTreeNode = {
+  allowToggle?: boolean;
   children?: SettingsTreeChildren;
   fields?: SettingsTreeFields;
   label?: string;
+  toggled?: boolean;
 };
 
 /**
@@ -53,13 +55,15 @@ type DistributivePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : n
  * Represents actions that can be dispatched to source of the SettingsTree to implement
  * edits and updates.
  */
-export type SettingsTreeAction = {
-  action: "update";
-  payload: { path: readonly string[] } & DistributivePick<
-    SettingsTreeFieldValue,
-    "input" | "value"
-  >;
-};
+export type SettingsTreeAction =
+  | { action: "toggle"; payload: { path: readonly string[] } }
+  | {
+      action: "update";
+      payload: { path: readonly string[] } & DistributivePick<
+        SettingsTreeFieldValue,
+        "input" | "value"
+      >;
+    };
 
 /**
  * A settings tree is a tree of panel settings that can be managed by

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -72,19 +72,20 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
+      const { path, input, value } = action.payload;
+
       saveConfig(
         produce(props.config, (draft) => {
-          if (["min", "max"].includes(action.payload.path[0] ?? "")) {
-            set(draft, ["sliderProps", ...action.payload.path], action.payload.value);
-          } else if (
-            action.payload.path[0] === "step" &&
-            action.payload.input === "number" &&
-            action.payload.value != undefined &&
-            action.payload.value > 0
-          ) {
-            set(draft, ["sliderProps", "step"], action.payload.value);
+          if (["min", "max"].includes(path[0] ?? "")) {
+            set(draft, ["sliderProps", ...path], value);
+          } else if (path[0] === "step" && input === "number" && value != undefined && value > 0) {
+            set(draft, ["sliderProps", "step"], value);
           } else {
-            set(draft, action.payload.path, action.payload.value);
+            set(draft, path, value);
           }
         }),
       );

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -197,6 +197,10 @@ function ImageView(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       saveConfig(
         produce(config, (draft) => {
           set(draft, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -185,6 +185,10 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   }, [topics]);
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     const { path, input, value } = action.payload;
 
     if (path[0] === "topics" && input === "boolean") {

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -213,6 +213,10 @@ function NodePlayground(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { input, value, path } = action.payload;
       if (input === "boolean" && path[0] === "autoFormatOnSave") {
         saveConfig({ ...config, autoFormatOnSave: value });

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -145,6 +145,10 @@ function Publish(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       saveConfig(
         produce(props.config, (draft) => {
           set(draft, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -155,6 +155,10 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
   });
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     setConfig((previous) => {
       const newConfig = { ...previous };
       set(newConfig, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -201,6 +201,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [cameraStore] = useState(() => new CameraStore(setCameraState, cameraState));
 
   const actionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     setConfig((oldConfig) =>
       produce(oldConfig, (draft) => {
         set(draft, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -224,6 +224,10 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { input, path, value } = action.payload;
       if (input === "boolean" && path[0] === "sortByLevel") {
         saveConfig(


### PR DESCRIPTION
**User-Facing Changes**
This removes the visibility toggle from panel settings where it's not useful.

**Description**
The visibility toggle we now show on all settings tree nodes doesn't make sense for all panels. It's up to each panel to decide if this is useful and what the semantics should be. So instead of showing it by default we make it opt in via the new `allowToggle` and `toggled` properties:

```typescript
export type SettingsTreeNode = {
  allowToggle?: boolean;
  children?: SettingsTreeChildren;
  fields?: SettingsTreeFields;
  label?: string;
  toggled?: boolean;
};
```

If panels want to opt-in to this feature they can set `allowToggle = true` and then handle the new `toggle` SettingsTreeAction:

```typescript
export type SettingsTreeAction =
  | { action: "toggle"; payload: { path: readonly string[] } }
...
```

Perhaps as this evolves we might want to also offer a `toggleIcon` property that allows users to choose from a predefined list of icons that can be shown in the toggle control position.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3241 