### PR TITLE
new3d rendering optimizations

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -6,6 +6,7 @@ import produce from "immer";
 // eslint-disable-next-line no-restricted-imports
 import { cloneDeep, merge, get, set } from "lodash";
 import React, { useCallback, useLayoutEffect, useEffect, useState, useMemo, useRef } from "react";
+import ReactDOM from "react-dom";
 import { useResizeDetector } from "react-resize-detector";
 import { DeepPartial } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
@@ -277,6 +278,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   useEffect(() => {
     if (renderer) {
       renderer.config = config;
+      renderRef.current.needsRender = true;
     }
   }, [config, renderer]);
 
@@ -284,7 +286,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   useEffect(() => {
     if (renderer?.config && followTf != undefined) {
       renderer.renderFrameId = followTf;
-      renderer.animationFrame();
+      renderRef.current.needsRender = true;
     }
   }, [followTf, renderer]);
 
@@ -308,35 +310,37 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     //
     // The render handler could be invoked as often as 60hz during playback if fields are changing often.
     context.onRender = (renderState: RenderState, done) => {
-      if (renderState.currentTime) {
-        setCurrentTime(toNanoSec(renderState.currentTime));
-      }
+      ReactDOM.unstable_batchedUpdates(() => {
+        if (renderState.currentTime) {
+          setCurrentTime(toNanoSec(renderState.currentTime));
+        }
 
-      // render functions receive a _done_ callback. You MUST call this callback to indicate your panel has finished rendering.
-      // Your panel will not receive another render callback until _done_ is called from a prior render. If your panel is not done
-      // rendering before the next render call, studio shows a notification to the user that your panel is delayed.
-      //
-      // Set the done callback into a state variable to trigger a re-render
-      setRenderDone(done);
+        // render functions receive a _done_ callback. You MUST call this callback to indicate your panel has finished rendering.
+        // Your panel will not receive another render callback until _done_ is called from a prior render. If your panel is not done
+        // rendering before the next render call, studio shows a notification to the user that your panel is delayed.
+        //
+        // Set the done callback into a state variable to trigger a re-render
+        setRenderDone(done);
 
-      // Keep UI elements and the renderer aware of the current color scheme
-      setColorScheme(renderState.colorScheme);
+        // Keep UI elements and the renderer aware of the current color scheme
+        setColorScheme(renderState.colorScheme);
 
-      // We may have new topics - since we are also watching for messages in the current frame, topics may not have changed
-      // It is up to you to determine the correct action when state has not changed
-      setTopics(renderState.topics);
+        // We may have new topics - since we are also watching for messages in the current frame, topics may not have changed
+        // It is up to you to determine the correct action when state has not changed
+        setTopics(renderState.topics);
 
-      // currentFrame has messages on subscribed topics since the last render call
-      if (renderState.currentFrame) {
-        // Fully parse lazy messages
-        for (const messageEvent of renderState.currentFrame) {
-          const maybeLazy = messageEvent.message as { toJSON?: () => unknown };
-          if ("toJSON" in maybeLazy) {
-            (messageEvent as { message: unknown }).message = maybeLazy.toJSON!();
+        // currentFrame has messages on subscribed topics since the last render call
+        if (renderState.currentFrame) {
+          // Fully parse lazy messages
+          for (const messageEvent of renderState.currentFrame) {
+            const maybeLazy = messageEvent.message as { toJSON?: () => unknown };
+            if ("toJSON" in maybeLazy) {
+              (messageEvent as { message: unknown }).message = maybeLazy.toJSON!();
+            }
           }
         }
-      }
-      setMessages(renderState.currentFrame);
+        setMessages(renderState.currentFrame);
+      });
     };
 
     context.watch("currentTime");

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -128,25 +128,24 @@ export class CoordinateFrame {
     maxDelta: Duration,
   ): boolean {
     // perf-sensitive: function params instead of options object to avoid allocations
-    if (this._transforms.size === 0) {
+    const transformCount = this._transforms.size;
+    if (transformCount === 0) {
+      return false;
+    } else if (transformCount === 1) {
+      // If only a single transform exists, check if `time` is before or equal to
+      // `latestTime + maxDelta`
+      const [latestTime, latestTf] = this._transforms.maxEntry()!;
+      if (time <= latestTime + maxDelta) {
+        outLower[0] = outUpper[0] = latestTime;
+        outLower[1] = outUpper[1] = latestTf;
+        return true;
+      }
       return false;
     }
 
     // If there is no transform at or before `time`, early exit
     const lte = this._transforms.findLessThanOrEqual(time);
     if (!lte) {
-      return false;
-    }
-
-    // If only a single transform exists, check if `time` is before or equal to
-    // `latestTime + maxDelta`
-    if (this._transforms.size === 1) {
-      const [latestTime, latestTf] = lte;
-      if (time <= latestTime + maxDelta) {
-        outLower[0] = outUpper[0] = latestTime;
-        outLower[1] = outUpper[1] = latestTf;
-        return true;
-      }
       return false;
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -388,7 +388,7 @@ export class CoordinateFrame {
     }
 
     mat4.multiply(tempMatrix, tempMatrix, tempTransform.setPose(input).matrix());
-    tempTransform.setMatrix(tempMatrix).toPose(out);
+    tempTransform.setMatrixUnscaled(tempMatrix).toPose(out);
     return true;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/Transform.ts
@@ -4,16 +4,7 @@
 
 import { mat4, vec3, quat, ReadonlyMat4, ReadonlyVec3, ReadonlyQuat } from "gl-matrix";
 
-import {
-  Pose,
-  approxEq,
-  getRotationNoScaling,
-  mat4Identity,
-  quatIdentity,
-  vec3Identity,
-} from "./geometry";
-
-const tempScale = vec3Identity();
+import { Pose, getRotationNoScaling, mat4Identity, quatIdentity, vec3Identity } from "./geometry";
 
 /**
  * Transform represents a position and rotation in 3D space. It can be set and
@@ -86,19 +77,9 @@ export class Transform {
   }
 
   /**
-   * Update position and rotation from a matrix
+   * Update position and rotation from a matrix with unit scale
    */
-  setMatrix(matrix: ReadonlyMat4): this {
-    // Ensure the matrix has no scaling
-    mat4.getScaling(tempScale, matrix);
-    if (!approxEq(tempScale[0], 1) || !approxEq(tempScale[1], 1) || !approxEq(tempScale[2], 1)) {
-      throw new Error(
-        `setMatrix given a matrix with non-unit scale [${tempScale[0]}, ${tempScale[1]}, ${
-          tempScale[2]
-        }]: ${mat4.str(matrix)}`,
-      );
-    }
-
+  setMatrixUnscaled(matrix: ReadonlyMat4): this {
     mat4.copy(this._matrix, matrix);
     mat4.getTranslation(this._position, matrix);
     getRotationNoScaling(this._rotation, matrix); // A faster mat4.getRotation when there is no scaling

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/time.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/time.ts
@@ -5,13 +5,15 @@
 export type Time = bigint;
 export type Duration = bigint;
 
+const ONE_SECOND_NS = BigInt(1e9);
+
 export function compareTime(a: Time, b: Time): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export function toSec(time: Time): number {
-  const sec = Math.trunc(Number(time / BigInt(1e9)));
-  const nsec = Number(time % BigInt(1e9));
+  const sec = Number(time / ONE_SECOND_NS);
+  const nsec = Number(time % ONE_SECOND_NS);
   return sec + nsec * 1e-9;
 }
 
@@ -20,16 +22,16 @@ export function fromSec(value: number): Time {
   let nsec = Math.round((value - sec) * 1e9);
   sec += Math.trunc(nsec / 1e9);
   nsec %= 1e9;
-  return BigInt(sec) * BigInt(1e9) + BigInt(nsec);
+  return BigInt(sec) * ONE_SECOND_NS + BigInt(nsec);
 }
 
 export function percentOf(start: Time, end: Time, target: Time): number {
   const totalDuration = end - start;
   const targetDuration = target - start;
-  return toSec(targetDuration) / toSec(totalDuration);
+  return Number(targetDuration) / Number(totalDuration);
 }
 
 export function interpolate(start: Time, end: Time, fraction: number): Time {
-  const duration = end - start;
-  return start + fromSec(fraction * toSec(duration));
+  const duration = Number(end - start);
+  return start + BigInt(Math.round(duration * fraction));
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/time.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/time.ts
@@ -5,24 +5,8 @@
 export type Time = bigint;
 export type Duration = bigint;
 
-const ONE_SECOND_NS = BigInt(1e9);
-
 export function compareTime(a: Time, b: Time): number {
   return a < b ? -1 : a > b ? 1 : 0;
-}
-
-export function toSec(time: Time): number {
-  const sec = Number(time / ONE_SECOND_NS);
-  const nsec = Number(time % ONE_SECOND_NS);
-  return sec + nsec * 1e-9;
-}
-
-export function fromSec(value: number): Time {
-  let sec = Math.trunc(value);
-  let nsec = Math.round((value - sec) * 1e9);
-  sec += Math.trunc(nsec / 1e9);
-  nsec %= 1e9;
-  return BigInt(sec) * ONE_SECOND_NS + BigInt(nsec);
 }
 
 export function percentOf(start: Time, end: Time, target: Time): number {


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
- Reduce to exactly one `animationFrame()` call site
- Batch react updates in extension context `onRender` (should happen automatically in React 18)
- [Reduce instruction count in percentOf() and interpolate()](https://github.com/foxglove/studio/pull/3428/commits/16bda733820587bbc6f20ac86df290811dfb48bd)


- [Remove expensive getScaling() check and rename to setMatrixUnscaled()](https://github.com/foxglove/studio/pull/3428/commits/3651b039b40716ef0289ef08439f2dba5abf860e)

- [Avoid findLessThanOrEqual() call when there is only one TF](https://github.com/foxglove/studio/pull/3428/commits/16009de88e2cb7b118c09b9e8bd6c23a957fa7bd)
