### PR TITLE
Limit RawMessage value path filterPath action to primitive values

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -75,6 +75,50 @@ describe("getValueActionForValue", () => {
     });
   });
 
+  it("returns paths with bigints inside object inside array", () => {
+    const structureItem: MessagePathStructureItem = {
+      structureType: "message",
+      nextByName: {
+        msg1: {
+          structureType: "array",
+          next: {
+            structureType: "message",
+            nextByName: {
+              msg2: {
+                structureType: "message",
+                datatype: "",
+                nextByName: {
+                  msg3: {
+                    datatype: "",
+                    structureType: "primitive",
+                    primitiveType: "int64",
+                  },
+                },
+              },
+            },
+            datatype: "",
+          },
+          datatype: "",
+        },
+      },
+      datatype: "",
+    };
+
+    expect(
+      getValueActionForValue({ msg1: [{ msg2: { msg3: 1234n } }] }, structureItem, [
+        "msg1",
+        0,
+        "msg2",
+        "msg3",
+      ]),
+    ).toEqual({
+      filterPath: "",
+      multiSlicePath: ".msg1[:].msg2.msg3",
+      primitiveType: "int64",
+      singleSlicePath: ".msg1[0].msg2.msg3",
+    });
+  });
+
   it("returns slice paths when pointing at a number (even when it looks like an id)", () => {
     const structureItem: MessagePathStructureItem = {
       structureType: "message",

--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
@@ -64,9 +64,8 @@ export function getValueActionForValue(
           ? structureItem.nextByName[pathItem]
           : { structureType: "primitive", primitiveType: "json", datatype: "" };
       value = (value as Record<string, unknown>)[pathItem];
-      if (multiSlicePath.endsWith("[:]")) {
+      if (multiSlicePath.endsWith("[:]") && structureItem?.structureType === "primitive") {
         // We're just inside a message that is inside an array, so we might want to pivot on this new value.
-
         if (typeof value === "bigint") {
           filterPath = `${multiSlicePath}{${pathItem}==${value.toString()}}`;
         } else {


### PR DESCRIPTION

**User-Facing Changes**
The Raw Message panel does not crash when a user hovers over (u)int64 values within object array fields on messages.

**Description**

The RawMessage getValueActionForValue function is responsible for computing the path actions (filter message path, plot message path, etc) for a value. When computing value actions for values within an array it would incorrectly try to create a filter path using complex array elements (i.e. {msg=={foo: "bar"}}). This is not supported and for complex elements with bigint values would cause the panel to crash with a "Do not know how to serialize a BigInt" error when the user would hover over their bigint value.

This fixes the behavior of getValueActionForValue to avoid making incorrect filterPaths for complex array elements and no longer crash when hovering over bigint values in the raw message display.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
