### PR TITLE
Add fg-user-agent to api requests

### DIFF
--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -87,7 +87,7 @@ export default async function* streamMessages({
     headers: {
       // Include the version of studio in the request Useful when scraping logs to determine what
       // versions of the app are making requests.
-      "fg-user-agent": `studio/${FOXGLOVE_STUDIO_VERSION ?? "??"} (commit ${GIT_SHA ?? "??"})`,
+      "fg-user-agent": FOXGLOVE_USER_AGENT,
     },
   });
   if (response.status === 404) {

--- a/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
+++ b/packages/studio-base/src/players/FoxgloveDataPlatformPlayer/streamMessages.ts
@@ -81,7 +81,15 @@ export default async function* streamMessages({
   }
 
   // Since every request is signed with a new token, there's no benefit to caching.
-  const response = await fetch(mcapUrl, { signal: controller.signal, cache: "no-cache" });
+  const response = await fetch(mcapUrl, {
+    signal: controller.signal,
+    cache: "no-cache",
+    headers: {
+      // Include the version of studio in the request Useful when scraping logs to determine what
+      // versions of the app are making requests.
+      "fg-user-agent": `studio/${FOXGLOVE_STUDIO_VERSION ?? "??"} (commit ${GIT_SHA ?? "??"})`,
+    },
+  });
   if (response.status === 404) {
     return;
   } else if (response.status !== 200) {

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -240,7 +240,7 @@ class ConsoleApi {
     const headers: Record<string, string> = {
       // Include the version of studio in the request Useful when scraping logs to determine what
       // versions of the app are making requests.
-      "fg-user-agent": `studio/${FOXGLOVE_STUDIO_VERSION ?? "??"} (commit ${GIT_SHA ?? "??"})`,
+      "fg-user-agent": FOXGLOVE_USER_AGENT,
     };
     if (this._authHeader != undefined) {
       headers["Authorization"] = this._authHeader;

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -135,85 +135,6 @@ class ConsoleApi {
     ).json;
   }
 
-  private async post<T>(apiPath: string, body?: unknown): Promise<T> {
-    return (
-      await this.request<T>(apiPath, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      })
-    ).json;
-  }
-
-  private async patch<T>(apiPath: string, body?: unknown): Promise<ApiResponse<T>> {
-    return await this.request<T>(
-      apiPath,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      },
-      { allowedStatuses: [409] },
-    );
-  }
-
-  private async delete<T>(
-    apiPath: string,
-    query?: Record<string, string>,
-  ): Promise<ApiResponse<T>> {
-    return await this.request<T>(
-      query == undefined ? apiPath : `${apiPath}?${new URLSearchParams(query).toString()}`,
-      { method: "DELETE" },
-      { allowedStatuses: [404] },
-    );
-  }
-
-  private async request<T>(
-    url: string,
-    config?: RequestInit,
-    {
-      allowedStatuses = [],
-    }: {
-      /** By default, status codes other than 200 will throw an error. */
-      allowedStatuses?: number[];
-    } = {},
-  ): Promise<ApiResponse<T>> {
-    const fullUrl = `${this._baseUrl}${url}`;
-
-    const headers: Record<string, string> = {};
-    if (this._authHeader != undefined) {
-      headers["Authorization"] = this._authHeader;
-    }
-    const fullConfig: RequestInit = {
-      ...config,
-      credentials: "include",
-      headers: { ...headers, ...config?.headers },
-    };
-
-    const res = await fetch(fullUrl, fullConfig);
-    this._responseObserver?.(res);
-    if (res.status !== 200 && !allowedStatuses.includes(res.status)) {
-      if (res.status === 401) {
-        throw new Error("Not logged in. Log in to your Foxglove account and try again.");
-      } else if (res.status === 403) {
-        throw new Error(
-          "Unauthorized. Check that you are logged in to the correct Foxglove organization.",
-        );
-      }
-      const json = (await res.json().catch((err) => {
-        throw new Error(`Status ${res.status}: ${err.message}`);
-      })) as { message?: string; error?: string };
-      const message = json.message ?? json.error;
-      throw new Error(`Status ${res.status}${message != undefined ? `: ${message}` : ""}`);
-    }
-
-    try {
-      return { status: res.status, json: (await res.json()) as T };
-    } catch (err) {
-      throw new Error("Request Failed.");
-    }
-  }
-
   async getLayouts(options: { includeData: boolean }): Promise<readonly ConsoleApiLayout[]> {
     return await this.get<ConsoleApiLayout[]>("/v1/layouts", {
       includeData: options.includeData ? "true" : "false",
@@ -300,6 +221,91 @@ class ConsoleApi {
     replayLookbackSeconds?: number;
   }): Promise<{ link: string }> {
     return await this.post<{ link: string }>("/v1/data/stream", params);
+  }
+
+  /// ----- private
+
+  private async request<T>(
+    url: string,
+    config?: RequestInit,
+    {
+      allowedStatuses = [],
+    }: {
+      /** By default, status codes other than 200 will throw an error. */
+      allowedStatuses?: number[];
+    } = {},
+  ): Promise<ApiResponse<T>> {
+    const fullUrl = `${this._baseUrl}${url}`;
+
+    const headers: Record<string, string> = {
+      // Include the version of studio in the request Useful when scraping logs to determine what
+      // versions of the app are making requests.
+      "fg-user-agent": `studio/${FOXGLOVE_STUDIO_VERSION ?? "??"} (commit ${GIT_SHA ?? "??"})`,
+    };
+    if (this._authHeader != undefined) {
+      headers["Authorization"] = this._authHeader;
+    }
+    const fullConfig: RequestInit = {
+      ...config,
+      credentials: "include",
+      headers: { ...headers, ...config?.headers },
+    };
+
+    const res = await fetch(fullUrl, fullConfig);
+    this._responseObserver?.(res);
+    if (res.status !== 200 && !allowedStatuses.includes(res.status)) {
+      if (res.status === 401) {
+        throw new Error("Not logged in. Log in to your Foxglove account and try again.");
+      } else if (res.status === 403) {
+        throw new Error(
+          "Unauthorized. Check that you are logged in to the correct Foxglove organization.",
+        );
+      }
+      const json = (await res.json().catch((err) => {
+        throw new Error(`Status ${res.status}: ${err.message}`);
+      })) as { message?: string; error?: string };
+      const message = json.message ?? json.error;
+      throw new Error(`Status ${res.status}${message != undefined ? `: ${message}` : ""}`);
+    }
+
+    try {
+      return { status: res.status, json: (await res.json()) as T };
+    } catch (err) {
+      throw new Error("Request Failed.");
+    }
+  }
+
+  private async post<T>(apiPath: string, body?: unknown): Promise<T> {
+    return (
+      await this.request<T>(apiPath, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    ).json;
+  }
+
+  private async patch<T>(apiPath: string, body?: unknown): Promise<ApiResponse<T>> {
+    return await this.request<T>(
+      apiPath,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+      { allowedStatuses: [409] },
+    );
+  }
+
+  private async delete<T>(
+    apiPath: string,
+    query?: Record<string, string>,
+  ): Promise<ApiResponse<T>> {
+    return await this.request<T>(
+      query == undefined ? apiPath : `${apiPath}?${new URLSearchParams(query).toString()}`,
+      { method: "DELETE" },
+      { allowedStatuses: [404] },
+    );
   }
 }
 

--- a/packages/studio-base/src/typings/webpack-defines.d.ts
+++ b/packages/studio-base/src/typings/webpack-defines.d.ts
@@ -5,4 +5,6 @@
 // Should match DefinePlugin in webpack configuration
 declare const ReactNull: ReactNull;
 
-declare const FOXGLOVE_STUDIO_VERSION: string;
+declare const FOXGLOVE_STUDIO_VERSION: string | undefined;
+
+declare const GIT_SHA: string | undefined;

--- a/packages/studio-base/src/typings/webpack-defines.d.ts
+++ b/packages/studio-base/src/typings/webpack-defines.d.ts
@@ -7,4 +7,4 @@ declare const ReactNull: ReactNull;
 
 declare const FOXGLOVE_STUDIO_VERSION: string | undefined;
 
-declare const GIT_SHA: string | undefined;
+declare const FOXGLOVE_USER_AGENT: string;

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -54,6 +54,8 @@ export function makeConfig(
   const isDev = argv.mode === "development";
   const isServe = argv.env?.WEBPACK_SERVE ?? false;
 
+  const commitHash = process.env.GITHUB_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA;
+
   const { allowUnusedVariables = isDev && isServe } = options ?? {};
 
   return {
@@ -247,6 +249,7 @@ export function makeConfig(
         // Should match webpack-defines.d.ts
         ReactNull: null, // eslint-disable-line no-restricted-syntax
         FOXGLOVE_STUDIO_VERSION: JSON.stringify(packageJson.version),
+        GIT_SHA: JSON.stringify(commitHash),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -249,7 +249,7 @@ export function makeConfig(
         // Should match webpack-defines.d.ts
         ReactNull: null, // eslint-disable-line no-restricted-syntax
         FOXGLOVE_STUDIO_VERSION: JSON.stringify(packageJson.version),
-        GIT_SHA: JSON.stringify(commitHash),
+        FOXGLOVE_USER_AGENT: `studio/${packageJson.version} (commit ${commitHash ?? "??"})`,
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -249,7 +249,9 @@ export function makeConfig(
         // Should match webpack-defines.d.ts
         ReactNull: null, // eslint-disable-line no-restricted-syntax
         FOXGLOVE_STUDIO_VERSION: JSON.stringify(packageJson.version),
-        FOXGLOVE_USER_AGENT: `studio/${packageJson.version} (commit ${commitHash ?? "??"})`,
+        FOXGLOVE_USER_AGENT: JSON.stringify(
+          `studio/${packageJson.version} (commit ${commitHash ?? "??"})`,
+        ),
       }),
       // https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales
       new webpack.IgnorePlugin({


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
The `fg-user-agent` header contains the studio version and commit hash. This helps identify requests to our hosted services by studio version. This is useful for debugging issues with requests.

Fixes: #3237

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
