### PR TITLE
Add help to panel context menu

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -22,6 +22,7 @@ import { PanelActionsDropdown } from "./PanelActionsDropdown";
 
 type PanelToolbarControlsProps = {
   additionalIcons?: React.ReactNode;
+  helpContent?: React.ReactNode;
   isUnknownPanel: boolean;
   menuOpen: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
@@ -32,6 +33,7 @@ type PanelToolbarControlsProps = {
 // whole PanelToolbar when only children change.
 export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   additionalIcons,
+  helpContent,
   isUnknownPanel,
   menuOpen,
   setMenuOpen,
@@ -42,6 +44,7 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
     <Stack direction="row" alignItems="center" paddingLeft={1}>
       {additionalIcons}
       <PanelActionsDropdown
+        helpContent={helpContent}
         isOpen={menuOpen}
         setIsOpen={setMenuOpen}
         isUnknownPanel={isUnknownPanel}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -27,9 +27,6 @@ type Props = {
   additionalIcons?: React.ReactNode;
   backgroundColor?: CSSProperties["backgroundColor"];
   children?: React.ReactNode;
-  // Keeping this prop for now in case we decide to expose it via some other mechanism
-  // like a context menu item.
-  // eslint-disable-next-line react/no-unused-prop-types
   helpContent?: React.ReactNode;
   isUnknownPanel?: boolean;
 };
@@ -57,6 +54,7 @@ export default React.memo<Props>(function PanelToolbar({
   additionalIcons,
   backgroundColor,
   children,
+  helpContent,
   isUnknownPanel = false,
 }: Props) {
   const { isFullscreen, enterFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
@@ -103,6 +101,7 @@ export default React.memo<Props>(function PanelToolbar({
         ))}
       <PanelToolbarControls
         additionalIcons={additionalIconsWithHelp}
+        helpContent={helpContent}
         isUnknownPanel={!!isUnknownPanel}
         menuOpen={menuOpen}
         setMenuOpen={setMenuOpen}


### PR DESCRIPTION
**User-Facing Changes**
This adds a help item to the panel context menu.

**Description**
We removed the help button from the panel toolbar in https://github.com/foxglove/studio/pull/3538 to reduce clutter and make room in the toolbar for more important items. But we can use the context menu to give the user a convenient shortcut to the panel help.

<img width="268" alt="Screen Shot 2022-06-09 at 9 24 13 AM" src="https://user-images.githubusercontent.com/93935560/172871074-45d2992f-805b-4083-b5ae-a458414c199c.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
