### PR TITLE
Settings UI fixes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -208,11 +208,12 @@ function FieldInput({
     case "rgb": {
       return (
         <ColorPickerInput
-          fullWidth
-          size="small"
-          variant="filled"
           alphaType="none"
+          fullWidth
+          placeholder={field.placeholder}
+          size="small"
           value={field.value?.toString()}
+          variant="filled"
           onChange={(value) =>
             actionHandler({
               action: "update",
@@ -227,6 +228,7 @@ function FieldInput({
         <ColorPickerInput
           alphaType="alpha"
           fullWidth
+          placeholder={field.placeholder}
           size="small"
           value={field.value?.toString()}
           variant="filled"

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -273,6 +273,7 @@ function FieldInput({
       return (
         <Select
           size="small"
+          displayEmpty
           fullWidth
           variant="filled"
           value={field.value}

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -205,17 +205,35 @@ function FieldInput({
         </StyledToggleButtonGroup>
       );
     }
-    case "color": {
+    case "rgb": {
       return (
         <ColorPickerInput
-          value={field.value?.toString()}
+          fullWidth
           size="small"
           variant="filled"
-          fullWidth
+          alphaType="none"
+          value={field.value?.toString()}
           onChange={(value) =>
             actionHandler({
               action: "update",
-              payload: { path, input: "color", value },
+              payload: { path, input: "rgb", value },
+            })
+          }
+        />
+      );
+    }
+    case "rgba": {
+      return (
+        <ColorPickerInput
+          alphaType="alpha"
+          fullWidth
+          size="small"
+          value={field.value?.toString()}
+          variant="filled"
+          onChange={(value) =>
+            actionHandler({
+              action: "update",
+              payload: { path, input: "rgba", value },
             })
           }
         />

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -94,6 +94,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     return (
       <NodeEditor
         actionHandler={actionHandler}
+        defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
         disableIcon={true}
         key={key}
         settings={child}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -53,6 +53,13 @@ const DefaultSettings: SettingsTreeNode = {
         },
       },
     },
+    defaultCollapsed: {
+      label: "Default Collapsed",
+      defaultExpansionState: "collapsed",
+      fields: {
+        field: { label: "Field", input: "string" },
+      },
+    },
     background: {
       label: "Background",
       fields: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -47,7 +47,8 @@ const DefaultSettings: SettingsTreeNode = {
     background: {
       label: "Background",
       fields: {
-        color: { label: "Color", value: "#000000", input: "color" },
+        colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
+        colorRGBA: { label: "Color RGBA", value: "rgba(0, 128, 255, 0.75)", input: "rgba" },
       },
     },
     threeDimensionalModel: {
@@ -55,7 +56,7 @@ const DefaultSettings: SettingsTreeNode = {
       fields: {
         color: {
           label: "Color",
-          input: "color",
+          input: "rgb",
           value: "#9480ed",
         },
         url: {
@@ -106,7 +107,7 @@ For ROS users, we also support package:// URLs
         },
         marker_color: {
           label: "Marker color",
-          input: "color",
+          input: "rgb",
           value: "#ff0000",
         },
       },
@@ -117,7 +118,7 @@ For ROS users, we also support package:// URLs
         color: {
           label: "Color",
           value: "#248eff",
-          input: "color",
+          input: "rgb",
         },
         size: {
           label: "Size",
@@ -168,7 +169,7 @@ For ROS users, we also support package:// URLs
             color: {
               label: "Color",
               value: "#00ff00",
-              input: "color",
+              input: "rgb",
             },
             click_handling: {
               label: "Selection mode",
@@ -191,7 +192,7 @@ For ROS users, we also support package:// URLs
                 color: {
                   label: "Color",
                   value: "#00ff00",
-                  input: "color",
+                  input: "rgb",
                 },
               },
             },
@@ -246,7 +247,7 @@ For ROS users, we also support package:// URLs
     pose: {
       label: "Pose",
       fields: {
-        color: { label: "Color", value: "#ffffff", input: "color" },
+        color: { label: "Color", value: "#ffffff", input: "rgb" },
         shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
         shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
         head_length: { label: "Head length", value: 2, input: "number" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -42,6 +42,15 @@ const DefaultSettings: SettingsTreeNode = {
           labels: ["U", "V", "W"],
           value: [1, 2, 3],
         },
+        emptySelect: {
+          label: "Empty Select",
+          value: "",
+          input: "select",
+          options: [
+            { label: "Nothing", value: "" },
+            { label: "Something", value: "something" },
+          ],
+        },
       },
     },
     background: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -67,6 +67,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
         {...props}
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        placeholder={props.placeholder}
         InputProps={{
           startAdornment: swatchOrientation === "start" && (
             <ColorSwatch color={swatchColor} onClick={togglePicker} />

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -11,6 +11,7 @@ import {
   ClickAwayListener,
 } from "@mui/material";
 import { useState } from "react";
+import tinycolor from "tinycolor2";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -45,6 +46,7 @@ const PickerWrapper = muiStyled(Card)(({ theme }) => ({
 }));
 
 type ColorPickerInputProps = {
+  alphaType: "none" | "alpha";
   value: undefined | string;
   onChange: (value: undefined | string) => void;
   swatchOrientation?: "start" | "end";
@@ -54,8 +56,8 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const { onChange, swatchOrientation = "start", value } = props;
   const [showPicker, setShowPicker] = useState(false);
 
-  const isValidColor = Boolean(value?.match(/^#[0-9a-fA-F]{6}$/i));
-  const swatchColor = isValidColor && value != undefined ? value : "#00000044";
+  const isValidColor = value != undefined && tinycolor(value).isValid();
+  const swatchColor = isValidColor ? value : "#00000044";
 
   const togglePicker = () => setShowPicker(!showPicker);
 
@@ -79,7 +81,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
           <PickerWrapper variant="elevation">
             <ColorPicker
               color={swatchColor}
-              alphaType={"none"}
+              alphaType={props.alphaType}
               styles={{
                 tableHexCell: { width: "35%" },
                 input: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -5,8 +5,8 @@
 export type SettingsTreeFieldValue =
   | { input: "autocomplete"; value?: string; items: string[] }
   | { input: "boolean"; value?: boolean }
-  | { input: "rgb"; value?: string; placeholder?: string }
-  | { input: "rgba"; value?: string; placeholder?: string }
+  | { input: "rgb"; value?: string }
+  | { input: "rgba"; value?: string }
   | { input: "gradient"; value?: string }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
   | { input: "number"; value?: number; step?: number }
@@ -29,8 +29,20 @@ export type SettingsTreeFieldValue =
     };
 
 export type SettingsTreeField = SettingsTreeFieldValue & {
+  /**
+   * Optional help text to explain the purpose of the field.
+   */
   help?: string;
+
+  /**
+   * The label displayed alongside the field.
+   */
   label: string;
+
+  /**
+   * Optional placeholder text displayed in the field input in the
+   * absence of a value.
+   */
   placeholder?: string;
 };
 
@@ -39,8 +51,24 @@ export type SettingsTreeFields = Record<string, SettingsTreeField>;
 export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
 
 export type SettingsTreeNode = {
+  /**
+   * Other settings tree nodes nested under this node.
+   */
   children?: SettingsTreeChildren;
+
+  /**
+   * Set to collapsed if the node should be initially collapsed.
+   */
+  defaultExpansionState?: "collapsed" | "expanded";
+
+  /**
+   * Field inputs attached directly to this node.
+   */
   fields?: SettingsTreeFields;
+
+  /**
+   * An optional label shown at the top of this node.
+   */
   label?: string;
 };
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -5,7 +5,8 @@
 export type SettingsTreeFieldValue =
   | { input: "autocomplete"; value?: string; items: string[] }
   | { input: "boolean"; value?: boolean }
-  | { input: "color"; value?: string }
+  | { input: "rgb"; value?: string; placeholder?: string }
+  | { input: "rgba"; value?: string; placeholder?: string }
   | { input: "gradient"; value?: string }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
   | { input: "number"; value?: number; step?: number }

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -58,7 +58,7 @@ function buildSettingsTree(config: Config): SettingsTreeNode {
       advancedView: { label: "Editing Mode", input: "boolean", value: config.advancedView },
       buttonText: { label: "Button Title", input: "string", value: config.buttonText },
       buttonTooltip: { label: "Button Tooltip", input: "string", value: config.buttonTooltip },
-      buttonColor: { label: "Button Color", input: "color", value: config.buttonColor },
+      buttonColor: { label: "Button Color", input: "rgb", value: config.buttonColor },
     },
   };
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
@@ -34,7 +34,7 @@ export function buildSettingsTree(config: ThreeDimensionalVizConfig): SettingsTr
   if (!config.useThemeBackgroundColor) {
     rootFields.customBackgroundColor = {
       label: "Background color",
-      input: "color",
+      input: "rgba",
       value: config.customBackgroundColor,
     };
   }


### PR DESCRIPTION
**User-Facing Changes**
Adds support for rgba color values in the settings panels.

**Description**
This adds support for rgba style colors in settings panels. For consistency the input type previously called `color` is now called `rgb` and the new type is `rgba`. `rgba` values must be expressed as the a css rgba-style value like `rgba(255, 255, 255, 0.5)`.

<img width="350" alt="Screen Shot 2022-05-02 at 12 22 18 PM" src="https://user-images.githubusercontent.com/93935560/166294889-accaf7e6-40b3-4119-a687-6c1f82ff009f.png">

This also shows a label in `select` inputs when the value is empty and adds a new `defaultExpansionState` field at the node level that can be used to made a node initially display as collapsed.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3277 