### PR TITLE
Don't trigger action handler on action menu click away

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -45,7 +45,7 @@ export function NodeActionsMenu({
         id="basic-menu"
         anchorEl={anchorEl}
         open={open}
-        onClose={handleClose}
+        onClose={() => setAnchorEl(undefined)}
         MenuListProps={{
           "aria-labelledby": "node-actions-button",
         }}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the settings node action menu logic to not trigger the action handler when the user clicks away to close the menu.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
