### PR TITLE
Fix imageview hitmap detection

### DIFF
--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -495,6 +495,8 @@ export function ImageCanvas(props: Props): JSX.Element {
       .then((r) => {
         if (r?.marker) {
           props.setActivePixelData(r);
+        } else {
+          props.setActivePixelData(undefined);
         }
       });
   }

--- a/packages/studio-base/src/panels/Image/components/Toolbar.tsx
+++ b/packages/studio-base/src/panels/Image/components/Toolbar.tsx
@@ -94,6 +94,8 @@ export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JS
   useEffect(() => {
     if (pixelData) {
       setSelectedTab(TabName.SELECTED_POINT);
+    } else {
+      setSelectedTab(undefined);
     }
   }, [pixelData]);
 

--- a/packages/studio-base/src/panels/Image/lib/HitmapRenderContext.ts
+++ b/packages/studio-base/src/panels/Image/lib/HitmapRenderContext.ts
@@ -16,8 +16,7 @@ export class HitmapRenderContext {
     private readonly _ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     private readonly _hitmapCanvas: HTMLCanvasElement | OffscreenCanvas | undefined,
   ) {
-    // this._hctx = this._hitmapCanvas?.getContext("2d", { alpha: false }) ?? undefined;
-    this._hctx = this._hitmapCanvas?.getContext("2d", { alpha: false }) ?? undefined;
+    this._hctx = this._hitmapCanvas?.getContext("2d") ?? undefined;
     if (this._hctx) {
       this._hctx.imageSmoothingEnabled = false;
       this._hctx.clearRect(0, 0, this._ctx.canvas.width, this._ctx.canvas.height);


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with marker click to inspect in the image panel.

**Description**
The issue was that the `HitmapRenderContext` was using a context with no alpha but we need the alpha value to signify the absence of a marker.

This PR also hides the inspection UI when the user clicks away from a point containing a marker.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3473