### PR TITLE
Don't use header.stamp time to expire point markers

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.test.ts
@@ -110,7 +110,7 @@ describe("MessageCollector", () => {
     expect(collector.getMessages()).toHaveLength(1);
 
     collector.setClock({ sec: 100, nsec: 90 + lifetimeNanos + 1 });
-    expect(collector.getMessages()).toHaveLength(0);
+    expect(collector.getMessages()).toHaveLength(1);
 
     collector.addMarker(marker, getName(marker));
     collector.setClock({ sec: 10000000, nsec: 100 });

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/MessageCollector.ts
@@ -131,8 +131,7 @@ export default class MessageCollector {
     const result: ObjectWithInteractionData[] = [];
     this.markers.forEach((marker, key) => {
       // Check if the marker has a lifetime and should be deleted
-      const messageStamp =
-        (marker.message as { header?: { stamp?: Time } }).header?.stamp ?? marker.receiveTime;
+      const messageStamp = marker.receiveTime;
       if (MessageCollector.markerIsExpired(marker.lifetime, messageStamp, this.clock)) {
         this.markers.delete(key);
       } else {


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the display of point cloud messages in the 3d panel when a delay time is set.

**Description**
We were using the message's `header.stamp` time to determine the expiration time of the point cloud message. We should use the messages `receiveTime` in this case.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3283 