### PR TITLE
Allow clearing number inputs

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -66,13 +66,15 @@ export function NumberInput(
   const stepAmount = shiftPressed ? step * 10 : step;
 
   const updateValue = useCallback(
-    (newValue: number) => {
+    (newValue: undefined | number) => {
       onChange(
-        clamp(
-          newValue,
-          props.min ?? Number.NEGATIVE_INFINITY,
-          props.max ?? Number.POSITIVE_INFINITY,
-        ),
+        newValue == undefined
+          ? undefined
+          : clamp(
+              newValue,
+              props.min ?? Number.NEGATIVE_INFINITY,
+              props.max ?? Number.POSITIVE_INFINITY,
+            ),
       );
     },
     [onChange, props.max, props.min],
@@ -83,7 +85,7 @@ export function NumberInput(
       {...props}
       value={value}
       onChange={(event) =>
-        event.target.value.length > 0 ? updateValue(Number(event.target.value)) : undefined
+        updateValue(event.target.value.length > 0 ? Number(event.target.value) : undefined)
       }
       type="number"
       inputProps={{ max: props.max, min: props.min, step: stepAmount }}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the logic on number inputs in the settings UI to allow user to clear the value and revert it to an undefined/default state.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
