### PR TITLE
Refactor Playback bar to use MUI components

### DIFF
--- a/packages/studio-base/src/components/HoverableIconButton.tsx
+++ b/packages/studio-base/src/components/HoverableIconButton.tsx
@@ -2,20 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { IconButton, IButtonProps, IIconProps } from "@fluentui/react";
+import { IconButton, IconButtonProps } from "@mui/material";
 import { forwardRef, useCallback, useEffect, useState } from "react";
 
 type Props = {
-  iconProps: {
-    iconNameActive?: RegisteredIconNames | undefined;
-  } & IIconProps;
-} & Omit<IButtonProps, "allowDisabledFocus">;
+  icon: React.ReactNode;
+  activeIcon?: React.ReactNode;
+} & Omit<IconButtonProps, "children">;
 
-const HoverableIconButton = forwardRef<HTMLElement, Props>((props, ref) => {
-  const {
-    iconProps: { iconName, iconNameActive, ...restIcon },
-    ...restProps
-  } = props;
+const HoverableIconButton = forwardRef<HTMLButtonElement, Props>((props, ref) => {
+  const { icon, activeIcon } = props;
 
   const [hovered, setHovered] = useState(false);
 
@@ -38,18 +34,17 @@ const HoverableIconButton = forwardRef<HTMLElement, Props>((props, ref) => {
 
   return (
     <IconButton
-      elementRef={ref}
-      {...restProps}
-      iconProps={{
-        ...restIcon,
-        iconName: iconNameActive != undefined ? (hovered ? iconNameActive : iconName) : iconName,
-      }}
-      allowDisabledFocus={true /* required to support mouse leave events for disabled buttons */}
+      ref={ref}
+      {...props}
+      component="button"
       onMouseEnter={onMouseOver}
       onMouseLeave={onMouseLeave}
-    />
+    >
+      {activeIcon != undefined ? (hovered ? activeIcon : icon) : icon}
+    </IconButton>
   );
 });
+
 HoverableIconButton.displayName = "HoverableIconButton";
 
 export default HoverableIconButton;

--- a/packages/studio-base/src/components/MessageOrderControls.tsx
+++ b/packages/studio-base/src/components/MessageOrderControls.tsx
@@ -2,10 +2,18 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { DefaultButton, DirectionalHint, useTheme } from "@fluentui/react";
-import { useCallback } from "react";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import CheckIcon from "@mui/icons-material/Check";
+import {
+  Button,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  styled as muiStyled,
+} from "@mui/material";
+import { useCallback, useState } from "react";
 
-import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import {
   LayoutState,
   useCurrentLayoutActions,
@@ -18,11 +26,19 @@ const messageOrderLabel = {
   headerStamp: "Header stamp",
 };
 
+const StyledButton = muiStyled(Button)(({ theme }) => ({
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+  minWidth: 140,
+  justifyContent: "space-between",
+}));
+
 const messageOrderSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.playbackConfig.messageOrder ?? "receiveTime";
 
 export default function MessageOrderControls(): JSX.Element {
-  const theme = useTheme();
+  const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
+  const open = Boolean(anchorEl);
   const messageOrder = useCurrentLayoutSelector(messageOrderSelector);
   const { setPlaybackConfig } = useCurrentLayoutActions();
 
@@ -33,59 +49,64 @@ export default function MessageOrderControls(): JSX.Element {
     [setPlaybackConfig],
   );
 
-  const orderText = messageOrderLabel[messageOrder];
-  const messageOrderTooltip = useTooltip({
-    contents: `Order messages by ${orderText.toLowerCase()}`,
-  });
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(undefined);
+  };
 
   return (
-    <div>
-      {messageOrderTooltip.tooltip}
-      <DefaultButton
-        elementRef={messageOrderTooltip.ref}
-        styles={{
-          root: {
-            background: theme.semanticColors.buttonBackgroundHovered,
-            border: "none",
-            margin: 0, // Remove this once global.scss has gone away
-            minWidth: "100px",
-            padding: theme.spacing.s1,
-          },
-          rootHovered: {
-            background: theme.semanticColors.buttonBackgroundPressed,
-          },
-          label: {
-            ...theme.fonts.small,
-            whiteSpace: "nowrap",
-          },
-          menuIcon: {
-            fontSize: theme.fonts.tiny.fontSize,
-          },
+    <>
+      <StyledButton
+        id="message-order-button"
+        aria-controls={open ? "message-order-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+        disableRipple
+        variant="contained"
+        color="inherit"
+        endIcon={<ArrowDropDownIcon />}
+        title={`Order messages by ${messageOrderLabel[messageOrder].toLowerCase()}`}
+      >
+        {messageOrderLabel[messageOrder]}
+      </StyledButton>
+      <Menu
+        id="message-order-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "message-order-button",
         }}
-        menuProps={{
-          directionalHint: DirectionalHint.topLeftEdge,
-          directionalHintFixed: true,
-          gapSpace: 3,
-          items: [
-            {
-              canCheck: true,
-              key: "receiveTime",
-              text: "Receive time",
-              isChecked: messageOrder === "receiveTime",
-              onClick: () => setMessageOrder("receiveTime"),
-            },
-            {
-              canCheck: true,
-              key: "headerStamp",
-              text: "Header stamp",
-              isChecked: messageOrder === "headerStamp",
-              onClick: () => setMessageOrder("headerStamp"),
-            },
-          ],
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
         }}
       >
-        {orderText}
-      </DefaultButton>
-    </div>
+        {Object.entries(messageOrderLabel).map(([key, label]) => (
+          <MenuItem
+            key={key}
+            selected={messageOrder === key}
+            onClick={async () => setMessageOrder(key as TimestampMethod)}
+          >
+            {messageOrder === key && (
+              <ListItemIcon>
+                <CheckIcon fontSize="small" />
+              </ListItemIcon>
+            )}
+            <ListItemText inset={messageOrder !== key} disableTypography>
+              {label}
+            </ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
   );
 }

--- a/packages/studio-base/src/components/MessageOrderControls.tsx
+++ b/packages/studio-base/src/components/MessageOrderControls.tsx
@@ -101,9 +101,11 @@ export default function MessageOrderControls(): JSX.Element {
                 <CheckIcon fontSize="small" />
               </ListItemIcon>
             )}
-            <ListItemText inset={messageOrder !== key} disableTypography>
-              {label}
-            </ListItemText>
+            <ListItemText
+              inset={messageOrder !== key}
+              primary={label}
+              primaryTypographyProps={{ variant: "body2" }}
+            />
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -1,28 +1,25 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2020-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import CheckIcon from "@mui/icons-material/Check";
+import WarningIcon from "@mui/icons-material/Warning";
 import {
-  DefaultButton,
-  DirectionalHint,
-  ITextFieldStyles,
   TextField,
-  useTheme,
-} from "@fluentui/react";
-import { Stack } from "@mui/material";
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  styled as muiStyled,
+} from "@mui/material";
+import { useState, useCallback, useMemo, useEffect, MouseEvent } from "react";
 
 import { Time, isTimeInRangeInclusive } from "@foxglove/rostime";
+import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import {
   formatDate,
   formatTime,
@@ -31,15 +28,7 @@ import {
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
-const PlaybackTimeDisplayMethod = ({
-  currentTime,
-  startTime,
-  endTime,
-  timezone,
-  onSeek,
-  onPause,
-  isPlaying,
-}: {
+type PlaybackTimeDisplayMethodProps = {
   currentTime?: Time;
   startTime?: Time;
   endTime?: Time;
@@ -47,8 +36,106 @@ const PlaybackTimeDisplayMethod = ({
   onSeek: (arg0: Time) => void;
   onPause: () => void;
   isPlaying: boolean;
-}): JSX.Element => {
-  const timestampInputRef = useRef<HTMLInputElement>(ReactNull);
+};
+
+const StyledTextField = muiStyled(TextField)(({ error, theme }) => ({
+  fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
+  borderRadius: theme.shape.borderRadius,
+
+  ".MuiIconButton-root": {
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0,
+    borderLeft: `1px solid ${theme.palette.background.paper}`,
+  },
+  ...(error != undefined && {
+    outline: `1px solid ${theme.palette.error.main}`,
+  }),
+}));
+
+function PlaybackTimeMethodMenu({
+  timeFormat,
+  timeRawString,
+  timeOfDayString,
+  setTimeFormat,
+}: {
+  timeFormat: TimeDisplayMethod;
+  timeRawString?: string;
+  timeOfDayString?: string;
+  setTimeFormat: (format: TimeDisplayMethod) => Promise<void>;
+}): JSX.Element {
+  const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(undefined);
+  };
+
+  return (
+    <>
+      <IconButton
+        edge="end"
+        id="playback-time-display-toggle-button"
+        aria-controls={open ? "playback-time-display-toggle-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={handleClick}
+      >
+        <ArrowDropDownIcon />
+      </IconButton>
+      <Menu
+        id="playback-time-display-toggle-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          "aria-labelledby": "playback-time-display-toggle-button",
+        }}
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+      >
+        {[
+          { key: "TOD", label: timeOfDayString ?? "Time of Day" },
+          { key: "SEC", label: timeRawString ?? "Seconds" },
+        ].map((option) => (
+          <MenuItem
+            key={option.key}
+            selected={timeFormat === option.key}
+            onClick={async () => await setTimeFormat(option.key as TimeDisplayMethod)}
+          >
+            {timeFormat === option.key && (
+              <ListItemIcon>
+                <CheckIcon fontSize="small" />
+              </ListItemIcon>
+            )}
+            <ListItemText inset={timeFormat !== option.key} disableTypography>
+              {option.label}
+            </ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}
+
+export default function PlaybackTimeDisplayMethod({
+  currentTime,
+  startTime,
+  endTime,
+  timezone,
+  onSeek,
+  onPause,
+  isPlaying,
+}: PlaybackTimeDisplayMethodProps): JSX.Element {
   const timeFormat = useAppTimeFormat();
   const timeRawString = useMemo(
     () => (currentTime ? formatTimeRaw(currentTime) : undefined),
@@ -64,52 +151,7 @@ const PlaybackTimeDisplayMethod = ({
   );
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [inputText, setInputText] = useState<string | undefined>(currentTimeString ?? undefined);
-  const [hasError, setHasError] = useState<boolean>(false);
-
-  const theme = useTheme();
-  const textFieldStyles = useMemo(
-    () =>
-      ({
-        errorMessage: {
-          display: "none",
-        },
-        field: {
-          margin: 0,
-          padding: "0px 8px",
-          whiteSpace: "nowrap",
-          fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
-          backgroundColor: "transparent",
-
-          ":hover": {
-            borderRadius: 2,
-            backgroundColor: theme.semanticColors.inputBackground,
-          },
-          ":focus": {
-            backgroundColor: theme.semanticColors.inputBackground,
-          },
-        },
-        fieldGroup: {
-          border: "none",
-          backgroundColor: "transparent",
-          // The flex-sizing does not correctly calculate the <input> field width for all font
-          // sizes, so we increase the width to compensate
-          width: "102%",
-        },
-        icon: {
-          height: 20,
-          color: hasError ? theme.semanticColors.errorIcon : undefined,
-        },
-        root: {
-          marginLeft: theme.spacing.s1,
-
-          "&.is-disabled input[disabled]": {
-            background: "transparent",
-            cursor: "not-allowed",
-          },
-        },
-      } as Partial<ITextFieldStyles>),
-    [hasError, theme],
-  );
+  const [hasError, setHasError] = useState<boolean>(true);
 
   const onSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -158,15 +200,30 @@ const PlaybackTimeDisplayMethod = ({
   }, [hasError, inputText, isPlaying]);
 
   return (
-    <Stack direction="row" alignItems="center" flexGrow={0} spacing={0.5}>
+    <Stack direction="row" alignItems="center" flexGrow={0} gap={0.5}>
       {currentTime ? (
         <form onSubmit={onSubmit} style={{ width: "100%" }}>
-          <TextField
-            ariaLabel="Playback Time Method"
+          <StyledTextField
+            aria-label="Playback Time Method"
             data-test="PlaybackTime-text"
-            elementRef={timestampInputRef}
             value={isEditing ? inputText : currentTimeString}
-            errorMessage={hasError ? "Invalid Time" : undefined}
+            error={hasError}
+            variant="filled"
+            InputProps={{
+              startAdornment: hasError ? <WarningIcon color="error" /> : undefined,
+              endAdornment: (
+                <PlaybackTimeMethodMenu
+                  {...{
+                    currentTime,
+                    timezone,
+                    timeOfDayString,
+                    timeRawString,
+                    timeFormat: timeFormat.timeFormat,
+                    setTimeFormat: timeFormat.setTimeFormat,
+                  }}
+                />
+              ),
+            }}
             onFocus={(e) => {
               onPause();
               setHasError(false);
@@ -179,55 +236,22 @@ const PlaybackTimeDisplayMethod = ({
               setIsEditing(false);
               setTimeout(() => setHasError(false), 600);
             }}
-            iconProps={{ iconName: hasError ? "Warning" : undefined }}
-            size={21}
-            styles={textFieldStyles}
-            onChange={(_, newValue) => setInputText(newValue)}
+            onChange={(event) => setInputText(event.target.value)}
           />
         </form>
       ) : (
-        <TextField disabled size={13} styles={textFieldStyles} defaultValue="–" />
+        <StyledTextField
+          disabled
+          defaultValue="–"
+          InputProps={{
+            endAdornment: (
+              <IconButton edge="end" disabled>
+                <ArrowDropDownIcon />
+              </IconButton>
+            ),
+          }}
+        />
       )}
-      <DefaultButton
-        menuProps={{
-          directionalHint: DirectionalHint.topLeftEdge,
-          directionalHintFixed: true,
-          gapSpace: 3,
-          items: [
-            {
-              canCheck: true,
-              key: "TOD",
-              text: timeOfDayString ? timeOfDayString : "Time of Day",
-              isChecked: timeFormat.timeFormat === "TOD",
-              onClick: () => void timeFormat.setTimeFormat("TOD"),
-            },
-            {
-              canCheck: true,
-              key: "SEC",
-              text: timeRawString ? timeRawString : "Seconds",
-              isChecked: timeFormat.timeFormat === "SEC",
-              onClick: () => void timeFormat.setTimeFormat("SEC"),
-            },
-          ],
-        }}
-        styles={{
-          root: {
-            border: "none",
-            background: theme.semanticColors.buttonBackgroundHovered,
-            padding: 0,
-            minWidth: "24px",
-          },
-          rootHovered: {
-            background: theme.semanticColors.buttonBackgroundPressed,
-          },
-          label: theme.fonts.small,
-          menuIcon: {
-            fontSize: theme.fonts.tiny.fontSize,
-          },
-        }}
-      ></DefaultButton>
     </Stack>
   );
-};
-
-export default PlaybackTimeDisplayMethod;
+}

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -38,16 +38,19 @@ type PlaybackTimeDisplayMethodProps = {
   isPlaying: boolean;
 };
 
-const StyledTextField = muiStyled(TextField)(({ error, theme }) => ({
+const StyledTextField = muiStyled(TextField)<{ error?: boolean }>(({ error, theme }) => ({
   fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero'`,
   borderRadius: theme.shape.borderRadius,
 
+  ".MuiInputBase-input": {
+    minWidth: "20ch",
+  },
   ".MuiIconButton-root": {
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
     borderLeft: `1px solid ${theme.palette.background.paper}`,
   },
-  ...(error != undefined && {
+  ...(error === true && {
     outline: `1px solid ${theme.palette.error.main}`,
   }),
 }));
@@ -151,7 +154,7 @@ export default function PlaybackTimeDisplayMethod({
   );
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [inputText, setInputText] = useState<string | undefined>(currentTimeString ?? undefined);
-  const [hasError, setHasError] = useState<boolean>(true);
+  const [hasError, setHasError] = useState<boolean>(false);
 
   const onSubmit = useCallback(
     (e: React.FormEvent) => {

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -99,11 +99,11 @@ function PlaybackTimeMethodMenu({
         }}
         anchorOrigin={{
           vertical: "top",
-          horizontal: "left",
+          horizontal: "right",
         }}
         transformOrigin={{
           vertical: "bottom",
-          horizontal: "left",
+          horizontal: "right",
         }}
       >
         {[
@@ -120,9 +120,11 @@ function PlaybackTimeMethodMenu({
                 <CheckIcon fontSize="small" />
               </ListItemIcon>
             )}
-            <ListItemText inset={timeFormat !== option.key} disableTypography>
-              {option.label}
-            </ListItemText>
+            <ListItemText
+              inset={timeFormat !== option.key}
+              primary={option.label}
+              primaryTypographyProps={{ variant: "body2" }}
+            />
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -11,15 +11,24 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { IButtonStyles, useTheme } from "@fluentui/react";
-import { styled as muiStyled } from "@mui/material";
-import { merge } from "lodash";
+import {
+  Pause20Filled,
+  Pause20Regular,
+  Play20Filled,
+  Play20Regular,
+  Next20Filled,
+  Next20Regular,
+  Previous20Filled,
+  Previous20Regular,
+} from "@fluentui/react-icons";
+import { Divider, styled as muiStyled } from "@mui/material";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { compare, Time } from "@foxglove/rostime";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
+import LoopIcon from "@foxglove/studio-base/components/LoopIcon";
 import MessageOrderControls from "@foxglove/studio-base/components/MessageOrderControls";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import {
@@ -28,7 +37,6 @@ import {
 } from "@foxglove/studio-base/components/PlaybackControls/sharedHelpers";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
 import Stack from "@foxglove/studio-base/components/Stack";
-import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
@@ -44,6 +52,27 @@ const PlaybackControlsRoot = muiStyled("div")(({ theme }) => ({
   borderTop: `1px solid ${theme.palette.divider}`,
 }));
 
+const ButtonGroup = muiStyled("div")(({ theme }) => ({
+  display: "flex",
+  backgroundColor: theme.palette.action.focus,
+  borderRadius: theme.shape.borderRadius,
+
+  ".MuiIconButton-root": {
+    "&:not(:first-child)": {
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    },
+    "&:not(:last-child)": {
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+  },
+  ".MuiDivider-root": {
+    borderColor: theme.palette.background.paper,
+    borderRightWidth: 2,
+  },
+}));
+
 export default function PlaybackControls({
   play,
   pause,
@@ -57,7 +86,6 @@ export default function PlaybackControls({
   isPlaying: boolean;
   getTimeInfo: () => { startTime?: Time; endTime?: Time; currentTime?: Time };
 }): JSX.Element {
-  const theme = useTheme();
   const [repeat, setRepeat] = useState(false);
   const stopAtTime = useRef<Time | undefined>(undefined);
 
@@ -148,44 +176,6 @@ export default function PlaybackControls({
     [seekBackwardAction, seekForwardAction, togglePlayPause],
   );
 
-  const iconButtonStyles: IButtonStyles = {
-    icon: { height: 20 },
-    root: {
-      color: theme.semanticColors.buttonText,
-    },
-    rootChecked: {
-      color: theme.palette.themePrimary,
-      backgroundColor: "transparent",
-    },
-    rootCheckedHovered: { color: theme.palette.themePrimary },
-    rootHovered: { color: theme.semanticColors.buttonTextHovered },
-    rootPressed: { color: theme.semanticColors.buttonTextPressed },
-  };
-
-  const seekIconButttonStyles = ({
-    left = false,
-    right = false,
-  }: {
-    left?: boolean | undefined;
-    right?: boolean | undefined;
-  }) =>
-    ({
-      root: {
-        background: theme.semanticColors.buttonBackgroundHovered,
-        ...(left && {
-          borderTopRightRadius: 0,
-          borderBottomRightRadius: 0,
-        }),
-        ...(right && {
-          borderTopLeftRadius: 0,
-          borderBottomLeftRadius: 0,
-        }),
-      },
-      rootHovered: {
-        background: theme.semanticColors.buttonBackgroundPressed,
-      },
-    } as IButtonStyles);
-
   const [enableMessageOrdering = false] = useAppConfigurationValue<boolean>(
     AppSetting.EXPERIMENTAL_MESSAGE_ORDER,
   );
@@ -207,61 +197,38 @@ export default function PlaybackControls({
         </Stack>
         <Stack direction="row" alignItems="center" flex={1} gap={1} paddingX={0.5}>
           <Stack direction="row" alignItems="center" gap={0.5}>
-            <div>
-              <Tooltip contents="Loop playback">
-                <HoverableIconButton
-                  checked={repeat}
-                  onClick={toggleRepeat}
-                  iconProps={{
-                    iconName: repeat ? "LoopFilled" : "Loop",
-                    iconNameActive: "LoopFilled",
-                  }}
-                  styles={merge(iconButtonStyles, {
-                    rootDisabled: { background: "transparent" },
-                  })}
-                />
-              </Tooltip>
-            </div>
-            <div>
-              <HoverableIconButton
-                onClick={isPlaying ? pause : resumePlay}
-                iconProps={{
-                  iconName: isPlaying ? "Pause" : "Play",
-                  iconNameActive: isPlaying ? "PauseFilled" : "PlayFilled",
-                }}
-                styles={merge(iconButtonStyles, {
-                  rootDisabled: { background: "transparent" },
-                })}
-              />
-            </div>
+            <HoverableIconButton
+              title="Loop playback"
+              color={repeat ? "primary" : "inherit"}
+              onClick={toggleRepeat}
+              icon={repeat ? <LoopIcon strokeWidth={1.9375} /> : <LoopIcon strokeWidth={1.375} />}
+              activeIcon={<LoopIcon strokeWidth={1.875} />}
+            />
+            <HoverableIconButton
+              title={isPlaying ? "Pause" : "Play"}
+              onClick={isPlaying ? pause : resumePlay}
+              icon={isPlaying ? <Pause20Regular /> : <Play20Regular />}
+              activeIcon={isPlaying ? <Pause20Filled /> : <Play20Filled />}
+            />
           </Stack>
           <Scrubber onSeek={seek} />
           <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
         </Stack>
-        <Stack direction="row" alignItems="center" gap={0.25}>
-          <div>
-            <Tooltip contents="Seek backward">
-              <HoverableIconButton
-                iconProps={{ iconName: "Previous", iconNameActive: "PreviousFilled" }}
-                onClick={() => {
-                  seekBackwardAction();
-                }}
-                styles={merge(seekIconButttonStyles({ left: true }), iconButtonStyles)}
-              />
-            </Tooltip>
-          </div>
-          <div>
-            <Tooltip contents="Seek forward">
-              <HoverableIconButton
-                iconProps={{ iconName: "Next", iconNameActive: "NextFilled" }}
-                onClick={() => {
-                  seekForwardAction();
-                }}
-                styles={merge(seekIconButttonStyles({ right: true }), iconButtonStyles)}
-              />
-            </Tooltip>
-          </div>
-        </Stack>
+        <ButtonGroup>
+          <HoverableIconButton
+            title="Seek backward"
+            icon={<Previous20Regular />}
+            activeIcon={<Previous20Filled />}
+            onClick={() => seekBackwardAction()}
+          />
+          <Divider flexItem orientation="vertical" />
+          <HoverableIconButton
+            title="Seek forward"
+            icon={<Next20Regular />}
+            activeIcon={<Next20Filled />}
+            onClick={() => seekForwardAction()}
+          />
+        </ButtonGroup>
       </PlaybackControlsRoot>
     </>
   );

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -195,8 +195,8 @@ export default function PlaybackControls({
           {enableMessageOrdering && <MessageOrderControls />}
           <PlaybackSpeedControls />
         </Stack>
-        <Stack direction="row" alignItems="center" flex={1} gap={1} paddingX={0.5}>
-          <Stack direction="row" alignItems="center" gap={0.5}>
+        <Stack direction="row" alignItems="center" flex={1} gap={1}>
+          <Stack direction="row" alignItems="center" gap={1}>
             <HoverableIconButton
               title="Loop playback"
               color={repeat ? "primary" : "inherit"}

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -2,12 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import CheckIcon from "@mui/icons-material/Check";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Button, ListItemIcon, ListItemText, Menu, MenuItem } from "@mui/material";
+import { Button, Menu, MenuItem, styled as muiStyled } from "@mui/material";
 import { useCallback, useEffect } from "react";
 
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
+import Stack from "@foxglove/studio-base/components/Stack";
 import {
   LayoutState,
   useCurrentLayoutActions,
@@ -20,6 +21,11 @@ const formatSpeed = (val: number) => `${val < 0.1 ? val.toFixed(2) : val}×`;
 
 const configSpeedSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.playbackConfig.speed;
+
+const StyledButton = muiStyled(Button)(({ theme }) => ({
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+}));
 
 export default function PlaybackSpeedControls(): JSX.Element {
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
@@ -57,7 +63,7 @@ export default function PlaybackSpeedControls(): JSX.Element {
 
   return (
     <>
-      <Button
+      <StyledButton
         id="playback-speed-button"
         aria-controls={open ? "playback-speed-menu" : undefined}
         aria-haspopup="true"
@@ -68,10 +74,10 @@ export default function PlaybackSpeedControls(): JSX.Element {
         disableRipple
         variant="contained"
         color="inherit"
-        endIcon={<ExpandMoreIcon />}
+        endIcon={<ArrowDropDownIcon />}
       >
         {displayedSpeed == undefined ? "–" : formatSpeed(displayedSpeed)}
-      </Button>
+      </StyledButton>
       <Menu
         id="playback-speed-menu"
         anchorEl={anchorEl}
@@ -79,9 +85,14 @@ export default function PlaybackSpeedControls(): JSX.Element {
         onClose={handleClose}
         MenuListProps={{
           "aria-labelledby": "basic-button",
+          dense: true,
         }}
         anchorOrigin={{
           vertical: "top",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "bottom",
           horizontal: "left",
         }}
       >
@@ -94,12 +105,12 @@ export default function PlaybackSpeedControls(): JSX.Element {
               handleClose();
             }}
           >
+            {formatSpeed(option)}
             {displayedSpeed === option && (
-              <ListItemIcon>
-                <CheckIcon />
-              </ListItemIcon>
+              <Stack paddingLeft={1}>
+                <CheckIcon fontSize="small" />
+              </Stack>
             )}
-            <ListItemText inset={displayedSpeed !== option}>{formatSpeed(option)}</ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -4,11 +4,17 @@
 
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import CheckIcon from "@mui/icons-material/Check";
-import { Button, Menu, MenuItem, styled as muiStyled } from "@mui/material";
+import {
+  Button,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  styled as muiStyled,
+} from "@mui/material";
 import { useCallback, useEffect } from "react";
 
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
-import Stack from "@foxglove/studio-base/components/Stack";
 import {
   LayoutState,
   useCurrentLayoutActions,
@@ -85,7 +91,6 @@ export default function PlaybackSpeedControls(): JSX.Element {
         onClose={handleClose}
         MenuListProps={{
           "aria-labelledby": "basic-button",
-          dense: true,
         }}
         anchorOrigin={{
           vertical: "top",
@@ -105,12 +110,17 @@ export default function PlaybackSpeedControls(): JSX.Element {
               handleClose();
             }}
           >
-            {formatSpeed(option)}
             {displayedSpeed === option && (
-              <Stack paddingLeft={1}>
+              <ListItemIcon>
                 <CheckIcon fontSize="small" />
-              </Stack>
+              </ListItemIcon>
             )}
+            <ListItemText
+              inset={displayedSpeed !== option}
+              primaryTypographyProps={{ variant: "inherit", align: "right" }}
+            >
+              {formatSpeed(option)}
+            </ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -117,10 +117,9 @@ export default function PlaybackSpeedControls(): JSX.Element {
             )}
             <ListItemText
               inset={displayedSpeed !== option}
-              primaryTypographyProps={{ variant: "inherit" }}
-            >
-              {formatSpeed(option)}
-            </ListItemText>
+              primary={formatSpeed(option)}
+              primaryTypographyProps={{ variant: "body2" }}
+            />
           </MenuItem>
         ))}
       </Menu>

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -117,7 +117,7 @@ export default function PlaybackSpeedControls(): JSX.Element {
             )}
             <ListItemText
               inset={displayedSpeed !== option}
-              primaryTypographyProps={{ variant: "inherit", align: "right" }}
+              primaryTypographyProps={{ variant: "inherit" }}
             >
               {formatSpeed(option)}
             </ListItemText>

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -12,7 +12,7 @@ import {
   MenuItem,
   styled as muiStyled,
 } from "@mui/material";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import {
@@ -34,7 +34,7 @@ const StyledButton = muiStyled(Button)(({ theme }) => ({
 }));
 
 export default function PlaybackSpeedControls(): JSX.Element {
-  const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
+  const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
   const open = Boolean(anchorEl);
   const configSpeed = useCurrentLayoutSelector(configSpeedSelector);
   const speed = useMessagePipeline(
@@ -90,7 +90,7 @@ export default function PlaybackSpeedControls(): JSX.Element {
         open={open}
         onClose={handleClose}
         MenuListProps={{
-          "aria-labelledby": "basic-button",
+          "aria-labelledby": "playback-speed-button",
         }}
         anchorOrigin={{
           vertical: "top",


### PR DESCRIPTION
**User-Facing Changes**
### Before
<img width="1382" alt="Screen Shot 2022-06-02 at 6 54 28 am" src="https://user-images.githubusercontent.com/924528/171499859-f272d57f-5753-445f-855f-472d2675fd7f.png">

### After
<img width="1382" alt="Screen Shot 2022-06-02 at 6 54 47 am" src="https://user-images.githubusercontent.com/924528/171499883-621a9c34-18f8-4a5b-bbbe-7b9514a7df76.png">


**Description**
Migrate Playback bar controls to use MUI Buttons and Menus

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
