### PR TITLE
Add URL scheme for loading resources from an extension

### DIFF
--- a/desktop/main/extensionResources.ts
+++ b/desktop/main/extensionResources.ts
@@ -17,9 +17,7 @@ const NET_ERROR_FAILED = -2;
 export function registerExtensionProtocolHandlers(): void {
   protocol.registerFileProtocol("x-foxglove-extension-rsrc", (request, callback) => {
     // Split the URL into an extension ID and the resource path
-    const urlPathParts = new URL(request.url).pathname.replace(/^\/+/, "").split("/");
-    const extId = urlPathParts[0] ?? "";
-    const rsrcPath = urlPathParts.slice(1).join("/");
+    const { host: extId, pathname: rsrcPath } = new URL(request.url);
 
     const homePath = app.getPath("home");
     const userExtensionRoot = pathJoin(homePath, ".foxglove-studio", "extensions");
@@ -38,4 +36,18 @@ export function registerExtensionProtocolHandlers(): void {
         callback({ error: NET_ERROR_FAILED });
       });
   });
+}
+
+export function registerExtensionProtocolSchemes(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: "x-foxglove-extension-rsrc",
+      privileges: {
+        // The URL scheme adheres to "generic URI syntax", with a host (i.e.,
+        // the extension's ID) and a path. This also allows resolving relative
+        // resources, like a CSS file that uses url("./icon.png")
+        standard: true,
+      },
+    },
+  ]);
 }

--- a/desktop/main/extensionResources.ts
+++ b/desktop/main/extensionResources.ts
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { app, protocol } from "electron";
+import { join as pathJoin } from "path";
+
+import Logger from "@foxglove/log";
+
+import { getExtensionFile } from "../preload/extensions";
+
+const log = Logger.getLogger(__filename);
+
+// https://source.chromium.org/chromium/chromium/src/+/master:net/base/net_error_list.h
+// The error code for registerFileProtocol must be from the net error list
+const NET_ERROR_FAILED = -2;
+
+export function registerExtensionProtocolHandlers(): void {
+  protocol.registerFileProtocol("x-foxglove-extension-rsrc", (request, callback) => {
+    // Split the URL into an extension ID and the resource path
+    const urlPathParts = new URL(request.url).pathname.replace(/^\/+/, "").split("/");
+    const extId = urlPathParts[0] ?? "";
+    const rsrcPath = urlPathParts.slice(1).join("/");
+
+    const homePath = app.getPath("home");
+    const userExtensionRoot = pathJoin(homePath, ".foxglove-studio", "extensions");
+
+    // Look up the resource path
+    void getExtensionFile(extId, userExtensionRoot, rsrcPath)
+      .then((fsPath) => {
+        if (fsPath === "") {
+          throw new Error(`Failed to locate extension resource for ${request.url}`);
+        }
+
+        callback({ path: fsPath });
+      })
+      .catch((err: Error) => {
+        log.warn(err.message);
+        callback({ error: NET_ERROR_FAILED });
+      });
+  });
+}

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -13,6 +13,7 @@ import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 import pkgInfo from "../../package.json";
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
+import { registerExtensionProtocolHandlers } from "./extensionResources";
 import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
 import installChromeExtensions from "./installChromeExtensions";
@@ -212,6 +213,7 @@ function main() {
     log.debug(`Elapsed (ms) until new StudioWindow: ${Date.now() - start}`);
     const initialWindow = new StudioWindow([...deepLinks, ...openUrls]);
 
+    registerExtensionProtocolHandlers();
     registerRosPackageProtocolHandlers();
 
     // Only production builds check for automatic updates
@@ -239,13 +241,13 @@ function main() {
     // Content Security Policy
     // See: https://www.electronjs.org/docs/tutorial/security
     const contentSecurityPolicy: Record<string, string> = {
-      "default-src": "'self'",
-      "script-src": `'self' 'unsafe-inline' 'unsafe-eval'`,
-      "worker-src": `'self' blob:`,
-      "style-src": "'self' 'unsafe-inline'",
-      "connect-src": "'self' ws: wss: http: https: package:",
-      "font-src": "'self' data:",
-      "img-src": "'self' data: https: package: x-foxglove-converted-tiff:",
+      "default-src": `'self' x-foxglove-extension-rsrc:`,
+      "script-src": `'self' 'unsafe-inline' 'unsafe-eval' x-foxglove-extension-rsrc:`,
+      "worker-src": `'self' blob: x-foxglove-extension-rsrc:`,
+      "style-src": `'self' 'unsafe-inline' x-foxglove-extension-rsrc:`,
+      "connect-src": `'self' ws: wss: http: https: package:`,
+      "font-src": `'self' data: x-foxglove-extension-rsrc:`,
+      "img-src": `'self' data: https: package: x-foxglove-converted-tiff: x-foxglove-extension-rsrc:`,
     };
     const cspHeader = Object.entries(contentSecurityPolicy)
       .map(([key, val]) => `${key} ${val}`)

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -13,7 +13,10 @@ import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 import pkgInfo from "../../package.json";
 import StudioAppUpdater from "./StudioAppUpdater";
 import StudioWindow from "./StudioWindow";
-import { registerExtensionProtocolHandlers } from "./extensionResources";
+import {
+  registerExtensionProtocolHandlers,
+  registerExtensionProtocolSchemes,
+} from "./extensionResources";
 import getDevModeIcon from "./getDevModeIcon";
 import injectFilesToOpen from "./injectFilesToOpen";
 import installChromeExtensions from "./installChromeExtensions";
@@ -194,6 +197,7 @@ function main() {
   ipcMain.handle("getHomePath", () => app.getPath("home"));
 
   // Must be called before app.ready event
+  registerExtensionProtocolSchemes();
   registerRosPackageProtocolSchemes();
 
   ipcMain.handle("updateNativeColorScheme", () => {

--- a/desktop/preload/extensions.ts
+++ b/desktop/preload/extensions.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { existsSync } from "fs";
-import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, realpath, rm, writeFile } from "fs/promises";
 import JSZip from "jszip";
 import { dirname, relative, join as pathJoin } from "path";
 
@@ -122,8 +122,8 @@ export async function getExtensionFile(
     return "";
   }
 
-  // Compute the path
-  const packagePath = pathJoin(extension.directory, file);
+  // Compute the absolute path to the resource, to avoid symlink attacks
+  const packagePath = await realpath(pathJoin(extension.directory, file));
 
   // Check that the path is actually still within the extension directory
   if (relative(extension.directory, packagePath).startsWith("../")) {

--- a/packages/studio-base/src/providers/ExtensionRegistryProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionRegistryProvider.tsx
@@ -13,6 +13,7 @@ import ExtensionRegistryContext, {
   ExtensionRegistry,
   RegisteredPanel,
 } from "@foxglove/studio-base/context/ExtensionRegistryContext";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const log = Logger.getLogger(__filename);
 
@@ -62,7 +63,16 @@ export default function ExtensionRegistryProvider(props: PropsWithChildren<unkno
       };
 
       try {
-        const unwrappedExtensionSource = await extensionLoader.loadExtension(extension.id);
+        let pathPrefix: string;
+        if (isDesktopApp()) {
+          pathPrefix = `x-foxglove-extension-rsrc://${extension.id}`;
+        } else {
+          throw new Error("Extensions are not supported in the browser");
+        }
+
+        const unwrappedExtensionSource = (
+          await extensionLoader.loadExtension(extension.id)
+        ).replace("@FOXGLOVE_EXTENSION_PATH_PREFIX@", pathPrefix);
 
         // eslint-disable-next-line no-new-func
         const fn = new Function("module", "require", unwrappedExtensionSource);


### PR DESCRIPTION
Dabbling with #3401, which is about making it so that extensions can load resources from their bundles.

This adds an `x-foxglove-extension-rsrc:` URL scheme which can be used to reference resources. The URL path begins with the ID of the extension, followed by the path to the resource within the bundle, as in:

    x-foxglove-extension-rsrc://foxglove.studio-extension-turtlesim/dist/turtle.svg

Extensions can configure Webpack to automatically add this prefix to resources using:

    config.output.publicPath =
        "x-foxglove-extension-rsrc://foxglove.studio-extension-turtlesim/dist/";

and then enable [Asset Modules](https://webpack.js.org/guides/asset-management/) with

    config.module.rules.push({
         test: /\.(png|svg|jpg|jpeg|gif)$/i,
         type: "asset/resource",
    });

Then the extension can proceed with things like `import TurtleIcon from "./turtle.svg"` and it works as expected.

---

I don't really know much about Electron and find the extension loader code a bit confusing.

I tested this with loading an SVG resource from my extension, but I didn't try something with an additional level of indirection like a relative include from a CSS file. (**Edit**: Those work fine too.)

This configures the scheme to be allowed by the Content Security Policy for all resource types; I don't know why using `protocol.registerSchemesAsPrivileged` to disable CSP didn't work.

**Fixed.** ~~☢️ There is probably a security vulnerability with resources that are symlinks outside of an extension's bundle. I did an experiment with this by replacing an image file with a symlink into `/tmp`, and it still loaded my image.~~

I make an attempt at avoiding path traversal by making sure that the resulting file is still within the bundle, even after resolving symlinks.