### PR TITLE
Add option for a node-level icons in settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 3 * (indent - 1);
+  const paddingLeft = 1.5 + 2 * (indent - 1);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 3 * (indent - 1);
+  const paddingLeft = 3 * (indent - 1) - (indent - 2);
 
   return (
     <>
@@ -368,12 +368,12 @@ function FieldEditorComponent({
       <div
         style={{
           border: field.error ? `1px solid ${theme.palette.error.main}` : 0,
-          marginRight: theme.spacing(2),
+          marginRight: theme.spacing(1.25),
         }}
       >
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
       </div>
-      <div style={{ gridColumn: "span 2", height: theme.spacing(0.25) }} />
+      <Stack paddingBottom={0.25} style={{ gridColumn: "span 2" }} />
     </>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 1.5 + 2 * (indent - 1);
+  const paddingLeft = 3 * (indent - 1);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,12 +4,13 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
-import { Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
+import { Divider, ListItemProps, styled as muiStyled, Typography, useTheme } from "@mui/material";
 import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
 import { FieldEditor } from "./FieldEditor";
 import { VisibilityToggle } from "./VisibilityToggle";
+import icons from "./icons";
 import { SettingsTreeAction, SettingsTreeNode } from "./types";
 
 export type NodeEditorProps = {
@@ -63,6 +64,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { actionHandler, defaultOpen = true, settings = {} } = props;
   const [open, setOpen] = useState(defaultOpen);
 
+  const theme = useTheme();
   const indent = props.path.length;
   const allowVisibilityToggle = props.settings?.visible != undefined;
   const visible = props.settings?.visible !== false;
@@ -101,6 +103,8 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
+  const IconComponent = settings.icon ? icons[settings.icon] : undefined;
+
   return (
     <>
       <NodeHeader>
@@ -114,6 +118,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           >
             {hasProperties && <ExpansionArrow expanded={open} />}
           </div>
+          {IconComponent && (
+            <IconComponent fontSize="small" style={{ marginRight: theme.spacing(0.5) }} />
+          )}
           <Typography
             noWrap={true}
             variant="subtitle2"

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -40,12 +40,16 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
   };
 });
 
-const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }) => {
+const NodeHeaderToggle = muiStyled("div", {
+  shouldForwardProp: (prop) => prop !== "indent" && prop !== "visible",
+})<{ indent: number; visible: boolean }>(({ theme, indent, visible }) => {
   return {
     display: "flex",
     alignItems: "center",
     cursor: "pointer",
-    paddingLeft: theme.spacing(1.5 + 2 * indent),
+    marginLeft: theme.spacing(1.5 + 2 * indent),
+    opacity: visible ? 1 : 0.6,
+    position: "relative",
     userSelect: "none",
     width: "100%",
   };
@@ -55,7 +59,7 @@ function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
   const Component = expanded ? ArrowDownIcon : ArrowRightIcon;
   return (
     <Component
-      style={{ position: "absolute", top: 0, left: 0, transform: "translate(-112%, -50%)" }}
+      style={{ position: "absolute", top: "50%", left: 0, transform: "translate(-112%, -50%)" }}
     />
   );
 }
@@ -108,16 +112,8 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   return (
     <>
       <NodeHeader>
-        <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
-          <div
-            style={{
-              display: "inline-flex",
-              opacity: visible ? 0.6 : 0.3,
-              position: "relative",
-            }}
-          >
-            {hasProperties && <ExpansionArrow expanded={open} />}
-          </div>
+        <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)} visible={visible}>
+          {hasProperties && <ExpansionArrow expanded={open} />}
           {IconComponent && (
             <IconComponent fontSize="small" style={{ marginRight: theme.spacing(0.5) }} />
           )}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -137,7 +137,11 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           <IconComponent
             fontSize="small"
             color="inherit"
-            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-0.75) }}
+            style={{
+              marginRight: theme.spacing(0.5),
+              marginLeft: theme.spacing(-0.75),
+              opacity: 0.8,
+            }}
           />
           <Typography
             noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -135,7 +135,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           <IconComponent
             fontSize="small"
             color="inherit"
-            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
+            style={{ marginRight: theme.spacing(0.5) }}
           />
           <Typography
             noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -32,7 +32,7 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
     display: "flex",
     gridColumn: "span 2",
-    paddingRight: theme.spacing(2),
+    paddingRight: theme.spacing(1.5),
 
     "&:hover": {
       outline: `1px solid ${theme.palette.primary.main}`,

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -23,7 +23,7 @@ export type NodeEditorProps = {
   updateSettings?: (path: readonly string[], value: unknown) => void;
 };
 
-const FieldsBottomPad = muiStyled("div", { skipSx: true })(({ theme }) => ({
+const FieldPadding = muiStyled("div", { skipSx: true })(({ theme }) => ({
   gridColumn: "span 2",
   height: theme.spacing(0.5),
 }));
@@ -120,12 +120,14 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
 
   const IconComponent =
     settings.icon != undefined
-      ? icons[settings.icon]
-      : fieldEditors.length > 0
-      ? open
+      ? icons[settings.icon] // if the icon is a custom icon, use it
+      : childNodes.length > 0
+      ? open // if there are children, use the folder icon
         ? icons.FolderOpen
         : icons.Folder
-      : icons.Note;
+      : open // if there are no children, use the note icon
+      ? icons.Note
+      : icons.NoteFilled;
 
   return (
     <>
@@ -135,7 +137,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           <IconComponent
             fontSize="small"
             color="inherit"
-            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
+            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-0.75) }}
           />
           <Typography
             noWrap={true}
@@ -157,8 +159,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
       </NodeHeader>
       {open && fieldEditors.length > 0 && (
         <>
+          <FieldPadding />
           {fieldEditors}
-          <FieldsBottomPad />
+          <FieldPadding />
         </>
       )}
       {open && childNodes}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -118,26 +118,25 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
-  const IconComponent = settings.icon
-    ? icons[settings.icon]
-    : fieldEditors.length > 0
-    ? open
-      ? icons.FolderOpen
-      : icons.Folder
-    : icons.Note;
+  const IconComponent =
+    settings.icon != undefined
+      ? icons[settings.icon]
+      : fieldEditors.length > 0
+      ? open
+        ? icons.FolderOpen
+        : icons.Folder
+      : icons.Note;
 
   return (
     <>
       <NodeHeader>
         <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)} visible={visible}>
           {hasProperties && <ExpansionArrow expanded={open} />}
-          {IconComponent != undefined && (
-            <IconComponent
-              fontSize="small"
-              color="inherit"
-              style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
-            />
-          )}
+          <IconComponent
+            fontSize="small"
+            color="inherit"
+            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
+          />
           <Typography
             noWrap={true}
             variant="subtitle2"

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -31,12 +31,13 @@ const FieldsBottomPad = muiStyled("div", { skipSx: true })(({ theme }) => ({
 const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
     display: "flex",
+    gridColumn: "span 2",
+    paddingRight: theme.spacing(2),
+
     "&:hover": {
       outline: `1px solid ${theme.palette.primary.main}`,
       outlineOffset: -1,
     },
-    gridColumn: "span 2",
-    paddingRight: theme.spacing(2.25),
   };
 });
 
@@ -55,12 +56,22 @@ const NodeHeaderToggle = muiStyled("div", {
   };
 });
 
+const IconWrapper = muiStyled("div")({
+  position: "absolute",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  top: "50%",
+  left: 0,
+  transform: "translate(-125%, -50%)",
+});
+
 function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
   const Component = expanded ? ArrowDownIcon : ArrowRightIcon;
   return (
-    <Component
-      style={{ position: "absolute", top: "50%", left: 0, transform: "translate(-112%, -50%)" }}
-    />
+    <IconWrapper>
+      <Component />
+    </IconWrapper>
   );
 }
 
@@ -107,19 +118,30 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     );
   });
 
-  const IconComponent = settings.icon ? icons[settings.icon] : undefined;
+  const IconComponent = settings.icon
+    ? icons[settings.icon]
+    : fieldEditors.length > 0
+    ? open
+      ? icons.FolderOpen
+      : icons.Folder
+    : icons.Note;
 
   return (
     <>
       <NodeHeader>
         <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)} visible={visible}>
           {hasProperties && <ExpansionArrow expanded={open} />}
-          {IconComponent && (
-            <IconComponent fontSize="small" style={{ marginRight: theme.spacing(0.5) }} />
+          {IconComponent != undefined && (
+            <IconComponent
+              fontSize="small"
+              color="inherit"
+              style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
+            />
           )}
           <Typography
             noWrap={true}
             variant="subtitle2"
+            fontWeight={600}
             color={visible ? "text.primary" : "text.disabled"}
           >
             {settings.label ?? "General"}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -135,7 +135,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           <IconComponent
             fontSize="small"
             color="inherit"
-            style={{ marginRight: theme.spacing(0.5) }}
+            style={{ marginRight: theme.spacing(0.5), marginLeft: theme.spacing(-1) }}
           />
           <Typography
             noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
@@ -2,30 +2,36 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import DirectionsWalkIcon from "@mui/icons-material/DirectionsWalk";
+import FolderIcon from "@mui/icons-material/Folder";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import GridOnIcon from "@mui/icons-material/GridOn";
-import HiveIcon from "@mui/icons-material/Hive";
+import HiveOutlinedIcon from "@mui/icons-material/HiveOutlined";
+import LayersIcon from "@mui/icons-material/Layers";
 import MapIcon from "@mui/icons-material/Map";
+import NoteOutlinedIcon from "@mui/icons-material/NoteOutlined";
 import OpenWithIcon from "@mui/icons-material/OpenWith";
-import QueryBuilderIcon from "@mui/icons-material/QueryBuilder";
 import SettingsIcon from "@mui/icons-material/Settings";
 import TopicIcon from "@mui/icons-material/Topic";
 import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
 import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
 import ViewInArIcon from "@mui/icons-material/ViewInAr";
-import WallpaperIcon from "@mui/icons-material/Wallpaper";
 
 export default {
-  Background: WallpaperIcon,
-  Clock: QueryBuilderIcon,
+  Background: LayersIcon,
+  Clock: AccessTimeIcon,
   Collapse: UnfoldLessIcon,
-  Cube: ViewInArIcon,
   Expand: UnfoldMoreIcon,
+  Cube: ViewInArIcon,
   Grid: GridOnIcon,
-  Hive: HiveIcon,
-  OpenWith: OpenWithIcon,
+  Hive: HiveOutlinedIcon,
   Settings: SettingsIcon,
-  Topic: TopicIcon,
   Map: MapIcon,
   Walk: DirectionsWalkIcon,
+  Move: OpenWithIcon,
+  Note: NoteOutlinedIcon,
+  Folder: FolderIcon,
+  FolderOpen: FolderOpenIcon,
+  Topic: TopicIcon,
 };

--- a/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
@@ -10,6 +10,7 @@ import GridOnIcon from "@mui/icons-material/GridOn";
 import HiveOutlinedIcon from "@mui/icons-material/HiveOutlined";
 import LayersIcon from "@mui/icons-material/Layers";
 import MapIcon from "@mui/icons-material/Map";
+import NoteIcon from "@mui/icons-material/Note";
 import NoteOutlinedIcon from "@mui/icons-material/NoteOutlined";
 import OpenWithIcon from "@mui/icons-material/OpenWith";
 import SettingsIcon from "@mui/icons-material/Settings";
@@ -31,6 +32,7 @@ export default {
   Walk: DirectionsWalkIcon,
   Move: OpenWithIcon,
   Note: NoteOutlinedIcon,
+  NoteFilled: NoteIcon,
   Folder: FolderIcon,
   FolderOpen: FolderOpenIcon,
   Topic: TopicIcon,

--- a/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/icons.tsx
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import DirectionsWalkIcon from "@mui/icons-material/DirectionsWalk";
+import GridOnIcon from "@mui/icons-material/GridOn";
+import HiveIcon from "@mui/icons-material/Hive";
+import MapIcon from "@mui/icons-material/Map";
+import OpenWithIcon from "@mui/icons-material/OpenWith";
+import QueryBuilderIcon from "@mui/icons-material/QueryBuilder";
+import SettingsIcon from "@mui/icons-material/Settings";
+import TopicIcon from "@mui/icons-material/Topic";
+import UnfoldLessIcon from "@mui/icons-material/UnfoldLess";
+import UnfoldMoreIcon from "@mui/icons-material/UnfoldMore";
+import ViewInArIcon from "@mui/icons-material/ViewInAr";
+import WallpaperIcon from "@mui/icons-material/Wallpaper";
+
+export default {
+  Background: WallpaperIcon,
+  Clock: QueryBuilderIcon,
+  Collapse: UnfoldLessIcon,
+  Cube: ViewInArIcon,
+  Expand: UnfoldMoreIcon,
+  Grid: GridOnIcon,
+  Hive: HiveIcon,
+  OpenWith: OpenWithIcon,
+  Settings: SettingsIcon,
+  Topic: TopicIcon,
+  Map: MapIcon,
+  Walk: DirectionsWalkIcon,
+};

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -27,6 +27,7 @@ const BasicSettings: SettingsTreeRoots = {
   general: {
     label: "General",
     icon: "Settings",
+    visible: true,
     fields: {
       numberWithPrecision: {
         input: "number",
@@ -46,6 +47,7 @@ const BasicSettings: SettingsTreeRoots = {
   complex_inputs: {
     label: "Complex Inputs",
     icon: "Hive",
+    visible: true,
     fields: {
       messagepath: {
         label: "Message Path",
@@ -82,6 +84,7 @@ const BasicSettings: SettingsTreeRoots = {
     label: "Default Collapsed",
     icon: "OpenWith",
     defaultExpansionState: "collapsed",
+    visible: true,
     fields: {
       field: { label: "Field", input: "string" },
     },
@@ -89,6 +92,7 @@ const BasicSettings: SettingsTreeRoots = {
   background: {
     label: "Background",
     icon: "Background",
+    visible: true,
     fields: {
       colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
       colorRGBA: { label: "Color RGBA", value: "rgba(0, 128, 255, 0.75)", input: "rgba" },
@@ -97,6 +101,7 @@ const BasicSettings: SettingsTreeRoots = {
   threeDimensionalModel: {
     label: "3D Model",
     icon: "Cube",
+    visible: true,
     fields: {
       color: {
         label: "Color",
@@ -206,6 +211,7 @@ const TopicSettings: SettingsTreeRoots = {
   topics: {
     label: "Topics",
     icon: "Topic",
+    visible: true,
     children: {
       drivable_area: {
         label: "/drivable_area",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -82,7 +82,6 @@ const BasicSettings: SettingsTreeRoots = {
   },
   defaultCollapsed: {
     label: "Default Collapsed",
-    icon: "OpenWith",
     defaultExpansionState: "collapsed",
     visible: true,
     fields: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -25,6 +25,8 @@ export default {
 
 const BasicSettings: SettingsTreeRoots = {
   general: {
+    label: "General",
+    icon: "Settings",
     fields: {
       numberWithPrecision: {
         input: "number",
@@ -43,6 +45,7 @@ const BasicSettings: SettingsTreeRoots = {
   },
   complex_inputs: {
     label: "Complex Inputs",
+    icon: "Hive",
     fields: {
       messagepath: {
         label: "Message Path",
@@ -77,6 +80,7 @@ const BasicSettings: SettingsTreeRoots = {
   },
   defaultCollapsed: {
     label: "Default Collapsed",
+    icon: "OpenWith",
     defaultExpansionState: "collapsed",
     fields: {
       field: { label: "Field", input: "string" },
@@ -84,6 +88,7 @@ const BasicSettings: SettingsTreeRoots = {
   },
   background: {
     label: "Background",
+    icon: "Background",
     fields: {
       colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
       colorRGBA: { label: "Color RGBA", value: "rgba(0, 128, 255, 0.75)", input: "rgba" },
@@ -91,6 +96,7 @@ const BasicSettings: SettingsTreeRoots = {
   },
   threeDimensionalModel: {
     label: "3D Model",
+    icon: "Cube",
     fields: {
       color: {
         label: "Color",
@@ -113,6 +119,7 @@ For ROS users, we also support package:// URLs
 const PanelExamplesSettings: SettingsTreeRoots = {
   map: {
     label: "Map",
+    icon: "Map",
     fields: {
       message_path: {
         label: "Message path",
@@ -155,6 +162,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
   },
   grid: {
     label: "Grid",
+    icon: "Grid",
     fields: {
       color: {
         label: "Color",
@@ -183,6 +191,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
   },
   pose: {
     label: "Pose",
+    icon: "Walk",
     fields: {
       color: { label: "Color", value: "#ffffff", input: "rgb" },
       shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
@@ -196,6 +205,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
 const TopicSettings: SettingsTreeRoots = {
   topics: {
     label: "Topics",
+    icon: "Topic",
     children: {
       drivable_area: {
         label: "/drivable_area",

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import icons from "./icons";
+
 export type SettingsTreeFieldValue =
   | { input: "autocomplete"; value?: string; items: ReadonlyArray<string> }
   | { input: "boolean"; value?: boolean }
@@ -79,6 +81,11 @@ export type SettingsTreeNode = {
    * Field inputs attached directly to this node.
    */
   fields?: SettingsTreeFields;
+
+  /**
+   * Optional icon to display next to the node label.
+   */
+  icon?: keyof typeof icons;
 
   /**
    * An optional label shown at the top of this node.

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -108,6 +108,7 @@ function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         transformMarkers: {
           input: "boolean",

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -95,6 +95,7 @@ function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTr
   const settings: SettingsTreeRoots = {
     general: {
       label: "General",
+      icon: "Settings",
       fields: generalSettings,
     },
     topics: {

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -120,6 +120,7 @@ export type Explorer = undefined | "nodes" | "utils" | "templates";
 function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
     general: {
+      icon: "Settings",
       fields: {
         autoFormatOnSave: {
           input: "boolean",

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -10,6 +10,7 @@ export function buildSettingsTree(config: PlotConfig): SettingsTreeRoots {
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         title: { label: "Title", input: "string", value: config.title },
         isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -55,6 +55,7 @@ type Props = {
 function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
     general: {
+      icon: "Settings",
       fields: {
         advancedView: { label: "Editing Mode", input: "boolean", value: config.advancedView },
         buttonText: { label: "Button Title", input: "string", value: config.buttonText },

--- a/packages/studio-base/src/panels/RawMessages/settings.ts
+++ b/packages/studio-base/src/panels/RawMessages/settings.ts
@@ -10,6 +10,7 @@ export function buildSettingsTree(config: RawMessagesPanelConfig): SettingsTreeR
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         expansionMode: {
           label: "Auto Expand",

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -178,6 +178,7 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         followTf: { label: "Frame", input: "select", options: coordinateFrames, value: followTf },
       },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
@@ -42,6 +42,7 @@ export function buildSettingsTree(config: ThreeDimensionalVizConfig): SettingsTr
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: rootFields,
     },
     meshRendering: {

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -44,6 +44,7 @@ function buildSettingsTree(config: VariableSliderConfig): SettingsTreeRoots {
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         min: { label: "Min", input: "number", value: config.sliderProps.min },
         max: { label: "Max", input: "number", value: config.sliderProps.max },

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -164,6 +164,7 @@ function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
     general: {
       label: "General",
+      icon: "Settings",
       fields: {
         sortByLevel: { label: "Sort By Level", input: "boolean", value: config.sortByLevel },
       },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This adds a node-level `icon` attribute, chosen from a predefined list of icons.

<img width="527" alt="Screen Shot 2022-05-18 at 12 19 14 PM" src="https://user-images.githubusercontent.com/93935560/169103625-cee77982-7f1d-4152-b8c7-f92811847ea5.png">
<img width="528" alt="Screen Shot 2022-05-18 at 12 19 37 PM" src="https://user-images.githubusercontent.com/93935560/169103631-ef6db31a-b021-419b-8e4f-913665dc4f58.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
