### PR TITLE
Require only ds param for initial deep link state

### DIFF
--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -71,7 +71,7 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
 
     // Apply any available datasource args
-    if (urlState.ds && urlState.dsParams) {
+    if (urlState.ds) {
       log.debug("Initialising source from url", urlState);
       selectSource(urlState.ds, { type: "connection", params: urlState.dsParams });
       urlState.ds = undefined;


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with deep linking to the sample data source using a link like https://studio.foxglove.dev/?ds=sample-nuscenes.

**Description**
The sample data source is a special data source that doesn't use `dsParams`. So we need to relax our requirement that both `ds` and `dsParams` are required to specify a deep link.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
