### PR TITLE
[New3D] Show coordinate frames in the settings sidebar

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
@@ -11,8 +11,7 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { Renderer } from "./Renderer";
 import { makeRgba, rgbaToCssString, stringToRgba, rgbaToLinear } from "./color";
 import { DetailLevel } from "./lod";
-import { ColorRGBA, Pose, Vector3 } from "./ros";
-import { updatePose } from "./updatePose";
+import { ColorRGBA } from "./ros";
 
 const log = Logger.getLogger(__filename);
 
@@ -29,17 +28,6 @@ const DARK_BACKGROUND_COLOR = stringToRgba(makeRgba(), DARK_BACKGROUND_COLOR_STR
 export type LabelOptions = {
   /** Text string of the label. */
   text: string;
-  /** Coordinate frame to render the label in. */
-  frameId: string;
-  /** World position of the label relative to the origin of frameId. */
-  position: Vector3;
-
-  /** If true, the label position is recomputed each frame as the scene
-   * coordinate frames move. Defaults to true. */
-  frameLocked?: boolean;
-  /** Timestamp when the label first appears. Only used when frameLocked is
-   * false. Defaults to 0 */
-  timestamp?: bigint;
   /** Text color. Defaults to a theme-derived color. */
   color?: ColorRGBA;
   /** Font size in pixels. Defaults to 14. */
@@ -74,7 +62,6 @@ export type LabelRenderable = THREE.Sprite & {
   userData: {
     id: string;
     label: LabelOptions;
-    pose: Pose;
   };
 };
 
@@ -99,9 +86,8 @@ export class Labels extends THREE.Object3D {
         sizeAttenuation: true,
       }),
     ) as LabelRenderable;
-    const pose = { position: label.position, orientation: { x: 0, y: 0, z: 0, w: 1 } };
     sprite.name = `label:${id}`;
-    sprite.userData = { id, label, pose };
+    sprite.userData = { id, label };
     const width = canvas.width / scale;
     const height = canvas.height / scale;
     const pixelsPerUnit = label.pixelsPerUnit ?? 100;
@@ -138,32 +124,6 @@ export class Labels extends THREE.Object3D {
     // Redraw all of the labels to use the new color scheme
     for (const [id, sprite] of this.sprites.entries()) {
       this.setLabel(id, sprite.userData.label);
-    }
-  }
-
-  startFrame(currentTime: bigint): void {
-    const renderFrameId = this.renderer.renderFrameId;
-    const fixedFrameId = this.renderer.fixedFrameId;
-    if (renderFrameId == undefined || fixedFrameId == undefined) {
-      this.visible = false;
-      return;
-    }
-    this.visible = true;
-
-    for (const sprite of this.sprites.values()) {
-      const frameLocked = sprite.userData.label.frameLocked ?? true;
-      const srcTime = frameLocked ? currentTime : sprite.userData.label.timestamp ?? 0n;
-      const frameId = sprite.userData.label.frameId;
-      const updated = updatePose(
-        sprite,
-        this.renderer.transformTree,
-        renderFrameId,
-        fixedFrameId,
-        frameId,
-        currentTime,
-        srcTime,
-      );
-      sprite.visible = updated;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
@@ -116,7 +116,6 @@ export class Labels extends THREE.Object3D {
     if (prevSprite) {
       this.remove(prevSprite);
     }
-    this.add(sprite);
     this.sprites.set(id, sprite);
 
     return sprite;
@@ -125,7 +124,6 @@ export class Labels extends THREE.Object3D {
   removeById(id: string): boolean {
     const sprite = this.sprites.get(id);
     if (sprite) {
-      this.remove(sprite);
       this.sprites.delete(id);
       return true;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -322,7 +322,6 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this._updateFrames();
     this.materialCache.update(this.input.canvasSize);
 
-    this.labels.startFrame(currentTime);
     this.frameAxes.startFrame(currentTime);
     this.occupancyGrids.startFrame(currentTime);
     this.pointClouds.startFrame(currentTime);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -40,6 +40,7 @@ import {
   LayerSettingsOccupancyGrid,
   LayerSettingsPointCloud2,
   LayerSettingsPose,
+  LayerSettingsTransform,
   LayerType,
   SettingsNodeProvider,
   ThreeDeeRenderConfig,
@@ -242,8 +243,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.frameAxes.addTransformMessage(tf);
   }
 
-  setTransformSettings(_name: string, _settings: { visible?: boolean }): void {
-    //
+  setTransformSettings(frameId: string, settings: Partial<LayerSettingsTransform>): void {
+    this.frameAxes.setTransformSettings(frameId, settings);
   }
 
   addOccupancyGridMessage(topic: string, occupancyGrid: OccupancyGrid): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -104,6 +104,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       cameraState,
       followTf: partialConfig?.followTf,
       scene: partialConfig?.scene ?? {},
+      transforms: {},
       topics: partialConfig?.topics ?? {},
     };
   });
@@ -155,14 +156,26 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
           set(draft, action.payload.path, action.payload.value);
         });
 
-        // If a topic setting was changed, inform the renderer about it and
-        // draw a new frame
-        if (renderer && action.payload.path[0] === "topics") {
-          const topic = action.payload.path[1]!;
-          const layerType = topicsToLayerTypes.get(topic);
-          if (layerType != undefined) {
-            updateTopicSettings(renderer, topic, layerType, newConfig);
-            renderRef.current.needsRender = true;
+        if (renderer) {
+          const basePath = action.payload.path[0];
+          if (basePath === "transforms") {
+            // A transform setting was changed, inform the renderer about it and
+            // draw a new frame
+            const frameId = action.payload.path[1]!;
+            const transformConfig = newConfig.transforms[frameId];
+            if (transformConfig) {
+              renderer.setTransformSettings(frameId, transformConfig);
+              renderRef.current.needsRender = true;
+            }
+          } else if (basePath === "topics") {
+            // A topic setting was changed, inform the renderer about it and
+            // draw a new frame
+            const topic = action.payload.path[1]!;
+            const layerType = topicsToLayerTypes.get(topic);
+            if (layerType != undefined) {
+              updateTopicSettings(renderer, topic, layerType, newConfig);
+              renderRef.current.needsRender = true;
+            }
           }
         }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -239,9 +239,8 @@ export class FrameAxes extends THREE.Object3D {
     }
 
     // Text label
-    const position = { x: 0, y: 0, z: 0.4 };
-    const labelOpts = { text: frameId, frameId, position };
-    const label = this.renderer.labels.setLabel(`tf:${frameId}`, labelOpts);
+    const label = this.renderer.labels.setLabel(`tf:${frameId}`, { text: frameId });
+    label.position.set(0, 0, 0.4);
     renderable.add(label);
 
     // Set the initial settings from default values merged with any user settings

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -8,14 +8,12 @@ import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
 import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
 
 import Logger from "@foxglove/log";
-import {
-  MaterialCache,
-  StandardColor,
-} from "@foxglove/studio-base/panels/ThreeDeeRender/MaterialCache";
 
+import { MaterialCache, StandardColor } from "../MaterialCache";
 import { Renderer } from "../Renderer";
 import { arrowHeadSubdivisions, arrowShaftSubdivisions, DetailLevel } from "../lod";
 import { Pose, rosTimeToNanoSec, TF } from "../ros";
+import { LayerSettingsTransform, LayerType } from "../settings";
 import { Transform } from "../transforms/Transform";
 import { makePose } from "../transforms/geometry";
 import { updatePose } from "../updatePose";
@@ -38,6 +36,10 @@ const PI_2 = Math.PI / 2;
 
 const PICKING_LINE_SIZE = 6;
 
+const DEFAULT_SETTINGS: LayerSettingsTransform = {
+  visible: true,
+};
+
 const tempMat4 = new THREE.Matrix4();
 const tempVec = new THREE.Vector3();
 const tempVecB = new THREE.Vector3();
@@ -46,8 +48,10 @@ type FrameAxisRenderable = THREE.Object3D & {
   userData: {
     frameId: string;
     pose: Pose;
+    settings: LayerSettingsTransform;
     shaftMesh: THREE.InstancedMesh;
     headMesh: THREE.InstancedMesh;
+    label: THREE.Sprite;
     parentLine?: Line2;
   };
 };
@@ -72,6 +76,11 @@ export class FrameAxes extends THREE.Object3D {
     this.lineMaterial.color = YELLOW_COLOR;
 
     this.linePickingMaterial = linePickingMaterial(PICKING_LINE_SIZE, this.renderer.materialCache);
+
+    renderer.setSettingsNodeProvider(LayerType.Transform, (_topicConfig) => {
+      // const cur = topicConfig as Partial<LayerSettingsTransform>;
+      return {};
+    });
   }
 
   dispose(): void {
@@ -79,6 +88,8 @@ export class FrameAxes extends THREE.Object3D {
       releaseStandardMaterial(this.renderer.materialCache);
       renderable.userData.shaftMesh.dispose();
       renderable.userData.headMesh.dispose();
+      this.renderer.labels.removeById(`tf:${renderable.userData.frameId}`);
+      renderable.children.length = 0;
     }
     this.children.length = 0;
     this.axesByFrameId.clear();
@@ -115,6 +126,13 @@ export class FrameAxes extends THREE.Object3D {
     }
   }
 
+  setTransformSettings(frameId: string, settings: Partial<LayerSettingsTransform>): void {
+    const renderable = this.axesByFrameId.get(frameId);
+    if (renderable) {
+      renderable.userData.settings = { ...renderable.userData.settings, ...settings };
+    }
+  }
+
   startFrame(currentTime: bigint): void {
     this.lineMaterial.resolution = this.renderer.input.canvasSize;
 
@@ -128,6 +146,11 @@ export class FrameAxes extends THREE.Object3D {
 
     // Update the arrow poses
     for (const [frameId, renderable] of this.axesByFrameId.entries()) {
+      renderable.visible = renderable.userData.settings.visible;
+      if (!renderable.visible) {
+        continue;
+      }
+
       const updated = updatePose(
         renderable,
         this.renderer.transformTree,
@@ -175,8 +198,6 @@ export class FrameAxes extends THREE.Object3D {
     // line to the parent frame if it exists
     const renderable = new THREE.Object3D() as FrameAxisRenderable;
     renderable.name = frameId;
-    renderable.userData.frameId = frameId;
-    renderable.userData.pose = makePose();
 
     // Create three arrow shafts
     const arrowMaterial = standardMaterial(this.renderer.materialCache);
@@ -212,9 +233,6 @@ export class FrameAxes extends THREE.Object3D {
     headInstances.setColorAt(1, GREEN_COLOR);
     headInstances.setColorAt(2, BLUE_COLOR);
 
-    renderable.userData.shaftMesh = shaftInstances;
-    renderable.userData.headMesh = headInstances;
-
     const frame = this.renderer.transformTree.frame(frameId);
     if (!frame) {
       throw new Error(`CoordinateFrame "${frameId}" was not created`);
@@ -222,7 +240,25 @@ export class FrameAxes extends THREE.Object3D {
 
     // Text label
     const position = { x: 0, y: 0, z: 0.4 };
-    this.renderer.labels.setLabel(`tf:${frameId}`, { text: frameId, frameId, position });
+    const labelOpts = { text: frameId, frameId, position };
+    const label = this.renderer.labels.setLabel(`tf:${frameId}`, labelOpts);
+    renderable.add(label);
+
+    // Set the initial settings from default values merged with any user settings
+    const userSettings = this.renderer.config.transforms[frameId] as
+      | Partial<LayerSettingsTransform>
+      | undefined;
+    const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+
+    renderable.userData = {
+      frameId,
+      pose: makePose(),
+      settings,
+      shaftMesh: shaftInstances,
+      headMesh: headInstances,
+      label,
+      parentLine: undefined,
+    };
 
     // Check if this frame's parent exists
     const parentFrame = frame.parent();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
@@ -7,7 +7,7 @@ import { areEqual } from "@foxglove/rostime";
 import { LabelRenderable } from "../../Labels";
 import type { Renderer } from "../../Renderer";
 import { rgbaEqual } from "../../color";
-import { Marker, rosTimeToNanoSec } from "../../ros";
+import { Marker } from "../../ros";
 import { poseApproxEq } from "../../transforms/geometry";
 import { RenderableMarker } from "./RenderableMarker";
 
@@ -39,15 +39,16 @@ export class RenderableTextViewFacing extends RenderableMarker {
       (!marker.frame_locked && !areEqual(marker.header.stamp, prevMarker.header.stamp)) ||
       !rgbaEqual(marker.color, prevMarker.color)
     ) {
+      if (this.label) {
+        this.remove(this.label);
+      }
+
       // A field that affects the label appearance has changed, rebuild the label
       this.label = this._renderer.labels.setLabel(this.name, {
         text: marker.text,
-        frameId: marker.header.frame_id,
-        timestamp: rosTimeToNanoSec(marker.header.stamp),
-        position: marker.pose.position,
         color: marker.color,
-        frameLocked: marker.frame_locked,
       });
+      this.add(this.label);
     } else if (!poseApproxEq(marker.pose, prevMarker.pose)) {
       // Just update the label pose
       this.label.userData.pose = { position: marker.pose.position, orientation: QUAT_IDENTITY };

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -24,6 +24,10 @@ import {
   TRANSFORM_STAMPED_DATATYPES,
 } from "./ros";
 
+export type LayerSettingsTransform = {
+  visible: boolean;
+};
+
 export type ThreeDeeRenderConfig = {
   cameraState: CameraState;
   followTf: string | undefined;
@@ -31,6 +35,7 @@ export type ThreeDeeRenderConfig = {
     enableStats?: boolean;
     backgroundColor?: string;
   };
+  transforms: Record<string, LayerSettingsTransform>;
   topics: Record<string, Record<string, unknown> | undefined>;
 };
 
@@ -117,6 +122,10 @@ mergeSetInto(SUPPORTED_DATATYPES, CAMERA_INFO_DATATYPES);
 
 const ONE_DEGREE = Math.PI / 180;
 
+// This is the unused topic parameter passed to the SettingsNodeProvider for
+// LayerType.Transform, since transforms do not map 1:1 to topics
+const EMPTY_TOPIC = { name: "", datatype: "" };
+
 export type SettingsTreeOptions = {
   config: ThreeDeeRenderConfig;
   coordinateFrames: ReadonlyArray<SelectEntry>;
@@ -126,8 +135,21 @@ export type SettingsTreeOptions = {
   settingsNodeProviders: Map<LayerType, SettingsNodeProvider>;
 };
 
+function buildTransformNode(
+  tfConfigOrFrameId: string | Partial<LayerSettingsTransform>,
+  frameId: string,
+  settingsNodeProvider: SettingsNodeProvider,
+): undefined | SettingsTreeNode {
+  const tfConfig = typeof tfConfigOrFrameId === "string" ? {} : tfConfigOrFrameId;
+  const node = settingsNodeProvider(tfConfig, EMPTY_TOPIC);
+  node.label ??= frameId;
+  node.visible ??= tfConfig.visible ?? true;
+  node.defaultExpansionState ??= "collapsed";
+  return node;
+}
+
 function buildTopicNode(
-  topicConfigOrTopicName: string | Record<string, unknown>,
+  topicConfigOrTopicName: string | Partial<LayerSettings>,
   topic: Topic,
   layerType: LayerType,
   settingsNodeProvider: SettingsNodeProvider,
@@ -138,14 +160,14 @@ function buildTopicNode(
   }
 
   const topicConfig = typeof topicConfigOrTopicName === "string" ? {} : topicConfigOrTopicName;
-  const visible = Boolean(topicConfig["visible"] ?? true);
   const node = settingsNodeProvider(topicConfig, topic);
   node.label ??= topic.name;
-  node.visible = visible;
+  node.visible ??= topicConfig.visible ?? true;
   node.defaultExpansionState ??= "collapsed";
   return node;
 }
 
+const memoBuildTransformNode = memoize(buildTransformNode);
 const memoBuildTopicNode = memoize(buildTopicNode);
 
 export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoots {
@@ -154,8 +176,24 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
   const { cameraState, scene } = config;
   const { backgroundColor } = scene;
 
-  const topicsChildren: SettingsTreeChildren = {};
+  // Build the settings tree for transforms
+  const transformsChildren: SettingsTreeChildren = {};
+  const tfSettingsNodeProvider = settingsNodeProviders.get(LayerType.Transform);
+  if (tfSettingsNodeProvider == undefined) {
+    throw new Error(`Missing required settings node provider for LayerType.Transform`);
+  }
+  for (const { value: frameId } of options.coordinateFrames) {
+    // We key our memoized function by the first argument. Since the config
+    // maybe be undefined we use the config or the topic name.
+    const transformConfig = config.transforms[frameId] ?? frameId;
+    const newNode = memoBuildTransformNode(transformConfig, frameId, tfSettingsNodeProvider);
+    if (newNode) {
+      transformsChildren[frameId] = newNode;
+    }
+  }
 
+  // Build the settings tree for topics
+  const topicsChildren: SettingsTreeChildren = {};
   const sortedTopics = sorted(topics, (a, b) => a.name.localeCompare(b.name));
   for (const topic of sortedTopics) {
     const layerType = topicsToLayerTypes.get(topic.name);
@@ -219,6 +257,11 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
         far: { label: "Far", input: "number", value: cameraState.far, step: 1 },
       },
       defaultExpansionState: "collapsed",
+    },
+    transforms: {
+      label: "Transforms",
+      children: transformsChildren,
+      defaultExpansionState: "expanded",
     },
     topics: {
       label: "Topics",

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -179,16 +179,15 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
   // Build the settings tree for transforms
   const transformsChildren: SettingsTreeChildren = {};
   const tfSettingsNodeProvider = settingsNodeProviders.get(LayerType.Transform);
-  if (tfSettingsNodeProvider == undefined) {
-    throw new Error(`Missing required settings node provider for LayerType.Transform`);
-  }
-  for (const { value: frameId } of options.coordinateFrames) {
-    // We key our memoized function by the first argument. Since the config
-    // maybe be undefined we use the config or the topic name.
-    const transformConfig = config.transforms[frameId] ?? frameId;
-    const newNode = memoBuildTransformNode(transformConfig, frameId, tfSettingsNodeProvider);
-    if (newNode) {
-      transformsChildren[frameId] = newNode;
+  if (tfSettingsNodeProvider != undefined) {
+    for (const { value: frameId } of options.coordinateFrames) {
+      // We key our memoized function by the first argument. Since the config
+      // may be undefined we use the config or the topic name
+      const transformConfig = config.transforms[frameId] ?? frameId;
+      const newNode = memoBuildTransformNode(transformConfig, frameId, tfSettingsNodeProvider);
+      if (newNode) {
+        transformsChildren[frameId] = newNode;
+      }
     }
   }
 
@@ -205,7 +204,7 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
       continue;
     }
     // We key our memoized function by the first argument. Since the config
-    // maybe be undefined we use the config or the topic name.
+    // may be undefined we use the config or the topic name
     const topicConfig = config.topics[topic.name] ?? topic.name;
     const newNode = memoBuildTopicNode(topicConfig, topic, layerType, settingsNodeProvider);
     if (newNode) {


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Adds a new top-level settings group called "Transforms" with each coordinate frame listed below. Only visibility toggling is currently supported, but all the code is in place to add more per-frame settings.

<img width="299" alt="Screen Shot 2022-05-20 at 2 22 19 PM" src="https://user-images.githubusercontent.com/195374/169612243-6f024893-a280-40e3-8769-f064af03099c.png">