### PR TITLE
Lighten divider color slightly on dark theme

### DIFF
--- a/packages/studio-base/src/theme/palette.ts
+++ b/packages/studio-base/src/theme/palette.ts
@@ -21,7 +21,7 @@ export const dark: PaletteOptions & CustomPaletteOptions = {
     primary: "#e1e1e4",
     secondary: "#a7a6af",
   },
-  divider: "#414141",
+  divider: "#585858",
   background: {
     default: "#121217",
     paper: "#27272b",


### PR DESCRIPTION
**User-Facing Changes**
Lighten divider color slightly on dark theme so that it is visible on Menus

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
