### PR TITLE
Move all settings under a top level root and clean up alignment

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 2 + 2 * Math.max(0, indent - 1);
+  const paddingLeft = 2 + 2 * indent;
 
   return (
     <>
@@ -373,6 +373,7 @@ function FieldEditorComponent({
       >
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
       </div>
+      <div style={{ gridColumn: "span 2", height: theme.spacing(0.25) }} />
     </>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 2 + 2 * indent;
+  const paddingLeft = 2 + 2 * (indent - 1);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -349,7 +349,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const theme = useTheme();
   const indent = Math.min(path.length, 4);
-  const paddingLeft = 2 + 2 * (indent - 1);
+  const paddingLeft = 1.5 + 2 * (indent - 1);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,8 +4,6 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
-import LayerIcon from "@mui/icons-material/Layers";
-import SettingsIcon from "@mui/icons-material/Settings";
 import { Divider, ListItemProps, styled as muiStyled, Typography } from "@mui/material";
 import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
@@ -17,10 +15,8 @@ import { SettingsTreeAction, SettingsTreeNode } from "./types";
 export type NodeEditorProps = {
   actionHandler: (action: SettingsTreeAction) => void;
   defaultOpen?: boolean;
-  disableIcon?: boolean;
   divider?: ListItemProps["divider"];
   group?: string;
-  icon?: JSX.Element;
   path: readonly string[];
   settings?: DeepReadonly<SettingsTreeNode>;
   updateSettings?: (path: readonly string[], value: unknown) => void;
@@ -31,9 +27,7 @@ const FieldsBottomPad = muiStyled("div", { skipSx: true })(({ theme }) => ({
   height: theme.spacing(0.5),
 }));
 
-const NodeHeader = muiStyled("div")<{
-  indent: number;
-}>(({ theme, indent }) => {
+const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
     display: "flex",
     "&:hover": {
@@ -41,8 +35,6 @@ const NodeHeader = muiStyled("div")<{
       outlineOffset: -1,
     },
     gridColumn: "span 2",
-    paddingBottom: indent === 1 ? theme.spacing(0.5) : 0,
-    paddingTop: indent === 1 ? theme.spacing(0.5) : 0,
     paddingRight: theme.spacing(2.25),
   };
 });
@@ -52,14 +44,23 @@ const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }
     display: "flex",
     alignItems: "center",
     cursor: "pointer",
-    paddingLeft: theme.spacing(1.25 + 2 * Math.max(0, indent - 1)),
+    paddingLeft: theme.spacing(2 + 2 * indent),
     userSelect: "none",
     width: "100%",
   };
 });
 
+function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
+  const Component = expanded ? ArrowDownIcon : ArrowRightIcon;
+  return (
+    <Component
+      style={{ position: "absolute", top: 0, left: 0, transform: "translate(-100%, -50%)" }}
+    />
+  );
+}
+
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
-  const { actionHandler, defaultOpen = true, disableIcon = false, icon, settings = {} } = props;
+  const { actionHandler, defaultOpen = true, settings = {} } = props;
   const [open, setOpen] = useState(defaultOpen);
 
   const indent = props.path.length;
@@ -93,7 +94,6 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
       <NodeEditor
         actionHandler={actionHandler}
         defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
-        disableIcon={true}
         key={key}
         settings={child}
         path={stablePath}
@@ -104,18 +104,16 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   return (
     <>
       {indent > 0 && (
-        <NodeHeader indent={indent}>
+        <NodeHeader>
           <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
             <div
               style={{
                 display: "inline-flex",
                 opacity: visible ? 0.6 : 0.3,
-                marginRight: "0.25rem",
+                position: "relative",
               }}
             >
-              {hasProperties && <>{open ? <ArrowDownIcon /> : <ArrowRightIcon />}</>}
-              {!disableIcon &&
-                (icon != undefined ? icon : indent > 0 ? <LayerIcon /> : <SettingsIcon />)}
+              {hasProperties && <ExpansionArrow expanded={open} />}
             </div>
             <Typography
               noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -103,36 +103,34 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
 
   return (
     <>
-      {indent > 0 && (
-        <NodeHeader>
-          <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
-            <div
-              style={{
-                display: "inline-flex",
-                opacity: visible ? 0.6 : 0.3,
-                position: "relative",
-              }}
-            >
-              {hasProperties && <ExpansionArrow expanded={open} />}
-            </div>
-            <Typography
-              noWrap={true}
-              variant="subtitle2"
-              color={visible ? "text.primary" : "text.disabled"}
-            >
-              {settings.label ?? "Settings"}
-            </Typography>
-          </NodeHeaderToggle>
-          <VisibilityToggle
-            edge="end"
-            size="small"
-            checked={visible}
-            onChange={toggleVisibility}
-            style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
-            disabled={!allowVisibilityToggle}
-          />
-        </NodeHeader>
-      )}
+      <NodeHeader>
+        <NodeHeaderToggle indent={indent} onClick={() => setOpen(!open)}>
+          <div
+            style={{
+              display: "inline-flex",
+              opacity: visible ? 0.6 : 0.3,
+              position: "relative",
+            }}
+          >
+            {hasProperties && <ExpansionArrow expanded={open} />}
+          </div>
+          <Typography
+            noWrap={true}
+            variant="subtitle2"
+            color={visible ? "text.primary" : "text.disabled"}
+          >
+            {settings.label ?? "Settings"}
+          </Typography>
+        </NodeHeaderToggle>
+        <VisibilityToggle
+          edge="end"
+          size="small"
+          checked={visible}
+          onChange={toggleVisibility}
+          style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
+          disabled={!allowVisibilityToggle}
+        />
+      </NodeHeader>
       {open && fieldEditors.length > 0 && (
         <>
           {fieldEditors}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -119,7 +119,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
             variant="subtitle2"
             color={visible ? "text.primary" : "text.disabled"}
           >
-            {settings.label ?? "Settings"}
+            {settings.label ?? "General"}
           </Typography>
         </NodeHeaderToggle>
         <VisibilityToggle

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -44,7 +44,7 @@ const NodeHeaderToggle = muiStyled("div")<{ indent: number }>(({ theme, indent }
     display: "flex",
     alignItems: "center",
     cursor: "pointer",
-    paddingLeft: theme.spacing(2 + 2 * indent),
+    paddingLeft: theme.spacing(1.5 + 2 * indent),
     userSelect: "none",
     width: "100%",
   };
@@ -54,7 +54,7 @@ function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
   const Component = expanded ? ArrowDownIcon : ArrowRightIcon;
   return (
     <Component
-      style={{ position: "absolute", top: 0, left: 0, transform: "translate(-100%, -50%)" }}
+      style={{ position: "absolute", top: 0, left: 0, transform: "translate(-112%, -50%)" }}
     />
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -72,6 +72,9 @@ const BasicSettings: SettingsTreeRoots = {
       },
     },
   },
+  emptyNode: {
+    label: "Empty node",
+  },
   defaultCollapsed: {
     label: "Default Collapsed",
     defaultExpansionState: "collapsed",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -11,287 +11,288 @@ import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanel
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
-import { SettingsTreeNode, SettingsTreeFieldValue, SettingsTreeAction } from "./types";
+import {
+  SettingsTreeNode,
+  SettingsTreeRoots,
+  SettingsTreeFieldValue,
+  SettingsTreeAction,
+} from "./types";
 
 export default {
   title: "components/SettingsTreeEditor",
   component: SettingsTreeEditor,
 };
 
-const BasicSettings: SettingsTreeNode = {
-  fields: {
-    numberWithPrecision: {
-      input: "number",
-      value: 10.123456789,
-      label: "Number with precision",
-      precision: 4,
-    },
-    gradient: { input: "gradient", label: "Gradient" },
-    emptyNumber: { input: "number", label: "Empty Number" },
-    fieldWithError: {
-      input: "string",
-      label: "Field With Error",
-      error: "This field has an error message that should be displayed to the user",
+const BasicSettings: SettingsTreeRoots = {
+  general: {
+    fields: {
+      numberWithPrecision: {
+        input: "number",
+        label: "Number with precision",
+        value: 1.2345789,
+        precision: 4,
+      },
+      gradient: { input: "gradient", label: "Gradient" },
+      emptyNumber: { input: "number", label: "Empty Number" },
+      fieldWithError: {
+        input: "string",
+        label: "Field With Error",
+        error: "This field has an error message that should be displayed to the user",
+      },
     },
   },
-  children: {
-    complex_inputs: {
-      label: "Complex Inputs",
-      fields: {
-        messagepath: {
-          label: "Message Path",
-          input: "messagepath",
-        },
-        topic: {
-          label: "Topic",
-          input: "autocomplete",
-          items: ["topic1", "topic2", "topic3"],
-        },
-        vec3: {
-          label: "Vec3",
-          input: "vec3",
-          labels: ["U", "V", "W"],
-          value: [1.111, 2.222, 3.333],
-          precision: 2,
-          step: 2,
-        },
-        emptySelect: {
-          label: "Empty Select",
-          value: "",
-          input: "select",
-          options: [
-            { label: "Nothing", value: "" },
-            { label: "Something", value: "something" },
-          ],
-        },
+  complex_inputs: {
+    label: "Complex Inputs",
+    fields: {
+      messagepath: {
+        label: "Message Path",
+        input: "messagepath",
+      },
+      topic: {
+        label: "Topic",
+        input: "autocomplete",
+        items: ["topic1", "topic2", "topic3"],
+      },
+      vec3: {
+        label: "Vec3",
+        input: "vec3",
+        labels: ["U", "V", "W"],
+        value: [1.1111, 2.2222, 3.3333],
+        precision: 2,
+        step: 2,
+      },
+      emptySelect: {
+        label: "Empty Select",
+        value: "",
+        input: "select",
+        options: [
+          { label: "Nothing", value: "" },
+          { label: "Something", value: "something" },
+        ],
       },
     },
-    defaultCollapsed: {
-      label: "Default Collapsed",
-      defaultExpansionState: "collapsed",
-      fields: {
-        field: { label: "Field", input: "string" },
-      },
+  },
+  defaultCollapsed: {
+    label: "Default Collapsed",
+    defaultExpansionState: "collapsed",
+    fields: {
+      field: { label: "Field", input: "string" },
     },
-    background: {
-      label: "Background",
-      fields: {
-        colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
-        colorRGBA: { label: "Color RGBA", value: "rgba(0, 128, 255, 0.75)", input: "rgba" },
-      },
+  },
+  background: {
+    label: "Background",
+    fields: {
+      colorRGB: { label: "Color RGB", value: "#000000", input: "rgb" },
+      colorRGBA: { label: "Color RGBA", value: "rgba(0, 128, 255, 0.75)", input: "rgba" },
     },
-    threeDimensionalModel: {
-      label: "3D Model",
-      fields: {
-        color: {
-          label: "Color",
-          input: "rgb",
-          value: "#9480ed",
-        },
-        url: {
-          label: "Model URL (URDF)",
-          input: "string",
-          placeholder: "https://example.com/.../model.urdf",
-          value: "",
-          help: `URL pointing to a Unified Robot Description Format (URDF) XML file.
+  },
+  threeDimensionalModel: {
+    label: "3D Model",
+    fields: {
+      color: {
+        label: "Color",
+        input: "rgb",
+        value: "#9480ed",
+      },
+      url: {
+        label: "Model URL (URDF)",
+        input: "string",
+        placeholder: "https://example.com/.../model.urdf",
+        value: "",
+        help: `URL pointing to a Unified Robot Description Format (URDF) XML file.
 For ROS users, we also support package:// URLs
 (loaded from the local filesystem) in our desktop app.`,
-        },
       },
     },
   },
 };
 
-const PanelExamplesSettings: SettingsTreeNode = {
-  children: {
-    map: {
-      label: "Map",
-      fields: {
-        message_path: {
-          label: "Message path",
-          input: "string",
-          value: "/gps/fix",
-        },
-        style: {
-          label: "Map style",
-          value: "Open Street Maps",
-          input: "select",
-          options: [
-            { label: "Open Street Maps", value: "Open Street Maps" },
-            {
-              label: "Stadia Maps (Adelaide Smooth Light)",
-              value: "Stadia Maps (Adelaide Smooth Light)",
-            },
-            {
-              label: "Stadia Maps (Adelaide Smooth Dark)",
-              value: "Stadia Maps (Adelaide Smooth Dark)",
-            },
-            { label: "Custom", value: "Custom" },
-          ],
-        },
-        api_key: {
-          label: "API key (optional)",
-          input: "string",
-        },
-        color_by: {
-          label: "Color by",
-          value: "Flat",
-          input: "toggle",
-          options: ["Flat", "Point data"],
-        },
-        marker_color: {
-          label: "Marker color",
-          input: "rgb",
-          value: "#ff0000",
-        },
+const PanelExamplesSettings: SettingsTreeRoots = {
+  map: {
+    label: "Map",
+    fields: {
+      message_path: {
+        label: "Message path",
+        input: "string",
+        value: "/gps/fix",
+      },
+      style: {
+        label: "Map style",
+        value: "Open Street Maps",
+        input: "select",
+        options: [
+          { label: "Open Street Maps", value: "Open Street Maps" },
+          {
+            label: "Stadia Maps (Adelaide Smooth Light)",
+            value: "Stadia Maps (Adelaide Smooth Light)",
+          },
+          {
+            label: "Stadia Maps (Adelaide Smooth Dark)",
+            value: "Stadia Maps (Adelaide Smooth Dark)",
+          },
+          { label: "Custom", value: "Custom" },
+        ],
+      },
+      api_key: {
+        label: "API key (optional)",
+        input: "string",
+      },
+      color_by: {
+        label: "Color by",
+        value: "Flat",
+        input: "toggle",
+        options: ["Flat", "Point data"],
+      },
+      marker_color: {
+        label: "Marker color",
+        input: "rgb",
+        value: "#ff0000",
       },
     },
-    grid: {
-      label: "Grid",
-      fields: {
-        color: {
-          label: "Color",
-          value: "#248eff",
-          input: "rgb",
-        },
-        size: {
-          label: "Size",
-          value: undefined,
-          input: "number",
-          max: 10,
-          min: 1,
-        },
-        subdivision: {
-          label: "Subdivision",
-          input: "number",
-          value: 9,
-        },
-        frame_lock: {
-          label: "Frame lock",
-          input: "boolean",
-          value: false,
-          help: "When enabled, the map will not be updated when the robot moves.",
-        },
+  },
+  grid: {
+    label: "Grid",
+    fields: {
+      color: {
+        label: "Color",
+        value: "#248eff",
+        input: "rgb",
+      },
+      size: {
+        label: "Size",
+        value: undefined,
+        input: "number",
+        max: 10,
+        min: 1,
+      },
+      subdivision: {
+        label: "Subdivision",
+        input: "number",
+        value: 9,
+      },
+      frame_lock: {
+        label: "Frame lock",
+        input: "boolean",
+        value: false,
+        help: "When enabled, the map will not be updated when the robot moves.",
       },
     },
-    pose: {
-      label: "Pose",
-      fields: {
-        color: { label: "Color", value: "#ffffff", input: "rgb" },
-        shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
-        shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
-        head_length: { label: "Head length", value: 2, input: "number" },
-        head_width: { label: "Head width", value: 2, input: "number" },
-      },
+  },
+  pose: {
+    label: "Pose",
+    fields: {
+      color: { label: "Color", value: "#ffffff", input: "rgb" },
+      shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
+      shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
+      head_length: { label: "Head length", value: 2, input: "number" },
+      head_width: { label: "Head width", value: 2, input: "number" },
     },
   },
 };
 
-const TopicSettings: SettingsTreeNode = {
-  children: {
-    topics: {
-      label: "Topics",
-      children: {
-        drivable_area: {
-          label: "/drivable_area",
-          visible: true,
-          fields: {
-            frame_lock: {
-              label: "Frame lock",
-              input: "boolean",
-              value: false,
-              help: "When enabled, the map will not be updated when the robot moves.",
-            },
+const TopicSettings: SettingsTreeRoots = {
+  topics: {
+    label: "Topics",
+    children: {
+      drivable_area: {
+        label: "/drivable_area",
+        visible: true,
+        fields: {
+          frame_lock: {
+            label: "Frame lock",
+            input: "boolean",
+            value: false,
+            help: "When enabled, the map will not be updated when the robot moves.",
           },
         },
-        map: {
-          label: "/map",
-          fields: {
-            frame_lock: {
-              label: "Frame lock",
-              input: "boolean",
-              value: false,
-              help: "When enabled, the map will not be updated when the robot moves.",
-            },
+      },
+      map: {
+        label: "/map",
+        fields: {
+          frame_lock: {
+            label: "Frame lock",
+            input: "boolean",
+            value: false,
+            help: "When enabled, the map will not be updated when the robot moves.",
           },
         },
-        semantic_map: {
-          label: "/semantic_map",
-          fields: {
-            color: {
-              label: "Color",
-              value: "#00ff00",
-              input: "rgb",
-            },
-            click_handling: {
-              label: "Selection mode",
-              value: "Line",
-              input: "select",
-              options: [
-                { value: "Line", label: "Line" },
-                { value: "Enclosed polygons", label: "Enclosed polygons" },
-              ],
-              help: `Treating line markers as polygons. Clicking inside the lines in the
+      },
+      semantic_map: {
+        label: "/semantic_map",
+        fields: {
+          color: {
+            label: "Color",
+            value: "#00ff00",
+            input: "rgb",
+          },
+          click_handling: {
+            label: "Selection mode",
+            value: "Line",
+            input: "select",
+            options: [
+              { value: "Line", label: "Line" },
+              { value: "Enclosed polygons", label: "Enclosed polygons" },
+            ],
+            help: `Treating line markers as polygons. Clicking inside the lines in the
                 marker selects the marker. The default behavior for line markers requires the
                 user to click exactly on the line to select the line marker.
                 Enabling this feature can reduce performance.`,
-            },
           },
-          children: {
-            centerline: {
-              label: "centerline",
-              fields: {
-                color: {
-                  label: "Color",
-                  value: "#00ff00",
-                  input: "rgb",
-                },
+        },
+        children: {
+          centerline: {
+            label: "centerline",
+            fields: {
+              color: {
+                label: "Color",
+                value: "#00ff00",
+                input: "rgb",
               },
             },
           },
         },
-        lidar_top: {
-          label: "/LIDAR_TOP",
-          fields: {
-            point_size: {
-              label: "Point Size",
-              input: "number",
-              step: 0.1,
-              value: 2,
-            },
-            point_shape: {
-              label: "Point Shape",
-              input: "toggle",
-              value: "Circle",
-              options: ["Circle", "Square"],
-            },
-            decay_time: {
-              label: "Decay Time (seconds)",
-              input: "number",
-              value: 0,
-            },
+      },
+      lidar_top: {
+        label: "/LIDAR_TOP",
+        fields: {
+          point_size: {
+            label: "Point Size",
+            input: "number",
+            step: 0.1,
+            value: 2,
+          },
+          point_shape: {
+            label: "Point Shape",
+            input: "toggle",
+            value: "Circle",
+            options: ["Circle", "Square"],
+          },
+          decay_time: {
+            label: "Decay Time (seconds)",
+            input: "number",
+            value: 0,
           },
         },
-        lidar_left: {
-          label: "/LIDAR_LEFT",
-          fields: {
-            point_size: {
-              label: "Point Size",
-              input: "number",
-              step: 2,
-              value: 2,
-            },
-            point_shape: {
-              label: "Point Shape",
-              input: "toggle",
-              value: "Circle",
-              options: ["Circle", "Square"],
-            },
-            decay_time: {
-              label: "Decay Time (seconds)",
-              input: "number",
-              value: 0,
-            },
+      },
+      lidar_left: {
+        label: "/LIDAR_LEFT",
+        fields: {
+          point_size: {
+            label: "Point Size",
+            input: "number",
+            step: 2,
+            value: 2,
+          },
+          point_shape: {
+            label: "Point Shape",
+            input: "toggle",
+            value: "Circle",
+            options: ["Circle", "Square"],
+          },
+          decay_time: {
+            label: "Decay Time (seconds)",
+            input: "number",
+            value: 0,
           },
         },
       },
@@ -299,14 +300,16 @@ const TopicSettings: SettingsTreeNode = {
   },
 };
 
-function updateSettingsTreeNode(
-  previous: SettingsTreeNode,
+function updateSettingsTreeRoots(
+  previous: SettingsTreeRoots,
   path: readonly string[],
   value: unknown,
-): SettingsTreeNode {
+): SettingsTreeRoots {
   const workingPath = [...path];
   return produce(previous, (draft) => {
-    let node: undefined | Partial<SettingsTreeNode> = draft;
+    let node: undefined | Partial<SettingsTreeNode> = draft[workingPath[0]!];
+    workingPath.shift();
+
     while (node != undefined && workingPath.length > 1) {
       const key = workingPath.shift()!;
       node = node.children?.[key];
@@ -328,12 +331,12 @@ function updateSettingsTreeNode(
   });
 }
 
-function Wrapper({ settings }: { settings: SettingsTreeNode }): JSX.Element {
-  const [settingsNode, setSettingsNode] = React.useState({ ...settings });
+function Wrapper({ roots }: { roots: SettingsTreeRoots }): JSX.Element {
+  const [settingsRoots, setSettingsRoots] = React.useState({ ...roots });
 
   const actionHandler = useCallback((action: SettingsTreeAction) => {
-    setSettingsNode((previous) =>
-      updateSettingsTreeNode(previous, action.payload.path, action.payload.value),
+    setSettingsRoots((previous) =>
+      updateSettingsTreeRoots(previous, action.payload.path, action.payload.value),
     );
   }, []);
 
@@ -341,9 +344,9 @@ function Wrapper({ settings }: { settings: SettingsTreeNode }): JSX.Element {
     () => ({
       actionHandler,
       enableFilter: true,
-      settings: settingsNode,
+      roots: settingsRoots,
     }),
-    [settingsNode, actionHandler],
+    [settingsRoots, actionHandler],
   );
 
   return (
@@ -364,13 +367,13 @@ function Wrapper({ settings }: { settings: SettingsTreeNode }): JSX.Element {
 }
 
 export function Basics(): JSX.Element {
-  return <Wrapper settings={BasicSettings} />;
+  return <Wrapper roots={BasicSettings} />;
 }
 
 export function PanelExamples(): JSX.Element {
-  return <Wrapper settings={PanelExamplesSettings} />;
+  return <Wrapper roots={PanelExamplesSettings} />;
 }
 
 export function Topics(): JSX.Element {
-  return <Wrapper settings={TopicSettings} />;
+  return <Wrapper roots={TopicSettings} />;
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -24,7 +24,6 @@ const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
   display: "grid",
   gridTemplateColumns: "minmax(4rem, 1fr) minmax(4rem, 12rem)",
   columnGap: theme.spacing(1),
-  rowGap: theme.spacing(0.25),
 }));
 
 const ROOT_PATH: readonly string[] = [];

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -62,7 +62,13 @@ export default function SettingsTreeEditor({
       )}
       <FieldGrid>
         {Object.entries(settings.roots).map(([key, root]) => (
-          <NodeEditor key={key} path={[key]} settings={root} actionHandler={actionHandler} />
+          <NodeEditor
+            key={key}
+            path={[key]}
+            settings={root}
+            defaultOpen={root.defaultExpansionState === "collapsed" ? false : true}
+            actionHandler={actionHandler}
+          />
         ))}
       </FieldGrid>
     </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -26,8 +26,6 @@ const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
   columnGap: theme.spacing(1),
 }));
 
-const ROOT_PATH: readonly string[] = [];
-
 export default function SettingsTreeEditor({
   settings,
 }: {
@@ -63,7 +61,9 @@ export default function SettingsTreeEditor({
         </StyledAppBar>
       )}
       <FieldGrid>
-        <NodeEditor path={ROOT_PATH} settings={settings.settings} actionHandler={actionHandler} />
+        {Object.entries(settings.roots).map(([key, root]) => (
+          <NodeEditor key={key} path={[key]} settings={root} actionHandler={actionHandler} />
+        ))}
       </FieldGrid>
     </Stack>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -111,6 +111,8 @@ export type SettingsTreeAction = {
   >;
 };
 
+export type SettingsTreeRoots = Record<string, SettingsTreeNode>;
+
 /**
  * A settings tree is a tree of panel settings that can be managed by
  * a default user interface in Studio.
@@ -127,8 +129,8 @@ export type SettingsTree = {
   enableFilter?: boolean;
 
   /**
-   * The actual settings tree. Updates to this will automatically be reflected in the
+   * The actual settings tree roots. Updates to these will automatically be reflected in the
    * editor UI.
    */
-  settings: SettingsTreeNode;
+  roots: SettingsTreeRoots;
 };

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -28,7 +28,7 @@ import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -104,52 +104,54 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-function buildSettingsTree(config: Config): SettingsTreeNode {
+function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
-    label: "General",
-    fields: {
-      transformMarkers: {
-        input: "boolean",
-        label: "Synchronize Markers",
-        value: config.transformMarkers,
-      },
-      smooth: {
-        input: "boolean",
-        label: "Bilinear Smoothing",
-        value: config.smooth ?? false,
-      },
-      flipHorizontal: {
-        input: "boolean",
-        label: "Flip Horizontal",
-        value: config.flipHorizontal ?? false,
-      },
-      flipVertical: {
-        input: "boolean",
-        label: "Flip Vertical",
-        value: config.flipVertical ?? false,
-      },
-      rotation: {
-        input: "select",
-        label: "Rotation",
-        value: config.rotation ?? 0,
-        options: [
-          { label: "0°", value: 0 },
-          { label: "90°", value: 90 },
-          { label: "180°", value: 180 },
-          { label: "270°", value: 270 },
-        ],
-      },
-      minValue: {
-        input: "number",
-        label: "Minimum Value (depth images)",
-        placeholder: "0",
-        value: config.minValue,
-      },
-      maxValue: {
-        input: "number",
-        label: "Maximum Value (depth images)",
-        placeholder: "10000",
-        value: config.maxValue,
+    general: {
+      label: "General",
+      fields: {
+        transformMarkers: {
+          input: "boolean",
+          label: "Synchronize Markers",
+          value: config.transformMarkers,
+        },
+        smooth: {
+          input: "boolean",
+          label: "Bilinear Smoothing",
+          value: config.smooth ?? false,
+        },
+        flipHorizontal: {
+          input: "boolean",
+          label: "Flip Horizontal",
+          value: config.flipHorizontal ?? false,
+        },
+        flipVertical: {
+          input: "boolean",
+          label: "Flip Vertical",
+          value: config.flipVertical ?? false,
+        },
+        rotation: {
+          input: "select",
+          label: "Rotation",
+          value: config.rotation ?? 0,
+          options: [
+            { label: "0°", value: 0 },
+            { label: "90°", value: 90 },
+            { label: "180°", value: 180 },
+            { label: "270°", value: 270 },
+          ],
+        },
+        minValue: {
+          input: "number",
+          label: "Minimum Value (depth images)",
+          placeholder: "0",
+          value: config.minValue,
+        },
+        maxValue: {
+          input: "number",
+          label: "Maximum Value (depth images)",
+          placeholder: "10000",
+          value: config.maxValue,
+        },
       },
     },
   };
@@ -200,7 +202,7 @@ function ImageView(props: Props) {
     (action: SettingsTreeAction) => {
       saveConfig(
         produce(config, (draft) => {
-          set(draft, action.payload.path, action.payload.value);
+          set(draft, action.payload.path.slice(1), action.payload.value);
         }),
       );
     },
@@ -210,7 +212,7 @@ function ImageView(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(config),
+      roots: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -23,7 +23,7 @@ import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import {
   SettingsTreeAction,
   SettingsTreeFields,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import FilteredPointLayer, {
   POINT_MARKER_RADIUS,
@@ -57,7 +57,7 @@ function isGeoJSONMessage(
   );
 }
 
-function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTreeNode {
+function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTreeRoots {
   const topics: SettingsTreeFields = transform(
     eligibleTopics,
     (result, topic) => {
@@ -92,14 +92,14 @@ function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTr
     };
   }
 
-  const settings: SettingsTreeNode = {
-    label: "General",
-    fields: generalSettings,
-    children: {
-      topics: {
-        label: "Topics",
-        fields: topics,
-      },
+  const settings: SettingsTreeRoots = {
+    general: {
+      label: "General",
+      fields: generalSettings,
+    },
+    topics: {
+      label: "Topics",
+      fields: topics,
     },
   };
 
@@ -278,7 +278,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
       actionHandler: settingsActionHandler,
-      settings: tree,
+      roots: tree,
     });
 
     return () => {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -226,13 +226,13 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       }
     }
 
-    if (path[0] === "layer" && input === "select") {
+    if (path[1] === "layer" && input === "select") {
       setConfig((oldConfig) => {
         return { ...oldConfig, layer: String(value) };
       });
     }
 
-    if (path[0] === "customTileUrl" && input === "string") {
+    if (path[1] === "customTileUrl" && input === "string") {
       setConfig((oldConfig) => {
         return { ...oldConfig, customTileUrl: String(value) };
       });

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -219,11 +219,11 @@ function NodePlayground(props: Props) {
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
       const { input, value, path } = action.payload;
-      if (input === "boolean" && path[0] === "autoFormatOnSave") {
-        saveConfig({ ...config, autoFormatOnSave: value });
+      if (input === "boolean" && path[1] === "autoFormatOnSave") {
+        saveConfig({ autoFormatOnSave: value });
       }
     },
-    [config, saveConfig],
+    [saveConfig],
   );
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -26,7 +26,7 @@ import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import TextContent from "@foxglove/studio-base/components/TextContent";
 import {
@@ -117,13 +117,15 @@ const SWelcomeScreen = styled.div`
 
 export type Explorer = undefined | "nodes" | "utils" | "templates";
 
-function buildSettingsStree(config: Config): SettingsTreeNode {
+function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
-    fields: {
-      autoFormatOnSave: {
-        input: "boolean",
-        label: "Auto-format on save",
-        value: config.autoFormatOnSave,
+    general: {
+      fields: {
+        autoFormatOnSave: {
+          input: "boolean",
+          label: "Auto-format on save",
+          value: config.autoFormatOnSave,
+        },
       },
     },
   };
@@ -227,7 +229,7 @@ function NodePlayground(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsStree(config),
+      roots: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -454,11 +454,7 @@ function Plot(props: Props) {
       const { path, value } = action.payload;
       saveConfig(
         produce(config, (draft) => {
-          if (path[0] === "timeSeriesOnly") {
-            set(draft, path.slice(1), value);
-          } else {
-            set(draft, path, value);
-          }
+          set(draft, path.slice(1), value);
         }),
       );
     },
@@ -467,7 +463,7 @@ function Plot(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(config),
+      roots: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -2,63 +2,64 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { SettingsTreeNode } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 import { PlotConfig } from "./types";
 
-export function buildSettingsTree(config: PlotConfig): SettingsTreeNode {
+export function buildSettingsTree(config: PlotConfig): SettingsTreeRoots {
   return {
-    fields: {
-      title: { label: "Title", input: "string", value: config.title },
-      isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },
-      legendDisplay: {
-        label: "Legend position",
-        input: "select",
-        value: config.legendDisplay,
-        options: [
-          { value: "floating", label: "Floating" },
-          { value: "left", label: "Left" },
-          { value: "top", label: "Top" },
-        ],
-      },
-      showPlotValuesInLegend: {
-        label: "Show plot values in legend",
-        input: "boolean",
-        value: config.showPlotValuesInLegend,
-      },
-      showXAxisLabels: {
-        label: "Show X axis labels",
-        input: "boolean",
-        value: config.showXAxisLabels,
-      },
-      showYAxisLabels: {
-        label: "Show Y axis labels",
-        input: "boolean",
-        value: config.showYAxisLabels,
-      },
-      minYValue: {
-        label: "Y min",
-        input: "number",
-        value: Number(config.minYValue),
-        placeholder: "auto",
-      },
-      maxYValue: {
-        label: "Y max",
-        input: "number",
-        value: Number(config.maxYValue),
-        placeholder: "auto",
+    general: {
+      label: "General",
+      fields: {
+        title: { label: "Title", input: "string", value: config.title },
+        isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },
+        legendDisplay: {
+          label: "Legend position",
+          input: "select",
+          value: config.legendDisplay,
+          options: [
+            { value: "floating", label: "Floating" },
+            { value: "left", label: "Left" },
+            { value: "top", label: "Top" },
+          ],
+        },
+        showPlotValuesInLegend: {
+          label: "Show plot values in legend",
+          input: "boolean",
+          value: config.showPlotValuesInLegend,
+        },
+        showXAxisLabels: {
+          label: "Show X axis labels",
+          input: "boolean",
+          value: config.showXAxisLabels,
+        },
+        showYAxisLabels: {
+          label: "Show Y axis labels",
+          input: "boolean",
+          value: config.showYAxisLabels,
+        },
+        minYValue: {
+          label: "Y min",
+          input: "number",
+          value: Number(config.minYValue),
+          placeholder: "auto",
+        },
+        maxYValue: {
+          label: "Y max",
+          input: "number",
+          value: Number(config.maxYValue),
+          placeholder: "auto",
+        },
       },
     },
-    children: {
-      timeSeriesOnly: {
-        label: "Time series only",
-        fields: {
-          followingViewWidth: {
-            label: "X range (seconds)",
-            input: "number",
-            placeholder: "auto",
-            value: config.followingViewWidth,
-          },
+    timeSeriesOnly: {
+      label: "Time series only",
+      fields: {
+        followingViewWidth: {
+          label: "X range (seconds)",
+          input: "number",
+          placeholder: "auto",
+          value: config.followingViewWidth,
         },
       },
     },

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -27,7 +27,7 @@ import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Stack from "@foxglove/studio-base/components/Stack";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
@@ -52,13 +52,15 @@ type Props = {
   saveConfig: (config: Partial<Config>) => void;
 };
 
-function buildSettingsTree(config: Config): SettingsTreeNode {
+function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
-    fields: {
-      advancedView: { label: "Editing Mode", input: "boolean", value: config.advancedView },
-      buttonText: { label: "Button Title", input: "string", value: config.buttonText },
-      buttonTooltip: { label: "Button Tooltip", input: "string", value: config.buttonTooltip },
-      buttonColor: { label: "Button Color", input: "rgb", value: config.buttonColor },
+    general: {
+      fields: {
+        advancedView: { label: "Editing Mode", input: "boolean", value: config.advancedView },
+        buttonText: { label: "Button Title", input: "string", value: config.buttonText },
+        buttonTooltip: { label: "Button Tooltip", input: "string", value: config.buttonTooltip },
+        buttonColor: { label: "Button Color", input: "rgb", value: config.buttonColor },
+      },
     },
   };
 }
@@ -149,7 +151,7 @@ function Publish(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(props.config),
+      roots: buildSettingsTree(props.config),
     });
   }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -141,7 +141,7 @@ function Publish(props: Props) {
     (action: SettingsTreeAction) => {
       saveConfig(
         produce(props.config, (draft) => {
-          set(draft, action.payload.path, action.payload.value);
+          set(draft, action.payload.path.slice(1), action.payload.value);
         }),
       );
     },

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -227,7 +227,7 @@ function RawMessages(props: Props) {
   useEffect(() => {
     updateSettingsTree(panelId, {
       actionHandler: settingsActionHandler,
-      settings: buildSettingsTree(config),
+      roots: buildSettingsTree(config),
     });
   }, [config, panelId, settingsActionHandler, updateSettingsTree]);
 

--- a/packages/studio-base/src/panels/RawMessages/settings.ts
+++ b/packages/studio-base/src/panels/RawMessages/settings.ts
@@ -2,22 +2,25 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { SettingsTreeNode } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 import { RawMessagesPanelConfig } from "./types";
 
-export function buildSettingsTree(config: RawMessagesPanelConfig): SettingsTreeNode {
+export function buildSettingsTree(config: RawMessagesPanelConfig): SettingsTreeRoots {
   return {
-    fields: {
-      expansionMode: {
-        label: "Auto Expand",
-        input: "select",
-        value: config.autoExpandMode,
-        options: [
-          { label: "Auto", value: "auto" },
-          { label: "Off", value: "off" },
-          { label: "All", value: "all" },
-        ],
+    general: {
+      label: "General",
+      fields: {
+        expansionMode: {
+          label: "Auto Expand",
+          input: "select",
+          value: config.autoExpandMode,
+          options: [
+            { label: "Auto", value: "auto" },
+            { label: "Off", value: "off" },
+            { label: "All", value: "all" },
+          ],
+        },
       },
     },
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -236,7 +236,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
     (context as unknown as any).__updatePanelSettingsTree({
       actionHandler,
-      settings: buildSettingsTree({
+      roots: buildSettingsTree({
         config,
         coordinateFrames,
         followTf,

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -9,6 +9,7 @@ import { Topic } from "@foxglove/studio";
 import {
   SettingsTreeChildren,
   SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 import {
@@ -147,7 +148,7 @@ function buildTopicNode(
 
 const memoBuildTopicNode = memoize(buildTopicNode);
 
-export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeNode {
+export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoots {
   const { config, coordinateFrames, followTf, topics, topicsToLayerTypes, settingsNodeProviders } =
     options;
   const { cameraState, scene } = config;
@@ -174,39 +175,54 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeNod
     }
   }
 
-  // prettier-ignore
   return {
-    fields: {
-      followTf: { label: "Frame", input: "select", options: coordinateFrames, value: followTf },
+    general: {
+      label: "General",
+      fields: {
+        followTf: { label: "Frame", input: "select", options: coordinateFrames, value: followTf },
+      },
     },
-    children: {
-      scene: {
-        label: "Scene",
-        fields: {
-          enableStats: { label: "Render stats", input: "boolean", value: config.scene.enableStats },
-          backgroundColor: { label: "Color", input: "rgb", value: backgroundColor },
+    scene: {
+      label: "Scene",
+      fields: {
+        enableStats: { label: "Render stats", input: "boolean", value: config.scene.enableStats },
+        backgroundColor: { label: "Color", input: "rgb", value: backgroundColor },
+      },
+      defaultExpansionState: "collapsed",
+    },
+    cameraState: {
+      label: "Camera",
+      fields: {
+        distance: { label: "Distance", input: "number", value: cameraState.distance, step: 1 },
+        perspective: { label: "Perspective", input: "boolean", value: cameraState.perspective },
+        targetOffset: {
+          label: "Target",
+          input: "vec3",
+          labels: ["X", "Y", "Z"],
+          value: cameraState.targetOffset,
         },
-        defaultExpansionState: "collapsed",
-      },
-      cameraState: {
-        label: "Camera",
-        fields: {
-          distance: { label: "Distance", input: "number", value: cameraState.distance, step: 1 },
-          perspective: { label: "Perspective", input: "boolean", value: cameraState.perspective },
-          targetOffset: { label: "Target", input: "vec3", labels: ["X", "Y", "Z"], value: cameraState.targetOffset },
-          thetaOffset: { label: "Theta", input: "number", value: cameraState.thetaOffset, step: ONE_DEGREE },
-          phi: { label: "Phi", input: "number", value: cameraState.phi, step: ONE_DEGREE },
-          fovy: { label: "Y-Axis FOV", input: "number", value: cameraState.fovy, step: ONE_DEGREE },
-          near: { label: "Near", input: "number", value: cameraState.near, step: DEFAULT_CAMERA_STATE.near },
-          far: { label: "Far", input: "number", value: cameraState.far, step: 1 },
+        thetaOffset: {
+          label: "Theta",
+          input: "number",
+          value: cameraState.thetaOffset,
+          step: ONE_DEGREE,
         },
-        defaultExpansionState: "collapsed",
+        phi: { label: "Phi", input: "number", value: cameraState.phi, step: ONE_DEGREE },
+        fovy: { label: "Y-Axis FOV", input: "number", value: cameraState.fovy, step: ONE_DEGREE },
+        near: {
+          label: "Near",
+          input: "number",
+          value: cameraState.near,
+          step: DEFAULT_CAMERA_STATE.near,
+        },
+        far: { label: "Far", input: "number", value: cameraState.far, step: 1 },
       },
-      topics: {
-        label: "Topics",
-        children: topicsChildren,
-        defaultExpansionState: "expanded",
-      },
+      defaultExpansionState: "collapsed",
+    },
+    topics: {
+      label: "Topics",
+      children: topicsChildren,
+      defaultExpansionState: "expanded",
     },
   };
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -384,7 +384,7 @@ function BaseRenderer(props: Props): JSX.Element {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(config),
+      roots: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/settings.ts
@@ -4,12 +4,12 @@
 
 import {
   SettingsTreeFields,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 import { ThreeDimensionalVizConfig } from "./types";
 
-export function buildSettingsTree(config: ThreeDimensionalVizConfig): SettingsTreeNode {
+export function buildSettingsTree(config: ThreeDimensionalVizConfig): SettingsTreeRoots {
   const rootFields: SettingsTreeFields = {
     flattenMarkers: {
       label: "Flatten markers",
@@ -40,58 +40,59 @@ export function buildSettingsTree(config: ThreeDimensionalVizConfig): SettingsTr
   }
 
   return {
-    fields: rootFields,
-    children: {
-      meshRendering: {
-        label: "Mesh rendering",
-        fields: {
-          ignoreColladaUpAxis: {
-            label: "Ignore COLLADA up_axis",
-            input: "boolean",
-            value: config.ignoreColladaUpAxis ?? false,
-            help: "Ignore <up_axis> in COLLADA meshes",
-          },
+    general: {
+      label: "General",
+      fields: rootFields,
+    },
+    meshRendering: {
+      label: "Mesh rendering",
+      fields: {
+        ignoreColladaUpAxis: {
+          label: "Ignore COLLADA up_axis",
+          input: "boolean",
+          value: config.ignoreColladaUpAxis ?? false,
+          help: "Ignore <up_axis> in COLLADA meshes",
         },
       },
-      publish: {
-        label: "Publish",
-        fields: {
-          clickToPublishPoseEstimateTopic: {
-            label: "Pose estimate topic",
-            input: "string",
-            value: config.clickToPublishPoseEstimateTopic,
-            help: "The topic on which to publish pose estimates",
-          },
-          clickToPublishPoseTopic: {
-            label: "Pose topic",
-            input: "string",
-            value: config.clickToPublishPoseTopic,
-            help: "The topic on which to publish poses",
-          },
-          clickToPublishPointTopic: {
-            label: "Point topic",
-            input: "string",
-            value: config.clickToPublishPointTopic,
-            help: "The topic on which to publish points",
-          },
-          clickToPublishPoseEstimateXDeviation: {
-            label: "X deviation",
-            input: "number",
-            value: config.clickToPublishPoseEstimateXDeviation,
-            help: "The X standard deviation to publish with poses",
-          },
-          clickToPublishPoseEstimateYDeviation: {
-            label: "Y deviation",
-            input: "number",
-            value: config.clickToPublishPoseEstimateYDeviation,
-            help: "The Y standard deviation to publish with poses",
-          },
-          clickToPublishPoseEstimateThetaDeviation: {
-            label: "Theta deviation",
-            input: "number",
-            value: config.clickToPublishPoseEstimateThetaDeviation,
-            help: "The theta standard deviation to publish with poses",
-          },
+    },
+    publish: {
+      label: "Publish",
+      fields: {
+        clickToPublishPoseEstimateTopic: {
+          label: "Pose estimate topic",
+          input: "string",
+          value: config.clickToPublishPoseEstimateTopic,
+          help: "The topic on which to publish pose estimates",
+        },
+        clickToPublishPoseTopic: {
+          label: "Pose topic",
+          input: "string",
+          value: config.clickToPublishPoseTopic,
+          help: "The topic on which to publish poses",
+        },
+        clickToPublishPointTopic: {
+          label: "Point topic",
+          input: "string",
+          value: config.clickToPublishPointTopic,
+          help: "The topic on which to publish points",
+        },
+        clickToPublishPoseEstimateXDeviation: {
+          label: "X deviation",
+          input: "number",
+          value: config.clickToPublishPoseEstimateXDeviation,
+          help: "The X standard deviation to publish with poses",
+        },
+        clickToPublishPoseEstimateYDeviation: {
+          label: "Y deviation",
+          input: "number",
+          value: config.clickToPublishPoseEstimateYDeviation,
+          help: "The Y standard deviation to publish with poses",
+        },
+        clickToPublishPoseEstimateThetaDeviation: {
+          label: "Theta deviation",
+          input: "number",
+          value: config.clickToPublishPoseEstimateThetaDeviation,
+          help: "The theta standard deviation to publish with poses",
         },
       },
     },

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -21,7 +21,7 @@ import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Stack from "@foxglove/studio-base/components/Stack";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
@@ -40,16 +40,18 @@ export type VariableSliderConfig = {
   globalVariableName: string;
 };
 
-function buildSettingsTree(config: VariableSliderConfig): SettingsTreeNode {
+function buildSettingsTree(config: VariableSliderConfig): SettingsTreeRoots {
   return {
-    fields: {
-      min: { label: "Min", input: "number", value: config.sliderProps.min },
-      max: { label: "Max", input: "number", value: config.sliderProps.max },
-      step: { label: "Step", input: "number", value: config.sliderProps.step },
-      globalVariableName: {
-        label: "Variable name",
-        input: "string",
-        value: config.globalVariableName,
+    general: {
+      fields: {
+        min: { label: "Min", input: "number", value: config.sliderProps.min },
+        max: { label: "Max", input: "number", value: config.sliderProps.max },
+        step: { label: "Step", input: "number", value: config.sliderProps.step },
+        globalVariableName: {
+          label: "Variable name",
+          input: "string",
+          value: config.globalVariableName,
+        },
       },
     },
   };
@@ -95,7 +97,7 @@ function VariableSliderPanel(props: Props): React.ReactElement {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(props.config),
+      roots: buildSettingsTree(props.config),
     });
   }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
 

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -43,6 +43,7 @@ export type VariableSliderConfig = {
 function buildSettingsTree(config: VariableSliderConfig): SettingsTreeRoots {
   return {
     general: {
+      label: "General",
       fields: {
         min: { label: "Min", input: "number", value: config.sliderProps.min },
         max: { label: "Max", input: "number", value: config.sliderProps.max },
@@ -76,17 +77,18 @@ function VariableSliderPanel(props: Props): React.ReactElement {
     (action: SettingsTreeAction) => {
       saveConfig(
         produce(props.config, (draft) => {
-          if (["min", "max"].includes(action.payload.path[0] ?? "")) {
-            set(draft, ["sliderProps", ...action.payload.path], action.payload.value);
+          const path = action.payload.path.slice(1);
+          if (["min", "max"].includes(path[0] ?? "")) {
+            set(draft, ["sliderProps", ...path], action.payload.value);
           } else if (
-            action.payload.path[0] === "step" &&
+            path[0] === "step" &&
             action.payload.input === "number" &&
             action.payload.value != undefined &&
             action.payload.value > 0
           ) {
             set(draft, ["sliderProps", "step"], action.payload.value);
           } else {
-            set(draft, action.payload.path, action.payload.value);
+            set(draft, path, action.payload.value);
           }
         }),
       );

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -39,7 +39,7 @@ import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import {
   SettingsTreeAction,
-  SettingsTreeNode,
+  SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import { Config as DiagnosticStatusConfig } from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.help.md";
@@ -160,10 +160,13 @@ type Props = {
   saveConfig: (arg0: Partial<Config>) => void;
 };
 
-function buildSettingsTree(config: Config): SettingsTreeNode {
+function buildSettingsTree(config: Config): SettingsTreeRoots {
   return {
-    fields: {
-      sortByLevel: { label: "Sort By Level", input: "boolean", value: config.sortByLevel },
+    general: {
+      label: "General",
+      fields: {
+        sortByLevel: { label: "Sort By Level", input: "boolean", value: config.sortByLevel },
+      },
     },
   };
 }
@@ -226,7 +229,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
       const { input, path, value } = action.payload;
-      if (input === "boolean" && path[0] === "sortByLevel") {
+      if (input === "boolean" && path[1] === "sortByLevel") {
         saveConfig(
           produce(config, (draft) => {
             draft.sortByLevel = value;
@@ -240,7 +243,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      settings: buildSettingsTree(config),
+      roots: buildSettingsTree(config),
     });
   }, [actionHandler, config, panelId, updatePanelSettingsTree]);
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This moves all settings under a top-level root and cleans up the horizontal alignment and vertical padding.

Now all settings trees follow this structure:

```typescript
export type SettingsTreeRoots = Record<string, SettingsTreeNode>;

export type SettingsTree = {
  actionHandler: (action: SettingsTreeAction) => void;
  enableFilter?: boolean;
  roots: SettingsTreeRoots;
};
```

This makes sure that all settings fields are grouped under a header.

<img width="373" alt="Screen Shot 2022-05-18 at 9 54 19 AM" src="https://user-images.githubusercontent.com/93935560/169071926-b6ed4651-55df-4929-89e8-e4ab4b8d5c16.png">
<img width="361" alt="Screen Shot 2022-05-18 at 9 54 28 AM" src="https://user-images.githubusercontent.com/93935560/169071928-027f61b7-9913-4fe1-a510-22f0eb75151d.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
