### PR TITLE
Improve settings grid layout

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -16,6 +16,7 @@ import {
   ListProps,
   useTheme,
 } from "@mui/material";
+import { CSSProperties } from "react";
 import { DeepReadonly } from "ts-essentials";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
@@ -338,10 +339,12 @@ function FieldEditorComponent({
   actionHandler,
   field,
   path,
+  style,
 }: {
   actionHandler: (action: SettingsTreeAction) => void;
   field: DeepReadonly<SettingsTreeField>;
   path: readonly string[];
+  style?: CSSProperties;
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
@@ -349,7 +352,7 @@ function FieldEditorComponent({
 
   return (
     <>
-      <Stack direction="row" alignItems="center" style={{ paddingLeft }} fullHeight>
+      <Stack direction="row" alignItems="center" style={{ ...style, paddingLeft }} fullHeight>
         <FieldLabel field={field} />
       </Stack>
       <div style={{ paddingRight: theme.spacing(2) }}>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -352,7 +352,7 @@ function FieldEditorComponent({
 
   return (
     <>
-      <Stack direction="row" alignItems="center" style={{ ...style, paddingLeft }} fullHeight>
+      <Stack direction="row" alignItems="center" style={style} paddingLeft={paddingLeft} fullHeight>
         <FieldLabel field={field} />
       </Stack>
       <div style={{ paddingRight: theme.spacing(2) }}>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -348,7 +348,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = theme.spacing(2 + 2 * Math.max(0, indent - 1));
+  const paddingLeft = 2 + 2 * Math.max(0, indent - 1);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -4,7 +4,7 @@
 
 import ClearIcon from "@mui/icons-material/Clear";
 import SearchIcon from "@mui/icons-material/Search";
-import { AppBar, IconButton, TextField, styled as muiStyled, List } from "@mui/material";
+import { AppBar, IconButton, TextField, styled as muiStyled } from "@mui/material";
 import { useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
@@ -18,6 +18,13 @@ const StyledAppBar = muiStyled(AppBar, { skipSx: true })(({ theme }) => ({
   zIndex: theme.zIndex.appBar - 1,
   borderBottom: `1px solid ${theme.palette.divider}`,
   padding: theme.spacing(1),
+}));
+
+const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "minmax(4rem, 1fr) minmax(min-content, 14rem)",
+  columnGap: theme.spacing(1),
+  rowGap: theme.spacing(0.25),
 }));
 
 const ROOT_PATH: readonly string[] = [];
@@ -56,9 +63,9 @@ export default function SettingsTreeEditor({
           />
         </StyledAppBar>
       )}
-      <List dense disablePadding>
+      <FieldGrid>
         <NodeEditor path={ROOT_PATH} settings={settings.settings} actionHandler={actionHandler} />
-      </List>
+      </FieldGrid>
     </Stack>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -22,7 +22,7 @@ const StyledAppBar = muiStyled(AppBar, { skipSx: true })(({ theme }) => ({
 
 const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
   display: "grid",
-  gridTemplateColumns: "minmax(4rem, 1fr) minmax(min-content, 14rem)",
+  gridTemplateColumns: "minmax(4rem, 1fr) minmax(min-content, 12rem)",
   columnGap: theme.spacing(1),
   rowGap: theme.spacing(0.25),
 }));


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This improves the settings field grid layout by putting all elements in a common parent grid and capping the width of the input fields.

https://user-images.githubusercontent.com/93935560/167870240-50f6db27-39b9-454d-b9a5-25f49282c84e.mov

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
