### PR TITLE
Handle empty string in node paths in settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -123,9 +123,10 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { fields, children } = settings;
   const hasProperties = fields != undefined || children != undefined;
 
-  // Provide stable subpaths so that memoization works.
+  // Provide stable subpaths so that memoization works. We force a dependency on path
+  // here to make sure we reset the cache if the path changes.
   const stablePaths = useMemo<Record<string, readonly string[]>>(
-    () => ({ "": props.path }),
+    () => ({ [Symbol()]: props.path }),
     [props.path],
   );
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes an issue with paths in nodes in the settings tree that have the empty string `""` as a key.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3483 