### PR TITLE
Open a new window when starting a second instance with no files.

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -101,6 +101,13 @@ function main() {
     for (const file of files) {
       app.emit("open-file", { preventDefault() {} }, file);
     }
+
+    // When being asked to open a second instance with no files or deep links then open a blank new
+    // window.
+    if (files.length === 0 && deepLinks.length === 0) {
+      log.debug("second-instance: No files or deeplinks. Opening a new window.");
+      new StudioWindow().load();
+    }
   });
 
   // Load opt-out settings for crash reporting and telemetry


### PR DESCRIPTION


**User-Facing Changes**
Clicking "New Window" from the desktop icon opens a new window much like the action says it will.

**Description**

When starting a second instance which can happen on linux either via the command line or via the "New Window" desktop icon action, the second-instance handler would be a no-op if the instance arguments had no files or deep-links. This gave the appearance of the feature being broken. This change fixes this behavior by opening a new empty window when there are no files or deep-links as the user would expect.

Fixes: #3452
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
