### PR TITLE
Fix raw message auto mode expanded fields logic

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -193,11 +193,7 @@ function RawMessages(props: Props) {
   const latestExpandedFields = useLatest(expandedFields);
 
   useEffect(() => {
-    if (
-      latestExpandedFields.current.keys.length === 0 &&
-      baseItem &&
-      config.autoExpandMode === "auto"
-    ) {
+    if (latestExpandedFields.current.size === 0 && baseItem && config.autoExpandMode === "auto") {
       const data = dataWithoutWrappingArray(baseItem.queriedData.map(({ value }) => value));
       const newExpandedFields = generateDeepKeyPaths(maybeDeepParse(data), 5);
       setExpandedFields(newExpandedFields);


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the behavior of the `auto` expansion mode of the raw messages panel.

**Description**
We have some logic in place to respect any paths the user has manually expanded in the raw messages panel in `auto` mode but it was incorrectly determining if there were any such paths.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3655 