### PR TITLE
Hide settings icon on panels with no settings

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -90,7 +90,9 @@ export const PanelNotFound = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
         omitDragAndDrop
       >
-        <PanelLayout />
+        <MockPanelContextProvider>
+          <PanelLayout />
+        </MockPanelContextProvider>
       </PanelSetup>
     </DndProvider>
   );
@@ -108,7 +110,9 @@ export const PanelWithError = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
         omitDragAndDrop
       >
-        <PanelLayout />
+        <MockPanelContextProvider>
+          <PanelLayout />
+        </MockPanelContextProvider>
       </PanelSetup>
     </DndProvider>
   );

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -12,13 +12,17 @@
 //   You may not use this file except in compliance with the License.
 
 import SettingsIcon from "@mui/icons-material/Settings";
-import { useCallback, useContext } from "react";
+import { useCallback } from "react";
 
-import PanelContext from "@foxglove/studio-base/components/PanelContext";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import {
+  PanelSettingsEditorStore,
+  usePanelSettingsEditorStore,
+} from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 
@@ -38,23 +42,30 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   menuOpen,
   setMenuOpen,
 }: PanelToolbarControlsProps) {
-  const panelContext = useContext(PanelContext);
+  const { id: panelId } = usePanelContext();
   const { setSelectedPanelIds } = useSelectedPanels();
   const { openPanelSettings } = useWorkspace();
 
+  const hasSettingsSelector = useCallback(
+    (store: PanelSettingsEditorStore) => store.settingsTrees[panelId] != undefined,
+    [panelId],
+  );
+
+  const hasSettings = usePanelSettingsEditorStore(hasSettingsSelector);
+
   const openSettings = useCallback(() => {
-    if (panelContext?.id != undefined) {
-      setSelectedPanelIds([panelContext.id]);
-      openPanelSettings();
-    }
-  }, [setSelectedPanelIds, openPanelSettings, panelContext?.id]);
+    setSelectedPanelIds([panelId]);
+    openPanelSettings();
+  }, [setSelectedPanelIds, openPanelSettings, panelId]);
 
   return (
     <Stack direction="row" alignItems="center" paddingLeft={1}>
       {additionalIcons}
-      <ToolbarIconButton title="Settings" onClick={openSettings}>
-        <SettingsIcon />
-      </ToolbarIconButton>
+      {hasSettings && (
+        <ToolbarIconButton title="Settings" onClick={openSettings}>
+          <SettingsIcon />
+        </ToolbarIconButton>
+      )}
       <PanelActionsDropdown
         isOpen={menuOpen}
         setIsOpen={setMenuOpen}

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -21,6 +21,7 @@ import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanel
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import HelpInfoProvider from "@foxglove/studio-base/providers/HelpInfoProvider";
+import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 
 import PanelToolbar from "./index";
 
@@ -41,17 +42,21 @@ class MosaicWrapper extends React.Component<{
             toolbarControls={<div />}
             renderPreview={() => undefined as any}
           >
-            <HelpInfoProvider>
-              <Box
-                width="100%"
-                height="100%"
-                padding={3}
-                position="relative"
-                bgcolor="background.default"
-              >
-                <Box width={width}>{id === "Sibling" ? "Sibling Panel" : this.props.children}</Box>
-              </Box>
-            </HelpInfoProvider>
+            <PanelSettingsEditorContextProvider>
+              <HelpInfoProvider>
+                <Box
+                  width="100%"
+                  height="100%"
+                  padding={3}
+                  position="relative"
+                  bgcolor="background.default"
+                >
+                  <Box width={width}>
+                    {id === "Sibling" ? "Sibling Panel" : this.props.children}
+                  </Box>
+                </Box>
+              </HelpInfoProvider>
+            </PanelSettingsEditorContextProvider>
           </MosaicWindow>
         )}
         value={this.props.layout ?? "dummy"}

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -14,6 +14,7 @@
 import { storiesOf } from "@storybook/react";
 import TestUtils from "react-dom/test-utils";
 
+import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelLayout from "@foxglove/studio-base/components/PanelLayout";
 import { PanelCatalog, PanelInfo } from "@foxglove/studio-base/context/PanelCatalogContext";
@@ -479,7 +480,9 @@ storiesOf("panels/Tab", module)
           }, DEFAULT_TIMEOUT);
         }}
       >
-        <PanelLayout />
+        <MockPanelContextProvider>
+          <PanelLayout />
+        </MockPanelContextProvider>
       </PanelSetup>
     );
   });

--- a/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
@@ -11,7 +11,7 @@ import { SettingsTree } from "@foxglove/studio-base/components/SettingsTreeEdito
 
 type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
 
-type PanelSettingsEditorStore = {
+export type PanelSettingsEditorStore = {
   settingsTrees: Record<string, ImmutableSettingsTree>;
   updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
 };


### PR DESCRIPTION
**User-Facing Changes**
This hides the settings cog icon on panel toolbars for panels with no settings.

**Description**
This hides the settings cog icon on panel toolbars for panels with no settings.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
