### PR TITLE
Fix overflow on long messages in error boundary

### DIFF
--- a/packages/studio-base/src/components/ErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.stories.tsx
@@ -17,16 +17,17 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 
 import ErrorBoundary from "./ErrorBoundary";
 
-class Broken extends React.Component {
-  override render() {
+function Broken({ depth = 1 }: { depth?: number }): JSX.Element {
+  if (depth > 20) {
     throw Object.assign(new Error("Hello!"), {
       stack: `
-  an error occurred
-  it's caught by this component
-  now the user sees
-      `,
+        an error occurred
+        it's caught by this component
+        now the user sees
+            `,
     });
-    return ReactNull;
+  } else {
+    return <Broken depth={depth + 1} />;
   }
 }
 

--- a/packages/studio-base/src/components/ErrorDisplay.tsx
+++ b/packages/studio-base/src/components/ErrorDisplay.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Theme, Typography, Link, Divider } from "@mui/material";
+import { Theme, Typography, Link, Divider, styled as muiStyled } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { ErrorInfo, useMemo, useState } from "react";
 
@@ -24,6 +24,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingTop: theme.spacing(2),
     textAlign: "right",
   },
+}));
+
+const Container = muiStyled("div")(({ theme }) => ({
+  display: "grid",
+  gridTemplateRows: "auto 1fr auto",
+  height: "100%",
+  padding: theme.spacing(2),
 }));
 
 /**
@@ -114,27 +121,28 @@ function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
   }, [error, errorInfo, hideErrorSourceLocations, showErrorDetails]);
 
   return (
-    <Stack fullHeight padding={2} overflow="auto">
-      <Stack fullHeight flexGrow={1}>
-        <Typography variant="h4" gutterBottom>
-          {props.title ?? "The app encountered an unexpected error"}
-        </Typography>
-        <Stack gap={2}>
+    <Container>
+      <Stack gap={2} paddingBottom={2}>
+        <Stack>
+          <Typography variant="h4" gutterBottom>
+            {props.title ?? "The app encountered an unexpected error"}
+          </Typography>
           <Typography variant="body1" component="div">
             {props.content}
           </Typography>
-          <Divider />
-          <Typography variant="subtitle2" component="code" fontWeight="bold">
-            {error?.message}
-          </Typography>
-          <Link color="secondary" onClick={() => setShowErrorDetails(!showErrorDetails)}>
-            {showErrorDetails ? "Hide" : "Show"} details
-          </Link>
-          {errorDetails && <div className={styles.errorDetailContainer}>{errorDetails}</div>}
         </Stack>
+        <Divider />
+        <Typography variant="subtitle2" component="code" fontWeight="bold">
+          {error?.message}
+        </Typography>
+        <Link color="secondary" onClick={() => setShowErrorDetails(!showErrorDetails)}>
+          {showErrorDetails ? "Hide" : "Show"} details
+        </Link>
       </Stack>
+      {errorDetails && <div className={styles.errorDetailContainer}>{errorDetails}</div>}
+      {!errorDetails && <div />}
       <div className={styles.actions}>{props.actions}</div>
-    </Stack>
+    </Container>
   );
 }
 

--- a/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
@@ -38,3 +38,17 @@ export const Default: Story = () => {
     </DndProvider>
   );
 };
+
+export const ShowingDetails: Story = () => {
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <PanelErrorBoundary
+        showErrorDetails
+        onRemovePanel={action("onRemovePanel")}
+        onResetPanel={action("onResetPanel")}
+      >
+        <Broken />
+      </PanelErrorBoundary>
+    </DndProvider>
+  );
+};

--- a/packages/studio-base/src/components/PanelErrorBoundary.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.tsx
@@ -11,6 +11,7 @@ import { AppError } from "@foxglove/studio-base/util/errors";
 import ErrorDisplay from "./ErrorDisplay";
 
 type Props = {
+  showErrorDetails?: boolean;
   onResetPanel: () => void;
   onRemovePanel: () => void;
 };
@@ -36,6 +37,7 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
           title="This panel encountered an unexpected error"
           error={this.state.currentError.error}
           errorInfo={this.state.currentError.errorInfo}
+          showErrorDetails={this.props.showErrorDetails}
           content={
             <p>
               Something went wrong in this panel.{" "}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This improves the error boundary's handling of long error messages. The solution is to fix the height of the component and only make the stack backtrace scrollable.

This also adds a story for the `PanelErrorBoundary` component with details expanded since they render slightly differently.

<img width="484" alt="Screen Shot 2022-05-26 at 9 55 39 AM" src="https://user-images.githubusercontent.com/93935560/170514869-466a985a-3175-4975-b67f-0cb4f6058849.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3445