### PR TITLE
Map log level severity values by message datatype

### DIFF
--- a/packages/studio-base/src/panels/Log/conversion.tsx
+++ b/packages/studio-base/src/panels/Log/conversion.tsx
@@ -25,7 +25,7 @@ export function getNormalizedMessage(logMessage: LogMessageEvent["message"]): st
   return "";
 }
 
-function getNormalizedLevel(datatype: string, raw: LogMessageEvent["message"]) {
+export function getNormalizedLevel(datatype: string, raw: LogMessageEvent["message"]): number {
   switch (datatype) {
     case "foxglove.Log":
       return (raw as FoxgloveMessages[typeof datatype]).level;

--- a/packages/studio-base/src/panels/Log/filterMessages.ts
+++ b/packages/studio-base/src/panels/Log/filterMessages.ts
@@ -11,14 +11,14 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { getNormalizedMessage } from "./conversion";
+import { getNormalizedMessage, getNormalizedLevel } from "./conversion";
 import { LogMessageEvent } from "./types";
 
 export default function filterMessages(
   events: readonly LogMessageEvent[],
-  filter: { minLogLevel: number; searchTerms: string[] },
+  filter: { minLogLevel: number; searchTerms: string[]; topicDatatype: string },
 ): readonly LogMessageEvent[] {
-  const { minLogLevel, searchTerms } = filter;
+  const { minLogLevel, searchTerms, topicDatatype } = filter;
   const hasActiveFilters = minLogLevel > 1 || searchTerms.length > 0;
   // return all messages if we wouldn't filter anything
   if (!hasActiveFilters) {
@@ -29,7 +29,8 @@ export default function filterMessages(
 
   return events.filter((event) => {
     const logMessage = event.message;
-    if (logMessage.level < minLogLevel) {
+    const effectiveLogLevel = getNormalizedLevel(topicDatatype, logMessage);
+    if (effectiveLogLevel < minLogLevel) {
       return false;
     }
 

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -117,9 +117,15 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
 
   const searchTermsSet = useMemo(() => new Set(searchTerms), [searchTerms]);
 
+  const topicDatatype = useMemo(
+    () => availableTopics.find((topic) => topic.name === topicToRender)?.datatype,
+    [availableTopics, topicToRender],
+  );
+
   const filteredMessages = useMemo(
-    () => filterMessages(msgEvents, { minLogLevel, searchTerms }),
-    [msgEvents, minLogLevel, searchTerms],
+    () =>
+      topicDatatype ? filterMessages(msgEvents, { minLogLevel, searchTerms, topicDatatype }) : [],
+    [msgEvents, minLogLevel, searchTerms, topicDatatype],
   );
 
   const listRef = useRef<IList>(ReactNull);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This allows the log panel message filtering logic to handle datasources that use different numeric values to indicate different message severity levels. 

This implementation uses the message datatype to determine if log level mapping is necessary.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3456 