### PR TITLE
Fix incorrect error messages for MCAP message decoding failures

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -138,7 +138,8 @@ export class McapIndexedIterableSource implements IIterableSource {
         yield {
           connectionId: undefined,
           problem: {
-            message: `Received message on channel ${message.channelId} without prior channel info`,
+            message: `Error decoding message on ${channelInfo.channel.topic}`,
+            error,
             severity: "error",
           },
           msgEvent: undefined,

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
@@ -140,7 +140,8 @@ export default class Mcap0IndexedDataProvider implements RandomAccessDataProvide
       } catch (error) {
         if (!this.reportedChannelsWithInvalidMessages.has(message.channelId)) {
           (problems ??= []).push({
-            message: `Received message on channel ${message.channelId} without prior channel info`,
+            message: `Error decoding message on ${channelInfo.channel.topic}`,
+            error,
             severity: "error",
           });
           this.reportedChannelsWithInvalidMessages.add(message.channelId);


### PR DESCRIPTION
**User-Facing Changes**
Fixed an incorrect error message when an MCAP file contains messages that can't be decoded.
