### PR TITLE
Add http to img-src CSP for desktop

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -245,7 +245,8 @@ function main() {
       "style-src": "'self' 'unsafe-inline'",
       "connect-src": "'self' ws: wss: http: https: package:",
       "font-src": "'self' data:",
-      "img-src": "'self' data: https: package: x-foxglove-converted-tiff:",
+      // Include http in the CSP to allow loading images (i.e. map tiles) from http endpoints like localhost
+      "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http:",
     };
     const cspHeader = Object.entries(contentSecurityPolicy)
       .map(([key, val]) => `${key} ${val}`)


### PR DESCRIPTION
**User-Facing Changes**
Allow using `http://localhost` for custom map tile urls in the map panel when using the desktop app.

**Description**

We want to allow loading images from http urls (i.e. http://localhost) to support users with local map tile servers. This works in the web version because browsers allow requests to http localhost from https pages.

Fixes: #3487



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
