### PR TITLE
Fix settings item alignment

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -347,7 +347,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 2 + 2 * Math.max(0, indent - 1);
+  const paddingLeft = 2 + 2 * indent;
 
   return (
     <>
@@ -371,6 +371,7 @@ function FieldEditorComponent({
       >
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
       </div>
+      <div style={{ gridColumn: "span 2", height: theme.spacing(0.25) }} />
     </>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,8 +4,6 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
-import LayerIcon from "@mui/icons-material/Layers";
-import SettingsIcon from "@mui/icons-material/Settings";
 import { Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
@@ -17,10 +15,8 @@ import { SettingsTreeAction, SettingsTreeNode } from "./types";
 export type NodeEditorProps = {
   actionHandler: (action: SettingsTreeAction) => void;
   defaultOpen?: boolean;
-  disableIcon?: boolean;
   divider?: ListItemProps["divider"];
   group?: string;
-  icon?: JSX.Element;
   path: readonly string[];
   settings?: DeepReadonly<SettingsTreeNode>;
   updateSettings?: (path: readonly string[], value: unknown) => void;
@@ -31,9 +27,7 @@ const FieldsBottomPad = muiStyled("div", { skipSx: true })(({ theme }) => ({
   height: theme.spacing(0.5),
 }));
 
-const NodeHeader = muiStyled("div")<{
-  indent: number;
-}>(({ theme, indent }) => {
+const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
     display: "flex",
     "&:hover": {
@@ -41,8 +35,6 @@ const NodeHeader = muiStyled("div")<{
       outlineOffset: -1,
     },
     gridColumn: "span 2",
-    paddingBottom: indent === 1 ? theme.spacing(0.5) : 0,
-    paddingTop: indent === 1 ? theme.spacing(0.5) : 0,
     paddingRight: theme.spacing(2.25),
   };
 });
@@ -52,14 +44,23 @@ const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }
     display: "flex",
     alignItems: "center",
     cursor: "pointer",
-    paddingLeft: theme.spacing(1.25 + 2 * Math.max(0, indent - 1)),
+    paddingLeft: theme.spacing(2 + 2 * indent),
     userSelect: "none",
     width: "100%",
   };
 });
 
+function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
+  const Component = expanded ? ArrowDownIcon : ArrowRightIcon;
+  return (
+    <Component
+      style={{ position: "absolute", top: 0, left: 0, transform: "translate(-100%, -50%)" }}
+    />
+  );
+}
+
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
-  const { actionHandler, defaultOpen = true, disableIcon = false, icon, settings = {} } = props;
+  const { actionHandler, defaultOpen = true, settings = {} } = props;
   const [open, setOpen] = useState(defaultOpen);
 
   const indent = props.path.length;
@@ -93,7 +94,6 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
       <NodeEditor
         actionHandler={actionHandler}
         defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
-        disableIcon={true}
         key={key}
         settings={child}
         path={stablePath}
@@ -104,18 +104,16 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   return (
     <>
       {indent > 0 && (
-        <NodeHeader indent={indent}>
+        <NodeHeader>
           <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
             <div
               style={{
                 display: "inline-flex",
                 opacity: visible ? 0.6 : 0.3,
-                marginRight: "0.25rem",
+                position: "relative",
               }}
             >
-              {hasProperties && <>{open ? <ArrowDownIcon /> : <ArrowRightIcon />}</>}
-              {!disableIcon &&
-                (icon != undefined ? icon : indent > 0 ? <LayerIcon /> : <SettingsIcon />)}
+              {hasProperties && <ExpansionArrow expanded={open} />}
             </div>
             <Typography
               noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -24,7 +24,6 @@ const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
   display: "grid",
   gridTemplateColumns: "minmax(4rem, 1fr) minmax(4rem, 12rem)",
   columnGap: theme.spacing(1),
-  rowGap: theme.spacing(0.25),
 }));
 
 const ROOT_PATH: readonly string[] = [];


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the horizontal alignment of items in the settings UI tree by using absolute positioning on the expansion arrows. It also tightens up the vertical spacing of items in the tree.

<img width="431" alt="Screen Shot 2022-05-18 at 8 00 51 AM" src="https://user-images.githubusercontent.com/93935560/169045082-45458106-cc31-4d83-ae02-4054f1ac35e4.png">

<img width="362" alt="Screen Shot 2022-05-18 at 8 01 11 AM" src="https://user-images.githubusercontent.com/93935560/169045085-1752ec3b-fcf3-4124-b522-35a4a8d2613d.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
