### PR TITLE
Fix logic for message path completion across arrays

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.test.ts
@@ -67,6 +67,12 @@ const datatypes: RosDatatypes = new Map(
     "tf/tfMessage": {
       definitions: [{ name: "transforms", type: "geometry_msgs/TransformStamped", isArray: true }],
     },
+    "visualization_msgs/Marker": {
+      definitions: [{ name: "id", type: "int32", isArray: false }],
+    },
+    "visualization_msgs/MarkerArray": {
+      definitions: [{ name: "markers", type: "visualization_msgs/Marker", isArray: true }],
+    },
   }),
 );
 
@@ -363,6 +369,38 @@ describe("messagePathStructures", () => {
         },
         structureType: "message",
       },
+      "visualization_msgs/Marker": {
+        datatype: "visualization_msgs/Marker",
+        nextByName: {
+          id: {
+            datatype: "visualization_msgs/Marker",
+            primitiveType: "int32",
+            structureType: "primitive",
+          },
+        },
+        structureType: "message",
+      },
+      "visualization_msgs/MarkerArray": {
+        datatype: "visualization_msgs/MarkerArray",
+        nextByName: {
+          markers: {
+            datatype: "visualization_msgs/MarkerArray",
+            next: {
+              datatype: "visualization_msgs/Marker",
+              nextByName: {
+                id: {
+                  datatype: "visualization_msgs/Marker",
+                  primitiveType: "int32",
+                  structureType: "primitive",
+                },
+              },
+              structureType: "message",
+            },
+            structureType: "array",
+          },
+        },
+        structureType: "message",
+      },
     });
   });
 
@@ -409,6 +447,13 @@ describe("messagePathsForDatatype", () => {
       ".transforms[0].transform",
       ".transforms[0].transform.rotation",
       ".transforms[0].transform.translation",
+    ]);
+
+    expect(messagePathsForDatatype("visualization_msgs/MarkerArray", datatypes)).toEqual([
+      "",
+      ".markers",
+      ".markers[:]{id==0}",
+      ".markers[:]{id==0}.id",
     ]);
   });
 

--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -45,7 +45,9 @@ function isRosPrimitive(type: string): type is RosPrimitive {
 }
 
 function structureItemIsIntegerPrimitive(item: MessagePathStructureItem) {
-  return item.structureType === "primitive" && STRUCTURE_ITEM_INTEGER_TYPES.includes(item.datatype);
+  return (
+    item.structureType === "primitive" && STRUCTURE_ITEM_INTEGER_TYPES.includes(item.primitiveType)
+  );
 }
 
 // Generate an easily navigable flat structure given some `datatypes`. We cache


### PR DESCRIPTION
**User-Facing Changes**
This improves our message path auto-completion logic

**Description**
The code was looking at the wrong field of `MessagePathStructureItem` to determine if it was a primitive. It should be looking at `primitiveType` not `datatype`.

This PR also adds some tests to cover this behavior.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3459 