### PR TITLE
Remove readonly from core settings fields types

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -293,7 +293,9 @@ function FieldInput({
                 path,
                 input: "select",
                 value:
-                  event.target.value === UNDEFINED_SENTINEL_VALUE ? undefined : event.target.value,
+                  event.target.value === UNDEFINED_SENTINEL_VALUE
+                    ? undefined
+                    : (event.target.value as undefined | string | string[]),
               },
             })
           }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
@@ -17,7 +17,7 @@ export function Vec2Input({
   value,
 }: {
   disabled?: boolean;
-  onChange: (value: undefined | readonly [undefined | number, undefined | number]) => void;
+  onChange: (value: undefined | [undefined | number, undefined | number]) => void;
   precision?: number;
   readOnly?: boolean;
   step?: number;

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -18,7 +18,7 @@ export function Vec3Input({
 }: {
   disabled?: boolean;
   onChange: (
-    value: undefined | readonly [undefined | number, undefined | number, undefined | number],
+    value: undefined | [undefined | number, undefined | number, undefined | number],
   ) => void;
   precision?: number;
   readOnly?: boolean;

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -2,10 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { DeepReadonly } from "ts-essentials";
+
 import CommonIcons from "@foxglove/studio-base/components/CommonIcons";
 
 export type SettingsTreeFieldValue =
-  | { input: "autocomplete"; value?: string; items: ReadonlyArray<string> }
+  | { input: "autocomplete"; value?: string; items: string[] }
   | { input: "boolean"; value?: boolean }
   | { input: "rgb"; value?: string }
   | { input: "rgba"; value?: string }
@@ -21,26 +23,26 @@ export type SettingsTreeFieldValue =
     }
   | {
       input: "select";
-      value?: number | ReadonlyArray<number>;
-      options: ReadonlyArray<{ label: string; value: undefined | number }>;
+      value?: number | number[];
+      options: Array<{ label: string; value: undefined | number }>;
     }
   | {
       input: "select";
-      value?: string | ReadonlyArray<string>;
-      options: ReadonlyArray<{ label: string; value: undefined | string }>;
+      value?: string | string[];
+      options: Array<{ label: string; value: undefined | string }>;
     }
   | { input: "string"; value?: string }
-  | { input: "toggle"; value?: string; options: ReadonlyArray<string> }
+  | { input: "toggle"; value?: string; options: string[] }
   | {
       input: "vec3";
-      value?: readonly [undefined | number, undefined | number, undefined | number];
+      value?: [undefined | number, undefined | number, undefined | number];
       step?: number;
       precision?: number;
       labels?: [string, string, string];
     }
   | {
       input: "vec2";
-      value?: readonly [undefined | number, undefined | number];
+      value?: [undefined | number, undefined | number];
       step?: number;
       precision?: number;
       labels?: [string, string];
@@ -170,7 +172,7 @@ type DistributivePick<T, K extends keyof T> = T extends unknown ? Pick<T, K> : n
 export type SettingsTreeAction =
   | {
       action: "update";
-      payload: { path: ReadonlyArray<string> } & DistributivePick<
+      payload: { path: readonly string[] } & DistributivePick<
         SettingsTreeFieldValue,
         "input" | "value"
       >;
@@ -206,5 +208,5 @@ export type SettingsTree = {
 
 // To be moved to PanelExtensionContext in index.d.ts when settings API is finalized.
 export type EXPERIMENTAL_PanelExtensionContextWithSettings = {
-  __updatePanelSettingsTree(settings: SettingsTree): void;
+  __updatePanelSettingsTree(settings: DeepReadonly<SettingsTree>): void;
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { DeepReadonly } from "ts-essentials";
 import { v4 as uuidv4 } from "uuid";
 
 import { CameraState, DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
@@ -220,7 +221,7 @@ function buildLayerNode(
   return node;
 }
 
-export function buildSettingsTree(options: SettingsTreeOptions): SettingsTreeRoots {
+export function buildSettingsTree(options: SettingsTreeOptions): DeepReadonly<SettingsTreeRoots> {
   const {
     config,
     coordinateFrames,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This removes `readonly` from the core settings input types. It's not necessary to mark these readonly at this level since we mark the entire tree readonly downstream in the settings context and making these individual types readonly just makes them harder to work with.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
