### PR TITLE
Fix extension panel toolbar & content layout

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -557,9 +557,20 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   }
 
   return (
-    <div style={{ width: "100%", height: "100%", overflow: "hidden", zIndex: 0, ...style }}>
+    <div
+      style={{
+        alignItems: "stretch",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        overflow: "hidden",
+        width: "100%",
+        zIndex: 0,
+        ...style,
+      }}
+    >
       <PanelToolbar helpContent={props.help} />
-      <div style={{ width: "100%", height: "100%", overflow: "hidden" }} ref={panelContainerRef} />
+      <div style={{ flex: 1, overflow: "hidden" }} ref={panelContainerRef} />
     </div>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -442,7 +442,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     refreshMode: "debounce",
   });
   return (
-    <div style={{ width: "100%", height: "100%", display: "flex" }} ref={resizeRef}>
+    <div
+      style={{ width: "100%", height: "100%", display: "flex", position: "relative" }}
+      ref={resizeRef}
+    >
       <CameraListener cameraStore={cameraStore} shiftKeys={true}>
         <div
           // This element forces CameraListener to fill its container. We need this instead of just


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes an issue with the layout of the fixed panel toolbar and panel content for extension panels. The fix is to use `display: flex` for the content wrapper to allow the content to resize logically.

<img width="853" alt="Screen Shot 2022-05-18 at 11 09 00 AM" src="https://user-images.githubusercontent.com/93935560/169090424-5ba4fa1c-9c7c-453c-8a71-e204c56b75d7.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3389 
Fixes #3386