### PR TITLE
Add EmptyImage to NormalizedImageMessage types

### DIFF
--- a/packages/studio-base/src/panels/ImageView/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/ImageView/lib/renderImage.stories.tsx
@@ -6,6 +6,7 @@ import { Story } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { useCompressedImage, cameraInfo, annotations } from "../storySupport";
+import { NormalizedImageMessage } from "../types";
 import { renderImage } from "./renderImage";
 
 export default {
@@ -121,6 +122,59 @@ export const MarkersWithRotations: Story = (_args) => {
           style={{ width, height }}
         />
       ))}
+    </div>
+  );
+};
+
+export const EmptyImage: Story = (_args) => {
+  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+  const hitmapRef = useRef<HTMLCanvasElement>(ReactNull);
+
+  const width = 400;
+  const height = 300;
+
+  useEffect(() => {
+    if (!canvasRef.current || !hitmapRef.current) {
+      return;
+    }
+
+    const imageMessage: NormalizedImageMessage = {
+      stamp: { sec: 0, nsec: 0 },
+      type: "empty",
+      data: new Uint8Array(0),
+      width,
+      height,
+    };
+
+    canvasRef.current.width = 2 * width;
+    canvasRef.current.height = 2 * height;
+    hitmapRef.current.width = 2 * width;
+    hitmapRef.current.height = 2 * height;
+
+    void renderImage({
+      canvas: canvasRef.current,
+      hitmapCanvas: hitmapRef.current,
+      geometry: {
+        flipHorizontal: false,
+        flipVertical: false,
+        panZoom: { x: 0, y: 0, scale: 1 },
+        rotation: 0,
+        viewport: { width, height },
+        zoomMode: "fill",
+      },
+      imageMessage,
+      rawMarkerData: {
+        markers: annotations,
+        cameraInfo,
+        transformMarkers: true,
+      },
+    });
+  }, []);
+
+  return (
+    <div style={{ backgroundColor: "white", padding: "1rem" }}>
+      <canvas ref={canvasRef} style={{ width, height }} />
+      <canvas ref={hitmapRef} style={{ width, height }} />
     </div>
   );
 };

--- a/packages/studio-base/src/panels/ImageView/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/ImageView/lib/renderImage.ts
@@ -125,6 +125,13 @@ function decodeMessageToBitmap(
   }
 
   switch (imageMessage.type) {
+    case "empty": {
+      return Promise.resolve({
+        width: imageMessage.width,
+        height: imageMessage.height,
+        close: () => {},
+      });
+    }
     case "compressed": {
       const image = new Blob([rawData], { type: `image/${imageMessage.format}` });
       return self.createImageBitmap(image);
@@ -240,7 +247,9 @@ function render({
   // also sets 0,0 as the upper left corner of the image since markers are drawn from 0,0 on the image
   ctx.translate(-bitmap.width / 2, -bitmap.height / 2);
 
-  ctx.drawImage(bitmap, 0, 0);
+  if (bitmap instanceof ImageBitmap) {
+    ctx.drawImage(bitmap, 0, 0);
+  }
 
   // The bitmap images from the image message may be resized to conserve space
   // while the markers are positioned relative to the original image size.

--- a/packages/studio-base/src/panels/ImageView/types.ts
+++ b/packages/studio-base/src/panels/ImageView/types.ts
@@ -124,6 +124,14 @@ export type TextAnnotation = {
 
 export type Annotation = CircleAnnotation | PointsAnnotation | TextAnnotation;
 
+export type EmptyImageMessage = {
+  type: "empty";
+  stamp: { sec: number; nsec: number };
+  data: Uint8Array;
+  width: number;
+  height: number;
+};
+
 export type RawImageMessage = {
   type: "raw";
   stamp: { sec: number; nsec: number };
@@ -142,4 +150,4 @@ export type CompressedImageMessage = {
   data: Uint8Array;
 };
 
-export type NormalizedImageMessage = RawImageMessage | CompressedImageMessage;
+export type NormalizedImageMessage = RawImageMessage | CompressedImageMessage | EmptyImageMessage;


### PR DESCRIPTION


**User-Facing Changes**
None. There are no messages that produce EmptyImages.

**Description**
The EmptyImage allows for specifying a width/height without specifying the image data. This is used with the ImageCanvas when rendering markers without an image.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
