### PR TITLE
[WIP] Fix for memory exhaustion issue

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -92,25 +92,6 @@ type IterablePlayerState =
   | "play"
   | "close";
 
-function messageHasLazyDataView(message: unknown): message is { _view: DataView } {
-  return message != undefined && typeof message === "object" && "_view" in message;
-}
-
-/**
- * Trims the underlying DataView in a lazy message to avoid retaining large
- * array buffers referenced by the DataView.
- */
-function trimMessageEventDataView(message: unknown) {
-  if (messageHasLazyDataView(message)) {
-    // eslint-disable-next-line no-underscore-dangle
-    const dataView = message._view;
-    // eslint-disable-next-line no-underscore-dangle
-    message._view = new DataView(
-      dataView.buffer.slice(dataView.byteOffset, dataView.byteOffset + dataView.byteLength),
-    );
-  }
-}
-
 /**
  * IterablePlayer implements the Player interface for IIterableSource instances.
  *
@@ -1043,7 +1024,6 @@ export class IterablePlayer implements Player {
         }
 
         totalBlockSizeBytes += messageSizeInBytes;
-        trimMessageEventDataView(iterResult.msgEvent.message);
         events.push(iterResult.msgEvent);
       }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
It looks like our lazy message strategy is biting us here. These individual messages are only 321 bytes but their DataView retains the entire 60mb buffer that we decompress from the bag and this exhausts memory as we fill up blocks.

Trimming the underlying DataView to only contain the data needed seems to fix the problem but I'm not sure this is the right place to fix this.

<img width="444" alt="Screen Shot 2022-05-10 at 7 21 27 AM" src="https://user-images.githubusercontent.com/93935560/167634866-202fda4d-f1fe-4eaf-8606-7956eca7e821.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3318