### PR TITLE
Update demo bag & range support check

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -30,8 +30,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
   }
 
   initialize(args: DataSourceFactoryInitializeArgs): ReturnType<IDataSourceFactory["initialize"]> {
-    const bagUrl =
-      "https://storage.googleapis.com/foxglove-public-assets/nuScenes-v1.0-mini-scene-0061.bag";
+    const bagUrl = "https://assets.foxglove.dev/nuScenes-v1.0-mini-scene-0061.bag";
 
     if (this.enableIterablePlayer) {
       const bagSource = new BagIterableSource({ type: "remote", url: bagUrl });

--- a/packages/studio-base/src/util/BrowserHttpReader.ts
+++ b/packages/studio-base/src/util/BrowserHttpReader.ts
@@ -32,8 +32,11 @@ export default class BrowserHttpReader implements FileReader {
       // Note that we cannot use `range: "bytes=0-1"` or so, because then we can't get the actual
       // file size without making Content-Range a CORS header, therefore making all this a bit less
       // robust.
+      // "no-store" forces an unconditional remote request. When the browser's cache is populated,
+      // it may add a `range` header to the request, which causes some servers to omit the
+      // `accept-ranges` header in the response.
       const controller = new AbortController();
-      response = await fetch(this._url, { signal: controller.signal });
+      response = await fetch(this._url, { signal: controller.signal, cache: "no-store" });
       controller.abort();
     } catch (error) {
       let errMsg = `Fetching remote file failed. ${error}`;


### PR DESCRIPTION
**User-Facing Changes**

- Serves the demo bag from our CDN
- Changes the check for range support in the browser reader

**Description**

The second change here requires some explanation and review.

The remote reader's setup ensures that a server advertises support for range requests:

https://github.com/foxglove/studio/blob/bf6aed9ce5b2ddbe522dac8b419bc0f1fdb6d029/packages/studio-base/src/util/BrowserHttpReader.ts#L56

The behavior I observe is that (1) once the bag is in its HTTP cache, Chrome will add `range` and `if-range` headers to this initial request; (2) the proxy server (outside of our control) omits the `accept-ranges` header iff the GET request includes a `range` header, causing bag loading to fail. (Compare the behavior between the dev deployments on the commits here.)

`no-store` forces a remote request, but in this case ensures that we receive the desired header. `no-store` also prevents storing the response, but we cancel the request immediately.