### PR TITLE
Make URL state tracking more robust

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -131,17 +131,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const { addToast } = useToasts();
 
-  const [selectedSource, setSelectedSource] = useState<IDataSourceFactory | undefined>();
-
   const selectSource = useCallback(
     async (sourceId: string, args?: DataSourceArgs) => {
       log.debug(`Select Source: ${sourceId}`);
-
-      // empty string sourceId
-      if (!sourceId) {
-        setSelectedSource(undefined);
-        return;
-      }
 
       const foundSource = playerSources.find((source) => source.id === sourceId);
       if (!foundSource) {
@@ -152,7 +144,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       }
 
       metricsCollector.setProperty("player", sourceId);
-      setSelectedSource(() => foundSource);
 
       // Sample sources don't need args or prompts to initialize
       if (foundSource.type === "sample") {
@@ -335,7 +326,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   const value: PlayerSelection = {
     selectSource,
     selectRecent,
-    selectedSource,
     availableSources: playerSources,
     recentSources,
   };

--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.tsx
@@ -53,6 +53,7 @@ class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
       return new IterablePlayer({
         metricsCollector: args.metricsCollector,
         source,
+        sourceId: this.id,
         urlParams: {
           deviceId,
           start: toRFC3339String(startTime),
@@ -70,6 +71,7 @@ class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
       },
       consoleApi: args.consoleApi,
       metricsCollector: args.metricsCollector,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.tsx
@@ -48,6 +48,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
     return new FoxgloveWebSocketPlayer({
       url,
       metricsCollector: args.metricsCollector,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -51,6 +51,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
       name: file.name,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -39,6 +39,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
         metricsCollector: args.metricsCollector,
         source,
         name: file.name,
+        sourceId: this.id,
       });
     }
 

--- a/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
@@ -36,6 +36,7 @@ export default class McapRemoteDataSourceFactory implements IDataSourceFactory {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
       name: url,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
@@ -39,6 +39,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
         metricsCollector: args.metricsCollector,
         source: bagSource,
         name: file.name,
+        sourceId: this.id,
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "file", file });
@@ -50,6 +51,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
         metricsCollector: args.metricsCollector,
         seekToTime: getSeekToTime(),
         name: file.name,
+        sourceId: this.id,
       });
     }
   }

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -46,6 +46,7 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
         urlParams: {
           url,
         },
+        sourceId: this.id,
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url });
@@ -63,6 +64,7 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
         urlParams: {
           url,
         },
+        sourceId: this.id,
       });
     }
   }

--- a/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
@@ -56,6 +56,7 @@ class Ros1SocketDataSourceFactory implements IDataSourceFactory {
       url,
       hostname,
       metricsCollector: args.metricsCollector,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -34,6 +34,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,
         seekToTime: getSeekToTime(),
+        sourceId: this.id,
       });
     } else if (args.file) {
       const bagWorkerDataProvider = new WorkerRosbag2DataProvider({
@@ -49,6 +50,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
         metricsCollector: args.metricsCollector,
         seekToTime: getSeekToTime(),
         name: args.file.name,
+        sourceId: this.id,
       });
     }
 

--- a/packages/studio-base/src/dataSources/Ros2SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2SocketDataSourceFactory.tsx
@@ -39,7 +39,7 @@ class Ros2SocketDataSourceFactory implements IDataSourceFactory {
     const domainIdStr = url;
     const domainId = parseInt(domainIdStr);
 
-    return new Ros2Player({ domainId, metricsCollector: args.metricsCollector });
+    return new Ros2Player({ domainId, metricsCollector: args.metricsCollector, sourceId: this.id });
   }
 }
 

--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.tsx
@@ -45,7 +45,7 @@ class RosbridgeDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    return new RosbridgePlayer({ url, metricsCollector: args.metricsCollector });
+    return new RosbridgePlayer({ url, metricsCollector: args.metricsCollector, sourceId: this.id });
   }
 }
 

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -42,6 +42,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
         metricsCollector: args.metricsCollector,
         // Use blank url params so the data source is set in the url
         urlParams: {},
+        sourceId: this.id,
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url: bagUrl });
@@ -56,6 +57,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
         name: "Adapted from nuScenes dataset.\nCopyright © 2020 nuScenes.\nhttps://www.nuscenes.org/terms-of-use",
         // Use blank url params so the data source is set in the url
         urlParams: {},
+        sourceId: this.id,
       });
     }
   }

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
@@ -34,6 +34,7 @@ class UlogLocalDataSourceFactory implements IDataSourceFactory {
       metricsCollector: args.metricsCollector,
       seekToTime: getSeekToTime(),
       name: file.name,
+      sourceId: this.id,
     });
   }
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -29,7 +29,7 @@ function Wrapper({
       datatypes={new Map()}
       capabilities={["hello"]}
       messages={[]}
-      urlState={{ url: "testurl", param: "one" }}
+      urlState={{ sourceId: "test", parameters: { url: "testurl", param: "one" } }}
       startTime={{ sec: 0, nsec: 1 }}
     >
       <PlayerSelectionContext.Provider value={playerSelection}>

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -12,86 +12,63 @@
 //   You may not use this file except in compliance with the License.
 
 import { renderHook } from "@testing-library/react-hooks";
+import { ReactNode } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
-import PlayerSelectionContext, {
-  PlayerSelection,
-} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useStateToURLSynchronization } from "@foxglove/studio-base/hooks/useStateToURLSynchronization";
-import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 
-// useLayoutEffect doesn't work in headless tests.
-jest.mock("react", () => ({
-  ...jest.requireActual("react"),
-  useLayoutEffect: jest.requireActual("react").useEffect,
-}));
+jest.mock("@foxglove/studio-base/context/CurrentLayoutContext");
 
-function makePlayerSelection(options: Partial<PlayerSelection>): PlayerSelection {
-  return {
-    selectSource: () => {},
-    selectRecent: () => {},
-    availableSources: [],
-    recentSources: [],
-    selectedSource: undefined,
-    ...options,
-  };
+function Wrapper({
+  children,
+  sourceId,
+  parameters,
+}: {
+  children?: ReactNode;
+  sourceId?: string;
+  parameters?: Record<string, string>;
+}) {
+  const urlState = sourceId == undefined ? undefined : { sourceId, parameters };
+
+  return <MockMessagePipelineProvider urlState={urlState}>{children}</MockMessagePipelineProvider>;
 }
 
 describe("useStateToURLSynchronization", () => {
   it("updates the url with a stable source & player state", () => {
-    const emptyPlayerSelection = makePlayerSelection({});
-
-    const selectedPlayerSelection = makePlayerSelection({
-      selectedSource: {
-        id: "test1",
-        type: "connection",
-        displayName: "test",
-        initialize: () => undefined,
-      },
-    });
-
+    const location = new URL("http://localhost");
     const replaceState = jest.fn();
 
     // eslint-disable-next-line id-denylist
     (global as unknown as any).window = {
       history: { replaceState },
-      location: new URL("http://localhost"),
+      location,
     };
 
-    const { rerender } = renderHook(useStateToURLSynchronization, {
-      initialProps: { presence: PlayerPresence.NOT_PRESENT, playerSelection: emptyPlayerSelection },
-      wrapper: ({ children, presence, playerSelection }) => {
-        return (
-          <MockMessagePipelineProvider
-            topics={[]}
-            presence={presence}
-            datatypes={new Map()}
-            capabilities={["hello"]}
-            messages={[]}
-            urlState={{ url: "testurl", param: "one" }}
-            startTime={{ sec: 0, nsec: 1 }}
-          >
-            <PlayerSelectionContext.Provider value={playerSelection}>
-              <MockCurrentLayoutProvider>{children}</MockCurrentLayoutProvider>
-            </PlayerSelectionContext.Provider>
-          </MockMessagePipelineProvider>
-        );
-      },
-    });
+    (useCurrentLayoutSelector as jest.Mock).mockReturnValue(undefined);
 
-    expect(replaceState).not.toHaveBeenCalled();
+    const { rerender } = renderHook(useStateToURLSynchronization, { wrapper: Wrapper });
 
-    rerender({ presence: PlayerPresence.NOT_PRESENT, playerSelection: selectedPlayerSelection });
+    expect(replaceState).toHaveBeenCalledWith(undefined, "", "http://localhost/");
 
-    expect(replaceState).not.toHaveBeenCalled();
+    rerender({ sourceId: "test" });
 
-    rerender({ presence: PlayerPresence.PRESENT, playerSelection: selectedPlayerSelection });
+    expect(replaceState).toHaveBeenLastCalledWith(undefined, "", "http://localhost/?ds=test");
 
-    expect(replaceState).toHaveBeenCalledWith(
+    rerender({ sourceId: "test2", parameters: { a: "one", b: "two" } });
+
+    expect(replaceState).toHaveBeenLastCalledWith(
       undefined,
       "",
-      "http://localhost/?ds=test1&ds.param=one&ds.url=testurl&layoutId=mock-layout",
+      "http://localhost/?ds=test2&ds.a=one&ds.b=two",
+    );
+
+    (useCurrentLayoutSelector as jest.Mock).mockReturnValue("test-layout");
+    rerender();
+    expect(replaceState).toHaveBeenLastCalledWith(
+      undefined,
+      "",
+      "http://localhost/?layoutId=test-layout",
     );
   });
 });

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.test.tsx
@@ -12,63 +12,77 @@
 //   You may not use this file except in compliance with the License.
 
 import { renderHook } from "@testing-library/react-hooks";
-import { ReactNode } from "react";
 
-import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import { useCurrentLayoutSelector } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useStateToURLSynchronization } from "@foxglove/studio-base/hooks/useStateToURLSynchronization";
 
 jest.mock("@foxglove/studio-base/context/CurrentLayoutContext");
-
-function Wrapper({
-  children,
-  sourceId,
-  parameters,
-}: {
-  children?: ReactNode;
-  sourceId?: string;
-  parameters?: Record<string, string>;
-}) {
-  const urlState = sourceId == undefined ? undefined : { sourceId, parameters };
-
-  return <MockMessagePipelineProvider urlState={urlState}>{children}</MockMessagePipelineProvider>;
-}
+jest.mock("@foxglove/studio-base/components/MessagePipeline");
 
 describe("useStateToURLSynchronization", () => {
   it("updates the url with a stable source & player state", () => {
-    const location = new URL("http://localhost");
     const replaceState = jest.fn();
 
     // eslint-disable-next-line id-denylist
     (global as unknown as any).window = {
       history: { replaceState },
-      location,
+      location: new URL("http://example.com/"),
     };
 
+    replaceState.mockImplementation(
+      (_data, _unused, newLocation: string) => (window.location = new URL(newLocation) as any),
+    );
+
     (useCurrentLayoutSelector as jest.Mock).mockReturnValue(undefined);
+    (useMessagePipeline as jest.Mock).mockImplementation((selector) =>
+      selector({
+        playerState: {
+          activeData: {
+            currentTime: { sec: 1, nsec: 1 },
+          },
+          capabilities: ["playbackControl"],
+          urlState: {
+            sourceId: "test-source",
+            parameters: { a: "one", b: "two" },
+          },
+        },
+      }),
+    );
 
-    const { rerender } = renderHook(useStateToURLSynchronization, { wrapper: Wrapper });
+    const { rerender } = renderHook(useStateToURLSynchronization);
 
-    expect(replaceState).toHaveBeenCalledWith(undefined, "", "http://localhost/");
-
-    rerender({ sourceId: "test" });
-
-    expect(replaceState).toHaveBeenLastCalledWith(undefined, "", "http://localhost/?ds=test");
-
-    rerender({ sourceId: "test2", parameters: { a: "one", b: "two" } });
-
+    expect(replaceState).toHaveBeenCalledWith(
+      undefined,
+      "",
+      "http://example.com/?time=1970-01-01T00%3A00%3A01.000000001Z",
+    );
     expect(replaceState).toHaveBeenLastCalledWith(
       undefined,
       "",
-      "http://localhost/?ds=test2&ds.a=one&ds.b=two",
+      "http://example.com/?ds=test-source&ds.a=one&ds.b=two&time=1970-01-01T00%3A00%3A01.000000001Z",
     );
 
+    (useMessagePipeline as jest.Mock).mockImplementation((selector) =>
+      selector({
+        playerState: {
+          activeData: {
+            currentTime: { sec: 10, nsec: 10 },
+          },
+          capabilities: ["playbackControl"],
+          urlState: {
+            sourceId: "test-source2",
+            parameters: { b: "two", c: "three" },
+          },
+        },
+      }),
+    );
     (useCurrentLayoutSelector as jest.Mock).mockReturnValue("test-layout");
     rerender();
     expect(replaceState).toHaveBeenLastCalledWith(
       undefined,
       "",
-      "http://localhost/?layoutId=test-layout",
+      "http://example.com/?ds=test-source2&ds.b=two&ds.c=three&layoutId=test-layout&time=1970-01-01T00%3A00%3A01.000000001Z",
     );
   });
 });

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -2,8 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useRef } from "react";
-import { useDebouncedCallback } from "use-debounce";
+import { useEffect } from "react";
+import { useDebounce } from "use-debounce";
 
 import {
   MessagePipelineContext,
@@ -13,78 +13,57 @@ import {
   LayoutState,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
-import { PlayerCapabilities, PlayerPresence } from "@foxglove/studio-base/players/types";
-import { AppURLState, encodeAppURLState } from "@foxglove/studio-base/util/appURLState";
+import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
+import { updateAppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectCanSeek = (ctx: MessagePipelineContext) =>
   ctx.playerState.capabilities.includes(PlayerCapabilities.playbackControl);
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
-const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
-
-// Write the unsaved app state to the url
-function writeStateToUrl(state: AppURLState) {
-  const url = encodeAppURLState(new URL(window.location.href), state);
-  window.history.replaceState(undefined, "", url.href);
-}
 
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
  */
 export function useStateToURLSynchronization(): void {
+  const playerUrlState = useMessagePipeline(selectUrlState);
+  const stablePlayerUrlState = useDeepMemo(playerUrlState);
   const canSeek = useMessagePipeline(selectCanSeek);
   const currentTime = useMessagePipeline(selectCurrentTime);
-  const playerUrlState = useMessagePipeline(selectUrlState);
   const layoutId = useCurrentLayoutSelector(selectLayoutId);
-  const stablePlayerUrlState = useDeepMemo(playerUrlState);
-  const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const { selectedSource } = usePlayerSelection();
+  const [debouncedCurrentTime] = useDebounce(currentTime, 500, { maxWait: 500 });
 
-  // This ref tracks the state of our player. Because the selected source and the active player
-  // are in different contexts we have to do some extra work to act on the state of both of
-  // them correctly.
-  const playerIsStableRef = useRef(false);
-
-  // Debounce url updates to prevent thrashing when currentTime updates tne unsaved state
-  const queueUpdateUrl = useDebouncedCallback(writeStateToUrl, 500, {
-    leading: true,
-    maxWait: 500,
-  });
-
-  // Mark our player state as unstable when a new source is selected.
+  // Sync current time with the url.
   useEffect(() => {
-    playerIsStableRef.current = false;
-  }, [selectedSource]);
+    const newStateUrl = updateAppURLState(new URL(window.location.href), {
+      time: canSeek ? debouncedCurrentTime : undefined,
+    });
+    window.history.replaceState(undefined, "", newStateUrl.href);
+  }, [canSeek, debouncedCurrentTime]);
 
-  // Wait until the player is present to switch player state back to stable.
+  // Sync layoutId with the url.
   useEffect(() => {
-    if (playerPresence === PlayerPresence.PRESENT) {
-      playerIsStableRef.current = true;
-    }
-  }, [playerPresence]);
-
-  useEffect(() => {
-    // Don't update url unless we have a stable player state and a selected source.
-    if (!playerIsStableRef.current || !selectedSource) {
+    if (!layoutId) {
       return;
     }
 
-    queueUpdateUrl({
+    const newStateUrl = updateAppURLState(new URL(window.location.href), {
       layoutId,
-      ds: selectedSource.id,
-      dsParams: stablePlayerUrlState,
-      time: canSeek ? currentTime : undefined,
     });
-  }, [
-    canSeek,
-    currentTime,
-    layoutId,
-    playerPresence,
-    queueUpdateUrl,
-    selectedSource,
-    stablePlayerUrlState,
-  ]);
+    window.history.replaceState(undefined, "", newStateUrl.href);
+  }, [layoutId]);
+
+  // Sync player state with the url.
+  useEffect(() => {
+    if (!stablePlayerUrlState) {
+      return;
+    }
+
+    const newStateUrl = updateAppURLState(new URL(window.location.href), {
+      ds: stablePlayerUrlState.sourceId,
+      dsParams: stablePlayerUrlState.parameters,
+    });
+    window.history.replaceState(undefined, "", newStateUrl.href);
+  }, [stablePlayerUrlState]);
 }

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -15,13 +15,18 @@ import {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
-import { updateAppURLState } from "@foxglove/studio-base/util/appURLState";
+import { AppURLState, updateAppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectCanSeek = (ctx: MessagePipelineContext) =>
   ctx.playerState.capabilities.includes(PlayerCapabilities.playbackControl);
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
+
+function updateUrl(newState: AppURLState) {
+  const newStateUrl = updateAppURLState(new URL(window.location.href), newState);
+  window.history.replaceState(undefined, "", newStateUrl.href);
+}
 
 /**
  * Syncs our current player, layout and other state with the URL in the address bar.
@@ -36,34 +41,26 @@ export function useStateToURLSynchronization(): void {
 
   // Sync current time with the url.
   useEffect(() => {
-    const newStateUrl = updateAppURLState(new URL(window.location.href), {
+    updateUrl({
       time: canSeek ? debouncedCurrentTime : undefined,
     });
-    window.history.replaceState(undefined, "", newStateUrl.href);
   }, [canSeek, debouncedCurrentTime]);
 
   // Sync layoutId with the url.
   useEffect(() => {
-    if (!layoutId) {
+    if (layoutId == undefined) {
       return;
     }
 
-    const newStateUrl = updateAppURLState(new URL(window.location.href), {
-      layoutId,
-    });
-    window.history.replaceState(undefined, "", newStateUrl.href);
+    updateUrl({ layoutId });
   }, [layoutId]);
 
   // Sync player state with the url.
   useEffect(() => {
-    if (!stablePlayerUrlState) {
+    if (stablePlayerUrlState == undefined) {
       return;
     }
 
-    const newStateUrl = updateAppURLState(new URL(window.location.href), {
-      ds: stablePlayerUrlState.sourceId,
-      dsParams: stablePlayerUrlState.parameters,
-    });
-    window.history.replaceState(undefined, "", newStateUrl.href);
+    updateUrl({ ds: stablePlayerUrlState.sourceId, dsParams: stablePlayerUrlState.parameters });
   }, [stablePlayerUrlState]);
 }

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/index.ts
@@ -63,6 +63,7 @@ type FoxgloveDataPlatformPlayerOpts = {
     deviceId: string;
   };
   metricsCollector: PlayerMetricsCollectorInterface;
+  sourceId: string;
 };
 
 export default class FoxgloveDataPlatformPlayer implements Player {
@@ -102,6 +103,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   private _progress: Progress = {};
   private _loadedMoreMessages?: Signal<void>;
   private _nextFrame: MessageEvent<unknown>[] = [];
+  private readonly _sourceId: string;
 
   /**
    * Cached readers for each schema so we don't have to re-parse definitions on each stream request.
@@ -114,7 +116,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
   private _problems: PlayerProblem[] = [];
   private _problemsById = new Map<string, PlayerProblem>();
 
-  constructor({ params, metricsCollector, consoleApi }: FoxgloveDataPlatformPlayerOpts) {
+  constructor({ params, metricsCollector, consoleApi, sourceId }: FoxgloveDataPlatformPlayerOpts) {
     log.info(`initializing FoxgloveDataPlatformPlayer ${JSON.stringify(params)}`);
     this._metricsCollector = metricsCollector;
     this._metricsCollector.playerConstructed();
@@ -129,6 +131,7 @@ export default class FoxgloveDataPlatformPlayer implements Player {
     this._deviceId = params.deviceId;
     this._name = `${this._deviceId}, ${formatTimeRaw(this._start)} to ${formatTimeRaw(this._end)}`;
     this._consoleApi = consoleApi;
+    this._sourceId = sourceId;
     this._open().catch((error) => {
       this._presence = PlayerPresence.ERROR;
       this._addProblem("open-failed", { message: error.message, error, severity: "error" });
@@ -273,9 +276,12 @@ export default class FoxgloveDataPlatformPlayer implements Player {
       playerId: this._id,
       problems: this._problems,
       urlState: {
-        start: toRFC3339String(this._start),
-        end: toRFC3339String(this._end),
-        deviceId: this._deviceId,
+        sourceId: this._sourceId,
+        parameters: {
+          start: toRFC3339String(this._start),
+          end: toRFC3339String(this._end),
+          deviceId: this._deviceId,
+        },
       },
 
       activeData: {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -65,19 +65,23 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _channelsById = new Map<ChannelId, ResolvedChannel>();
   private _unsupportedChannelIds = new Set<ChannelId>();
   private _recentlyCanceledSubscriptions = new Set<SubscriptionId>();
+  private readonly _sourceId: string;
 
   constructor({
     url,
     metricsCollector,
+    sourceId,
   }: {
     url: string;
     metricsCollector: PlayerMetricsCollectorInterface;
+    sourceId: string;
   }) {
     this._presence = PlayerPresence.INITIALIZING;
     this._metricsCollector = metricsCollector;
     this._url = url;
     this._name = url;
     this._metricsCollector.playerConstructed();
+    this._sourceId = sourceId;
     this._open();
   }
 
@@ -342,7 +346,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
       playerId: this._id,
       problems: this._problems.problems(),
       urlState: {
-        url: this._url,
+        sourceId: this._sourceId,
+        parameters: { url: this._url },
       },
 
       activeData: {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -122,7 +122,10 @@ describe("IterablePlayer", () => {
       presence: PlayerPresence.INITIALIZING,
       progress: {},
       filePath: undefined,
-      urlState: undefined,
+      urlState: {
+        sourceId: "test",
+        parameters: undefined,
+      },
       name: undefined,
     };
 
@@ -201,7 +204,10 @@ describe("IterablePlayer", () => {
       presence: PlayerPresence.PRESENT,
       progress: {},
       filePath: undefined,
-      urlState: undefined,
+      urlState: {
+        sourceId: "test",
+        parameters: undefined,
+      },
       name: undefined,
     };
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -95,6 +95,7 @@ describe("IterablePlayer", () => {
     const player = new IterablePlayer({
       source,
       enablePreload: false,
+      sourceId: "test",
     });
     const store = new PlayerStateStore(4);
     player.setListener(async (state) => await store.add(state));
@@ -144,6 +145,7 @@ describe("IterablePlayer", () => {
     const player = new IterablePlayer({
       source,
       enablePreload: false,
+      sourceId: "test",
     });
     const store = new PlayerStateStore(4);
     player.setSubscriptions([{ topic: "foo" }]);

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -73,6 +73,9 @@ type IterablePlayerOptions = {
   // Optional set of key/values to store with url handling
   urlParams?: Record<string, string>;
 
+  // Source identifier used in constructing state urls.
+  sourceId: string;
+
   isSampleDataSource?: boolean;
 
   // Set to _false_ to disable preloading. (default: true)
@@ -168,8 +171,10 @@ export class IterablePlayer implements Player {
   // The iterator for processing ticks. This persists between tick calls and is cleared when changing state.
   private _tickIterator?: AsyncIterator<Readonly<IteratorResult>>;
 
+  private readonly _sourceId: string;
+
   constructor(options: IterablePlayerOptions) {
-    const { metricsCollector, urlParams, source, name, enablePreload } = options;
+    const { metricsCollector, urlParams, source, name, enablePreload, sourceId } = options;
 
     this._iterableSource = source;
     this._name = name;
@@ -177,6 +182,7 @@ export class IterablePlayer implements Player {
     this._metricsCollector = metricsCollector ?? new NoopMetricsCollector();
     this._metricsCollector.playerConstructed();
     this._enablePreload = enablePreload ?? true;
+    this._sourceId = sourceId;
   }
 
   setListener(listener: (playerState: PlayerState) => Promise<void>): void {
@@ -593,7 +599,10 @@ export class IterablePlayer implements Player {
         playerId: this._id,
         activeData: undefined,
         problems: this._problemManager.problems(),
-        urlState: this._urlParams,
+        urlState: {
+          sourceId: this._sourceId,
+          parameters: this._urlParams,
+        },
       });
     }
 
@@ -625,7 +634,12 @@ export class IterablePlayer implements Player {
         datatypes: this._providerDatatypes,
         publishedTopics: this._publishedTopics,
       },
-      urlState: this._urlParams,
+      urlState: this._urlParams
+        ? {
+            sourceId: this._sourceId,
+            parameters: this._urlParams,
+          }
+        : undefined,
     };
 
     return await this._listener(data);

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -634,12 +634,10 @@ export class IterablePlayer implements Player {
         datatypes: this._providerDatatypes,
         publishedTopics: this._publishedTopics,
       },
-      urlState: this._urlParams
-        ? {
-            sourceId: this._sourceId,
-            parameters: this._urlParams,
-          }
-        : undefined,
+      urlState: {
+        sourceId: this._sourceId,
+        parameters: this._urlParams,
+      },
     };
 
     return await this._listener(data);

--- a/packages/studio-base/src/players/RandomAccessPlayer.test.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.test.ts
@@ -43,6 +43,7 @@ import TestProvider from "./TestProvider";
 const playerOptions: RandomAccessPlayerOptions = {
   metricsCollector: undefined,
   seekToTime: { type: "absolute", time: { sec: 10, nsec: 0 } },
+  sourceId: "test",
 };
 
 type PlayerStateWithoutPlayerId = Omit<PlayerState, "playerId">;
@@ -109,6 +110,7 @@ describe("RandomAccessPlayer", () => {
         capabilities: [],
         presence: PlayerPresence.INITIALIZING,
         progress: {},
+        urlState: { sourceId: "test", parameters: undefined },
       },
       {
         activeData: {
@@ -137,6 +139,7 @@ describe("RandomAccessPlayer", () => {
         capabilities: [PlayerCapabilities.setSpeed, PlayerCapabilities.playbackControl],
         presence: PlayerPresence.PRESENT,
         progress: {},
+        urlState: { sourceId: "test", parameters: undefined },
       },
     ]);
 

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -85,6 +85,9 @@ export type RandomAccessPlayerOptions = {
   // Optional set of key/values to store with url handling
   urlParams?: Record<string, string>;
 
+  // Source identifier used to construct state urls.
+  sourceId: string;
+
   isSampleDataSource?: boolean;
 };
 
@@ -134,6 +137,7 @@ export default class RandomAccessPlayer implements Player {
   private _seekToTime: SeekToTimeSpec;
   private _lastRangeMillis?: number;
   private _isSampleDataSource: boolean;
+  private readonly _sourceId: string;
 
   // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
   // See additional comments below where _currentTime is set
@@ -145,7 +149,7 @@ export default class RandomAccessPlayer implements Player {
   private _problems = new Map<string, PlayerProblem>();
 
   constructor(provider: RandomAccessDataProvider, options: RandomAccessPlayerOptions) {
-    const { metricsCollector, seekToTime, urlParams, name } = options;
+    const { metricsCollector, seekToTime, urlParams, name, sourceId } = options;
     const seekBackNs = options.seekBackNs ?? DEFAULT_SEEK_BACK_NANOSECONDS;
 
     if (SEEK_ON_START_NS >= seekBackNs) {
@@ -159,6 +163,7 @@ export default class RandomAccessPlayer implements Player {
     this._seekToTime = seekToTime;
     this._seekBackNs = seekBackNs;
     this._metricsCollector.playerConstructed();
+    this._sourceId = sourceId;
     this._isSampleDataSource = options.isSampleDataSource ?? false;
   }
 
@@ -363,7 +368,10 @@ export default class RandomAccessPlayer implements Player {
             parameters: this._providerParameters,
             publishedTopics,
           },
-      urlState: this._urlParams,
+      urlState: {
+        sourceId: this._sourceId,
+        parameters: this._urlParams,
+      },
     };
 
     return this._listener(data);

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -55,6 +55,7 @@ type Ros1PlayerOpts = {
   url: string;
   hostname?: string;
   metricsCollector: PlayerMetricsCollectorInterface;
+  sourceId: string;
 };
 
 // Connects to `rosmaster` instance using `@foxglove/ros1`
@@ -84,14 +85,16 @@ export default class Ros1Player implements Player {
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
   private _problems = new PlayerProblemManager();
   private _emitTimer?: ReturnType<typeof setTimeout>;
+  private readonly _sourceId: string;
 
-  constructor({ url, hostname, metricsCollector }: Ros1PlayerOpts) {
+  constructor({ url, hostname, metricsCollector, sourceId }: Ros1PlayerOpts) {
     log.info(`initializing Ros1Player (url=${url}, hostname=${hostname})`);
     this._metricsCollector = metricsCollector;
     this._url = url;
     this._hostname = hostname;
     this._start = this._getCurrentTime();
     this._metricsCollector.playerConstructed();
+    this._sourceId = sourceId;
     void this._open();
   }
 
@@ -312,7 +315,8 @@ export default class Ros1Player implements Player {
       playerId: this._id,
       problems: this._problems.problems(),
       urlState: {
-        url: this._url,
+        sourceId: this._sourceId,
+        parameters: { url: this._url },
       },
 
       activeData: {

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -49,6 +49,7 @@ enum Problem {
 type Ros2PlayerOpts = {
   domainId: number;
   metricsCollector: PlayerMetricsCollectorInterface;
+  sourceId: string;
 };
 
 // Connects to a ROS 2 network using RTPS over UDP, discovering peers via UDP multicast.
@@ -76,13 +77,15 @@ export default class Ros2Player implements Player {
   private _presence: PlayerPresence = PlayerPresence.INITIALIZING;
   private _problems = new PlayerProblemManager();
   private _emitTimer?: ReturnType<typeof setTimeout>;
+  private readonly _sourceId: string;
 
-  constructor({ domainId, metricsCollector }: Ros2PlayerOpts) {
+  constructor({ domainId, metricsCollector, sourceId }: Ros2PlayerOpts) {
     log.info(`initializing Ros2Player (domainId=${domainId})`);
     this._domainId = domainId;
     this._metricsCollector = metricsCollector;
     this._start = this._getCurrentTime();
     this._metricsCollector.playerConstructed();
+    this._sourceId = sourceId;
 
     // The ros1ToRos2Type() hack can be removed when @foxglove/rosmsg-msgs-* packages are updated to
     // natively support ROS 2
@@ -312,7 +315,8 @@ export default class Ros2Player implements Player {
       playerId: this._id,
       problems: this._problems.problems(),
       urlState: {
-        url: String(this._domainId),
+        sourceId: this._sourceId,
+        parameters: { url: String(this._domainId) },
       },
 
       activeData: {

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -135,6 +135,7 @@ describe("RosbridgePlayer", () => {
     player = new RosbridgePlayer({
       url: "ws://some-url",
       metricsCollector: new NoopMetricsCollector(),
+      sourceId: "rosbridge-websocket",
     });
   });
 

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -89,19 +89,23 @@ export default class RosbridgePlayer implements Player {
   private _presence: PlayerPresence = PlayerPresence.NOT_PRESENT;
   private _problems = new PlayerProblemManager();
   private _emitTimer?: ReturnType<typeof setTimeout>;
+  private readonly _sourceId: string;
 
   constructor({
     url,
     metricsCollector,
+    sourceId,
   }: {
     url: string;
     metricsCollector: PlayerMetricsCollectorInterface;
+    sourceId: string;
   }) {
     this._presence = PlayerPresence.INITIALIZING;
     this._metricsCollector = metricsCollector;
     this._url = url;
     this._start = fromMillis(Date.now());
     this._metricsCollector.playerConstructed();
+    this._sourceId = sourceId;
     this._open();
   }
 
@@ -344,7 +348,8 @@ export default class RosbridgePlayer implements Player {
         activeData: undefined,
         problems: this._problems.problems(),
         urlState: {
-          url: this._url,
+          sourceId: this._sourceId,
+          parameters: { url: this._url },
         },
       });
     }
@@ -369,7 +374,8 @@ export default class RosbridgePlayer implements Player {
       playerId: this._id,
       problems: this._problems.problems(),
       urlState: {
-        url: this._url,
+        sourceId: this._sourceId,
+        parameters: { url: this._url },
       },
 
       activeData: {

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { DeepReadonly } from "ts-essentials";
+
 import { RosMsgDefinition } from "@foxglove/rosmsg";
 import { Time } from "@foxglove/rostime";
 import type { MessageEvent, ParameterValue } from "@foxglove/studio";
@@ -93,7 +95,10 @@ export type PlayerProblem = {
   tip?: string;
 };
 
-export type PlayerURLState = Record<string, string>;
+export type PlayerURLState = DeepReadonly<{
+  sourceId: string;
+  parameters?: Record<string, string>;
+}>;
 
 export type PlayerState = {
   // Information about the player's presence or connection status, for the UI to show a loading indicator.

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -6,7 +6,7 @@ import { Time, toRFC3339String } from "@foxglove/rostime";
 import { LayoutID } from "@foxglove/studio-base/index";
 import {
   AppURLState,
-  encodeAppURLState,
+  updateAppURLState,
   parseAppURLState,
 } from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
@@ -82,7 +82,7 @@ describe("app state encoding", () => {
 
   it("encodes rosbag urls", () => {
     expect(
-      encodeAppURLState(baseURL(), {
+      updateAppURLState(baseURL(), {
         layoutId: "123" as LayoutID,
         time: undefined,
         ds: "ros1-remote-bagfile",
@@ -115,7 +115,7 @@ describe("app state encoding", () => {
       },
     ])("encodes url state", (state) => {
       const url = state.dsParams?.url;
-      const encodededURL = encodeAppURLState(baseURL(), state).href;
+      const encodededURL = updateAppURLState(baseURL(), state).href;
       expect(encodededURL).toEqual(
         `http://example.com/?ds=${state.ds}&ds.url=${encodeURIComponent(
           url ?? "",

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -21,23 +21,41 @@ export type AppURLState = {
  * @param urlState The player state to encode.
  * @returns A url with all app state stored as query pararms.
  */
-export function encodeAppURLState(url: URL, urlState: AppURLState): URL {
+export function updateAppURLState(url: URL, urlState: AppURLState): URL {
   const newURL = new URL(url.href);
 
-  // Clear all exisiting params first.
-  [...newURL.searchParams].forEach(([k, _]) => newURL.searchParams.delete(k));
-
-  if (urlState.layoutId) {
-    newURL.searchParams.set("layoutId", urlState.layoutId);
+  if ("layoutId" in urlState) {
+    if (urlState.layoutId) {
+      newURL.searchParams.set("layoutId", urlState.layoutId);
+    } else {
+      newURL.searchParams.delete("layoutId");
+    }
   }
 
-  if (urlState.time) {
-    newURL.searchParams.set("time", toRFC3339String(urlState.time));
+  if ("time" in urlState) {
+    if (urlState.time) {
+      newURL.searchParams.set("time", toRFC3339String(urlState.time));
+    } else {
+      newURL.searchParams.delete("time");
+    }
   }
 
-  if (urlState.ds && urlState.dsParams) {
-    newURL.searchParams.set("ds", urlState.ds);
-    Object.entries(urlState.dsParams).forEach(([k, v]) => {
+  if ("ds" in urlState) {
+    if (urlState.ds) {
+      newURL.searchParams.set("ds", urlState.ds);
+    } else {
+      newURL.searchParams.delete("ds");
+    }
+  }
+
+  if ("dsParams" in urlState) {
+    [...newURL.searchParams].forEach(([k, _]) => {
+      if (k.startsWith("ds.")) {
+        newURL.searchParams.delete(k);
+      }
+    });
+
+    Object.entries(urlState.dsParams ?? "").forEach(([k, v]) => {
       newURL.searchParams.set("ds." + k, v);
     });
   }


### PR DESCRIPTION
**User-Facing Changes**
The `layoutId` url parameter (web app) updates when changing layouts and no data source is selected.

**Description**
This fixes an issue with layoutId not being tracked in the absence of a datasource. Currently `PlayerManager` has a separate notion of `selectedSource` and the actually active player. This makes managing URL state very difficult because these two things can be out of sync. This patch removes `selectedSource` as a separate state variable from `PlayerManager` and moves the `sourceId` that the url state hook needs into the live `PlayerState` so that it's always in sync with the other data the url state hook needs.

This patch also separates updates to the layoutId and time portions of the url from updates to the datasource related portions of the url. Overall the url state handling logic is much simpler and easier to understand with these changes.

Unfortunately this touches quite a few files but most of the changes are just plumbing through the `sourceId` to the players.

Also I should note that this _will_ show a `ds` value for local files like `?ds=mcap-local-file`. This makes the logic more consistent and I don't see any end-user value in making a special case for local files that shows no `ds`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3188 