### PR TITLE
Support dividers in settings action menus

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -4,7 +4,7 @@
 
 import CheckIcon from "@mui/icons-material/Check";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { Menu, MenuItem, IconButton, ListItemIcon, ListItemText } from "@mui/material";
+import { Menu, MenuItem, IconButton, ListItemIcon, ListItemText, Divider } from "@mui/material";
 import { useState } from "react";
 
 import CommonIcons from "@foxglove/studio-base/components/CommonIcons";
@@ -54,7 +54,10 @@ export function NodeActionsMenu({
           "aria-label": "node actions button",
         }}
       >
-        {actions.map((action) => {
+        {actions.map((action, index) => {
+          if (action.type === "divider") {
+            return <Divider key={`divider_${index}`} />;
+          }
           const Icon = action.icon ? CommonIcons[action.icon] : undefined;
           return (
             <MenuItem key={action.id} onClick={() => handleClose(action.id)}>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -30,7 +30,7 @@ export function NodeActionsMenu({
     setAnchorEl(undefined);
   };
 
-  const anyItemHasIcon = actions.some((action) => action.icon);
+  const anyItemHasIcon = actions.some((action) => action.type === "action" && action.icon);
 
   return (
     <>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeActionsMenu.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import CheckIcon from "@mui/icons-material/Check";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { Menu, MenuItem, IconButton, ListItemIcon, ListItemText, Divider } from "@mui/material";
 import { useState } from "react";
@@ -56,7 +55,9 @@ export function NodeActionsMenu({
       >
         {actions.map((action, index) => {
           if (action.type === "divider") {
-            return <Divider key={`divider_${index}`} />;
+            return (
+              <Divider variant={anyItemHasIcon ? "inset" : "fullWidth"} key={`divider_${index}`} />
+            );
           }
           const Icon = action.icon ? CommonIcons[action.icon] : undefined;
           return (
@@ -66,13 +67,7 @@ export function NodeActionsMenu({
                   <Icon fontSize="small" />
                 </ListItemIcon>
               )}
-              {/* Use hidden icon for consistent padding */}
-              {anyItemHasIcon && !Icon && (
-                <ListItemIcon style={{ visibility: "hidden" }}>
-                  <CheckIcon />
-                </ListItemIcon>
-              )}
-              <ListItemText>{action.label}</ListItemText>
+              <ListItemText inset={!Icon && anyItemHasIcon}>{action.label}</ListItemText>
             </MenuItem>
           );
         })}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -35,10 +35,11 @@ const BasicSettings: SettingsTreeRoots = {
     visible: true,
     error: "This topic has an error",
     actions: [
-      { id: "add-grid", label: "Add new grid", icon: "Grid" },
-      { id: "add-background", label: "Add new background", icon: "Background" },
-      { id: "toggle-value", label: "Toggle Value", icon: "Check" },
-      { id: "reset-values", label: "Reset values" },
+      { type: "action", id: "add-grid", label: "Add new grid", icon: "Grid" },
+      { type: "action", id: "add-background", label: "Add new background", icon: "Background" },
+      { type: "action", id: "toggle-value", label: "Toggle Value", icon: "Check" },
+      { type: "divider" },
+      { type: "action", id: "reset-values", label: "Reset values" },
     ],
     fields: {
       numberWithPrecision: {
@@ -66,7 +67,7 @@ const BasicSettings: SettingsTreeRoots = {
     label: "Complex Inputs",
     icon: "Hive",
     visible: true,
-    actions: [{ id: "action", label: "Action" }],
+    actions: [{ type: "action", id: "action", label: "Action" }],
     fields: {
       messagepath: {
         label: "Message Path",
@@ -432,7 +433,7 @@ function makeBackgroundNode(index: number): SettingsTreeNode {
     fields: {
       url: { label: "URL", input: "string", value: "http://example.com/img.jpg" },
     },
-    actions: [{ id: "remove-background", label: "Remove Background" }],
+    actions: [{ type: "action", id: "remove-background", label: "Remove Background" }],
   };
 }
 
@@ -444,7 +445,7 @@ function makeGridNode(index: number): SettingsTreeNode {
       xsize: { label: "X Size", input: "number", value: 1 },
       ysize: { label: "Y Size", input: "number", value: 2 },
     },
-    actions: [{ id: "remove-grid", label: "Remove Grid" }],
+    actions: [{ type: "action", id: "remove-grid", label: "Remove Grid" }],
   };
 }
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -70,22 +70,26 @@ export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
  * An action that can be offered to the user to perform at the
  * level of a settings node.
  */
-export type SettingsTreeNodeAction = {
-  /**
-   * A unique idenfier for the action.
-   */
-  id: string;
+export type SettingsTreeNodeAction =
+  | {
+      type: "action";
 
-  /**
-   * A descriptive label for the action.
-   */
-  label: string;
+      /**
+       * A unique idenfier for the action.
+       */
+      id: string;
 
-  /**
-   * Optional icon to display with the action.
-   */
-  icon?: keyof typeof CommonIcons;
-};
+      /**
+       * A descriptive label for the action.
+       */
+      label: string;
+
+      /**
+       * Optional icon to display with the action.
+       */
+      icon?: keyof typeof CommonIcons;
+    }
+  | { type: "divider" };
 
 export type SettingsTreeNode = {
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -290,8 +290,11 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
     if (newNode) {
       newNode.error = layerErrors.errorAtPath(["layers", layerId]);
       newNode.actions ??= [];
-      if (newNode.actions.find((action) => action.id === "delete") == undefined) {
-        newNode.actions.push({ id: "delete", label: "Delete" });
+      if (
+        newNode.actions.find((action) => action.type === "action" && action.id === "delete") ==
+        undefined
+      ) {
+        newNode.actions.push({ type: "action", id: "delete", label: "Delete" });
       }
       layersChildren[layerId] = newNode;
     }
@@ -362,7 +365,7 @@ export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoo
       label: "Custom Layers",
       children: layersChildren,
       defaultExpansionState: "expanded",
-      actions: [{ id: "add-grid " + uuidv4(), label: "Add Grid", icon: "Grid" }],
+      actions: [{ type: "action", id: "add-grid " + uuidv4(), label: "Add Grid", icon: "Grid" }],
     },
   };
 }

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -290,6 +290,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       defaultProps: {
         disableRipple: true,
       },
+      styleOverrides: {
+        root: {
+          minHeight: 32,
+        },
+      },
     },
     MuiOutlinedInput: {
       styleOverrides: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This adds support for dividers in settings node action menus.

<img width="383" alt="Screen Shot 2022-06-14 at 6 54 40 AM" src="https://user-images.githubusercontent.com/93935560/173571244-b1e44018-aff9-4696-8755-eec045f9ef65.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
