### PR TITLE
Fix settings node stable path logic

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -5,6 +5,7 @@
 import ClearIcon from "@mui/icons-material/Clear";
 import SearchIcon from "@mui/icons-material/Search";
 import { AppBar, IconButton, TextField, styled as muiStyled } from "@mui/material";
+import memoizeWeak from "memoize-weak";
 import { useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 
@@ -25,6 +26,8 @@ const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
   gridTemplateColumns: "minmax(4rem, 1fr) minmax(4rem, 12rem)",
   columnGap: theme.spacing(1),
 }));
+
+const makeStablePath = memoizeWeak((key: string) => [key]);
 
 export default function SettingsTreeEditor({
   settings,
@@ -64,7 +67,7 @@ export default function SettingsTreeEditor({
         {Object.entries(settings.roots).map(([key, root]) => (
           <NodeEditor
             key={key}
-            path={[key]}
+            path={makeStablePath(key)}
             settings={root}
             defaultOpen={root.defaultExpansionState === "collapsed" ? false : true}
             actionHandler={actionHandler}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the settings tree node stable path generation logic which was never generating stable paths since the top level nodes' paths were generated on the fly via an array expression like `[key]`.

This fix is a necessary precursor to more memoization in the new 3d panel settings.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
