### PR TITLE
Replace sx style prop

### DIFF
--- a/packages/studio-base/src/components/ChildToggle/index.tsx
+++ b/packages/studio-base/src/components/ChildToggle/index.tsx
@@ -222,7 +222,7 @@ export default function ChildToggle(props: Props): ReactElement {
           direction={position === "left" || position === "bottom-left" ? "row-reverse" : "row"}
           alignItems={position === "above" ? "flex-end" : "flex-start"}
           position="fixed"
-          sx={{ pointerEvents: "none", ...styleObj }}
+          style={{ pointerEvents: "none", ...styleObj }}
         >
           {/* shrinkable spacer allows child to have a default position but slide over when it would go offscreen */}
           <Box flexBasis={spacerSize} flexShrink={1} />

--- a/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
@@ -35,8 +35,8 @@ export default function SignInPrompt(props: SignInPromptProps): JSX.Element {
       alignItems="center"
       padding={2}
       spacing={2}
-      sx={{
-        bgcolor: theme.palette.themeLighterAlt,
+      style={{
+        backgroundColor: theme.palette.themeLighterAlt,
         position: "sticky",
         bottom: 0,
       }}

--- a/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/UnsavedChangesPrompt.tsx
@@ -116,7 +116,7 @@ export function UnsavedChangesPrompt({
       maxWidth={320}
     >
       <form onSubmit={handleSubmit}>
-        <Stack spacing={2} sx={{ minHeight: 180 }}>
+        <Stack spacing={2} style={{ minHeight: 180 }}>
           <ChoiceGroup
             selectedKey={selectedKey}
             options={options}

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -470,7 +470,7 @@ export default function LayoutBrowser({
         {layoutDebug?.syncNow && (
           <Stack
             spacing={0.5}
-            sx={{
+            style={{
               position: "sticky",
               bottom: 0,
               left: 0,

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { CompoundButton, Text, IButtonProps, useTheme, Checkbox } from "@fluentui/react";
-import { Stack } from "@mui/material";
+import { Stack, styled as muiStyled } from "@mui/material";
 import { useMemo } from "react";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -55,6 +55,11 @@ export type IStartProps = {
   supportedRemoteFileExtensions?: string[];
   onSelectView: (newValue: OpenDialogViews) => void;
 };
+
+const RecentStack = muiStyled(Stack)(({ theme }) => ({
+  overflow: "hidden",
+  "&:hover": { color: theme.palette.primary.dark },
+}));
 
 export default function Start(props: IStartProps): JSX.Element {
   const {
@@ -140,10 +145,7 @@ export default function Start(props: IStartProps): JSX.Element {
       return {
         id: recent.id,
         children: (
-          <Stack
-            direction="row"
-            sx={{ overflow: "hidden", "&:hover": { color: theme.palette.themeDark } }}
-          >
+          <RecentStack direction="row">
             <Text
               variant="small"
               styles={{
@@ -170,7 +172,7 @@ export default function Start(props: IStartProps): JSX.Element {
                 {recent.label}
               </Text>
             )}
-          </Stack>
+          </RecentStack>
         ),
         onClick: () => selectRecent(recent.id),
       };

--- a/packages/studio-base/src/components/OpenDialog/View.tsx
+++ b/packages/studio-base/src/components/OpenDialog/View.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { ActionButton, DefaultButton, PrimaryButton, useTheme } from "@fluentui/react";
-import { Stack } from "@mui/material";
+import { Stack, styled as muiStyled } from "@mui/material";
 import { PropsWithChildren } from "react";
 
 type ViewProps = {
@@ -12,23 +12,19 @@ type ViewProps = {
   onOpen?: () => void;
 };
 
+const ViewStack = muiStyled(Stack)({
+  "@media (min-height: 512px)": { overflow: "hidden" },
+});
+
 export default function View(props: PropsWithChildren<ViewProps>): JSX.Element {
   const { onCancel, onOpen, onBack } = props;
   const theme = useTheme();
 
   return (
     <>
-      <Stack
-        flexGrow={1}
-        height="100%"
-        justifyContent="space-between"
-        spacing={2}
-        sx={{
-          "@media (min-height: 512px)": { overflow: "hidden" },
-        }}
-      >
+      <ViewStack flexGrow={1} height="100%" justifyContent="space-between" spacing={2}>
         {props.children}
-      </Stack>
+      </ViewStack>
       <Stack direction="row" justifyContent="space-between" alignItems="center">
         <ActionButton
           iconProps={{ iconName: "ChevronLeft" }}

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -189,7 +189,7 @@ export default function PlaybackControls({
         alignItems="center"
         spacing={1}
         padding={1}
-        sx={{
+        style={{
           backgroundColor: theme.palette.neutralLighterAlt,
           borderTop: `1px solid ${theme.palette.neutralLighter}`,
         }}

--- a/packages/studio-base/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/studio-base/src/components/Sidebar/SidebarButton.tsx
@@ -8,7 +8,7 @@ import {
   IIconProps,
   IRenderFunction,
 } from "@fluentui/react";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, useTheme } from "@mui/material";
 import { useCallback } from "react";
 
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
@@ -32,6 +32,7 @@ type SidebarButtonProps = {
 
 export default function SidebarButton(props: SidebarButtonProps): JSX.Element {
   const { dataSidebarKey, selected, title, iconProps, onClick, menuProps, badge } = props;
+  const theme = useTheme();
 
   const { ref: tooltipRef, tooltip } = useTooltip({ contents: title, placement: "right" });
   const renderStack = useCallback(
@@ -78,13 +79,13 @@ export default function SidebarButton(props: SidebarButtonProps): JSX.Element {
       />
       {selected && (
         <Box
-          sx={{
+          style={{
             position: "absolute",
             left: 0,
             top: 0,
             bottom: 0,
             width: 3,
-            bgcolor: "primary.main",
+            backgroundColor: theme.palette.primary.main,
           }}
         />
       )}

--- a/packages/studio-base/src/panels/InternalLogs/index.tsx
+++ b/packages/studio-base/src/panels/InternalLogs/index.tsx
@@ -43,7 +43,7 @@ function InternalLogs(props: Props) {
   }, [disabledChannels]);
 
   return (
-    <Stack maxWidth="100%" sx={{ overflowY: "auto" }}>
+    <Stack maxWidth="100%" style={{ overflowY: "auto" }}>
       <PanelToolbar floating helpContent={helpContent} />
       <Stack padding={1} spacing={1}>
         {channels.map((logger) => {

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
@@ -139,7 +139,7 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
             setAutoScroll(true);
           }
         }}
-        sx={{
+        style={{
           overflowY: bottomBarDisplay !== "closed" ? "scroll" : "auto",
           height: bottomBarDisplay !== "closed" ? 150 : 0,
           color: colors.DARK9,

--- a/packages/studio-base/src/panels/URDFViewer/JointValueSliders.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/JointValueSliders.tsx
@@ -31,7 +31,7 @@ export function JointValueSliders({
   );
 
   return (
-    <Stack padding={1} sx={{ overflowY: "auto", width: "40%", maxWidth: 300 }}>
+    <Stack padding={1} style={{ overflowY: "auto", width: "40%", maxWidth: 300 }}>
       {joints.map(([name, joint]) => {
         const min = joint.jointType === "continuous" ? -Math.PI : +joint.limit.lower;
         const max = joint.jointType === "continuous" ? Math.PI : +joint.limit.upper;

--- a/packages/studio-base/src/panels/WelcomePanel/index.tsx
+++ b/packages/studio-base/src/panels/WelcomePanel/index.tsx
@@ -71,7 +71,7 @@ function WelcomePanel() {
     !loading;
 
   return (
-    <Stack data-test="welcome-content" padding={2.5} sx={{ overflowY: "auto" }}>
+    <Stack data-test="welcome-content" padding={2.5} style={{ overflowY: "auto" }}>
       <PanelToolbar floating />
       <TextContent>
         <h1>Welcome</h1>

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -61,7 +61,7 @@ export function LaunchingInDesktopScreen(): ReactElement {
         justifyContent="center"
         height="100%"
         spacing={2.5}
-        sx={{ textAlign: "center", maxWidth: 480 }}
+        style={{ textAlign: "center", maxWidth: 480 }}
       >
         <Text variant="xxLarge">Launching Foxglove Studio…</Text>
         <Text>We’ve directed you to the desktop app.</Text>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This replaces all but one of our remaining uses of the `sx` prop. The remaining case on the extension sidebar is going to require some judgement calls on colors.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
