### PR TITLE
Allow explicit sort order on settings nodes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -24,6 +24,7 @@ import { useImmer } from "use-immer";
 
 import { filterMap } from "@foxglove/den/collection";
 import CommonIcons from "@foxglove/studio-base/components/CommonIcons";
+import { prepareSettingsRoots } from "@foxglove/studio-base/components/SettingsTreeEditor/utils";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { FieldEditor } from "./FieldEditor";
@@ -157,8 +158,8 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     ) : undefined;
   });
 
-  const childNodes = filterMap(Object.entries(children ?? {}), ([key, child]) => {
-    return child ? (
+  const childNodes = prepareSettingsRoots(children ?? {}).map(([key, child]) => {
+    return (
       <NodeEditor
         actionHandler={actionHandler}
         defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
@@ -166,7 +167,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
         settings={child}
         path={makeStablePath(props.path, key)}
       />
-    ) : undefined;
+    );
   });
 
   const IconComponent = settings.icon ? CommonIcons[settings.icon] : undefined;

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -323,7 +323,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Map",
     icon: "Map",
     renamable: true,
-    sortOrder: 3,
+    order: 3,
     fields: {
       message_path: {
         label: "Message path",
@@ -368,7 +368,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Grid",
     icon: "Grid",
     renamable: true,
-    sortOrder: 2,
+    order: 2,
     fields: {
       color: {
         label: "Color",
@@ -399,7 +399,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Pose",
     icon: "Walk",
     renamable: true,
-    sortOrder: 1,
+    order: 1,
     fields: {
       color: { label: "Color", value: "#ffffff", input: "rgb" },
       shaft_length: { label: "Shaft length", value: 1.5, input: "number" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -323,6 +323,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Map",
     icon: "Map",
     renamable: true,
+    sortOrder: 3,
     fields: {
       message_path: {
         label: "Message path",
@@ -367,6 +368,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Grid",
     icon: "Grid",
     renamable: true,
+    sortOrder: 2,
     fields: {
       color: {
         label: "Color",
@@ -397,6 +399,7 @@ const PanelExamplesSettings: SettingsTreeRoots = {
     label: "Pose",
     icon: "Walk",
     renamable: true,
+    sortOrder: 1,
     fields: {
       color: { label: "Color", value: "#ffffff", input: "rgb" },
       shaft_length: { label: "Shaft length", value: 1.5, input: "number" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -12,7 +12,8 @@ import { DeepReadonly } from "ts-essentials";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NodeEditor } from "./NodeEditor";
-import { SettingsTree, SettingsTreeNode } from "./types";
+import { SettingsTree } from "./types";
+import { prepareSettingsRoots } from "./utils";
 
 const StyledAppBar = muiStyled(AppBar, { skipSx: true })(({ theme }) => ({
   top: -1,
@@ -37,13 +38,7 @@ export default function SettingsTreeEditor({
   const { actionHandler } = settings;
   const [filterText, setFilterText] = useState<string>("");
 
-  const definedRoots = useMemo(
-    () =>
-      Object.entries(settings.roots).filter(
-        (kv): kv is [string, SettingsTreeNode] => kv[1] != undefined,
-      ),
-    [settings.roots],
-  );
+  const definedRoots = useMemo(() => prepareSettingsRoots(settings.roots), [settings.roots]);
 
   return (
     <Stack fullHeight>

--- a/packages/studio-base/src/components/SettingsTreeEditor/types.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/types.ts
@@ -152,6 +152,15 @@ export type SettingsTreeNode = {
   renamable?: boolean;
 
   /**
+   * Optional sort order to override natural object ordering. All nodes
+   * with a sort order will be rendered before nodes all with no sort order.
+   *
+   * Nodes without an explicit order will be ordered according to ES2015
+   * object ordering rules.
+   */
+  order?: number;
+
+  /**
    * An optional visibility status. If this is not undefined, the node
    * editor will display a visiblity toggle button and send update actions
    * to the action handler.

--- a/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { sortBy } from "lodash";
+import { DeepReadonly } from "ts-essentials";
+
+import { SettingsTreeRoots, SettingsTreeNode } from "./types";
+
+/**
+ * Filters and sorts roots to prepare them for rendering.
+ */
+export function prepareSettingsRoots(
+  roots: DeepReadonly<SettingsTreeRoots>,
+): DeepReadonly<Array<[string, SettingsTreeNode]>> {
+  // Use sortBy here for stable sorting.
+  return sortBy(
+    Object.entries(roots).filter((kv): kv is [string, SettingsTreeNode] => kv[1] != undefined),
+    (kv) => kv[1].order ?? Number.MAX_SAFE_INTEGER,
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This allows panel authors to optionally override the natural sort order of settings tree nodes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
