### PR TITLE
Fix pose publication

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/PublishClickTool.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/PublishClickTool.tsx
@@ -63,7 +63,7 @@ function makePoseMessage(topic: string, start: Point, end: Point, frameId: strin
     msg: {
       header: { seq: 0, stamp: time, frame_id: frameId },
       pose: {
-        position: { x: end.x, y: end.y, z: 0 },
+        position: { x: start.x, y: start.y, z: 0 },
         orientation: quaternionFromPoints(start, end),
       },
     },


### PR DESCRIPTION
**User-Facing Changes**
The pose that gets published using the 3D panel's pose tool will now use the position of the first click (start of the pose arrow), rather than the position of the second click (end of the pose arrow).

**Description**
When setting a pose, two mouse clicks are required: one to specify the point, and a second one to provide direction. However, the current code is sending the position of the _second_ click (i.e., the end of the pose arrow) to the robot. This makes sending a robot to a goal pose very challenging.

![end_of_arrow](https://user-images.githubusercontent.com/5042191/171216191-94f68faa-6307-40bc-992a-669f6b2d6979.gif)


