### PR TITLE
Update tab panel tabs to look more like tabs

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -129,7 +129,7 @@ function AddPanel() {
           <Link onClick={openLayoutBrowser}>Select a layout</Link> to get started!
         </Text>
       ) : (
-        <PanelList onPanelSelect={addPanel} backgroundColor={theme.palette.neutralLighterAlt} />
+        <PanelList onPanelSelect={addPanel} />
       )}
     </SidebarContent>
   );

--- a/packages/studio-base/src/components/EmptyPanelLayout.tsx
+++ b/packages/studio-base/src/components/EmptyPanelLayout.tsx
@@ -11,15 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useTheme } from "@fluentui/react";
-import { Link, Theme, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { Link, Typography, styled as muiStyled } from "@mui/material";
 import { useCallback } from "react";
 import { useDrop } from "react-dnd";
 import { MosaicDragType } from "react-mosaic-component";
 
 import PanelList, { PanelSelection } from "@foxglove/studio-base/components/PanelList";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { MosaicDropResult } from "@foxglove/studio-base/types/panels";
 import { getPanelIdForType } from "@foxglove/studio-base/util/layout";
@@ -28,22 +26,18 @@ type Props = {
   tabId?: string;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  content: {
-    display: "flex",
-    flexDirection: "column",
-    paddingBottom: theme.spacing(2),
-  },
-  root: {
-    width: "100%",
-    height: "100%",
-    overflowY: "auto",
-  },
-  dropzone: {
-    width: "100%",
-    height: "100%",
-  },
-  dropzoneOver: {
+const Root = muiStyled("div")(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  width: "100%",
+  height: "100%",
+  overflowY: "auto",
+}));
+
+const DropTarget = muiStyled("div")<{ isOver: boolean }>(({ isOver, theme }) => ({
+  width: "100%",
+  height: "100%",
+
+  ...(isOver && {
     "&:after": {
       content: "''",
       borderColor: `1px solid ${theme.palette.action.selected}`,
@@ -55,12 +49,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       bottom: 0,
       zIndex: theme.zIndex.appBar,
     },
-  },
+  }),
 }));
 
 export const EmptyPanelLayout = ({ tabId }: Props): JSX.Element => {
-  const fluentUiTheme = useTheme();
-  const classes = useStyles({ fluentUiTheme });
   const { addPanel } = useCurrentLayoutActions();
 
   const [{ isOver }, drop] = useDrop<unknown, MosaicDropResult, { isOver: boolean }>({
@@ -82,15 +74,9 @@ export const EmptyPanelLayout = ({ tabId }: Props): JSX.Element => {
   );
 
   return (
-    <div
-      ref={drop}
-      data-test="empty-drop-target"
-      className={cx(classes.dropzone, {
-        [classes.dropzoneOver]: isOver,
-      })}
-    >
-      <div className={classes.root}>
-        <div className={classes.content}>
+    <DropTarget isOver={isOver} ref={drop} data-test="empty-drop-target">
+      <Root>
+        <Stack paddingBottom={2}>
           <Typography variant="body2" paddingX={2} paddingTop={2}>
             Select a panel below to add it to your layout.{" "}
             <Link
@@ -102,8 +88,8 @@ export const EmptyPanelLayout = ({ tabId }: Props): JSX.Element => {
             </Link>
           </Typography>
           <PanelList mode="grid" onPanelSelect={onPanelSelect} />
-        </div>
-      </div>
-    </div>
+        </Stack>
+      </Root>
+    </DropTarget>
   );
 };

--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useTheme } from "@fluentui/react";
+import { useTheme } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -79,7 +79,7 @@ const PanelListWithInteractions = ({
   const theme = useTheme();
   return (
     <div
-      style={{ margin: 50, height: 480, backgroundColor: theme.palette.neutralLighterAlt }}
+      style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}
       ref={(el) => {
         if (el) {
           const input: HTMLInputElement | undefined = el.querySelector("input") as any;
@@ -131,7 +131,7 @@ storiesOf("components/PanelList", module)
   .add("panel list", () => {
     const theme = useTheme();
     return (
-      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.neutralLighterAlt }}>
+      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
         <PanelList onPanelSelect={() => {}} />
       </div>
     );
@@ -139,7 +139,7 @@ storiesOf("components/PanelList", module)
   .add("panel grid", () => {
     const theme = useTheme();
     return (
-      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.neutralLighterAlt }}>
+      <div style={{ margin: 50, height: 480, backgroundColor: theme.palette.background.paper }}>
         <PanelList mode="grid" onPanelSelect={() => {}} />
       </div>
     );

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) => {
     },
     appBarBackground: ({ backgroundColor }: { backgroundColor?: string }) => ({
       backgroundImage: `linear-gradient(to top, transparent, ${
-        backgroundColor ?? theme.palette.background.default
+        backgroundColor ?? theme.palette.background.paper
       } ${theme.spacing(1.5)}) !important`,
     }),
     toolbar: {

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -13,7 +13,6 @@
 
 import SearchIcon from "@mui/icons-material/Search";
 import {
-  AppBar,
   Theme,
   Card,
   CardActionArea,
@@ -99,8 +98,9 @@ const useStyles = makeStyles((theme: Theme) => {
   };
 });
 
-const StyledAppBar = muiStyled(AppBar)(({ theme }) => ({
-  top: -0.5, // half a pixel to avoid a gap between the appbar and panel top
+const StickyToolbar = muiStyled("div")(({ theme }) => ({
+  position: "sticky",
+  top: -0.5, // yep that's a half pixel to avoid a gap between the appbar and panel top
   zIndex: 100,
   display: "flex",
   padding: theme.spacing(2),
@@ -466,7 +466,7 @@ function PanelList(props: Props): JSX.Element {
 
   return (
     <div className={classes.fullHeight}>
-      <StyledAppBar position="sticky" color="transparent" elevation={0}>
+      <StickyToolbar>
         <div className={classes.inputWrapper}>
           <SearchIcon fontSize="small" color="primary" />
           <LegacyInput
@@ -479,7 +479,7 @@ function PanelList(props: Props): JSX.Element {
             autoFocus
           />
         </div>
-      </StyledAppBar>
+      </StickyToolbar>
       {mode === "grid" ? (
         <Container className={classes.grid} maxWidth={false}>
           {allFilteredPanels.map(displayPanelListItem)}

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -99,18 +99,16 @@ const useStyles = makeStyles((theme: Theme) => {
   };
 });
 
-const StyledAppBar = muiStyled(AppBar)<{ backgroundColor?: string }>(
-  ({ backgroundColor, theme }) => ({
-    top: -0.5, // half a pixel to avoid a gap between the appbar and panel top
-    zIndex: 100,
-    display: "flex",
-    padding: theme.spacing(2),
-    justifyContent: "stretch",
-    backgroundImage: `linear-gradient(to top, transparent, ${
-      backgroundColor ? backgroundColor : theme.palette.background.paper
-    } ${theme.spacing(1.5)}) !important`,
-  }),
-);
+const StyledAppBar = muiStyled(AppBar)(({ theme }) => ({
+  top: -0.5, // half a pixel to avoid a gap between the appbar and panel top
+  zIndex: 100,
+  display: "flex",
+  padding: theme.spacing(2),
+  justifyContent: "stretch",
+  backgroundImage: `linear-gradient(to top, transparent, ${
+    theme.palette.background.paper
+  } ${theme.spacing(1.5)}) !important`,
+}));
 
 type DropDescription = {
   type: string;
@@ -468,12 +466,7 @@ function PanelList(props: Props): JSX.Element {
 
   return (
     <div className={classes.fullHeight}>
-      <StyledAppBar
-        backgroundColor={backgroundColor}
-        position="sticky"
-        color="transparent"
-        elevation={0}
-      >
+      <StyledAppBar position="sticky" color="transparent" elevation={0}>
         <div className={classes.inputWrapper}>
           <SearchIcon fontSize="small" color="primary" />
           <LegacyInput

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -491,7 +491,9 @@ function PanelList(props: Props): JSX.Element {
       )}
       {noResults && (
         <Stack alignItems="center" justifyContent="center" paddingX={1} paddingY={2}>
-          <Typography color="text.secondary">No panels match search criteria.</Typography>
+          <Typography variant="body2" color="text.secondary">
+            No panels match search criteria.
+          </Typography>
         </Stack>
       )}
     </div>

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -15,7 +15,6 @@ import SearchIcon from "@mui/icons-material/Search";
 import {
   AppBar,
   Theme,
-  Toolbar,
   Card,
   CardActionArea,
   CardContent,
@@ -27,9 +26,9 @@ import {
   ListItemText,
   Stack,
   Typography,
+  styled as muiStyled,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import cx from "classnames";
 import fuzzySort from "fuzzysort";
 import { isEmpty } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
@@ -72,19 +71,6 @@ const useStyles = makeStyles((theme: Theme) => {
         backgroundColor: "transparent",
       },
     },
-    appBar: {
-      top: 0,
-      zIndex: 2,
-    },
-    appBarBackground: ({ backgroundColor }: { backgroundColor?: string }) => ({
-      backgroundImage: `linear-gradient(to top, transparent, ${
-        backgroundColor ?? theme.palette.background.paper
-      } ${theme.spacing(1.5)}) !important`,
-    }),
-    toolbar: {
-      padding: theme.spacing(2),
-      justifyContent: "stretch",
-    },
     inputWrapper: {
       display: "flex",
       flex: "auto",
@@ -110,16 +96,21 @@ const useStyles = makeStyles((theme: Theme) => {
       gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
       gap: theme.spacing(2),
     },
-    noResults: {
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      justifyContent: "center",
-      padding: theme.spacing(2, 1),
-      color: theme.palette.text.secondary,
-    },
   };
 });
+
+const StyledAppBar = muiStyled(AppBar)<{ backgroundColor?: string }>(
+  ({ backgroundColor, theme }) => ({
+    top: -0.5, // half a pixel to avoid a gap between the appbar and panel top
+    zIndex: 100,
+    display: "flex",
+    padding: theme.spacing(2),
+    justifyContent: "stretch",
+    backgroundImage: `linear-gradient(to top, transparent, ${
+      backgroundColor ? backgroundColor : theme.palette.background.paper
+    } ${theme.spacing(1.5)}) !important`,
+  }),
+);
 
 type DropDescription = {
   type: string;
@@ -477,27 +468,25 @@ function PanelList(props: Props): JSX.Element {
 
   return (
     <div className={classes.fullHeight}>
-      <AppBar
-        className={cx(classes.appBar, { [classes.appBarBackground]: !backgroundColor })}
+      <StyledAppBar
+        backgroundColor={backgroundColor}
         position="sticky"
         color="transparent"
         elevation={0}
       >
-        <Toolbar disableGutters className={classes.toolbar}>
-          <div className={classes.inputWrapper}>
-            <SearchIcon fontSize="small" color="primary" />
-            <LegacyInput
-              className={classes.searchInput}
-              placeholder="Search panels"
-              value={searchQuery}
-              onChange={handleSearchChange}
-              onKeyDown={onKeyDown}
-              onBlur={() => setHighlightedPanelIdx(undefined)}
-              autoFocus
-            />
-          </div>
-        </Toolbar>
-      </AppBar>
+        <div className={classes.inputWrapper}>
+          <SearchIcon fontSize="small" color="primary" />
+          <LegacyInput
+            className={classes.searchInput}
+            placeholder="Search panels"
+            value={searchQuery}
+            onChange={handleSearchChange}
+            onKeyDown={onKeyDown}
+            onBlur={() => setHighlightedPanelIdx(undefined)}
+            autoFocus
+          />
+        </div>
+      </StyledAppBar>
       {mode === "grid" ? (
         <Container className={classes.grid} maxWidth={false}>
           {allFilteredPanels.map(displayPanelListItem)}
@@ -507,7 +496,11 @@ function PanelList(props: Props): JSX.Element {
           {allFilteredPanels.map(displayPanelListItem)}
         </List>
       )}
-      {noResults && <div className={classes.noResults}>No panels match search criteria.</div>}
+      {noResults && (
+        <Stack alignItems="center" justifyContent="center" paddingX={1} paddingY={2}>
+          <Typography color="text.secondary">No panels match search criteria.</Typography>
+        </Stack>
+      )}
     </div>
   );
 }

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -29,6 +29,7 @@ import { PanelToolbarControls } from "./PanelToolbarControls";
 type Props = {
   additionalIcons?: React.ReactNode;
   alwaysVisible?: boolean;
+  backgroundColor?: string;
   children?: React.ReactNode;
   floating?: boolean;
   helpContent?: React.ReactNode;
@@ -38,18 +39,22 @@ type Props = {
 
 const PanelToolbarRoot = muiStyled("div", {
   shouldForwardProp: (prop) =>
-    prop !== "shouldShow" && prop !== "floating" && prop !== "hasChildren",
+    prop !== "backgroundColor" &&
+    prop !== "floating" &&
+    prop !== "hasChildren" &&
+    prop !== "shouldShow",
 })<{
-  shouldShow: boolean;
+  backgroundColor?: string;
   floating: boolean;
   hasChildren: boolean;
-}>(({ shouldShow, floating, hasChildren, theme }) => ({
+  shouldShow: boolean;
+}>(({ backgroundColor, floating, hasChildren, shouldShow, theme }) => ({
   transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
   flex: "0 0 auto",
   justifyContent: "flex-end",
   padding: theme.spacing(0.5),
   display: !shouldShow ? "none" : "flex",
-  backgroundColor: floating ? "transparent" : theme.palette.background.paper,
+  backgroundColor: backgroundColor ?? theme.palette.background.paper,
 
   ...(floating && {
     position: "absolute",
@@ -93,6 +98,7 @@ const selectSetHelpInfo = (store: HelpInfoStore) => store.setHelpInfo;
 export default React.memo<Props>(function PanelToolbar({
   additionalIcons,
   alwaysVisible = false,
+  backgroundColor,
   children,
   floating = false,
   helpContent,
@@ -172,10 +178,11 @@ export default React.memo<Props>(function PanelToolbar({
 
   return (
     <PanelToolbarRoot
-      shouldShow={shouldShow}
+      backgroundColor={floating ? "transparent" : backgroundColor}
       floating={floating}
       hasChildren={Boolean(children)}
       ref={containerRef}
+      shouldShow={shouldShow}
     >
       {children}
       <PanelToolbarControls

--- a/packages/studio-base/src/panels/Tab/DraggableToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/DraggableToolbarTab.tsx
@@ -11,14 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { useRef } from "react";
-import { useDrag, useDrop } from "react-dnd";
+import { useDrag, useDrop, DropTargetMonitor } from "react-dnd";
 
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import {
-  DraggingTabItem,
-  TAB_DRAG_TYPE,
-  TabActions,
-} from "@foxglove/studio-base/panels/Tab/TabDndContext";
+import { TAB_DRAG_TYPE, TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
 import { ToolbarTab } from "@foxglove/studio-base/panels/Tab/ToolbarTab";
 import { TabLocation } from "@foxglove/studio-base/types/layouts";
 
@@ -29,7 +25,6 @@ type Props = {
   tabCount: number;
   tabIndex: number;
   tabTitle: string;
-  setDraggingTabState: (arg0: { isOver: boolean; item?: DraggingTabItem }) => void;
 };
 
 export function DraggableToolbarTab(props: Props): JSX.Element {
@@ -45,10 +40,18 @@ export function DraggableToolbarTab(props: Props): JSX.Element {
     }),
   });
 
-  const [{ isOver }, dropRef] = useDrop<TabLocation, void, { isOver: boolean }>({
+  const [{ highlight }, dropRef] = useDrop<
+    TabLocation,
+    void,
+    { highlight: "before" | "after" | undefined }
+  >({
     accept: TAB_DRAG_TYPE,
-    collect: (monitor) => ({
-      isOver: monitor.isOver(),
+    collect: (monitor: DropTargetMonitor<TabLocation, void>) => ({
+      highlight: monitor.isOver()
+        ? monitor.getItem().tabIndex! < tabIndex
+          ? "after"
+          : "before"
+        : undefined,
     }),
     drop: (sourceItem, _monitor) => {
       const source = {
@@ -71,7 +74,7 @@ export function DraggableToolbarTab(props: Props): JSX.Element {
     isDragging,
     innerRef: ref,
     hidden: isDragging,
-    highlight: isOver,
+    highlight,
   };
   return <ToolbarTab {...tabProps} />;
 }

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import AddIcon from "@mui/icons-material/Add";
-import { IconButton, alpha, styled as muiStyled, useTheme } from "@mui/material";
+import { IconButton, styled as muiStyled, useTheme } from "@mui/material";
 import { useContext, useEffect } from "react";
 import { DropTargetMonitor, useDrop } from "react-dnd";
 

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import AddIcon from "@mui/icons-material/Add";
-import { IconButton, styled as muiStyled } from "@mui/material";
+import { IconButton, styled as muiStyled, useTheme } from "@mui/material";
 import { useEffect } from "react";
 import { useDrop } from "react-dnd";
 
@@ -56,6 +56,7 @@ type Props = {
 
 export function TabbedToolbar(props: Props): JSX.Element {
   const { panelId, actions, tabs, activeTabIdx, setDraggingTabState } = props;
+  const theme = useTheme();
 
   const [{ isOver, item }, dropRef] = useDrop({
     accept: TAB_DRAG_TYPE,
@@ -70,7 +71,7 @@ export function TabbedToolbar(props: Props): JSX.Element {
 
   return (
     <STabbedToolbar>
-      <PanelToolbar helpContent={helpContent}>
+      <PanelToolbar backgroundColor={theme.palette.background.default} helpContent={helpContent}>
         <STabs role="tab" ref={dropRef} data-test="toolbar-droppable">
           {tabs.map((tab, i) => (
             <DraggableToolbarTab

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -37,10 +37,7 @@ const STabbedToolbar = muiStyled("div")<{ highlight: boolean }>(({ highlight, th
   backgroundColor: theme.palette.background.default,
 
   "&:after": {
-    border: `2px solid ${highlight ? theme.palette.primary.main : "transparent"}`,
-    backgroundColor: highlight
-      ? alpha(theme.palette.primary.main, theme.palette.action.focusOpacity)
-      : undefined,
+    border: `2px solid ${highlight ? theme.palette.action.hover : "transparent"}`,
     content: "''",
     height: "100%",
     left: 0,

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -11,12 +11,11 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import PlusIcon from "@mdi/svg/svg/plus.svg";
+import AddIcon from "@mui/icons-material/Add";
+import { IconButton, alpha, styled as muiStyled, useTheme } from "@mui/material";
 import { useContext, useEffect } from "react";
 import { DropTargetMonitor, useDrop } from "react-dnd";
-import styled from "styled-components";
 
-import Icon from "@foxglove/studio-base/components/Icon";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { DraggableToolbarTab } from "@foxglove/studio-base/panels/Tab/DraggableToolbarTab";
@@ -29,32 +28,40 @@ import {
 import helpContent from "@foxglove/studio-base/panels/Tab/index.help.md";
 import { TabConfig } from "@foxglove/studio-base/types/layouts";
 
-const STabbedToolbar = styled.div<{ highlight: boolean }>`
-  flex: 0 0;
-  display: flex;
-  position: relative;
-  flex-direction: column;
-  border-bottom: 1px solid ${({ theme }) => theme.semanticColors.bodyDivider};
+const STabbedToolbar = muiStyled("div")<{ highlight: boolean }>(({ highlight, theme }) => ({
+  flex: "0 0",
+  display: "flex",
+  position: "relative",
+  flexDirection: "column",
+  borderBottom: `1px solid ${theme.palette.divider}`,
+  backgroundColor: theme.palette.background.default,
 
-  &:after {
-    border: 2px solid
-      ${({ highlight, theme }) =>
-        highlight ? theme.semanticColors.listItemBackgroundChecked : "transparent"};
-    content: "";
-    height: 100%;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    width: 100%;
-    z-index: 1;
-  }
-`;
-const STabs = styled.div`
-  flex: 1 1;
-  display: flex;
-  align-items: flex-end;
-`;
+  "&:after": {
+    border: `2px solid ${highlight ? theme.palette.primary.main : "transparent"}`,
+    backgroundColor: highlight
+      ? alpha(theme.palette.primary.main, theme.palette.action.focusOpacity)
+      : undefined,
+    content: "''",
+    height: "100%",
+    left: 0,
+    top: 0,
+    pointerEvents: "none",
+    position: "absolute",
+    width: "100%",
+    zIndex: 1,
+  },
+}));
+
+const STabs = muiStyled("div")({
+  flex: "auto",
+  display: "flex",
+  alignItems: "flex-end",
+});
+
+const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.25),
+  margin: theme.spacing(0, 0.5, -0.25),
+}));
 
 type Props = {
   panelId: string;
@@ -65,6 +72,7 @@ type Props = {
 };
 
 export function TabbedToolbar(props: Props): JSX.Element {
+  const theme = useTheme();
   const { panelId, actions, tabs, activeTabIdx, setDraggingTabState } = props;
   const { moveTab } = useCurrentLayoutActions();
 
@@ -96,7 +104,7 @@ export function TabbedToolbar(props: Props): JSX.Element {
   return (
     <STabbedToolbar highlight={isOver}>
       <PanelToolbar helpContent={helpContent}>
-        <STabs ref={dropRef} data-test="toolbar-droppable">
+        <STabs role="tab" ref={dropRef} data-test="toolbar-droppable">
           {tabs.map((tab, i) => (
             <DraggableToolbarTab
               isActive={activeTabIdx === i}
@@ -109,20 +117,14 @@ export function TabbedToolbar(props: Props): JSX.Element {
               tabTitle={tab.title}
             />
           ))}
-          <Icon
+          <StyledIconButton
             size="small"
-            fade
-            dataTest="add-tab"
-            tooltip="Add tab"
-            style={{
-              flexShrink: 0,
-              margin: "0 8px",
-              transition: "opacity 0.2s",
-            }}
+            data-test="add-tab"
+            title="Add tab"
             onClick={actions.addTab}
           >
-            <PlusIcon onMouseDown={(e) => e.preventDefault()} />
-          </Icon>
+            <AddIcon fontSize="inherit" />
+          </StyledIconButton>
         </STabs>
       </PanelToolbar>
     </STabbedToolbar>

--- a/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
+++ b/packages/studio-base/src/panels/Tab/TabbedToolbar.tsx
@@ -12,41 +12,27 @@
 //   You may not use this file except in compliance with the License.
 
 import AddIcon from "@mui/icons-material/Add";
-import { IconButton, styled as muiStyled, useTheme } from "@mui/material";
-import { useContext, useEffect } from "react";
-import { DropTargetMonitor, useDrop } from "react-dnd";
+import { IconButton, styled as muiStyled } from "@mui/material";
+import { useEffect } from "react";
+import { useDrop } from "react-dnd";
 
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { DraggableToolbarTab } from "@foxglove/studio-base/panels/Tab/DraggableToolbarTab";
 import {
   DraggingTabItem,
   TAB_DRAG_TYPE,
   TabActions,
-  TabDndContext,
 } from "@foxglove/studio-base/panels/Tab/TabDndContext";
 import helpContent from "@foxglove/studio-base/panels/Tab/index.help.md";
 import { TabConfig } from "@foxglove/studio-base/types/layouts";
 
-const STabbedToolbar = muiStyled("div")<{ highlight: boolean }>(({ highlight, theme }) => ({
+const STabbedToolbar = muiStyled("div")(({ theme }) => ({
   flex: "0 0",
   display: "flex",
   position: "relative",
   flexDirection: "column",
   borderBottom: `1px solid ${theme.palette.divider}`,
   backgroundColor: theme.palette.background.default,
-
-  "&:after": {
-    border: `2px solid ${highlight ? theme.palette.action.hover : "transparent"}`,
-    content: "''",
-    height: "100%",
-    left: 0,
-    top: 0,
-    pointerEvents: "none",
-    position: "absolute",
-    width: "100%",
-    zIndex: 1,
-  },
 }));
 
 const STabs = muiStyled("div")({
@@ -69,37 +55,21 @@ type Props = {
 };
 
 export function TabbedToolbar(props: Props): JSX.Element {
-  const theme = useTheme();
   const { panelId, actions, tabs, activeTabIdx, setDraggingTabState } = props;
-  const { moveTab } = useCurrentLayoutActions();
 
-  const { preventTabDrop } = useContext(TabDndContext);
   const [{ isOver, item }, dropRef] = useDrop({
     accept: TAB_DRAG_TYPE,
     collect: (monitor) => ({
       item: monitor.getItem(),
       isOver: monitor.isOver(),
     }),
-    canDrop: () => !preventTabDrop,
-    drop: (sourceItem: DraggingTabItem, monitor: DropTargetMonitor) => {
-      // Drop was already handled by DraggableToolTab, ignore here
-      if (monitor.didDrop()) {
-        return;
-      }
-      const source = {
-        panelId: sourceItem.panelId,
-        tabIndex: sourceItem.tabIndex,
-      };
-      const target = { panelId };
-      moveTab({ source, target });
-    },
   });
   useEffect(() => {
     setDraggingTabState({ item, isOver });
   }, [item, isOver, setDraggingTabState]);
 
   return (
-    <STabbedToolbar highlight={isOver}>
+    <STabbedToolbar>
       <PanelToolbar helpContent={helpContent}>
         <STabs role="tab" ref={dropRef} data-test="toolbar-droppable">
           {tabs.map((tab, i) => (
@@ -107,7 +77,6 @@ export function TabbedToolbar(props: Props): JSX.Element {
               isActive={activeTabIdx === i}
               key={i}
               panelId={panelId}
-              setDraggingTabState={setDraggingTabState}
               actions={actions}
               tabCount={tabs.length}
               tabIndex={i}

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -20,7 +20,7 @@ import tick from "@foxglove/studio-base/util/tick";
 
 const baseProps = {
   hidden: false,
-  highlight: false,
+  highlight: undefined,
   innerRef: undefined,
   isActive: false,
   isDragging: false,
@@ -69,7 +69,7 @@ storiesOf("panels/Tab/ToolbarTab", module)
   ))
   .add("highlight", () => (
     <Container>
-      <ToolbarTab {...{ ...baseProps, highlight: true }} />
+      <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
     </Container>
   ))
   .add("dragging", () => (

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -30,6 +30,7 @@ const Tab = muiStyled("div")<{
   tabCount: number;
   title: string;
 }>(({ active, dragging, hidden, tabCount, title, theme }) => ({
+  fontSize: theme.typography.body2.fontSize,
   position: "relative",
   borderTopLeftRadius: theme.shape.borderRadius,
   borderTopRightRadius: theme.shape.borderRadius,

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -11,19 +11,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
-import { IconButton, styled as muiStyled } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { IconButton, InputBase, styled as muiStyled } from "@mui/material";
 import React, { Ref as ReactRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import textMetrics from "text-metrics";
 
-import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledComponents";
 import { TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-const MAX_TAB_WIDTH = 100;
+const MAX_TAB_WIDTH = 120;
 const MIN_ACTIVE_TAB_WIDTH = 40;
 const MIN_OTHER_TAB_WIDTH = 14;
 
@@ -50,13 +46,12 @@ const Tab = muiStyled("div")<{
   maxWidth: MAX_TAB_WIDTH,
   top: 5, // Shift the tab down so it's flush with the bottom of the PanelToolbar
   marginTop: -4,
-  minWidth: active
-    ? `calc(max(${MIN_ACTIVE_TAB_WIDTH}px,  min(${Math.ceil(
-        measureText(title) + 30,
-      )}px, ${MAX_TAB_WIDTH}px, 100% - ${MIN_OTHER_TAB_WIDTH * (tabCount - 1)}px)))`
-    : undefined,
+  gap: theme.spacing(0.5),
 
   ...(active && {
+    minWidth: `calc(max(${MIN_ACTIVE_TAB_WIDTH}px,  min(${Math.ceil(
+      measureText(title) + 30,
+    )}px, ${MAX_TAB_WIDTH}px, 100% - ${MIN_OTHER_TAB_WIDTH * (tabCount - 1)}px)))`,
     backgroundColor: theme.palette.background.paper,
     borderColor: theme.palette.divider,
     userSelect: "all",
@@ -77,19 +72,6 @@ const Tab = muiStyled("div")<{
 const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
   padding: theme.spacing(0.25),
 }));
-
-const useStyles = makeStyles({
-  input: {
-    backgroundColor: "transparent !important",
-    padding: "0px !important",
-    pointerEvents: "none",
-    width: "100%",
-
-    "&.isEditable": {
-      pointerEvents: "all",
-    },
-  },
-});
 
 const fontFamily = fonts.SANS_SERIF;
 const fontSize = "12px";
@@ -127,7 +109,6 @@ export function ToolbarTab(props: Props): JSX.Element {
     highlight,
     hidden,
   } = props;
-  const styles = useStyles();
 
   const inputRef = useRef<HTMLInputElement>(ReactNull);
   const [title, setTitle] = useState<string>(tabTitle);
@@ -216,27 +197,25 @@ export function ToolbarTab(props: Props): JSX.Element {
       title={tabTitle ? tabTitle : "Enter tab name"}
       tabCount={tabCount}
     >
-      <div>
-        <LegacyInput
-          className={cx(styles.input, { isEditable: editingTitle })}
-          readOnly={!editingTitle}
-          placeholder="Enter tab name"
-          value={title}
-          onChange={onChangeTitleInput}
-          onBlur={setTabTitle}
-          onKeyDown={onKeyDown}
-          ref={inputRef}
-        />
-      </div>
+      <InputBase
+        readOnly={!editingTitle}
+        placeholder="Enter tab name"
+        value={title}
+        onChange={onChangeTitleInput}
+        onBlur={setTabTitle}
+        onKeyDown={onKeyDown}
+        inputRef={inputRef}
+        style={{ pointerEvents: editingTitle ? "all" : "none" }}
+      />
       {isActive && (
         <StyledIconButton
           edge="end"
           size="small"
           data-test="tab-icon"
-          title={editingTitle ? "Set new name" : "Remove tab"}
-          onClick={editingTitle ? confirmNewTitle : removeTab}
+          title={"Remove tab"}
+          onClick={removeTab}
         >
-          {editingTitle ? <CheckIcon fontSize="inherit" /> : <CloseIcon fontSize="inherit" />}
+          <CloseIcon fontSize="inherit" />
         </StyledIconButton>
       )}
     </Tab>

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -30,7 +30,7 @@ const Tab = muiStyled("div")<{
   tabCount: number;
   title: string;
 }>(({ active, dragging, hidden, tabCount, title, theme }) => ({
-  fontSize: theme.typography.body2.fontSize,
+  fontSize: theme.typography.overline.fontSize,
   position: "relative",
   borderTopLeftRadius: theme.shape.borderRadius,
   borderTopRightRadius: theme.shape.borderRadius,

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -11,16 +11,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { makeStyles } from "@fluentui/react";
-import CheckIcon from "@mdi/svg/svg/check.svg";
-import CloseIcon from "@mdi/svg/svg/close.svg";
+import CheckIcon from "@mui/icons-material/Check";
+import CloseIcon from "@mui/icons-material/Close";
+import { IconButton, styled as muiStyled } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import React, { Ref as ReactRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import textMetrics from "text-metrics";
 
-import Icon from "@foxglove/studio-base/components/Icon";
 import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledComponents";
-import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import { TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
@@ -28,47 +27,58 @@ const MAX_TAB_WIDTH = 100;
 const MIN_ACTIVE_TAB_WIDTH = 40;
 const MIN_OTHER_TAB_WIDTH = 14;
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    position: "relative",
-    borderTopLeftRadius: 4,
-    borderTopRightRadius: 4,
-    display: "flex",
-    alignItems: "center",
-    width: "100%",
-    height: 26,
-    padding: "0 6px",
-    userSelect: "none",
-    border: "1px solid transparent",
-    backgroundColor: "transparent",
-    maxWidth: MAX_TAB_WIDTH,
-    top: 4, // Shift the tab down so it's flush with the bottom of the PanelToolbar
-    marginTop: -4,
+const Tab = muiStyled("div")<{
+  active: boolean;
+  dragging: boolean;
+  highlighted: boolean;
+  hidden: boolean;
+  tabCount: number;
+  title: string;
+}>(({ active, dragging, highlighted, hidden, tabCount, title, theme }) => ({
+  position: "relative",
+  borderTopLeftRadius: theme.shape.borderRadius,
+  borderTopRightRadius: theme.shape.borderRadius,
+  display: "flex",
+  alignItems: "center",
+  width: "100%",
+  height: 26,
+  padding: theme.spacing(0, 0.75),
+  userSelect: "none",
+  border: "1px solid transparent",
+  borderBottom: "none",
+  backgroundColor: "transparent",
+  maxWidth: MAX_TAB_WIDTH,
+  top: 5, // Shift the tab down so it's flush with the bottom of the PanelToolbar
+  marginTop: -4,
+  minWidth: active
+    ? `calc(max(${MIN_ACTIVE_TAB_WIDTH}px,  min(${Math.ceil(
+        measureText(title) + 30,
+      )}px, ${MAX_TAB_WIDTH}px, 100% - ${MIN_OTHER_TAB_WIDTH * (tabCount - 1)}px)))`
+    : undefined,
 
-    "&.isActive": {
-      backgroundColor: theme.semanticColors.listItemBackgroundChecked,
-      userSelect: "all",
-    },
-    "&.isDragging": {
-      backgroundColor: theme.semanticColors.listItemBackgroundHovered,
-      borderColor: theme.semanticColors.listItemBackgroundChecked,
-    },
-    "&.highlight": {
-      borderColor: theme.semanticColors.listItemBackgroundCheckedHovered,
-    },
-    "&.hidden": {
-      opacity: 0,
-    },
-    "&:not(.isActive) + &:not(.isActive):before": {
-      borderLeft: `1px solid ${theme.semanticColors.bodyDivider}`,
-      content: '""',
-      height: 16,
-      left: 0,
-      position: "absolute", // within .draggableTab
-      top: 4,
-      zIndex: 1,
-    },
-  },
+  ...(active && {
+    backgroundColor: theme.palette.background.paper,
+    borderColor: theme.palette.divider,
+    userSelect: "all",
+    zIndex: 1,
+  }),
+  ...(dragging && {
+    backgroundColor: theme.palette.background.paper,
+    borderColor: theme.palette.action.selected,
+  }),
+  ...(highlighted && {
+    borderColor: theme.palette.action.focus,
+  }),
+  ...(hidden && {
+    visibility: "hidden",
+  }),
+}));
+
+const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.25),
+}));
+
+const useStyles = makeStyles({
   input: {
     backgroundColor: "transparent !important",
     padding: "0px !important",
@@ -79,11 +89,13 @@ const useStyles = makeStyles((theme) => ({
       pointerEvents: "all",
     },
   },
-}));
+});
 
 const fontFamily = fonts.SANS_SERIF;
 const fontSize = "12px";
+
 let textMeasure: undefined | textMetrics.TextMeasure;
+
 function measureText(text: string): number {
   if (textMeasure == undefined) {
     textMeasure = textMetrics.init({ fontFamily, fontSize });
@@ -193,52 +205,40 @@ export function ToolbarTab(props: Props): JSX.Element {
     setTitle(tabTitle);
   }, [tabTitle]);
 
-  const tooltip = tabTitle ? tabTitle : "Enter tab name";
-
   return (
-    <div
+    <Tab
+      active={isActive}
+      dragging={isDragging}
+      highlighted={highlight}
+      hidden={hidden}
       onClick={onClickTab}
       ref={innerRef}
-      className={cx(styles.root, { isActive, isDragging, highlight, hidden })}
-      style={{
-        minWidth: isActive
-          ? `calc(max(${MIN_ACTIVE_TAB_WIDTH}px,  min(${Math.ceil(
-              measureText(tabTitle) + 30,
-            )}px, ${MAX_TAB_WIDTH}px, 100% - ${MIN_OTHER_TAB_WIDTH * (tabCount - 1)}px)))`
-          : undefined,
-      }}
+      title={tabTitle ? tabTitle : "Enter tab name"}
+      tabCount={tabCount}
     >
-      <Tooltip contents={editingTitle ? "" : tooltip} placement="top">
-        {/* This div has to be here because the <ToolTip> overwrites the ref of its child*/}
-        <div>
-          <LegacyInput
-            className={cx(styles.input, { isEditable: editingTitle })}
-            readOnly={!editingTitle}
-            placeholder="Enter tab name"
-            value={title}
-            onChange={onChangeTitleInput}
-            onBlur={setTabTitle}
-            onKeyDown={onKeyDown}
-            ref={inputRef}
-          />
-        </div>
-      </Tooltip>
-      {isActive ? (
-        <Icon
+      <div>
+        <LegacyInput
+          className={cx(styles.input, { isEditable: editingTitle })}
+          readOnly={!editingTitle}
+          placeholder="Enter tab name"
+          value={title}
+          onChange={onChangeTitleInput}
+          onBlur={setTabTitle}
+          onKeyDown={onKeyDown}
+          ref={inputRef}
+        />
+      </div>
+      {isActive && (
+        <StyledIconButton
+          edge="end"
           size="small"
-          fade
-          dataTest="tab-icon"
-          tooltip={editingTitle ? "Set new name" : "Remove tab"}
-          style={{ width: "22px" }}
+          data-test="tab-icon"
+          title={editingTitle ? "Set new name" : "Remove tab"}
           onClick={editingTitle ? confirmNewTitle : removeTab}
         >
-          {editingTitle ? (
-            <CheckIcon onMouseDown={(e) => e.preventDefault()} />
-          ) : (
-            <CloseIcon onMouseDown={(e) => e.preventDefault()} />
-          )}
-        </Icon>
-      ) : undefined}
-    </div>
+          {editingTitle ? <CheckIcon fontSize="inherit" /> : <CloseIcon fontSize="inherit" />}
+        </StyledIconButton>
+      )}
+    </Tab>
   );
 }

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -26,11 +26,10 @@ const MIN_OTHER_TAB_WIDTH = 14;
 const Tab = muiStyled("div")<{
   active: boolean;
   dragging: boolean;
-  highlighted: boolean;
   hidden: boolean;
   tabCount: number;
   title: string;
-}>(({ active, dragging, highlighted, hidden, tabCount, title, theme }) => ({
+}>(({ active, dragging, hidden, tabCount, title, theme }) => ({
   position: "relative",
   borderTopLeftRadius: theme.shape.borderRadius,
   borderTopRightRadius: theme.shape.borderRadius,
@@ -61,9 +60,6 @@ const Tab = muiStyled("div")<{
     backgroundColor: theme.palette.background.paper,
     borderColor: theme.palette.action.selected,
   }),
-  ...(highlighted && {
-    borderColor: theme.palette.action.focus,
-  }),
   ...(hidden && {
     visibility: "hidden",
   }),
@@ -71,6 +67,19 @@ const Tab = muiStyled("div")<{
 
 const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
   padding: theme.spacing(0.25),
+}));
+
+const DropIndicator = muiStyled("div")<{ dir: "before" | "after" }>(({ dir }) => ({
+  position: "absolute",
+  top: 0,
+  bottom: 0,
+  width: "2px",
+  height: "100%",
+  backgroundColor: "#f0f",
+  opacity: 0.5,
+  zIndex: 1,
+  left: dir === "before" ? 0 : "auto",
+  right: dir === "before" ? "auto" : 0,
 }));
 
 const fontFamily = fonts.SANS_SERIF;
@@ -87,7 +96,7 @@ function measureText(text: string): number {
 
 type Props = {
   hidden: boolean;
-  highlight: boolean;
+  highlight: "before" | "after" | undefined;
   innerRef?: ReactRef<HTMLDivElement>;
   isActive: boolean;
   isDragging: boolean;
@@ -190,13 +199,13 @@ export function ToolbarTab(props: Props): JSX.Element {
     <Tab
       active={isActive}
       dragging={isDragging}
-      highlighted={highlight}
       hidden={hidden}
       onClick={onClickTab}
       ref={innerRef}
       title={tabTitle ? tabTitle : "Enter tab name"}
       tabCount={tabCount}
     >
+      {highlight != undefined && <DropIndicator dir={highlight} />}
       <InputBase
         readOnly={!editingTitle}
         placeholder="Enter tab name"
@@ -212,7 +221,7 @@ export function ToolbarTab(props: Props): JSX.Element {
           edge="end"
           size="small"
           data-test="tab-icon"
-          title={"Remove tab"}
+          title="Remove tab"
           onClick={removeTab}
         >
           <CloseIcon fontSize="inherit" />

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -69,14 +69,15 @@ const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
   padding: theme.spacing(0.25),
 }));
 
-const DropIndicator = muiStyled("div")<{ dir: "before" | "after" }>(({ dir }) => ({
+const DropIndicator = muiStyled("div")<{ dir: "before" | "after" }>(({ theme, dir }) => ({
   position: "absolute",
   top: 0,
   bottom: 0,
-  width: "2px",
+  width: 2,
   height: "100%",
-  backgroundColor: "#f0f",
-  opacity: 0.5,
+  backgroundColor: theme.palette.primary.main,
+  opacity: 0.8,
+  borderRadius: theme.shape.borderRadius,
   zIndex: 1,
   left: dir === "before" ? 0 : "auto",
   right: dir === "before" ? "auto" : 0,

--- a/packages/studio-base/src/panels/Tab/index.tsx
+++ b/packages/studio-base/src/panels/Tab/index.tsx
@@ -11,15 +11,15 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Stack } from "@mui/material";
+import { styled as muiStyled } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import { MosaicNode } from "react-mosaic-component";
-import styled from "styled-components";
 
 import { EmptyPanelLayout } from "@foxglove/studio-base/components/EmptyPanelLayout";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import { UnconnectedPanelLayout } from "@foxglove/studio-base/components/PanelLayout";
+import Stack from "@foxglove/studio-base/components/Stack";
 import {
   DraggingTabPanelState,
   TabDndContext,
@@ -30,13 +30,13 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 import { DEFAULT_TAB_PANEL_CONFIG, updateTabPanelLayout } from "@foxglove/studio-base/util/layout";
 
-const SPanelCover = styled.div`
+const SPanelCover = muiStyled("div")`
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   z-index: 1;
-  background: ${({ theme }) => theme.semanticColors.bodyBackground};
+  background: ${({ theme }) => theme.palette.background.paper};
   position: absolute;
 `;
 
@@ -114,7 +114,7 @@ function Tab({ config, saveConfig }: Props) {
         activeTabIdx={activeTabIdx}
         setDraggingTabState={setDraggingTabState}
       />
-      <Stack direction="row" flex="auto" overflow="hidden" position="relative">
+      <Stack direction="row" flex="auto" overflow="hidden" style={{ position: "relative" }}>
         {activeLayout != undefined ? (
           <TabDndContext.Provider value={{ preventTabDrop }}>
             <UnconnectedPanelLayout

--- a/packages/studio-base/src/theme/palette.ts
+++ b/packages/studio-base/src/theme/palette.ts
@@ -21,6 +21,7 @@ export const dark: PaletteOptions & CustomPaletteOptions = {
     primary: "#e1e1e4",
     secondary: "#bbbac0",
   },
+  divider: "#414141",
   background: {
     default: "#121217",
     paper: "#27272b",
@@ -60,6 +61,7 @@ export const light: PaletteOptions & CustomPaletteOptions = {
     primary: "#393939",
     secondary: "#5d5c65",
   },
+  divider: "#D6d6d6",
   grey: {
     50: "#fafafa",
     100: "#f5f5f5",


### PR DESCRIPTION
**User-Facing Changes**
Update tab panel tabs to look more like tabs in light mode

**Description**
<img width="651" alt="Screen Shot 2022-05-10 at 11 52 24 am" src="https://user-images.githubusercontent.com/924528/167526651-bb7b1091-078c-41b8-a574-801213f67342.png">



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
