### PR TITLE
Increase sidebar width with a size cap for larger screens

### DIFF
--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -57,6 +57,16 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+function defaultInitialSidebarPercentage() {
+  if (window.innerWidth < 1024) {
+    // Use percentage for smaller screens.
+    return 23;
+  } else {
+    // Use fixed width for larger screens.
+    return 100 * (384 / window.innerWidth);
+  }
+}
+
 export default function Sidebar<K extends string>({
   children,
   items,
@@ -84,7 +94,7 @@ export default function Sidebar<K extends string>({
           direction: "row",
           first: "sidebar",
           second: "children",
-          splitPercentage: 23,
+          splitPercentage: defaultInitialSidebarPercentage(),
         });
       }
       prevSelectedKey.current = selectedKey;

--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -57,14 +57,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+// Determine initial sidebar width, with a cap for larger
+// screens.
 function defaultInitialSidebarPercentage() {
-  if (window.innerWidth < 1024) {
-    // Use percentage for smaller screens.
-    return 23;
-  } else {
-    // Use fixed width for larger screens.
-    return 100 * (384 / window.innerWidth);
-  }
+  const defaultFraction = 0.3;
+  const width = Math.min(384, defaultFraction * window.innerWidth);
+  return (100 * width) / window.innerWidth;
 }
 
 export default function Sidebar<K extends string>({


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This increases the default width of our sidebar from 23% to 30% to make room for more content in cases like the settings for the new 3d panel. It also adds a pixel-width cap for larger screens. 

30% seems to be the point at which the new 3d panel topics fit without clipping labels on a 1024px wide screen.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3277 