### PR TITLE
Allow 100 milliseconds for IterablePlayer to backfill

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -153,9 +153,12 @@ describe("IterablePlayer", () => {
     const store = new PlayerStateStore(4);
     player.setSubscriptions([{ topic: "foo" }]);
     player.setListener(async (state) => await store.add(state));
+
+    // Wait for initial setup
     await store.done;
 
-    store.reset(4);
+    // Reset store to get state from the seeks
+    store.reset(2);
 
     // replace the message iterator with our own implementation
     // This implementation performs a seekPlayback during backfill.
@@ -241,7 +244,7 @@ describe("IterablePlayer", () => {
     // 2. a state update with the _new_ seek time to ack the second seek
     // 3. a state update with the messages from the new seek
     // 4. a state update from idle
-    expect(playerStates).toEqual([baseState, newSeekBase, withMessages, newSeekBase]);
+    expect(playerStates).toEqual([newSeekBase, withMessages]);
 
     player.close();
   });

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -165,6 +165,7 @@ describe("IterablePlayer", () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalMethod = source.getBackfillMessages;
     source.getBackfillMessages = async function () {
+      // Set a new backfill method and initiate another seek
       source.getBackfillMessages = async function () {
         source.getBackfillMessages = originalMethod;
         return [
@@ -188,7 +189,7 @@ describe("IterablePlayer", () => {
 
     const baseState: PlayerStateWithoutPlayerId = {
       activeData: {
-        currentTime: { sec: 0, nsec: 0 },
+        currentTime: { sec: 0, nsec: 1 },
         startTime: { sec: 0, nsec: 0 },
         endTime: { sec: 0, nsec: 0 },
         datatypes: new Map(),
@@ -214,18 +215,10 @@ describe("IterablePlayer", () => {
       name: undefined,
     };
 
-    const newSeekBase = {
+    const withMessages: PlayerStateWithoutPlayerId = {
       ...baseState,
       activeData: {
         ...baseState.activeData!,
-        currentTime: { sec: 0, nsec: 1 },
-      },
-    };
-
-    const withMessages: PlayerStateWithoutPlayerId = {
-      ...newSeekBase,
-      activeData: {
-        ...newSeekBase.activeData,
         currentTime: { sec: 0, nsec: 1 },
         messages: [
           {
@@ -240,11 +233,9 @@ describe("IterablePlayer", () => {
 
     // The first seek is interrupted by the second seek.
     // The state order:
-    // 1. a state update with the currentTime to ack the seek
-    // 2. a state update with the _new_ seek time to ack the second seek
-    // 3. a state update with the messages from the new seek
-    // 4. a state update from idle
-    expect(playerStates).toEqual([newSeekBase, withMessages]);
+    // 1. a state update completing the second seek
+    // 1. a state update for moving to idle
+    expect(playerStates).toEqual([withMessages, baseState]);
 
     player.close();
   });

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -541,12 +541,20 @@ export class IterablePlayer implements Player {
     // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
     // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
     const seekAckTimeout = setTimeout(async () => {
+      // fixme - we never emit anything now because we constantly keep scrubbing
+      // so do we want to allow some previous state to emit? and then start again?
+      // Why would we emit previous messages?
+      if (this._nextState) {
+        return;
+      }
+
       this._messages = [];
       this._currentTime = targetTime;
       this._lastSeekEmitTime = Date.now();
 
       // emit a state message for the seek time, we only do this if we haven't already emitted one
       await this._emitState();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
       if (this._nextState) {
         return;
       }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -538,13 +538,19 @@ export class IterablePlayer implements Player {
     this._lastMessage = undefined;
     this._seekTarget = undefined;
 
-    this._messages = [];
-    this._currentTime = targetTime;
-    this._lastSeekEmitTime = Date.now();
-    await this._emitState();
-    if (this._nextState) {
-      return;
-    }
+    // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
+    // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
+    const seekAckTimeout = setTimeout(async () => {
+      this._messages = [];
+      this._currentTime = targetTime;
+      this._lastSeekEmitTime = Date.now();
+
+      // emit a state message for the seek time, we only do this if we haven't already emitted one
+      await this._emitState();
+      if (this._nextState) {
+        return;
+      }
+    }, 100);
 
     const topics = Array.from(this._allTopics);
 
@@ -557,7 +563,6 @@ export class IterablePlayer implements Player {
       });
       this._messages = messages;
     } catch (err) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
       if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
         log.debug("Aborted backfill");
       } else {
@@ -567,7 +572,9 @@ export class IterablePlayer implements Player {
       this._abort = undefined;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
+    // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
+    clearTimeout(seekAckTimeout);
+
     if (this._nextState) {
       return;
     }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -538,26 +538,18 @@ export class IterablePlayer implements Player {
     this._lastMessage = undefined;
     this._seekTarget = undefined;
 
+    // If the seekAckTimeout emits a state, _stateSeekBackfill must wait for it to complete.
+    // It would be invalid to allow the _stateSeekBackfill to finish prior to completion
+    let seekAckWait: Promise<void> | undefined;
+
     // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
     // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
-    const seekAckTimeout = setTimeout(async () => {
-      // fixme - we never emit anything now because we constantly keep scrubbing
-      // so do we want to allow some previous state to emit? and then start again?
-      // Why would we emit previous messages?
-      if (this._nextState) {
-        return;
-      }
-
+    const seekAckTimeout = setTimeout(() => {
       this._messages = [];
       this._currentTime = targetTime;
       this._lastSeekEmitTime = Date.now();
 
-      // emit a state message for the seek time, we only do this if we haven't already emitted one
-      await this._emitState();
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-      if (this._nextState) {
-        return;
-      }
+      seekAckWait = this._emitState();
     }, 100);
 
     const topics = Array.from(this._allTopics);
@@ -582,6 +574,11 @@ export class IterablePlayer implements Player {
 
     // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
     clearTimeout(seekAckTimeout);
+
+    // timeout may have triggered, so we need to wait for any emit that happened
+    if (seekAckWait) {
+      await seekAckWait;
+    }
 
     if (this._nextState) {
       return;


### PR DESCRIPTION
**User-Facing Changes**
When seeking or scrubbing, the panels no longer flash to an empty state. They display the previous state for a short window (100 milliseconds), and if the new seek location is not loaded by this time, _then_ the panels flash to an empty state indicating loading. If the new seek location _is_ loaded before the timeout, then the panels display the new message data.

**Description**
When seeking, the IterablePlayer would immediately emit a message with the new seek time. This would show an updated seek location in the scrub bar but would also clear all messages from the screen since there were no messages loaded for the seek time yet.

This change gives the backfill 100 milliseconds to emit state before emitting the new seek time. For local data this allows users to scrub continuously and see the scene or messages rather than a black screen.

Fixes: #3297

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
