### PR TITLE
Fix unknown prop error in EmptyPanelLayout

### DIFF
--- a/packages/studio-base/src/components/EmptyPanelLayout.tsx
+++ b/packages/studio-base/src/components/EmptyPanelLayout.tsx
@@ -33,7 +33,9 @@ const Root = muiStyled("div")(({ theme }) => ({
   overflowY: "auto",
 }));
 
-const DropTarget = muiStyled("div")<{ isOver: boolean }>(({ isOver, theme }) => ({
+const DropTarget = muiStyled("div", { shouldForwardProp: (prop) => prop !== "isOver" })<{
+  isOver: boolean;
+}>(({ isOver, theme }) => ({
   width: "100%",
   height: "100%",
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes an unknown prop error in `EmptyPanelLayout`. We just needed a `shouldForwardProp`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
