### PR TITLE
Put related annotation topics at top of annotation list in image panel settings

### DIFF
--- a/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
@@ -44,6 +44,7 @@ export function TopicDropdown(props: Props): JSX.Element {
         disabled={items.length === 0}
         displayEmpty
         title={title}
+        renderValue={(_selected) => title}
         size="small"
         variant="filled"
         onChange={handleChange}

--- a/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
@@ -2,17 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import {
-  MenuItem,
-  Select,
-  ListItemText,
-  SelectChangeEvent,
-  Radio,
-  ListSubheader,
-  SelectProps,
-  MenuProps,
-} from "@mui/material";
+import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
 import { useMemo } from "react";
 
 type TopicDropdownItem = {
@@ -23,16 +13,18 @@ type TopicDropdownItem = {
 type Props = {
   title: string;
   items: TopicDropdownItem[];
-  multiple: boolean;
-  size?: SelectProps["size"];
   open?: boolean;
-  anchorEl?: Element | ReactNull;
-
   onChange: (activeTopics: string[]) => void;
 };
 
+const menuProps = {
+  MenuListProps: {
+    dense: true,
+  },
+};
+
 export function TopicDropdown(props: Props): JSX.Element {
-  const { items, onChange, multiple, title, size = "small" } = props;
+  const { items, onChange, title } = props;
 
   const selectedTopics = useMemo<string[]>(() => {
     return items.filter((item) => item.selected).map((item) => item.name);
@@ -45,51 +37,27 @@ export function TopicDropdown(props: Props): JSX.Element {
     onChange(typeof value === "string" ? [value] : value);
   };
 
-  const menuProps: Partial<MenuProps> = {
-    MenuListProps: {
-      dense: true,
-      subheader: multiple ? <ListSubheader>Select multiple topics</ListSubheader> : undefined,
-    },
-  };
-
-  // We avoid setting the anchorEl property unless it is specified.
-  // The underlying menu component treats the presence of the property (even if undefined or null)
-  // as a value.
-  if ("anchorEl" in props) {
-    menuProps.anchorEl = props.anchorEl;
-  }
-
   return (
     <>
       <Select
         value={selectedTopics}
         disabled={items.length === 0}
         displayEmpty
-        renderValue={(_selected) => title}
         title={title}
-        size={size}
+        size="small"
+        variant="filled"
         onChange={handleChange}
-        multiple={multiple}
         open={props.open}
         MenuProps={menuProps}
       >
         {items.length === 0 && (
           <MenuItem disabled value="">
-            <ListItemText
-              primary="No topics"
-              primaryTypographyProps={{ variant: "inherit", color: "text.secondary" }}
-            />
+            No topics
           </MenuItem>
         )}
         {items.map((item) => (
           <MenuItem key={item.name} value={item.name}>
-            <Radio
-              checked={selectedTopics.includes(item.name)}
-              size="small"
-              edge="start"
-              checkedIcon={<CheckCircleIcon />}
-            />
-            <ListItemText primary={item.name} primaryTypographyProps={{ variant: "inherit" }} />
+            {item.name}
           </MenuItem>
         ))}
       </Select>

--- a/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
@@ -2,7 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import {
+  MenuItem,
+  Select,
+  ListItemText,
+  SelectChangeEvent,
+  SelectProps,
+  MenuProps,
+} from "@mui/material";
 import { useMemo } from "react";
 
 type TopicDropdownItem = {
@@ -13,18 +20,15 @@ type TopicDropdownItem = {
 type Props = {
   title: string;
   items: TopicDropdownItem[];
+  size?: SelectProps["size"];
   open?: boolean;
+  anchorEl?: Element | ReactNull;
+
   onChange: (activeTopics: string[]) => void;
 };
 
-const menuProps = {
-  MenuListProps: {
-    dense: true,
-  },
-};
-
 export function TopicDropdown(props: Props): JSX.Element {
-  const { items, onChange, title } = props;
+  const { items, onChange, title, size = "small" } = props;
 
   const selectedTopics = useMemo<string[]>(() => {
     return items.filter((item) => item.selected).map((item) => item.name);
@@ -37,28 +41,43 @@ export function TopicDropdown(props: Props): JSX.Element {
     onChange(typeof value === "string" ? [value] : value);
   };
 
+  const menuProps: Partial<MenuProps> = {
+    MenuListProps: {
+      dense: true,
+    },
+  };
+
+  // We avoid setting the anchorEl property unless it is specified.
+  // The underlying menu component treats the presence of the property (even if undefined or null)
+  // as a value.
+  if ("anchorEl" in props) {
+    menuProps.anchorEl = props.anchorEl;
+  }
+
   return (
     <>
       <Select
         value={selectedTopics}
         disabled={items.length === 0}
         displayEmpty
-        title={title}
         renderValue={(_selected) => title}
-        size="small"
-        variant="filled"
+        title={title}
+        size={size}
         onChange={handleChange}
         open={props.open}
         MenuProps={menuProps}
       >
         {items.length === 0 && (
           <MenuItem disabled value="">
-            No camera topics
+            <ListItemText
+              primary="No topics"
+              primaryTypographyProps={{ variant: "inherit", color: "text.secondary" }}
+            />
           </MenuItem>
         )}
         {items.map((item) => (
           <MenuItem key={item.name} value={item.name}>
-            {item.name}
+            <ListItemText primary={item.name} primaryTypographyProps={{ variant: "inherit" }} />
           </MenuItem>
         ))}
       </Select>

--- a/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
@@ -52,7 +52,7 @@ export function TopicDropdown(props: Props): JSX.Element {
       >
         {items.length === 0 && (
           <MenuItem disabled value="">
-            No topics
+            No camera topics
           </MenuItem>
         )}
         {items.map((item) => (

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -304,7 +304,7 @@ function ImageView(props: Props) {
       ? "No camera topics"
       : "Select a camera topic";
 
-    return <TopicDropdown multiple={false} title={title} items={items} onChange={onChange} />;
+    return <TopicDropdown title={title} items={items} onChange={onChange} />;
   }, [cameraTopic, imageTopics, onChangeCameraTopic]);
 
   const showEmptyState = !imageMessageToRender;

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -127,7 +127,7 @@ function ImageView(props: Props) {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
   const { id: panelId } = usePanelContext();
 
-  const allImageTopics = useMemo(() => {
+  const imageTopics = useMemo(() => {
     return topics.filter(({ datatype }) => NORMALIZABLE_IMAGE_DATATYPES.includes(datatype));
   }, [topics]);
 
@@ -135,11 +135,11 @@ function ImageView(props: Props) {
   useEffect(() => {
     const maybeCameraTopic = mightActuallyBePartial(config).cameraTopic;
     if (maybeCameraTopic == undefined || maybeCameraTopic === "") {
-      if (allImageTopics[0] && allImageTopics[0].name !== "") {
-        saveConfig({ cameraTopic: allImageTopics[0].name });
+      if (imageTopics[0] && imageTopics[0].name !== "") {
+        saveConfig({ cameraTopic: imageTopics[0].name });
       }
     }
-  }, [allImageTopics, config, saveConfig]);
+  }, [imageTopics, config, saveConfig]);
 
   const onChangeCameraTopic = useCallback(
     (newCameraTopic: string) => {
@@ -160,6 +160,11 @@ function ImageView(props: Props) {
       });
     },
     [enabledMarkerTopics, saveConfig, topics],
+  );
+
+  const relatedMarkerTopics = useMemo(
+    () => getMarkerOptions(config.cameraTopic, topics, ANNOTATION_DATATYPES),
+    [config.cameraTopic, topics],
   );
 
   const actionHandler = useCallback(
@@ -191,7 +196,7 @@ function ImageView(props: Props) {
     [config, onChangeCameraTopic, saveConfig],
   );
 
-  const allAnnotationTopics = useMemo(() => {
+  const markerTopics = useMemo(() => {
     return topics
       .filter((topic) => (ANNOTATION_DATATYPES as readonly string[]).includes(topic.datatype))
       .map((topic) => topic.name);
@@ -200,15 +205,22 @@ function ImageView(props: Props) {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      roots: buildSettingsTree(config, allImageTopics, allAnnotationTopics, enabledMarkerTopics),
+      roots: buildSettingsTree({
+        config,
+        imageTopics,
+        markerTopics,
+        enabledMarkerTopics,
+        relatedMarkerTopics,
+      }),
     });
   }, [
     actionHandler,
-    allAnnotationTopics,
-    allImageTopics,
     config,
     enabledMarkerTopics,
+    imageTopics,
+    markerTopics,
     panelId,
+    relatedMarkerTopics,
     updatePanelSettingsTree,
   ]);
 
@@ -272,7 +284,7 @@ function ImageView(props: Props) {
   };
 
   const imageTopicDropdown = useMemo(() => {
-    const items = allImageTopics.map((topic) => {
+    const items = imageTopics.map((topic) => {
       return {
         name: topic.name,
         selected: topic.name === cameraTopic,
@@ -293,7 +305,7 @@ function ImageView(props: Props) {
       : "Select a camera topic";
 
     return <TopicDropdown multiple={false} title={title} items={items} onChange={onChange} />;
-  }, [cameraTopic, allImageTopics, onChangeCameraTopic]);
+  }, [cameraTopic, imageTopics, onChangeCameraTopic]);
 
   const showEmptyState = !imageMessageToRender;
 

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -3,26 +3,33 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Immutable } from "immer";
+import { chain } from "lodash";
 
 import { Topic } from "@foxglove/studio";
-import {
-  SettingsTreeNode,
-  SettingsTreeRoots,
-} from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 import { Config } from "./types";
 
-export function buildSettingsTree(
-  config: Immutable<Config>,
-  imageTopics: readonly Topic[],
-  allMarkerTopics: readonly string[],
-  enabledMarkerTopics: readonly string[],
-): SettingsTreeRoots {
-  const markerFields: Record<string, SettingsTreeNode> = Object.fromEntries(
-    [...allMarkerTopics]
-      .sort()
-      .map((topic) => [topic, { label: topic, visible: enabledMarkerTopics.includes(topic) }]),
-  );
+export function buildSettingsTree({
+  config,
+  imageTopics,
+  markerTopics,
+  enabledMarkerTopics,
+  relatedMarkerTopics,
+}: {
+  config: Immutable<Config>;
+  imageTopics: readonly Topic[];
+  markerTopics: readonly string[];
+  enabledMarkerTopics: readonly string[];
+  relatedMarkerTopics: readonly string[];
+}): SettingsTreeRoots {
+  const markerFields = chain(markerTopics)
+    .sort()
+    .partition((topic) => relatedMarkerTopics.includes(topic))
+    .thru((topics) => topics.flat())
+    .map((topic) => [topic, { label: topic, visible: enabledMarkerTopics.includes(topic) }])
+    .fromPairs()
+    .value();
 
   return {
     general: {


### PR DESCRIPTION
**User-Facing Changes**
This sorts the annotation topics in the image panel settings so that topics related to the camera topic are at the top of the list.

**Description**
This also changes the styling of the in-panel camera topic picker to a standard select since it's no longer a multi-valued select.

<img width="386" alt="Screen Shot 2022-06-07 at 9 42 25 AM" src="https://user-images.githubusercontent.com/93935560/172410138-67575f84-c3a1-46eb-94b1-f239dbc92cbb.png">

Note that this does not implement annotation separation / segmentation as described in #3505 since it seems we need to think through the right approach in more detail first.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3505 