### PR TITLE
Throw on console.error in stories

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -58,7 +58,7 @@ function StudioContextProviders({
     console.error = (...args: unknown[]) => {
       throw new Error(args.toString());
     };
-  }, []);
+  });
 
   if (ctx.parameters.useReadySignal === true) {
     const sig = signal();

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Story, StoryContext } from "@storybook/react";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useEffect } from "react";
 import { ToastProvider } from "react-toast-notifications";
 
 import { signal } from "@foxglove/den/async";
@@ -54,6 +54,12 @@ function StudioContextProviders({
   children,
   ctx,
 }: React.PropsWithChildren<{ ctx: StoryContext }>): JSX.Element {
+  useEffect(() => {
+    console.error = (...args: unknown[]) => {
+      throw new Error(args.toString());
+    };
+  }, []);
+
   if (ctx.parameters.useReadySignal === true) {
     const sig = signal();
     ctx.parameters.storyReady = sig;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This treats all `console.error` calls in stories as story errors by throwing an exception. This should help us catch console errors.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
