### PR TITLE
Fix sample layout duplication issue

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -40,7 +40,6 @@ import PlayerSelectionContext, {
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useUserNodeState } from "@foxglove/studio-base/context/UserNodeStateContext";
-import { SAMPLE_DATA_SOURCE_LAYOUT_NAME } from "@foxglove/studio-base/dataSources/SampleNuscenesDataSourceFactory";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import useIndexedDbRecents from "@foxglove/studio-base/hooks/useIndexedDbRecents";
@@ -162,9 +161,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         if (foundSource.sampleLayout) {
           try {
             const layouts = await layoutStorage.getLayouts();
-            let sourceLayout = layouts.find(
-              (layout) => layout.name === SAMPLE_DATA_SOURCE_LAYOUT_NAME,
-            );
+            let sourceLayout = layouts.find((layout) => layout.name === foundSource.displayName);
             if (sourceLayout == undefined) {
               sourceLayout = await layoutStorage.saveNewLayout({
                 name: foundSource.displayName,

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -15,10 +15,12 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
 import * as SampleNuscenesLayout from "./SampleNuscenesLayout.json";
 
+export const SAMPLE_DATA_SOURCE_LAYOUT_NAME = "Sample: Nuscenes";
+
 class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
   id = "sample-nuscenes";
   type: IDataSourceFactory["type"] = "sample";
-  displayName = "Sample: Nuscenes";
+  displayName = SAMPLE_DATA_SOURCE_LAYOUT_NAME;
   iconName: IDataSourceFactory["iconName"] = "FileASPX";
   hidden = true;
   sampleLayout = SampleNuscenesLayout as IDataSourceFactory["sampleLayout"];

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -15,12 +15,10 @@ import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
 import * as SampleNuscenesLayout from "./SampleNuscenesLayout.json";
 
-export const SAMPLE_DATA_SOURCE_LAYOUT_NAME = "Sample: Nuscenes";
-
 class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
   id = "sample-nuscenes";
   type: IDataSourceFactory["type"] = "sample";
-  displayName = SAMPLE_DATA_SOURCE_LAYOUT_NAME;
+  displayName = "Sample: Nuscenes";
   iconName: IDataSourceFactory["iconName"] = "FileASPX";
   hidden = true;
   sampleLayout = SampleNuscenesLayout as IDataSourceFactory["sampleLayout"];


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with proliferation of sample layouts when repeatedly loading the sample data set

**Description**
The solution here is to look for an existing layout with the same name as our sample layout and load that instead of creating a new layout. This implementation requires loading the entire list of local layouts in order to look for one with a matching name but maybe in practice this won't be a performance issue since it seems unlikely that someone would have a very large number of layouts and also often be loading the sample data set.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #2722 