### PR TITLE
Fix image panel zoom to fit / zoom to fill

### DIFF
--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -327,6 +327,8 @@ export function ImageCanvas(props: Props): JSX.Element {
   const resetPanZoom = useCallback(() => {
     setPan({ x: 0, y: 0 });
     setZoom(1);
+    // We have to force an update here becase pan & zoom are not state
+    // variables and setting them alone will not trigger a re-render.
     forceUpdate();
   }, [setPan, setZoom]);
 

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -13,7 +13,15 @@
 
 import { makeStyles } from "@fluentui/react";
 import cx from "classnames";
-import { useCallback, useLayoutEffect, useRef, MouseEvent, useState, useMemo } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  MouseEvent,
+  useState,
+  useMemo,
+  useReducer,
+} from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useAsync } from "react-use";
 import usePanZoom from "use-pan-and-zoom";
@@ -103,6 +111,8 @@ export function ImageCanvas(props: Props): JSX.Element {
   const classes = useStyles();
 
   const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
+
+  const [_, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
   // generic errors within the panel
   const [error, setError] = useState<Error | undefined>();
@@ -317,6 +327,7 @@ export function ImageCanvas(props: Props): JSX.Element {
   const resetPanZoom = useCallback(() => {
     setPan({ x: 0, y: 0 });
     setZoom(1);
+    forceUpdate();
   }, [setPan, setZoom]);
 
   const zoomIn = useCallback(() => {
@@ -353,7 +364,13 @@ export function ImageCanvas(props: Props): JSX.Element {
         onClick={onCanvasClick}
         ref={canvasRef}
       />
-      <ZoomMenu zoom={scaleValue} setZoom={setZoom} setPan={setPan} setZoomMode={setZoomMode} />
+      <ZoomMenu
+        zoom={scaleValue}
+        setZoom={setZoom}
+        setPan={setPan}
+        setZoomMode={setZoomMode}
+        resetPanZoom={resetPanZoom}
+      />
     </div>
   );
 }

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -367,7 +367,6 @@ export function ImageCanvas(props: Props): JSX.Element {
       <ZoomMenu
         zoom={scaleValue}
         setZoom={setZoom}
-        setPan={setPan}
         setZoomMode={setZoomMode}
         resetPanZoom={resetPanZoom}
       />

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
@@ -14,7 +14,14 @@ export default {
 export const Dark: Story = () => {
   return (
     <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} setPan={() => {}} />
+      <ZoomMenu
+        open
+        zoom={1}
+        setZoom={() => {}}
+        setZoomMode={() => {}}
+        setPan={() => {}}
+        resetPanZoom={() => {}}
+      />
     </div>
   );
 };
@@ -24,7 +31,14 @@ Dark.parameters = { colorScheme: "dark" };
 export const Light: Story = () => {
   return (
     <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} setPan={() => {}} />
+      <ZoomMenu
+        open
+        zoom={1}
+        setZoom={() => {}}
+        setZoomMode={() => {}}
+        setPan={() => {}}
+        resetPanZoom={() => {}}
+      />
     </div>
   );
 };

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.stories.tsx
@@ -14,14 +14,7 @@ export default {
 export const Dark: Story = () => {
   return (
     <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu
-        open
-        zoom={1}
-        setZoom={() => {}}
-        setZoomMode={() => {}}
-        setPan={() => {}}
-        resetPanZoom={() => {}}
-      />
+      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
     </div>
   );
 };
@@ -31,14 +24,7 @@ Dark.parameters = { colorScheme: "dark" };
 export const Light: Story = () => {
   return (
     <div style={{ height: 250, margin: 10, position: "relative" }}>
-      <ZoomMenu
-        open
-        zoom={1}
-        setZoom={() => {}}
-        setZoomMode={() => {}}
-        setPan={() => {}}
-        resetPanZoom={() => {}}
-      />
+      <ZoomMenu open zoom={1} setZoom={() => {}} setZoomMode={() => {}} resetPanZoom={() => {}} />
     </div>
   );
 };

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.tsx
@@ -52,7 +52,6 @@ export default function ZoomMenu({
   zoom: number;
   setZoom: (zoom: number) => void;
   setZoomMode: (zoomMode: "fit" | "fill" | "other") => void;
-  setPan: (pan: { x: number; y: number }) => void;
   resetPanZoom: () => void;
   open?: boolean;
 }): JSX.Element {

--- a/packages/studio-base/src/panels/Image/components/ZoomMenu.tsx
+++ b/packages/studio-base/src/panels/Image/components/ZoomMenu.tsx
@@ -45,7 +45,7 @@ export default function ZoomMenu({
   zoom,
   setZoom,
   setZoomMode,
-  setPan,
+  resetPanZoom,
   open = false,
   ...props
 }: {
@@ -53,6 +53,7 @@ export default function ZoomMenu({
   setZoom: (zoom: number) => void;
   setZoomMode: (zoomMode: "fit" | "fill" | "other") => void;
   setPan: (pan: { x: number; y: number }) => void;
+  resetPanZoom: () => void;
   open?: boolean;
 }): JSX.Element {
   const [anchorEl, setAnchorEl] = useState<undefined | HTMLElement>(undefined);
@@ -75,11 +76,6 @@ export default function ZoomMenu({
   const zoomOut = useCallback(() => {
     setZoom(zoom - 1 * 0.5);
   }, [setZoom, zoom]);
-
-  const resetPanZoom = useCallback(() => {
-    setPan({ x: 0, y: 0 });
-    setZoom(1);
-  }, [setPan, setZoom]);
 
   const onZoomFit = useCallback(() => {
     setZoomMode("fit");


### PR DESCRIPTION
**User-Facing Changes**
This fixes the image panel zoom to fit / zoom to fill function.

**Description**
Our recent conversion of the image panel `ZoomMenu` to MUI removed a state variable that was used to track the open state of the zoom menu:

```typescript
  const [openZoomContext, setOpenZoomContext] = useState(false);
```

Without this state variable which changed as the menu was opened and closed, changing zoom and pan alone didn't change component state in `ImageCanvas` so it didn't force a re-render.

The solution here is just to force a re-render on `resetPanZoom`.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3560 