### PR TITLE
Don't emit undefined messages from ROS2 data source

### DIFF
--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -482,9 +482,11 @@ export default class Ros2Player implements Player {
       this._metricsCollector.recordTimeToFirstMsgs();
     }
 
-    const msg: MessageEvent<unknown> = { topic, receiveTime, publishTime, message, sizeInBytes };
-    this._parsedMessages.push(msg);
-    this._handleInternalMessage(msg);
+    if (message != undefined) {
+      const msg: MessageEvent<unknown> = { topic, receiveTime, publishTime, message, sizeInBytes };
+      this._parsedMessages.push(msg);
+      this._handleInternalMessage(msg);
+    }
 
     // Update the message count for this topic
     let stats = this._providerTopicsStats.get(topic);


### PR DESCRIPTION
**User-Facing Changes**

* Fixes a crash when trying to visualize a ROS2 topic with a missing message definition

**Description**

The @foxglove/ros2 library emits message events even when messages are unparseable due to missing message definitions. Now we continue to count stats for these messages but don't emit the messages in Studio. A data source problem is already shown for these topics.
