### PR TITLE
Fix settings toggle interaction

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -191,12 +191,14 @@ function FieldInput({
           value={field.value}
           exclusive
           size="small"
-          onChange={(_event, value) =>
-            actionHandler({
-              action: "update",
-              payload: { path, input: "boolean", value },
-            })
-          }
+          onChange={(_event, value) => {
+            if (value != undefined) {
+              actionHandler({
+                action: "update",
+                payload: { path, input: "boolean", value },
+              });
+            }
+          }}
         >
           <ToggleButton value={true}>On</ToggleButton>
           <ToggleButton value={false}>Off</ToggleButton>


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the toggle control in the settings UI.

**Description**
MUI's ToggleGroup tries to send a null value for a toggle of an existing state. We need to ignore these events.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
FIxes #3266 