### PR TITLE
[New3D] PointCloud fixes

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
@@ -176,7 +176,7 @@ export class Labels extends THREE.Object3D {
 
     const color = rgbaToLinear(makeRgba(), label.color ?? fgColor);
     const fontSize = label.fontSize ?? 14;
-    const fontFamily = fonts.SANS_SERIF;
+    const fontFamily = fonts.MONOSPACE;
     const fontWeight = 400;
     // const padding = label.padding ?? 2;
     const backgroundColor = rgbaToLinear(makeRgba(), label.backgroundColor ?? bgColor);

--- a/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
@@ -18,6 +18,37 @@ type MaterialCacheEntry = {
   disposer: DisposeMaterial;
 };
 
+// Fragment shader chunk to convert sRGB to linear RGB. This is used by some
+// PointCloud materials to avoid expensive per-point colorspace conversion on
+// the CPU. Source: <https://github.com/mrdoob/three.js/blob/13b67d96/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js#L16-L18>
+const FS_SRGB_TO_LINEAR = /* glsl */ `
+vec4 sRGBToLinear(in vec4 value) {
+	return vec4(mix(
+    pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
+    value.rgb * 0.0773993808,
+    vec3(lessThanEqual(value.rgb, vec3(0.04045)))
+  ), value.a);
+}
+vec3 sRGBToLinear(in vec3 value) {
+	return vec3(mix(
+    pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
+    value.rgb * 0.0773993808,
+    vec3(lessThanEqual(value.rgb, vec3(0.04045)))
+  ));
+}
+`;
+
+// Fragment shader chunk to convert sRGB to linear RGB
+const FS_POINTCLOUD_SRGB_TO_LINEAR = /* glsl */ `
+outgoingLight = sRGBToLinear(outgoingLight);
+`;
+
+// Fragment shader chunk to render a GL_POINT as a circle
+const FS_POINTCLOUD_CIRCLE = /* glsl */ `
+vec2 cxy = 2.0 * gl_PointCoord - 1.0;
+if (dot(cxy, cxy) > 1.0) { discard; }
+`;
+
 export class MaterialCache {
   materials = new Map<string, MaterialCacheEntry>();
   outlineMaterial = new THREE.LineBasicMaterial({ dithering: true });
@@ -176,18 +207,44 @@ export const PointsVertexColor = {
 };
 
 export const PointCloudColor = {
-  id: (scale: number, transparent: boolean): string =>
-    `PointCloudColor-${scale}${transparent ? "-t" : ""}`,
+  id: (
+    shape: "circle" | "square",
+    encoding: "srgb" | "linear",
+    scale: number,
+    transparent: boolean,
+  ): string => `PointCloudColor-${shape}-${encoding}-${scale}${transparent ? "-t" : ""}`,
 
-  create: (scale: number, transparent: boolean): THREE.PointsMaterial => {
+  create: (
+    shape: "circle" | "square",
+    encoding: "srgb" | "linear",
+    scale: number,
+    transparent: boolean,
+  ): THREE.PointsMaterial => {
     const material = new THREE.PointsMaterial({
       vertexColors: true,
       size: scale,
       sizeAttenuation: false,
     });
-    material.name = PointCloudColor.id(scale, transparent);
+    material.name = PointCloudColor.id(shape, encoding, scale, transparent);
     material.transparent = transparent;
     material.depthWrite = !transparent;
+    // Tell three.js to recompile the shader when `shape` or `encoding` change
+    material.customProgramCacheKey = () => `${shape}-${encoding}`;
+    material.onBeforeCompile = (shader) => {
+      const SEARCH = "#include <output_fragment>";
+      if (shape === "circle") {
+        // Patch the fragment shader to render points as circles
+        shader.fragmentShader =
+          FS_SRGB_TO_LINEAR + shader.fragmentShader.replace(SEARCH, FS_POINTCLOUD_CIRCLE + SEARCH);
+      }
+      if (encoding === "srgb") {
+        // Patch the fragment shader to add sRGB->linear color conversion
+        shader.fragmentShader = shader.fragmentShader.replace(
+          SEARCH,
+          FS_POINTCLOUD_SRGB_TO_LINEAR + SEARCH,
+        );
+      }
+    };
     return material;
   },
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
@@ -22,19 +22,16 @@ type MaterialCacheEntry = {
 // PointCloud materials to avoid expensive per-point colorspace conversion on
 // the CPU. Source: <https://github.com/mrdoob/three.js/blob/13b67d96/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js#L16-L18>
 const FS_SRGB_TO_LINEAR = /* glsl */ `
-vec4 sRGBToLinear(in vec4 value) {
-	return vec4(mix(
-    pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
-    value.rgb * 0.0773993808,
-    vec3(lessThanEqual(value.rgb, vec3(0.04045)))
-  ), value.a);
-}
 vec3 sRGBToLinear(in vec3 value) {
 	return vec3(mix(
     pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
     value.rgb * 0.0773993808,
     vec3(lessThanEqual(value.rgb, vec3(0.04045)))
   ));
+}
+
+vec4 sRGBToLinear(in vec4 value) {
+  return vec4(sRGBToLinear(value.rgb), value.a);
 }
 `;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -90,7 +90,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   // target: THREE.WebGLRenderTarget;
   // composer: EffectComposer;
   // outlinePass: OutlinePass;
-  config: ThreeDeeRenderConfig | undefined;
+  config: ThreeDeeRenderConfig;
   scene: THREE.Scene;
   dirLight: THREE.DirectionalLight;
   hemiLight: THREE.HemisphereLight;
@@ -118,13 +118,14 @@ export class Renderer extends EventEmitter<RendererEvents> {
   poses = new Poses(this);
   cameras = new Cameras(this);
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement, config: ThreeDeeRenderConfig) {
     super();
 
     // NOTE: Global side effect
     THREE.Object3D.DefaultUp = new THREE.Vector3(0, 0, 1);
 
     this.canvas = canvas;
+    this.config = config;
     this.gl = new THREE.WebGLRenderer({
       canvas,
       alpha: true,

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -107,12 +107,16 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       topics: partialConfig?.topics ?? {},
     };
   });
+  const configRef = useRef(config);
   const { cameraState, followTf: configFollowTf } = config;
   const backgroundColor = config.scene.backgroundColor;
 
   const [canvas, setCanvas] = useState<HTMLCanvasElement | ReactNull>(ReactNull);
   const [renderer, setRenderer] = useState<Renderer | ReactNull>(ReactNull);
-  useEffect(() => setRenderer(canvas ? new Renderer(canvas) : ReactNull), [canvas]);
+  useEffect(
+    () => setRenderer(canvas ? new Renderer(canvas, configRef.current) : ReactNull),
+    [canvas],
+  );
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -89,7 +89,7 @@ export class Cameras extends THREE.Object3D {
       renderable.userData.topic = topic;
 
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config?.topics[topic] as
+      const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsCameraInfo>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -46,10 +46,9 @@ export class Markers extends THREE.Object3D {
     const prevNsCount = topicMarkers.namespaces.size;
     topicMarkers.addMarkerMessage(marker);
 
-    // If the topic has a new namespace, rebuild the settings node for th
+    // If the topic has a new namespace, rebuild the settings node for this topic
     if (prevNsCount !== topicMarkers.namespaces.size) {
-      const path = ["topics", topic];
-      this.renderer.emit("settingsTreeChange", { path });
+      this.renderer.emit("settingsTreeChange", { path: ["topics", topic] });
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -98,7 +98,7 @@ export class OccupancyGrids extends THREE.Object3D {
       renderable.userData.topic = topic;
 
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config?.topics[topic] as
+      const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsOccupancyGrid>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -109,6 +109,8 @@ export class PointClouds extends THREE.Object3D {
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, pointCloud);
+        // FIXME: Persist the auto-selected field to the config
+        // this.renderer.emit("settingsTreeChange", { path: ["topics", topic] });
       }
       renderable.userData.settings = settings;
 
@@ -255,7 +257,17 @@ export class PointClouds extends THREE.Object3D {
       }
 
       if (field.name === settings.colorField) {
-        colorReader = getReader(field, pointCloud.point_step);
+        // If the selected color mode is rgb/rgba and the field only has one channel with at least a
+        // four byte width, force the color data to be interpreted as four individual bytes. This
+        // overcomes a common problem where the color field data type is set to float32 or something
+        // other than uint32
+        const forceType =
+          (settings.colorMode === "rgb" || settings.colorMode === "rgba") &&
+          field.count === 1 &&
+          pointFieldWidth(field.datatype) >= 4
+            ? PointFieldType.UINT32
+            : undefined;
+        colorReader = getReader(field, pointCloud.point_step, forceType);
         if (!colorReader) {
           const typeName = pointFieldTypeName(field.datatype);
           const message = `PointCloud2 field "${field.name}" is invalid. type=${typeName}, offset=${field.offset}, point_step=${pointCloud.point_step}`;
@@ -597,6 +609,25 @@ function settingsFields(
 
 function pointFieldTypeName(type: PointFieldType): string {
   return PointFieldType[type] ?? `${type}`;
+}
+
+function pointFieldWidth(type: PointFieldType): number {
+  switch (type) {
+    case PointFieldType.INT8:
+    case PointFieldType.UINT8:
+      return 1;
+    case PointFieldType.INT16:
+    case PointFieldType.UINT16:
+      return 2;
+    case PointFieldType.INT32:
+    case PointFieldType.UINT32:
+    case PointFieldType.FLOAT32:
+      return 4;
+    case PointFieldType.FLOAT64:
+      return 8;
+    default:
+      return 0;
+  }
 }
 
 function invalidPointCloudError(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -353,6 +353,8 @@ function releasePointsMaterial(
 function createPickingMaterial(settings: LayerSettingsPointCloud2): THREE.ShaderMaterial {
   const MIN_PICKING_POINT_SIZE = 8;
 
+  // Use a custom shader for picking that sets a minimum point size to make
+  // individual points easier to click on
   const pointSize = Math.max(settings.pointSize, MIN_PICKING_POINT_SIZE);
   return new THREE.ShaderMaterial({
     vertexShader: /* glsl */ `
@@ -404,18 +406,22 @@ function pointCloudColorEncoding(settings: LayerSettingsPointCloud2): "srgb" | "
 }
 
 function autoSelectColorField(output: LayerSettingsPointCloud2, pointCloud: PointCloud2): void {
+  // Prefer color fields first
   for (const field of pointCloud.fields) {
-    if (COLOR_FIELDS.has(field.name)) {
+    const fieldNameLower = field.name.toLowerCase();
+    if (COLOR_FIELDS.has(fieldNameLower)) {
       output.colorField = field.name;
-      switch (field.name) {
+      switch (fieldNameLower) {
         case "rgb":
           output.colorMode = "rgb";
-          output.rgbByteOrder = "rgba";
+          // PointCloud2 messages follow a convention of obeying `is_bigendian`
+          // for the byte ordering of rgb/rgba fields
+          output.rgbByteOrder = pointCloud.is_bigendian ? "rgba" : "abgr";
           break;
         default:
         case "rgba":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "rgba";
+          output.rgbByteOrder = pointCloud.is_bigendian ? "rgba" : "abgr";
           break;
         case "bgr":
           output.colorMode = "rgb";
@@ -434,6 +440,7 @@ function autoSelectColorField(output: LayerSettingsPointCloud2, pointCloud: Poin
     }
   }
 
+  // Intensity fields are second priority
   for (const field of pointCloud.fields) {
     if (INTENSITY_FIELDS.has(field.name)) {
       output.colorField = field.name;
@@ -443,6 +450,7 @@ function autoSelectColorField(output: LayerSettingsPointCloud2, pointCloud: Poin
     }
   }
 
+  // Fall back to using the first point cloud field
   if (pointCloud.fields.length > 0) {
     const firstField = pointCloud.fields[0]!;
     output.colorField = firstField.name;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -213,12 +213,12 @@ export class PointClouds extends THREE.Object3D {
       return;
     } else if (data.length < pointCloud.height * pointCloud.row_step) {
       const message = `PointCloud2 data length ${data.length} is less than height ${pointCloud.height} * row_step ${pointCloud.row_step}`;
-      invalidPointCloudError(this.renderer, renderable, message);
-      return;
+      this.renderer.layerErrors.addToTopic(renderable.userData.topic, INVALID_POINT_CLOUD, message);
+      // Allow this error for now since we currently ignore row_step
     } else if (pointCloud.width * pointCloud.point_step > pointCloud.row_step) {
       const message = `PointCloud2 width ${pointCloud.width} * point_step ${pointCloud.point_step} is greater than row_step ${pointCloud.row_step}`;
-      invalidPointCloudError(this.renderer, renderable, message);
-      return;
+      this.renderer.layerErrors.addToTopic(renderable.userData.topic, INVALID_POINT_CLOUD, message);
+      // Allow this error for now since we currently ignore row_step
     }
 
     // Parse the fields and create typed readers for x/y/z and color
@@ -283,8 +283,8 @@ export class PointClouds extends THREE.Object3D {
 
     const geometry = renderable.userData.geometry;
     geometry.resize(pointCount);
-    const positionAttribute = geometry.getAttribute("position") as THREE.BufferAttribute;
-    const colorAttribute = geometry.getAttribute("color") as THREE.BufferAttribute;
+    const positionAttribute = geometry.attributes.position!;
+    const colorAttribute = geometry.attributes.color!;
 
     const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
 
@@ -583,8 +583,7 @@ function invalidPointCloudError(
   message: string,
 ): void {
   renderer.layerErrors.addToTopic(renderable.userData.topic, INVALID_POINT_CLOUD, message);
-  renderable.userData.positionAttribute.resize(0);
-  renderable.userData.colorAttribute.resize(0);
+  renderable.userData.geometry.resize(0);
 }
 
 function zeroReader(): number {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -331,10 +331,11 @@ function pointsMaterial(
   materialCache: MaterialCache,
 ): THREE.PointsMaterial {
   const transparent = pointCloudHasTransparency(settings);
+  const encoding = pointCloudColorEncoding(settings);
   const scale = settings.pointSize;
   return materialCache.acquire(
-    PointCloudColor.id(scale, transparent),
-    () => PointCloudColor.create(scale, transparent),
+    PointCloudColor.id(settings.pointShape, encoding, scale, transparent),
+    () => PointCloudColor.create(settings.pointShape, encoding, scale, transparent),
     PointCloudColor.dispose,
   );
 }
@@ -344,8 +345,9 @@ function releasePointsMaterial(
   materialCache: MaterialCache,
 ): void {
   const transparent = pointCloudHasTransparency(settings);
+  const encoding = pointCloudColorEncoding(settings);
   const scale = settings.pointSize;
-  materialCache.release(PointCloudColor.id(scale, transparent));
+  materialCache.release(PointCloudColor.id(settings.pointShape, encoding, scale, transparent));
 }
 
 function createPickingMaterial(settings: LayerSettingsPointCloud2): THREE.ShaderMaterial {
@@ -375,17 +377,29 @@ function pointCloudHasTransparency(settings: LayerSettingsPointCloud2): boolean 
   switch (settings.colorMode) {
     case "flat":
       return stringToRgba(tempColor, settings.flatColor).a < 1.0;
-    case "gradient": {
-      if (stringToRgba(tempColor, settings.gradient[0]).a < 1.0) {
-        return true;
-      }
-      return stringToRgba(tempColor, settings.gradient[1]).a < 1.0;
-    }
+    case "gradient":
+      return (
+        stringToRgba(tempColor, settings.gradient[0]).a < 1.0 ||
+        stringToRgba(tempColor, settings.gradient[1]).a < 1.0
+      );
     case "colormap":
     case "rgb":
       return false;
     case "rgba":
+      // It's too expensive to check the alpha value of each color. Just assume it's transparent
       return true;
+  }
+}
+
+function pointCloudColorEncoding(settings: LayerSettingsPointCloud2): "srgb" | "linear" {
+  switch (settings.colorMode) {
+    case "flat":
+    case "colormap":
+    case "gradient":
+      return "linear";
+    case "rgb":
+    case "rgba":
+      return "srgb";
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -104,13 +104,21 @@ export class PointClouds extends THREE.Object3D {
       renderable.userData.topic = topic;
 
       // Set the initial settings from default values merged with any user settings
-      this.renderer.config?.topics[topic] as Partial<LayerSettingsPointCloud2> | undefined;
-      const userSettings = this.renderer.config?.topics[topic];
+      const userSettings = this.renderer.config.topics[topic] as
+        | Partial<LayerSettingsPointCloud2>
+        | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, pointCloud);
-        // FIXME: Persist the auto-selected field to the config
-        // this.renderer.emit("settingsTreeChange", { path: ["topics", topic] });
+
+        // Update user settings with the newly selected color field
+        const updatedUserSettings = userSettings ?? {};
+        updatedUserSettings.colorField = settings.colorField;
+        updatedUserSettings.colorMode = settings.colorMode;
+        updatedUserSettings.colorMap = settings.colorMap;
+        this.renderer.config.topics[topic] = updatedUserSettings;
+        // Normally we would emit "settingsTreeChange" from Renderer here, but we know the topic to
+        // field name mapping will be updated below and trigger the same event, so skip it here
       }
       renderable.userData.settings = settings;
 
@@ -141,6 +149,7 @@ export class PointClouds extends THREE.Object3D {
     if (!fields || fields.length !== pointCloud.fields.length) {
       fields = pointCloud.fields.map((field) => field.name);
       this.pointCloudFieldsByTopic.set(topic, fields);
+      this.renderer.emit("settingsTreeChange", { path: ["topics", topic] });
     }
 
     this._updatePointCloudRenderable(renderable, pointCloud);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -105,7 +105,7 @@ export class Poses extends THREE.Object3D {
       renderable.userData.topic = topic;
 
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config?.topics[topic] as
+      const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsPose>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -52,7 +52,7 @@ export class MarkersNamespace {
     this.namespace = namespace;
 
     // Set the initial settings from default values merged with any user settings
-    const topicSettings = renderer.config?.topics[topic] as PartialMarkerSettings;
+    const topicSettings = renderer.config.topics[topic] as PartialMarkerSettings;
     const userSettings = topicSettings?.namespaces?.[namespace];
     this.settings = { ...DEFAULT_NAMESPACE_SETTINGS, ...userSettings };
   }
@@ -70,7 +70,7 @@ export class TopicMarkers extends THREE.Object3D {
     this.renderer = renderer;
 
     // Set the initial settings from default values merged with any user settings
-    const userSettings = renderer.config?.topics[topic] as PartialMarkerSettings;
+    const userSettings = renderer.config.topics[topic] as PartialMarkerSettings;
     this.userData = { settings: { ...DEFAULT_TOPIC_SETTINGS, ...userSettings } };
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -19,7 +19,7 @@ export function getColorConverter(
   minValue: number,
   maxValue: number,
 ): ColorConverter {
-  const valueDelta = maxValue - minValue;
+  const valueDelta = Math.max(maxValue - minValue, Number.EPSILON);
   switch (settings.colorMode) {
     case "flat": {
       const flatColor = stringToRgba(tempColor1, settings.flatColor);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -4,7 +4,7 @@
 
 import * as THREE from "three";
 
-import { SRGBToLinear, stringToRgba } from "../../color";
+import { rgbaToLinear, SRGBToLinear, stringToRgba } from "../../color";
 import { clamp, lerp } from "../../math";
 import { ColorRGBA } from "../../ros";
 import { LayerSettingsPointCloud2 } from "../../settings";
@@ -23,21 +23,24 @@ export function getColorConverter(
   switch (settings.colorMode) {
     case "flat": {
       const flatColor = stringToRgba(tempColor1, settings.flatColor);
+      rgbaToLinear(flatColor, flatColor);
       return (output: ColorRGBA, _colorValue: number) => {
-        output.r = SRGBToLinear(flatColor.r);
-        output.g = SRGBToLinear(flatColor.g);
-        output.b = SRGBToLinear(flatColor.b);
+        output.r = flatColor.r;
+        output.g = flatColor.g;
+        output.b = flatColor.b;
         output.a = flatColor.a;
       };
     }
     case "gradient": {
       const minColor = stringToRgba(tempColor1, settings.gradient[0]);
       const maxColor = stringToRgba(tempColor2, settings.gradient[1]);
+      rgbaToLinear(minColor, minColor);
+      rgbaToLinear(maxColor, maxColor);
       return (output: ColorRGBA, colorValue: number) => {
         const t = (colorValue - minValue) / valueDelta;
-        output.r = SRGBToLinear(lerp(minColor.r, maxColor.r, t));
-        output.g = SRGBToLinear(lerp(minColor.g, maxColor.g, t));
-        output.b = SRGBToLinear(lerp(minColor.b, maxColor.b, t));
+        output.r = lerp(minColor.r, maxColor.r, t);
+        output.g = lerp(minColor.g, maxColor.g, t);
+        output.b = lerp(minColor.b, maxColor.b, t);
         output.a = lerp(minColor.a, maxColor.a, t);
       };
     }
@@ -81,54 +84,54 @@ export function getColorConverter(
 // 0xrrggbb00
 function getColorRgb(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0xff000000) >>> 24) / 255);
-  output.g = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
-  output.b = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
+  output.r = ((num & 0xff000000) >>> 24) / 255;
+  output.g = ((num & 0x00ff0000) >>> 16) / 255;
+  output.b = ((num & 0x0000ff00) >>> 8) / 255;
   output.a = 1;
 }
 
 // 0xrrggbbaa
 function getColorRgba(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0xff000000) >>> 24) / 255);
-  output.g = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
-  output.b = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
+  output.r = ((num & 0xff000000) >>> 24) / 255;
+  output.g = ((num & 0x00ff0000) >>> 16) / 255;
+  output.b = ((num & 0x0000ff00) >>> 8) / 255;
   output.a = ((num & 0x000000ff) >>> 0) / 255;
 }
 
 // 0xbbggrr00
 function getColorBgr(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
-  output.g = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
-  output.b = SRGBToLinear(((num & 0xff000000) >>> 24) / 255);
+  output.r = ((num & 0x0000ff00) >>> 8) / 255;
+  output.g = ((num & 0x00ff0000) >>> 16) / 255;
+  output.b = ((num & 0xff000000) >>> 24) / 255;
   output.a = 1;
 }
 
 // 0xbbggrraa
 function getColorBgra(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
-  output.g = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
-  output.b = SRGBToLinear(((num & 0xff000000) >>> 24) / 255);
+  output.r = ((num & 0x0000ff00) >>> 8) / 255;
+  output.g = ((num & 0x00ff0000) >>> 16) / 255;
+  output.b = ((num & 0xff000000) >>> 24) / 255;
   output.a = ((num & 0x000000ff) >>> 0) / 255;
 }
 
 // 0x00bbggrr
 function getColor0bgr(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0x000000ff) >>> 0) / 255);
-  output.g = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
-  output.b = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
+  output.r = ((num & 0x000000ff) >>> 0) / 255;
+  output.g = ((num & 0x0000ff00) >>> 8) / 255;
+  output.b = ((num & 0x00ff0000) >>> 16) / 255;
   output.a = 1;
 }
 
 // 0xaabbggrr
 function getColorAbgr(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = SRGBToLinear(((num & 0x000000ff) >>> 0) / 255);
-  output.g = SRGBToLinear(((num & 0x0000ff00) >>> 8) / 255);
-  output.b = SRGBToLinear(((num & 0x00ff0000) >>> 16) / 255);
+  output.r = ((num & 0x000000ff) >>> 0) / 255;
+  output.g = ((num & 0x0000ff00) >>> 8) / 255;
+  output.b = ((num & 0x00ff0000) >>> 16) / 255;
   output.a = ((num & 0xff000000) >>> 24) / 255;
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
@@ -38,8 +38,12 @@ export function float64Reader(fieldOffset: number): FieldReader {
   return (view: DataView, pointOffset: number) => view.getFloat64(pointOffset + fieldOffset, true);
 }
 
-export function getReader(field: PointField, pointStep: number): FieldReader | undefined {
-  switch (field.datatype) {
+export function getReader(
+  field: PointField,
+  pointStep: number,
+  forceType?: PointFieldType,
+): FieldReader | undefined {
+  switch (forceType ?? field.datatype) {
     case PointFieldType.INT8:
       return field.offset + 1 <= pointStep ? int8Reader(field.offset) : undefined;
     case PointFieldType.UINT8:


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

This includes a collection of fixes, additional implementation, and perf improvements for New3D point clouds that should address all point cloud issues except decay time.

- Fix divide by zero for pointcloud fields where min==max
- Make row_step errors non-critical since we currently ignore row_step
- Do per-point sRGB -> linear conversion on the GPU
- Render points as circles or squares
- Fix XBGR auto-selection for little-endian "rgb" fields
- Handle "rgb" fields misreported as FLOAT32
- Switch labels from sans-serif to monospace font
- Initialize Renderer with a config so it is never undefined, fix settings updates for point clouds when the first message is received
