### PR TITLE
Add custom map url config

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -150,11 +150,10 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const [customLayer] = useState(
     new TileLayer("https://example.com/{z}/{y}/{x}", {
-        attribution: "",
-        maxNativeZoom: 20,
-        maxZoom: 24,
-      },
-    ),
+      attribution: "",
+      maxNativeZoom: 20,
+      maxZoom: 24,
+    }),
   );
 
   // Panel state management to update our set of messages
@@ -252,7 +251,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     if (config.layer === "custom") {
       // validate URL to avoid leaflet map placeholder variable error
       const placeholders = config.customUrl.match(/\{.+?\}/g) ?? [];
-      const valid_placeholders = ['{x}', '{y}', '{z}'];
+      const valid_placeholders = ["{x}", "{y}", "{z}"];
       for (const placeholder of placeholders) {
         if (!valid_placeholders.includes(placeholder)) {
           return;
@@ -260,7 +259,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       }
       customLayer.setUrl(config.customUrl);
     }
-  }, [config.layer, config.customUrl, customLayer])
+  }, [config.layer, config.customUrl, customLayer]);
 
   // Subscribe to eligible and enabled topics
   useEffect(() => {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -149,9 +149,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   );
 
   const [customLayer] = useState(
-    new TileLayer(
-      "https://example.com/{z}/{y}/{x}",
-      {
+    new TileLayer("https://example.com/{z}/{y}/{x}", {
         attribution: "",
         maxNativeZoom: 20,
         maxZoom: 24,
@@ -248,21 +246,21 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       currentMap?.removeLayer(tileLayer);
       currentMap?.removeLayer(satelliteLayer);
     }
-  }, [config.layer, currentMap, satelliteLayer, tileLayer]);
+  }, [config.layer, currentMap, customLayer, satelliteLayer, tileLayer]);
 
   useEffect(() => {
     if (config.layer === "custom") {
       // validate URL to avoid leaflet map placeholder variable error
       const placeholders = config.customUrl.match(/\{.+?\}/g) ?? [];
       const valid_placeholders = ['{x}', '{y}', '{z}'];
-      for(let placeholder of placeholders){
-        if(!valid_placeholders.includes(placeholder)){
+      for (const placeholder of placeholders) {
+        if (!valid_placeholders.includes(placeholder)) {
           return;
         }
       }
       customLayer.setUrl(config.customUrl);
     }
-  }, [config.layer, config.customUrl])
+  }, [config.layer, config.customUrl, customLayer])
 
   // Subscribe to eligible and enabled topics
   useEffect(() => {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -37,6 +37,7 @@ import { MapPanelMessage, Point } from "./types";
 
 // Persisted panel state
 type Config = {
+  customUrl: string;
   disabledTopics: string[];
   layer: string;
   zoomLevel?: number;
@@ -79,7 +80,13 @@ function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTr
         options: [
           { label: "Map", value: "map" },
           { label: "Satellite", value: "satellite" },
+          { label: "Custom", value: "custom" },
         ],
+      },
+      customUrl: {
+        label: "Custom map tile URL",
+        input: "string",
+        value: config.customUrl,
       },
     },
     children: {
@@ -117,6 +124,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     const initialConfig = props.context.initialState as Partial<Config>;
     initialConfig.disabledTopics = initialConfig.disabledTopics ?? [];
     initialConfig.layer = initialConfig.layer ?? "map";
+    initialConfig.customUrl = initialConfig.customUrl ?? "";
     return initialConfig as Config;
   });
 
@@ -135,6 +143,17 @@ function MapPanel(props: MapPanelProps): JSX.Element {
         attribution:
           "&copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
         maxNativeZoom: 18,
+        maxZoom: 24,
+      },
+    ),
+  );
+
+  const [customLayer] = useState(
+    new TileLayer(
+      "https://example.com/{z}/{y}/{x}",
+      {
+        attribution: "",
+        maxNativeZoom: 20,
         maxZoom: 24,
       },
     ),
@@ -207,17 +226,43 @@ function MapPanel(props: MapPanelProps): JSX.Element {
         return { ...oldConfig, layer: String(value) };
       });
     }
+
+    if (path[0] === "customUrl" && input === "string") {
+      setConfig((oldConfig) => {
+        return { ...oldConfig, customUrl: String(value) };
+      });
+    }
   }, []);
 
   useEffect(() => {
     if (config.layer === "map") {
       currentMap?.addLayer(tileLayer);
       currentMap?.removeLayer(satelliteLayer);
-    } else {
+      currentMap?.removeLayer(customLayer);
+    } else if (config.layer === "satellite") {
       currentMap?.addLayer(satelliteLayer);
       currentMap?.removeLayer(tileLayer);
+      currentMap?.removeLayer(customLayer);
+    } else if (config.layer === "custom") {
+      currentMap?.addLayer(customLayer);
+      currentMap?.removeLayer(tileLayer);
+      currentMap?.removeLayer(satelliteLayer);
     }
   }, [config.layer, currentMap, satelliteLayer, tileLayer]);
+
+  useEffect(() => {
+    if (config.layer === "custom") {
+      // validate URL to avoid leaflet map placeholder variable error
+      const placeholders = config.customUrl.match(/\{.+?\}/g) ?? [];
+      const valid_placeholders = ['{x}', '{y}', '{z}'];
+      for(let placeholder of placeholders){
+        if(!valid_placeholders.includes(placeholder)){
+          return;
+        }
+      }
+      customLayer.setUrl(config.customUrl);
+    }
+  }, [config.layer, config.customUrl])
 
   // Subscribe to eligible and enabled topics
   useEffect(() => {


### PR DESCRIPTION
**User-Facing Changes**
This extends the map panel configuration sidepanel to include a custom map layer which points to a custom map tile URL.
![Screenshot from 2022-05-13 11-45-25](https://user-images.githubusercontent.com/47291559/168184857-a3a8d888-4234-4833-a84a-af0aca9e7799.png)

Users can now leverage custom URLs that may provide better imagery. For example, using a custom URL on the left:
![Screenshot from 2022-05-13 11-54-01](https://user-images.githubusercontent.com/47291559/168185587-bbe159de-aa03-47aa-8016-a187da737da2.png)


**Description**
I had to add some basic validation to ensure the URL placeholders had the correct format (e.g. `{x}`), otherwise the leaflet js library would throw errors.

I'm not sure what the best way to handle image attribution is with custom map tile urls.

