### PR TITLE
Reorganize panel toolbar buttons

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -169,7 +169,10 @@ export const FullScreen = (): JSX.Element => {
         omitDragAndDrop
         onMount={() => {
           setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-toolbar-fullscreen]")[0] as any).click();
+            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
+          }, DEFAULT_CLICK_DELAY);
+          setTimeout(() => {
+            (document.querySelectorAll("[data-test=panel-menu-fullscreen]")[0] as any).click();
           }, DEFAULT_CLICK_DELAY);
         }}
       >

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { ContextualMenu, IContextualMenuItem, useTheme } from "@fluentui/react";
-import SettingsIcon from "@mui/icons-material/Settings";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useCallback, useContext, useMemo, useRef } from "react";
 import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
 
@@ -20,11 +20,7 @@ import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelList, { PanelSelection } from "@foxglove/studio-base/components/PanelList";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import { getPanelTypeFromMosaic } from "@foxglove/studio-base/components/PanelToolbar/utils";
-import {
-  useCurrentLayoutActions,
-  useSelectedPanels,
-} from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 
 type Props = {
   isOpen: boolean;
@@ -44,8 +40,6 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
     splitPanel,
     swapPanel,
   } = useCurrentLayoutActions();
-  const { setSelectedPanelIds } = useSelectedPanels();
-
   const getPanelType = useCallback(
     () => getPanelTypeFromMosaic(mosaicWindowActions, mosaicActions),
     [mosaicActions, mosaicWindowActions],
@@ -101,28 +95,14 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
     [mosaicActions, mosaicWindowActions, panelContext?.type, setIsOpen, swapPanel, tabId],
   );
 
-  const { openPanelSettings } = useWorkspace();
-  const openSettings = useCallback(() => {
-    if (panelContext?.id != undefined) {
-      setSelectedPanelIds([panelContext.id]);
-      openPanelSettings();
-    }
-  }, [setSelectedPanelIds, openPanelSettings, panelContext?.id]);
-
   const theme = useTheme();
 
   const menuItems: IContextualMenuItem[] = useMemo(() => {
     const items: IContextualMenuItem[] = [
       {
-        key: "settings",
-        text: "Panel settings",
-        onClick: openSettings,
-        iconProps: { iconName: "SingleColumnEdit" },
-      },
-      {
         key: "change-panel",
         text: "Change panel",
-        onClick: openSettings,
+        onClick: () => undefined,
         iconProps: {
           iconName: "ShapeSubtract",
           styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
@@ -172,6 +152,20 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         },
       );
     }
+
+    if (panelContext?.isFullscreen !== true) {
+      items.push({
+        key: "enter-fullscreen",
+        text: "Fullscreen",
+        onClick: panelContext?.enterFullscreen,
+        iconProps: {
+          iconName: "FullScreenMaximize",
+          styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
+        },
+        "data-test": "panel-menu-fullscreen",
+      });
+    }
+
     items.push({
       key: "remove",
       text: "Remove panel",
@@ -179,8 +173,19 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
       iconProps: { iconName: "Delete" },
       "data-test": "panel-menu-remove",
     });
+
     return items;
-  }, [close, isUnknownPanel, openSettings, panelContext, split, swap, theme]);
+  }, [
+    close,
+    isUnknownPanel,
+    panelContext?.enterFullscreen,
+    panelContext?.id,
+    panelContext?.isFullscreen,
+    panelContext?.title,
+    split,
+    swap,
+    theme.semanticColors.menuBackground,
+  ]);
 
   const buttonRef = useRef<HTMLDivElement>(ReactNull);
 
@@ -198,7 +203,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         onDismiss={() => setIsOpen(false)}
       />
       <ToolbarIconButton title="More" data-test="panel-menu" onClick={() => setIsOpen(!isOpen)}>
-        <SettingsIcon />
+        <MoreVertIcon />
       </ToolbarIconButton>
     </div>
   );

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -12,11 +12,14 @@
 //   You may not use this file except in compliance with the License.
 
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
-import { useContext } from "react";
+import SettingsIcon from "@mui/icons-material/Settings";
+import { useCallback, useContext } from "react";
 
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 
@@ -37,10 +40,22 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   setMenuOpen,
 }: PanelToolbarControlsProps) {
   const panelContext = useContext(PanelContext);
+  const { setSelectedPanelIds } = useSelectedPanels();
+  const { openPanelSettings } = useWorkspace();
+
+  const openSettings = useCallback(() => {
+    if (panelContext?.id != undefined) {
+      setSelectedPanelIds([panelContext.id]);
+      openPanelSettings();
+    }
+  }, [setSelectedPanelIds, openPanelSettings, panelContext?.id]);
 
   return (
     <Stack direction="row" alignItems="center" paddingLeft={1}>
       {additionalIcons}
+      <ToolbarIconButton title="Settings" onClick={openSettings}>
+        <SettingsIcon />
+      </ToolbarIconButton>
       <PanelActionsDropdown
         isOpen={menuOpen}
         setIsOpen={setMenuOpen}

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { useCallback, useContext } from "react";
 
@@ -61,13 +60,6 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
         setIsOpen={setMenuOpen}
         isUnknownPanel={isUnknownPanel}
       />
-      {!isUnknownPanel && panelContext?.connectToolbarDragHandle && (
-        <span ref={panelContext.connectToolbarDragHandle} data-test="mosaic-drag-handle">
-          <ToolbarIconButton title="Move panel (shortcut: ` or ~)" style={{ cursor: "grab" }}>
-            <DragIndicatorIcon color="disabled" />
-          </ToolbarIconButton>
-        </span>
-      )}
     </Stack>
   );
 });

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
 import { styled as muiStyled, Typography } from "@mui/material";
 import { useContext, useState, useMemo, CSSProperties } from "react";
@@ -59,7 +58,7 @@ export default React.memo<Props>(function PanelToolbar({
   children,
   isUnknownPanel = false,
 }: Props) {
-  const { isFullscreen, enterFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
+  const { isFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
   const [menuOpen, setMenuOpen] = useState(false);
 
   const panelContext = useContext(PanelContext);
@@ -70,16 +69,6 @@ export default React.memo<Props>(function PanelToolbar({
     return (
       <>
         {additionalIcons}
-        {isFullscreen === false && (
-          <ToolbarIconButton
-            title="Fullscreen"
-            data-test="panel-toolbar-fullscreen"
-            onClick={enterFullscreen}
-            value="fullscreen"
-          >
-            <FullscreenIcon />
-          </ToolbarIconButton>
-        )}
         {isFullscreen === true && (
           <ToolbarIconButton
             value="exit-fullscreen"
@@ -91,7 +80,7 @@ export default React.memo<Props>(function PanelToolbar({
         )}
       </>
     );
-  }, [additionalIcons, isFullscreen, enterFullscreen, exitFullscreen]);
+  }, [additionalIcons, isFullscreen, exitFullscreen]);
 
   return (
     <PanelToolbarRoot backgroundColor={backgroundColor}>

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -37,6 +37,7 @@ const PanelToolbarRoot = muiStyled("div", {
   shouldForwardProp: (prop) => prop !== "backgroundColor",
 })<{ backgroundColor?: CSSProperties["backgroundColor"] }>(({ theme, backgroundColor }) => ({
   transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
+  cursor: "grab",
   flex: "0 0 auto",
   alignItems: "center",
   justifyContent: "flex-end",
@@ -83,7 +84,10 @@ export default React.memo<Props>(function PanelToolbar({
   }, [additionalIcons, isFullscreen, exitFullscreen]);
 
   return (
-    <PanelToolbarRoot backgroundColor={backgroundColor}>
+    <PanelToolbarRoot
+      backgroundColor={backgroundColor}
+      ref={panelContext?.connectToolbarDragHandle}
+    >
       {children ??
         (panelContext != undefined && (
           <Typography noWrap variant="body2" color="text.secondary" flex="auto">

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -86,7 +86,8 @@ export default React.memo<Props>(function PanelToolbar({
   return (
     <PanelToolbarRoot
       backgroundColor={backgroundColor}
-      ref={panelContext?.connectToolbarDragHandle}
+      data-test="mosaic-drag-handle"
+      ref={isUnknownPanel ? undefined : panelContext?.connectToolbarDragHandle}
     >
       {children ??
         (panelContext != undefined && (

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -293,7 +293,7 @@ export function ResetZoom(): JSX.Element {
   const step = useStepSequence(
     zoomOut,
     useCallback(() => {
-      elRef.current?.querySelector("button")?.click();
+      elRef.current?.querySelector<HTMLButtonElement>("button.button")?.click();
     }, []),
     readySignal,
   );

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -214,6 +214,7 @@ export function ToolbarTab(props: Props): JSX.Element {
       ref={innerRef}
       title={tabTitle ? tabTitle : "Enter tab name"}
       tabCount={tabCount}
+      data-test="toolbar-tab"
     >
       {highlight != undefined && <DropIndicator direction={highlight} />}
       <InputBase

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -366,7 +366,7 @@ storiesOf("panels/Tab", module)
         onMount={() => {
           setTimeout(async () => {
             await tick();
-            const tabs = document.querySelectorAll("[draggable=true]");
+            const tabs = document.querySelectorAll("[data-test=toolbar-tab]");
             const toolbar = document.querySelectorAll('[data-test="toolbar-droppable"]')[1];
 
             // Drag and drop the first tab onto the toolbar of the second tab panel


### PR DESCRIPTION
**User-Facing Changes**
This reorganizes the panel toolbar buttons to make them more ergonomic.

**Description**
This makes the following changes:
1. The cog icon now directly opens settings.
2. There is now a more options button that opens the menu that used to be attached to the cog icon.
3. The drag handle has been removed and the entire panel toolbar is now draggable.

<img width="222" alt="Screen Shot 2022-06-09 at 9 00 08 AM" src="https://user-images.githubusercontent.com/93935560/172865546-14a2a85d-3b11-4d01-89c9-ec09c5f54cfc.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3515 