### PR TITLE
Add visible property to settings tree nodes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -7,7 +7,7 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import LayerIcon from "@mui/icons-material/Layers";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { Collapse, Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
-import { ChangeEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
 import { FieldEditor } from "./FieldEditor";
@@ -69,10 +69,16 @@ const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { actionHandler, defaultOpen = true, disableIcon = false, icon, settings = {} } = props;
   const [open, setOpen] = useState(defaultOpen);
-  const [visible, setVisiblity] = useState(true);
 
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setVisiblity(event.target.checked);
+  const indent = props.path.length;
+  const allowVisibilityToggle = props.settings?.visible != undefined;
+  const visible = props.settings?.visible !== false;
+
+  const toggleVisibility = () => {
+    actionHandler({
+      action: "update",
+      payload: { input: "boolean", path: [...props.path, "visible"], value: !visible },
+    });
   };
 
   const { fields, children } = settings;
@@ -103,8 +109,6 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
-  const indent = props.path.length;
-
   return (
     <>
       {indent > 0 && (
@@ -133,9 +137,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
             edge="end"
             size="small"
             checked={visible}
-            onChange={handleChange}
-            style={{ opacity: 0 }}
-            disabled
+            onChange={toggleVisibility}
+            style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
+            disabled={!allowVisibilityToggle}
           />
         </NodeHeader>
       )}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -18,7 +18,7 @@ export default {
   component: SettingsTreeEditor,
 };
 
-const DefaultSettings: SettingsTreeNode = {
+const BasicSettings: SettingsTreeNode = {
   fields: {
     firstRootField: { input: "string", label: "First Root Field" },
     secondRootField: { input: "string", label: "Second Root Field" },
@@ -87,6 +87,11 @@ For ROS users, we also support package:// URLs
         },
       },
     },
+  },
+};
+
+const PanelExamplesSettings: SettingsTreeNode = {
+  children: {
     map: {
       label: "Map",
       fields: {
@@ -157,11 +162,27 @@ For ROS users, we also support package:// URLs
         },
       },
     },
+    pose: {
+      label: "Pose",
+      fields: {
+        color: { label: "Color", value: "#ffffff", input: "rgb" },
+        shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
+        shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
+        head_length: { label: "Head length", value: 2, input: "number" },
+        head_width: { label: "Head width", value: 2, input: "number" },
+      },
+    },
+  },
+};
+
+const TopicSettings: SettingsTreeNode = {
+  children: {
     topics: {
       label: "Topics",
       children: {
         drivable_area: {
           label: "/drivable_area",
+          visible: true,
           fields: {
             frame_lock: {
               label: "Frame lock",
@@ -263,16 +284,6 @@ For ROS users, we also support package:// URLs
         },
       },
     },
-    pose: {
-      label: "Pose",
-      fields: {
-        color: { label: "Color", value: "#ffffff", input: "rgb" },
-        shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
-        shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
-        head_length: { label: "Head length", value: 2, input: "number" },
-        head_width: { label: "Head width", value: 2, input: "number" },
-      },
-    },
   },
 };
 
@@ -288,16 +299,25 @@ function updateSettingsTreeNode(
       const key = workingPath.shift()!;
       node = node.children?.[key];
     }
+
+    if (!node) {
+      return;
+    }
+
     const key = workingPath.shift()!;
-    const field = node?.fields?.[key];
-    if (field != undefined) {
-      field.value = value as SettingsTreeFieldValue["value"];
+    if (key === "visible") {
+      node.visible = Boolean(value);
+    } else {
+      const field = node.fields?.[key];
+      if (field != undefined) {
+        field.value = value as SettingsTreeFieldValue["value"];
+      }
     }
   });
 }
 
-export const Default = (): JSX.Element => {
-  const [settingsNode, setSettingsNode] = React.useState({ ...DefaultSettings });
+function Wrapper({ settings }: { settings: SettingsTreeNode }): JSX.Element {
+  const [settingsNode, setSettingsNode] = React.useState({ ...settings });
 
   const actionHandler = useCallback((action: SettingsTreeAction) => {
     setSettingsNode((previous) =>
@@ -305,7 +325,7 @@ export const Default = (): JSX.Element => {
     );
   }, []);
 
-  const settings = useMemo(
+  const settingsTree = useMemo(
     () => ({
       actionHandler,
       enableFilter: true,
@@ -324,9 +344,21 @@ export const Default = (): JSX.Element => {
           bgcolor="background.paper"
           overflow="auto"
         >
-          <SettingsTreeEditor settings={settings} />
+          <SettingsTreeEditor settings={settingsTree} />
         </Box>
       </PanelSetup>
     </MockPanelContextProvider>
   );
-};
+}
+
+export function Basics(): JSX.Element {
+  return <Wrapper settings={BasicSettings} />;
+}
+
+export function PanelExamples(): JSX.Element {
+  return <Wrapper settings={PanelExamplesSettings} />;
+}
+
+export function Topics(): JSX.Element {
+  return <Wrapper settings={TopicSettings} />;
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -70,6 +70,13 @@ export type SettingsTreeNode = {
    * An optional label shown at the top of this node.
    */
   label?: string;
+
+  /**
+   * An optional visibility status. If this is not undefined, the node
+   * editor will display a visiblity toggle button and send update actions
+   * to the action handler.
+   **/
+  visible?: boolean;
 };
 
 /**


### PR DESCRIPTION
**User-Facing Changes**
This allows toggling the visibility of notes in the new settings UI.

**Description**
This enables the visibility toggle at node level in the new settings UI. Panel authors can opt-into this feature by setting the `visible` property to either true or false instead of undefined. Clicking on the visibility toggle will send an `update` action with the path set to the path of the node + `visible`, which should make incorporating this into existing implementations straightforward.

<img width="467" alt="Screen Shot 2022-05-03 at 12 21 51 PM" src="https://user-images.githubusercontent.com/93935560/166506089-2ef83d6c-f785-47ca-a588-6c97fbbd3ba7.png">

This also breaks up the existing single settings tree Storybook story into three separate stories so that each of them renders completely onscreen and works for visual diffing.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
