### PR TITLE
Implement requestBackfill for IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -259,7 +259,9 @@ export class IterablePlayer implements Player {
 
     this._allTopics = allTopics;
     this._partialTopics = partialTopics;
+  }
 
+  requestBackfill(): void {
     // Once we are in an active state (i.e. done initializing), we use seeking to indicate
     // that subscriptions have changed so restart our loading
     if (this._state === "idle" || this._state === "seek-backfill" || this._state === "play") {
@@ -267,10 +269,6 @@ export class IterablePlayer implements Player {
         this.seekPlayback(this._currentTime);
       }
     }
-  }
-
-  requestBackfill(): void {
-    // no-op
   }
 
   setPublishers(_publishers: AdvertiseOptions[]): void {


### PR DESCRIPTION


**User-Facing Changes**
When using any of the experimental players and subscribing to a topic which already has a subscription panels correctly receive their requested message.

**Description**
The IterablePlayer setSubscriptions implementation would ignore any calls which did not result in actually changing the subscriptions. This behavior resulted in panels which want to subscribe to a topic that is already subscribed from getting the message. The way message pipeline handles this is by invoking requestBackfill after a setSubscriptions call but since requestBackfill was not implemented in IterablePlayer (since setSubscriptions itself changed the state to load when needed), this meant panels did not get messages they needed.

This change fixes this behavior by moving the "backfill" state change logic from setSubscriptions into requestBackfill for the IterablePlayer. In a future world we can remove requestBackfill and have message pipeline understand when subscriptions have not changed since it also has the last player state but for now we adhere to the expected pattern of setSubscriptions followed by requestBackfill.

Fixes: #3481

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
