### PR TITLE
Added support for running Foxglove Studio behind a proxy and under a subpath (not just `/`)

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -91,7 +91,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
-      publicPath: "/",
+      publicPath: "./",
 
       // Output filenames should include content hashes in order to cache bust when new versions are available
       filename: isDev ? "[name].js" : "[name].[contenthash].js",
@@ -112,9 +112,9 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
   <html>
     <head>
       <meta charset="utf-8">
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+      <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
       <title>Foxglove Studio</title>
     </head>
     <script>


### PR DESCRIPTION
**User-Facing Changes**

Hopefully none.

**Description**

Foxglove Studio is quite difficult to put behind a proxy server right now because it insists on loading all the assets from the root path of the server. Since it is a single-page application we only need to change the URLs for the favicons and the initial JS bundle to relative and everything else seems to work automatically.