### PR TITLE
Change Diagnostics panel names to "ROS Diagnostics"

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.help.md
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.help.md
@@ -1,4 +1,4 @@
-Display diagnostics data for a given `diagnostic_name/hardware_id`.
+Display ROS diagnostics data for a given `diagnostic_name/hardware_id`.
 
 Select a diagnostic to see its details. Clicking any entry in the `Diagnostics – Summary` panel will also open this panel with the relevant data.
 

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.help.md
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.help.md
@@ -1,4 +1,4 @@
-Display the status of your nodes from topics with a [`diagnostic_msgs/DiagnosticArray`](https://docs.ros.org/en/noetic/api/diagnostic_msgs/html/msg/DiagnosticArray.html) or [`diagnostic_msgs/msg/DiagnosticArray`](https://github.com/ros2/common_interfaces/blob/master/diagnostic_msgs/msg/DiagnosticArray.msg) datatype.
+Display the status of your nodes from topics with a ROS [`diagnostic_msgs/DiagnosticArray`](https://docs.ros.org/en/noetic/api/diagnostic_msgs/html/msg/DiagnosticArray.html) or [`diagnostic_msgs/msg/DiagnosticArray`](https://github.com/ros2/common_interfaces/blob/master/diagnostic_msgs/msg/DiagnosticArray.msg) datatype.
 
 You can pin a node to the top of your feed, filter entries by `hardware_id` and node, or sort nodes by level. You can also click any entry to see its details in the `Diagnostics – Detail` panel.
 

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -56,7 +56,7 @@ const builtin: PanelInfo[] = [
     module: async () => await import("./ThreeDimensionalViz"),
   },
   {
-    title: `ROS Diagnostics – Detail`,
+    title: `Diagnostics – Detail (ROS)`,
     type: "DiagnosticStatusPanel",
     description: "Display ROS DiagnosticArray messages for a specific hardware_id.",
     help: DiagnosticStatusPanelHelp,
@@ -64,7 +64,7 @@ const builtin: PanelInfo[] = [
     module: async () => await import("./diagnostics/DiagnosticStatusPanel"),
   },
   {
-    title: `ROS Diagnostics – Summary`,
+    title: `Diagnostics – Summary (ROS)`,
     type: "DiagnosticSummary",
     description: "Display a summary of all ROS DiagnosticArray messages.",
     help: DiagnosticSummaryHelp,

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -56,7 +56,7 @@ const builtin: PanelInfo[] = [
     module: async () => await import("./ThreeDimensionalViz"),
   },
   {
-    title: `Diagnostics – Detail`,
+    title: `ROS Diagnostics – Detail`,
     type: "DiagnosticStatusPanel",
     description: "Display ROS DiagnosticArray messages for a specific hardware_id.",
     help: DiagnosticStatusPanelHelp,
@@ -64,7 +64,7 @@ const builtin: PanelInfo[] = [
     module: async () => await import("./diagnostics/DiagnosticStatusPanel"),
   },
   {
-    title: `Diagnostics – Summary`,
+    title: `ROS Diagnostics – Summary`,
     type: "DiagnosticSummary",
     description: "Display a summary of all ROS DiagnosticArray messages.",
     help: DiagnosticSummaryHelp,


### PR DESCRIPTION
**User-Facing Changes**
Changed the names of "Diagnostics – Summary" and "Diagnostics – Detail" panels to reflect that they are ROS-specific.

**Description**
We don't intend to create Foxglove equivalent messages under @foxglove/message-schemas for these panels in their current form, because they are so ROS-specific. In the future, if there is user demand, we may consider a redesign of these panels so that they are more widely applicable.

Relates to https://github.com/foxglove/roadmap/issues/10