### PR TITLE
Fix dom nesting warning

### DIFF
--- a/packages/studio-base/src/components/EmptyState.tsx
+++ b/packages/studio-base/src/components/EmptyState.tsx
@@ -21,7 +21,13 @@ export default function EmptyState({ children }: PropsWithChildren<unknown>): JS
   return (
     <StyledStack flex="auto" alignItems="center" justifyContent="center">
       <Container maxWidth={false}>
-        <Typography variant="body2" color="text.secondary" lineHeight={1.4} align="center">
+        <Typography
+          component="div"
+          variant="body2"
+          color="text.secondary"
+          lineHeight={1.4}
+          align="center"
+        >
           {children}
         </Typography>
       </Container>

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -150,6 +150,7 @@ export default function Start(props: IStartProps): JSX.Element {
             <Typography
               variant="body2"
               color="inherit"
+              component="div"
               noWrap
               style={{
                 overflow: "hidden",
@@ -159,7 +160,7 @@ export default function Start(props: IStartProps): JSX.Element {
               <TextMiddleTruncate text={recent.title} />
             </Typography>
             {recent.label && (
-              <Typography variant="body2" color="text.secondary" noWrap>
+              <Typography component="div" variant="body2" color="text.secondary" noWrap>
                 {recent.label}
               </Typography>
             )}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes some invalid DOM nesting warnings. It looks like the MUI `Typography` component renders as an HTML `<p>` element in some cases, which doesn't allow `<div>` children.

<img width="474" alt="Screen Shot 2022-05-19 at 9 58 03 AM" src="https://user-images.githubusercontent.com/93935560/169341656-42605206-0efc-4c1c-b94c-e17f61b2ec6f.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
