### PR TITLE
Stylistic changes for map panel config and zoom handling

### DIFF
--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -4,6 +4,7 @@
 
 import { transform } from "lodash";
 
+import { filterMap } from "@foxglove/den/collection";
 import {
   SettingsTreeFields,
   SettingsTreeRoots,
@@ -43,12 +44,10 @@ export function buildSettingsTree(config: Config, eligibleTopics: string[]): Set
     {} as SettingsTreeFields,
   );
 
-  const followTopics = [
-    { label: "Off", value: "" },
-    ...eligibleTopics
-      .filter((topic) => !config.disabledTopics.includes(topic))
-      .map((topic) => ({ label: topic, value: topic })),
-  ];
+  const eligibleFollowTopicOptions = filterMap(eligibleTopics, (topic) =>
+    config.disabledTopics.includes(topic) ? undefined : { label: topic, value: topic },
+  );
+  const followTopicOptions = [{ label: "Off", value: "" }, ...eligibleFollowTopicOptions];
   const generalSettings: SettingsTreeFields = {
     layer: {
       label: "Tile Layer",
@@ -64,7 +63,7 @@ export function buildSettingsTree(config: Config, eligibleTopics: string[]): Set
       label: "Follow topic",
       input: "select",
       value: config.followTopic,
-      options: followTopics,
+      options: followTopicOptions,
     },
   };
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
A few tweaks as follow-up from https://github.com/foxglove/studio/pull/3602.

- prefer filterMap rather than filter().map()
- Replace a state variable with a ref for tracking whether zoom has happened
- Remove a cast during initial config handling

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
