### PR TITLE
Move diagnostic detail panel topic selector to settings sidebar

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
@@ -29,11 +29,16 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 import { openSiblingPlotPanel } from "@foxglove/studio-base/panels/Plot";
 import { openSiblingStateTransitionsPanel } from "@foxglove/studio-base/panels/StateTransitions";
-import { Config } from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
-import { OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
+import { OpenSiblingPanel, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
-import { LEVEL_NAMES, DiagnosticInfo, KeyValue, DiagnosticStatusMessage } from "./util";
+import {
+  LEVEL_NAMES,
+  DiagnosticInfo,
+  DiagnosticStatusConfig,
+  KeyValue,
+  DiagnosticStatusMessage,
+} from "./util";
 
 const MIN_SPLIT_FRACTION = 0.1;
 
@@ -44,7 +49,7 @@ type Props = {
   topicToRender: string;
   openSiblingPanel: OpenSiblingPanel;
   collapsedSections: { name: string; section: string }[];
-  saveConfig: (arg0: Partial<Config>) => void;
+  saveConfig: SaveConfig<DiagnosticStatusConfig>;
 };
 
 type FormattedKeyValue = {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -37,6 +37,21 @@ export function Empty(): JSX.Element {
   );
 }
 
+export function WithSettings(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture} includeSettings>
+      <DiagnosticStatusPanel
+        overrideConfig={{
+          topicToRender: "/diagnostics",
+          selectedHardwareId: "hardware_id1",
+          selectedName: "name2",
+          collapsedSections: [],
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
 export function SelectedHardwareIDOnly(): JSX.Element {
   return (
     <PanelSetup fixture={fixture}>

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -42,7 +42,6 @@ import {
   SettingsTreeRoots,
 } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { Config as DiagnosticStatusConfig } from "@foxglove/studio-base/panels/diagnostics/DiagnosticStatusPanel";
 import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.help.md";
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
@@ -52,6 +51,7 @@ import toggle from "@foxglove/studio-base/util/toggle";
 import {
   DiagnosticId,
   DiagnosticInfo,
+  DiagnosticStatusConfig,
   getDiagnosticsByLevel,
   filterAndSortDiagnostics,
   LEVEL_NAMES,

--- a/packages/studio-base/src/panels/diagnostics/settings.ts
+++ b/packages/studio-base/src/panels/diagnostics/settings.ts
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+
+export function buildStatusPanelSettingsTree(
+  topicToRender: string,
+  availableTopics: readonly string[],
+): SettingsTreeRoots {
+  const topicOptions = availableTopics.map((topic) => ({ label: topic, value: topic }));
+  const topicIsAvailable = availableTopics.includes(topicToRender);
+  if (!topicIsAvailable) {
+    topicOptions.unshift({ value: topicToRender, label: topicToRender });
+  }
+  const topicError = topicIsAvailable ? undefined : `Topic ${topicToRender} is not available`;
+
+  return {
+    general: {
+      label: "General",
+      icon: "Settings",
+      fields: {
+        topicToRender: {
+          label: "Topic",
+          input: "select",
+          value: topicToRender,
+          error: topicError,
+          options: topicOptions,
+        },
+      },
+    },
+  };
+}

--- a/packages/studio-base/src/panels/diagnostics/util.ts
+++ b/packages/studio-base/src/panels/diagnostics/util.ts
@@ -44,6 +44,14 @@ interface ToString {
   toString(): string;
 }
 
+export type DiagnosticStatusConfig = {
+  selectedHardwareId?: string;
+  selectedName?: string;
+  splitFraction?: number;
+  topicToRender: string;
+  collapsedSections: { name: string; section: string }[];
+};
+
 export type DiagnosticId = string & ToString;
 
 export type KeyValue = { key: string; value: string };


### PR DESCRIPTION
**User-Facing Changes**
This moves the topic selector in the toolbar of the diagnostic detail panel into sidebar settings.

**Description**
This moves the topic selector in the toolbar of the diagnostic detail panel into sidebar settings.

<img width="402" alt="Screen Shot 2022-06-13 at 1 57 08 PM" src="https://user-images.githubusercontent.com/93935560/173426068-426e1fa0-f3c2-4d62-93e7-df6af7cc8d61.png">

<img width="510" alt="Screen Shot 2022-06-13 at 1 57 10 PM" src="https://user-images.githubusercontent.com/93935560/173426097-3be22f0b-ec80-4755-aeec-724c1d17b6e8.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3586 