### PR TITLE
Allow New3D experimental setting in production builds

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -89,13 +89,13 @@ const features: Feature[] = [
       <>The experimental mcap player uses a new approach to loading messages from mcap files.</>
     ),
   },
-];
-if (process.env.NODE_ENV === "development") {
-  features.push({
+  {
     key: AppSetting.EXPERIMENTAL_3D_PANEL,
     name: "Experimental 3D panel",
     description: <>Enable the experimental 3D panel.</>,
-  });
+  },
+];
+if (process.env.NODE_ENV === "development") {
   features.push({
     key: AppSetting.ENABLE_LAYOUT_DEBUGGING,
     name: "Layout debugging",


### PR DESCRIPTION
**User-Facing Changes**

(Exclude from release notes) - Adds an experimental setting to enable the "3D (Experimental)" panel

**Description**

Adds a new experimental flag for enabling the New3D panel in production builds
