### PR TITLE
Remove panel error boundary showing details story

### DIFF
--- a/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
@@ -38,17 +38,3 @@ export const Default: Story = () => {
     </DndProvider>
   );
 };
-
-export const ShowingDetails: Story = () => {
-  return (
-    <DndProvider backend={HTML5Backend}>
-      <PanelErrorBoundary
-        showErrorDetails
-        onRemovePanel={action("onRemovePanel")}
-        onResetPanel={action("onResetPanel")}
-      >
-        <Broken />
-      </PanelErrorBoundary>
-    </DndProvider>
-  );
-};


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This removes the `PanelErrorBoundary` story with the error details shown. Since the error details contain checksums that vary from build to build this story gets erroneously flagged as changed on every PR.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
