### PR TITLE
Add remote fallback to LayoutManager#getLayout

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -19,7 +19,7 @@ import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayout
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import LayoutManagerProvider from "@foxglove/studio-base/providers/LayoutManagerProvider";
 import { ISO8601Timestamp, Layout, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
-import LayoutManager from "@foxglove/studio-base/services/LayoutManager";
+import LayoutManager from "@foxglove/studio-base/services/LayoutManager/LayoutManager";
 import MockLayoutStorage from "@foxglove/studio-base/services/MockLayoutStorage";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
 import delay from "@foxglove/studio-base/util/delay";

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -2,8 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { DefaultButton, IconButton, Spinner, Toggle, useTheme } from "@fluentui/react";
-import { Box, Stack } from "@mui/material";
+import { IconButton, Spinner, useTheme } from "@fluentui/react";
+import { Box, Stack, Button, Switch, FormGroup, FormControlLabel } from "@mui/material";
 import { partition } from "lodash";
 import moment from "moment";
 import path from "path";
@@ -467,7 +467,7 @@ export default function LayoutBrowser({
         </div>
         <div style={{ flexGrow: 1 }} />
         {showSignInPrompt && <SignInPrompt onDismiss={() => void setHideSignInPrompt(true)} />}
-        {layoutDebug?.syncNow && (
+        {layoutDebug && (
           <Stack
             spacing={0.5}
             style={{
@@ -482,28 +482,30 @@ export default function LayoutBrowser({
           >
             <Box flexGrow={1} alignSelf="stretch">
               <Stack direction="row" flexShrink={0} spacing={1}>
-                <Box flexGrow={1}>
-                  <DefaultButton
-                    text="Sync"
-                    onClick={async () => {
-                      await layoutDebug.syncNow();
-                      await reloadLayouts();
-                    }}
-                    styles={{
-                      root: {
-                        display: "block",
-                        width: "100%",
-                        margin: 0,
-                      },
-                    }}
+                <Button
+                  onClick={async () => {
+                    await layoutDebug.syncNow();
+                    await reloadLayouts();
+                  }}
+                >
+                  Sync
+                </Button>
+
+                <Box flexGrow={1} />
+
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={layoutManager.isOnline}
+                        onChange={(_, checked) => {
+                          layoutDebug.setOnline(checked);
+                        }}
+                      />
+                    }
+                    label={layoutManager.isOnline ? "Online" : "Offline"}
                   />
-                </Box>
-                <Toggle
-                  checked={layoutManager.isOnline}
-                  onText="Online"
-                  offText="Offline"
-                  onChange={(_, checked) => checked != undefined && layoutDebug.setOnline(checked)}
-                />
+                </FormGroup>
               </Stack>
             </Box>
           </Stack>

--- a/packages/studio-base/src/providers/LayoutManagerProvider.tsx
+++ b/packages/studio-base/src/providers/LayoutManagerProvider.tsx
@@ -16,7 +16,7 @@ import { useRemoteLayoutStorage } from "@foxglove/studio-base/context/RemoteLayo
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import { ISO8601Timestamp, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
-import LayoutManager from "@foxglove/studio-base/services/LayoutManager";
+import LayoutManager from "@foxglove/studio-base/services/LayoutManager/LayoutManager";
 import delay from "@foxglove/studio-base/util/delay";
 
 const log = Logger.getLogger(__filename);

--- a/packages/studio-base/src/services/LayoutManager/NamespacedLayoutStorage.ts
+++ b/packages/studio-base/src/services/LayoutManager/NamespacedLayoutStorage.ts
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Logger from "@foxglove/log";
+import { ILayoutStorage, Layout, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
+
+const log = Logger.getLogger(__filename);
+
+/**
+ * A wrapper around ILayoutStorage for a particular namespace.
+ */
+export class NamespacedLayoutStorage {
+  private migration: Promise<void>;
+  constructor(
+    private storage: ILayoutStorage,
+    private namespace: string,
+    {
+      migrateUnnamespacedLayouts,
+      importFromNamespace,
+    }: { migrateUnnamespacedLayouts: boolean; importFromNamespace: string | undefined },
+  ) {
+    this.migration = (async function () {
+      if (migrateUnnamespacedLayouts) {
+        await storage
+          .migrateUnnamespacedLayouts?.(namespace)
+          .catch((error) => log.error("Migration failed:", error));
+      }
+
+      if (importFromNamespace != undefined) {
+        await storage
+          .importLayouts({
+            fromNamespace: importFromNamespace,
+            toNamespace: namespace,
+          })
+          .catch((error) => log.error("Import failed:", error));
+      }
+    })();
+  }
+
+  async list(): Promise<readonly Layout[]> {
+    await this.migration;
+    return await this.storage.list(this.namespace);
+  }
+  async get(id: LayoutID): Promise<Layout | undefined> {
+    await this.migration;
+    return await this.storage.get(this.namespace, id);
+  }
+  async put(layout: Layout): Promise<Layout> {
+    await this.migration;
+    return await this.storage.put(this.namespace, layout);
+  }
+  async delete(id: LayoutID): Promise<void> {
+    await this.migration;
+    await this.storage.delete(this.namespace, id);
+  }
+}


### PR DESCRIPTION
**User-Facing Changes**
When a user loads a url with a layoutId, Studio attempts to load the layout id from their account (if signed in). This creates a better link-sharing experience when working with team shared layouts.

**Description**
When a user visits a studio url (or deep link) with a specific layoutId, the expectation is that the app will display this layout to the user. The app attempts to load the layout by asking the LayoutManager to getLayout with the layout id. The layout manager consults its local cache and returns the layout with that id.

When working in a team setting, a user may receive a link from a co-worker with a layout id. When the user clicks this link, studio attempts to open the layout id but is unable to because the app has not yet sync'd the user's local cache with the team's remote layouts. This leaves the user with an undesirable message to "Select a layout to get started" rather than showing the user the available layout.

This change alters the behavior of LayoutManager#getLayout to fall-back to fetching the remote layout if a local one is not available. The newly fetched remote layout is inserted into the local cache for future lookups.

Additionally, this change ports the layout debugging controls to MUI to continue our ongoing effort to deprecate fluent. These changes have no user facing impact.

Fixes: #3119

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
