### PR TITLE
Hide floating arrow button on image panel when nothing is selected

### DIFF
--- a/packages/studio-base/src/panels/Image/components/Toolbar.tsx
+++ b/packages/studio-base/src/panels/Image/components/Toolbar.tsx
@@ -101,7 +101,7 @@ export function Toolbar({ pixelData }: { pixelData: PixelData | undefined }): JS
   const mousePresent = usePanelMousePresence(ref);
 
   return (
-    <ToolbarRoot ref={ref} visible={mousePresent}>
+    <ToolbarRoot ref={ref} visible={mousePresent && pixelData != undefined}>
       <ExpandingToolbar
         tooltip="Inspect objects"
         icon={<CursorIcon />}


### PR DESCRIPTION
**User-Facing Changes**
This hides the floating arrow button on the image panel unless an annotation has been selected.

**Description**
The floating arrow button is distracting and takes up space. We can hide it until the user clicks on an annotation.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
