### PR TITLE
Fix Image panel error when transformMarkers is enabled

### DIFF
--- a/packages/studio-base/src/panels/ImageView/index.tsx
+++ b/packages/studio-base/src/panels/ImageView/index.tsx
@@ -344,7 +344,8 @@ function ImageView(props: Props) {
     return {
       markers: annotations ?? [],
       transformMarkers,
-      cameraInfo,
+      // Convert to plain object before sending to web worker
+      cameraInfo: (cameraInfo as { toJSON?: () => unknown } | undefined)?.toJSON?.() ?? cameraInfo,
     };
   }, [annotations, cameraInfo, transformMarkers]);
 


### PR DESCRIPTION
**User-Facing Changes**
Fixes an Image panel error when the "transform markers" setting is enabled.

**Description**
Fixes this error:
![](https://user-images.githubusercontent.com/14237/167175773-8743757b-b2bc-4831-aae9-59be9ce18037.png)