### PR TITLE
Port URDF panel toolbar items to settings API

### DIFF
--- a/packages/studio-base/src/panels/URDFViewer/Renderer.ts
+++ b/packages/studio-base/src/panels/URDFViewer/Renderer.ts
@@ -7,7 +7,7 @@ import { URDFRobot } from "urdf-loader";
 
 import { CameraState } from "@foxglove/regl-worldview";
 
-import { EventTypes } from "./index";
+import { EventTypes } from "./types";
 
 // https://github.com/gkjohnson/urdf-loaders/issues/205
 function cloneModel(robot: URDFRobot): URDFRobot {

--- a/packages/studio-base/src/panels/URDFViewer/index.stories.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.stories.tsx
@@ -46,6 +46,16 @@ export function Default(): JSX.Element {
   );
 }
 
+export function WithSettings(): JSX.Element {
+  return (
+    <ExampleAssetsProvider>
+      <PanelSetup includeSettings>
+        <URDFViewer />
+      </PanelSetup>
+    </ExampleAssetsProvider>
+  );
+}
+
 export function CustomOpacity(): JSX.Element {
   return (
     <ExampleAssetsProvider>

--- a/packages/studio-base/src/panels/URDFViewer/settings.ts
+++ b/packages/studio-base/src/panels/URDFViewer/settings.ts
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { isEmpty } from "lodash";
+
+import { Topic } from "@foxglove/studio";
+import { SettingsTreeRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/types";
+
+import { Config } from "./types";
+
+export function buildSettingsTree(config: Config, topics: readonly Topic[]): SettingsTreeRoots {
+  const manualControl = isEmpty(config.jointStatesTopic);
+  const topicOptions = topics.map((topic) => ({ label: topic.name, value: topic.name }));
+
+  // Insert our selected topic into the options list even if it's not in the
+  // list of available topics.
+  if (
+    config.jointStatesTopic != undefined &&
+    config.jointStatesTopic !== "" &&
+    !topics.some((topic) => topic.name === config.jointStatesTopic)
+  ) {
+    topicOptions.unshift({ label: config.jointStatesTopic, value: config.jointStatesTopic });
+  }
+
+  const settings: SettingsTreeRoots = {
+    general: {
+      icon: "Settings",
+      fields: {
+        manualControl: {
+          label: "Manual Control",
+          input: "boolean",
+          value: manualControl,
+        },
+        jointStatesTopic: manualControl
+          ? undefined
+          : {
+              input: "select",
+              label: "Topic",
+              value: config.jointStatesTopic,
+              options: topicOptions,
+            },
+      },
+    },
+  };
+
+  return settings;
+}

--- a/packages/studio-base/src/panels/URDFViewer/types.ts
+++ b/packages/studio-base/src/panels/URDFViewer/types.ts
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type EventTypes = {
+  cameraMove: () => void;
+};
+
+export type Config = {
+  jointStatesTopic?: string;
+  customJointValues?: Record<string, number>;
+  opacity?: number;
+};


### PR DESCRIPTION
**User-Facing Changes**
This moves the controls in the URDF panel toolbar into the settings sidebar.

**Description**
This is a straightforward port of the URDF toolbar controls to the settings API.

<img width="730" alt="Screen Shot 2022-06-14 at 11 16 29 AM" src="https://user-images.githubusercontent.com/93935560/173626383-9b4ef8d4-0147-4a3a-9d8e-348b7c7e6a46.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
