### PR TITLE
Move notched theme property to silence react warnings

### DIFF
--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -230,6 +230,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
     },
     MuiInputLabel: {
       defaultProps: {
+        shrink: true,
         variant: "standard",
         sx: { position: "relative" },
       },
@@ -305,6 +306,9 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
           padding: theme.spacing(0.75, 1),
         },
       },
+      defaultProps: {
+        notched: false,
+      },
     },
     MuiSelect: {
       styleOverrides: {
@@ -348,13 +352,6 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       styleOverrides: {
         stickyHeader: {
           backgroundColor: theme.palette.background.paper,
-        },
-      },
-    },
-    MuiTextField: {
-      defaultProps: {
-        InputLabelProps: {
-          shrink: true,
         },
       },
     },

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -356,9 +356,6 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
         InputLabelProps: {
           shrink: true,
         },
-        InputProps: {
-          notched: false,
-        },
       },
     },
     MuiToggleButton: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the unrecognized property error logged by react caused by the `notched` property in our theme definition. The fix is to move the property overrides down into the input components instead of nested inside the `MuiTextField` overrides.

```
Warning: Received `false` for a non-boolean attribute `notched`.

If you want to write it to the DOM, pass a string instead: notched="false" or notched={value.toString()}.

If you used to conditionally omit it with notched={condition && value}, pass notched={condition ? value : undefined} instead.
    at div
    at eval (webpack-internal:///../../node_modules/@emotion/react/dist/emotion-element-699e6908.browser.esm.js:54:66)
    at InputBase (webpack-internal:///../../node_modules/@mui/material/InputBase/InputBase.js:240:83)
    at FilledInput (webpack-internal:///../../node_modules/@mui/material/FilledInput/FilledInput.js:182:82)
    at div
    at eval (webpack-internal:///../../node_modules/@emotion/react/dist/emotion-element-699e6908.browser.esm.js:54:66)
    at FormControl (webpack-internal:///../../node_modules/@mui/material/FormControl/FormControl.js:103:82)
```

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
