### PR TITLE
Don't show drag cursor on single panel layout

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -34,21 +34,23 @@ type Props = {
 };
 
 const PanelToolbarRoot = muiStyled("div", {
-  shouldForwardProp: (prop) => prop !== "backgroundColor",
-})<{ backgroundColor?: CSSProperties["backgroundColor"] }>(({ theme, backgroundColor }) => ({
-  transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
-  cursor: "grab",
-  flex: "0 0 auto",
-  alignItems: "center",
-  justifyContent: "flex-end",
-  padding: theme.spacing(0.25, 0.75),
-  display: "flex",
-  minHeight: PANEL_TOOLBAR_MIN_HEIGHT,
-  backgroundColor: backgroundColor ?? theme.palette.background.paper,
-  width: "100%",
-  left: 0,
-  zIndex: theme.zIndex.appBar,
-}));
+  shouldForwardProp: (prop) => prop !== "backgroundColor" && prop !== "enableDrag",
+})<{ backgroundColor?: CSSProperties["backgroundColor"]; enableDrag: boolean }>(
+  ({ theme, backgroundColor, enableDrag }) => ({
+    transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
+    cursor: enableDrag ? "grab" : "auto",
+    flex: "0 0 auto",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    padding: theme.spacing(0.25, 0.75),
+    display: "flex",
+    minHeight: PANEL_TOOLBAR_MIN_HEIGHT,
+    backgroundColor: backgroundColor ?? theme.palette.background.paper,
+    width: "100%",
+    left: 0,
+    zIndex: theme.zIndex.appBar,
+  }),
+);
 
 // Panel toolbar should be added to any panel that's part of the
 // react-mosaic layout.  It adds a drag handle, remove/replace controls
@@ -87,6 +89,7 @@ export default React.memo<Props>(function PanelToolbar({
     <PanelToolbarRoot
       backgroundColor={backgroundColor}
       data-test="mosaic-drag-handle"
+      enableDrag={panelContext?.connectToolbarDragHandle != undefined}
       ref={isUnknownPanel ? undefined : panelContext?.connectToolbarDragHandle}
     >
       {children ??


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This only shows the grab cursor on panel toolbars if they're draggable, i.e. not the only panel in the layout.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3585 