### PR TITLE
Configure webpack to allow foxglove to be served at a URL other than the root

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -91,7 +91,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
-      publicPath: "/",
+      publicPath: "./",
 
       // Output filenames should include content hashes in order to cache bust when new versions are available
       filename: isDev ? "[name].js" : "[name].[contenthash].js",
@@ -112,9 +112,9 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
   <html>
     <head>
       <meta charset="utf-8">
-      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+      <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
       <title>Foxglove Studio</title>
     </head>
     <script>

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -91,7 +91,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     devtool: isDev ? "eval-cheap-module-source-map" : "source-map",
 
     output: {
-      publicPath: "./",
+      publicPath: "auto",
 
       // Output filenames should include content hashes in order to cache bust when new versions are available
       filename: isDev ? "[name].js" : "[name].[contenthash].js",
@@ -112,9 +112,9 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
   <html>
     <head>
       <meta charset="utf-8">
-      <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png" />
+      <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
       <title>Foxglove Studio</title>
     </head>
     <script>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This uses the webpack `auto` publicPath feature to make it possible for foxglove to be served at a URL other than the root and still load assets correctly.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
