### PR TITLE
Add option to include settings in storybook panel stories

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -346,6 +346,7 @@ const exampleConfig: PlotConfig = {
 
 function PlotWrapper(props: {
   style?: { [key: string]: string | number };
+  includeSettings?: boolean;
   fixture?: Fixture;
   pauseFrame: (_arg: string) => () => void;
   config: PlotConfig;
@@ -354,6 +355,7 @@ function PlotWrapper(props: {
     <PanelSetup
       fixture={props.fixture ?? fixture}
       pauseFrame={props.pauseFrame}
+      includeSettings={props.includeSettings}
       style={{ ...props.style }}
     >
       <Plot overrideConfig={props.config} />
@@ -376,6 +378,16 @@ export function LineGraph(): JSX.Element {
   return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} />;
 }
 LineGraph.parameters = {
+  useReadySignal: true,
+};
+
+LineGraphWithSettings.storyName = "line graph with settings";
+export function LineGraphWithSettings(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  return <PlotWrapper pauseFrame={pauseFrame} config={exampleConfig} includeSettings />;
+}
+LineGraphWithSettings.parameters = {
   useReadySignal: true,
 };
 

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -65,6 +65,17 @@ storiesOf("panels/RawMessages", module)
       </PanelSetup>
     );
   })
+  .add("expanded with settings", () => {
+    return (
+      <PanelSetup fixture={fixture} includeSettings>
+        <RawMessages
+          overrideConfig={
+            { topicPath: "/msgs/big_topic", ...noDiffConfig, autoExpandMode: "all" } as any
+          }
+        />
+      </PanelSetup>
+    );
+  })
   .add("auto expanded", () => {
     return (
       <PanelSetup fixture={fixture}>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Since the sidebar settings are now an important part of the UI of some panels it makes sense to have some way of including them in storybook stories.

This adds a new `includeSettings` option to the `PanelSetup` component that renders the panel settings editor alongside the panel in the story.

<img width="768" alt="Screen Shot 2022-05-24 at 1 19 49 PM" src="https://user-images.githubusercontent.com/93935560/170105219-0f1b13d3-5377-42f3-b623-efa816faa7ed.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
