### PR TITLE
[New3D] Fix glTF loading for DRACO-compressed meshes

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 import type { GLTF } from "three/examples/jsm/loaders/GLTFLoader";
 
@@ -13,7 +14,11 @@ export class ModelCache {
   private _gltfLoader = new GLTFLoader();
   private _models = new Map<string, Promise<GLTF | undefined>>();
 
-  constructor(private loadModelOptions: LoadModelOptions) {}
+  constructor(private loadModelOptions: LoadModelOptions) {
+    const dracoLoader = new DRACOLoader();
+    dracoLoader.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
+    this._gltfLoader.setDRACOLoader(dracoLoader);
+  }
 
   async load(url: string, reportError: (_: Error) => void): Promise<GLTF | undefined> {
     let promise = this._models.get(url);
@@ -33,7 +38,9 @@ export class ModelCache {
     // TODO: Support other model formats
     const gltf = await this._gltfLoader.loadAsync(url);
 
-    // Y-up to Z-up
+    // THREE.js uses Y-up, while we follow the ROS [REP-0103](https://www.ros.org/reps/rep-0103.html)
+    // convention of Z-up
+    gltf.scene.rotateZ(Math.PI / 2);
     gltf.scene.rotateX(Math.PI / 2);
 
     return gltf;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import dracoDecoderWasmUrl from "three/examples/jsm/../js/libs/draco/draco_decoder.wasm";
+import dracoWasmWrapperJs from "three/examples/jsm/../js/libs/draco/draco_wasm_wrapper.js?raw";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader";
 import type { GLTF } from "three/examples/jsm/loaders/GLTFLoader";
@@ -16,7 +18,19 @@ export class ModelCache {
 
   constructor(private loadModelOptions: LoadModelOptions) {
     const dracoLoader = new DRACOLoader();
-    dracoLoader.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
+
+    // Hack in a replacement function to load assets from the webpack bundle
+    (dracoLoader as { _loadLibrary?: (url: string, responseType: string) => unknown })[
+      "_loadLibrary"
+    ] = async function (url: string, responseType: string) {
+      if (url === "draco_wasm_wrapper.js" && responseType === "text") {
+        return dracoWasmWrapperJs;
+      } else if (url === "draco_decoder.wasm" && responseType === "arraybuffer") {
+        return await (await fetch(dracoDecoderWasmUrl)).arrayBuffer();
+      } else {
+        throw new Error(`DRACOLoader attempt to load non-bundled asset: ${url} as ${responseType}`);
+      }
+    };
     this._gltfLoader.setDRACOLoader(dracoLoader);
   }
 


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Instantiating a DRACOLoader manually is required for decoding DRACO-compressed glTF meshes.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/195374/169917857-b8e19c72-dd3f-429b-a2f8-05ea2917d2e4.png">