### PR TITLE
Remove redundant toolbar on extension panels

### DIFF
--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -43,7 +43,6 @@ export default function PanelCatalogProvider(
       const PanelWrapper = (panelProps: PanelProps) => {
         return (
           <>
-            <PanelToolbar />
             <PanelExtensionAdapter
               config={panelProps.config}
               saveConfig={panelProps.saveConfig}


### PR DESCRIPTION
**User-Facing Changes**
This fixes the issue of two toolbars being shown on extension panels

**Description**
Extension panels show two toolbars. It looks like this was always the case but was masked by the fact that they were floating on top of each other. The solution is just to remove one of the toolbars.

<img width="662" alt="Screen Shot 2022-05-24 at 9 02 54 AM" src="https://user-images.githubusercontent.com/93935560/170060521-019cd7cb-2b04-45e8-ba49-67d564833dd1.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
