### PR TITLE
Set tabindex on image canvas so it can receive keyboard events

### DIFF
--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -340,8 +340,9 @@ export function ImageCanvas(props: Props): JSX.Element {
     };
   }, [onZoom100, zoomIn, zoomOut]);
 
+  // We have to set tabIndex here so we can be focused and receive keyboard events.
   return (
-    <div ref={rootRef} className={classes.root}>
+    <div ref={rootRef} className={classes.root} tabIndex={0}>
       <KeyListener keyDownHandlers={keyDownHandlers} />
       {error && <div className={classes.errorMessage}>Error: {error.message}</div>}
       {renderError && <div className={classes.errorMessage}>Error: {renderError.message}</div>}


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with keyboard shortcuts in the image panel.

**Description**
We need to set tabIndex on the image canvas so we can be focused and receive keyboard events.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3542 