### PR TITLE
Fix Log panel support for ROS 2 Log messages

### DIFF
--- a/packages/studio-base/src/panels/Log/conversion.tsx
+++ b/packages/studio-base/src/panels/Log/conversion.tsx
@@ -30,7 +30,7 @@ function getNormalizedLevel(datatype: string, raw: LogMessageEvent["message"]) {
     case "foxglove.Log":
       return (raw as FoxgloveMessages[typeof datatype]).level;
     case "rosgraph_msgs/Log":
-    case "rosgraph_msgs/msg/Log":
+    case "rcl_interfaces/msg/Log":
       return rosLevelToLogLevel((raw as Ros1RosgraphMsgs$Log).level);
   }
 
@@ -48,7 +48,7 @@ function getNormalizedStamp(datatype: string, raw: LogMessageEvent["message"]): 
     }
     case "rosgraph_msgs/Log":
       return (raw as Ros1RosgraphMsgs$Log).header.stamp;
-    case "rosgraph_msgs/msg/Log":
+    case "rcl_interfaces/msg/Log":
       return (raw as Ros2RosgraphMsgs$Log).stamp;
   }
 

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -47,6 +47,7 @@ export default function Metadata({
     <SMetadata>
       {!diffMessage && datatype && (
         <Link
+          target="_blank"
           color="inherit"
           underline="hover"
           rel="noopener noreferrer"


### PR DESCRIPTION
**User-Facing Changes**
Fixed support for ROS 2 `rcl_interfaces/msg/Log` messages in the Log panel.

**Description**
Fixes https://github.com/foxglove/studio/issues/3417, a bug which seems like it was probably introduced in https://github.com/foxglove/studio/pull/2835. An erroneous datatype `rosgraph_msgs/msg/Log` was being used.