### PR TITLE
Make settings editor filter opt-in instead of opt-out

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -287,8 +287,9 @@ export const Default = (): JSX.Element => {
 
   const settings = useMemo(
     () => ({
-      settings: settingsNode,
       actionHandler,
+      enableFilter: true,
+      settings: settingsNode,
     }),
     [settingsNode, actionHandler],
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -32,7 +32,7 @@ export default function SettingsTreeEditor({
 
   return (
     <Stack fullHeight>
-      {settings.disableFilter !== true && (
+      {settings.enableFilter === true && (
         <StyledAppBar position="sticky" color="default" elevation={0}>
           <TextField
             onChange={(event) => setFilterText(event.target.value)}

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -72,9 +72,9 @@ export type SettingsTree = {
   actionHandler: (action: SettingsTreeAction) => void;
 
   /**
-   * True if the editor should not show the filter control.
+   * True if the editor should show the filter control.
    */
-  disableFilter?: boolean;
+  enableFilter?: boolean;
 
   /**
    * The actual settings tree. Updates to this will automatically be reflected in the

--- a/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/GlobalVariableSlider/index.tsx
@@ -95,7 +95,6 @@ function GlobalVariableSliderPanel(props: Props): React.ReactElement {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsTree(props.config),
     });
   }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);

--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -209,7 +209,6 @@ function ImageView(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -228,7 +228,6 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
       actionHandler: settingsActionHandler,
-      disableFilter: true,
       settings: tree,
     });
 

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -224,7 +224,6 @@ function NodePlayground(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsStree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -157,7 +157,6 @@ function Publish(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsTree(props.config),
     });
   }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -183,7 +183,6 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
       actionHandler: settingsActionHandler,
-      disableFilter: true,
       settings: tree,
     });
     saveState(config);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -212,7 +212,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsTree(config, topics ?? []),
     });
   }, [actionHandler, config, context, topics]);

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -239,7 +239,6 @@ function DiagnosticSummary(props: Props): JSX.Element {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      disableFilter: true,
       settings: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This makes the top filter on the settings editor opt-in instead of opt-out. This makes more sense since the filter is not useful for most of our panels, which only have a few settings.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
