### PR TITLE
Make settings nodes renameable

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -9,9 +9,9 @@ import ErrorIcon from "@mui/icons-material/Error";
 import {
   Divider,
   IconButton,
+  InputBase,
   ListItemProps,
   styled as muiStyled,
-  TextField,
   Tooltip,
   Typography,
   useTheme,
@@ -219,18 +219,23 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               }}
             />
           )}
-          {state.editing && (
-            <TextField
-              autoFocus
-              onChange={onEditLabel}
-              value={settings.label}
-              onKeyDown={onLabelKeyUp}
-            />
-          )}
-          <Stack direction="row" alignItems="center" gap={0.5}>
-            {!state.editing && (
+          <Stack direction="row" alignItems="center" gap={0.5} flex="auto">
+            {state.editing ? (
+              <form onSubmit={toggleEditing} style={{ flex: "auto" }}>
+                <InputBase
+                  autoFocus
+                  fullWidth
+                  onChange={onEditLabel}
+                  value={settings.label}
+                  onKeyDown={onLabelKeyUp}
+                  onFocus={(event) => event.target.select()}
+                  style={{ font: "inherit" }}
+                />
+              </form>
+            ) : (
               <Typography
                 noWrap={true}
+                flex="auto"
                 variant="subtitle2"
                 fontWeight={indent < 2 ? 600 : 400}
                 color={visible ? "text.primary" : "text.disabled"}
@@ -238,17 +243,19 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
                 {settings.label ?? "General"}
               </Typography>
             )}
-            <EditButton
-              data-node-function="edit-label"
-              color="primary"
-              onClick={(event) => {
-                event.stopPropagation();
-                toggleEditing();
-              }}
-              style={{ opacity: settings.renamable === true ? 1 : 0 }}
-            >
-              <EditIcon fontSize="small" />
-            </EditButton>
+            {settings.renamable === true && (
+              <EditButton
+                title="Rename"
+                data-node-function="edit-label"
+                color="primary"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  toggleEditing();
+                }}
+              >
+                <EditIcon fontSize="small" />
+              </EditButton>
+            )}
           </Stack>
         </NodeHeaderToggle>
         <Stack alignItems="center" direction="row">

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -46,6 +46,10 @@ const FieldPadding = muiStyled("div", { skipSx: true })(({ theme }) => ({
   height: theme.spacing(0.5),
 }));
 
+const EditButton = muiStyled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.25),
+}));
+
 const NodeHeader = muiStyled("div")(({ theme }) => {
   return {
     display: "flex",
@@ -223,7 +227,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               onKeyDown={onLabelKeyUp}
             />
           )}
-          <Stack direction="row" alignItems="center">
+          <Stack direction="row" alignItems="center" gap={0.5}>
             {!state.editing && (
               <Typography
                 noWrap={true}
@@ -234,16 +238,17 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
                 {settings.label ?? "General"}
               </Typography>
             )}
-            <IconButton
+            <EditButton
               data-node-function="edit-label"
+              color="primary"
               onClick={(event) => {
                 event.stopPropagation();
                 toggleEditing();
               }}
               style={{ opacity: settings.renamable === true ? 1 : 0 }}
             >
-              <EditIcon />
-            </IconButton>
+              <EditIcon fontSize="small" />
+            </EditButton>
           </Stack>
         </NodeHeaderToggle>
         <Stack alignItems="center" direction="row">

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -48,7 +48,7 @@ const FieldPadding = muiStyled("div", { skipSx: true })(({ theme }) => ({
 }));
 
 const EditButton = muiStyled(IconButton)(({ theme }) => ({
-  padding: theme.spacing(0.25),
+  padding: theme.spacing(0.5),
 }));
 
 const NodeHeader = muiStyled("div")(({ theme }) => {

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,19 +4,22 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
+import EditIcon from "@mui/icons-material/Edit";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
   Divider,
   IconButton,
   ListItemProps,
   styled as muiStyled,
+  TextField,
   Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
 import memoizeWeak from "memoize-weak";
-import { useState } from "react";
+import { ChangeEvent, useCallback } from "react";
 import { DeepReadonly } from "ts-essentials";
+import { useImmer } from "use-immer";
 
 import CommonIcons from "@foxglove/studio-base/components/CommonIcons";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -54,11 +57,20 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
       ".MuiCheckbox-root": {
         visibility: "hidden",
       },
+
+      "[data-node-function=edit-label]": {
+        visibility: "hidden",
+      },
+
       "&:hover": {
         outline: `1px solid ${theme.palette.primary.main}`,
         outlineOffset: -1,
 
         ".MuiCheckbox-root": {
+          visibility: "visible",
+        },
+
+        "[data-node-function=edit-label]": {
           visibility: "visible",
         },
       },
@@ -107,7 +119,7 @@ const makeStablePath = memoizeWeak((path: readonly string[], key: string) => [..
 
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { actionHandler, defaultOpen = true, settings = {} } = props;
-  const [open, setOpen] = useState(defaultOpen);
+  const [state, setState] = useImmer({ open: defaultOpen, editing: false });
 
   const theme = useTheme();
   const indent = props.path.length;
@@ -148,16 +160,51 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
 
   const IconComponent = settings.icon ? CommonIcons[settings.icon] : undefined;
 
+  const onEditLabel = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (settings.renamable === true) {
+        actionHandler({
+          action: "update",
+          payload: { path: [...props.path, "label"], input: "string", value: event.target.value },
+        });
+      }
+    },
+    [actionHandler, props.path, settings.renamable],
+  );
+
+  const toggleEditing = useCallback(() => {
+    setState((draft) => {
+      draft.editing = !draft.editing;
+    });
+  }, [setState]);
+
+  const toggleOpen = useCallback(() => {
+    setState((draft) => {
+      if (!draft.editing) {
+        draft.open = !draft.open;
+      }
+    });
+  }, [setState]);
+
+  const onLabelKeyUp = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter" || event.key === "Escape") {
+        toggleEditing();
+      }
+    },
+    [toggleEditing],
+  );
+
   return (
     <>
       <NodeHeader>
         <NodeHeaderToggle
           hasProperties={hasProperties}
           indent={indent}
-          onClick={() => setOpen(!open)}
+          onClick={toggleOpen}
           visible={visible}
         >
-          {hasProperties && <ExpansionArrow expanded={open} />}
+          {hasProperties && <ExpansionArrow expanded={state.open} />}
           {IconComponent && (
             <IconComponent
               fontSize="small"
@@ -168,14 +215,36 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               }}
             />
           )}
-          <Typography
-            noWrap={true}
-            variant="subtitle2"
-            fontWeight={indent < 2 ? 600 : 400}
-            color={visible ? "text.primary" : "text.disabled"}
-          >
-            {settings.label ?? "General"}
-          </Typography>
+          {state.editing && (
+            <TextField
+              autoFocus
+              onChange={onEditLabel}
+              value={settings.label}
+              onKeyDown={onLabelKeyUp}
+            />
+          )}
+          <Stack direction="row" alignItems="center">
+            {!state.editing && (
+              <Typography
+                noWrap={true}
+                variant="subtitle2"
+                fontWeight={indent < 2 ? 600 : 400}
+                color={visible ? "text.primary" : "text.disabled"}
+              >
+                {settings.label ?? "General"}
+              </Typography>
+            )}
+            <IconButton
+              data-node-function="edit-label"
+              onClick={(event) => {
+                event.stopPropagation();
+                toggleEditing();
+              }}
+              style={{ opacity: settings.renamable === true ? 1 : 0 }}
+            >
+              <EditIcon />
+            </IconButton>
+          </Stack>
         </NodeHeaderToggle>
         <Stack alignItems="center" direction="row">
           {settings.visible != undefined && (
@@ -202,14 +271,14 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           )}
         </Stack>
       </NodeHeader>
-      {open && fieldEditors.length > 0 && (
+      {state.open && fieldEditors.length > 0 && (
         <>
           <FieldPadding />
           {fieldEditors}
           <FieldPadding />
         </>
       )}
-      {open && childNodes}
+      {state.open && childNodes}
       {indent === 1 && <Divider style={{ gridColumn: "span 2" }} />}
     </>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -4,6 +4,7 @@
 
 import ArrowDownIcon from "@mui/icons-material/ArrowDropDown";
 import ArrowRightIcon from "@mui/icons-material/ArrowRight";
+import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import ErrorIcon from "@mui/icons-material/Error";
 import {
@@ -253,7 +254,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
                   toggleEditing();
                 }}
               >
-                <EditIcon fontSize="small" />
+                {state.editing ? <CheckIcon fontSize="small" /> : <EditIcon fontSize="small" />}
               </EditButton>
             )}
           </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -220,44 +220,42 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               }}
             />
           )}
-          <Stack direction="row" alignItems="center" gap={0.5} flex="auto">
-            {state.editing ? (
-              <InputBase
-                autoFocus
-                fullWidth
-                onChange={onEditLabel}
-                value={settings.label}
-                onKeyDown={onLabelKeyDown}
-                onFocus={(event) => event.target.select()}
-                style={{ font: "inherit" }}
-              />
-            ) : (
-              <Typography
-                noWrap={true}
-                flex="auto"
-                variant="subtitle2"
-                fontWeight={indent < 2 ? 600 : 400}
-                color={visible ? "text.primary" : "text.disabled"}
-              >
-                {settings.label ?? "General"}
-              </Typography>
-            )}
-            {settings.renamable === true && (
-              <EditButton
-                title="Rename"
-                data-node-function="edit-label"
-                color="primary"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  toggleEditing();
-                }}
-              >
-                {state.editing ? <CheckIcon fontSize="small" /> : <EditIcon fontSize="small" />}
-              </EditButton>
-            )}
-          </Stack>
+          {state.editing ? (
+            <InputBase
+              autoFocus
+              fullWidth
+              onChange={onEditLabel}
+              value={settings.label}
+              onKeyDown={onLabelKeyDown}
+              onFocus={(event) => event.target.select()}
+              style={{ font: "inherit" }}
+            />
+          ) : (
+            <Typography
+              noWrap={true}
+              flex="auto"
+              variant="subtitle2"
+              fontWeight={indent < 2 ? 600 : 400}
+              color={visible ? "text.primary" : "text.disabled"}
+            >
+              {settings.label ?? "General"}
+            </Typography>
+          )}
         </NodeHeaderToggle>
         <Stack alignItems="center" direction="row">
+          {settings.renamable === true && (
+            <EditButton
+              title="Rename"
+              data-node-function="edit-label"
+              color="primary"
+              onClick={(event) => {
+                event.stopPropagation();
+                toggleEditing();
+              }}
+            >
+              {state.editing ? <CheckIcon fontSize="small" /> : <EditIcon fontSize="small" />}
+            </EditButton>
+          )}
           {settings.visible != undefined && (
             <VisibilityToggle
               size="small"

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -191,7 +191,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     });
   }, [setState]);
 
-  const onLabelKeyUp = useCallback(
+  const onLabelKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key === "Enter" || event.key === "Escape") {
         toggleEditing();
@@ -222,17 +222,15 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           )}
           <Stack direction="row" alignItems="center" gap={0.5} flex="auto">
             {state.editing ? (
-              <form onSubmit={toggleEditing} style={{ flex: "auto" }}>
-                <InputBase
-                  autoFocus
-                  fullWidth
-                  onChange={onEditLabel}
-                  value={settings.label}
-                  onKeyDown={onLabelKeyUp}
-                  onFocus={(event) => event.target.select()}
-                  style={{ font: "inherit" }}
-                />
-              </form>
+              <InputBase
+                autoFocus
+                fullWidth
+                onChange={onEditLabel}
+                value={settings.label}
+                onKeyDown={onLabelKeyDown}
+                onFocus={(event) => event.target.select()}
+                style={{ font: "inherit" }}
+              />
             ) : (
               <Typography
                 noWrap={true}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -34,6 +34,7 @@ const BasicSettings: SettingsTreeRoots = {
     icon: "Settings",
     visible: true,
     error: "This topic has an error",
+    renamable: true,
     actions: [
       { type: "action", id: "add-grid", label: "Add new grid", icon: "Grid" },
       { type: "action", id: "add-background", label: "Add new background", icon: "Background" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -305,6 +305,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
   map: {
     label: "Map",
     icon: "Map",
+    renamable: true,
     fields: {
       message_path: {
         label: "Message path",
@@ -348,6 +349,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
   grid: {
     label: "Grid",
     icon: "Grid",
+    renamable: true,
     fields: {
       color: {
         label: "Color",
@@ -377,6 +379,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
   pose: {
     label: "Pose",
     icon: "Walk",
+    renamable: true,
     fields: {
       color: { label: "Color", value: "#ffffff", input: "rgb" },
       shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
@@ -577,6 +580,8 @@ function updateSettingsTreeRoots(
     const key = workingPath.shift()!;
     if (key === "visible") {
       node.visible = Boolean(value);
+    } else if (key === "label") {
+      node.label = String(value);
     } else {
       const field = node.fields?.[key];
       if (field != undefined) {
@@ -689,7 +694,9 @@ export function Basics(): JSX.Element {
 }
 
 Basics.play = () => {
-  fireEvent.click(document.querySelector("[data-test=node-actions-menu-button]")!);
+  Array.from(document.querySelectorAll("[data-test=node-actions-menu-button]"))
+    .slice(0, 1)
+    .forEach((node) => fireEvent.click(node));
 };
 
 export function DisabledFields(): JSX.Element {
@@ -703,6 +710,16 @@ export function ReadonlyFields(): JSX.Element {
 export function PanelExamples(): JSX.Element {
   return <Wrapper roots={PanelExamplesSettings} />;
 }
+
+PanelExamples.play = () => {
+  Array.from(document.querySelectorAll("[data-node-function=edit-label]"))
+    .slice(0, 1)
+    .forEach((node) => {
+      fireEvent.click(node);
+      fireEvent.change(document.activeElement!, { target: { value: "Renamed Node" } });
+      fireEvent.keyDown(document.activeElement!, { key: "Enter" });
+    });
+};
 
 export function IconExamples(): JSX.Element {
   return <Wrapper roots={IconExamplesSettings} />;

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -138,6 +138,11 @@ export type SettingsTreeNode = {
   label?: string;
 
   /**
+   * True if the node label can be edited by the user.
+   */
+  renamable?: boolean;
+
+  /**
    * An optional visibility status. If this is not undefined, the node
    * editor will display a visiblity toggle button and send update actions
    * to the action handler.


### PR DESCRIPTION
**User-Facing Changes**
This makes it possible to rename node labels in the settings tree UI.

**Description**
If a settings tree node is marked as `renamable = true` then we allow users to rename the node. Editing the label generates an action with `action: update` and `path: label`.

https://user-images.githubusercontent.com/93935560/173381128-c83ad502-43c4-4d00-a52f-4fbbfa614db3.mov

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
