### PR TITLE
Refactor settings update hook

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter.tsx
@@ -347,13 +347,12 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   useMessagePipeline(messagePipelineSelector);
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
-  const { id: panelLayoutId } = usePanelContext();
 
   const updateSettings = useCallback(
     (settings: SettingsTree) => {
-      updatePanelSettingsTree(panelLayoutId, settings);
+      updatePanelSettingsTree(settings);
     },
-    [panelLayoutId, updatePanelSettingsTree],
+    [updatePanelSettingsTree],
   );
 
   type PartialPanelExtensionContext = Omit<PanelExtensionContext, "panelElement">;

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -20,7 +20,6 @@ import { useUpdateEffect } from "react-use";
 import { useDataSourceInfo } from "@foxglove/studio-base/PanelAPI";
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   PanelContextMenu,
   PanelContextMenuItem,
@@ -81,7 +80,6 @@ function ImageView(props: Props) {
   );
   const [activePixelData, setActivePixelData] = useState<PixelData | undefined>();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
-  const { id: panelId } = usePanelContext();
 
   const imageTopics = useMemo(() => {
     return topics.filter(({ datatype }) => NORMALIZABLE_IMAGE_DATATYPES.includes(datatype));
@@ -159,7 +157,7 @@ function ImageView(props: Props) {
   }, [topics]);
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree({
         config,
@@ -175,7 +173,6 @@ function ImageView(props: Props) {
     enabledMarkerTopics,
     imageTopics,
     markerTopics,
-    panelId,
     relatedMarkerTopics,
     updatePanelSettingsTree,
   ]);

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -20,7 +20,6 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import { useDataSourceInfo, useMessagesByTopic } from "@foxglove/studio-base/PanelAPI";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import { SettingsTreeAction } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -67,7 +66,6 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
   const { topics } = useDataSourceInfo();
   const { minLogLevel, searchTerms } = config;
   const { timeFormat, timeZone } = useAppTimeFormat();
-  const { id: panelId } = usePanelContext();
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
@@ -118,11 +116,11 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(topicToRender, availableTopics),
     });
-  }, [actionHandler, availableTopics, panelId, topicToRender, updatePanelSettingsTree]);
+  }, [actionHandler, availableTopics, topicToRender, updatePanelSettingsTree]);
 
   // avoid making new sets for node names
   // the filter bar uses the node names during on-demand filtering

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -30,7 +30,6 @@ import { v4 as uuidv4 } from "uuid";
 
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
@@ -49,7 +48,7 @@ import Sidebar from "@foxglove/studio-base/panels/NodePlayground/Sidebar";
 import PlaygroundIcon from "@foxglove/studio-base/panels/NodePlayground/playground-icon.svg";
 import { HelpInfoStore, useHelpInfo } from "@foxglove/studio-base/providers/HelpInfoProvider";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
-import { UserNodes } from "@foxglove/studio-base/types/panels";
+import { SaveConfig, UserNodes } from "@foxglove/studio-base/types/panels";
 
 import Config from "./Config";
 import helpContent from "./index.help.md";
@@ -94,7 +93,7 @@ export default function node(event: Input<"/input/topic">): Output {
 
 type Props = {
   config: Config;
-  saveConfig: (config: Partial<Config>) => void;
+  saveConfig: SaveConfig<Config>;
 };
 
 const UnsavedDot = muiStyled("div", {
@@ -185,7 +184,6 @@ const userNodeSelector = (state: LayoutState) =>
 function NodePlayground(props: Props) {
   const { config, saveConfig } = props;
   const { autoFormatOnSave = false, selectedNodeId, editorForStorybook } = config;
-  const { id: panelId } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const theme = useTheme();
@@ -246,11 +244,11 @@ function NodePlayground(props: Props) {
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(config),
     });
-  }, [actionHandler, config, panelId, updatePanelSettingsTree]);
+  }, [actionHandler, config, updatePanelSettingsTree]);
 
   React.useLayoutEffect(() => {
     if (selectedNode) {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -45,7 +45,6 @@ import {
   useMessagePipelineGetter,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar, {
   PANEL_TOOLBAR_MIN_HEIGHT,
 } from "@foxglove/studio-base/components/PanelToolbar";
@@ -58,7 +57,7 @@ import {
 } from "@foxglove/studio-base/components/TimeBasedChart";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
-import { OpenSiblingPanel, PanelConfig } from "@foxglove/studio-base/types/panels";
+import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import PlotChart from "./PlotChart";
@@ -92,7 +91,7 @@ export function openSiblingPlotPanel(openSiblingPanel: OpenSiblingPanel, topicNa
 
 type Props = {
   config: PlotConfig;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
+  saveConfig: SaveConfig<PlotConfig>;
 };
 
 // messagePathItems contains the whole parsed message, and we don't need to cache all of that.
@@ -447,7 +446,6 @@ function Plot(props: Props) {
     [messagePipeline, xAxisVal],
   );
 
-  const { id: panelId } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const actionHandler = useCallback(
@@ -458,19 +456,19 @@ function Plot(props: Props) {
 
       const { path, value } = action.payload;
       saveConfig(
-        produce(config, (draft) => {
+        produce((draft) => {
           set(draft, path.slice(1), value);
         }),
       );
     },
-    [config, saveConfig],
+    [saveConfig],
   );
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(config),
     });
-  }, [actionHandler, config, panelId, updatePanelSettingsTree]);
+  }, [actionHandler, config, updatePanelSettingsTree]);
 
   const stackDirection = useMemo(
     () => (legendDisplay === "top" ? "column" : "row"),

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -23,7 +23,6 @@ import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Au
 import Button from "@foxglove/studio-base/components/Button";
 import { LegacyTextarea } from "@foxglove/studio-base/components/LegacyStyledComponents";
 import Panel from "@foxglove/studio-base/components/Panel";
-import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import {
   SettingsTreeAction,
@@ -33,6 +32,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
 import { PlayerCapabilities, Topic } from "@foxglove/studio-base/players/types";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import buildSampleMessage from "./buildSampleMessage";
 import helpContent from "./index.help.md";
@@ -49,7 +49,7 @@ type Config = Partial<{
 
 type Props = {
   config: Config;
-  saveConfig: (config: Partial<Config>) => void;
+  saveConfig: SaveConfig<Config>;
 };
 
 function buildSettingsTree(config: Config): SettingsTreeRoots {
@@ -115,7 +115,6 @@ function Publish(props: Props) {
 
   const datatypeNames = useMemo(() => Array.from(datatypes.keys()).sort(), [datatypes]);
   const { error, parsedObject } = useMemo(() => parseInput(value), [value]);
-  const { id: panelId } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   // when the selected datatype changes, replace the textarea contents with a sample message of the correct shape
@@ -145,20 +144,20 @@ function Publish(props: Props) {
       }
 
       saveConfig(
-        produce(props.config, (draft) => {
+        produce((draft) => {
           set(draft, action.payload.path.slice(1), action.payload.value);
         }),
       );
     },
-    [props.config, saveConfig],
+    [saveConfig],
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(props.config),
     });
-  }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
+  }, [actionHandler, props.config, updatePanelSettingsTree]);
 
   const onChangeTopic = useCallback(
     (_event: unknown, name: string) => {

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -57,6 +57,7 @@ import getDiff, {
 } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 import { Topic } from "@foxglove/studio-base/players/types";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/selectors";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -80,7 +81,7 @@ export const PREV_MSG_METHOD = "previous message";
 
 type Props = {
   config: Immutable<RawMessagesPanelConfig>;
-  saveConfig: (arg0: Partial<RawMessagesPanelConfig>) => void;
+  saveConfig: SaveConfig<RawMessagesPanelConfig>;
 };
 
 const isSingleElemArray = (obj: unknown): obj is unknown[] => {
@@ -151,7 +152,6 @@ function RawMessages(props: Props) {
   const { openSiblingPanel } = usePanelContext();
   const { topicPath, diffMethod, diffTopicPath, diffEnabled, showFullMessageForDiff } = config;
   const { topics, datatypes } = useDataSourceInfo();
-  const { id: panelId } = usePanelContext();
 
   const defaultGetItemString = useGetItemStringWithTimezone();
   const getItemString = useMemo(
@@ -229,11 +229,11 @@ function RawMessages(props: Props) {
   );
 
   useEffect(() => {
-    updateSettingsTree(panelId, {
+    updateSettingsTree({
       actionHandler: settingsActionHandler,
       roots: buildSettingsTree(config),
     });
-  }, [config, panelId, settingsActionHandler, updateSettingsTree]);
+  }, [config, settingsActionHandler, updateSettingsTree]);
 
   const onTopicPathChange = useCallback(
     (newTopicPath: string) => {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/index.tsx
@@ -13,7 +13,7 @@
 
 import produce from "immer";
 import { uniq, omit, debounce, set, takeRight, round } from "lodash";
-import React, { useCallback, useMemo, useState, useRef, useEffect, useLayoutEffect } from "react";
+import { useCallback, useMemo, useState, useRef, useEffect, useLayoutEffect } from "react";
 import { useLatest } from "react-use";
 
 import { CameraState } from "@foxglove/regl-worldview";
@@ -23,7 +23,7 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Panel from "@foxglove/studio-base/components/Panel";
-import PanelContext, { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import { SettingsTreeAction } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import Layout from "@foxglove/studio-base/panels/ThreeDimensionalViz/Layout";
@@ -116,7 +116,7 @@ function BaseRenderer(props: Props): JSX.Element {
 
   const { autoSyncCameraState = false, followMode = "follow", followTf } = config;
 
-  const { updatePanelConfigs } = React.useContext(PanelContext) ?? {};
+  const { updatePanelConfigs } = usePanelContext();
 
   const { topics } = useDataSourceInfo();
 
@@ -341,7 +341,7 @@ function BaseRenderer(props: Props): JSX.Element {
 
       // If autoSyncCameraState is enabled, we can't wait for the debounce and need to call updatePanelConfig right away
       if (autoSyncCameraState) {
-        updatePanelConfigs?.("3D Panel", (oldConfig) => ({
+        updatePanelConfigs("3D Panel", (oldConfig) => ({
           ...oldConfig,
           cameraState: newCurrentCameraState,
         }));
@@ -364,7 +364,6 @@ function BaseRenderer(props: Props): JSX.Element {
     };
   }, [urdfBuilder]);
 
-  const { id: panelId } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const actionHandler = useCallback(
@@ -386,11 +385,11 @@ function BaseRenderer(props: Props): JSX.Element {
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(config),
     });
-  }, [actionHandler, config, panelId, updatePanelSettingsTree]);
+  }, [actionHandler, config, updatePanelSettingsTree]);
 
   return (
     <Layout

--- a/packages/studio-base/src/panels/VariableSlider/index.tsx
+++ b/packages/studio-base/src/panels/VariableSlider/index.tsx
@@ -69,7 +69,7 @@ function VariableSliderPanel(props: Props): React.ReactElement {
 
   const globalVariableValue = globalVariables[globalVariableName];
 
-  const { id: panelId, saveConfig } = usePanelContext();
+  const { saveConfig } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const theme = useTheme();
@@ -81,7 +81,7 @@ function VariableSliderPanel(props: Props): React.ReactElement {
       }
 
       saveConfig(
-        produce(props.config, (draft) => {
+        produce((draft) => {
           const path = action.payload.path.slice(1);
           if (["min", "max"].includes(path[0] ?? "")) {
             set(draft, ["sliderProps", ...path], action.payload.value);
@@ -98,15 +98,15 @@ function VariableSliderPanel(props: Props): React.ReactElement {
         }),
       );
     },
-    [props.config, saveConfig],
+    [saveConfig],
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSettingsTree(props.config),
     });
-  }, [actionHandler, panelId, props.config, updatePanelSettingsTree]);
+  }, [actionHandler, props.config, updatePanelSettingsTree]);
 
   const sliderOnChange = (_event: Event, value: number | number[]) => {
     if (value !== globalVariableValue) {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -49,7 +49,7 @@ const ALLOWED_DATATYPES: string[] = [
 function DiagnosticStatusPanel(props: Props) {
   const { saveConfig, config } = props;
   const { topics } = useDataSourceInfo();
-  const { id: panelId, openSiblingPanel } = usePanelContext();
+  const { openSiblingPanel } = usePanelContext();
   const {
     selectedHardwareId,
     selectedName,
@@ -135,17 +135,17 @@ function DiagnosticStatusPanel(props: Props) {
       }
 
       const { path, value } = action.payload;
-      saveConfig(produce<Config>((draft) => set(draft, path.slice(1), value)));
+      saveConfig(produce((draft) => set(draft, path.slice(1), value)));
     },
     [saveConfig],
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildStatusPanelSettingsTree(topicToRender, availableTopics),
     });
-  }, [actionHandler, availableTopics, panelId, topicToRender, updatePanelSettingsTree]);
+  }, [actionHandler, availableTopics, topicToRender, updatePanelSettingsTree]);
 
   return (
     <Stack flex="auto" overflow="hidden">

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -195,7 +195,7 @@ function DiagnosticSummary(props: Props): JSX.Element {
   const { config, saveConfig } = props;
   const { topics } = useDataSourceInfo();
   const { minLevel, topicToRender, pinnedIds, hardwareIdFilter, sortByLevel = true } = config;
-  const { id: panelId, openSiblingPanel } = usePanelContext();
+  const { openSiblingPanel } = usePanelContext();
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const togglePinned = useCallback(
@@ -333,11 +333,11 @@ function DiagnosticSummary(props: Props): JSX.Element {
   );
 
   useEffect(() => {
-    updatePanelSettingsTree(panelId, {
+    updatePanelSettingsTree({
       actionHandler,
       roots: buildSummarySettingsTree(config, topicToRender, availableTopics),
     });
-  }, [actionHandler, availableTopics, config, panelId, topicToRender, updatePanelSettingsTree]);
+  }, [actionHandler, availableTopics, config, topicToRender, updatePanelSettingsTree]);
 
   const renderOption = (option: ISelectableOption | undefined) =>
     option ? (

--- a/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
@@ -2,11 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { ReactNode } from "react";
+import { ReactNode, useCallback } from "react";
 import { DeepReadonly } from "ts-essentials";
 import create, { StoreApi } from "zustand";
 import createContext from "zustand/context";
 
+import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import { SettingsTree } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
 
 type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
@@ -36,8 +37,21 @@ export function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> 
 
 export const usePanelSettingsEditorStore = useStore;
 
-export function usePanelSettingsTreeUpdate(): PanelSettingsEditorStore["updateSettingsTree"] {
-  return useStore((state) => state.updateSettingsTree);
+/**
+ * Returns updater function for the current panels settings tree.
+ */
+export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) => void {
+  const { id } = usePanelContext();
+  const updateStoreTree = useStore((state) => state.updateSettingsTree);
+
+  const updateSettingsTree = useCallback(
+    (newTree: ImmutableSettingsTree) => {
+      updateStoreTree(id, newTree);
+    },
+    [id, updateStoreTree],
+  );
+
+  return updateSettingsTree;
 }
 
 export function PanelSettingsEditorContextProvider({

--- a/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
@@ -37,12 +37,14 @@ export function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> 
 
 export const usePanelSettingsEditorStore = useStore;
 
+const updateSettingsTreeSelector = (store: PanelSettingsEditorStore) => store.updateSettingsTree;
+
 /**
  * Returns updater function for the current panels settings tree.
  */
 export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) => void {
   const { id } = usePanelContext();
-  const updateStoreTree = useStore((state) => state.updateSettingsTree);
+  const updateStoreTree = useStore(updateSettingsTreeSelector);
 
   const updateSettingsTree = useCallback(
     (newTree: ImmutableSettingsTree) => {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This refactors the settings update hook to no longer require the panel id. We can get this from the panel context so there's no need to force panels to specify it manually.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
