### PR TITLE
Add new message expansion options in the raw messages panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -40,6 +40,9 @@ export const fixture = {
             str: "a string",
             nothing: undefined,
           },
+          timestamp_array: Array(6)
+            .fill(undefined)
+            .map((_, i) => ({ sec: i, nsec: i })),
           timestamp_example_1: { sec: 0, nsec: 0 },
           timestamp_example_2: { sec: 1, nsec: 1 },
           timestamp_example_3: { sec: 1500000000, nsec: 1 },

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -169,8 +169,9 @@ storiesOf("panels/RawMessages", module)
     return (
       <PanelSetup fixture={topicsToDiffFixture} style={{ width: 500 }}>
         <RawMessages
-          overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any}
-          defaultExpandAll
+          overrideConfig={
+            { ...diffConfig, expansionMode: "all", showFullMessageForDiff: false } as any
+          }
         />
       </PanelSetup>
     );
@@ -179,8 +180,9 @@ storiesOf("panels/RawMessages", module)
     return (
       <PanelSetup fixture={topicsToDiffFixture} style={{ width: 500 }}>
         <RawMessages
-          overrideConfig={{ ...diffConfig, showFullMessageForDiff: true } as any}
-          defaultExpandAll
+          overrideConfig={
+            { ...diffConfig, expansionMode: "all", showFullMessageForDiff: true } as any
+          }
         />
       </PanelSetup>
     );
@@ -191,10 +193,11 @@ storiesOf("panels/RawMessages", module)
       topicPath: "/baz/enum_advanced_array.value",
       diffTopicPath: "/another/baz/enum_advanced_array.value",
       showFullMessageForDiff: false,
+      expansionMode: "all",
     };
     return (
       <PanelSetup fixture={topicsWithIdsToDiffFixture} style={{ width: 380 }}>
-        <RawMessages overrideConfig={config as any} defaultExpandAll />
+        <RawMessages overrideConfig={config as any} />
       </PanelSetup>
     );
   })
@@ -230,8 +233,8 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
+            expansionMode: "all",
           }}
-          defaultExpandAll
         />
       </PanelSetup>
     );
@@ -246,8 +249,8 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
+            expansionMode: "all",
           }}
-          defaultExpandAll
         />
       </PanelSetup>
     );
@@ -262,8 +265,8 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
+            expansionMode: "all",
           }}
-          defaultExpandAll
         />
       </PanelSetup>
     );
@@ -278,8 +281,8 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "/another/baz/enum_advanced",
             diffEnabled: false,
             showFullMessageForDiff: true,
+            expansionMode: "all",
           }}
-          defaultExpandAll
         />
       </PanelSetup>
     );

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -64,12 +64,12 @@ storiesOf("panels/RawMessages", module)
       </PanelSetup>
     );
   })
-  .add("smart expanded", () => {
+  .add("auto expanded", () => {
     return (
       <PanelSetup fixture={fixture} style={{ width: 380 }}>
         <RawMessages
           overrideConfig={
-            { topicPath: "/msgs/big_topic", ...noDiffConfig, autoExpandMode: "smart" } as any
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, autoExpandMode: "auto" } as any
           }
         />
       </PanelSetup>

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -53,6 +53,28 @@ storiesOf("panels/RawMessages", module)
       </PanelSetup>
     );
   })
+  .add("expanded", () => {
+    return (
+      <PanelSetup fixture={fixture} style={{ width: 380 }}>
+        <RawMessages
+          overrideConfig={
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansionMode: "all" } as any
+          }
+        />
+      </PanelSetup>
+    );
+  })
+  .add("smart expanded", () => {
+    return (
+      <PanelSetup fixture={fixture} style={{ width: 380 }}>
+        <RawMessages
+          overrideConfig={
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansionMode: "smart" } as any
+          }
+        />
+      </PanelSetup>
+    );
+  })
   .add("with receiveTime", () => {
     return (
       <PanelSetup fixture={fixture} style={{ width: 380 }}>

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -58,7 +58,7 @@ storiesOf("panels/RawMessages", module)
       <PanelSetup fixture={fixture} style={{ width: 380 }}>
         <RawMessages
           overrideConfig={
-            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansionMode: "all" } as any
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, autoExpandMode: "all" } as any
           }
         />
       </PanelSetup>
@@ -69,7 +69,7 @@ storiesOf("panels/RawMessages", module)
       <PanelSetup fixture={fixture} style={{ width: 380 }}>
         <RawMessages
           overrideConfig={
-            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansionMode: "smart" } as any
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, autoExpandMode: "smart" } as any
           }
         />
       </PanelSetup>
@@ -192,7 +192,7 @@ storiesOf("panels/RawMessages", module)
       <PanelSetup fixture={topicsToDiffFixture} style={{ width: 500 }}>
         <RawMessages
           overrideConfig={
-            { ...diffConfig, expansionMode: "all", showFullMessageForDiff: false } as any
+            { ...diffConfig, autoExpandMode: "all", showFullMessageForDiff: false } as any
           }
         />
       </PanelSetup>
@@ -203,7 +203,7 @@ storiesOf("panels/RawMessages", module)
       <PanelSetup fixture={topicsToDiffFixture} style={{ width: 500 }}>
         <RawMessages
           overrideConfig={
-            { ...diffConfig, expansionMode: "all", showFullMessageForDiff: true } as any
+            { ...diffConfig, autoExpandMode: "all", showFullMessageForDiff: true } as any
           }
         />
       </PanelSetup>
@@ -215,7 +215,7 @@ storiesOf("panels/RawMessages", module)
       topicPath: "/baz/enum_advanced_array.value",
       diffTopicPath: "/another/baz/enum_advanced_array.value",
       showFullMessageForDiff: false,
-      expansionMode: "all",
+      autoExpandMode: "all",
     };
     return (
       <PanelSetup fixture={topicsWithIdsToDiffFixture} style={{ width: 380 }}>
@@ -255,7 +255,7 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
-            expansionMode: "all",
+            autoExpandMode: "all",
           }}
         />
       </PanelSetup>
@@ -271,7 +271,7 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
-            expansionMode: "all",
+            autoExpandMode: "all",
           }}
         />
       </PanelSetup>
@@ -287,7 +287,7 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "",
             diffEnabled: true,
             showFullMessageForDiff: true,
-            expansionMode: "all",
+            autoExpandMode: "all",
           }}
         />
       </PanelSetup>
@@ -303,7 +303,7 @@ storiesOf("panels/RawMessages", module)
             diffTopicPath: "/another/baz/enum_advanced",
             diffEnabled: false,
             showFullMessageForDiff: true,
-            expansionMode: "all",
+            autoExpandMode: "all",
           }}
         />
       </PanelSetup>

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -28,6 +28,7 @@ import {
 } from "./fixture";
 
 const noDiffConfig = {
+  autoExpandMode: "off",
   diffMethod: "custom",
   diffTopicPath: "",
   diffEnabled: false,

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -19,6 +19,7 @@ import LessIcon from "@mdi/svg/svg/unfold-less-horizontal.svg";
 import MoreIcon from "@mdi/svg/svg/unfold-more-horizontal.svg";
 import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import { Immutable } from "immer";
 // eslint-disable-next-line no-restricted-imports
 import { first, isEqual, get, last } from "lodash";
 import { useState, useCallback, useMemo, useEffect } from "react";
@@ -71,25 +72,15 @@ import {
 } from "./getValueActionForValue";
 import helpContent from "./index.help.md";
 import { buildSettingsTree } from "./settings";
+import { RawMessagesPanelConfig } from "./types";
 import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, getItemStringForDiff } from "./utils";
 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
 
-type AutoExpandMode = "auto" | "off" | "all";
-
-export type RawMessagesConfig = {
-  autoExpandMode?: AutoExpandMode;
-  diffEnabled: boolean;
-  diffMethod: "custom" | "previous message";
-  diffTopicPath: string;
-  showFullMessageForDiff: boolean;
-  topicPath: string;
-};
-
 type Props = {
-  config: RawMessagesConfig;
-  saveConfig: (arg0: Partial<RawMessagesConfig>) => void;
+  config: Immutable<RawMessagesPanelConfig>;
+  saveConfig: (arg0: Partial<RawMessagesPanelConfig>) => void;
 };
 
 const isSingleElemArray = (obj: unknown): obj is unknown[] => {
@@ -225,7 +216,9 @@ function RawMessages(props: Props) {
   const settingsActionHandler = useCallback(
     (action: SettingsTreeAction) => {
       if (action.payload.input === "select") {
-        saveConfig({ autoExpandMode: action.payload.value as AutoExpandMode });
+        saveConfig({
+          autoExpandMode: action.payload.value as RawMessagesPanelConfig["autoExpandMode"],
+        });
       }
     },
     [saveConfig],
@@ -694,7 +687,7 @@ function RawMessages(props: Props) {
   );
 }
 
-const defaultConfig: RawMessagesConfig = {
+const defaultConfig: RawMessagesPanelConfig = {
   autoExpandMode: "auto",
   diffEnabled: false,
   diffMethod: CUSTOM_METHOD,

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -24,6 +24,7 @@ import { first, isEqual, get, last } from "lodash";
 import { useState, useCallback, useMemo, useEffect } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
+import { useLatest } from "react-use";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
@@ -75,12 +76,13 @@ import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, getItemStringForDiff } 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
 
-type FieldExpansionMode = "manual" | "smart" | "all";
+type AutoExpandMode = "auto" | "off" | "all";
+
 export type RawMessagesConfig = {
+  autoExpandMode?: AutoExpandMode;
   diffEnabled: boolean;
   diffMethod: "custom" | "previous message";
   diffTopicPath: string;
-  expansionMode?: FieldExpansionMode;
   showFullMessageForDiff: boolean;
   topicPath: string;
 };
@@ -186,7 +188,7 @@ function RawMessages(props: Props) {
   }, [datatypes, topic, topicRosPath]);
 
   // When expandAll is unset, we'll use expandedFields to get expanded info
-  const [expandAll, setExpandAll] = useState<boolean | undefined>(config.expansionMode === "all");
+  const [expandAll, setExpandAll] = useState<boolean | undefined>(config.autoExpandMode === "all");
   const [expandedFields, setExpandedFields] = useState(new Set<string>());
 
   const matchedMessages = useMessageDataItem(topicPath, { historySize: 2 });
@@ -200,21 +202,30 @@ function RawMessages(props: Props) {
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
+  const latestExpandedFields = useLatest(expandedFields);
+
   useEffect(() => {
-    if (expandedFields.keys.length === 0 && baseItem && config.expansionMode === "smart") {
+    if (
+      latestExpandedFields.current.keys.length === 0 &&
+      baseItem &&
+      config.autoExpandMode === "auto"
+    ) {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
       const newExpandedFields = generateDeepKeyPaths(maybeDeepParse(data), 5);
-      setExpandAll(undefined);
       setExpandedFields(newExpandedFields);
+      setExpandAll(undefined);
+    } else if (config.autoExpandMode === "all") {
+      setExpandedFields(new Set());
+      setExpandAll(true);
     }
-  }, [baseItem, config.expansionMode, expandedFields]);
+  }, [baseItem, config.autoExpandMode, latestExpandedFields]);
 
   const updateSettingsTree = usePanelSettingsTreeUpdate();
 
   const settingsActionHandler = useCallback(
     (action: SettingsTreeAction) => {
       if (action.payload.input === "select") {
-        saveConfig({ expansionMode: action.payload.value as FieldExpansionMode });
+        saveConfig({ autoExpandMode: action.payload.value as AutoExpandMode });
       }
     },
     [saveConfig],
@@ -684,10 +695,10 @@ function RawMessages(props: Props) {
 }
 
 const defaultConfig: RawMessagesConfig = {
+  autoExpandMode: "auto",
   diffEnabled: false,
   diffMethod: CUSTOM_METHOD,
   diffTopicPath: "",
-  expansionMode: "manual",
   showFullMessageForDiff: false,
   topicPath: "",
 };

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -24,7 +24,6 @@ import { first, isEqual, get, last } from "lodash";
 import { useState, useCallback, useMemo, useEffect } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
-import { useLatest } from "react-use";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
@@ -47,6 +46,7 @@ import { useMessageDataItem } from "@foxglove/studio-base/components/MessagePath
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { SettingsTreeAction } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import getDiff, {
   diffLabels,
@@ -54,6 +54,7 @@ import getDiff, {
   DiffObject,
 } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 import { Topic } from "@foxglove/studio-base/players/types";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/selectors";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -68,16 +69,20 @@ import {
   getStructureItemForPath,
 } from "./getValueActionForValue";
 import helpContent from "./index.help.md";
+import { buildSettingsTree } from "./settings";
 import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, getItemStringForDiff } from "./utils";
 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
+
+type FieldExpansionMode = "manual" | "smart" | "all";
 export type RawMessagesConfig = {
-  topicPath: string;
+  diffEnabled: boolean;
   diffMethod: "custom" | "previous message";
   diffTopicPath: string;
-  diffEnabled: boolean;
+  expansionMode?: FieldExpansionMode;
   showFullMessageForDiff: boolean;
+  topicPath: string;
 };
 
 type Props = {
@@ -154,6 +159,7 @@ function RawMessages(props: Props) {
   const { openSiblingPanel } = usePanelContext();
   const { topicPath, diffMethod, diffTopicPath, diffEnabled, showFullMessageForDiff } = config;
   const { topics, datatypes } = useDataSourceInfo();
+  const { id: panelId } = usePanelContext();
 
   const defaultGetItemString = useGetItemStringWithTimezone();
   const getItemString = useMemo(
@@ -181,10 +187,8 @@ function RawMessages(props: Props) {
   }, [datatypes, topic, topicRosPath]);
 
   // When expandAll is unset, we'll use expandedFields to get expanded info
-  const [expandAll, setExpandAll] = useState<boolean | undefined>(props.defaultExpandAll ?? false);
-  const [expandedFields, setExpandedFields] = useState(
-    () => new Set<string>(["header", "stamp~header"]),
-  );
+  const [expandAll, setExpandAll] = useState<boolean | undefined>(config.expansionMode === "all");
+  const [expandedFields, setExpandedFields] = useState(new Set<string>());
 
   const matchedMessages = useMessageDataItem(topicPath, { historySize: 2 });
   const diffMessages = useMessageDataItem(diffEnabled ? diffTopicPath : "");
@@ -197,16 +201,32 @@ function RawMessages(props: Props) {
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
 
-  const latestExpandedKeys = useLatest(expandedFields);
-
   useEffect(() => {
-    if (latestExpandedKeys.current.keys.length === 0 && baseItem) {
+    if (expandedFields.keys.length === 0 && baseItem && config.expansionMode === "smart") {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
       const newExpandedFields = generateDeepKeyPaths(maybeDeepParse(data), 5);
       setExpandAll(undefined);
       setExpandedFields(newExpandedFields);
     }
-  }, [baseItem, latestExpandedKeys]);
+  }, [baseItem, config.expansionMode, expandedFields]);
+
+  const updateSettingsTree = usePanelSettingsTreeUpdate();
+
+  const settingsActionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.payload.input === "select") {
+        saveConfig({ expansionMode: action.payload.value as FieldExpansionMode });
+      }
+    },
+    [saveConfig],
+  );
+
+  useEffect(() => {
+    updateSettingsTree(panelId, {
+      actionHandler: settingsActionHandler,
+      settings: buildSettingsTree(config),
+    });
+  }, [config, panelId, settingsActionHandler, updateSettingsTree]);
 
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {
@@ -665,11 +685,12 @@ function RawMessages(props: Props) {
 }
 
 const defaultConfig: RawMessagesConfig = {
-  topicPath: "",
-  diffTopicPath: "",
-  diffMethod: CUSTOM_METHOD,
   diffEnabled: false,
+  diffMethod: CUSTOM_METHOD,
+  diffTopicPath: "",
+  expansionMode: "manual",
   showFullMessageForDiff: false,
+  topicPath: "",
 };
 
 export default Panel(

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -86,7 +86,6 @@ export type RawMessagesConfig = {
 };
 
 type Props = {
-  defaultExpandAll?: boolean;
   config: RawMessagesConfig;
   saveConfig: (arg0: Partial<RawMessagesConfig>) => void;
 };

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -21,9 +21,10 @@ import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 // eslint-disable-next-line no-restricted-imports
 import { first, isEqual, get, last } from "lodash";
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import ReactHoverObserver from "react-hover-observer";
 import Tree from "react-json-tree";
+import { useLatest } from "react-use";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
@@ -67,7 +68,7 @@ import {
   getStructureItemForPath,
 } from "./getValueActionForValue";
 import helpContent from "./index.help.md";
-import { DATA_ARRAY_PREVIEW_LIMIT, getItemStringForDiff } from "./utils";
+import { DATA_ARRAY_PREVIEW_LIMIT, generateDeepKeyPaths, getItemStringForDiff } from "./utils";
 
 export const CUSTOM_METHOD = "custom";
 export const PREV_MSG_METHOD = "previous message";
@@ -181,7 +182,9 @@ function RawMessages(props: Props) {
 
   // When expandAll is unset, we'll use expandedFields to get expanded info
   const [expandAll, setExpandAll] = useState<boolean | undefined>(props.defaultExpandAll ?? false);
-  const [expandedFields, setExpandedFields] = useState(() => new Set());
+  const [expandedFields, setExpandedFields] = useState(
+    () => new Set<string>(["header", "stamp~header"]),
+  );
 
   const matchedMessages = useMessageDataItem(topicPath, { historySize: 2 });
   const diffMessages = useMessageDataItem(diffEnabled ? diffTopicPath : "");
@@ -193,6 +196,17 @@ function RawMessages(props: Props) {
   const inTimetickDiffMode = diffEnabled && diffMethod === PREV_MSG_METHOD;
   const baseItem = inTimetickDiffMode ? prevTickObj : currTickObj;
   const diffItem = inTimetickDiffMode ? currTickObj : diffTopicObj;
+
+  const latestExpandedKeys = useLatest(expandedFields);
+
+  useEffect(() => {
+    if (latestExpandedKeys.current.keys.length === 0 && baseItem) {
+      const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
+      const newExpandedFields = generateDeepKeyPaths(maybeDeepParse(data), 5);
+      setExpandAll(undefined);
+      setExpandedFields(newExpandedFields);
+    }
+  }, [baseItem, latestExpandedKeys]);
 
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {

--- a/packages/studio-base/src/panels/RawMessages/settings.ts
+++ b/packages/studio-base/src/panels/RawMessages/settings.ts
@@ -3,9 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { SettingsTreeNode } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
-import { RawMessagesConfig } from "@foxglove/studio-base/panels/RawMessages";
 
-export function buildSettingsTree(config: RawMessagesConfig): SettingsTreeNode {
+import { RawMessagesPanelConfig } from "./types";
+
+export function buildSettingsTree(config: RawMessagesPanelConfig): SettingsTreeNode {
   return {
     fields: {
       expansionMode: {

--- a/packages/studio-base/src/panels/RawMessages/settings.ts
+++ b/packages/studio-base/src/panels/RawMessages/settings.ts
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { SettingsTreeNode } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { RawMessagesConfig } from "@foxglove/studio-base/panels/RawMessages";
+
+export function buildSettingsTree(config: RawMessagesConfig): SettingsTreeNode {
+  return {
+    fields: {
+      expansionMode: {
+        label: "Expand Fields",
+        input: "select",
+        value: config.expansionMode,
+        options: [
+          { label: "Manual", value: "manual" },
+          { label: "Smart", value: "smart" },
+          { label: "All", value: "all" },
+        ],
+      },
+    },
+  };
+}

--- a/packages/studio-base/src/panels/RawMessages/settings.ts
+++ b/packages/studio-base/src/panels/RawMessages/settings.ts
@@ -9,12 +9,12 @@ export function buildSettingsTree(config: RawMessagesConfig): SettingsTreeNode {
   return {
     fields: {
       expansionMode: {
-        label: "Expand Fields",
+        label: "Auto Expand",
         input: "select",
-        value: config.expansionMode,
+        value: config.autoExpandMode,
         options: [
-          { label: "Manual", value: "manual" },
-          { label: "Smart", value: "smart" },
+          { label: "Auto", value: "auto" },
+          { label: "Off", value: "off" },
           { label: "All", value: "all" },
         ],
       },

--- a/packages/studio-base/src/panels/RawMessages/types.ts
+++ b/packages/studio-base/src/panels/RawMessages/types.ts
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type AutoExpandMode = "auto" | "off" | "all";
+
+export type RawMessagesPanelConfig = {
+  autoExpandMode?: AutoExpandMode;
+  diffEnabled: boolean;
+  diffMethod: "custom" | "previous message";
+  diffTopicPath: string;
+  showFullMessageForDiff: boolean;
+  topicPath: string;
+};

--- a/packages/studio-base/src/panels/RawMessages/utils.tsx
+++ b/packages/studio-base/src/panels/RawMessages/utils.tsx
@@ -10,6 +10,7 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
+
 import { first, last } from "lodash";
 import { ReactNode } from "react";
 
@@ -31,27 +32,43 @@ export const ROS_COMMON_MSGS: Set<string> = new Set([
   "turtlesim",
 ]);
 
-function isArrayOrTypedArray(obj: unknown) {
+function isTypedArray(obj: unknown) {
   return Boolean(
     obj != undefined &&
       typeof obj === "object" &&
-      (Array.isArray(obj) || (ArrayBuffer.isView(obj) && !(obj instanceof DataView))),
+      ArrayBuffer.isView(obj) &&
+      !(obj instanceof DataView),
   );
 }
 
-export function deepMapKeys(obj: object): Set<string> {
+/**
+ * Recursively traverses all keypaths in obj, for use in JSON tree expansion.
+ */
+export function generateDeepKeyPaths(obj: unknown, maxArrayLength: number): Set<string> {
   const keys = new Set<string>();
   const recurseMapKeys = (path: string[], nestedObj: unknown) => {
-    if (typeof nestedObj !== "object" || nestedObj == undefined) {
-      return;
-    }
-    if (isArrayOrTypedArray(nestedObj)) {
+    if (nestedObj == undefined) {
       return;
     }
 
+    if (typeof nestedObj !== "object" && typeof nestedObj !== "function") {
+      return;
+    }
+
+    if (Array.isArray(nestedObj) && nestedObj.length > maxArrayLength) {
+      return;
+    }
+
+    if (isTypedArray(nestedObj)) {
+      return;
+    }
+
+    if (path.length > 0) {
+      keys.add(path.join("~"));
+    }
+
     for (const key of Object.getOwnPropertyNames(nestedObj)) {
-      const newPath = [...path, key];
-      keys.add(newPath.join("~"));
+      const newPath = [key, ...path];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const value = (nestedObj as any)[key];
       recurseMapKeys(newPath, value as object);

--- a/packages/studio-base/src/panels/RawMessages/utils.tsx
+++ b/packages/studio-base/src/panels/RawMessages/utils.tsx
@@ -31,6 +31,36 @@ export const ROS_COMMON_MSGS: Set<string> = new Set([
   "turtlesim",
 ]);
 
+function isArrayOrTypedArray(obj: unknown) {
+  return Boolean(
+    obj != undefined &&
+      typeof obj === "object" &&
+      (Array.isArray(obj) || (ArrayBuffer.isView(obj) && !(obj instanceof DataView))),
+  );
+}
+
+export function deepMapKeys(obj: object): Set<string> {
+  const keys = new Set<string>();
+  const recurseMapKeys = (path: string[], nestedObj: unknown) => {
+    if (typeof nestedObj !== "object" || nestedObj == undefined) {
+      return;
+    }
+    if (isArrayOrTypedArray(nestedObj)) {
+      return;
+    }
+
+    for (const key of Object.getOwnPropertyNames(nestedObj)) {
+      const newPath = [...path, key];
+      keys.add(newPath.join("~"));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const value = (nestedObj as any)[key];
+      recurseMapKeys(newPath, value as object);
+    }
+  };
+  recurseMapKeys([], obj);
+  return keys;
+}
+
 function getChangeCounts(
   data: DiffObject,
   startingCounts: {


### PR DESCRIPTION
**User-Facing Changes**
This adds new auto-expansion behavior to the raw messages panel, giving users more control over when message fields are expanded.

**Description**
This adds a new "auto expand" setting to the raw messages panel with three modes:

1. Off - the current behavior
2. On - all message fields are automatically expanded
3. Auto - message fields under a certain size are expanded (currently this limits arrays to < 5 members)

<img width="462" alt="Screen Shot 2022-05-13 at 10 39 09 AM" src="https://user-images.githubusercontent.com/93935560/168318732-e8e94c19-02c1-4b7f-bed9-ef453be0db7e.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3303 