### PR TITLE
Handle both empty string and undefined for select in settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -18,12 +18,16 @@ import {
   ListProps,
 } from "@mui/material";
 import { DeepReadonly } from "ts-essentials";
+import { v4 as uuid } from "uuid";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { ColorPickerInput, ColorGradientInput, NumberInput, Vec3Input } from "./inputs";
 import { SettingsTreeAction, SettingsTreeField } from "./types";
+
+// Used to both undefined and empty string in select inputs.
+const UNDEFINED_SENTINEL_VALUE = uuid();
 
 const StyledToggleButtonGroup = muiStyled(ToggleButtonGroup)(({ theme }) => ({
   backgroundColor: theme.palette.action.hover,
@@ -261,16 +265,21 @@ function FieldInput({
           displayEmpty
           fullWidth
           variant="filled"
-          value={field.value ?? ""}
+          value={field.value ?? UNDEFINED_SENTINEL_VALUE}
           onChange={(event) =>
             actionHandler({
               action: "update",
-              payload: { path, input: "select", value: event.target.value },
+              payload: {
+                path,
+                input: "select",
+                value:
+                  event.target.value === UNDEFINED_SENTINEL_VALUE ? undefined : event.target.value,
+              },
             })
           }
           MenuProps={{ MenuListProps: { dense: true } }}
         >
-          {field.options.map(({ label, value }) => (
+          {field.options.map(({ label, value = UNDEFINED_SENTINEL_VALUE }) => (
             <MenuItem key={value} value={value}>
               {label}
             </MenuItem>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -7,6 +7,7 @@ import produce from "immer";
 import { last } from "lodash";
 import { useCallback, useMemo, useState, useEffect } from "react";
 
+import Logger from "@foxglove/log";
 import { MessagePathInputStoryFixture } from "@foxglove/studio-base/components/MessagePathSyntax/fixture";
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
@@ -23,6 +24,8 @@ export default {
   title: "components/SettingsTreeEditor",
   component: SettingsTreeEditor,
 };
+
+const log = Logger.getLogger(__filename);
 
 const BasicSettings: SettingsTreeRoots = {
   general: {
@@ -77,9 +80,10 @@ const BasicSettings: SettingsTreeRoots = {
       },
       emptySelect: {
         label: "Empty Select",
-        value: "",
+        value: undefined,
         input: "select",
         options: [
+          { label: "Undefined", value: undefined },
           { label: "Nothing", value: "" },
           { label: "Something", value: "something" },
         ],
@@ -443,6 +447,7 @@ function Wrapper({ roots }: { roots: SettingsTreeRoots }): JSX.Element {
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
+      log.info("Handling action", action);
       if (action.action === "perform-node-action") {
         if (action.payload.id === "add-grid") {
           const nodeCount = Object.keys(dynamicNodes).length;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This uses a sentinel value to make it possible for the select input in settings to distinguish `undefined` from `""`. This is needed for selecting frame ids in the new 3d panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
