### PR TITLE
[New3D] Show additional per-transform info in the sidebar

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -416,6 +416,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         for (const tf of tfMessage.transforms) {
           renderer.addTransformMessage(tf);
         }
+        renderer.emit("settingsTreeChange", { path: ["transforms"] });
       } else if (TRANSFORM_STAMPED_DATATYPES.has(datatype)) {
         // geometry_msgs/TransformStamped - Ingest this single transform into our TF tree
         const tf = message.message as TF;

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -122,10 +122,6 @@ mergeSetInto(SUPPORTED_DATATYPES, CAMERA_INFO_DATATYPES);
 
 const ONE_DEGREE = Math.PI / 180;
 
-// This is the unused topic parameter passed to the SettingsNodeProvider for
-// LayerType.Transform, since transforms do not map 1:1 to topics
-const EMPTY_TOPIC = { name: "", datatype: "" };
-
 export type SettingsTreeOptions = {
   config: ThreeDeeRenderConfig;
   coordinateFrames: ReadonlyArray<SelectEntry>;
@@ -141,7 +137,7 @@ function buildTransformNode(
   settingsNodeProvider: SettingsNodeProvider,
 ): undefined | SettingsTreeNode {
   const tfConfig = typeof tfConfigOrFrameId === "string" ? {} : tfConfigOrFrameId;
-  const node = settingsNodeProvider(tfConfig, EMPTY_TOPIC);
+  const node = settingsNodeProvider(tfConfig, { name: frameId, datatype: "" });
   node.label ??= frameId;
   node.visible ??= tfConfig.visible ?? true;
   node.defaultExpansionState ??= "collapsed";


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Each coordinate frame in the sidebar now has a list of fields under it that give information such as its parent frame, age of the most recent TF, and XYZRPY. This makes it more obvious that you are actually viewing transforms and not just a list of coordinate frames.

**TODO**

- [ ] Make the fields read-only labels, not user inputs

https://user-images.githubusercontent.com/195374/170101566-6a5870f6-18dd-4e1f-bcf6-e92447bd03d6.mov