### PR TITLE
Use local paths state in plot legend to improve interactivity

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -261,13 +261,18 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     return topics.find(({ name }) => name === topicName);
   }, [rosPath, topics]);
 
+  const messagePathStructuresForDataype = useMemo(
+    () => messagePathStructures(datatypes),
+    [datatypes],
+  );
+
   const structureTraversalResult = useMemo(() => {
     if (!topic || !rosPath?.messagePath) {
       return undefined;
     }
 
-    return traverseStructure(messagePathStructures(datatypes)[topic.datatype], rosPath.messagePath);
-  }, [datatypes, rosPath?.messagePath, topic]);
+    return traverseStructure(messagePathStructuresForDataype[topic.datatype], rosPath.messagePath);
+  }, [messagePathStructuresForDataype, rosPath?.messagePath, topic]);
 
   const invalidGlobalVariablesVariable = useMemo(() => {
     if (!rosPath) {

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -177,9 +177,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   // when data changes, we pause and wait for onFinishRender to resume
   const onStartRender = useCallback(() => {
     if (resumeFrame.current) {
-      if (process.env.NODE_ENV === "development") {
-        log.warn("force resumed paused frame");
-      }
       resumeFrame.current();
     }
     // during streaming the message pipeline should not give us any more data until we finish

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.stories.tsx
@@ -25,7 +25,7 @@ export function DefaultIndex0(): JSX.Element {
       paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      savePaths={action("savePaths")}
     />
   );
 }
@@ -43,7 +43,7 @@ export function DefaultIndex1(): JSX.Element {
       paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      savePaths={action("savePaths")}
     />
   );
 }
@@ -61,7 +61,7 @@ export function CustomColor(): JSX.Element {
       paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      savePaths={action("savePaths")}
     />
   );
 }
@@ -78,7 +78,7 @@ export function CustomXAxis(): JSX.Element {
       paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      savePaths={action("savePaths")}
     />
   );
 }
@@ -93,7 +93,7 @@ export function ReferenceLine(): JSX.Element {
       paths={paths}
       index={index}
       onDismiss={action("onDismiss")}
-      saveConfig={action("saveConfig")}
+      savePaths={action("savePaths")}
     />
   );
 }

--- a/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
+++ b/packages/studio-base/src/panels/Plot/PathSettingsModal.tsx
@@ -14,14 +14,14 @@ import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 import { TimestampMethod } from "@foxglove/studio-base/util/time";
 
 import { isReferenceLinePlotPathType, PlotPath } from "./internalTypes";
-import { PlotConfig, PlotXAxisVal } from "./types";
+import { PlotXAxisVal } from "./types";
 
 type PathSettingsModalProps = {
   xAxisVal: PlotXAxisVal;
   path: PlotPath;
   paths: PlotPath[];
   index: number;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
+  savePaths: (paths: PlotPath[]) => void;
   onDismiss: () => void;
 };
 
@@ -35,7 +35,7 @@ export default function PathSettingsModal({
   path,
   paths,
   index,
-  saveConfig,
+  savePaths,
   onDismiss,
 }: PathSettingsModalProps): JSX.Element {
   const hostId = useDialogHostId();
@@ -47,9 +47,9 @@ export default function PathSettingsModal({
       if (newPath) {
         newPaths[index] = { ...newPath, ...newConfig };
       }
-      saveConfig({ paths: newPaths });
+      savePaths(newPaths);
     },
-    [paths, index, saveConfig],
+    [paths, index, savePaths],
   );
 
   const resetToDefaults = useCallback(() => {

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -23,7 +23,8 @@ import { Button, IconButton, Theme, alpha } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import { last } from "lodash";
-import { ComponentProps, useCallback, useMemo, useRef } from "react";
+import { ComponentProps, useCallback, useMemo, useRef, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 import Dropdown from "@foxglove/studio-base/components/Dropdown";
 import DropdownItem from "@foxglove/studio-base/components/Dropdown/DropdownItem";
@@ -31,6 +32,7 @@ import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import PlotLegendRow from "@foxglove/studio-base/panels/Plot/PlotLegendRow";
+import { PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { PlotPath, BasePlotPath, isReferenceLinePlotPathType } from "./internalTypes";
 import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
@@ -42,7 +44,7 @@ type PlotLegendProps = {
   paths: PlotPath[];
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
   currentTime?: number;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
+  saveConfig: SaveConfig<PlotConfig>;
   showLegend: boolean;
   xAxisVal: PlotXAxisVal;
   xAxisPath?: BasePlotPath;
@@ -228,25 +230,41 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export default function PlotLegend(props: PlotLegendProps): JSX.Element {
   const {
-    paths,
-    datasets,
     currentTime,
-    saveConfig,
-    showLegend,
-    xAxisVal,
-    xAxisPath,
-    pathsWithMismatchedDataLengths,
-    sidebarDimension,
+    datasets,
     legendDisplay,
+    pathsWithMismatchedDataLengths,
+    showLegend,
     showPlotValuesInLegend,
+    sidebarDimension,
+    xAxisPath,
+    xAxisVal,
   } = props;
-  const lastPath = last(paths);
   const classes = useStyles({
     legendDisplay,
     sidebarDimension,
     showLegend,
     showPlotValuesInLegend,
   });
+
+  // We keep and update a local copy of paths and periodically flush to config
+  // because changing paths forces the whole plot to rerender and results in
+  // bad interactive performance on the path input.
+  const [localConfig, setlocalConfig] = useState({ paths: props.paths });
+
+  const debouncedSaveConfig = useDebouncedCallback((newConfig: Partial<PanelConfig>) => {
+    props.saveConfig(newConfig);
+  }, 500);
+
+  const saveConfig = useCallback(
+    (newConfig: Partial<PlotConfig>) => {
+      setlocalConfig((prevConfig) => ({ ...prevConfig, ...newConfig }));
+      debouncedSaveConfig(newConfig);
+    },
+    [debouncedSaveConfig],
+  );
+
+  const lastPath = last(localConfig.paths);
 
   const toggleLegend = useCallback(
     () => saveConfig({ showLegend: !showLegend }),
@@ -265,6 +283,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
   }, [showLegend, legendDisplay]);
 
   const originalWrapper = useRef<DOMRect | undefined>(undefined);
+
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       const offset = originalWrapper.current?.[legendDisplay as "top" | "left"] ?? 0;
@@ -325,13 +344,13 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
           )}
         </header>
         <div className={classes.grid}>
-          {paths.map((path: PlotPath, index: number) => (
+          {localConfig.paths.map((path: PlotPath, index: number) => (
             <PlotLegendRow
               key={index}
               index={index}
               xAxisVal={xAxisVal}
               path={path}
-              paths={paths}
+              paths={localConfig.paths}
               hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
               datasets={datasets}
               currentTime={currentTime}
@@ -349,7 +368,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
             onClick={() =>
               saveConfig({
                 paths: [
-                  ...paths,
+                  ...localConfig.paths,
                   {
                     value: "",
                     enabled: true,
@@ -366,22 +385,22 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
       </div>
     ),
     [
-      classes.legendContent,
-      classes.header,
-      classes.dropdownWrapper,
-      classes.dropdown,
-      classes.grid,
-      classes.footer,
       classes.addButton,
-      xAxisVal,
-      xAxisPath,
-      paths,
-      saveConfig,
-      pathsWithMismatchedDataLengths,
-      datasets,
+      classes.dropdown,
+      classes.dropdownWrapper,
+      classes.footer,
+      classes.grid,
+      classes.header,
+      classes.legendContent,
       currentTime,
-      showPlotValuesInLegend,
+      datasets,
       lastPath,
+      localConfig.paths,
+      pathsWithMismatchedDataLengths,
+      saveConfig,
+      showPlotValuesInLegend,
+      xAxisPath,
+      xAxisVal,
     ],
   );
 

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -32,7 +32,7 @@ import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@foxglove/studio-base/components/PanelToolbar";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import PlotLegendRow from "@foxglove/studio-base/panels/Plot/PlotLegendRow";
-import { PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { PlotPath, BasePlotPath, isReferenceLinePlotPathType } from "./internalTypes";
 import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
@@ -234,6 +234,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
     datasets,
     legendDisplay,
     pathsWithMismatchedDataLengths,
+    saveConfig,
     showLegend,
     showPlotValuesInLegend,
     sidebarDimension,
@@ -250,21 +251,21 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
   // We keep and update a local copy of paths and periodically flush to config
   // because changing paths forces the whole plot to rerender and results in
   // bad interactive performance on the path input.
-  const [localConfig, setlocalConfig] = useState({ paths: props.paths });
+  const [localPaths, setLocalPaths] = useState(props.paths);
 
-  const debouncedSaveConfig = useDebouncedCallback((newConfig: Partial<PanelConfig>) => {
-    props.saveConfig(newConfig);
+  const debouncedSavePaths = useDebouncedCallback((paths: PlotPath[]) => {
+    props.saveConfig({ paths });
   }, 500);
 
-  const saveConfig = useCallback(
-    (newConfig: Partial<PlotConfig>) => {
-      setlocalConfig((prevConfig) => ({ ...prevConfig, ...newConfig }));
-      debouncedSaveConfig(newConfig);
+  const savePaths = useCallback(
+    (paths: PlotPath[]) => {
+      setLocalPaths(paths);
+      debouncedSavePaths(paths);
     },
-    [debouncedSaveConfig],
+    [debouncedSavePaths],
   );
 
-  const lastPath = last(localConfig.paths);
+  const lastPath = last(localPaths);
 
   const toggleLegend = useCallback(
     () => saveConfig({ showLegend: !showLegend }),
@@ -344,17 +345,17 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
           )}
         </header>
         <div className={classes.grid}>
-          {localConfig.paths.map((path: PlotPath, index: number) => (
+          {localPaths.map((path: PlotPath, index: number) => (
             <PlotLegendRow
               key={index}
               index={index}
               xAxisVal={xAxisVal}
               path={path}
-              paths={localConfig.paths}
+              paths={localPaths}
               hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
               datasets={datasets}
               currentTime={currentTime}
-              saveConfig={saveConfig}
+              savePaths={savePaths}
               showPlotValuesInLegend={showPlotValuesInLegend}
             />
           ))}
@@ -366,17 +367,15 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
             fullWidth
             startIcon={<AddIcon />}
             onClick={() =>
-              saveConfig({
-                paths: [
-                  ...localConfig.paths,
-                  {
-                    value: "",
-                    enabled: true,
-                    // For convenience, default to the `timestampMethod` of the last path.
-                    timestampMethod: lastPath ? lastPath.timestampMethod : "receiveTime",
-                  },
-                ],
-              })
+              savePaths([
+                ...localPaths,
+                {
+                  value: "",
+                  enabled: true,
+                  // For convenience, default to the `timestampMethod` of the last path.
+                  timestampMethod: lastPath ? lastPath.timestampMethod : "receiveTime",
+                },
+              ])
             }
           >
             Add line
@@ -395,9 +394,10 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
       currentTime,
       datasets,
       lastPath,
-      localConfig.paths,
+      localPaths,
       pathsWithMismatchedDataLengths,
       saveConfig,
+      savePaths,
       showPlotValuesInLegend,
       xAxisPath,
       xAxisVal,

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -21,7 +21,7 @@ import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 
 import PathSettingsModal from "./PathSettingsModal";
 import { PlotPath, isReferenceLinePlotPathType } from "./internalTypes";
-import { plotableRosTypes, PlotConfig, PlotXAxisVal } from "./types";
+import { plotableRosTypes, PlotXAxisVal } from "./types";
 
 type PlotLegendRowProps = {
   index: number;
@@ -31,7 +31,7 @@ type PlotLegendRowProps = {
   hasMismatchedDataLength: boolean;
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
   currentTime?: number;
-  saveConfig: (arg0: Partial<PlotConfig>) => void;
+  savePaths: (paths: PlotPath[]) => void;
   showPlotValuesInLegend: boolean;
 };
 
@@ -110,7 +110,7 @@ export default function PlotLegendRow({
   hasMismatchedDataLength,
   datasets,
   currentTime,
-  saveConfig,
+  savePaths,
   showPlotValuesInLegend,
 }: PlotLegendRowProps): JSX.Element {
   const correspondingData = useMemo(() => {
@@ -175,9 +175,9 @@ export default function PlotLegendRow({
       if (newPath) {
         newPaths[idx] = { ...newPath, value: value.trim() };
       }
-      saveConfig({ paths: newPaths });
+      savePaths(newPaths);
     },
-    [paths, saveConfig],
+    [paths, savePaths],
   );
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
@@ -195,7 +195,7 @@ export default function PlotLegendRow({
             path={path}
             paths={paths}
             index={index}
-            saveConfig={saveConfig}
+            savePaths={savePaths}
             onDismiss={() => setSettingsModalOpen(false)}
           />
         )}
@@ -212,7 +212,7 @@ export default function PlotLegendRow({
             if (newPath) {
               newPaths[index] = { ...newPath, enabled: !newPath.enabled };
             }
-            saveConfig({ paths: newPaths });
+            savePaths(newPaths);
           }}
         >
           <RemoveIcon style={{ color: legendIconColor }} color="inherit" />
@@ -262,7 +262,7 @@ export default function PlotLegendRow({
           onClick={() => {
             const newPaths = paths.slice();
             newPaths.splice(index, 1);
-            saveConfig({ paths: newPaths });
+            savePaths(newPaths);
           }}
         >
           <CloseIcon fontSize="small" />

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -182,6 +182,10 @@ export default function PlotLegendRow({
 
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
 
+  const messagePathInputStyle = useMemo(() => {
+    return { textDecoration: !path.enabled ? "line-through" : undefined };
+  }, [path.enabled]);
+
   return (
     <div className={classes.root}>
       <div style={{ position: "absolute" }}>
@@ -224,7 +228,7 @@ export default function PlotLegendRow({
           index={index}
           autoSize
           disableAutocomplete={isReferenceLinePlotPath}
-          inputStyle={{ textDecoration: !path.enabled ? "line-through" : undefined }}
+          inputStyle={messagePathInputStyle}
         />
         {hasMismatchedDataLength && (
           <Tooltip


### PR DESCRIPTION
**User-Facing Changes**
This improves interactivity of the plot legend message path input.

**Description**
Currently we immediately flush every edit to a plot message path input to  the panel config, and this results in studio doing a lot of work including updating subscriptions, rebuilding callbacks etc and re-rendering the entire plot on every keystroke.

The approach here is for the plot legend to maintain its own local copy of the paths and use a debounced flush to push this back to the underlying panel config.

It also adds a few missing memoizations.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3146 