### PR TITLE
Add target=_blank to Help sidebar links

### DIFF
--- a/packages/studio-base/src/components/HelpSidebar/index.tsx
+++ b/packages/studio-base/src/components/HelpSidebar/index.tsx
@@ -164,6 +164,7 @@ export default function HelpSidebar({
                         key={title}
                         data-test={title}
                         href={url}
+                        target="_blank"
                         onClick={() => (url ? undefined : setHelpInfo({ title, content }))}
                       >
                         {title}


### PR DESCRIPTION
**User-Facing Changes**
Changed external links in Help sidebar to open in a new window instead of replacing the current Studio window.

**Description**
Closes https://github.com/foxglove/studio/issues/2438