### PR TITLE
Move diagnostic summary topic selector to settings

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.stories.tsx
@@ -64,6 +64,14 @@ export function Basic(): JSX.Element {
   );
 }
 
+export function WithSettings(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture} includeSettings>
+      <DiagnosticSummary />
+    </PanelSetup>
+  );
+}
+
 export function WithPinnedNodes(): JSX.Element {
   return (
     <PanelSetup fixture={fixture}>

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -18,14 +18,13 @@ import {
   ISelectableOption,
   useTheme,
 } from "@fluentui/react";
-import DatabaseIcon from "@mdi/svg/svg/database.svg";
 import PinIcon from "@mdi/svg/svg/pin.svg";
-import { Theme, Menu, MenuItem } from "@mui/material";
+import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import produce from "immer";
-import { compact, uniq } from "lodash";
-import { useCallback, useEffect, useMemo, useRef, useState, MouseEvent } from "react";
+import { compact, set, uniq } from "lodash";
+import { useCallback, useEffect, useMemo } from "react";
 import { List, AutoSizer, ListRowProps } from "react-virtualized";
 
 import { filterMap } from "@foxglove/den/collection";
@@ -36,20 +35,18 @@ import { LegacyInput } from "@foxglove/studio-base/components/LegacyStyledCompon
 import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
-import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
-import {
-  SettingsTreeAction,
-  SettingsTreeRoots,
-} from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+import { SettingsTreeAction } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Stack from "@foxglove/studio-base/components/Stack";
 import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.help.md";
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import toggle from "@foxglove/studio-base/util/toggle";
 
+import { buildSettingsTree } from "./settings";
 import {
-  DiagnosticId,
+  Config,
   DiagnosticInfo,
   DiagnosticStatusConfig,
   getDiagnosticsByLevel,
@@ -148,30 +145,10 @@ const NodeRow = React.memo(function NodeRow(props: NodeRowProps) {
   );
 });
 
-type Config = {
-  minLevel: number;
-  pinnedIds: DiagnosticId[];
-  topicToRender: string;
-  hardwareIdFilter: string;
-  sortByLevel?: boolean;
-};
-
 type Props = {
   config: Config;
-  saveConfig: (arg0: Partial<Config>) => void;
+  saveConfig: SaveConfig<Config>;
 };
-
-function buildSettingsTree(config: Config): SettingsTreeRoots {
-  return {
-    general: {
-      label: "General",
-      icon: "Settings",
-      fields: {
-        sortByLevel: { label: "Sort By Level", input: "boolean", value: config.sortByLevel },
-      },
-    },
-  };
-}
 
 const ALLOWED_DATATYPES: string[] = [
   "diagnostic_msgs/DiagnosticArray",
@@ -228,31 +205,6 @@ function DiagnosticSummary(props: Props): JSX.Element {
     [pinnedIds, saveConfig],
   );
 
-  const actionHandler = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
-        return;
-      }
-
-      const { input, path, value } = action.payload;
-      if (input === "boolean" && path[1] === "sortByLevel") {
-        saveConfig(
-          produce(config, (draft) => {
-            draft.sortByLevel = value;
-          }),
-        );
-      }
-    },
-    [config, saveConfig],
-  );
-
-  useEffect(() => {
-    updatePanelSettingsTree(panelId, {
-      actionHandler,
-      roots: buildSettingsTree(config),
-    });
-  }, [actionHandler, config, panelId, updatePanelSettingsTree]);
-
   const showDetails = useCallback(
     (info: DiagnosticInfo) => {
       openSiblingPanel({
@@ -303,9 +255,6 @@ function DiagnosticSummary(props: Props): JSX.Element {
     />
   );
 
-  const menuRef = useRef<HTMLDivElement>(ReactNull);
-  const [topicMenuOpen, setTopicMenuOpen] = useState(false);
-
   // Filter down all topics to those that conform to our supported datatypes
   const availableTopics = useMemo(() => {
     const filtered = topics
@@ -315,21 +264,6 @@ function DiagnosticSummary(props: Props): JSX.Element {
     // Keeps only the first occurrence of each topic.
     return uniq([DIAGNOSTIC_TOPIC, ...filtered, topicToRender]);
   }, [topics, topicToRender]);
-
-  const changeTopicToRender = useCallback(
-    (newTopicToRender: string) => {
-      saveConfig({ topicToRender: newTopicToRender });
-      setTopicMenuOpen(false);
-    },
-    [saveConfig],
-  );
-
-  const toggleTopicMenuAction = useCallback((ev: MouseEvent<HTMLElement>) => {
-    // To accurately position the topic dropdown menu we set the location of our menu ref to the
-    // click location
-    menuRef.current!.style.left = `${ev.clientX}px`;
-    setTopicMenuOpen((isOpen) => !isOpen);
-  }, []);
 
   const diagnostics = useDiagnostics(topicToRender);
   const summary = useMemo(() => {
@@ -386,6 +320,25 @@ function DiagnosticSummary(props: Props): JSX.Element {
     );
   }, [diagnostics, hardwareIdFilter, pinnedIds, renderRow, sortByLevel, minLevel, topicToRender]);
 
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
+      const { path, value } = action.payload;
+      saveConfig(produce<Config>((draft) => set(draft, path.slice(1), value)));
+    },
+    [saveConfig],
+  );
+
+  useEffect(() => {
+    updatePanelSettingsTree(panelId, {
+      actionHandler,
+      roots: buildSettingsTree(config, topicToRender, availableTopics),
+    });
+  }, [actionHandler, availableTopics, config, panelId, topicToRender, updatePanelSettingsTree]);
+
   const renderOption = (option: ISelectableOption | undefined) =>
     option ? (
       <div
@@ -404,41 +357,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
 
   return (
     <Stack flex="auto">
-      <PanelToolbar
-        helpContent={helpContent}
-        additionalIcons={
-          <>
-            <div ref={menuRef}>
-              <ToolbarIconButton
-                title={`Supported datatypes: ${ALLOWED_DATATYPES.join(", ")}`}
-                data-test={"topic-set"}
-                onClick={toggleTopicMenuAction}
-                subMenuActive={topicMenuOpen}
-              >
-                <DatabaseIcon />
-              </ToolbarIconButton>
-            </div>
-            <Menu
-              anchorEl={menuRef.current}
-              open={topicMenuOpen}
-              onClose={() => setTopicMenuOpen(false)}
-              MenuListProps={{
-                dense: true,
-              }}
-            >
-              {availableTopics.map((topic) => (
-                <MenuItem
-                  key={topic}
-                  onClick={() => changeTopicToRender(topic)}
-                  selected={topicToRender === topic}
-                >
-                  {topic}
-                </MenuItem>
-              ))}
-            </Menu>
-          </>
-        }
-      >
+      <PanelToolbar helpContent={helpContent}>
         <Dropdown
           styles={dropdownStyles}
           onRenderOption={renderOption}

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -44,9 +44,9 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import toggle from "@foxglove/studio-base/util/toggle";
 
-import { buildSettingsTree } from "./settings";
+import { buildSummarySettingsTree } from "./settings";
 import {
-  Config,
+  DiagnosticSummaryConfig,
   DiagnosticInfo,
   DiagnosticStatusConfig,
   getDiagnosticsByLevel,
@@ -146,8 +146,8 @@ const NodeRow = React.memo(function NodeRow(props: NodeRowProps) {
 });
 
 type Props = {
-  config: Config;
-  saveConfig: SaveConfig<Config>;
+  config: DiagnosticSummaryConfig;
+  saveConfig: SaveConfig<DiagnosticSummaryConfig>;
 };
 
 const ALLOWED_DATATYPES: string[] = [
@@ -327,7 +327,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
       }
 
       const { path, value } = action.payload;
-      saveConfig(produce<Config>((draft) => set(draft, path.slice(1), value)));
+      saveConfig(produce<DiagnosticSummaryConfig>((draft) => set(draft, path.slice(1), value)));
     },
     [saveConfig],
   );
@@ -335,7 +335,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   useEffect(() => {
     updatePanelSettingsTree(panelId, {
       actionHandler,
-      roots: buildSettingsTree(config, topicToRender, availableTopics),
+      roots: buildSummarySettingsTree(config, topicToRender, availableTopics),
     });
   }, [actionHandler, availableTopics, config, panelId, topicToRender, updatePanelSettingsTree]);
 
@@ -379,7 +379,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   );
 }
 
-const defaultConfig: Config = {
+const defaultConfig: DiagnosticSummaryConfig = {
   minLevel: 0,
   pinnedIds: [],
   hardwareIdFilter: "",

--- a/packages/studio-base/src/panels/diagnostics/settings.ts
+++ b/packages/studio-base/src/panels/diagnostics/settings.ts
@@ -4,6 +4,38 @@
 
 import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
+import { Config } from "./util";
+
+export function buildSettingsTree(
+  config: Config,
+  topicToRender: string,
+  availableTopics: readonly string[],
+): SettingsTreeRoots {
+  const topicOptions = availableTopics.map((topic) => ({ label: topic, value: topic }));
+  const topicIsAvailable = availableTopics.includes(topicToRender);
+  if (!topicIsAvailable) {
+    topicOptions.unshift({ value: topicToRender, label: topicToRender });
+  }
+  const topicError = topicIsAvailable ? undefined : `Topic ${topicToRender} is not available`;
+
+  return {
+    general: {
+      label: "General",
+      icon: "Settings",
+      fields: {
+        topicToRender: {
+          label: "Topic",
+          input: "select",
+          value: topicToRender,
+          error: topicError,
+          options: topicOptions,
+        },
+        sortByLevel: { label: "Sort By Level", input: "boolean", value: config.sortByLevel },
+      },
+    },
+  };
+}
+
 export function buildStatusPanelSettingsTree(
   topicToRender: string,
   availableTopics: readonly string[],

--- a/packages/studio-base/src/panels/diagnostics/settings.ts
+++ b/packages/studio-base/src/panels/diagnostics/settings.ts
@@ -4,10 +4,10 @@
 
 import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
-import { Config } from "./util";
+import { DiagnosticSummaryConfig } from "./util";
 
-export function buildSettingsTree(
-  config: Config,
+export function buildSummarySettingsTree(
+  config: DiagnosticSummaryConfig,
   topicToRender: string,
   availableTopics: readonly string[],
 ): SettingsTreeRoots {

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -52,7 +52,7 @@ export type DiagnosticStatusConfig = {
   collapsedSections: { name: string; section: string }[];
 };
 
-export type Config = {
+export type DiagnosticSummaryConfig = {
   minLevel: number;
   pinnedIds: DiagnosticId[];
   topicToRender: string;

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -52,6 +52,14 @@ export type DiagnosticStatusConfig = {
   collapsedSections: { name: string; section: string }[];
 };
 
+export type Config = {
+  minLevel: number;
+  pinnedIds: DiagnosticId[];
+  topicToRender: string;
+  hardwareIdFilter: string;
+  sortByLevel?: boolean;
+};
+
 export type DiagnosticId = string & ToString;
 
 export type KeyValue = { key: string; value: string };


### PR DESCRIPTION
**User-Facing Changes**
This moves the topic selector in the diagnostic summary panel toolbar into the settings sidebar.

**Description**
This moves the topic selector in the diagnostic summary panel toolbar into the settings sidebar.

<img width="371" alt="Screen Shot 2022-06-13 at 1 33 36 PM" src="https://user-images.githubusercontent.com/93935560/173421287-b401d49f-496e-4af1-b420-374caf46e607.png">
<img width="472" alt="Screen Shot 2022-06-13 at 1 33 38 PM" src="https://user-images.githubusercontent.com/93935560/173421290-7109fd68-d95b-4343-83a7-cfc26d8e850c.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3586 