### PR TITLE
Display an error icon and message tooltip for settings fields with errors

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import ClearIcon from "@mui/icons-material/Clear";
+import ErrorIcon from "@mui/icons-material/ErrorOutline";
 import {
   Autocomplete,
   ToggleButton,
@@ -12,6 +13,7 @@ import {
   List,
   MenuItem,
   Select,
+  Tooltip,
   TextField,
   ListProps,
   useTheme,
@@ -351,8 +353,22 @@ function FieldEditorComponent({
     <>
       <Stack direction="row" alignItems="center" style={{ paddingLeft }} fullHeight>
         <FieldLabel field={field} />
+        {field.error && (
+          <Tooltip
+            arrow
+            placement="top"
+            title={<Typography variant="subtitle1">{field.error}</Typography>}
+          >
+            <ErrorIcon color="error" fontSize="small" />
+          </Tooltip>
+        )}
       </Stack>
-      <div style={{ paddingRight: theme.spacing(2) }}>
+      <div
+        style={{
+          border: field.error ? `1px solid ${theme.palette.error.main}` : 0,
+          marginRight: theme.spacing(2),
+        }}
+      >
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
       </div>
     </>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -23,6 +23,11 @@ const BasicSettings: SettingsTreeNode = {
     firstRootField: { input: "string", label: "Root Field" },
     gradient: { input: "gradient", label: "Gradient" },
     emptyNumber: { input: "number", label: "Empty Number" },
+    fieldWithError: {
+      input: "string",
+      label: "Field With Error",
+      error: "This field has an error message that should be displayed to the user",
+    },
   },
   children: {
     complex_inputs: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -45,6 +45,11 @@ export type SettingsTreeField = SettingsTreeFieldValue & {
    * absence of a value.
    */
   placeholder?: string;
+
+  /**
+   * Optional message indicating any error state for the field.
+   */
+  error?: string;
 };
 
 export type SettingsTreeFields = Record<string, SettingsTreeField>;


### PR DESCRIPTION
**User-Facing Changes**
This allows the settings UI to indicate field-level errors to the user

**Description**
This adds a new `error` attribute at the field level in the settings tree. In the UI this is represented as a red error icon with a hover tooltip containing the error message as well as a red outline on the field input.

<img width="449" alt="Screen Shot 2022-05-16 at 9 10 52 AM" src="https://user-images.githubusercontent.com/93935560/168612765-dde2bd9c-9a30-470d-9645-038dcccd5cd1.png">

<img width="442" alt="Screen Shot 2022-05-16 at 9 11 02 AM" src="https://user-images.githubusercontent.com/93935560/168612777-8734ac7d-3901-466d-bedf-711f8187c0e2.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
