### PR TITLE
Extension sidebar cleanup

### DIFF
--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -3,7 +3,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
-import { IconButton, Button, Link, Tab, Tabs, Typography, Divider } from "@mui/material";
+import {
+  IconButton,
+  Button,
+  Link,
+  Tab,
+  Tabs,
+  Typography,
+  Divider,
+  styled as muiStyled,
+} from "@mui/material";
 import { useCallback, useState } from "react";
 import { useToasts } from "react-toast-notifications";
 import { useAsync, useMountedState } from "react-use";
@@ -24,6 +33,8 @@ type Props = {
   extension: ExtensionMarketplaceDetail;
   onClose: () => void;
 };
+
+const StyledButton = muiStyled(Button)({ minWidth: 100 });
 
 export function ExtensionDetails({ extension, onClose, installed }: Props): React.ReactElement {
   const [isInstalled, setIsInstalled] = useState<boolean>(installed);
@@ -106,7 +117,7 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
           </Typography>
         </Stack>
         {isInstalled ? (
-          <Button
+          <StyledButton
             size="small"
             key="uninstall"
             color="inherit"
@@ -114,19 +125,18 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
             onClick={uninstall}
           >
             Uninstall
-          </Button>
+          </StyledButton>
         ) : (
           canInstall && (
-            <Button
+            <StyledButton
               size="small"
               key="install"
               color="inherit"
               variant="contained"
               onClick={install}
-              style={{ minWidth: "100px" }}
             >
               Install
-            </Button>
+            </StyledButton>
           )
         )}
       </Stack>

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -2,14 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { IconButton, Link, Pivot, PivotItem } from "@fluentui/react";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import { IconButton, Button, Link, Tab, Tabs, Typography, Divider } from "@mui/material";
 import { useCallback, useState } from "react";
 import { useToasts } from "react-toast-notifications";
 import { useAsync, useMountedState } from "react-use";
-import styled from "styled-components";
 
-import Button from "@foxglove/studio-base/components/Button";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import Stack from "@foxglove/studio-base/components/Stack";
 import TextContent from "@foxglove/studio-base/components/TextContent";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
@@ -25,31 +25,9 @@ type Props = {
   onClose: () => void;
 };
 
-const Publisher = styled.div`
-  color: #e2dce9;
-  margin-top: 8px;
-  margin-bottom: 16px;
-`;
-
-const Version = styled.span`
-  color: #7a777d;
-  font-size: 80%;
-  margin-left: 8px;
-`;
-
-const License = styled.span`
-  color: #7a777d;
-  font-size: 80%;
-  margin-left: 8px;
-`;
-
-const Description = styled.div`
-  margin-top: 16px;
-  margin-bottom: 16px;
-`;
-
 export function ExtensionDetails({ extension, onClose, installed }: Props): React.ReactElement {
-  const [isInstalled, setIsInstalled] = useState(installed);
+  const [isInstalled, setIsInstalled] = useState<boolean>(installed);
+  const [activeTab, setActiveTab] = useState<number>(0);
   const isMounted = useMountedState();
   const extensionLoader = useExtensionLoader();
   const marketplace = useExtensionMarketplace();
@@ -101,43 +79,74 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
       title={extension.name}
       leadingItems={[
         // eslint-disable-next-line react/jsx-key
-        <IconButton iconProps={{ iconName: "ChevronLeft" }} onClick={onClose} />,
+        <IconButton onClick={onClose} color="primary" edge="start">
+          <ChevronLeftIcon />
+        </IconButton>,
       ]}
     >
-      <Link href={extension.homepage}>{extension.id}</Link>
-      <Version>{`v${extension.version}`}</Version>
-      <License>{extension.license}</License>
-      <Publisher>{extension.publisher}</Publisher>
-      <Description>{extension.description}</Description>
-      {isInstalled ? (
-        <UninstallButton onClick={uninstall} />
-      ) : canInstall ? (
-        <InstallButton onClick={install} />
-      ) : undefined}
-      <Pivot style={{ marginTop: "16px" }}>
-        <PivotItem headerText="README">
-          <TextContent>{readmeContent}</TextContent>
-        </PivotItem>
-        <PivotItem headerText="CHANGELOG">
-          <TextContent>{changelogContent}</TextContent>
-        </PivotItem>
-      </Pivot>
+      <Stack gap={1} alignItems="flex-start">
+        <Stack gap={0.5} paddingBottom={1}>
+          <Stack direction="row" gap={1} alignItems="baseline">
+            <Link variant="body2" color="primary" href={extension.homepage} underline="hover">
+              {extension.id}
+            </Link>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+            >{`v${extension.version}`}</Typography>
+            <Typography variant="caption" color="text.secondary">
+              {extension.license}
+            </Typography>
+          </Stack>
+          <Typography variant="subtitle2" gutterBottom>
+            {extension.publisher}
+          </Typography>
+          <Typography variant="body2" gutterBottom>
+            {extension.description}
+          </Typography>
+        </Stack>
+        {isInstalled ? (
+          <Button
+            size="small"
+            key="uninstall"
+            color="inherit"
+            variant="contained"
+            onClick={uninstall}
+          >
+            Uninstall
+          </Button>
+        ) : (
+          canInstall && (
+            <Button
+              size="small"
+              key="install"
+              color="inherit"
+              variant="contained"
+              onClick={install}
+              style={{ minWidth: "100px" }}
+            >
+              Install
+            </Button>
+          )
+        )}
+      </Stack>
+
+      <Stack paddingTop={2} style={{ marginLeft: -16, marginRight: -16 }}>
+        <Tabs
+          textColor="inherit"
+          value={activeTab}
+          onChange={(_event, newValue: number) => setActiveTab(newValue)}
+        >
+          <Tab disableRipple label="README" value={0} />
+          <Tab disableRipple label="CHANGELOG" value={1} />
+        </Tabs>
+        <Divider />
+      </Stack>
+
+      <Stack flex="auto" paddingY={2}>
+        {activeTab === 0 && <TextContent>{readmeContent}</TextContent>}
+        {activeTab === 1 && <TextContent>{changelogContent}</TextContent>}
+      </Stack>
     </SidebarContent>
-  );
-}
-
-function UninstallButton({ onClick }: { onClick: () => void }): React.ReactElement {
-  return (
-    <Button style={{ minWidth: "100px" }} onClick={onClick}>
-      Uninstall
-    </Button>
-  );
-}
-
-function InstallButton({ onClick }: { onClick: () => void }): React.ReactElement {
-  return (
-    <Button style={{ minWidth: "100px" }} onClick={onClick}>
-      Install
-    </Button>
   );
 }

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -37,7 +37,7 @@ type Props = {
 const StyledButton = muiStyled(Button)({ minWidth: 100 });
 
 export function ExtensionDetails({ extension, onClose, installed }: Props): React.ReactElement {
-  const [isInstalled, setIsInstalled] = useState<boolean>(installed);
+  const [isInstalled, setIsInstalled] = useState(installed);
   const [activeTab, setActiveTab] = useState<number>(0);
   const isMounted = useMountedState();
   const extensionLoader = useExtensionLoader();

--- a/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
@@ -35,28 +35,31 @@ function ExtensionListEntry(props: {
   entry: ExtensionMarketplaceDetail;
   onClick: () => void;
 }): JSX.Element {
-  const { entry } = props;
+  const {
+    entry: { id, description, name, publisher, version },
+    onClick,
+  } = props;
   return (
-    <ListItem disablePadding key={entry.id}>
-      <StyledListItemButton onClick={props.onClick}>
+    <ListItem disablePadding key={id}>
+      <StyledListItemButton onClick={onClick}>
         <ListItemText
           primary={
             <Stack direction="row" alignItems="baseline" gap={0.5}>
               <Typography variant="subtitle2" fontWeight={600}>
-                {entry.name}
+                {name}
               </Typography>
               <Typography variant="caption" color="text.secondary">
-                {entry.version}
+                {version}
               </Typography>
             </Stack>
           }
           secondary={
             <Stack gap={0.5}>
               <Typography variant="body2" color="text.secondary">
-                {entry.description}
+                {description}
               </Typography>
               <Typography color="text.primary" variant="body2">
-                {entry.publisher}
+                {publisher}
               </Typography>
             </Stack>
           }
@@ -166,20 +169,19 @@ export default function ExtensionsSidebar(): React.ReactElement {
               Installed
             </Typography>
           </Stack>
-          {installedEntries.length > 0
-            ? installedEntries.map((entry) => (
-                <ExtensionListEntry
-                  key={entry.id}
-                  entry={entry}
-                  onClick={() =>
-                    setFocusedExtension({
-                      installed: true,
-                      entry,
-                    })
-                  }
-                />
-              ))
-            : "No installed extensions"}
+          {installedEntries.length > 0 ? (
+            installedEntries.map((entry) => (
+              <ExtensionListEntry
+                key={entry.id}
+                entry={entry}
+                onClick={() => setFocusedExtension({ installed: true, entry })}
+              />
+            ))
+          ) : (
+            <ListItem>
+              <ListItemText primary="No installed extensions" />
+            </ListItem>
+          )}
         </List>
         <List>
           <Stack paddingY={0.25} paddingX={2}>
@@ -191,12 +193,7 @@ export default function ExtensionsSidebar(): React.ReactElement {
             <ExtensionListEntry
               key={entry.id}
               entry={entry}
-              onClick={() =>
-                setFocusedExtension({
-                  installed: false,
-                  entry,
-                })
-              }
+              onClick={() => setFocusedExtension({ installed: false, entry })}
             />
           ))}
         </List>

--- a/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
@@ -2,14 +2,21 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageBar, MessageBarType, makeStyles } from "@fluentui/react";
-import { Stack } from "@mui/material";
+import {
+  Button,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+  styled as muiStyled,
+} from "@mui/material";
 import { useMemo, useState } from "react";
 import { useAsync } from "react-use";
 
-import Button from "@foxglove/studio-base/components/Button";
 import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { useExtensionLoader } from "@foxglove/studio-base/context/ExtensionLoaderContext";
 import {
   ExtensionMarketplaceDetail,
@@ -18,49 +25,48 @@ import {
 
 import helpContent from "./index.help.md";
 
-const useStyles = makeStyles((theme) => ({
-  name: {
-    fontWeight: "bold",
-  },
-  version: {
-    color: theme.palette.neutralSecondaryAlt,
-    fontSize: "80%",
-    marginLeft: 8,
-  },
-  description: {
-    color: theme.palette.neutralSecondaryAlt,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    width: "100%",
-    display: "inline-block",
-    overflow: "hidden",
-  },
-  publisher: {
-    color: theme.semanticColors.bodyText,
-  },
-  sectionHeader: {
-    ...theme.fonts.xSmall,
-    display: "block",
-    textTransform: "uppercase",
-    color: theme.palette.neutralSecondaryAlt,
-    letterSpacing: "0.025em",
-    marginBottom: theme.spacing.s1,
-  },
-  extensionListStack: {
-    margin: `0 -${theme.spacing.m}`,
-    borderBottom: `1px solid ${theme.semanticColors.bodyBackground}`,
-    borderTop: `1px solid ${theme.semanticColors.bodyBackground}`,
-
-    "&:hover": {
-      backgroundColor: theme.semanticColors.menuItemBackgroundHovered,
-      color: theme.semanticColors.accentButtonBackground,
-      cursor: "pointer",
-    },
+const StyledListItemButton = muiStyled(ListItemButton)(({ theme }) => ({
+  "&:hover": {
+    color: theme.palette.primary.main,
   },
 }));
 
+function ExtensionListEntry(props: {
+  entry: ExtensionMarketplaceDetail;
+  onClick: () => void;
+}): JSX.Element {
+  const { entry } = props;
+  return (
+    <ListItem disablePadding key={entry.id}>
+      <StyledListItemButton onClick={props.onClick}>
+        <ListItemText
+          primary={
+            <Stack direction="row" alignItems="baseline" gap={0.5}>
+              <Typography variant="subtitle2" fontWeight={600}>
+                {entry.name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {entry.version}
+              </Typography>
+            </Stack>
+          }
+          secondary={
+            <Stack gap={0.5}>
+              <Typography variant="body2" color="text.secondary">
+                {entry.description}
+              </Typography>
+              <Typography color="text.primary" variant="body2">
+                {entry.publisher}
+              </Typography>
+            </Stack>
+          }
+        />
+      </StyledListItemButton>
+    </ListItem>
+  );
+}
+
 export default function ExtensionsSidebar(): React.ReactElement {
-  const classes = useStyles();
   const [shouldFetch, setShouldFetch] = useState<boolean>(true);
   const [marketplaceEntries, setMarketplaceEntries] = useState<ExtensionMarketplaceDetail[]>([]);
   const [focusedExtension, setFocusedExtension] = useState<
@@ -138,105 +144,63 @@ export default function ExtensionsSidebar(): React.ReactElement {
   }
 
   if (availableError) {
-    return <FetchError onRetry={() => setShouldFetch(true)}></FetchError>;
+    return (
+      <SidebarContent title="Extensions">
+        <Stack gap={1} alignItems="center" justifyContent="center" fullHeight>
+          <Typography align="center" variant="body2" color="text.secondary">
+            Failed to fetch the list of available extensions. Check your Internet connection and try
+            again.
+          </Typography>
+          <Button onClick={() => setShouldFetch(true)}>Retry Fetching Extensions</Button>
+        </Stack>
+      </SidebarContent>
+    );
   }
 
   return (
-    <SidebarContent title="Extensions" helpContent={helpContent}>
-      <Stack spacing={3.75}>
-        <div>
-          <h2 className={classes.sectionHeader}>Installed</h2>
-          <Stack spacing={1}>
-            {installedEntries.length > 0
-              ? installedEntries.map((entry) => (
-                  <ExtensionListEntry
-                    key={entry.id}
-                    entry={entry}
-                    onClick={() =>
-                      setFocusedExtension({
-                        installed: true,
-                        entry,
-                      })
-                    }
-                  />
-                ))
-              : "No installed extensions"}
+    <SidebarContent title="Extensions" helpContent={helpContent} disablePadding>
+      <Stack gap={1}>
+        <List>
+          <Stack paddingY={0.25} paddingX={2}>
+            <Typography component="li" variant="overline" color="text.secondary">
+              Installed
+            </Typography>
           </Stack>
-        </div>
-        <div>
-          <h2 className={classes.sectionHeader}>Available</h2>
-          <Stack spacing={1}>
-            {filteredMarketplaceEntries.map((entry) => (
-              <ExtensionListEntry
-                key={entry.id}
-                entry={entry}
-                onClick={() =>
-                  setFocusedExtension({
-                    installed: false,
-                    entry,
-                  })
-                }
-              />
-            ))}
+          {installedEntries.length > 0
+            ? installedEntries.map((entry) => (
+                <ExtensionListEntry
+                  key={entry.id}
+                  entry={entry}
+                  onClick={() =>
+                    setFocusedExtension({
+                      installed: true,
+                      entry,
+                    })
+                  }
+                />
+              ))
+            : "No installed extensions"}
+        </List>
+        <List>
+          <Stack paddingY={0.25} paddingX={2}>
+            <Typography component="li" variant="overline" color="text.secondary">
+              Avaiable
+            </Typography>
           </Stack>
-        </div>
+          {filteredMarketplaceEntries.map((entry) => (
+            <ExtensionListEntry
+              key={entry.id}
+              entry={entry}
+              onClick={() =>
+                setFocusedExtension({
+                  installed: false,
+                  entry,
+                })
+              }
+            />
+          ))}
+        </List>
       </Stack>
-    </SidebarContent>
-  );
-}
-
-function ExtensionListEntry(props: {
-  entry: ExtensionMarketplaceDetail;
-  onClick: () => void;
-}): JSX.Element {
-  const { entry } = props;
-  const classes = useStyles();
-  return (
-    <Stack
-      key={entry.id}
-      onClick={props.onClick}
-      className={classes.extensionListStack}
-      spacing={0.75}
-      paddingX={2}
-      paddingY={1}
-    >
-      <div>
-        <span className={classes.name}>{entry.name}</span>
-        <span className={classes.version}>{entry.version}</span>
-      </div>
-      <div>
-        <span className={classes.description}>{entry.description}</span>
-      </div>
-      <div>
-        <span className={classes.publisher}>{entry.publisher}</span>
-      </div>
-    </Stack>
-  );
-}
-
-function FetchError(props: { onRetry: () => void }): React.ReactElement {
-  const errorMsg =
-    "Failed to fetch the list of available extensions. Check your Internet connection and try again.";
-  return (
-    <SidebarContent title="Extensions">
-      <MessageBar
-        messageBarType={MessageBarType.error}
-        isMultiline={true}
-        dismissButtonAriaLabel="Close"
-      >
-        {errorMsg}
-      </MessageBar>
-      <Button
-        style={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-        }}
-        onClick={props.onRetry}
-      >
-        Retry Fetching Extensions
-      </Button>
     </SidebarContent>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Clean up extension styling

Before
<img width="1201" alt="Screen Shot 2022-05-26 at 3 32 27 pm" src="https://user-images.githubusercontent.com/924528/170423034-d00b8104-f587-4eb3-85f4-f99e6b991464.png">

After
<img width="1201" alt="Screen Shot 2022-05-26 at 3 32 24 pm" src="https://user-images.githubusercontent.com/924528/170423012-e625bfb2-694f-42d6-a5c3-4c14270662d6.png">


**Description**
Refactor Extension Sidebar to use MUI styles, one less instance of fluentui, makeStyles and @foxglove/Button

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
