### PR TITLE
Allow undefined elements in settings trees

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -28,7 +28,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { FieldEditor } from "./FieldEditor";
 import { NodeActionsMenu } from "./NodeActionsMenu";
 import { VisibilityToggle } from "./VisibilityToggle";
-import { SettingsTreeAction, SettingsTreeNode } from "./types";
+import { SettingsTreeAction, SettingsTreeField, SettingsTreeNode } from "./types";
 
 export type NodeEditorProps = {
   actionHandler: (action: SettingsTreeAction) => void;
@@ -145,23 +145,29 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { fields, children } = settings;
   const hasProperties = fields != undefined || children != undefined;
 
-  const fieldEditors = Object.entries(fields ?? {}).map(([key, field]) => {
-    const stablePath = makeStablePath(props.path, key);
-    return <FieldEditor key={key} field={field} path={stablePath} actionHandler={actionHandler} />;
-  });
+  const fieldEditors = Object.entries(fields ?? {})
+    .filter((kv): kv is [string, SettingsTreeField] => kv[1] != undefined)
+    .map(([key, field]) => {
+      const stablePath = makeStablePath(props.path, key);
+      return (
+        <FieldEditor key={key} field={field} path={stablePath} actionHandler={actionHandler} />
+      );
+    });
 
-  const childNodes = Object.entries(children ?? {}).map(([key, child]) => {
-    const stablePath = makeStablePath(props.path, key);
-    return (
-      <NodeEditor
-        actionHandler={actionHandler}
-        defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
-        key={key}
-        settings={child}
-        path={stablePath}
-      />
-    );
-  });
+  const childNodes = Object.entries(children ?? {})
+    .filter((kv): kv is [string, SettingsTreeNode] => kv[1] != undefined)
+    .map(([key, child]) => {
+      const stablePath = makeStablePath(props.path, key);
+      return (
+        <NodeEditor
+          actionHandler={actionHandler}
+          defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
+          key={key}
+          settings={child}
+          path={stablePath}
+        />
+      );
+    });
 
   const IconComponent = settings.icon ? CommonIcons[settings.icon] : undefined;
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -43,6 +43,7 @@ const BasicSettings: SettingsTreeRoots = {
       { type: "action", id: "reset-values", label: "Reset values" },
     ],
     fields: {
+      emptyField: undefined,
       numberWithPrecision: {
         input: "number",
         label: "Number with precision",
@@ -62,7 +63,9 @@ const BasicSettings: SettingsTreeRoots = {
         error: "This field has an error message that should be displayed to the user",
       },
     },
-    children: {},
+    children: {
+      emptyChild: undefined,
+    },
   },
   complex_inputs: {
     label: "Complex Inputs",
@@ -140,6 +143,7 @@ For ROS users, we also support package:// URLs
       },
     },
   },
+  empty: undefined,
 };
 
 const DisabledSettings: SettingsTreeRoots = {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -12,7 +12,7 @@ import { DeepReadonly } from "ts-essentials";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NodeEditor } from "./NodeEditor";
-import { SettingsTree } from "./types";
+import { SettingsTree, SettingsTreeNode } from "./types";
 
 const StyledAppBar = muiStyled(AppBar, { skipSx: true })(({ theme }) => ({
   top: -1,
@@ -36,6 +36,10 @@ export default function SettingsTreeEditor({
 }): JSX.Element {
   const { actionHandler } = settings;
   const [filterText, setFilterText] = useState<string>("");
+
+  const definedRoots = Object.entries(settings.roots).filter(
+    (kv): kv is [string, SettingsTreeNode] => kv[1] != undefined,
+  );
 
   return (
     <Stack fullHeight>
@@ -64,7 +68,7 @@ export default function SettingsTreeEditor({
         </StyledAppBar>
       )}
       <FieldGrid>
-        {Object.entries(settings.roots).map(([key, root]) => (
+        {definedRoots.map(([key, root]) => (
           <NodeEditor
             key={key}
             path={makeStablePath(key)}

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -72,9 +72,9 @@ export type SettingsTreeField = SettingsTreeFieldValue & {
   error?: string;
 };
 
-export type SettingsTreeFields = Record<string, SettingsTreeField>;
+export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;
 
-export type SettingsTreeChildren = Record<string, SettingsTreeNode>;
+export type SettingsTreeChildren = Record<string, undefined | SettingsTreeNode>;
 
 /**
  * An action that can be offered to the user to perform at the
@@ -173,7 +173,7 @@ export type SettingsTreeAction =
       payload: { id: string; path: readonly string[] };
     };
 
-export type SettingsTreeRoots = Record<string, SettingsTreeNode>;
+export type SettingsTreeRoots = Record<string, undefined | SettingsTreeNode>;
 
 /**
  * A settings tree is a tree of panel settings that can be managed by


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This allows undefined elements in settings tree nodes & fields. This just makes life a little bit easier for panel authors that need to optionally exclude elements of the tree. Undefined elements will just be ignored by the settings tree editor.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
