### PR TITLE
Align settings node action menu items without icons

### DIFF
--- a/packages/studio-base/src/components/CommonIcons.tsx
+++ b/packages/studio-base/src/components/CommonIcons.tsx
@@ -4,6 +4,7 @@
 
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import BlurOnIcon from "@mui/icons-material/BlurOn";
+import CheckIcon from "@mui/icons-material/Check";
 import CircleIcon from "@mui/icons-material/Circle";
 import DirectionsWalkIcon from "@mui/icons-material/DirectionsWalk";
 import FlagIcon from "@mui/icons-material/Flag";
@@ -35,6 +36,7 @@ export default {
   Background: LayersIcon,
   Camera: PhotoCameraIcon,
   Cells: ViewComfyIcon,
+  Check: CheckIcon,
   Circle: CircleIcon,
   Clock: AccessTimeIcon,
   Collapse: UnfoldLessIcon,

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -33,11 +33,11 @@ export function NodeActionsMenu({
     <>
       <IconButton
         title="More actions"
-        id="node-actions-button"
-        aria-controls={open ? "noce-actions-menu" : undefined}
+        aria-controls={open ? "node-actions-menu" : undefined}
         aria-haspopup="true"
         aria-expanded={open ? "true" : undefined}
         onClick={handleClick}
+        data-test="node-actions-menu-button"
         size="small"
       >
         <MoreVertIcon fontSize="small" />
@@ -48,7 +48,7 @@ export function NodeActionsMenu({
         open={open}
         onClose={() => setAnchorEl(undefined)}
         MenuListProps={{
-          "aria-labelledby": "node-actions-button",
+          "aria-label": "node actions button",
         }}
       >
         {actions.map((action) => {

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -63,7 +63,7 @@ export function NodeActionsMenu({
                   <Icon fontSize="small" />
                 </ListItemIcon>
               )}
-              {/* Use hidden icon for consisten padding */}
+              {/* Use hidden icon for consistent padding */}
               {anyItemHasIcon && !Icon && (
                 <ListItemIcon style={{ visibility: "hidden" }}>
                   <CheckIcon />

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import CheckIcon from "@mui/icons-material/Check";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { Menu, MenuItem, IconButton, ListItemIcon, ListItemText } from "@mui/material";
 import { useState } from "react";
@@ -28,6 +29,8 @@ export function NodeActionsMenu({
     onSelectAction(id);
     setAnchorEl(undefined);
   };
+
+  const anyItemHasIcon = actions.some((action) => action.icon);
 
   return (
     <>
@@ -58,6 +61,12 @@ export function NodeActionsMenu({
               {Icon && (
                 <ListItemIcon>
                   <Icon fontSize="small" />
+                </ListItemIcon>
+              )}
+              {/* Use hidden icon for consisten padding */}
+              {anyItemHasIcon && !Icon && (
+                <ListItemIcon style={{ visibility: "hidden" }}>
+                  <CheckIcon />
                 </ListItemIcon>
               )}
               <ListItemText>{action.label}</ListItemText>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box } from "@mui/material";
+import { fireEvent } from "@testing-library/dom";
 import produce from "immer";
 import { last } from "lodash";
 import { useCallback, useMemo, useState, useEffect } from "react";
@@ -524,6 +525,10 @@ function Wrapper({ roots }: { roots: SettingsTreeRoots }): JSX.Element {
 export function Basics(): JSX.Element {
   return <Wrapper roots={BasicSettings} />;
 }
+
+Basics.play = () => {
+  fireEvent.click(document.querySelector("[data-test=node-actions-menu-button]")!);
+};
 
 export function PanelExamples(): JSX.Element {
   return <Wrapper roots={PanelExamplesSettings} />;

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -37,6 +37,7 @@ const BasicSettings: SettingsTreeRoots = {
     actions: [
       { id: "add-grid", label: "Add new grid", icon: "Grid" },
       { id: "add-background", label: "Add new background", icon: "Background" },
+      { id: "toggle-value", label: "Toggle Value", icon: "Check" },
       { id: "reset-values", label: "Reset values" },
     ],
     fields: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This aligns settings node action menu items with & without icons consistently and also modifies the default story so that the action menu is displayed.

<img width="603" alt="Screen Shot 2022-06-10 at 1 38 07 PM" src="https://user-images.githubusercontent.com/93935560/173129817-9d45eda8-b42a-4c9b-87d5-a4a1351202e4.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
