### PR TITLE
Fix plot panel y axis min/max settings

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -539,8 +539,8 @@ function Plot(props: Props) {
 const defaultConfig: PlotConfig = {
   title: undefined,
   paths: [{ value: "", enabled: true, timestampMethod: "receiveTime" }],
-  minYValue: "",
-  maxYValue: "",
+  minYValue: undefined,
+  maxYValue: undefined,
   showXAxisLabels: true,
   showYAxisLabels: true,
   showLegend: true,

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -42,13 +42,13 @@ export function buildSettingsTree(config: PlotConfig): SettingsTreeRoots {
         minYValue: {
           label: "Y min",
           input: "number",
-          value: Number(config.minYValue),
+          value: config.minYValue != undefined ? Number(config.minYValue) : undefined,
           placeholder: "auto",
         },
         maxYValue: {
           label: "Y max",
           input: "number",
-          value: Number(config.maxYValue),
+          value: config.maxYValue != undefined ? Number(config.maxYValue) : undefined,
           placeholder: "auto",
         },
       },


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the y axis min/max settings values

**Description**
This makes two changes:
1. It defaults the `minYValue` & `maxYValue` config values for plots to undefined instead of the empty string.
2. It passes the undefined value through to the settings editor instead of forcing it through the `Number` constructor.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3437 