### PR TITLE
Fix the tick handling for IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -681,14 +681,15 @@ export class IterablePlayer implements Player {
       this._end,
     );
 
-    let lastMessageTime: Time | undefined = this._lastMessage?.receiveTime;
+    // fixme - comment
+    let lastMessageTime: Time = this._currentTime;
 
     const msgEvents: MessageEvent<unknown>[] = [];
 
     // When ending the previous tick, we might have already read a message from the iterator which
     // belongs to our tick. This logic brings that message into our current batch of message events.
     if (this._lastMessage) {
-      // If the last message we saw is still ahead of the tick time, we don't emit anything
+      // If the last message we saw is still ahead of the tick end time, we don't emit anything
       if (compare(this._lastMessage.receiveTime, end) > 0) {
         this._currentTime = end;
         this._messages = msgEvents;
@@ -697,29 +698,36 @@ export class IterablePlayer implements Player {
       }
 
       msgEvents.push(this._lastMessage);
+      lastMessageTime = this._lastMessage.receiveTime;
       this._lastMessage = undefined;
     }
 
-    // If we have no forward iterator then we create one at 1 nanosecond past the current time.
-    // currentTime is assumed to have already been read previously
-    if (!this._tickIterator) {
-      const next = add(this._currentTime, { sec: 0, nsec: 1 });
-      // Next would be past our desired range so we stop
-      if (compare(next, this._end) > 0) {
-        return;
+    for (;;) {
+      // If we have no forward iterator then we create one at 1 nanosecond past the current time.
+      // currentTime is assumed to have already been read previously
+      if (!this._tickIterator) {
+        const next = add(lastMessageTime, { sec: 0, nsec: 1 });
+        // Next would be past our desired range
+        if (compare(next, end) > 0) {
+          break;
+        }
+
+        const iteratorEnd = add(next, fromNanoSec(BigInt(this._iteratorDurationNanos)));
+
+        // fixme - we assume the last message time is the iteratorEnd time if there are no messages
+        // so we start the next iterator after this one
+        // if there are messages, those will override the last time
+        lastMessageTime = iteratorEnd;
+
+        log.debug("Initializing forward iterator from", next, "to", iteratorEnd);
+
+        this._tickIterator = this._iterableSource.messageIterator({
+          topics: Array.from(this._allTopics),
+          start: next,
+          end: iteratorEnd,
+        });
       }
 
-      log.debug("Initializing forward iterator from", next);
-
-      const iteratorEnd = add(next, fromNanoSec(BigInt(this._iteratorDurationNanos)));
-      this._tickIterator = this._iterableSource.messageIterator({
-        topics: Array.from(this._allTopics),
-        start: next,
-        end: iteratorEnd,
-      });
-    }
-
-    for (;;) {
       const result = await this._tickIterator.next();
       if (result.done === true) {
         if (this._nextState) {
@@ -730,27 +738,9 @@ export class IterablePlayer implements Player {
         // Start a new iterator at 1 nanosecond past the last message we've processed. Iterators
         // are always inclusive so when our iterator has ended we know we've seen every message up-to
         // and-at that time.
-        if (lastMessageTime) {
-          const next = add(lastMessageTime, { sec: 0, nsec: 1 });
-
-          // Next would be past our desired range so we stop reading from the iterators
-          if (compare(next, this._end) > 0) {
-            break;
-          }
-
-          log.debug("Initializing forward iterator from", next);
-
-          const iteratorEnd = clampTime(
-            add(next, fromNanoSec(BigInt(this._iteratorDurationNanos))),
-            next,
-            this._end,
-          );
-          this._tickIterator = this._iterableSource.messageIterator({
-            topics: Array.from(this._allTopics),
-            start: next,
-            end: iteratorEnd,
-          });
-
+        if (compare(lastMessageTime, end) <= 0) {
+          // if (lastMessageTime) {
+          this._tickIterator = undefined;
           continue;
         }
 
@@ -766,11 +756,11 @@ export class IterablePlayer implements Player {
         return;
       }
 
+      lastMessageTime = iterResult.msgEvent?.receiveTime ?? lastMessageTime;
+
       if (iterResult.problem) {
         continue;
       }
-
-      lastMessageTime = iterResult.msgEvent.receiveTime;
 
       // The message is past the end time, we need to save it for next tick
       if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
@@ -781,7 +771,6 @@ export class IterablePlayer implements Player {
       msgEvents.push(iterResult.msgEvent);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
     if (this._nextState) {
       return;
     }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -681,7 +681,9 @@ export class IterablePlayer implements Player {
       this._end,
     );
 
-    // fixme - comment
+    // The last message time tracks the receiveTime of the last message we've emitted.
+    // Iterator bounds are inclusive so when making a new iterator we need to avoid including
+    // a time which we've already emitted.
     let lastMessageTime: Time = this._currentTime;
 
     const msgEvents: MessageEvent<unknown>[] = [];
@@ -714,9 +716,9 @@ export class IterablePlayer implements Player {
 
         const iteratorEnd = add(next, fromNanoSec(BigInt(this._iteratorDurationNanos)));
 
-        // fixme - we assume the last message time is the iteratorEnd time if there are no messages
-        // so we start the next iterator after this one
-        // if there are messages, those will override the last time
+        // Our iterator might not produce any messages, so we set the lastMessageTime to the iterator
+        // end range so if we need to make another iterator in this same tick we don't include time
+        // which we've already iterated over.
         lastMessageTime = iteratorEnd;
 
         log.debug("Initializing forward iterator from", next, "to", iteratorEnd);
@@ -739,7 +741,6 @@ export class IterablePlayer implements Player {
         // are always inclusive so when our iterator has ended we know we've seen every message up-to
         // and-at that time.
         if (compare(lastMessageTime, end) <= 0) {
-          // if (lastMessageTime) {
           this._tickIterator = undefined;
           continue;
         }


### PR DESCRIPTION

**User-Facing Changes**
When seeking near the end of the data, the app no longer freezes if there are no messages between the start of the seek and the end of the dataset time.

**Description**
When performing a _tick_ the iterable player would fail to track the correct _next_ start time for an iterator when the _tick_ needs to span two iterators (i.e. the current iterator ends but we still need to read more messages to finish the tick). This change fixes this logic to always set the next start time to the end of the iterator and also clear the lastMessageTime when it is used to setup the new iterator.

Fixes: #3285

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
