### PR TITLE
Fix image panel settings error

### DIFF
--- a/packages/studio-base/src/panels/ImageView/components/ImageEmptyState.tsx
+++ b/packages/studio-base/src/panels/ImageView/components/ImageEmptyState.tsx
@@ -17,7 +17,7 @@ import EmptyState from "@foxglove/studio-base/components/EmptyState";
 
 type Props = {
   cameraTopic: string;
-  markerTopics: string[];
+  markerTopics: readonly string[];
   shouldSynchronize: boolean;
 };
 
@@ -51,7 +51,7 @@ export function ImageEmptyState(props: Props): JSX.Element {
           <div>
             <code>{cameraTopic}</code>
           </div>
-          {markerTopics.sort().map((topic) => (
+          {[...markerTopics].sort().map((topic) => (
             <div key={topic}>
               <code>{topic}</code>
             </div>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes an issue with the image panel settings. The issue is that when settings are changed in the new settings UI using immer the resulting config is a frozen object. The `ImageEmptyState` was using an in-place sort on the resulting topics and blowing up:

https://github.com/foxglove/studio/blob/6e2c8ca905e582d14dfeb95dd351bfc94698ec3d/packages/studio-base/src/panels/ImageView/components/ImageEmptyState.tsx#L54-L58

TS didn't catch this because the typings didn't reflect the frozen state. We should probably more rigorously define incoming configs to panels as `DeepReadonly`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
