### PR TITLE
Limit seeking to valid range for IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -236,8 +236,11 @@ export class IterablePlayer implements Player {
       return;
     }
 
-    this._metricsCollector.seek(time);
-    this._seekTarget = time;
+    // Limit seek to within the valid range
+    const targetTime = clampTime(time, this._start, this._end);
+
+    this._metricsCollector.seek(targetTime);
+    this._seekTarget = targetTime;
     this._setState("seek-backfill");
   }
 


### PR DESCRIPTION


**User-Facing Changes**
When using any of the new experimental players, seeking is limited to the valid range. This fixes broken UX with the "Seek back" button allowing the user to seek prior to start.

**Description**
When seeking, clamp the seek time to [start, end] to prevent the user seeking off the start or end.

Fixes: #3359

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
