### PR TITLE
Remove title attribute from internal LegacyButton within Button

### DIFF
--- a/packages/studio-base/src/components/Button.tsx
+++ b/packages/studio-base/src/components/Button.tsx
@@ -118,7 +118,6 @@ export default function Button({
       onFocus={onFocus}
       {...eventHandlers}
       style={{ position: "relative", ...styles }}
-      title={tooltip}
       disabled={disabled}
       ref={innerRef}
     >


### PR DESCRIPTION
**User-Facing Changes**
When hovering over some buttons that have tooltips, the app properly displays only a single tooltip rather than the tooltip and a button title.

Before:
![image](https://user-images.githubusercontent.com/84792/168396075-c95333e4-9fe6-4ce2-81ac-6e7e83718a62.png)


After:
![image](https://user-images.githubusercontent.com/84792/168396100-a6c07a10-5269-4e0e-a66f-d6e4ef85abc2.png)

**Description**
The Button already creates a tooltip from the tooltip parameter. Passing a title prop to the LegacyButton creates a second popup with the same information. This removes the title property from the LegacyButton component within Button so only one tooltip is shown.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
