### PR TITLE
Fix numberinput step and add min/max

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -143,6 +143,8 @@ function FieldInput({
           value={field.value}
           placeholder={field.placeholder}
           fullWidth
+          max={field.max}
+          min={field.min}
           step={field.step}
           onChange={(value) =>
             actionHandler({ action: "update", payload: { path, input: "number", value } })

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -22,6 +22,7 @@ const DefaultSettings: SettingsTreeNode = {
   fields: {
     firstRootField: { input: "string", label: "First Root Field" },
     secondRootField: { input: "string", label: "Second Root Field" },
+    emptyNumber: { input: "number", label: "Empty Number" },
   },
   children: {
     complex_inputs: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -124,6 +124,8 @@ For ROS users, we also support package:// URLs
           label: "Size",
           value: undefined,
           input: "number",
+          max: 10,
+          min: 1,
         },
         subdivision: {
           label: "Subdivision",

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -5,7 +5,7 @@
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { IconButton, TextFieldProps, TextField, styled as muiStyled } from "@mui/material";
-import { ReactNode } from "react";
+import { ReactNode, useCallback } from "react";
 import { useKeyPress } from "react-use";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -51,6 +51,8 @@ export function NumberInput(
   props: {
     iconUp?: ReactNode;
     iconDown?: ReactNode;
+    max?: number;
+    min?: number;
     step?: number;
     value?: number;
     onChange: (value: undefined | number) => void;
@@ -62,20 +64,36 @@ export function NumberInput(
 
   const stepAmount = shiftPressed ? step * 10 : step;
 
+  const updateValue = useCallback(
+    (newValue: number) => {
+      if (props.max != undefined && newValue > props.max) {
+        return;
+      }
+
+      if (props.min != undefined && newValue < props.min) {
+        return;
+      }
+
+      onChange(newValue);
+    },
+    [onChange, props.max, props.min],
+  );
+
   return (
     <StyledTextField
       {...props}
       value={value}
       onChange={(event) =>
-        onChange(event.target.value.length > 0 ? Number(event.target.value) : undefined)
+        event.target.value.length > 0 ? updateValue(Number(event.target.value)) : undefined
       }
       type="number"
+      inputProps={{ max: props.max, min: props.min, step: stepAmount }}
       InputProps={{
         startAdornment: (
           <StyledIconButton
             size="small"
             edge="start"
-            onClick={() => value != undefined && onChange(value - stepAmount)}
+            onClick={() => value != undefined && updateValue(value - stepAmount)}
           >
             {iconDown ?? <ChevronLeftIcon fontSize="small" />}
           </StyledIconButton>
@@ -84,7 +102,7 @@ export function NumberInput(
           <StyledIconButton
             size="small"
             edge="end"
-            onClick={() => value != undefined && onChange(value + stepAmount)}
+            onClick={() => value != undefined && updateValue(value + stepAmount)}
           >
             {iconUp ?? <ChevronRightIcon fontSize="small" />}
           </StyledIconButton>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -93,7 +93,7 @@ export function NumberInput(
           <StyledIconButton
             size="small"
             edge="start"
-            onClick={() => value != undefined && updateValue(value - stepAmount)}
+            onClick={() => updateValue((value ?? 0) - stepAmount)}
           >
             {iconDown ?? <ChevronLeftIcon fontSize="small" />}
           </StyledIconButton>
@@ -102,7 +102,7 @@ export function NumberInput(
           <StyledIconButton
             size="small"
             edge="end"
-            onClick={() => value != undefined && updateValue(value + stepAmount)}
+            onClick={() => updateValue((value ?? 0) + stepAmount)}
           >
             {iconUp ?? <ChevronRightIcon fontSize="small" />}
           </StyledIconButton>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -5,6 +5,7 @@
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { IconButton, TextFieldProps, TextField, styled as muiStyled } from "@mui/material";
+import { clamp } from "lodash";
 import { ReactNode, useCallback } from "react";
 import { useKeyPress } from "react-use";
 
@@ -66,15 +67,13 @@ export function NumberInput(
 
   const updateValue = useCallback(
     (newValue: number) => {
-      if (props.max != undefined && newValue > props.max) {
-        return;
-      }
-
-      if (props.min != undefined && newValue < props.min) {
-        return;
-      }
-
-      onChange(newValue);
+      onChange(
+        clamp(
+          newValue,
+          props.min ?? Number.NEGATIVE_INFINITY,
+          props.max ?? Number.POSITIVE_INFINITY,
+        ),
+      );
     },
     [onChange, props.max, props.min],
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -8,7 +8,7 @@ export type SettingsTreeFieldValue =
   | { input: "color"; value?: string }
   | { input: "gradient"; value?: string }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
-  | { input: "number"; value?: number; step?: number }
+  | { input: "number"; value?: number; step?: number; max?: number; min?: number }
   | {
       input: "select";
       value?: number | readonly number[];


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes an issue with the number inputs in the new settings UI. The `step` value now also controls increments initiated by pressing the up & down arrow keys.

This PR also adds support for a min & max value on number inputs that will be enforced for user edits.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3276 