### PR TITLE
Move settings panel actions buttons into action menu

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/ActionMenu.tsx
+++ b/packages/studio-base/src/components/PanelSettings/ActionMenu.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { Button, Menu, MenuItem } from "@mui/material";
+import { IconButton, Menu, MenuItem } from "@mui/material";
 
 export function ActionMenu({
   allowShare,
@@ -25,7 +25,7 @@ export function ActionMenu({
 
   return (
     <div>
-      <Button
+      <IconButton
         id="basic-button"
         aria-controls={open ? "basic-menu" : undefined}
         aria-haspopup="true"
@@ -33,7 +33,7 @@ export function ActionMenu({
         onClick={handleClick}
       >
         <MoreVertIcon />
-      </Button>
+      </IconButton>
       <Menu
         id="basic-menu"
         anchorEl={anchorEl}

--- a/packages/studio-base/src/components/PanelSettings/ActionMenu.tsx
+++ b/packages/studio-base/src/components/PanelSettings/ActionMenu.tsx
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { Button, Menu, MenuItem } from "@mui/material";
+
+export function ActionMenu({
+  allowShare,
+  onReset,
+  onShare,
+}: {
+  allowShare: boolean;
+  onReset: () => void;
+  onShare: () => void;
+}): JSX.Element {
+  const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>();
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(undefined);
+  };
+
+  return (
+    <div>
+      <Button
+        id="basic-button"
+        aria-controls={open ? "basic-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </Button>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "basic-button",
+        }}
+      >
+        <MenuItem
+          disabled={!allowShare}
+          onClick={() => {
+            onShare();
+            handleClose();
+          }}
+        >
+          Import/export settings...
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            onReset();
+            handleClose();
+          }}
+        >
+          Reset to defaults
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+}

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -2,11 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Button, Link, SvgIcon, Typography } from "@mui/material";
-import { useEffect, useMemo, useState } from "react";
+import { Link, Typography } from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useUnmount } from "react-use";
 
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
+import { ActionMenu } from "@foxglove/studio-base/components/PanelSettings/ActionMenu";
 import SettingsEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import ShareJsonModal from "@foxglove/studio-base/components/ShareJsonModal";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
@@ -97,11 +98,19 @@ export default function PanelSettings({
     );
   }, [selectedPanelId, showShareModal, getCurrentLayout, savePanelConfigs]);
 
-  const [config] = useConfigById<Record<string, unknown>>(selectedPanelId);
+  const [config] = useConfigById(selectedPanelId);
 
   const settingsTree = usePanelSettingsEditorStore((state) =>
     selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
   );
+
+  const resetToDefaults = useCallback(() => {
+    if (selectedPanelId) {
+      savePanelConfigs({
+        configs: [{ id: selectedPanelId, config: {}, override: true }],
+      });
+    }
+  }, [savePanelConfigs, selectedPanelId]);
 
   if (selectedLayoutId == undefined) {
     return (
@@ -138,7 +147,18 @@ export default function PanelSettings({
   const isSettingsTree = settingsTree != undefined;
 
   return (
-    <SidebarContent disablePadding={isSettingsTree} title={`${panelInfo.title} panel settings`}>
+    <SidebarContent
+      disablePadding={isSettingsTree}
+      title={`${panelInfo.title} panel settings`}
+      trailingItems={[
+        <ActionMenu
+          key={1}
+          allowShare={panelType !== TAB_PANEL_TYPE}
+          onReset={resetToDefaults}
+          onShare={() => setShowShareModal(true)}
+        />,
+      ]}
+    >
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
         <div>
@@ -147,48 +167,6 @@ export default function PanelSettings({
             <Typography color="text.secondary">No additional settings available.</Typography>
           )}
         </div>
-        <Stack
-          paddingX={isSettingsTree ? 2 : 0}
-          paddingBottom={isSettingsTree ? 2 : 0}
-          gap={1}
-          alignItems="flex-start"
-        >
-          <Button
-            size="large"
-            fullWidth
-            disableRipple
-            variant="contained"
-            color="inherit"
-            disabled={panelType === TAB_PANEL_TYPE}
-            onClick={() => setShowShareModal(true)}
-            startIcon={
-              <SvgIcon viewBox="0 0 2048 2048">
-                <path d="M219 1024l205 205-37 145-350-350 430-429 90 90-338 339zm1792 0l-430 429-90-90 338-339-149-149q26-26 47-48t38-48l246 245zm-547-640q42 0 78 15t64 42 42 63 16 78q0 39-15 76t-43 65l-717 719-377 94 94-377 717-718q28-28 65-42t76-15zm51 249q21-21 21-51 0-31-20-50t-52-20q-14 0-27 4t-23 15l-692 694-34 135 135-34 692-693z" />
-              </SvgIcon>
-            }
-          >
-            Import/export settings…
-          </Button>
-          <Button
-            size="large"
-            fullWidth
-            disableRipple
-            variant="contained"
-            color="inherit"
-            onClick={() =>
-              savePanelConfigs({
-                configs: [{ id: selectedPanelId, config: {}, override: true }],
-              })
-            }
-            startIcon={
-              <SvgIcon viewBox="0 0 2048 2048">
-                <path d="M1713 896q69 0 130 26t106 72 72 107 27 131q0 66-25 127t-73 110l-449 448-90-90 448-449q29-29 45-67t16-79q0-43-16-80t-45-66-66-45-81-17q-41 0-79 16t-67 45l-195 195h165v128h-384v-384h128v165q47-47 93-99t97-95 111-71 132-28zm79-128h-128V640h128v128zm0-256h-128V384h128v128zm0-256h-128V128h128v128zm-256 0h-128V128h128v128zm-256 0h-128V128h128v128zM896 128h128v128H896V128zm-256 0h128v128H640V128zm-256 0h128v128H384V128zm-256 0h128v128H128V128zm0 256h128v128H128V384zm0 256h128v128H128V640zm0 256h128v128H128V896zm0 256h128v128H128v-128zm0 256h128v128H128v-128zm0 256h128v128H128v-128zm256 0h128v128H384v-128zm256 0h128v128H640v-128zm256 0h128v128H896v-128zm256 0h128v128h-128v-128z" />
-              </SvgIcon>
-            }
-          >
-            Reset to defaults
-          </Button>
-        </Stack>
       </Stack>
     </SidebarContent>
   );


### PR DESCRIPTION
**User-Facing Changes**
This moves the action button at the bottom of the settings sidebar to an action menu in the title.

**Description**
These functions are still useful but the big buttons we currently have at the bottom of the settings sidebar are too prominent. This PR moves them to an action menu with a trigger button to the right of the title.

<img width="553" alt="Screen Shot 2022-05-05 at 7 13 17 AM" src="https://user-images.githubusercontent.com/93935560/166921697-f2722ab1-591e-4b30-ab1e-7ae455136dd5.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/3304