### PR TITLE
Fix image view empty state logic

### DIFF
--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -285,7 +285,7 @@ function ImageView(props: Props) {
     return <TopicDropdown multiple={false} title={title} items={items} onChange={onChange} />;
   }, [cameraTopic, allImageTopics, onChangeCameraTopic]);
 
-  const showEmptyState = !image;
+  const showEmptyState = !imageMessageToRender;
 
   return (
     <Stack flex="auto" overflow="hidden" position="relative">

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -17,6 +17,7 @@ import cx from "classnames";
 import produce from "immer";
 import { difference, set, union } from "lodash";
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
+import { useUpdateEffect } from "react-use";
 
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
@@ -228,6 +229,10 @@ function ImageView(props: Props) {
   // Keep the last image message, if it exists, to render on the ImageCanvas.
   // Improve perf by hiding the ImageCanvas while seeking, instead of unmounting and remounting it.
   const imageMessageToRender = image ?? lastImageMessageRef.current;
+
+  useUpdateEffect(() => {
+    lastImageMessageRef.current = undefined;
+  }, [cameraTopic]);
 
   const pauseFrame = useMessagePipeline(
     useCallback((messagePipeline) => messagePipeline.pauseFrame, []),

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -223,13 +223,18 @@ function ImageView(props: Props) {
   });
 
   const lastImageMessageRef = useRef(image);
-  if (image) {
-    lastImageMessageRef.current = image;
-  }
+
+  useEffect(() => {
+    if (image) {
+      lastImageMessageRef.current = image;
+    }
+  }, [image]);
+
   // Keep the last image message, if it exists, to render on the ImageCanvas.
   // Improve perf by hiding the ImageCanvas while seeking, instead of unmounting and remounting it.
   const imageMessageToRender = image ?? lastImageMessageRef.current;
 
+  // Clear our cached last image when the camera topic changes since it came from the old topic.
   useUpdateEffect(() => {
     lastImageMessageRef.current = undefined;
   }, [cameraTopic]);


### PR DESCRIPTION
**User-Facing Changes**
Fix fixes an erroneous waiting state in the image panel UI

**Description**
The new experimental players have different message loading behavior and that has exposed an error in the logic we use to determine whether or not we should show an empty state in the image panel where the empty state is sometimes shown on top of an image.

This PR changes the logic to be consistent between determining what to render and showing the empty state and also clears the cached last image on topic change.

<img width="438" alt="Screen Shot 2022-06-01 at 12 18 26 PM" src="https://user-images.githubusercontent.com/93935560/171464513-8de8c6ff-be27-4d68-b6da-c6f91dbb5081.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
