### PR TITLE
Avoid addMessages in plot panel depending on blocks

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -298,6 +298,13 @@ function Plot(props: Props) {
     [allPaths],
   );
 
+  // The addMessages function below is passed to useMessageReducer to handle new messages during
+  // playback. If we have messages for a specific path in _blocks_ then we ignore the messages in
+  // the reducer.
+  //
+  // To keep the addMessages function "stable" when loading new blocks we grab only the paths from
+  // the blocks and make addMessages depend on the paths. To keep paths referentially stable when
+  // the paths values haven't changed we use a shallow memo.
   const blockPaths = useMemo(() => Object.keys(plotDataForBlocks), [plotDataForBlocks]);
   const blockPathsMemo = useShallowMemo(Object.keys(blockPaths));
 

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -306,7 +306,7 @@ function Plot(props: Props) {
   // the blocks and make addMessages depend on the paths. To keep paths referentially stable when
   // the paths values haven't changed we use a shallow memo.
   const blockPaths = useMemo(() => Object.keys(plotDataForBlocks), [plotDataForBlocks]);
-  const blockPathsMemo = useShallowMemo(Object.keys(blockPaths));
+  const blockPathsMemo = useShallowMemo(blockPaths);
 
   const addMessages = useCallback(
     (accumulated: PlotDataByPath, msgEvents: readonly MessageEvent<unknown>[]) => {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -20,6 +20,7 @@ import memoizeWeak from "memoize-weak";
 import { useEffect, useCallback, useMemo, ComponentProps, useContext } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
+import { useShallowMemo } from "@foxglove/hooks";
 import {
   Time,
   add as addTimes,
@@ -297,6 +298,9 @@ function Plot(props: Props) {
     [allPaths],
   );
 
+  const blockPaths = useMemo(() => Object.keys(plotDataForBlocks), [plotDataForBlocks]);
+  const blockPathsMemo = useShallowMemo(Object.keys(blockPaths));
+
   const addMessages = useCallback(
     (accumulated: PlotDataByPath, msgEvents: readonly MessageEvent<unknown>[]) => {
       const lastEventTime = msgEvents[msgEvents.length - 1]?.receiveTime;
@@ -315,7 +319,7 @@ function Plot(props: Props) {
         for (const path of paths) {
           // Skip any paths we already service in plotDataForBlocks.
           // We don't need to accumulate these because the block data takes precedence.
-          if (path in plotDataForBlocks) {
+          if (blockPathsMemo.includes(path)) {
             continue;
           }
 
@@ -364,7 +368,7 @@ function Plot(props: Props) {
       return { ...accumulated };
     },
     [
-      plotDataForBlocks,
+      blockPathsMemo,
       cachedGetMessagePathDataItems,
       followingView,
       showSingleCurrentMessage,


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
During initial datasource loading, blocks are changing quickly. This resulted in the addMessages function constantly changing because it had logic that depended on ignoring paths that are present in blocks. useMessageReducer doesn't like that and produces a lot of warnings to the console because it keeps re-running the reducer.

This change memoizes the paths that exist in blocks and uses this variable for the addMessages logic rather than all the block data. These paths are more stable and do not change as blocks are loading.

While we no longer spam warning messages about "addMessages changing too frequently" to the console, we are now comparing the array of paths on every render. Practically this is no different than comparing all the dependency arrays for react hooks since the paths array is typically short.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
