### PR TITLE
Fix unnecessary re-renders in PlayerManager

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -60,7 +60,12 @@ type PlayerManagerProps = {
   playerSources: IDataSourceFactory[];
 };
 
-const selectedLayoutSelector = (state: LayoutState) => state.selectedLayout;
+const messageOrderSelector = (state: LayoutState) =>
+  state.selectedLayout?.data?.playbackConfig.messageOrder ?? DEFAULT_MESSAGE_ORDER;
+const userNodesSelector = (state: LayoutState) =>
+  state.selectedLayout?.data?.userNodes ?? EMPTY_USER_NODES;
+const globalVariablesSelector = (state: LayoutState) =>
+  state.selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES;
 
 export default function PlayerManager(props: PropsWithChildren<PlayerManagerProps>): JSX.Element {
   const { children, playerSources } = props;
@@ -96,11 +101,9 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
 
   const [basePlayer, setBasePlayer] = useState<Player | undefined>();
 
-  const selectedLayout = useCurrentLayoutSelector(selectedLayoutSelector);
-
-  const messageOrder = selectedLayout?.data?.playbackConfig.messageOrder ?? DEFAULT_MESSAGE_ORDER;
-  const userNodes = selectedLayout?.data?.userNodes ?? EMPTY_USER_NODES;
-  const globalVariables = selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES;
+  const messageOrder = useCurrentLayoutSelector(messageOrderSelector);
+  const userNodes = useCurrentLayoutSelector(userNodesSelector);
+  const globalVariables = useCurrentLayoutSelector(globalVariablesSelector);
 
   const { recents, addRecent } = useIndexedDbRecents();
 


### PR DESCRIPTION
**User-Facing Changes**
None (performance improvement only)

**Description**
Fixed a performance regression in PlayerManager. The PlayerManager was re-rendering any time the layout changed (including config for any panel) even though it only cares about userNodes, globalVariables, and messageOrder. This regressed in https://github.com/foxglove/studio/pull/2456. 
