### PR TITLE
[ROS2] Print datatype along with topic in errors

### DIFF
--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -388,7 +388,7 @@ export default class Ros2Player implements Player {
       if (!rosEndpoint) {
         this._problems.addProblem(`subscription:${topicName}`, {
           severity: "warn",
-          message: `No publisher for "${topicName}"`,
+          message: `No publisher for "${topicName}" ("${dataType}")`,
           tip: `Publish "${topicName}"`,
         });
         continue;
@@ -404,7 +404,7 @@ export default class Ros2Player implements Player {
       } catch (error) {
         this._problems.addProblem(`msgdef:${topicName}`, {
           severity: "warn",
-          message: `Unknown message definition for "${topicName}"`,
+          message: `Unknown message definition for "${topicName}" ("${dataType}")`,
           tip: `Only core ROS 2 data types are currently supported`,
         });
       }


### PR DESCRIPTION
**User-Facing Changes**

* Datatype is shown along with topic in ROS2 data source errors
