### PR TITLE
Add new precision attribute to number inputs

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -129,6 +129,7 @@ function FieldInput({
           fullWidth
           max={field.max}
           min={field.min}
+          precision={field.precision}
           step={field.step}
           onChange={(value) =>
             actionHandler({ action: "update", payload: { path, input: "number", value } })
@@ -269,6 +270,7 @@ function FieldInput({
         <Vec3Input
           step={field.step}
           value={field.value}
+          precision={field.precision}
           onChange={(value) =>
             actionHandler({ action: "update", payload: { path, input: "vec3", value } })
           }

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -20,7 +20,12 @@ export default {
 
 const BasicSettings: SettingsTreeNode = {
   fields: {
-    firstRootField: { input: "string", label: "Root Field" },
+    numberWithPrecision: {
+      input: "number",
+      value: 10.123456789,
+      label: "Number with precision",
+      precision: 4,
+    },
     gradient: { input: "gradient", label: "Gradient" },
     emptyNumber: { input: "number", label: "Empty Number" },
     fieldWithError: {
@@ -46,7 +51,8 @@ const BasicSettings: SettingsTreeNode = {
           label: "Vec3",
           input: "vec3",
           labels: ["U", "V", "W"],
-          value: [1, 2, 3],
+          value: [1.111, 2.222, 3.333],
+          precision: 2,
           step: 2,
         },
         emptySelect: {

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -48,12 +48,18 @@ const StyledIconButton = muiStyled(IconButton)(({ theme }) => ({
   },
 }));
 
+function limitPrecision(x: number, digits: number): number {
+  const factor = Math.pow(10, digits);
+  return Math.round(x * factor) / factor;
+}
+
 export function NumberInput(
   props: {
     iconUp?: ReactNode;
     iconDown?: ReactNode;
     max?: number;
     min?: number;
+    precision?: number;
     step?: number;
     value?: number;
     onChange: (value: undefined | number) => void;
@@ -67,23 +73,32 @@ export function NumberInput(
 
   const updateValue = useCallback(
     (newValue: undefined | number) => {
-      onChange(
+      const clampedValue =
         newValue == undefined
           ? undefined
           : clamp(
               newValue,
               props.min ?? Number.NEGATIVE_INFINITY,
               props.max ?? Number.POSITIVE_INFINITY,
-            ),
-      );
+            );
+      const newLimitedValue =
+        props.precision != undefined && clampedValue != undefined
+          ? limitPrecision(clampedValue, props.precision)
+          : clampedValue;
+      onChange(newLimitedValue);
     },
-    [onChange, props.max, props.min],
+    [onChange, props.max, props.min, props.precision],
   );
+
+  const limitedValue =
+    props.precision != undefined && value != undefined
+      ? limitPrecision(value, props.precision)
+      : value;
 
   return (
     <StyledTextField
       {...props}
-      value={value ?? ""}
+      value={limitedValue ?? ""}
       onChange={(event) =>
         updateValue(event.target.value.length > 0 ? Number(event.target.value) : undefined)
       }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -10,12 +10,14 @@ import { NumberInput } from "./NumberInput";
 
 export function Vec3Input({
   onChange,
+  precision,
   step,
   value,
 }: {
   onChange: (
     value: undefined | readonly [undefined | number, undefined | number, undefined | number],
   ) => void;
+  precision?: number;
   step?: number;
   value: undefined | readonly [undefined | number, undefined | number, undefined | number];
 }): JSX.Element {
@@ -42,6 +44,7 @@ export function Vec3Input({
           size="small"
           variant="filled"
           fullWidth
+          precision={precision}
           step={step}
           value={pval}
           onChange={(newValue) => onChangeCallback(position, newValue)}

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -9,7 +9,14 @@ export type SettingsTreeFieldValue =
   | { input: "rgba"; value?: string }
   | { input: "gradient"; value?: [string, string] }
   | { input: "messagepath"; value?: string; validTypes?: string[] }
-  | { input: "number"; value?: number; step?: number; max?: number; min?: number }
+  | {
+      input: "number";
+      value?: number;
+      step?: number;
+      max?: number;
+      min?: number;
+      precision?: number;
+    }
   | {
       input: "select";
       value?: number | ReadonlyArray<number>;
@@ -26,6 +33,7 @@ export type SettingsTreeFieldValue =
       input: "vec3";
       value?: readonly [undefined | number, undefined | number, undefined | number];
       step?: number;
+      precision?: number;
       labels?: [string, string, string];
     };
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This adds a new `precision` attribute to number attributes that both rounds the displayed number and prevents input of numbers of greater precision than the specified number of digits.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3277 