### PR TITLE
Fix foxglove.FrameTransform handling in 3d panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/constants.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/constants.ts
@@ -27,10 +27,18 @@ export const TRANSFORM_STAMPED_DATATYPES = [
   "ros.geometry_msgs.TransformStamped",
   "geometry_msgs/msg/TransformStamped",
 ];
-export const TF_DATATYPES = [
+
+export const ROS_TF_DATATYPES = [
   "tf/tfMessage",
-  "ros.tf.tfMessage",
   "tf2_msgs/TFMessage",
   "tf2_msgs/msg/TFMessage",
+  // legacy protobuf formats from when we published protobuf copies of ROS messages
+  "ros.tf.tfMessage",
   "ros.tf2_msgs.TFMessage",
 ];
+export const FOXGLOVE_TF_DATATYPES = [
+  "foxglove.FrameTransform",
+  "foxglove_msgs/FrameTransform",
+  "foxglove_msgs/msg/FrameTransform",
+];
+export const TF_DATATYPES = [...ROS_TF_DATATYPES, ...FOXGLOVE_TF_DATATYPES];

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -14,7 +14,8 @@
 import { useMemo, useRef } from "react";
 
 import {
-  TF_DATATYPES,
+  ROS_TF_DATATYPES,
+  FOXGLOVE_TF_DATATYPES,
   TRANSFORM_STAMPED_DATATYPES,
 } from "@foxglove/studio-base/panels/ThreeDimensionalViz/constants";
 import {
@@ -150,21 +151,18 @@ function useTransforms(args: Args): IImmutableTransformTree {
       }
 
       // Process all TF topics (ex: /tf and /tf_static)
-      if (TF_DATATYPES.includes(datatype)) {
+      if (ROS_TF_DATATYPES.includes(datatype)) {
         consumeTfs(msgs as MessageEvent<TfMessage>[], transforms);
         updated = true;
       } else if (TRANSFORM_STAMPED_DATATYPES.includes(datatype)) {
         consumeSingleTfs(msgs as MessageEvent<TF>[], transforms);
         updated = true;
-      } else if (
-        datatype === "foxglove.FrameTransform" ||
-        datatype === "foxglove_msgs/FrameTransform" ||
-        datatype === "foxglove_msgs/msg/FrameTransform"
-      ) {
+      } else if (FOXGLOVE_TF_DATATYPES.includes(datatype)) {
         consumeFoxgloveFrameTransform(
           msgs as MessageEvent<FoxgloveMessages["foxglove.FrameTransform"]>[],
           transforms,
         );
+        updated = true;
       }
     }
 


### PR DESCRIPTION


**User-Facing Changes**
Loading data sources with foxglove.FrameTransform works with the 3d panel.

**Description**
The 3d panel subscribes to transform topics based on datatype. The `foxglove.FrameTransform` datatype was not listed in the TF_DATATYPES constant which meant the 3d panel never subscribed to topics of that datatype.

This change fixes this behavior by adding the foxglove FrameTransform datatypes to the TF_DATATYPES constant.

Additionally, useTransforms is updated to take the correct code paths for foxglove FrameTransforms vs ROS transforms and mark the transforms as updated.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
