### PR TITLE
Force panel to update when moved from root to non-root

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -153,7 +153,8 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
               </EmptyState>
             }
           >
-            <Panel childId={id} tabId={tabId} />
+            {/* We put the path length in the key here to force an update when the panel moves from root to non-root. */}
+            <Panel childId={id} tabId={tabId} key={`${id}${tabId}${path.length}`} />
           </Suspense>
         </MosaicWindow>
       );

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -138,6 +138,10 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
         panelCompoentCache.current.set(type, Panel);
       }
 
+      // When a panel changes from being the only panel to one of many in a layout and
+      // is no longer the top level panel we need to force it to update to recalculate
+      // whether it should be draggable or not. Since the panel component is memoized we use
+      // a key to break through the memoization when the panel's layout path changes.
       const mosaicWindow = (
         <MosaicWindow
           title=""
@@ -153,7 +157,6 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
               </EmptyState>
             }
           >
-            {/* We put the path length in the key here to force an update when the panel moves from root to non-root. */}
             <Panel childId={id} tabId={tabId} key={`${id}${tabId}${path.length}`} />
           </Suspense>
         </MosaicWindow>


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with undraggable panels.

**Description**
The issue is that the panel component is memoized and when it changes from being the root panel to one panel of several in a layout nothing changes in the panel props so it doesn't update. The solution here is to put the path length in the panel key which forces it to update as its position in the layout hierarchy changes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3632 