### PR TITLE
Animate panels' transitions into/out of fullscreen

### DIFF
--- a/packages/studio-base/src/components/MockPanelContextProvider.tsx
+++ b/packages/studio-base/src/components/MockPanelContextProvider.tsx
@@ -21,21 +21,12 @@ const DEFAULT_MOCK_PANEL_CONTEXT: PanelContextType<PanelConfig> = {
   id: "bar",
   title: "Foo Panel",
   config: {},
-  saveConfig: () => {
-    // no-op
-  },
-  updatePanelConfigs: () => {
-    // no-op
-  },
-  openSiblingPanel: () => {
-    // no-op
-  },
-  enterFullscreen: () => {
-    // no-op
-  },
-  exitFullscreen: () => {
-    // no-op
-  },
+  saveConfig: () => {},
+  updatePanelConfigs: () => {},
+  openSiblingPanel: () => {},
+  enterFullscreen: () => {},
+  exitFullscreen: () => {},
+  setHasFullscreenDescendant: () => {},
   isFullscreen: false,
   connectToolbarDragHandle: () => {},
 };

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -39,6 +39,7 @@ import {
   updateTree,
   MosaicNode,
 } from "react-mosaic-component";
+import { Transition } from "react-transition-group";
 import { useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
@@ -48,7 +49,10 @@ import Icon from "@foxglove/studio-base/components/Icon";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelErrorBoundary from "@foxglove/studio-base/components/PanelErrorBoundary";
-import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
+import {
+  FULLSCREEN_TRANSITION_DURATION_MS,
+  PanelRoot,
+} from "@foxglove/studio-base/components/PanelRoot";
 import {
   useCurrentLayoutActions,
   useSelectedPanels,
@@ -243,12 +247,13 @@ export default function Panel<
     const [quickActionsKeyPressed, setQuickActionsKeyPressed] = useState(false);
     const [shiftKeyPressed, setShiftKeyPressed] = useState(false);
     const [cmdKeyPressed, setCmdKeyPressed] = useState(false);
-    const [fullScreen, setFullscreen] = useState(false);
+    const [fullscreen, setFullscreen] = useState(false);
+    const [fullscreenSourceRect, setFullscreenSourceRect] = useState<DOMRect | undefined>(
+      undefined,
+    );
+    const panelRootRef = useRef<HTMLDivElement>(ReactNull);
     const panelCatalog = usePanelCatalog();
     const isTopLevelPanel = mosaicWindowActions.getPath().length === 0 && tabId == undefined;
-
-    // There may be a parent panel (when a panel is in a tab).
-    const parentPanelContext = useContext(PanelContext);
 
     const type = PanelComponent.panelType;
     const title = useMemo(
@@ -477,18 +482,15 @@ export default function Panel<
           }
         }) as MouseEventHandler<HTMLDivElement>,
         enterFullscreen: () => {
+          setFullscreenSourceRect(panelRootRef.current?.getBoundingClientRect());
           setFullscreen(true);
-
-          // When entering fullscreen for a panel within a tab we need to put the tab into fullscreen mode
-          // to have our panel properly overlay other panels outside the tab.
-          parentPanelContext?.enterFullscreen();
         },
         exitFullscreen: () => {
+          // don't clear fullscreenSourceRect, it is needed for the exit transition
           setFullscreen(false);
-          parentPanelContext?.exitFullscreen();
         },
       }),
-      [cmdKeyPressed, parentPanelContext],
+      [cmdKeyPressed],
     );
 
     // We use two separate sets of key handlers because the panel context and exitFullScreen
@@ -594,73 +596,83 @@ export default function Panel<
             openSiblingPanel,
             enterFullscreen,
             exitFullscreen,
-            isFullscreen: fullScreen,
+            isFullscreen: fullscreen,
             tabId,
             // disallow dragging the root panel in a layout
             connectToolbarDragHandle: isTopLevelPanel ? undefined : connectToolbarDragHandle,
           }}
         >
           <KeyListener global keyUpHandlers={keyUpHandlers} keyDownHandlers={keyDownHandlers} />
-          <KeyListener global keyDownHandlers={fullScreenKeyHandlers} />
-          <PanelRoot
-            onClick={onPanelRootClick}
-            onMouseMove={onMouseMove}
-            fullscreen={fullScreen}
-            selected={isSelected}
-            data-test={`panel-mouseenter-container ${childId ?? ""}`}
-            ref={(el) => {
-              // disallow dragging the root panel in a layout
-              if (!isTopLevelPanel) {
-                connectOverlayDragPreview(el);
-                connectToolbarDragPreview(el);
-              }
-            }}
+          {fullscreen && <KeyListener global keyDownHandlers={fullScreenKeyHandlers} />}
+          <Transition
+            in={fullscreen}
+            timeout={{ exit: FULLSCREEN_TRANSITION_DURATION_MS }}
+            nodeRef={panelRootRef}
           >
-            {isSelected && !fullScreen && numSelectedPanelsIfSelected > 1 && (
-              <ActionsOverlay>
-                <Button className={classes.tabActionsOverlayButton} onClick={groupPanels}>
-                  <Icon size="small" style={{ marginBottom: 5 }}>
-                    <BorderAllIcon />
-                  </Icon>
-                  Group in tab
-                </Button>
-                <Button className={classes.tabActionsOverlayButton} onClick={createTabs}>
-                  <Icon size="small" style={{ marginBottom: 5 }}>
-                    <ExpandAllOutlineIcon />
-                  </Icon>
-                  Create {numSelectedPanelsIfSelected} tabs
-                </Button>
-              </ActionsOverlay>
-            )}
-            {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullScreen && (
-              <ActionsOverlay
+            {(fullscreenState) => (
+              <PanelRoot
+                onClick={onPanelRootClick}
+                onMouseMove={onMouseMove}
+                fullscreenState={fullscreenState}
+                sourceRect={fullscreenSourceRect}
+                selected={isSelected}
+                data-test={`panel-mouseenter-container ${childId ?? ""}`}
                 ref={(el) => {
-                  quickActionsOverlayRef.current = el;
+                  panelRootRef.current = el;
                   // disallow dragging the root panel in a layout
                   if (!isTopLevelPanel) {
-                    connectOverlayDragSource(el);
+                    connectOverlayDragPreview(el);
+                    connectToolbarDragPreview(el);
                   }
                 }}
               >
-                <div>
-                  <Button className={classes.quickActionsOverlayButton} onClick={removePanel}>
-                    <TrashCanOutlineIcon />
-                    Remove
-                  </Button>
-                  <Button className={classes.quickActionsOverlayButton} onClick={splitPanel}>
-                    <GridLargeIcon />
-                    Split
-                  </Button>
-                </div>
-              </ActionsOverlay>
+                {isSelected && !fullscreen && numSelectedPanelsIfSelected > 1 && (
+                  <ActionsOverlay>
+                    <Button className={classes.tabActionsOverlayButton} onClick={groupPanels}>
+                      <Icon size="small" style={{ marginBottom: 5 }}>
+                        <BorderAllIcon />
+                      </Icon>
+                      Group in tab
+                    </Button>
+                    <Button className={classes.tabActionsOverlayButton} onClick={createTabs}>
+                      <Icon size="small" style={{ marginBottom: 5 }}>
+                        <ExpandAllOutlineIcon />
+                      </Icon>
+                      Create {numSelectedPanelsIfSelected} tabs
+                    </Button>
+                  </ActionsOverlay>
+                )}
+                {type !== TAB_PANEL_TYPE && quickActionsKeyPressed && !fullscreen && (
+                  <ActionsOverlay
+                    ref={(el) => {
+                      quickActionsOverlayRef.current = el;
+                      // disallow dragging the root panel in a layout
+                      if (!isTopLevelPanel) {
+                        connectOverlayDragSource(el);
+                      }
+                    }}
+                  >
+                    <div>
+                      <Button className={classes.quickActionsOverlayButton} onClick={removePanel}>
+                        <TrashCanOutlineIcon />
+                        Remove
+                      </Button>
+                      <Button className={classes.quickActionsOverlayButton} onClick={splitPanel}>
+                        <GridLargeIcon />
+                        Split
+                      </Button>
+                    </div>
+                  </ActionsOverlay>
+                )}
+                <PanelErrorBoundary onRemovePanel={removePanel} onResetPanel={resetPanel}>
+                  <React.StrictMode>{child}</React.StrictMode>
+                </PanelErrorBoundary>
+                {process.env.NODE_ENV !== "production" && (
+                  <div className={classes.perfInfo} ref={perfInfo} />
+                )}
+              </PanelRoot>
             )}
-            <PanelErrorBoundary onRemovePanel={removePanel} onResetPanel={resetPanel}>
-              <React.StrictMode>{child}</React.StrictMode>
-            </PanelErrorBoundary>
-            {process.env.NODE_ENV !== "production" && (
-              <div className={classes.perfInfo} ref={perfInfo} />
-            )}
-          </PanelRoot>
+          </Transition>
         </PanelContext.Provider>
       </Profiler>
     );

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -251,9 +251,13 @@ export default function Panel<
     const [fullscreenSourceRect, setFullscreenSourceRect] = useState<DOMRect | undefined>(
       undefined,
     );
+    const [hasFullscreenDescendant, _setHasFullscreenDescendant] = useState(false);
     const panelRootRef = useRef<HTMLDivElement>(ReactNull);
     const panelCatalog = usePanelCatalog();
     const isTopLevelPanel = mosaicWindowActions.getPath().length === 0 && tabId == undefined;
+
+    // There may be a parent panel (when a panel is in a tab).
+    const parentPanelContext = useContext(PanelContext);
 
     const type = PanelComponent.panelType;
     const title = useMemo(
@@ -484,13 +488,26 @@ export default function Panel<
         enterFullscreen: () => {
           setFullscreenSourceRect(panelRootRef.current?.getBoundingClientRect());
           setFullscreen(true);
+
+          // When entering fullscreen for a panel within a tab, we need to adjust the ancestor
+          // tab(s)'s z-index to have our panel properly overlay other panels outside the tab.
+          parentPanelContext?.setHasFullscreenDescendant(true);
         },
         exitFullscreen: () => {
-          // don't clear fullscreenSourceRect, it is needed for the exit transition
+          // Don't clear fullscreenSourceRect or hasFullscreenDescendant, they are needed during the exit transition
           setFullscreen(false);
         },
       }),
-      [cmdKeyPressed],
+      [cmdKeyPressed, parentPanelContext],
+    );
+
+    const setHasFullscreenDescendant = useCallback(
+      // eslint-disable-next-line @foxglove/no-boolean-parameters
+      (value: boolean) => {
+        _setHasFullscreenDescendant(value);
+        parentPanelContext?.setHasFullscreenDescendant(value);
+      },
+      [parentPanelContext],
     );
 
     // We use two separate sets of key handlers because the panel context and exitFullScreen
@@ -596,6 +613,7 @@ export default function Panel<
             openSiblingPanel,
             enterFullscreen,
             exitFullscreen,
+            setHasFullscreenDescendant,
             isFullscreen: fullscreen,
             tabId,
             // disallow dragging the root panel in a layout
@@ -607,12 +625,14 @@ export default function Panel<
           <Transition
             in={fullscreen}
             timeout={{ exit: FULLSCREEN_TRANSITION_DURATION_MS }}
+            onExited={() => setHasFullscreenDescendant(false)}
             nodeRef={panelRootRef}
           >
             {(fullscreenState) => (
               <PanelRoot
                 onClick={onPanelRootClick}
                 onMouseMove={onMouseMove}
+                hasFullscreenDescendant={hasFullscreenDescendant}
                 fullscreenState={fullscreenState}
                 sourceRect={fullscreenSourceRect}
                 selected={isSelected}

--- a/packages/studio-base/src/components/PanelContext.ts
+++ b/packages/studio-base/src/components/PanelContext.ts
@@ -29,6 +29,10 @@ export type PanelContextType<T> = {
   exitFullscreen: () => void;
   isFullscreen: boolean;
 
+  /** Used to adjust z-index settings on parent panels when children are fullscreen */
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setHasFullscreenDescendant: (hasFullscreenDescendant: boolean) => void;
+
   connectToolbarDragHandle?: (el: Element | ReactNull) => void;
 };
 

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -2,24 +2,77 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import styled from "styled-components";
+import { TransitionStatus } from "react-transition-group";
+import styled, { css } from "styled-components";
 
 import { spacing } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+export const FULLSCREEN_TRANSITION_DURATION_MS = 250;
+
 // This is in a separate file to prevent circular import issues.
-export const PanelRoot = styled.div<{ fullscreen: boolean; selected: boolean }>`
+export const PanelRoot = styled.div<{
+  fullscreenState: TransitionStatus;
+  selected: boolean;
+  sourceRect: DOMRectReadOnly | undefined;
+}>`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   overflow: hidden;
-  z-index: ${({ fullscreen }) => (fullscreen ? 10000 : 1)};
   background-color: ${({ theme }) => theme.semanticColors.bodyBackground};
-  position: ${({ fullscreen }) => (fullscreen ? "fixed" : "relative")};
-  border: ${({ fullscreen }) => (fullscreen ? "4px solid rgba(110, 81, 238, 0.3)" : "none")};
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: ${({ fullscreen }) => (fullscreen ? spacing.PLAYBACK_CONTROL_HEIGHT : 0)};
+  border: 0px solid rgba(110, 81, 238, 0.3);
+  transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
+
+  ${({ fullscreenState, sourceRect }) => {
+    switch (fullscreenState) {
+      case "entering":
+        return css`
+          position: fixed;
+          top: ${sourceRect?.top ?? 0}px;
+          left: ${sourceRect?.left ?? 0}px;
+          right: ${sourceRect ? window.innerWidth - sourceRect.right : 0}px;
+          bottom: ${sourceRect ? window.innerHeight - sourceRect.bottom : 0}px;
+          z-index: 10000;
+        `;
+      case "entered":
+        return css`
+          transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            top ${FULLSCREEN_TRANSITION_DURATION_MS}ms, left ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            right ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            bottom ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
+          border-width: 4px;
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: ${spacing.PLAYBACK_CONTROL_HEIGHT};
+          z-index: 10000;
+        `;
+      case "exiting":
+        return css`
+          transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            top ${FULLSCREEN_TRANSITION_DURATION_MS}ms, left ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            right ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
+            bottom ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
+          position: fixed;
+          top: ${sourceRect?.top ?? 0}px;
+          left: ${sourceRect?.left ?? 0}px;
+          right: ${sourceRect ? window.innerWidth - sourceRect.right : 0}px;
+          bottom: ${sourceRect ? window.innerHeight - sourceRect.bottom : 0}px;
+          z-index: 10000;
+        `;
+      case "exited":
+        return css`
+          position: relative;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        `;
+      case "unmounted":
+        return css``;
+    }
+  }}
 
   :after {
     content: "";

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -7,13 +7,14 @@ import styled, { css } from "styled-components";
 
 import { spacing } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-export const FULLSCREEN_TRANSITION_DURATION_MS = 250;
+export const FULLSCREEN_TRANSITION_DURATION_MS = 200;
 
 // This is in a separate file to prevent circular import issues.
 export const PanelRoot = styled.div<{
   fullscreenState: TransitionStatus;
   selected: boolean;
   sourceRect: DOMRectReadOnly | undefined;
+  hasFullscreenDescendant: boolean;
 }>`
   display: flex;
   flex-direction: column;
@@ -23,7 +24,7 @@ export const PanelRoot = styled.div<{
   border: 0px solid rgba(110, 81, 238, 0.3);
   transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
 
-  ${({ fullscreenState, sourceRect }) => {
+  ${({ fullscreenState, sourceRect, hasFullscreenDescendant }) => {
     switch (fullscreenState) {
       case "entering":
         return css`
@@ -68,6 +69,11 @@ export const PanelRoot = styled.div<{
           left: 0;
           right: 0;
           bottom: 0;
+          // "z-index: 1" makes panel drag & drop work more reliably (see
+          // https://github.com/foxglove/studio/pull/3355), but it also makes fullscreen panels get
+          // overlapped by other parts of the panel layout. So we turn it back to auto when a
+          // descendant is fullscreen.
+          z-index: ${hasFullscreenDescendant ? "auto" : 1};
         `;
       case "unmounted":
         return css``;


### PR DESCRIPTION
**User-Facing Changes**
Added animation effect when panels enter or exit fullscreen mode.

**Description**
Uses [`<Transition>`](https://reactcommunity.org/react-transition-group/transition) to manage enter/exit transition states.

Was able to remove the need for making ancestor panels fullscreen at the same time (added in https://github.com/foxglove/studio/pull/2276) by removing the `z-index: 1` when not in fullscreen mode.


https://user-images.githubusercontent.com/14237/170348201-4387f9ce-6ce5-4c9f-b867-5c4029cac805.mov
