### PR TITLE
Revert "Remove panel error boundary showing details story (#3471)"

### DIFF
--- a/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.stories.tsx
@@ -38,3 +38,18 @@ export const Default: Story = () => {
     </DndProvider>
   );
 };
+
+export const ShowingDetails: Story = () => {
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <PanelErrorBoundary
+        showErrorDetails
+        hideErrorSourceLocations
+        onRemovePanel={action("onRemovePanel")}
+        onResetPanel={action("onResetPanel")}
+      >
+        <Broken />
+      </PanelErrorBoundary>
+    </DndProvider>
+  );
+};

--- a/packages/studio-base/src/components/PanelErrorBoundary.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.tsx
@@ -12,6 +12,7 @@ import ErrorDisplay from "./ErrorDisplay";
 
 type Props = {
   showErrorDetails?: boolean;
+  hideErrorSourceLocations?: boolean;
   onResetPanel: () => void;
   onRemovePanel: () => void;
 };
@@ -38,6 +39,7 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
           error={this.state.currentError.error}
           errorInfo={this.state.currentError.errorInfo}
           showErrorDetails={this.props.showErrorDetails}
+          hideErrorSourceLocations={this.props.hideErrorSourceLocations}
           content={
             <p>
               Something went wrong in this panel.{" "}


### PR DESCRIPTION
This reverts commit 84ac02483ce1dcbb107c692452fb4423ca305cd6.

**User-Facing Changes**
None

**Description**
Adds missing `hideErrorSourceLocations` to PanelErrorBoundary story.