### PR TITLE
[New3D] Fix Line2 picking shader, support world units

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/MaterialCache.ts
@@ -311,11 +311,12 @@ export const LineVertexColor = {
 };
 
 export const LineVertexColorPicking = {
-  id: (lineWidth: number): string => `LineVertexColorPicking-${lineWidth.toFixed(4)}`,
+  id: (lineWidth: number, worldUnits: boolean): string =>
+    `LineVertexColorPicking-${lineWidth.toFixed(4)}${worldUnits ? "-w" : ""}`,
 
-  create: (lineWidth: number): THREE.ShaderMaterial => {
+  create: (lineWidth: number, worldUnits: boolean): THREE.ShaderMaterial => {
     return new THREE.ShaderMaterial({
-      vertexShader: THREE.ShaderLib["line"]!.vertexShader,
+      vertexShader: THREE.ShaderLib["foxglove.line"]!.vertexShader,
       fragmentShader: /* glsl */ `
         uniform vec4 objectId;
         void main() {
@@ -325,7 +326,6 @@ export const LineVertexColorPicking = {
       clipping: true,
       uniforms: {
         objectId: { value: [NaN, NaN, NaN, NaN] },
-        worldUnits: { value: 0 },
         linewidth: { value: lineWidth },
         resolution: { value: new THREE.Vector2(1, 1) },
         dashOffset: { value: 0 },
@@ -333,6 +333,7 @@ export const LineVertexColorPicking = {
         dashSize: { value: 1 },
         gapSize: { value: 1 },
       },
+      defines: worldUnits ? { WORLD_UNITS: "" } : {},
     });
   },
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -450,10 +450,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
     // Traverse the scene looking for this objectId
     const obj = this.scene.getObjectById(objectId);
 
-    // Find the first ancestor of the clicked object that has a name
-    // TODO: We should probably use a better way to identify the clicked object
+    // Find the first ancestor of the clicked object that has a Pose
     let selectedObj = obj;
-    while (selectedObj && selectedObj.name === "") {
+    while (selectedObj && selectedObj.userData.pose == undefined) {
       selectedObj = selectedObj.parent ?? undefined;
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -76,7 +76,11 @@ export class FrameAxes extends THREE.Object3D {
     this.lineMaterial = new LineMaterial({ linewidth: 2 });
     this.lineMaterial.color = YELLOW_COLOR;
 
-    this.linePickingMaterial = linePickingMaterial(PICKING_LINE_SIZE, this.renderer.materialCache);
+    this.linePickingMaterial = linePickingMaterial(
+      PICKING_LINE_SIZE,
+      false,
+      this.renderer.materialCache,
+    );
 
     renderer.setSettingsNodeProvider(LayerType.Transform, (_topicConfig) => {
       // const cur = topicConfig as Partial<LayerSettingsTransform>;
@@ -95,7 +99,7 @@ export class FrameAxes extends THREE.Object3D {
     this.children.length = 0;
     this.axesByFrameId.clear();
     this.lineMaterial.dispose();
-    releaseLinePickingMaterial(PICKING_LINE_SIZE, this.renderer.materialCache);
+    releaseLinePickingMaterial(PICKING_LINE_SIZE, false, this.renderer.materialCache);
   }
 
   addTransformMessage(tf: TF): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -20,8 +20,6 @@ import {
   releaseLinePickingMaterial,
 } from "./materials";
 
-const MIN_PICKING_LINE_SIZE = 6;
-
 export class RenderableLineList extends RenderableMarker {
   geometry: LineSegmentsGeometry;
   linePrepass: LineSegments2;
@@ -43,9 +41,10 @@ export class RenderableLineList extends RenderableMarker {
     const matLine = lineMaterial(marker, renderer.materialCache);
     this.line = new LineSegments2(this.geometry, matLine);
     this.line.renderOrder = 2;
-    const pickingLineWidth = Math.max(marker.scale.x, MIN_PICKING_LINE_SIZE);
+    const pickingLineWidth = marker.scale.x * 1.2;
     this.line.userData.pickingMaterial = linePickingMaterial(
       pickingLineWidth,
+      true,
       renderer.materialCache,
     );
     this.add(this.line);
@@ -57,8 +56,8 @@ export class RenderableLineList extends RenderableMarker {
     releaseLinePrepassMaterial(this.userData.marker, this._renderer.materialCache);
     releaseLineMaterial(this.userData.marker, this._renderer.materialCache);
 
-    const pickingLineWidth = Math.max(this.userData.marker.scale.x, MIN_PICKING_LINE_SIZE);
-    releaseLinePickingMaterial(pickingLineWidth, this._renderer.materialCache);
+    const pickingLineWidth = this.userData.marker.scale.x * 1.2;
+    releaseLinePickingMaterial(pickingLineWidth, true, this._renderer.materialCache);
     this.line.userData.pickingMaterial = undefined;
 
     this.geometry.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -20,8 +20,6 @@ import {
   releaseLinePickingMaterial,
 } from "./materials";
 
-const MIN_PICKING_LINE_SIZE = 6;
-
 export class RenderableLineStrip extends RenderableMarker {
   geometry: LineGeometry;
   linePrepass: Line2;
@@ -43,9 +41,10 @@ export class RenderableLineStrip extends RenderableMarker {
     const matLine = lineMaterial(marker, renderer.materialCache);
     this.line = new Line2(this.geometry, matLine);
     this.line.renderOrder = 2;
-    const pickingLineWidth = Math.max(marker.scale.x, MIN_PICKING_LINE_SIZE);
+    const pickingLineWidth = marker.scale.x * 1.2;
     this.line.userData.pickingMaterial = linePickingMaterial(
       pickingLineWidth,
+      true,
       renderer.materialCache,
     );
     this.add(this.line);
@@ -57,8 +56,8 @@ export class RenderableLineStrip extends RenderableMarker {
     releaseLinePrepassMaterial(this.userData.marker, this._renderer.materialCache);
     releaseLineMaterial(this.userData.marker, this._renderer.materialCache);
 
-    const pickingLineWidth = Math.max(this.userData.marker.scale.x, MIN_PICKING_LINE_SIZE);
-    releaseLinePickingMaterial(pickingLineWidth, this._renderer.materialCache);
+    const pickingLineWidth = this.userData.marker.scale.x * 1.2;
+    releaseLinePickingMaterial(pickingLineWidth, true, this._renderer.materialCache);
     this.line.userData.pickingMaterial = undefined;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
@@ -131,17 +131,24 @@ export function releaseLineMaterial(marker: Marker, materialCache: MaterialCache
 
 export function linePickingMaterial(
   lineWidth: number,
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  worldUnits: boolean,
   materialCache: MaterialCache,
 ): THREE.ShaderMaterial {
   return materialCache.acquire(
-    LineVertexColorPicking.id(lineWidth),
-    () => LineVertexColorPicking.create(lineWidth),
+    LineVertexColorPicking.id(lineWidth, worldUnits),
+    () => LineVertexColorPicking.create(lineWidth, worldUnits),
     LineVertexColorPicking.dispose,
   );
 }
 
-export function releaseLinePickingMaterial(lineWidth: number, materialCache: MaterialCache): void {
-  materialCache.release(LineVertexColorPicking.id(lineWidth));
+export function releaseLinePickingMaterial(
+  lineWidth: number,
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  worldUnits: boolean,
+  materialCache: MaterialCache,
+): void {
+  materialCache.release(LineVertexColorPicking.id(lineWidth, worldUnits));
 }
 
 export function pointsMaterial(marker: Marker, materialCache: MaterialCache): THREE.PointsMaterial {


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Line lists and line strips are now clickable in New3D. Previously, we were using the wrong vertex shader and didn't support lines in world units.
