### PR TITLE
Improve plot panel message path interaction

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -17,7 +17,8 @@ import { Stack } from "@mui/material";
 import produce from "immer";
 import { compact, set, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
-import { useEffect, useCallback, useMemo, ComponentProps, useContext } from "react";
+import { useEffect, useCallback, useMemo, ComponentProps, useContext, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import { filterMap } from "@foxglove/den/collection";
 import {
@@ -171,7 +172,30 @@ function selectEndTime(ctx: MessagePipelineContext) {
 }
 
 function Plot(props: Props) {
-  const { saveConfig, config } = props;
+  const { saveConfig: persistConfig, config: savedConfig } = props;
+
+  // We make a working copy of our config for real time editing since changing the config
+  // forces the entire component to re-render and results in race conditions from
+  // the async write to layout storage.
+  const [config, setConfig] = useState(savedConfig);
+  const saveConfig = useCallback((newConfig: Partial<PlotConfig>) => {
+    setConfig((oldConfig) => ({ ...oldConfig, ...newConfig }));
+  }, []);
+
+  // Commit our working config to the layout with a debounce to prevent thrashing.
+  const debouncedSaveConfig = useDebouncedCallback(
+    (newConfig: Partial<PlotConfig>) => persistConfig(newConfig),
+    1000,
+  );
+  useEffect(() => {
+    debouncedSaveConfig(config);
+  }, [config, debouncedSaveConfig]);
+
+  // Sync our working config with the external config to support changes from settings etc.
+  useEffect(() => {
+    setConfig(savedConfig);
+  }, [savedConfig]);
+
   const {
     title,
     followingViewWidth,


### PR DESCRIPTION
**User-Facing Changes**
Fixes a bug in message path inputs in the plot panel that could cause edits to be dropped or scrambled.

**Description**
Currently making any changes to one of the message paths in the plot legend, even changing a single character, forces a write to the panel config which forces a re-render of the entire plot panel and also sends a write to the layout and to storage. This creates a race condition that manifests when studio is busy and the user is rapidly editing the message path.

The solution in this PR is to create a stateful working copy of the panel config and commit edits to that working copy instead of pushing the edits all the way through to the layout. This working copy is used to render the plot. A debounced `useEffect` hook is used to flush state back to the layout so that the user's changes are saved.

Note - the performance of the plot panel accumulating messages from a live data source over time could probably be improved. We're doing a lot of work every time we receive new messages.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3146 