### PR TITLE
Prefer rosbridge connection option

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -50,13 +50,13 @@ export default function Root({
 
   const dataSources: IDataSourceFactory[] = useMemo(() => {
     const sources = [
+      new RosbridgeDataSourceFactory(),
+      new FoxgloveWebSocketDataSourceFactory(),
       new Ros1SocketDataSourceFactory(),
       new Ros1LocalBagDataSourceFactory({ useIterablePlayer: enableExperimentalBagPlayer }),
       new Ros1RemoteBagDataSourceFactory({ useIterablePlayer: enableExperimentalBagPlayer }),
       new Ros2SocketDataSourceFactory(),
       new Ros2LocalBagDataSourceFactory(),
-      new RosbridgeDataSourceFactory(),
-      new FoxgloveWebSocketDataSourceFactory(),
       new UlogLocalDataSourceFactory(),
       new VelodyneDataSourceFactory(),
       new FoxgloveDataPlatformDataSourceFactory({

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -110,8 +110,6 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             </Text>
           )}
 
-          {selectedSource?.docsLink && <Link href={selectedSource.docsLink}>View docs.</Link>}
-
           {selectedSource?.formConfig != undefined && (
             <Stack flexGrow={1} justifyContent="space-between">
               <Stack spacing={2}>
@@ -144,6 +142,8 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             </Stack>
           )}
           {selectedSource?.disabledReason}
+
+          {selectedSource?.docsLink && <Link href={selectedSource.docsLink}>View docs.</Link>}
         </Stack>
       </Stack>
     </View>


### PR DESCRIPTION

**User-Facing Changes**

Before:
<img width="808" alt="Screen Shot 2022-05-04 at 11 57 50 AM" src="https://user-images.githubusercontent.com/84792/166806911-9602f630-b706-413d-9a11-dd08c0f968b7.png">

After:
<img width="806" alt="Screen Shot 2022-05-04 at 11 57 30 AM" src="https://user-images.githubusercontent.com/84792/166806921-d15192c7-b414-4e4a-8abb-cb191928bce7.png">

I've also moved the _View docs_ link to **after** the fields. For users that are familiar with the fields the View docs links are noise that gets in the way.

**Description**
Move the Rosbridge connection option before ROS native connection options. Rosbridge connections are easier to get right in a multi-host setting and avoid pitfalls with protocol gotchas.

Fixes #3310


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
