### PR TITLE
Prompt for login when opening data platform urls

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -53,6 +53,7 @@ import Preferences from "@foxglove/studio-base/components/Preferences";
 import RemountOnValueChange from "@foxglove/studio-base/components/RemountOnValueChange";
 import Sidebar, { SidebarItem } from "@foxglove/studio-base/components/Sidebar";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import { SignInFormModal } from "@foxglove/studio-base/components/SignInFormModal";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { URLStateSyncAdapter } from "@foxglove/studio-base/components/URLStateSyncAdapter";
 import { useAssets } from "@foxglove/studio-base/context/AssetsContext";
@@ -74,6 +75,7 @@ import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
 import { useCalloutDismissalBlocker } from "@foxglove/studio-base/hooks/useCalloutDismissalBlocker";
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
+import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { HelpInfoStore, useHelpInfo } from "@foxglove/studio-base/providers/HelpInfoProvider";
@@ -185,13 +187,19 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
 
+  const { currentUser } = useCurrentUser();
+
+  const { currentUserRequired } = useInitialDeepLinkState(props.deepLinks ?? []);
+
   const [showOpenDialogOnStartup = true] = useAppConfigurationValue<boolean>(
     AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,
   );
 
+  const showSignInForm = currentUserRequired && currentUser == undefined;
+
   const [showOpenDialog, setShowOpenDialog] = useState<
     { view: OpenDialogViews; activeDataSource?: IDataSourceFactory } | undefined
-  >(isPlayerPresent || !showOpenDialogOnStartup ? undefined : { view: "start" });
+  >(isPlayerPresent || !showOpenDialogOnStartup || showSignInForm ? undefined : { view: "start" });
 
   const [selectedSidebarItem, setSelectedSidebarItem] = useState<SidebarItemKey | undefined>(() => {
     // When using the open dialog ui - we always start with the connection sidebar open.
@@ -478,8 +486,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     [selectedSidebarItem, supportsAccountSettings],
   );
 
-  const { currentUser } = useCurrentUser();
-
   // Since the _component_ field of a sidebar item entry is a component and accepts no additional
   // props we need to wrap our DataSourceSidebar component to connect the open data source action to
   // open the data source dialog.
@@ -556,6 +562,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         /* eslint-enable react/jsx-key */
       ]}
     >
+      {showSignInForm && <SignInFormModal />}
       {enableOpenDialog === true && showOpenDialog != undefined && (
         <OpenDialog
           activeView={showOpenDialog.view}
@@ -568,7 +575,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           <div className={classes.dropzone}>Drop a file here</div>
         </DropOverlay>
       </DocumentDropListener>
-      <URLStateSyncAdapter deepLinks={props.deepLinks ?? []} />
+      <URLStateSyncAdapter />
       <div className={classes.container} ref={containerRef} tabIndex={0}>
         <Sidebar
           items={sidebarItems}

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -74,6 +74,7 @@ import { useWorkspace, WorkspaceContext } from "@foxglove/studio-base/context/Wo
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
 import { useCalloutDismissalBlocker } from "@foxglove/studio-base/hooks/useCalloutDismissalBlocker";
+import { useDefaultWebLaunchPreference } from "@foxglove/studio-base/hooks/useDefaultWebLaunchPreference";
 import useElectronFilesToOpen from "@foxglove/studio-base/hooks/useElectronFilesToOpen";
 import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
@@ -148,6 +149,8 @@ type WorkspaceProps = {
   deepLinks?: string[];
 };
 
+const DEFAULT_DEEPLINKS = Object.freeze([]);
+
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
 const selectRequestBackfill = ({ requestBackfill }: MessagePipelineContext) => requestBackfill;
 const selectPlayerProblems = ({ playerState }: MessagePipelineContext) => playerState.problems;
@@ -189,7 +192,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const { currentUser } = useCurrentUser();
 
-  const { currentUserRequired } = useInitialDeepLinkState(props.deepLinks ?? []);
+  const { currentUserRequired } = useInitialDeepLinkState(props.deepLinks ?? DEFAULT_DEEPLINKS);
+
+  useDefaultWebLaunchPreference();
 
   const [showOpenDialogOnStartup = true] = useAppConfigurationValue<boolean>(
     AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,

--- a/packages/studio-base/src/components/SignInFormModal.tsx
+++ b/packages/studio-base/src/components/SignInFormModal.tsx
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import CloseIcon from "@mui/icons-material/Close";
+import { Dialog, IconButton } from "@mui/material";
+import { useState } from "react";
+
+import SigninForm from "@foxglove/studio-base/components/AccountSettingsSidebar/SigninForm";
+import Stack from "@foxglove/studio-base/components/Stack";
+
+export function SignInFormModal(): JSX.Element {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Dialog open={open} onClose={() => setOpen(false)}>
+      <Stack alignItems="end">
+        <IconButton onClick={() => setOpen(false)}>
+          <CloseIcon />
+        </IconButton>
+      </Stack>
+      <Stack padding={3}>
+        <SigninForm />
+      </Stack>
+    </Dialog>
+  );
+}

--- a/packages/studio-base/src/components/URLStateSyncAdapter.tsx
+++ b/packages/studio-base/src/components/URLStateSyncAdapter.tsx
@@ -2,13 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
 import { useStateToURLSynchronization } from "@foxglove/studio-base/hooks/useStateToURLSynchronization";
 
 // This is in a simple subcomponent so it doesn't trigger rerenders of an entire expensive
 // component like Workspace while it's listening for time values.
-export function URLStateSyncAdapter({ deepLinks }: { deepLinks: string[] }): ReactNull {
-  useInitialDeepLinkState(deepLinks);
+export function URLStateSyncAdapter(): ReactNull {
   useStateToURLSynchronization();
 
   return ReactNull;

--- a/packages/studio-base/src/hooks/useDefaultWebLaunchPreference.ts
+++ b/packages/studio-base/src/hooks/useDefaultWebLaunchPreference.ts
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useEffect } from "react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+const selectHasUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState != undefined;
+
+export function useDefaultWebLaunchPreference(): void {
+  const hasUrlState = useMessagePipeline(selectHasUrlState);
+  const [launchPreference, setLaunchPreference] = useSessionStorageValue(
+    AppSetting.LAUNCH_PREFERENCE,
+  );
+
+  // Set a sessionStorage preference for web if we have a stable URL state.
+  // This allows us to avoid asking for the preference immediately on
+  // launch of an empty session and makes refreshes do the right thing.
+  useEffect(() => {
+    if (isDesktopApp()) {
+      return;
+    }
+
+    if (hasUrlState && !launchPreference) {
+      setLaunchPreference("web");
+    }
+  }, [launchPreference, setLaunchPreference, hasUrlState]);
+}

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -106,7 +106,10 @@ describe("Initial deep link state", () => {
   });
 
   it("waits for a current user to select a data platform source", () => {
-    const { result, rerender } = renderHook<WrapperProps, { currentUserRequired: boolean }>(
+    const { result, rerender } = renderHook<
+      WrapperProps,
+      ReturnType<typeof useInitialDeepLinkState>
+    >(
       () =>
         useInitialDeepLinkState([
           "https://studio.foxglove.dev/?ds=foxglove-data-platform&ds.deviceId=dev&layoutId=12345",

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -3,10 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { renderHook } from "@testing-library/react-hooks";
-import { ReactNode } from "react";
+import { PropsWithChildren } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import CurrentUserContext, { User } from "@foxglove/studio-base/context/CurrentUserContext";
 import PlayerSelectionContext, {
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
@@ -16,13 +17,17 @@ import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionSt
 jest.mock("@foxglove/studio-base/hooks/useSessionStorageValue");
 jest.mock("@foxglove/studio-base/context/CurrentLayoutContext");
 
-function Wrapper({
-  children,
-  playerSelection,
-}: {
-  children?: ReactNode;
+type WrapperProps = {
+  currentUser?: User;
   playerSelection: PlayerSelection;
-}) {
+};
+
+function Wrapper({ children, currentUser, playerSelection }: PropsWithChildren<WrapperProps>) {
+  const userContextValue = {
+    currentUser,
+    signIn: () => undefined,
+    signOut: async () => undefined,
+  };
   return (
     <MockMessagePipelineProvider
       topics={[]}
@@ -32,9 +37,11 @@ function Wrapper({
       urlState={{ sourceId: "test", parameters: { url: "testurl", param: "one" } }}
       startTime={{ sec: 0, nsec: 1 }}
     >
-      <PlayerSelectionContext.Provider value={playerSelection}>
-        {children}
-      </PlayerSelectionContext.Provider>
+      <CurrentUserContext.Provider value={userContextValue}>
+        <PlayerSelectionContext.Provider value={playerSelection}>
+          {children}
+        </PlayerSelectionContext.Provider>
+      </CurrentUserContext.Provider>
     </MockMessagePipelineProvider>
   );
 }
@@ -53,6 +60,8 @@ describe("Initial deep link state", () => {
   beforeEach(() => {
     (useSessionStorageValue as jest.Mock).mockReturnValue(["web", jest.fn()]);
     (useCurrentLayoutActions as jest.Mock).mockReturnValue({ setSelectedLayoutId });
+    selectSource.mockClear();
+    setSelectedLayoutId.mockClear();
   });
 
   it("doesn't select a source without ds params", () => {
@@ -94,5 +103,41 @@ describe("Initial deep link state", () => {
       type: "connection",
     });
     expect(setSelectedLayoutId).toHaveBeenCalledWith("a288e116-d177-4b57-8f30-6ada61919638");
+  });
+
+  it("waits for a current user to select a data platform source", () => {
+    const { result, rerender } = renderHook<WrapperProps, { currentUserRequired: boolean }>(
+      () =>
+        useInitialDeepLinkState([
+          "https://studio.foxglove.dev/?ds=foxglove-data-platform&ds.deviceId=dev&layoutId=12345",
+        ]),
+      {
+        initialProps: { currentUser: undefined, playerSelection: emptyPlayerSelection },
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(result.current.currentUserRequired).toBeTruthy();
+
+    expect(selectSource).not.toHaveBeenCalled();
+
+    rerender({
+      currentUser: {
+        id: "id",
+        email: "email",
+        orgId: "org",
+        orgDisplayName: "org name",
+        orgSlug: "org",
+        orgPaid: true,
+      },
+      playerSelection: emptyPlayerSelection,
+    });
+
+    expect(selectSource).toHaveBeenCalledWith("foxglove-data-platform", {
+      params: { deviceId: "dev" },
+      type: "connection",
+    });
+
+    expect(setSelectedLayoutId).toHaveBeenCalledWith("12345");
   });
 });

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -5,7 +5,6 @@
 import { useEffect, useMemo, useState } from "react";
 
 import Log from "@foxglove/log";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -13,15 +12,11 @@ import {
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
-import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
-import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
-const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 
 const log = Log.getLogger(__filename);
 
@@ -31,12 +26,9 @@ const log = Log.getLogger(__filename);
 export function useInitialDeepLinkState(deepLinks: readonly string[]): {
   currentUserRequired: boolean;
 } {
-  const stableUrlState = useDeepMemo(useMessagePipeline(selectUrlState));
   const { selectSource } = usePlayerSelection();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
-  const [launchPreference, setLaunchPreference] = useSessionStorageValue(
-    AppSetting.LAUNCH_PREFERENCE,
-  );
+
   const seekPlayback = useMessagePipeline(selectSeek);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const { currentUser } = useCurrentUser();
@@ -54,19 +46,6 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
   const [unappliedUrlState, setUnappliedUrlState] = useState(
     targetUrlState ? { ...targetUrlState } : undefined,
   );
-
-  // Set a sessionStorage preference for web if we have a stable URL state.
-  // This allows us to avoid asking for the preference immediately on
-  // launch of an empty session and makes refreshes do the right thing.
-  useEffect(() => {
-    if (isDesktopApp()) {
-      return;
-    }
-
-    if (stableUrlState && !launchPreference) {
-      setLaunchPreference("web");
-    }
-  }, [launchPreference, setLaunchPreference, stableUrlState]);
 
   // Load data source from URL.
   useEffect(() => {
@@ -96,15 +75,9 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
       return;
     }
 
-    // Wait for current user session if one is required for this source.
-    if (currentUserRequired && !currentUser) {
-      return;
-    }
-
-    // If we have a target DS then wait until the player has loaded until
-    // we try to select the layout. This also handles the case where the
-    // data source requires a logged in user since the player won't start
-    // until we have a current user.
+    // If we have a target datasource then wait until the player has loaded to select the layout.
+    // This also handles the case where the datasource requires a logged in user
+    // since the player won't start until we have a current user.
     if (targetUrlState?.ds && playerPresence !== PlayerPresence.PRESENT) {
       return;
     }
@@ -114,14 +87,7 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
       setSelectedLayoutId(unappliedUrlState.layoutId);
       setUnappliedUrlState((oldState) => ({ ...oldState, layoutId: undefined }));
     }
-  }, [
-    currentUser,
-    currentUserRequired,
-    playerPresence,
-    setSelectedLayoutId,
-    targetUrlState,
-    unappliedUrlState,
-  ]);
+  }, [playerPresence, setSelectedLayoutId, targetUrlState, unappliedUrlState]);
 
   // Seek to time in URL.
   useEffect(() => {

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import Log from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -11,11 +11,12 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import useDeepMemo from "@foxglove/studio-base/hooks/useDeepMemo";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import { AppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
@@ -27,7 +28,9 @@ const log = Log.getLogger(__filename);
 /**
  * Restores our session state from any deep link we were passed on startup.
  */
-export function useInitialDeepLinkState(deepLinks: string[]): void {
+export function useInitialDeepLinkState(deepLinks: readonly string[]): {
+  currentUserRequired: boolean;
+} {
   const stableUrlState = useDeepMemo(useMessagePipeline(selectUrlState));
   const { selectSource } = usePlayerSelection();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
@@ -36,20 +39,21 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
   );
   const seekPlayback = useMessagePipeline(selectSeek);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
+  const { currentUser } = useCurrentUser();
 
-  const appUrlRef = useRef<AppURLState | undefined>();
-  if (!appUrlRef.current) {
-    const firstLink = deepLinks[0];
-    if (firstLink) {
-      try {
-        appUrlRef.current = parseAppURLState(new URL(firstLink));
-      } catch (error) {
-        log.error(error);
-      }
-    }
-  }
+  const targetUrlState = useMemo(
+    () => (deepLinks[0] ? parseAppURLState(new URL(deepLinks[0])) : undefined),
+    [deepLinks],
+  );
 
-  const shouldSeekTimeRef = useRef(false);
+  // Maybe this should be abstracted somewhere but that would require a
+  // more intimate interface with this hook and the player selection logic.
+  const currentUserRequired = targetUrlState?.ds === "foxglove-data-platform";
+
+  // Tracks what portions of the URL state we have yet to apply to the current session.
+  const [unappliedUrlState, setUnappliedUrlState] = useState(
+    targetUrlState ? { ...targetUrlState } : undefined,
+  );
 
   // Set a sessionStorage preference for web if we have a stable URL state.
   // This allows us to avoid asking for the preference immediately on
@@ -64,50 +68,76 @@ export function useInitialDeepLinkState(deepLinks: string[]): void {
     }
   }, [launchPreference, setLaunchPreference, stableUrlState]);
 
+  // Load data source from URL.
   useEffect(() => {
-    const urlState = appUrlRef.current;
-    if (!urlState) {
+    if (!unappliedUrlState) {
+      return;
+    }
+
+    // Wait for current user session if one is required for this source.
+    if (currentUserRequired && !currentUser) {
       return;
     }
 
     // Apply any available datasource args
-    if (urlState.ds) {
-      log.debug("Initialising source from url", urlState);
-      selectSource(urlState.ds, { type: "connection", params: urlState.dsParams });
-      urlState.ds = undefined;
-      urlState.dsParams = undefined;
-      shouldSeekTimeRef.current = true;
+    if (unappliedUrlState.ds) {
+      log.debug("Initialising source from url", unappliedUrlState);
+      selectSource(unappliedUrlState.ds, {
+        type: "connection",
+        params: unappliedUrlState.dsParams,
+      });
+      setUnappliedUrlState((oldState) => ({ ...oldState, ds: undefined, dsParams: undefined }));
     }
+  }, [currentUser, currentUserRequired, selectSource, unappliedUrlState]);
 
-    // Apply any available layout id
-    if (urlState.layoutId != undefined) {
-      log.debug(`Initializing layout from url: ${urlState.layoutId}`);
-      setSelectedLayoutId(urlState.layoutId);
-      urlState.layoutId = undefined;
-    }
-  }, [selectSource, setSelectedLayoutId]);
-
+  // Select layout from URL.
   useEffect(() => {
+    if (!unappliedUrlState) {
+      return;
+    }
+
+    // Wait for current user session if one is required for this source.
+    if (currentUserRequired && !currentUser) {
+      return;
+    }
+
+    // If we have a target DS then wait until the player has loaded until
+    // we try to select the layout. This also handles the case where the
+    // data source requires a logged in user since the player won't start
+    // until we have a current user.
+    if (targetUrlState?.ds && playerPresence !== PlayerPresence.PRESENT) {
+      return;
+    }
+
+    if (unappliedUrlState.layoutId != undefined) {
+      log.debug(`Initializing layout from url: ${unappliedUrlState.layoutId}`);
+      setSelectedLayoutId(unappliedUrlState.layoutId);
+      setUnappliedUrlState((oldState) => ({ ...oldState, layoutId: undefined }));
+    }
+  }, [
+    currentUser,
+    currentUserRequired,
+    playerPresence,
+    setSelectedLayoutId,
+    targetUrlState,
+    unappliedUrlState,
+  ]);
+
+  // Seek to time in URL.
+  useEffect(() => {
+    if (unappliedUrlState?.time == undefined || !seekPlayback) {
+      return;
+    }
+
     // Wait until player is ready before we try to seek.
     if (playerPresence !== PlayerPresence.PRESENT) {
       return;
     }
 
-    const urlState = appUrlRef.current;
-    if (urlState?.time == undefined || !seekPlayback) {
-      return;
-    }
+    log.debug(`Seeking to url time:`, unappliedUrlState.time);
+    seekPlayback(unappliedUrlState.time);
+    setUnappliedUrlState((oldState) => ({ ...oldState, time: undefined }));
+  }, [playerPresence, seekPlayback, unappliedUrlState]);
 
-    if (!shouldSeekTimeRef.current) {
-      log.debug("Clearing urlState time");
-      urlState.time = undefined;
-      return;
-    }
-
-    shouldSeekTimeRef.current = false;
-
-    log.debug(`Seeking to url time:`, urlState.time);
-    seekPlayback(urlState.time);
-    urlState.time = undefined;
-  }, [playerPresence, seekPlayback]);
+  return useMemo(() => ({ currentUserRequired }), [currentUserRequired]);
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This prompts the user to sign in and then continues to open the URL if the user tries to open a data platform URL before signing in to studio. This touches on some complex and fragile aspects of the studio session startup process and is a bit of a bandaid solution given that the state we're concerned with here spans several independent React contexts each with their own async transitions and error states.

The approach here depends on the following points:
1. `Workspace` now accesses the `useInitialDeepLinkState` hook directly, which now returns a value indicating that a user session is required for the datasource in the URL.
2. If the datasource requires a user session and the user isn't logged in, `Workspace` will present a sign in modal to the user.
3. The `useInitialDeepLinkState` now tracks the various pieces of URL state to apply more explicitly and in separate `useEffect` instances, in the case of the datasource waiting for a user session to try to select it.
4. The web vs desktop launch preference default has been separated into a separate, unrelated hook to reduce the complexity of `useInitialDeepLinkState`.

I suspect at some point we're going to have to commit to a larger refactor of our session bootstrapping code, including user sessions, layout syncing, datasource loading and timestamp seeking but this PR should address the immediate issue of guiding users to sign in upon opening a datasource URL.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3411