### PR TITLE
Fix the View Docs link in the open dialog

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -111,7 +111,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
           )}
 
           {selectedSource?.docsLink && (
-            <Link href={`https://foxglove.dev/docs/studio/connection${selectedSource.docsLink}`}>
+            <Link href={selectedSource.docsLink}>
               View docs.
             </Link>
           )}

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -110,11 +110,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             </Text>
           )}
 
-          {selectedSource?.docsLink && (
-            <Link href={selectedSource.docsLink}>
-              View docs.
-            </Link>
-          )}
+          {selectedSource?.docsLink && <Link href={selectedSource.docsLink}>View docs.</Link>}
 
           {selectedSource?.formConfig != undefined && (
             <Stack flexGrow={1} justifyContent="space-between">


### PR DESCRIPTION

**User-Facing Changes**
When a user clicks the `View docs` link in the open dialog they are taken to the selected source's docsLink rather than an invalid url.

**Description**
The `View Docs` link was prepending the entire docs url to the selected source `docsLink` property. That property already has the full url so the final url was incorrect. This removes the prepended url and uses only the `docsLink` property.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
