### PR TITLE
Add basic gradient picker to settings UI

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -21,7 +21,7 @@ import { DeepReadonly } from "ts-essentials";
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
 
-import { ColorPickerInput, ColorScalePicker, NumberInput, Vec3Input } from "./inputs";
+import { ColorPickerInput, ColorGradientInput, NumberInput, Vec3Input } from "./inputs";
 import { SettingsTreeAction, SettingsTreeField } from "./types";
 
 const StyledToggleButtonGroup = muiStyled(ToggleButtonGroup)(({ theme }) => ({
@@ -151,7 +151,7 @@ function FieldInput({
           ))}
         </StyledToggleButtonGroup>
       );
-    case "string": {
+    case "string":
       return (
         <TextField
           variant="filled"
@@ -167,8 +167,7 @@ function FieldInput({
           }
         />
       );
-    }
-    case "boolean": {
+    case "boolean":
       return (
         <StyledToggleButtonGroup
           fullWidth
@@ -188,8 +187,7 @@ function FieldInput({
           <ToggleButton value={false}>Off</ToggleButton>
         </StyledToggleButtonGroup>
       );
-    }
-    case "rgb": {
+    case "rgb":
       return (
         <ColorPickerInput
           alphaType="none"
@@ -206,8 +204,7 @@ function FieldInput({
           }
         />
       );
-    }
-    case "rgba": {
+    case "rgba":
       return (
         <ColorPickerInput
           alphaType="alpha"
@@ -224,8 +221,7 @@ function FieldInput({
           }
         />
       );
-    }
-    case "messagepath": {
+    case "messagepath":
       return (
         <PsuedoInputWrapper direction="row">
           <MessagePathInput
@@ -240,8 +236,7 @@ function FieldInput({
           />
         </PsuedoInputWrapper>
       );
-    }
-    case "select": {
+    case "select":
       return (
         <Select
           size="small"
@@ -264,11 +259,16 @@ function FieldInput({
           ))}
         </Select>
       );
-    }
-    case "gradient": {
-      return <ColorScalePicker color="inherit" size="small" />;
-    }
-    case "vec3": {
+    case "gradient":
+      return (
+        <ColorGradientInput
+          colors={field.value}
+          onChange={(value) =>
+            actionHandler({ action: "update", payload: { path, input: "gradient", value } })
+          }
+        />
+      );
+    case "vec3":
       return (
         <Vec3Input
           value={field.value}
@@ -277,7 +277,6 @@ function FieldInput({
           }
         />
       );
-    }
   }
 }
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -20,8 +20,8 @@ export default {
 
 const BasicSettings: SettingsTreeNode = {
   fields: {
-    firstRootField: { input: "string", label: "First Root Field" },
-    secondRootField: { input: "string", label: "Second Root Field" },
+    firstRootField: { input: "string", label: "Root Field" },
+    gradient: { input: "gradient", label: "Gradient" },
     emptyNumber: { input: "number", label: "Empty Number" },
   },
   children: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { ColorPicker } from "@fluentui/react";
-import { Card, ClickAwayListener, TextField, styled as muiStyled } from "@mui/material";
+import { Popover, TextField } from "@mui/material";
 import { useState } from "react";
 import tinycolor from "tinycolor2";
 
@@ -12,21 +12,6 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { ColorSwatch } from "./ColorSwatch";
 
-const PickerWrapperLeft = muiStyled(Card)(({ theme }) => ({
-  position: "absolute",
-  zIndex: theme.zIndex.modal,
-  top: "100%",
-  left: 0,
-  transform: "translateX(-50%)",
-}));
-
-const PickerWrapperRight = muiStyled(Card)(({ theme }) => ({
-  position: "absolute",
-  zIndex: theme.zIndex.modal,
-  top: "100%",
-  right: 0,
-}));
-
 export function ColorGradientInput({
   colors,
   onChange,
@@ -34,8 +19,24 @@ export function ColorGradientInput({
   colors: undefined | readonly [string, string];
   onChange: (colors: [string, string]) => void;
 }): JSX.Element {
-  const [showLeftPicker, setShowLeftPicker] = useState(false);
-  const [showRightPicker, setShowRightPicker] = useState(false);
+  const [leftAnchor, setLeftAnchor] = useState<undefined | HTMLDivElement>(undefined);
+  const [rightAnchor, setRightAnchor] = useState<undefined | HTMLDivElement>(undefined);
+
+  const handleLeftClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    setLeftAnchor(event.currentTarget);
+    setRightAnchor(undefined);
+  };
+
+  const handleRightClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    setLeftAnchor(undefined);
+    setRightAnchor(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setLeftAnchor(undefined);
+    setRightAnchor(undefined);
+  };
+
   const leftColor = colors?.[0] ?? "#000000";
   const rightColor = colors?.[1] ?? "#FFFFFF";
   const safeLeftColor = tinycolor(leftColor).isValid() ? leftColor : "#000000";
@@ -49,7 +50,7 @@ export function ColorGradientInput({
         backgroundImage: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor})`,
       }}
     >
-      <ColorSwatch color={safeLeftColor} onClick={() => setShowLeftPicker(true)} />
+      <ColorSwatch color={safeLeftColor} onClick={handleLeftClick} />
       <TextField
         variant="filled"
         size="small"
@@ -57,51 +58,61 @@ export function ColorGradientInput({
         value={`${leftColor} / ${rightColor}`}
         style={{ visibility: "hidden" }}
       />
-      <ColorSwatch color={safeRightColor} onClick={() => setShowRightPicker(true)} />
-      {showLeftPicker && (
-        <ClickAwayListener onClickAway={() => setShowLeftPicker(false)}>
-          <PickerWrapperLeft variant="elevation">
-            <ColorPicker
-              color={leftColor}
-              alphaType="alpha"
-              styles={{
-                root: {
-                  minWidth: 216,
-                },
-                tableHexCell: { width: "35%" },
-                input: {
-                  input: {
-                    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
-                  },
-                },
-              }}
-              onChange={(_event, newValue) => onChange([newValue.str, rightColor])}
-            />
-          </PickerWrapperLeft>
-        </ClickAwayListener>
-      )}
-      {showRightPicker && (
-        <ClickAwayListener onClickAway={() => setShowRightPicker(false)}>
-          <PickerWrapperRight variant="elevation">
-            <ColorPicker
-              color={rightColor}
-              alphaType="alpha"
-              styles={{
-                root: {
-                  minWidth: 216,
-                },
-                tableHexCell: { width: "35%" },
-                input: {
-                  input: {
-                    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
-                  },
-                },
-              }}
-              onChange={(_event, newValue) => onChange([leftColor, newValue.str])}
-            />
-          </PickerWrapperRight>
-        </ClickAwayListener>
-      )}
+      <ColorSwatch color={safeRightColor} onClick={handleRightClick} />
+      <Popover
+        open={leftAnchor != undefined}
+        anchorEl={leftAnchor}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        <ColorPicker
+          color={leftColor}
+          alphaType="alpha"
+          styles={{
+            tableHexCell: { width: "35%" },
+            input: {
+              input: {
+                fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
+              },
+            },
+          }}
+          onChange={(_event, newValue) => onChange([newValue.str, rightColor])}
+        />
+      </Popover>
+      <Popover
+        open={rightAnchor != undefined}
+        anchorEl={rightAnchor}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "center",
+        }}
+      >
+        <ColorPicker
+          color={rightColor}
+          alphaType="alpha"
+          styles={{
+            tableHexCell: { width: "35%" },
+            input: {
+              input: {
+                fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
+              },
+            },
+          }}
+          onChange={(_event, newValue) => onChange([leftColor, newValue.str])}
+        />
+      </Popover>
     </Stack>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ColorPicker } from "@fluentui/react";
+import { Card, ClickAwayListener, TextField, styled as muiStyled } from "@mui/material";
+import { useState } from "react";
+import tinycolor from "tinycolor2";
+
+import Stack from "@foxglove/studio-base/components/Stack";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import { ColorSwatch } from "./ColorSwatch";
+
+const PickerWrapperLeft = muiStyled(Card)(({ theme }) => ({
+  position: "absolute",
+  zIndex: theme.zIndex.modal,
+  top: 0,
+  marginTop: 28,
+}));
+
+const PickerWrapperRight = muiStyled(Card)(({ theme }) => ({
+  position: "absolute",
+  zIndex: theme.zIndex.modal,
+  top: 0,
+  marginTop: 28,
+  right: 0,
+}));
+
+export function ColorGradientInput({
+  colors,
+  onChange,
+}: {
+  colors: undefined | readonly [string, string];
+  onChange: (colors: [string, string]) => void;
+}): JSX.Element {
+  const [showLeftPicker, setShowLeftPicker] = useState(false);
+  const [showRightPicker, setShowRightPicker] = useState(false);
+  const leftColor = colors?.[0] ?? "#000000";
+  const rightColor = colors?.[1] ?? "#FFFFFF";
+  const safeLeftColor = tinycolor(leftColor).isValid() ? leftColor : "#000000";
+  const safeRightColor = tinycolor(rightColor).isValid() ? rightColor : "#FFFFFF";
+
+  return (
+    <Stack
+      direction="row"
+      style={{
+        position: "relative",
+        backgroundImage: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor})`,
+      }}
+    >
+      <ColorSwatch color={safeLeftColor} onClick={() => setShowLeftPicker(true)} />
+      <TextField
+        variant="filled"
+        size="small"
+        fullWidth
+        value={`${leftColor} / ${rightColor}`}
+        style={{ visibility: "hidden" }}
+      />
+      <ColorSwatch color={safeRightColor} onClick={() => setShowRightPicker(true)} />
+      {showLeftPicker && (
+        <ClickAwayListener onClickAway={() => setShowLeftPicker(false)}>
+          <PickerWrapperLeft variant="elevation">
+            <ColorPicker
+              color={leftColor}
+              alphaType="alpha"
+              styles={{
+                tableHexCell: { width: "35%" },
+                input: {
+                  input: {
+                    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
+                  },
+                },
+              }}
+              onChange={(_event, newValue) => onChange([newValue.str, rightColor])}
+            />
+          </PickerWrapperLeft>
+        </ClickAwayListener>
+      )}
+      {showRightPicker && (
+        <ClickAwayListener onClickAway={() => setShowRightPicker(false)}>
+          <PickerWrapperRight variant="elevation">
+            <ColorPicker
+              color={rightColor}
+              alphaType="alpha"
+              styles={{
+                tableHexCell: { width: "35%" },
+                input: {
+                  input: {
+                    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
+                  },
+                },
+              }}
+              onChange={(_event, newValue) => onChange([leftColor, newValue.str])}
+            />
+          </PickerWrapperRight>
+        </ClickAwayListener>
+      )}
+    </Stack>
+  );
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -4,7 +4,7 @@
 
 import { ColorPicker } from "@fluentui/react";
 import { Popover, TextField } from "@mui/material";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import tinycolor from "tinycolor2";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -22,20 +22,20 @@ export function ColorGradientInput({
   const [leftAnchor, setLeftAnchor] = useState<undefined | HTMLDivElement>(undefined);
   const [rightAnchor, setRightAnchor] = useState<undefined | HTMLDivElement>(undefined);
 
-  const handleLeftClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleLeftClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     setLeftAnchor(event.currentTarget);
     setRightAnchor(undefined);
-  };
+  }, []);
 
-  const handleRightClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleRightClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     setLeftAnchor(undefined);
     setRightAnchor(event.currentTarget);
-  };
+  }, []);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setLeftAnchor(undefined);
     setRightAnchor(undefined);
-  };
+  }, []);
 
   const leftColor = colors?.[0] ?? "#000000";
   const rightColor = colors?.[1] ?? "#FFFFFF";

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -16,6 +16,8 @@ const PickerWrapperLeft = muiStyled(Card)(({ theme }) => ({
   position: "absolute",
   zIndex: theme.zIndex.modal,
   top: "100%",
+  left: 0,
+  transform: "translateX(-50%)",
 }));
 
 const PickerWrapperRight = muiStyled(Card)(({ theme }) => ({
@@ -63,6 +65,9 @@ export function ColorGradientInput({
               color={leftColor}
               alphaType="alpha"
               styles={{
+                root: {
+                  minWidth: 216,
+                },
                 tableHexCell: { width: "35%" },
                 input: {
                   input: {
@@ -82,6 +87,9 @@ export function ColorGradientInput({
               color={rightColor}
               alphaType="alpha"
               styles={{
+                root: {
+                  minWidth: 216,
+                },
                 tableHexCell: { width: "35%" },
                 input: {
                   input: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -15,15 +15,13 @@ import { ColorSwatch } from "./ColorSwatch";
 const PickerWrapperLeft = muiStyled(Card)(({ theme }) => ({
   position: "absolute",
   zIndex: theme.zIndex.modal,
-  top: 0,
-  marginTop: 28,
+  top: "100%",
 }));
 
 const PickerWrapperRight = muiStyled(Card)(({ theme }) => ({
   position: "absolute",
   zIndex: theme.zIndex.modal,
-  top: 0,
-  marginTop: 28,
+  top: "100%",
   right: 0,
 }));
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -43,6 +43,7 @@ type ColorPickerInputProps = {
   swatchOrientation?: "start" | "end";
 } & Omit<TextFieldProps, "onChange">;
 
+// ts-prune-ignore-next
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const { onChange, swatchOrientation = "start", value } = props;
   const [showPicker, setShowPicker] = useState(false);

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -43,7 +43,6 @@ type ColorPickerInputProps = {
   swatchOrientation?: "start" | "end";
 } & Omit<TextFieldProps, "onChange">;
 
-// ts-prune-ignore-next
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const { onChange, swatchOrientation = "start", value } = props;
   const [showPicker, setShowPicker] = useState(false);

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -15,6 +15,8 @@ import tinycolor from "tinycolor2";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+import { ColorSwatch } from "./ColorSwatch";
+
 const StyledTextField = muiStyled(TextField)({
   ".MuiInputBase-formControl.MuiInputBase-root": {
     padding: 0,
@@ -24,17 +26,6 @@ const StyledTextField = muiStyled(TextField)({
     alignItems: "center",
   },
 });
-
-const ColorSwatch = muiStyled("div", {
-  shouldForwardProp: (prop) => prop !== "color",
-})<{ color: string }>(({ theme, color }) => ({
-  backgroundColor: color,
-  height: theme.spacing(2.5),
-  width: theme.spacing(3),
-  margin: theme.spacing(0.625),
-  borderRadius: 1,
-  border: `1px solid ${theme.palette.getContrastText(color)}`,
-}));
 
 const Root = muiStyled("div")({
   position: "relative",

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorScalePicker.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorScalePicker.tsx
@@ -124,6 +124,7 @@ const ColorScale = muiStyled("div")<{ colorScale: string[] }>(({ theme, colorSca
   flex: "auto",
 }));
 
+// ts-prune-ignore-next
 export function ColorScalePicker(props: ColorScalePickerProps): JSX.Element {
   const [selectedOption, setSelectedOption] = useState<number>(0);
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { styled as muiStyled } from "@mui/material";
+
+export const ColorSwatch = muiStyled("div", {
+  shouldForwardProp: (prop) => prop !== "color",
+})<{ color: string }>(({ theme, color }) => ({
+  backgroundColor: color,
+  height: theme.spacing(2.5),
+  width: theme.spacing(3),
+  margin: theme.spacing(0.625),
+  borderRadius: 1,
+  border: `1px solid ${theme.palette.getContrastText(color)}`,
+}));

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export * from "./ColorPickerInput";
+export * from "./ColorGradientInput";
 export * from "./ColorScalePicker";
 export * from "./NumberInput";
 export * from "./Vec3Input";

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/index.ts
@@ -4,6 +4,5 @@
 
 export * from "./ColorPickerInput";
 export * from "./ColorGradientInput";
-export * from "./ColorScalePicker";
 export * from "./NumberInput";
 export * from "./Vec3Input";

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -7,8 +7,8 @@ export type SettingsTreeFieldValue =
   | { input: "boolean"; value?: boolean }
   | { input: "rgb"; value?: string }
   | { input: "rgba"; value?: string }
-  | { input: "gradient"; value?: string }
-  | { input: "messagepath"; value?: string; validTypes?: ReadonlyArray<string> }
+  | { input: "gradient"; value?: [string, string] }
+  | { input: "messagepath"; value?: string; validTypes?: string[] }
   | { input: "number"; value?: number; step?: number; max?: number; min?: number }
   | {
       input: "select";


### PR DESCRIPTION
**User-Facing Changes**
This adds a simple, two-point gradient color picker to the settings UI.

**Description**
This just uses two instances of the color picker and a gradient background to show the selected gradient.

https://user-images.githubusercontent.com/93935560/166979624-6da711ab-3fb7-42e4-9ce2-3a78b7a1c244.mov

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses https://github.com/foxglove/studio/issues/3277