### PR TITLE
Add function style panel saveConfig

### DIFF
--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -176,7 +176,7 @@ function ImageView(props: Props) {
 
       const { path, value } = action.payload;
       saveConfig(
-        produce(config, (draft) => {
+        produce<Config>((draft) => {
           if (path[0] === "markers") {
             const markerTopic = path[1] ?? "unknown";
             const newValue =
@@ -194,7 +194,7 @@ function ImageView(props: Props) {
         onChangeCameraTopic(value);
       }
     },
-    [config, onChangeCameraTopic, saveConfig],
+    [onChangeCameraTopic, saveConfig],
   );
 
   const markerTopics = useMemo(() => {

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -29,6 +29,7 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import useDeepChangeDetector from "@foxglove/studio-base/hooks/useDeepChangeDetector";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { TwoDimensionalTooltip } from "./Tooltip";
 import { safeParseFloat } from "./helpers";
@@ -84,7 +85,7 @@ type Config = {
 };
 type Props = {
   config: Config;
-  saveConfig: (arg0: Partial<Config>) => void;
+  saveConfig: SaveConfig<Config>;
   onFinishRender?: () => void;
 };
 export type Line = {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -46,7 +46,7 @@ import {
   ChartData,
   OnClickArg as OnChartClickArgs,
 } from "@foxglove/studio-base/src/components/Chart";
-import { OpenSiblingPanel, PanelConfig } from "@foxglove/studio-base/types/panels";
+import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
@@ -208,7 +208,7 @@ function selectCurrentTime(ctx: MessagePipelineContext) {
 
 type Props = {
   config: StateTransitionConfig;
-  saveConfig: (arg0: Partial<StateTransitionConfig>) => void;
+  saveConfig: SaveConfig<StateTransitionConfig>;
 };
 
 const StateTransitions = React.memo(function StateTransitions(props: Props) {

--- a/packages/studio-base/src/types/panels.ts
+++ b/packages/studio-base/src/types/panels.ts
@@ -39,7 +39,9 @@ export type UserNodes = {
   [nodeId: string]: UserNode;
 };
 
-export type SaveConfig<Config> = (arg0: Partial<Config>) => void;
+export type SaveConfig<Config> = (
+  newConfig: Partial<Config> | ((oldConfig: Config) => Partial<Config>),
+) => void;
 
 export type SavedProps = {
   [panelId: string]: PanelConfig;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This expands on the panel's `saveConfig` method to allow a function form similar to the react form of `setState` that takes the old state as an argument to a function that returns a new derived state. 

This makes it easier to write stable callbacks that update a panel config as a derived value of the old config, as commonly seen in the `actionHandler` in the panel settings API.

As a concrete example, you can see we can now effectively memoize part of the image panel's settings API which previously had no effect because the `actionHandler` was rebuilt on every config change.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
