### PR TITLE
Fix react uncontrolled component warnings

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -162,7 +162,7 @@ export default function PanelSettings({
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
         <div>
-          {settingsTree && <SettingsEditor settings={settingsTree} />}
+          {settingsTree && <SettingsEditor key={selectedPanelId} settings={settingsTree} />}
           {!settingsTree && (
             <Typography color="text.secondary">No additional settings available.</Typography>
           )}

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -159,7 +159,7 @@ function FieldInput({
           variant="filled"
           size="small"
           fullWidth
-          value={field.value}
+          value={field.value ?? ""}
           placeholder={field.placeholder}
           onChange={(event) =>
             actionHandler({

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -173,7 +173,7 @@ function FieldInput({
       return (
         <StyledToggleButtonGroup
           fullWidth
-          value={field.value}
+          value={field.value ?? false}
           exclusive
           size="small"
           onChange={(_event, value) => {
@@ -239,7 +239,7 @@ function FieldInput({
           displayEmpty
           fullWidth
           variant="filled"
-          value={field.value}
+          value={field.value ?? ""}
           onChange={(event) =>
             actionHandler({
               action: "update",

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -58,7 +58,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
         onChange={(event) => onChange(event.target.value)}
         placeholder={props.placeholder}
         size="small"
-        value={value}
+        value={value ?? ""}
         variant="filled"
         InputProps={{
           startAdornment: swatchOrientation === "start" && (

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -81,7 +81,7 @@ export function NumberInput(
   return (
     <StyledTextField
       {...props}
-      value={value}
+      value={value ?? ""}
       onChange={(event) =>
         event.target.value.length > 0 ? updateValue(Number(event.target.value)) : undefined
       }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the uncontrolled component warnings we're getting from React on some settings inputs by rendering an empty string instead of `undefined` for the number & textfield inputs. This makes these always "controlled" components in React's semantics.

It also sets a react `key` equal to the selected panel id on the `SettingsEditor` to avoid any inadvertent UI sharing between different instances of settings trees for different instances of the same panel type.

```
Warning: A component is changing a controlled input to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components
    at input
    at eval (webpack-internal:///../../node_modules/@emotion/react/dist/emotion-element-699e6908.browser.esm.js:54:66)
    at div
    at eval (webpack-internal:///../../node_modules/@emotion/react/dist/emotion-element-699e6908.browser.esm.js:54:66)
    at InputBase (webpack-internal:///../../node_modules/@mui/material/InputBase/InputBase.js:240:83)
    at FilledInput (webpack-internal:///../../node_modules/@mui/material/FilledInput/FilledInput.js:182:82)
    at div
```

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
