### PR TITLE
Add node-level settings actions

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { ListItemIcon, ListItemText } from "@mui/material";
+import IconButton from "@mui/material/Button";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { useState } from "react";
+
+import icons from "./icons";
+import { SettingsTreeNodeAction } from "./types";
+
+export function NodeActionsMenu({
+  actions,
+  onSelectAction,
+}: {
+  actions: readonly SettingsTreeNodeAction[];
+  onSelectAction: (actionId: string) => void;
+}): JSX.Element {
+  const [anchorEl, setAnchorEl] = useState<undefined | HTMLButtonElement>(undefined);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = (id: string) => {
+    onSelectAction(id);
+    setAnchorEl(undefined);
+  };
+
+  return (
+    <>
+      <IconButton
+        id="node-actions-button"
+        aria-controls={open ? "noce-actions-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        size="small"
+        style={{ minWidth: "auto" }}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Menu
+        id="basic-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "node-actions-button",
+        }}
+      >
+        {actions.map((action) => {
+          const Icon = action.icon ? icons[action.icon] : undefined;
+          return (
+            <MenuItem key={action.id} onClick={() => handleClose(action.id)}>
+              {Icon && (
+                <ListItemIcon>
+                  <Icon fontSize="small" />
+                </ListItemIcon>
+              )}
+              <ListItemText>{action.label}</ListItemText>
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,11 +4,21 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
-import { Divider, ListItemProps, styled as muiStyled, Typography, useTheme } from "@mui/material";
+import {
+  Divider,
+  IconButton,
+  ListItemProps,
+  styled as muiStyled,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
+import Stack from "@foxglove/studio-base/components/Stack";
+
 import { FieldEditor } from "./FieldEditor";
+import { NodeActionsMenu } from "./NodeActionsMenu";
 import { VisibilityToggle } from "./VisibilityToggle";
 import icons from "./icons";
 import { SettingsTreeAction, SettingsTreeNode } from "./types";
@@ -91,6 +101,10 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     });
   };
 
+  const handleNodeAction = (actionId: string) => {
+    actionHandler({ action: "perform-node-action", payload: { id: actionId, path: props.path } });
+  };
+
   const { fields, children } = settings;
   const hasProperties = fields != undefined || children != undefined;
 
@@ -152,14 +166,25 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
             {settings.label ?? "General"}
           </Typography>
         </NodeHeaderToggle>
-        <VisibilityToggle
-          edge="end"
-          size="small"
-          checked={visible}
-          onChange={toggleVisibility}
-          style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
-          disabled={!allowVisibilityToggle}
-        />
+        <Stack alignItems="center" direction="row">
+          {/* this is just here to get consistent height */}
+          <IconButton style={{ visibility: "hidden" }}>
+            <ArrowDownIcon fontSize="small" color="inherit" />
+          </IconButton>
+          {settings.actions && (
+            <NodeActionsMenu actions={settings.actions} onSelectAction={handleNodeAction} />
+          )}
+          {settings.visible != undefined && (
+            <VisibilityToggle
+              edge="end"
+              size="small"
+              checked={visible}
+              onChange={toggleVisibility}
+              style={{ opacity: allowVisibilityToggle ? 1 : 0 }}
+              disabled={!allowVisibilityToggle}
+            />
+          )}
+        </Stack>
       </NodeHeader>
       {open && fieldEditors.length > 0 && (
         <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -66,7 +66,33 @@ export type SettingsTreeFields = Record<string, SettingsTreeField>;
 
 export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
 
+/**
+ * An action that can be offered to the user to perform at the
+ * level of a settings node.
+ */
+export type SettingsTreeNodeAction = {
+  /**
+   * A unique idenfier for the action.
+   */
+  id: string;
+
+  /**
+   * A descriptive label for the action.
+   */
+  label: string;
+
+  /**
+   * Optional icon to display with the action.
+   */
+  icon?: keyof typeof icons;
+};
+
 export type SettingsTreeNode = {
+  /**
+   * An array of actions that can be performeed on this node.
+   */
+  actions?: SettingsTreeNodeAction[];
+
   /**
    * Other settings tree nodes nested under this node.
    */
@@ -110,13 +136,18 @@ type DistributivePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : n
  * Represents actions that can be dispatched to source of the SettingsTree to implement
  * edits and updates.
  */
-export type SettingsTreeAction = {
-  action: "update";
-  payload: { path: ReadonlyArray<string> } & DistributivePick<
-    SettingsTreeFieldValue,
-    "input" | "value"
-  >;
-};
+export type SettingsTreeAction =
+  | {
+      action: "update";
+      payload: { path: ReadonlyArray<string> } & DistributivePick<
+        SettingsTreeFieldValue,
+        "input" | "value"
+      >;
+    }
+  | {
+      action: "perform-node-action";
+      payload: { id: string; path: readonly string[] };
+    };
 
 export type SettingsTreeRoots = Record<string, SettingsTreeNode>;
 

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -201,6 +201,10 @@ function ImageView(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       saveConfig(
         produce(config, (draft) => {
           set(draft, action.payload.path.slice(1), action.payload.value);

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -210,6 +210,10 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   }, [topics]);
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     const { path, input, value } = action.payload;
 
     if (path[0] === "topics" && input === "boolean") {

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -219,6 +219,10 @@ function NodePlayground(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { input, value, path } = action.payload;
       if (input === "boolean" && path[1] === "autoFormatOnSave") {
         saveConfig({ autoFormatOnSave: value });

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -451,6 +451,10 @@ function Plot(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { path, value } = action.payload;
       saveConfig(
         produce(config, (draft) => {

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -140,6 +140,10 @@ function Publish(props: Props) {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       saveConfig(
         produce(props.config, (draft) => {
           set(draft, action.payload.path.slice(1), action.payload.value);

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -215,6 +215,10 @@ function RawMessages(props: Props) {
 
   const settingsActionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       if (action.payload.input === "select") {
         saveConfig({
           autoExpandMode: action.payload.value as RawMessagesPanelConfig["autoExpandMode"],

--- a/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
+++ b/packages/studio-base/src/panels/Teleop/TeleopPanel.tsx
@@ -136,6 +136,10 @@ function TeleopPanel(props: TeleopPanelProps): JSX.Element {
   });
 
   const settingsActionHandler = useCallback((action: SettingsTreeAction) => {
+    if (action.action !== "update") {
+      return;
+    }
+
     setConfig((previous) => {
       const newConfig = { ...previous };
       set(newConfig, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -146,6 +146,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       setConfig((oldConfig) => {
         const newConfig = produce(oldConfig, (draft) => {
           set(draft, action.payload.path, action.payload.value);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -369,6 +369,10 @@ function BaseRenderer(props: Props): JSX.Element {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { path, value } = action.payload;
       saveConfig(
         produce(config, (draft) => {

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -76,6 +76,10 @@ function VariableSliderPanel(props: Props): React.ReactElement {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       saveConfig(
         produce(props.config, (draft) => {
           const path = action.payload.path.slice(1);

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -229,6 +229,10 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
       const { input, path, value } = action.payload;
       if (input === "boolean" && path[1] === "sortByLevel") {
         saveConfig(


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This adds node-level actions to items in the settings UI. The goal is to make this a flexible & generic system. The panel author simply adds items to the `actions` attribute of a settings node that take this form:

```typescript
/**
 * An action that can be offered to the user to perform at the
 * level of a settings node.
 */
export type SettingsTreeNodeAction = {
  /**
   * A unique idenfier for the action.
   */
  id: string;

  /**
   * A descriptive label for the action.
   */
  label: string;

  /**
   * Optional icon to display with the action.
   */
  icon?: keyof typeof icons;
};
```

To respond to these actions the panel author will look for a new incoming action type in their action handlers with an action of `perform-node-action`:

```typescript
/**
 * Represents actions that can be dispatched to source of the SettingsTree to implement
 * edits and updates.
 */
export type SettingsTreeAction =
  | {
      action: "update";
      payload: { path: ReadonlyArray<string> } & DistributivePick<
        SettingsTreeFieldValue,
        "input" | "value"
      >;
    }
  | {
      action: "perform-node-action";
      payload: { id: string; path: readonly string[] };
    };
```

<img width="680" alt="Screen Shot 2022-05-20 at 10 23 46 AM" src="https://user-images.githubusercontent.com/93935560/169561156-55144d77-605a-4ebd-8803-7b6b4e7140b5.png">

<img width="626" alt="Screen Shot 2022-05-20 at 10 23 51 AM" src="https://user-images.githubusercontent.com/93935560/169561173-18619c74-4de5-42af-b94f-e2252747fc0d.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
