### PR TITLE
Improve settings tree node header styling

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -34,9 +34,17 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
     gridColumn: "span 2",
     paddingRight: theme.spacing(1.5),
 
+    ".MuiCheckbox-root": {
+      visibility: "hidden",
+    },
+
     "&:hover": {
       outline: `1px solid ${theme.palette.primary.main}`,
       outlineOffset: -1,
+
+      ".MuiCheckbox-root": {
+        visibility: "visible",
+      },
     },
   };
 });
@@ -146,7 +154,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           <Typography
             noWrap={true}
             variant="subtitle2"
-            fontWeight={600}
+            fontWeight={indent < 2 ? 600 : 400}
             color={visible ? "text.primary" : "text.disabled"}
           >
             {settings.label ?? "General"}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -34,16 +34,17 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
     gridColumn: "span 2",
     paddingRight: theme.spacing(1.5),
 
-    ".MuiCheckbox-root": {
-      visibility: "hidden",
-    },
-
-    "&:hover": {
-      outline: `1px solid ${theme.palette.primary.main}`,
-      outlineOffset: -1,
-
+    "@media (pointer: fine)": {
       ".MuiCheckbox-root": {
-        visibility: "visible",
+        visibility: "hidden",
+      },
+      "&:hover": {
+        outline: `1px solid ${theme.palette.primary.main}`,
+        outlineOffset: -1,
+
+        ".MuiCheckbox-root": {
+          visibility: "visible",
+        },
       },
     },
   };


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This makes two changes:
1. Node headers are only bolded at indent level 0 and 1
2. The visibility toggles are only visible when the node is hovered

<img width="389" alt="Screen Shot 2022-05-23 at 9 14 25 AM" src="https://user-images.githubusercontent.com/93935560/169839626-65609aab-fb97-4f9d-8d2e-927d459e0b3b.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
