### PR TITLE
Clear topic subscription errors when new messages are received

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -393,9 +393,11 @@ export default class Ros1Player implements Player {
         const newDatatypes = this._getRosDatatypes(datatype, msgdef);
         this._providerDatatypes = new Map([...this._providerDatatypes, ...newDatatypes]);
       });
-      subscription.on("message", (message, data, _pub) =>
-        this._handleMessage(topicName, message, data.byteLength, true),
-      );
+      subscription.on("message", (message, data, _pub) => {
+        this._handleMessage(topicName, message, data.byteLength, true);
+        // Clear any existing subscription problems for this topic if we're receiving messages again.
+        this._clearProblem(`subscribe:${topicName}`, { skipEmit: true });
+      });
       subscription.on("error", (error) => {
         this._addProblem(`subscribe:${topicName}`, {
           severity: "warn",

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -440,9 +440,11 @@ export default class Ros2Player implements Player {
         msgDefinition,
       });
 
-      subscription.on("message", (timestamp, message, data, _pub) =>
-        this._handleMessage(topicName, timestamp, message, data.byteLength, true),
-      );
+      subscription.on("message", (timestamp, message, data, _pub) => {
+        this._handleMessage(topicName, timestamp, message, data.byteLength, true);
+        // Clear any existing subscription problems for this topic if we're receiving messages again.
+        this._problems.removeProblem(`subscription:${topicName}`);
+      });
       subscription.on("error", (err) => {
         log.error(`Subscription error for ${topicName}: ${err}`);
         this._problems.addProblem(`subscription:${topicName}`, {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Currently once we encounter a subscription error on a topic on a ROS connection we display a player error but we don't clear this error once the subscription to that topic is working again. The solution here is to clear the error once we successfully receive a message on that topic again.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3293 