### PR TITLE
Allow panels to control node collapse state with new expanded attribute

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -55,13 +55,14 @@ const BasicSettings: SettingsTreeNode = {
       },
     },
     defaultCollapsed: {
+      expanded: false,
       label: "Default Collapsed",
-      defaultExpansionState: "collapsed",
       fields: {
         field: { label: "Field", input: "string" },
       },
     },
     background: {
+      expanded: true,
       label: "Background",
       fields: {
         colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
@@ -307,6 +308,8 @@ function updateSettingsTreeNode(
     const key = workingPath.shift()!;
     if (key === "visible") {
       node.visible = Boolean(value);
+    } else if (key === "expanded") {
+      node.expanded = Boolean(value);
     } else {
       const field = node.fields?.[key];
       if (field != undefined) {

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -57,9 +57,11 @@ export type SettingsTreeNode = {
   children?: SettingsTreeChildren;
 
   /**
-   * Set to collapsed if the node should be initially collapsed.
+   * Set to a non-undefined value to control the expanded state manually.
+   * If this is undefined the settings UI will maintain the expanded state.
+   * By default all nodes are expanded.
    */
-  defaultExpansionState?: "collapsed" | "expanded";
+  expanded?: boolean;
 
   /**
    * Field inputs attached directly to this node.


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This allows panel authors to optionally manually control the expansion state of each node by setting the new `expanded` attribute to either true or false. Omitting this field delegates control of the node's expansion state to the settings editor. Panels that set this to a non-undefined value will receive update actions with a path ending in `expanded`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
