### PR TITLE
[WIP] Cache layouts for better layout browser user experience

### DIFF
--- a/packages/studio-base/src/context/LayoutManagerContext.ts
+++ b/packages/studio-base/src/context/LayoutManagerContext.ts
@@ -2,19 +2,31 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext, useContext } from "react";
+import { createContext } from "react";
 
+import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 import { ILayoutManager } from "@foxglove/studio-base/services/ILayoutManager";
+import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
 
-const LayoutManagerContext = createContext<ILayoutManager | undefined>(undefined);
+type LayoutsContext = {
+  cachedLayouts: readonly Layout[];
+  layoutManager: ILayoutManager;
+  reloadLayouts: () => Promise<void>;
+};
+
+const LayoutManagerContext = createContext<LayoutsContext | undefined>(undefined);
 LayoutManagerContext.displayName = "LayoutManagerContext";
 
 export function useLayoutManager(): ILayoutManager {
-  const ctx = useContext(LayoutManagerContext);
-  if (ctx == undefined) {
-    throw new Error("A LayoutManager provider is required to useLayoutManager");
-  }
-  return ctx;
+  return useGuaranteedContext(LayoutManagerContext).layoutManager;
+}
+
+export function useCachedLayouts(): readonly Layout[] {
+  return useGuaranteedContext(LayoutManagerContext).cachedLayouts;
+}
+
+export function useReloadLayouts(): () => Promise<void> {
+  return useGuaranteedContext(LayoutManagerContext).reloadLayouts;
 }
 
 export default LayoutManagerContext;

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -81,10 +81,15 @@ function renderTest({
     }),
     {
       wrapper: function Wrapper({ children }) {
+        const value = {
+          cachedLayouts: [],
+          layoutManager: mockLayoutManager,
+          reloadLayouts: async () => undefined,
+        };
         useEffect(() => childMounted.resolve(), []);
         return (
           <ToastProvider>
-            <LayoutManagerContext.Provider value={mockLayoutManager}>
+            <LayoutManagerContext.Provider value={value}>
               <UserProfileStorageContext.Provider value={mockUserProfile}>
                 <CurrentLayoutProvider>{children}</CurrentLayoutProvider>
               </UserProfileStorageContext.Provider>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This loads layouts on startup and then maintains a cache so that we don't have to reload them all every time the user switches to the layout browser.

We may also want to revive https://github.com/foxglove/studio/pull/3489 as a companion to this.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/3274