### PR TITLE
Improve handling of invalid color values in settings editor

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -49,7 +49,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const open = Boolean(anchorElement);
 
   const isValidColor = value != undefined && tinycolor(value).isValid();
-  const swatchColor = isValidColor ? value : "#00000044";
+  const swatchColor = isValidColor ? tinycolor(value).toHex8String() : "#00000044";
 
   return (
     <Root>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This uses `tinycolor` to validate & format color values before they are passed to the `ColorSwatch` component.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3415 