### PR TITLE
Only select swapped panel if original panel was selected

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -308,16 +308,20 @@ export default function CurrentLayoutProvider({
       },
       splitPanel: (payload: SplitPanelPayload) => performAction({ type: "SPLIT_PANEL", payload }),
       swapPanel: (payload: SwapPanelPayload) => {
-        // Select the new panel. We don't know what the new panel id will be so we diff
-        // the panelIds of the old and new layout so we can select the new panel.
+        // Select the new panel if the original panel was selected. We don't know what
+        // the new panel id will be so we diff the panelIds of the old and
+        // new layout so we can select the new panel.
+        const originalIsSelected = selectedPanelIds.current.includes(payload.originalId);
         const beforePanelIds = Object.keys(
           layoutStateRef.current.selectedLayout?.data?.configById ?? {},
         );
         performAction({ type: "SWAP_PANEL", payload });
-        const afterPanelIds = Object.keys(
-          layoutStateRef.current.selectedLayout?.data?.configById ?? {},
-        );
-        setSelectedPanelIds(difference(afterPanelIds, beforePanelIds));
+        if (originalIsSelected) {
+          const afterPanelIds = Object.keys(
+            layoutStateRef.current.selectedLayout?.data?.configById ?? {},
+          );
+          setSelectedPanelIds(difference(afterPanelIds, beforePanelIds));
+        }
         void analytics.logEvent(AppEvent.PANEL_ADD, { type: payload.type, action: "swap" });
         void analytics.logEvent(AppEvent.PANEL_DELETE, {
           type: getPanelTypeFromId(payload.originalId),


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes a secondary issue caused by the fix for #3625. The change here is to only select the new panel if the panel we're swapping out was already selected.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3625 