### PR TITLE
[New3D] Port object inspector from Old3D

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/LinkToGlobalVariable.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/LinkToGlobalVariable.tsx
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import LinkPlusIcon from "@mdi/svg/svg/link-plus.svg";
+import { Button, Card, FilledInput, Typography } from "@mui/material";
+import classNames from "classnames";
+import React, { CSSProperties, FormEvent } from "react";
+
+import ChildToggle from "@foxglove/studio-base/components/ChildToggle";
+import Icon from "@foxglove/studio-base/components/Icon";
+import Stack from "@foxglove/studio-base/components/Stack";
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import GlobalVariableName from "../GlobalVariableName";
+import useLinkedGlobalVariables from "../useLinkedGlobalVariables";
+import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
+
+type AddToLinkedGlobalVariable = {
+  topic: string;
+  markerKeyPath: string[];
+  variableValue: unknown;
+};
+
+type Props = {
+  highlight?: boolean;
+  addToLinkedGlobalVariable: AddToLinkedGlobalVariable;
+  style?: CSSProperties;
+};
+
+function getInitialName(markerKeyPath: string[]) {
+  return markerKeyPath.slice(0, 2).reverse().join("_");
+}
+
+export default function LinkToGlobalVariable({
+  style = {},
+  addToLinkedGlobalVariable: { topic, variableValue, markerKeyPath },
+  highlight = false,
+}: Props): JSX.Element {
+  const [isOpen, _setIsOpen] = React.useState<boolean>(false);
+  const [name, setName] = React.useState(() => getInitialName(markerKeyPath));
+
+  const setIsOpen = React.useCallback(
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    (newValue: boolean) => {
+      _setIsOpen(newValue);
+      if (newValue) {
+        setName(getInitialName(markerKeyPath));
+      }
+    },
+    [markerKeyPath],
+  );
+
+  const { linkedGlobalVariables, setLinkedGlobalVariables } = useLinkedGlobalVariables();
+
+  const addLink = (ev: FormEvent) => {
+    ev.preventDefault();
+    void variableValue;
+    // setGlobalVariables({ [name]: variableValue });
+    const newLinkedGlobalVariables = [...linkedGlobalVariables, { topic, markerKeyPath, name }];
+    setLinkedGlobalVariables(newLinkedGlobalVariables);
+    setIsOpen(false);
+  };
+
+  const highlightIconStyle = highlight ? { color: colors.HIGHLIGHT } : {};
+
+  return (
+    <ChildToggle
+      dataTest={`link-${name}`}
+      position="above"
+      onToggle={setIsOpen}
+      isOpen={isOpen}
+      style={style}
+    >
+      <Icon
+        className={classNames("link-icon", { highlight })}
+        style={highlightIconStyle}
+        fade={!highlight}
+        tooltip="Link this field to a global variable"
+        tooltipProps={{ placement: "top" }}
+      >
+        <LinkPlusIcon />
+      </Icon>
+      <Card
+        elevation={4}
+        component="form"
+        variant="elevation"
+        style={{ overflowWrap: "break-word", pointerEvents: "auto", width: 240 }}
+        onSubmit={addLink}
+        data-test="link-form"
+      >
+        <Stack padding={2} gap={1}>
+          <Typography variant="body2">
+            When linked, clicking a new object from {topic} will update the global variable&nbsp;
+            <GlobalVariableName name={name} />.
+          </Typography>
+          <UnlinkGlobalVariables name={name} showList />
+          <FilledInput
+            size="small"
+            autoFocus
+            type="text"
+            value={`$${name}`}
+            onChange={(e) => setName(e.target.value.replace(/^\$/, ""))}
+          />
+          <Stack direction="row" gap={1} data-test="action-buttons">
+            <Button
+              variant="contained"
+              color={name.length > 0 ? "primary" : "inherit"}
+              disabled={name.length === 0}
+              onClick={addLink}
+            >
+              Add Link
+            </Button>
+            <Button variant="contained" color="inherit" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+          </Stack>
+        </Stack>
+      </Card>
+    </ChildToggle>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/SGlobalVariableLink.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/SGlobalVariableLink.tsx
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import styled from "styled-components";
+
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+export default styled.span`
+  height: 15px;
+  flex-direction: row;
+  display: inline-flex;
+  align-items: center;
+  word-break: normal;
+
+  span.icon {
+    color: ${colors.BLUE};
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+    display: inline-block;
+  }
+  .link-icon {
+    opacity: 0.2;
+    display: none;
+  }
+  .highlight {
+    opacity: 1;
+    display: inline;
+  }
+  &:hover {
+    .link-icon {
+      opacity: 1;
+    }
+  }
+`;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariable.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariable.tsx
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Button, Card, Typography } from "@mui/material";
+import { isEqual } from "lodash";
+import { useCallback } from "react";
+
+import Stack from "@foxglove/studio-base/components/Stack";
+
+import GlobalVariableName from "../GlobalVariableName";
+import { getPath } from "../interactionUtils";
+import useLinkedGlobalVariables, { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
+
+type Props = {
+  linkedGlobalVariable: LinkedGlobalVariable;
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setIsOpen: (arg0: boolean) => void;
+};
+
+export default function UnlinkGlobalVariable({
+  linkedGlobalVariable: { topic, markerKeyPath, name },
+  setIsOpen,
+}: Props): JSX.Element {
+  const { linkedGlobalVariables, setLinkedGlobalVariables } = useLinkedGlobalVariables();
+  const handleClick = useCallback(() => {
+    const newLinkedGlobalVariables = linkedGlobalVariables.filter(
+      (linkedGlobalVariable) =>
+        !(
+          linkedGlobalVariable.topic === topic &&
+          isEqual(linkedGlobalVariable.markerKeyPath, markerKeyPath) &&
+          linkedGlobalVariable.name === name
+        ),
+    );
+    setLinkedGlobalVariables(newLinkedGlobalVariables);
+    setIsOpen(false);
+  }, [linkedGlobalVariables, markerKeyPath, name, setIsOpen, setLinkedGlobalVariables, topic]);
+
+  return (
+    <Card
+      elevation={4}
+      component="form"
+      variant="elevation"
+      data-test="unlink-form"
+      style={{ overflowWrap: "break-word", pointerEvents: "auto" }}
+    >
+      <Stack padding={2} gap={1.5}>
+        <Typography variant="body2" noWrap>
+          Unlink <GlobalVariableName name={name} /> from {topic}.
+          <Typography variant="inherit" display="inline" color="text.secondary">
+            {getPath(markerKeyPath)}?
+          </Typography>
+        </Typography>
+        <Stack direction="row" gap={1}>
+          <Button size="small" color="error" variant="contained" onClick={handleClick}>
+            Unlink
+          </Button>
+          <Button size="small" variant="contained" color="inherit" onClick={() => setIsOpen(false)}>
+            Cancel
+          </Button>
+        </Stack>
+      </Stack>
+    </Card>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariables.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariables.stories.tsx
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { storiesOf } from "@storybook/react";
+
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import UnlinkGlobalVariables from "./UnlinkGlobalVariables";
+
+const linkedGlobalVariables = [
+  {
+    topic: "/foo/bar",
+    markerKeyPath: ["id"],
+    name: "some_id",
+  },
+  {
+    topic: "/abc/xyz",
+    markerKeyPath: ["id", "some_path"],
+    name: "some_id",
+  },
+  {
+    topic: "/foo/bar",
+    markerKeyPath: ["x", "scale", "some_very_very_long_path"],
+    name: "some_id",
+  },
+  {
+    topic: "/foo/bar",
+    markerKeyPath: ["x", "scale", "some_very_very_long_path"],
+    name: "someOtherName",
+  },
+];
+
+storiesOf(
+  "panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariables",
+  module,
+).add("default", () => {
+  return (
+    <PanelSetup
+      fixture={{
+        topics: [],
+        datatypes: new Map(),
+        frame: {},
+        linkedGlobalVariables,
+        globalVariables: {
+          scaleY: 2.4,
+          fooScaleX: 3,
+        },
+      }}
+    >
+      <div
+        ref={(el) => {
+          if (el) {
+            const btn = el.querySelector<HTMLElement>("[data-test='unlink-some_id']");
+            if (btn) {
+              btn.click();
+            }
+          }
+        }}
+      >
+        <UnlinkGlobalVariables name="some_id" />
+      </div>
+    </PanelSetup>
+  );
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariables.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkGlobalVariables.tsx
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Button, Card, Typography, styled as muiStyled } from "@mui/material";
+import { isEqual } from "lodash";
+
+import Stack from "@foxglove/studio-base/components/Stack";
+
+import GlobalVariableName from "../GlobalVariableName";
+import { getPath } from "../interactionUtils";
+import useLinkedGlobalVariables, { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
+import SGlobalVariableLink from "./SGlobalVariableLink";
+import UnlinkWrapper from "./UnlinkWrapper";
+
+type Props = {
+  name: string;
+  showList?: boolean;
+};
+
+const StyledButton = muiStyled(Button)({
+  lineHeight: 1.125,
+  minWidth: "auto",
+});
+
+export default function UnlinkGlobalVariables({
+  name,
+  showList = false,
+}: Props): JSX.Element | ReactNull {
+  const { linkedGlobalVariables, linkedGlobalVariablesByName, setLinkedGlobalVariables } =
+    useLinkedGlobalVariables();
+
+  const links: LinkedGlobalVariable[] = linkedGlobalVariablesByName[name] ?? [];
+  const firstLink = links[0];
+
+  if (!firstLink) {
+    return ReactNull;
+  }
+
+  // the list UI is shared between 3D panel and Global Variables panel
+  const listHtml = (
+    <Stack gap={1} padding={showList ? 0 : 2}>
+      {links.map(({ topic, markerKeyPath, name: linkedGlobalVariableName }, idx) => {
+        return (
+          <Stack key={idx} gap={1} alignItems="center" direction="row">
+            <StyledButton
+              variant="contained"
+              color="error"
+              size="small"
+              onClick={() => {
+                const newLinkedGlobalVariables = linkedGlobalVariables.filter(
+                  (linkedGlobalVariable) =>
+                    !(
+                      linkedGlobalVariable.topic === topic &&
+                      isEqual(linkedGlobalVariable.markerKeyPath, markerKeyPath) &&
+                      linkedGlobalVariable.name === linkedGlobalVariableName
+                    ),
+                );
+                setLinkedGlobalVariables(newLinkedGlobalVariables);
+              }}
+            >
+              Unlink
+            </StyledButton>
+            <Typography
+              variant="body2"
+              noWrap
+              flex="auto"
+              title={`${topic}.${getPath(markerKeyPath)}`}
+            >
+              {topic}.
+              <Typography variant="inherit" display="inline" color="text.secondary">
+                {getPath(markerKeyPath)}
+              </Typography>
+            </Typography>
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
+  if (showList) {
+    return (
+      <>
+        <Typography variant="body2" gutterBottom>
+          Some links already exist for this variable. The variable’s value will be taken from the
+          most recently clicked linked topic.
+        </Typography>
+        {listHtml}
+      </>
+    );
+  }
+
+  return (
+    <SGlobalVariableLink>
+      <UnlinkWrapper
+        tooltip={
+          <span>
+            Unlink <GlobalVariableName name={name} />
+          </span>
+        }
+        linkedGlobalVariable={firstLink}
+      >
+        {() => (
+          <Card
+            elevation={4}
+            variant="elevation"
+            component="form"
+            data-test="unlink-form"
+            style={{ pointerEvents: "auto", maxWidth: 320 }}
+          >
+            {listHtml}
+          </Card>
+        )}
+      </UnlinkWrapper>
+    </SGlobalVariableLink>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkWrapper.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/UnlinkWrapper.tsx
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import LinkVariantOffIcon from "@mdi/svg/svg/link-variant-off.svg";
+import LinkVariantIcon from "@mdi/svg/svg/link-variant.svg";
+import { useState, ReactNode } from "react";
+import styled from "styled-components";
+
+import ChildToggle from "@foxglove/studio-base/components/ChildToggle";
+import Icon from "@foxglove/studio-base/components/Icon";
+
+import GlobalVariableName from "../GlobalVariableName";
+import { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
+
+const SIconWrapper = styled.span`
+  .icon {
+    /* TODO(Audrey): remove the hard-coded icon style once we clean up 3D panel styles   */
+    width: 15px !important;
+    height: 15px !important;
+    font-size: 15px !important;
+  }
+  .linked-icon {
+    opacity: 1;
+    display: inline-block;
+  }
+  .link-off-icon {
+    opacity: 0;
+    display: none;
+  }
+  &:hover {
+    .linked-icon {
+      opacity: 0;
+      display: none;
+    }
+    .link-off-icon {
+      opacity: 1;
+      display: inline-block;
+    }
+  }
+`;
+
+type Props = {
+  linkedGlobalVariable: LinkedGlobalVariable;
+  children: (arg0: {
+    // eslint-disable-next-line @foxglove/no-boolean-parameters
+    setIsOpen: (arg0: boolean) => void;
+    linkedGlobalVariable: LinkedGlobalVariable;
+  }) => ReactNode;
+  tooltip?: ReactNode;
+};
+
+export default function UnlinkWrapper({
+  children,
+  linkedGlobalVariable,
+  tooltip,
+}: Props): JSX.Element {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  return (
+    <>
+      <ChildToggle
+        dataTest={`unlink-${linkedGlobalVariable.name}`}
+        position="above"
+        onToggle={setIsOpen}
+        isOpen={isOpen}
+      >
+        <SIconWrapper>
+          <Icon
+            fade
+            tooltipProps={{
+              contents: tooltip ?? (
+                <span>
+                  Unlink this field from <GlobalVariableName name={linkedGlobalVariable.name} />
+                </span>
+              ),
+            }}
+          >
+            <LinkVariantOffIcon className="link-off-icon" />
+            <LinkVariantIcon className="linked-icon" />
+          </Icon>
+        </SIconWrapper>
+        <span>{children({ setIsOpen, linkedGlobalVariable })}</span>
+      </ChildToggle>
+      <GlobalVariableName name={linkedGlobalVariable.name} leftPadding />
+    </>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableLink/index.tsx
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { CSSProperties } from "react";
+import styled from "styled-components";
+
+import { getLinkedGlobalVariable } from "../interactionUtils";
+import useLinkedGlobalVariables, { LinkedGlobalVariable } from "../useLinkedGlobalVariables";
+import LinkToGlobalVariable from "./LinkToGlobalVariable";
+import SGlobalVariableLink from "./SGlobalVariableLink";
+import UnlinkGlobalVariable from "./UnlinkGlobalVariable";
+import UnlinkWrapper from "./UnlinkWrapper";
+
+const SWrapper = styled.span`
+  display: inline-flex;
+  align-items: center;
+`;
+
+const SValue = styled.span`
+  padding: 0;
+`;
+
+type Props = {
+  hasNestedValue?: boolean;
+  highlight?: boolean;
+  label?: string;
+  linkedGlobalVariable?: LinkedGlobalVariable;
+  markerKeyPath?: string[];
+  nestedValueStyle?: CSSProperties;
+  onlyRenderAddLink?: boolean;
+  style?: CSSProperties;
+  topic?: string;
+  unlinkTooltip?: React.ReactNode;
+  variableValue?: unknown;
+};
+
+export default function GlobalVariableLink({
+  hasNestedValue = false,
+  highlight,
+  label,
+  linkedGlobalVariable,
+  markerKeyPath,
+  nestedValueStyle = { marginLeft: 8 },
+  onlyRenderAddLink = false,
+  style = { marginLeft: 4 },
+  topic,
+  unlinkTooltip,
+  variableValue,
+}: Props): JSX.Element | ReactNull {
+  const { linkedGlobalVariables } = useLinkedGlobalVariables();
+  let linkedGlobalVariableLocal: LinkedGlobalVariable | undefined = linkedGlobalVariable;
+  if (!linkedGlobalVariableLocal && topic && markerKeyPath) {
+    linkedGlobalVariableLocal = getLinkedGlobalVariable({
+      topic,
+      markerKeyPath,
+      linkedGlobalVariables,
+    });
+  }
+
+  const isArrayBuffer = ArrayBuffer.isView(variableValue);
+  const renderUnlink = !!linkedGlobalVariableLocal;
+  const addToLinkedGlobalVariable =
+    topic && markerKeyPath ? { topic, markerKeyPath, variableValue } : undefined;
+  const renderAddLink = !renderUnlink && !isArrayBuffer && addToLinkedGlobalVariable != undefined;
+  if (!renderUnlink && !renderAddLink) {
+    return ReactNull;
+  }
+
+  const arrayBufferStyle = isArrayBuffer ? style : { cursor: "pointer" };
+  let wrapperStyle = hasNestedValue ? nestedValueStyle : style;
+  wrapperStyle = { ...arrayBufferStyle, ...wrapperStyle };
+
+  return (
+    <SWrapper>
+      {label && <SValue>{label}</SValue>}
+      <SGlobalVariableLink style={wrapperStyle}>
+        {linkedGlobalVariableLocal && !onlyRenderAddLink && (
+          <UnlinkWrapper linkedGlobalVariable={linkedGlobalVariableLocal} tooltip={unlinkTooltip}>
+            {({ setIsOpen, linkedGlobalVariable: linkedVar }) => (
+              <UnlinkGlobalVariable linkedGlobalVariable={linkedVar} setIsOpen={setIsOpen} />
+            )}
+          </UnlinkWrapper>
+        )}
+        {renderAddLink && (
+          <LinkToGlobalVariable
+            highlight={highlight}
+            addToLinkedGlobalVariable={addToLinkedGlobalVariable}
+          />
+        )}
+      </SGlobalVariableLink>
+    </SWrapper>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableName.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/GlobalVariableName.tsx
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import styled from "styled-components";
+
+const SGlobalVariableName = styled.span<{ leftPadding?: boolean }>`
+  color: #ccb862;
+  font-weight: bold;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-left: ${(props) => (props.leftPadding === true ? "6px" : 0)};
+`;
+
+export default function GlobalVariableName({
+  name,
+  leftPadding,
+}: {
+  name: string;
+  leftPadding?: boolean;
+}): JSX.Element {
+  return (
+    <SGlobalVariableName title={name} leftPadding={leftPadding}>
+      ${name}
+    </SGlobalVariableName>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -247,24 +247,6 @@ storiesOf("panels/ThreeDeeRender/Interactions/Interaction", module)
   })
   .add("default", DefaultStory, { colorScheme: "dark" })
   .add("default light", DefaultStory, { colorScheme: "light" })
-  .add("instanced interactionData", () => {
-    return (
-      <SWrapper>
-        <PanelSetupWithData title="With instanced interactionData">
-          <Interactions
-            {...(sharedProps as any)}
-            interactionsTabType={OBJECT_TAB_TYPE}
-            selectedObject={{
-              object: {
-                metadataByIndex: [{ ...markerObject, interactionData: { topic: "/foo/bar" } }],
-              },
-              instanceIndex: 0,
-            }}
-          />
-        </PanelSetupWithData>
-      </SWrapper>
-    );
-  })
   .add("PointCloud", () => {
     const cloud1 = { ...selectedObject.object, ...decodeMarker(POINT_CLOUD_MESSAGE) };
     const cloud2 = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -1,0 +1,431 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { Stack } from "@mui/material";
+import { storiesOf } from "@storybook/react";
+import styled from "styled-components";
+
+import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
+import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
+import { decodeMarker } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker";
+import {
+  POINT_CLOUD_MESSAGE,
+  POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/fixture/pointCloudData";
+import PanelSetup, { triggerInputChange } from "@foxglove/studio-base/stories/PanelSetup";
+
+import Interactions, { OBJECT_TAB_TYPE, LINKED_VARIABLES_TAB_TYPE } from "./Interactions";
+import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
+
+const SWrapper = styled.div`
+  background: ${({ theme }) => theme.palette.neutralLighterAlt};
+  display: flex;
+  flex-wrap: wrap;
+  height: 100%;
+`;
+
+const SP = styled.p`
+  color: ${({ theme }) => theme.semanticColors.disabledText};
+`;
+
+const markerObject = {
+  id: "12345",
+  header: { frame_id: "some_frame", stamp: { sec: 0, nsec: 0 } },
+  action: 0,
+  ns: "",
+  text: "hello\nthere",
+  type: 0,
+  scale: {
+    x: 2,
+    y: 2,
+    z: 4,
+  },
+  color: {
+    r: 1,
+    g: 0.1,
+    b: 0,
+    a: 0.7,
+  },
+  pose: {
+    position: {
+      x: -1,
+      y: 1,
+      z: -5,
+    },
+    orientation: {
+      x: 0,
+      y: 0,
+      z: 0,
+      w: 1,
+    },
+  },
+};
+
+const interactiveMarkerObject = {
+  ...markerObject,
+  interactionData: { topic: "/foo/bar", originalMessage: markerObject },
+};
+const selectedObject = { object: interactiveMarkerObject, instanceIndex: undefined };
+
+const sharedProps = {
+  selectedObject,
+  interactionsTabType: OBJECT_TAB_TYPE,
+  setInteractionsTabType: () => {
+    // no-op
+  },
+};
+
+function GlobalVariablesDisplay() {
+  const { globalVariables } = useGlobalVariables();
+  return (
+    <SP>
+      <strong>Global variables: </strong>
+      {JSON.stringify(globalVariables)}
+    </SP>
+  );
+}
+function LinkedGlobalVariablesDisplay() {
+  const { linkedGlobalVariables } = useLinkedGlobalVariables();
+  return (
+    <SP>
+      <strong>Global variable links: </strong>
+      {JSON.stringify(linkedGlobalVariables)}
+    </SP>
+  );
+}
+
+function PanelSetupWithData({
+  children,
+  showGlobalVariables = false,
+  showLinkedGlobalVariables = false,
+  title,
+  onMount,
+  disableAutoOpenClickedObject = true,
+}: {
+  children: React.ReactNode;
+  showGlobalVariables?: boolean;
+  showLinkedGlobalVariables?: boolean;
+  title: React.ReactNode;
+  onMount?: (el: HTMLDivElement) => void;
+  disableAutoOpenClickedObject?: boolean;
+}) {
+  return (
+    <PanelSetup
+      omitDragAndDrop
+      style={{ width: "auto", height: "auto", display: "inline-flex" }}
+      fixture={{
+        topics: [],
+        datatypes: new Map(),
+        frame: {},
+        linkedGlobalVariables: [
+          {
+            topic: "/foo/bar",
+            markerKeyPath: ["frame_id", "header"],
+            name: "some_val",
+          },
+          {
+            topic: "/foo/bar",
+            markerKeyPath: ["type"],
+            name: "type",
+          },
+          {
+            topic: "/foo/bar",
+            markerKeyPath: ["action"],
+            name: "some_val",
+          },
+          {
+            topic: "/some_topic",
+            markerKeyPath: ["scale"],
+            name: "scale",
+          },
+          {
+            topic: "/other_topic",
+            markerKeyPath: ["scale"],
+            name: "scale",
+          },
+          {
+            topic: "/foo/bar",
+            markerKeyPath: ["y", "some_very_very_long_path"],
+            name: "scaleY",
+          },
+        ],
+        globalVariables: {
+          id: 100,
+          scaleY: 2.4,
+          fooScaleX: 3,
+        },
+      }}
+    >
+      <MockPanelContextProvider config={{ disableAutoOpenClickedObject }}>
+        <div
+          style={{ margin: 16 }}
+          ref={(el) => {
+            if (el && onMount) {
+              onMount(el);
+            }
+          }}
+        >
+          <p>{title}</p>
+          <Stack direction="row" flex="auto">
+            <Stack flex={1}>
+              {showGlobalVariables && <GlobalVariablesDisplay />}
+              {showLinkedGlobalVariables && <LinkedGlobalVariablesDisplay />}
+            </Stack>
+            {children}
+          </Stack>
+        </div>
+      </MockPanelContextProvider>
+    </PanelSetup>
+  );
+}
+
+function DefaultStory() {
+  return (
+    <SWrapper>
+      <PanelSetupWithData title="Link Tab">
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={undefined}
+          interactionsTabType={LINKED_VARIABLES_TAB_TYPE}
+        />
+      </PanelSetupWithData>
+      <PanelSetupWithData title="Default without clicked object">
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={undefined}
+          interactionsTabType={OBJECT_TAB_TYPE}
+        />
+      </PanelSetupWithData>
+      <PanelSetupWithData title="With interactionData">
+        <Interactions {...(sharedProps as any)} />
+      </PanelSetupWithData>
+      <PanelSetupWithData
+        title="Clicked link button"
+        onMount={(el) => {
+          const btn = el.querySelector("[data-test='link-id']");
+          if (btn) {
+            (btn as any).click();
+          }
+        }}
+      >
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={{ ...selectedObject, interactionData: { topic: "/foo/bar" } }}
+        />
+      </PanelSetupWithData>
+      <PanelSetupWithData
+        title="Add link to existing linked global variable"
+        onMount={(el) => {
+          const btn = el.querySelector("[data-test='link-scale']");
+          if (btn) {
+            (btn as any).click();
+          }
+        }}
+      >
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={{ ...selectedObject, interactionData: { topic: "/foo/bar" } }}
+        />
+      </PanelSetupWithData>
+    </SWrapper>
+  );
+}
+
+storiesOf("panels/ThreeDeeRender/Interactions/Interaction", module)
+  .addParameters({
+    chromatic: { viewport: { width: 1001, height: 1101 } },
+  })
+  .add("default", DefaultStory, { colorScheme: "dark" })
+  .add("default light", DefaultStory, { colorScheme: "light" })
+  .add("instanced interactionData", () => {
+    return (
+      <SWrapper>
+        <PanelSetupWithData title="With instanced interactionData">
+          <Interactions
+            {...(sharedProps as any)}
+            interactionsTabType={OBJECT_TAB_TYPE}
+            selectedObject={{
+              object: {
+                metadataByIndex: [{ ...markerObject, interactionData: { topic: "/foo/bar" } }],
+              },
+              instanceIndex: 0,
+            }}
+          />
+        </PanelSetupWithData>
+      </SWrapper>
+    );
+  })
+  .add("PointCloud", () => {
+    const cloud1 = { ...selectedObject.object, ...decodeMarker(POINT_CLOUD_MESSAGE) };
+    const cloud2 = {
+      ...selectedObject.object,
+      ...decodeMarker(POINT_CLOUD_WITH_ADDITIONAL_FIELDS),
+    };
+
+    return (
+      <SWrapper>
+        <PanelSetupWithData title="default with point color">
+          <Interactions
+            {...(sharedProps as any)}
+            selectedObject={{
+              instanceIndex: 0,
+              object: {
+                ...cloud1,
+                type: 102,
+                interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
+              },
+            }}
+          />
+        </PanelSetupWithData>
+        <PanelSetupWithData title="with additional fields">
+          <Interactions
+            {...(sharedProps as any)}
+            selectedObject={{
+              instanceIndex: 0,
+              object: {
+                ...cloud2,
+                type: 102,
+                interactionData: {
+                  topic: "/foo/bar",
+                  originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+                },
+              },
+            }}
+          />
+        </PanelSetupWithData>
+      </SWrapper>
+    );
+  })
+  .add("link and multi-link global variables", () => {
+    return (
+      <SWrapper>
+        <PanelSetupWithData showGlobalVariables showLinkedGlobalVariables title="Default">
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+
+        <PanelSetupWithData
+          showGlobalVariables
+          showLinkedGlobalVariables
+          title={
+            <>
+              Added a new link between <code>id</code> field and <code>$id</code> variable
+            </>
+          }
+          onMount={(el) => {
+            const btn = el.querySelector("[data-test='link-id']");
+            if (btn) {
+              (btn as any).click();
+              setImmediate(() => {
+                const linkFormBtn = document.querySelector("[data-test='link-form'] button");
+                if (linkFormBtn) {
+                  (linkFormBtn as any).click();
+                }
+              });
+            }
+          }}
+        >
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+        <PanelSetupWithData
+          showGlobalVariables
+          showLinkedGlobalVariables
+          title={
+            <>
+              Added another field <code>scale</code> to <code>$id</code> variable
+            </>
+          }
+          onMount={(el) => {
+            // click the "link" icon button, manually change the input from "scale" to "id", then click "link" icon
+            const btn = el.querySelector("[data-test='link-scale']");
+            if (btn) {
+              (btn as any).click();
+              setImmediate(() => {
+                const linkNameInput = document.querySelector<HTMLInputElement>(
+                  "[data-test='link-form'] input",
+                );
+                if (linkNameInput) {
+                  triggerInputChange(linkNameInput, "id");
+                  const linkFormBtn = document.querySelector(
+                    "[data-test='link-form'] [data-test='action-buttons'] button",
+                  );
+                  if (linkFormBtn) {
+                    (linkFormBtn as any).click();
+                  }
+                }
+              });
+            }
+          }}
+        >
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+      </SWrapper>
+    );
+  })
+  .add("unlink single linked global variable", () => {
+    return (
+      <SWrapper>
+        <PanelSetupWithData
+          title={
+            <>
+              Unlinked <code>type</code> field from <code>$type</code> variable
+            </>
+          }
+          showGlobalVariables
+          showLinkedGlobalVariables
+          onMount={(el) => {
+            const btn = el.querySelector("[data-test='unlink-type']");
+            if (btn) {
+              (btn as any).click();
+              setImmediate(() => {
+                const unlinkBtn = document.querySelector("[data-test='unlink-form'] button");
+                if (unlinkBtn) {
+                  (unlinkBtn as any).click();
+                }
+              });
+            }
+          }}
+        >
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+      </SWrapper>
+    );
+  })
+  .add("unlink multi-linked global variable", () => {
+    return (
+      <SWrapper>
+        <PanelSetupWithData
+          title={
+            <>
+              Unlinked <code>header.frame_id</code> field from <code>$some_val</code> variable{" "}
+            </>
+          }
+          showGlobalVariables
+          showLinkedGlobalVariables
+          onMount={(el) => {
+            const btn = el.querySelector("[data-test='unlink-some_val']");
+            if (btn) {
+              (btn as any).click();
+              setImmediate(() => {
+                const unlinkBtn = document.querySelector("[data-test='unlink-form'] button");
+                if (unlinkBtn) {
+                  (unlinkBtn as any).click();
+                }
+              });
+            }
+          }}
+        >
+          <Interactions {...(sharedProps as any)} />
+        </PanelSetupWithData>
+      </SWrapper>
+    );
+  });

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.stories.tsx
@@ -1,0 +1,93 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { storiesOf } from "@storybook/react";
+
+import InteractionContextMenu from "./InteractionContextMenu";
+
+const selectedObject = {
+  id: "obj-1",
+  header: { frame_id: "some_frame", stamp: { sec: 0, nsec: 0 } },
+  action: 0,
+  ns: "",
+  type: 0,
+  scale: {
+    x: 2,
+    y: 2,
+    z: 4,
+  },
+  color: {
+    r: 1,
+    g: 0.1,
+    b: 0,
+    a: 0.7,
+  },
+  pose: {
+    position: {
+      x: -1,
+      y: 1,
+      z: -5,
+    },
+    orientation: {
+      x: 0,
+      y: 0,
+      z: 0,
+      w: 1,
+    },
+  },
+};
+const sharedProps = {
+  selectObject: () => {
+    // no-op
+  },
+  clickedObjects: [
+    {
+      object: { ...selectedObject, interactionData: { topic: "/foo/bar" } },
+      instanceIndex: undefined,
+    },
+    {
+      object: { ...selectedObject, interactionData: { topic: "/foo1/bar" }, id: undefined },
+      instanceIndex: undefined,
+    },
+    { object: { ...selectedObject, interactionData: { topic: "/abc/xyz" } }, instanceIndex: 10 },
+    {
+      object: {
+        ...selectedObject,
+        id: undefined,
+        interactionData: { topic: "/some_topic_name/nested_name/with_very_very_very_longer_name/" },
+      },
+      instanceIndex: 10,
+    },
+    {
+      object: {
+        ...selectedObject,
+        interactionData: { topic: "/some_topic/with_slightly_longer_names" },
+      },
+      instanceIndex: 10,
+    },
+  ],
+  clickedPosition: { clientX: 100, clientY: 200 },
+};
+
+storiesOf("panels/ThreeDeeRender/Interactions/InteractionContextMenu", module).add(
+  "default",
+  () => {
+    return (
+      <div
+        style={{ background: "#2d2c33", display: "flex", flexDirection: "row", flexWrap: "wrap" }}
+      >
+        <InteractionContextMenu {...sharedProps} />
+      </div>
+    );
+  },
+);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2020-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { useCallback } from "react";
+import styled from "styled-components";
+
+import { MouseEventObject } from "@foxglove/regl-worldview";
+import { getObject } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
+import { BaseMarker } from "@foxglove/studio-base/types/Messages";
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+import { Interactive, SelectedObject } from "./types";
+
+type ClickedPosition = { clientX: number; clientY: number };
+
+const SInteractionContextMenu = styled.div`
+  position: fixed;
+  width: 240px;
+  color: ${colors.LIGHT1};
+  background: ${colors.DARK4};
+  opacity: 0.9;
+  z-index: 101; /* above the Text marker */
+`;
+
+const SMenu = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;
+
+const STooltip = styled.div`
+  cursor: pointer;
+  background: ${colors.PURPLE1};
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: none;
+  padding: 8px;
+`;
+
+const SMenuItem = styled.li`
+  cursor: pointer;
+  padding: 8px;
+  position: relative;
+  &:hover {
+    background: ${colors.PURPLE1};
+    ${STooltip} {
+      display: block;
+    }
+  }
+`;
+
+const STopic = styled.div`
+  width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+
+const SId = styled.span`
+  color: ${colors.YELLOW1};
+`;
+
+type Props = {
+  clickedPosition: ClickedPosition;
+  clickedObjects: MouseEventObject[];
+  selectObject: (arg0?: MouseEventObject) => void;
+};
+
+export default function InteractionContextMenu({
+  clickedObjects = [],
+  clickedPosition = { clientX: 0, clientY: 0 },
+  selectObject,
+}: Props): JSX.Element {
+  return (
+    <SInteractionContextMenu
+      style={{
+        top: clickedPosition.clientY,
+        left: clickedPosition.clientX,
+      }}
+    >
+      <SMenu>
+        {clickedObjects.map((interactiveObject, index) => (
+          <InteractionContextMenuItem
+            key={index}
+            interactiveObject={interactiveObject}
+            selectObject={selectObject}
+          />
+        ))}
+      </SMenu>
+    </SInteractionContextMenu>
+  );
+}
+
+function InteractionContextMenuItem({
+  interactiveObject,
+  selectObject,
+}: {
+  selectObject: (arg0?: SelectedObject) => void;
+  interactiveObject?: MouseEventObject;
+}) {
+  const object = getObject(interactiveObject) as Partial<Interactive<BaseMarker>>;
+  // const topic = getInteractionData(interactiveObject)?.topic;
+  const menuText = (
+    <>
+      {object.id != undefined && object.id !== "" && <SId>{object.id}</SId>}
+      {object.interactionData?.topic}
+    </>
+  );
+
+  // const { setHoveredMarkerMatchers } = useContext(ThreeDimensionalVizContext);
+  // const onMouseEnter = useCallback(() => {
+  //   if (topic) {
+  //     const { id, ns } = object;
+  //     const checks = [{ markerKeyPath: ["id"], value: id }];
+  //     if (ns != undefined && ns !== "") {
+  //       checks.push({ markerKeyPath: ["ns"], value: ns });
+  //     }
+  //     return setHoveredMarkerMatchers([{ topic, checks }]);
+  //   }
+  // }, [object, setHoveredMarkerMatchers, topic]);
+  // const onMouseLeave = useCallback(() => setHoveredMarkerMatchers([]), [setHoveredMarkerMatchers]);
+  // useEffect(() => onMouseLeave, [onMouseLeave]);
+
+  const selectItemObject = useCallback(
+    () => selectObject(interactiveObject as SelectedObject),
+    [interactiveObject, selectObject],
+  );
+
+  return (
+    <SMenuItem
+      // onMouseEnter={onMouseEnter}
+      // onMouseLeave={onMouseLeave}
+      data-test="InteractionContextMenuItem"
+    >
+      <STopic onClick={selectItemObject}>
+        {menuText}
+        <STooltip>{menuText}</STooltip>
+      </STopic>
+    </SMenuItem>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
@@ -13,34 +13,41 @@
 
 import CursorIcon from "@mdi/svg/svg/cursor-default.svg";
 
-import { MouseEventObject } from "@foxglove/regl-worldview";
 import type { LayoutActions } from "@foxglove/studio";
 import ExpandingToolbar, {
   ToolGroup,
   ToolGroupFixedSizePane,
 } from "@foxglove/studio-base/components/ExpandingToolbar";
 import { decodeAdditionalFields } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/selection";
-import { getInteractionData } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 
+import { Pose } from "../transforms";
 import LinkedGlobalVariableList from "./LinkedGlobalVariableList";
 import ObjectDetails from "./ObjectDetails";
 import PointCloudDetails from "./PointCloudDetails";
 import TopicLink from "./TopicLink";
 import { SEmptyState, SRow, SValue } from "./styling";
-import { SelectedObject } from "./types";
+import { InteractionData } from "./types";
 import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
 
 export const OBJECT_TAB_TYPE = "Selected object";
 export const LINKED_VARIABLES_TAB_TYPE = "Linked variables";
 export type TabType = typeof OBJECT_TAB_TYPE | typeof LINKED_VARIABLES_TAB_TYPE;
 
+export type SelectionObject = {
+  object: {
+    pose: Pose;
+    interactionData?: InteractionData;
+  };
+  instanceIndex: number | undefined;
+};
+
 type Props = {
   interactionsTabType?: TabType;
   setInteractionsTabType: (arg0?: TabType) => void;
   addPanel: LayoutActions["addPanel"];
-  selectedObject?: MouseEventObject;
+  selectedObject?: SelectionObject;
 };
 
 const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseComponent({
@@ -50,7 +57,7 @@ const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseCom
   setInteractionsTabType,
 }: Props) {
   const { object } = selectedObject ?? {};
-  const selectedInteractionData = getInteractionData(selectedObject);
+  const selectedInteractionData = selectedObject?.object.interactionData;
 
   const { originalMessage } = selectedInteractionData ?? {};
 
@@ -83,9 +90,7 @@ const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseCom
                   </SValue>
                 </SRow>
               )}
-              {isPointCloud && (
-                <PointCloudDetails selectedObject={selectedObject as SelectedObject} />
-              )}
+              {isPointCloud && <PointCloudDetails selectedObject={selectedObject!} />}
               <ObjectDetails
                 selectedObject={maybeFullyDecodedObject}
                 interactionData={selectedInteractionData}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import CursorIcon from "@mdi/svg/svg/cursor-default.svg";
+
+import { MouseEventObject } from "@foxglove/regl-worldview";
+import type { LayoutActions } from "@foxglove/studio";
+import ExpandingToolbar, {
+  ToolGroup,
+  ToolGroupFixedSizePane,
+} from "@foxglove/studio-base/components/ExpandingToolbar";
+import { decodeAdditionalFields } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/selection";
+import { getInteractionData } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
+import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
+import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
+
+import LinkedGlobalVariableList from "./LinkedGlobalVariableList";
+import ObjectDetails from "./ObjectDetails";
+import PointCloudDetails from "./PointCloudDetails";
+import TopicLink from "./TopicLink";
+import { SEmptyState, SRow, SValue } from "./styling";
+import { SelectedObject } from "./types";
+import useLinkedGlobalVariables from "./useLinkedGlobalVariables";
+
+export const OBJECT_TAB_TYPE = "Selected object";
+export const LINKED_VARIABLES_TAB_TYPE = "Linked variables";
+export type TabType = typeof OBJECT_TAB_TYPE | typeof LINKED_VARIABLES_TAB_TYPE;
+
+type Props = {
+  interactionsTabType?: TabType;
+  setInteractionsTabType: (arg0?: TabType) => void;
+  addPanel: LayoutActions["addPanel"];
+  selectedObject?: MouseEventObject;
+};
+
+const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseComponent({
+  addPanel,
+  selectedObject,
+  interactionsTabType,
+  setInteractionsTabType,
+}: Props) {
+  const { object } = selectedObject ?? {};
+  const selectedInteractionData = getInteractionData(selectedObject);
+
+  const { originalMessage } = selectedInteractionData ?? {};
+
+  const isPointCloud = maybeCast<{ type?: number }>(object)?.type === 102;
+  const maybeFullyDecodedObject = React.useMemo(
+    () =>
+      isPointCloud
+        ? decodeAdditionalFields(originalMessage as unknown as PointCloud2)
+        : originalMessage,
+    [isPointCloud, originalMessage],
+  );
+
+  const { linkedGlobalVariables } = useLinkedGlobalVariables();
+
+  return (
+    <ExpandingToolbar
+      tooltip="Inspect objects"
+      icon={<CursorIcon />}
+      selectedTab={interactionsTabType}
+      onSelectTab={(newSelectedTab) => setInteractionsTabType(newSelectedTab)}
+    >
+      <ToolGroup name={OBJECT_TAB_TYPE}>
+        <ToolGroupFixedSizePane>
+          {maybeFullyDecodedObject ? (
+            <>
+              {selectedInteractionData && (
+                <SRow>
+                  <SValue>
+                    <TopicLink addPanel={addPanel} topic={selectedInteractionData.topic} />
+                  </SValue>
+                </SRow>
+              )}
+              {isPointCloud && (
+                <PointCloudDetails selectedObject={selectedObject as SelectedObject} />
+              )}
+              <ObjectDetails
+                selectedObject={maybeFullyDecodedObject}
+                interactionData={selectedInteractionData}
+              />
+            </>
+          ) : (
+            <SEmptyState>Click an object in the 3D view to select it.</SEmptyState>
+          )}
+        </ToolGroupFixedSizePane>
+      </ToolGroup>
+      <ToolGroup name={LINKED_VARIABLES_TAB_TYPE}>
+        <ToolGroupFixedSizePane>
+          <LinkedGlobalVariableList linkedGlobalVariables={linkedGlobalVariables} />
+        </ToolGroupFixedSizePane>
+      </ToolGroup>
+    </ExpandingToolbar>
+  );
+});
+
+// Wrap the Interactions so that we don't rerender every time any part of the PanelContext config changes, but just the
+// one value that we care about.
+export default function Interactions(props: Props): JSX.Element {
+  return <InteractionsBaseComponent {...props} />;
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/LinkedGlobalVariableList.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/LinkedGlobalVariableList.tsx
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import LinkPlusIcon from "@mdi/svg/svg/link-plus.svg";
+import styled from "styled-components";
+
+import Icon from "@foxglove/studio-base/components/Icon";
+import { LegacyTable } from "@foxglove/studio-base/components/LegacyStyledComponents";
+
+import GlobalVariableLink from "./GlobalVariableLink/index";
+import GlobalVariableName from "./GlobalVariableName";
+import { getPath } from "./interactionUtils";
+import { SEmptyState } from "./styling";
+import { LinkedGlobalVariables } from "./useLinkedGlobalVariables";
+
+const SPath = styled.span`
+  opacity: 0.8;
+`;
+
+const STable = styled(LegacyTable)`
+  td {
+    padding: 0.3em;
+    border: none;
+    vertical-align: middle;
+  }
+`;
+
+type Props = {
+  linkedGlobalVariables: LinkedGlobalVariables;
+};
+
+export default function LinkedGlobalVariableList({ linkedGlobalVariables }: Props): JSX.Element {
+  if (linkedGlobalVariables.length === 0) {
+    return (
+      <SEmptyState>
+        Click the{" "}
+        <Icon
+          style={{ display: "inline", verticalAlign: "middle", lineHeight: 1 }}
+          clickable={false}
+        >
+          <LinkPlusIcon />
+        </Icon>{" "}
+        icon in the “Selected object” tab to link values with global variables.
+      </SEmptyState>
+    );
+  }
+  return (
+    <>
+      <SEmptyState>
+        Clicking on objects from these topics will update the linked global variables.
+      </SEmptyState>
+      <STable>
+        <tbody>
+          {linkedGlobalVariables.map((linkedGlobalVariable, index) => (
+            <tr key={index}>
+              <td>
+                <GlobalVariableLink
+                  linkedGlobalVariable={linkedGlobalVariable}
+                  unlinkTooltip={
+                    <span>
+                      Unlink <GlobalVariableName name={linkedGlobalVariable.name} />
+                    </span>
+                  }
+                />
+              </td>
+              <td style={{ wordBreak: "break-all" }}>
+                {linkedGlobalVariable.topic}.
+                <SPath>{getPath(linkedGlobalVariable.markerKeyPath)}</SPath>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </STable>
+    </>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { first, omit, sortBy } from "lodash";
+import { ReactNode } from "react";
+import Tree from "react-json-tree";
+import styled from "styled-components";
+
+import { isTypicalFilterName } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
+import { RosValue } from "@foxglove/studio-base/players/types";
+import { format, formatDuration } from "@foxglove/studio-base/util/formatTime";
+import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
+
+import GlobalVariableLink from "./GlobalVariableLink/index";
+import { InteractionData } from "./types";
+
+const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
+
+// Sort the keys of objects to make their presentation more predictable
+const PREFERRED_OBJECT_KEY_ORDER = [
+  "id",
+  "ns",
+  "type",
+  "action",
+  "header",
+  "lifetime",
+  "color",
+  "colors",
+  "pose",
+  "points",
+].reverse();
+
+const TreeContainer = styled.div`
+  padding: 12px 0 16px 0;
+`;
+
+type Props = {
+  readonly interactionData?: InteractionData;
+  readonly selectedObject?: RosValue;
+};
+
+function maybePlainObject(rawVal: unknown) {
+  if (typeof rawVal === "object" && rawVal && "toJSON" in rawVal) {
+    return (rawVal as { toJSON: () => unknown }).toJSON();
+  }
+  return rawVal;
+}
+
+function ObjectDetails({ interactionData, selectedObject }: Props): JSX.Element {
+  const jsonTreeTheme = useJsonTreeTheme();
+  const topic = interactionData?.topic ?? "";
+
+  // object to display may not be a plain-ole-data
+  // We need a plain object to sort the keys and omit interaction data
+  const plainObject = maybePlainObject(selectedObject);
+  const originalObject = omit(plainObject as Record<string, unknown>, "interactionData");
+
+  if (topic.length === 0) {
+    // show the original object directly if there is no interaction data
+    return (
+      <TreeContainer>
+        <Tree
+          data={selectedObject}
+          shouldExpandNode={(_markerKeyPath, _data, level) => level < 2}
+          invertTheme={false}
+          postprocessValue={maybePlainObject}
+          theme={{ ...jsonTreeTheme, tree: { margin: 0 } }}
+          hideRoot
+        />
+      </TreeContainer>
+    );
+  }
+
+  const sortedDataObject = Object.fromEntries(
+    sortBy(Object.keys(originalObject), (key) => -PREFERRED_OBJECT_KEY_ORDER.indexOf(key)).map(
+      (key) => [key, originalObject[key]],
+    ),
+  );
+
+  return (
+    <TreeContainer>
+      <Tree
+        data={sortedDataObject}
+        shouldExpandNode={() => false}
+        invertTheme={false}
+        theme={{ ...jsonTreeTheme, tree: { margin: 0, whiteSpace: "pre-line" } }}
+        hideRoot
+        getItemString={getItemString}
+        postprocessValue={maybePlainObject}
+        labelRenderer={(markerKeyPath, _p1, _p2, hasChildren) => {
+          const label = first(markerKeyPath);
+          if (!hasChildren) {
+            return <span style={{ padding: "0 4px 0 0" }}>{label}</span>;
+          }
+
+          let objectForPath: Record<string, unknown> | undefined = sortedDataObject;
+          for (let i = markerKeyPath.length - 1; i >= 0; i--) {
+            objectForPath = objectForPath[markerKeyPath[i]!] as Record<string, unknown> | undefined;
+            if (!objectForPath) {
+              break;
+            }
+          }
+
+          if (objectForPath) {
+            return (
+              <GlobalVariableLink
+                hasNestedValue
+                style={{ marginLeft: 4 }}
+                label={label?.toString()}
+                markerKeyPath={markerKeyPath.map((item) => item.toString())}
+                topic={topic}
+                variableValue={objectForPath}
+              />
+            );
+          }
+          return <></>;
+        }}
+        valueRenderer={(
+          label: string,
+          itemValue: unknown,
+          ...markerKeyPath: (string | number)[]
+        ) => {
+          return (
+            <GlobalVariableLink
+              style={{ marginLeft: 16 }}
+              label={label}
+              markerKeyPath={markerKeyPath.map((item) => item.toString())}
+              topic={topic}
+              variableValue={itemValue}
+            />
+          );
+        }}
+      />
+    </TreeContainer>
+  );
+}
+
+function getArrow(x: number, y: number) {
+  if (x === 0 && y === 0) {
+    return;
+  }
+  return (
+    <span style={{ transform: `rotate(${Math.atan2(-y, x)}rad)`, display: "inline-block" }}>→</span>
+  );
+}
+
+function getItemString(
+  _nodeType: string,
+  data: unknown,
+  itemType: ReactNode,
+  itemString: string,
+  _keyPath: (string | number)[],
+  timezone?: string,
+): ReactNode {
+  if (typeof data !== "object" || data == undefined) {
+    return (
+      <span>
+        {itemType} {itemString}
+      </span>
+    );
+  }
+
+  const keys = Object.keys(data);
+  if (keys.length === 2) {
+    const { sec, nsec } = data as { sec?: number; nsec?: number };
+    if (typeof sec === "number" && typeof nsec === "number") {
+      // Values "too small" to be absolute epoch-based times are probably relative durations.
+      return sec < DURATION_20_YEARS_SEC ? (
+        formatDuration({ sec, nsec })
+      ) : (
+        <span>{format({ sec, nsec }, timezone)}</span>
+      );
+    }
+  }
+
+  // for vectors/points display length
+  if (keys.length === 2) {
+    const { x, y } = data as { x?: unknown; y?: unknown };
+    if (typeof x === "number" && typeof y === "number") {
+      const length = Math.sqrt(x * x + y * y);
+      return (
+        <span>
+          norm = {length.toFixed(2)} {getArrow(x, y)}
+        </span>
+      );
+    }
+  }
+
+  if (keys.length === 3) {
+    const { x, y, z } = data as { x?: unknown; y?: unknown; z?: unknown };
+    if (typeof x === "number" && typeof y === "number" && typeof z === "number") {
+      const length = Math.sqrt(x * x + y * y + z * z);
+      return (
+        <span>
+          norm = {length.toFixed(2)} {z === 0 ? getArrow(x, y) : undefined}
+        </span>
+      );
+    }
+  }
+
+  // Surface typically-used keys directly in the object summary so the user doesn't have to expand it.
+  const filterKeys = keys
+    .filter(isTypicalFilterName)
+    .map((key) => `${key}: ${(data as { [key: string]: unknown })[key]}`)
+    .join(", ");
+  return (
+    <span>
+      {itemType} {filterKeys.length > 0 ? filterKeys : itemString}
+    </span>
+  );
+}
+
+export default ObjectDetails;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/PointCloudDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/PointCloudDetails.tsx
@@ -15,7 +15,6 @@ import ExportVariantIcon from "@mdi/svg/svg/export-variant.svg";
 import { useMemo, useState, useCallback } from "react";
 import styled from "styled-components";
 
-import { MouseEventObject } from "@foxglove/regl-worldview";
 import ChildToggle from "@foxglove/studio-base/components/ChildToggle";
 import Icon from "@foxglove/studio-base/components/Icon";
 import Menu from "@foxglove/studio-base/components/Menu";
@@ -30,6 +29,7 @@ import clipboard from "@foxglove/studio-base/util/clipboard";
 import { downloadFiles } from "@foxglove/studio-base/util/download";
 import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
 
+import type { SelectionObject } from "./Interactions";
 import { SValue, SLabel } from "./styling";
 
 const SRow = styled.div`
@@ -40,7 +40,7 @@ const SRow = styled.div`
   margin: 4px 0;
 `;
 type Props = {
-  selectedObject: MouseEventObject;
+  selectedObject: SelectionObject;
 };
 
 export default function PointCloudDetails({

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/PointCloudDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/PointCloudDetails.tsx
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import ExportVariantIcon from "@mdi/svg/svg/export-variant.svg";
+import { useMemo, useState, useCallback } from "react";
+import styled from "styled-components";
+
+import { MouseEventObject } from "@foxglove/regl-worldview";
+import ChildToggle from "@foxglove/studio-base/components/ChildToggle";
+import Icon from "@foxglove/studio-base/components/Icon";
+import Menu from "@foxglove/studio-base/components/Menu";
+import Item from "@foxglove/studio-base/components/Menu/Item";
+import { DecodedMarker } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker";
+import {
+  getClickedInfo,
+  getAllPoints,
+  ClickedInfo,
+} from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/selection";
+import clipboard from "@foxglove/studio-base/util/clipboard";
+import { downloadFiles } from "@foxglove/studio-base/util/download";
+import { maybeCast } from "@foxglove/studio-base/util/maybeCast";
+
+import { SValue, SLabel } from "./styling";
+
+const SRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0;
+  margin: 4px 0;
+`;
+type Props = {
+  selectedObject: MouseEventObject;
+};
+
+export default function PointCloudDetails({
+  selectedObject: { object, instanceIndex },
+}: Props): JSX.Element | ReactNull {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const { clickedPoint, clickedPointColor, additionalFieldValues } = useMemo(() => {
+    return (
+      getClickedInfo(object as unknown as DecodedMarker, instanceIndex) ??
+      ({} as Partial<ClickedInfo>)
+    );
+  }, [instanceIndex, object]);
+
+  const additionalFieldNames = useMemo(
+    () => (additionalFieldValues ? Object.keys(additionalFieldValues) : []),
+    [additionalFieldValues],
+  );
+
+  const hasAdditionalFieldNames = additionalFieldNames.length > 0;
+  const onCopy = useCallback(() => {
+    // GPU point clouds need to extract positions using getAllPoints()
+    const allPoints: number[] =
+      (object as { points?: number[] }).points ?? getAllPoints(object as unknown as DecodedMarker);
+    const dataRows = [];
+    const len = allPoints.length / 3;
+    // get copy data
+    for (let i = 0; i < len; i++) {
+      const rowData = [allPoints[i * 3], allPoints[i * 3 + 1], allPoints[i * 3 + 2]];
+      rowData.push(
+        ...additionalFieldNames.map(
+          (fieldName) => maybeCast<Record<string, number[]>>(object)?.[fieldName]?.[i],
+        ),
+      );
+      dataRows.push(rowData.join(","));
+    }
+
+    const additionalColumns = hasAdditionalFieldNames ? `,${additionalFieldNames.join(",")}` : "";
+    const dataStr = `x,y,z${additionalColumns}\n${dataRows.join("\n")}`;
+    const blob = new Blob([dataStr], { type: "text/csv;charset=utf-8;" });
+    downloadFiles([{ blob, fileName: "PointCloud.csv" }]);
+    setIsOpen(false);
+  }, [additionalFieldNames, hasAdditionalFieldNames, object]);
+
+  if (!clickedPoint) {
+    return ReactNull;
+  }
+
+  const colorStyle = clickedPointColor ? { color: `rgba(${clickedPointColor.join(",")})` } : {};
+
+  return (
+    <>
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <ChildToggle position="below" onToggle={setIsOpen} isOpen={isOpen}>
+          <Icon
+            size="small"
+            fade
+            active={isOpen}
+            tooltip={hasAdditionalFieldNames ? "Export points and fields" : "Export points"}
+          >
+            <ExportVariantIcon />
+          </Icon>
+          <Menu>
+            <Item
+              onClick={() => {
+                void clipboard.copy(clickedPoint.join(", ")).then(() => {
+                  setIsOpen(false);
+                });
+              }}
+            >
+              Copy clicked point to clipboard
+            </Item>
+            <Item onClick={onCopy}>
+              {hasAdditionalFieldNames
+                ? "Download all points and fields as CSV"
+                : "Download all points as CSV"}
+            </Item>
+          </Menu>
+        </ChildToggle>
+      </div>
+      <SRow>
+        <SLabel width={hasAdditionalFieldNames ? 72 : 44}>Point:</SLabel>
+        <SValue style={{ flex: 1, lineHeight: 1.4, ...colorStyle }}>
+          {clickedPoint.map((x) => (typeof x === "number" ? x : JSON.stringify(x))).join(", ")}
+        </SValue>
+      </SRow>
+      {additionalFieldValues && (
+        <>
+          {Object.keys(additionalFieldValues).map((fieldName) => (
+            <SRow key={fieldName}>
+              <SLabel width={72}>{fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}:</SLabel>
+              <SValue>{additionalFieldValues[fieldName]}</SValue>
+            </SRow>
+          ))}
+        </>
+      )}
+    </>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/TopicLink.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/TopicLink.tsx
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import styled from "styled-components";
+
+import type { LayoutActions } from "@foxglove/studio";
+import Tooltip from "@foxglove/studio-base/components/Tooltip";
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+const STopicLink = styled.span`
+  cursor: pointer;
+  color: ${colors.HIGHLIGHT};
+`;
+
+type Props = {
+  topic: string;
+  addPanel: LayoutActions["addPanel"];
+};
+
+export default function TopicLink({ addPanel, topic }: Props): JSX.Element {
+  const openRawMessages = React.useCallback(() => {
+    addPanel({
+      position: "sibling",
+      type: "RawMessages",
+      updateIfExists: true,
+      getState: (existingState?: unknown) => ({
+        ...(existingState as Record<string, unknown> | undefined),
+        topicPath: topic,
+      }),
+    });
+  }, [addPanel, topic]);
+
+  return (
+    <Tooltip placement="top" contents={`View ${topic} in Raw Messages panel`}>
+      {/* extra span to work around tooltip NaN positioning bug */}
+      <span>
+        <STopicLink onClick={openRawMessages}>{topic}</STopicLink>
+      </span>
+    </Tooltip>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/index.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/index.ts
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import Interactions from "./Interactions";
+
+export { default as Interactions, OBJECT_TAB_TYPE } from "./Interactions";
+export type { TabType } from "./Interactions";
+export { default as InteractionContextMenu } from "./InteractionContextMenu";
+
+export default Interactions;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/index.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/index.ts
@@ -14,7 +14,7 @@
 import Interactions from "./Interactions";
 
 export { default as Interactions, OBJECT_TAB_TYPE } from "./Interactions";
-export type { TabType } from "./Interactions";
+export type { SelectionObject, TabType } from "./Interactions";
 export { default as InteractionContextMenu } from "./InteractionContextMenu";
 
 export default Interactions;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/interactionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/interactionUtils.ts
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { keyBy } from "lodash";
+
+import { LinkedGlobalVariables, LinkedGlobalVariable } from "./useLinkedGlobalVariables";
+
+export function getTopicWithPath({
+  topic,
+  markerKeyPath,
+}: {
+  topic: string;
+  markerKeyPath: string[];
+}): string {
+  return `${topic}.${getPath(markerKeyPath)}`;
+}
+
+export function getPath(markerKeyPath: string[]): string {
+  return [...markerKeyPath].reverse().join(".");
+}
+
+export function getLinkedGlobalVariableKeyByTopicWithPath(
+  linkedGlobalVariables: LinkedGlobalVariables,
+): {
+  [key: string]: LinkedGlobalVariable;
+} {
+  return keyBy(linkedGlobalVariables, ({ topic, markerKeyPath }) =>
+    getTopicWithPath({ topic, markerKeyPath }),
+  );
+}
+
+export function getLinkedGlobalVariable({
+  topic,
+  markerKeyPath,
+  linkedGlobalVariables,
+}: {
+  topic: string;
+  markerKeyPath: string[];
+  linkedGlobalVariables: LinkedGlobalVariables;
+}): LinkedGlobalVariable | undefined {
+  const linkedGlobalVariablesKeyByTopicWithPath =
+    getLinkedGlobalVariableKeyByTopicWithPath(linkedGlobalVariables);
+  const topicWithPath = getTopicWithPath({ topic, markerKeyPath });
+  return linkedGlobalVariablesKeyByTopicWithPath[topicWithPath];
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/styling.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/styling.ts
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import styled from "styled-components";
+
+import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+export const SRow = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0;
+  margin: 4px 0;
+`;
+export const SLabel = styled.label<{ width?: number }>`
+  width: ${(props) => `${props.width ?? 80}px`};
+  margin: 4px 0;
+  font-size: 10px;
+`;
+export const SValue = styled.div`
+  color: ${colors.HIGHLIGHT};
+  word-break: break-word;
+`;
+export const SEmptyState = styled.div`
+  color: ${({ theme }) => theme.semanticColors.disabledText};
+  line-height: 1.4;
+  margin-bottom: 8px;
+`;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/types.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/types.ts
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { RosObject } from "@foxglove/studio-base/players/types";
+import { Marker } from "@foxglove/studio-base/types/Messages";
+
+export type InteractionData = {
+  readonly topic: string;
+  highlighted?: boolean;
+  readonly originalMessage: RosObject;
+};
+export type Interactive<T> = T & { interactionData: InteractionData };
+export type SelectedObject = { object: Marker; instanceIndex?: number };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/useLinkedGlobalVariables.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/useLinkedGlobalVariables.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+export type LinkedGlobalVariable = {
+  topic: string;
+  markerKeyPath: string[];
+  name: string;
+};
+
+export type LinkedGlobalVariables = readonly LinkedGlobalVariable[];
+
+export default function useLinkedGlobalVariables(): {
+  linkedGlobalVariables: LinkedGlobalVariables;
+  setLinkedGlobalVariables: (arg0: LinkedGlobalVariables) => void;
+  linkedGlobalVariablesByName: { [name: string]: LinkedGlobalVariable[] };
+} {
+  return {
+    linkedGlobalVariables: [],
+    linkedGlobalVariablesByName: {},
+    setLinkedGlobalVariables: () => {},
+  };
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
@@ -17,7 +17,7 @@ export type BaseUserData = {
   settings: BaseSettings;
 };
 
-export class Renderable<TUserData extends BaseUserData> extends THREE.Object3D {
+export class Renderable<TUserData extends BaseUserData = BaseUserData> extends THREE.Object3D {
   readonly isRenderable = true;
   readonly renderer: Renderer;
   override userData: TUserData;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -24,6 +24,7 @@ import { Labels } from "./Labels";
 import { MaterialCache } from "./MaterialCache";
 import { ModelCache } from "./ModelCache";
 import { Picker } from "./Picker";
+import type { Renderable } from "./Renderable";
 import { SceneExtension } from "./SceneExtension";
 import { ScreenOverlay } from "./ScreenOverlay";
 import { SettingsManager, SettingsTreeEntry } from "./SettingsManager";
@@ -56,7 +57,7 @@ export type RendererEvents = {
   startFrame: (currentTime: bigint, renderer: Renderer) => void;
   endFrame: (currentTime: bigint, renderer: Renderer) => void;
   cameraMove: (renderer: Renderer) => void;
-  renderableSelected: (renderable: THREE.Object3D | undefined, renderer: Renderer) => void;
+  renderableSelected: (renderable: Renderable | undefined, renderer: Renderer) => void;
   transformTreeUpdated: (renderer: Renderer) => void;
   settingsTreeChange: (renderer: Renderer) => void;
   configChange: (renderer: Renderer) => void;
@@ -147,7 +148,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   camera: THREE.PerspectiveCamera;
   picker: Picker;
   selectionBackdrop: ScreenOverlay;
-  selectedObject: THREE.Object3D | undefined;
+  selectedObject: Renderable | undefined;
   materialCache = new MaterialCache();
   colorScheme: "dark" | "light" = "light";
   modelCache: ModelCache;
@@ -559,15 +560,16 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
 
     // Traverse the scene looking for this objectId
-    const obj = this.scene.getObjectById(objectId);
+    const pickedObject = this.scene.getObjectById(objectId);
 
-    // Find the first ancestor of the clicked object that has a Pose
-    let selectedObj = obj;
-    while (selectedObj && selectedObj.userData.pose == undefined) {
-      selectedObj = selectedObj.parent ?? undefined;
+    // Find the first ancestor of thes clicked object that is a Renderable
+    let maybeRenderable = pickedObject as Partial<Renderable> | undefined;
+    while (maybeRenderable && maybeRenderable.isRenderable !== true) {
+      maybeRenderable = (maybeRenderable.parent ?? undefined) as Partial<Renderable> | undefined;
     }
 
-    if (selectedObj === prevSelected) {
+    const selectedRenderable = maybeRenderable as Renderable | undefined;
+    if (selectedRenderable === prevSelected) {
       log.debug(
         `Deselecting previously selected object ${prevSelected?.id} (${prevSelected?.name})`,
       );
@@ -578,18 +580,18 @@ export class Renderer extends EventEmitter<RendererEvents> {
       return;
     }
 
-    this.selectedObject = selectedObj;
+    this.selectedObject = selectedRenderable;
 
-    if (!selectedObj) {
-      log.warn(`No renderable found for objectId ${objectId}`);
+    if (!selectedRenderable) {
+      log.warn(`No renderable found for object ${objectId}`);
       this.emit("renderableSelected", undefined, this);
       return;
     }
 
     // Select the newly selected object
-    selectObject(selectedObj);
-    this.emit("renderableSelected", selectedObj, this);
-    log.debug(`Selected object ${selectedObj.id} (${selectedObj.name})`);
+    selectObject(selectedRenderable);
+    this.emit("renderableSelected", selectedRenderable, this);
+    log.debug(`Selected renderable ${selectedRenderable.id} (${selectedRenderable.name})`);
 
     if (!DEBUG_PICKING) {
       // Re-render with the selected object

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -562,7 +562,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     // Traverse the scene looking for this objectId
     const pickedObject = this.scene.getObjectById(objectId);
 
-    // Find the first ancestor of thes clicked object that is a Renderable
+    // Find the first ancestor of the picked object that is a Renderable
     let maybeRenderable = pickedObject as Partial<Renderable> | undefined;
     while (maybeRenderable && maybeRenderable.isRenderable !== true) {
       maybeRenderable = (maybeRenderable.parent ?? undefined) as Partial<Renderable> | undefined;
@@ -571,7 +571,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     const selectedRenderable = maybeRenderable as Renderable | undefined;
     if (selectedRenderable === prevSelected) {
       log.debug(
-        `Deselecting previously selected object ${prevSelected?.id} (${prevSelected?.name})`,
+        `Deselecting previously selected Renderable ${prevSelected?.id} (${prevSelected?.name})`,
       );
       if (!DEBUG_PICKING) {
         // Re-render with no object selected
@@ -583,7 +583,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.selectedObject = selectedRenderable;
 
     if (!selectedRenderable) {
-      log.warn(`No renderable found for object ${objectId}`);
+      log.warn(`No Renderable found for objectId ${objectId}`);
       this.emit("renderableSelected", undefined, this);
       return;
     }
@@ -591,7 +591,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     // Select the newly selected object
     selectObject(selectedRenderable);
     this.emit("renderableSelected", selectedRenderable, this);
-    log.debug(`Selected renderable ${selectedRenderable.id} (${selectedRenderable.name})`);
+    log.debug(`Selected Renderable ${selectedRenderable.id} (${selectedRenderable.name})`);
 
     if (!DEBUG_PICKING) {
       // Re-render with the selected object

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -32,27 +32,20 @@ import {
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 
 import { DebugGui } from "./DebugGui";
-import Interactions, { InteractionContextMenu, OBJECT_TAB_TYPE, TabType } from "./Interactions";
-import type { InteractionData } from "./Interactions/types";
+import Interactions, {
+  InteractionContextMenu,
+  OBJECT_TAB_TYPE,
+  SelectionObject,
+  TabType,
+} from "./Interactions";
 import type { Renderable } from "./Renderable";
 import { Renderer, RendererConfig } from "./Renderer";
 import { RendererContext, useRendererEvent } from "./RendererContext";
 import { Stats } from "./Stats";
 import type { MarkerUserData } from "./renderables/markers/RenderableMarker";
 import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "./ros";
-import type { Pose } from "./transforms";
 
 const log = Logger.getLogger(__filename);
-
-type SelectionObject = {
-  object: {
-    pose: Pose;
-    scale: [number, number, number];
-    color: [number, number, number, number];
-    interactionData?: InteractionData;
-  };
-  instanceIndex: number | undefined;
-};
 
 const SHOW_DEBUG: true | false = false;
 const PANEL_STYLE: React.CSSProperties = {
@@ -104,8 +97,6 @@ function RendererOverlay(props: {
     return {
       object: {
         pose: selectedRenderable.userData.pose,
-        scale: [1, 1, 1],
-        color: [0, 0, 0, 1],
         interactionData: {
           topic,
           highlighted: true,

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -17,7 +17,13 @@ import {
   DEFAULT_CAMERA_STATE,
 } from "@foxglove/regl-worldview";
 import { toNanoSec } from "@foxglove/rostime";
-import { PanelExtensionContext, RenderState, Topic, MessageEvent } from "@foxglove/studio";
+import {
+  PanelExtensionContext,
+  RenderState,
+  Topic,
+  MessageEvent,
+  LayoutActions,
+} from "@foxglove/studio";
 import {
   EXPERIMENTAL_PanelExtensionContextWithSettings,
   SettingsTreeAction,
@@ -26,12 +32,27 @@ import {
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 
 import { DebugGui } from "./DebugGui";
+import Interactions, { OBJECT_TAB_TYPE, TabType } from "./Interactions";
+import type { InteractionData } from "./Interactions/types";
+import type { Renderable } from "./Renderable";
 import { Renderer, RendererConfig } from "./Renderer";
 import { RendererContext, useRendererEvent } from "./RendererContext";
 import { Stats } from "./Stats";
+import type { MarkerUserData } from "./renderables/markers/RenderableMarker";
 import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "./ros";
+import type { Pose } from "./transforms";
 
 const log = Logger.getLogger(__filename);
+
+type SelectionObject = {
+  object: {
+    pose: Pose;
+    scale: [number, number, number];
+    color: [number, number, number, number];
+    interactionData?: InteractionData;
+  };
+  instanceIndex: number | undefined;
+};
 
 const SHOW_DEBUG: true | false = false;
 const PANEL_STYLE: React.CSSProperties = {
@@ -45,25 +66,72 @@ const CANVAS_STYLE: React.CSSProperties = { position: "absolute", top: 0, left: 
 /**
  * Provides DOM overlay elements on top of the 3D scene (e.g. stats, debug GUI).
  */
-function RendererOverlay(props: { enableStats: boolean }): JSX.Element {
-  const [_, setSelectedRenderable] = useState<THREE.Object3D | undefined>(undefined);
+function RendererOverlay(props: {
+  addPanel: LayoutActions["addPanel"];
+  enableStats: boolean;
+}): JSX.Element {
+  const [selectedRenderable, setSelectedRenderable] = useState<Renderable | undefined>(undefined);
+  const [interactionsTabType, setInteractionsTabType] = useState<TabType | undefined>(undefined);
 
-  useRendererEvent("renderableSelected", (renderable) => setSelectedRenderable(renderable));
+  useRendererEvent("renderableSelected", (renderable) => {
+    setSelectedRenderable(renderable);
+    setInteractionsTabType(renderable ? OBJECT_TAB_TYPE : undefined);
+  });
 
   const stats = props.enableStats ? (
-    <div id="stats" style={{ position: "absolute", top: 0 }}>
+    <div id="stats" style={{ position: "absolute", top: "10px", left: "10px" }}>
       <Stats />
     </div>
   ) : undefined;
 
   const debug = SHOW_DEBUG ? (
-    <div id="debug" style={{ position: "absolute", top: 60 }}>
+    <div id="debug" style={{ position: "absolute", top: "70px", left: "10px" }}>
       <DebugGui />
     </div>
   ) : undefined;
 
+  const selectedObject = useMemo<SelectionObject | undefined>(() => {
+    if (!selectedRenderable) {
+      return undefined;
+    }
+
+    // Retrieve the original message for Markers. This needs to be rethought for
+    // other renderables that are generated from received messages
+    const maybeMarkerUserData = selectedRenderable.userData as Partial<MarkerUserData>;
+    const topic = maybeMarkerUserData.topic ?? "";
+    const originalMessage = maybeMarkerUserData.marker ?? {};
+
+    return {
+      object: {
+        pose: selectedRenderable.userData.pose,
+        scale: [1, 1, 1],
+        color: [0, 0, 0, 1],
+        interactionData: {
+          topic,
+          highlighted: true,
+          originalMessage,
+        },
+      },
+      instanceIndex: undefined,
+    };
+  }, [selectedRenderable]);
+
   return (
     <React.Fragment>
+      <div
+        style={{
+          position: "absolute",
+          top: "10px",
+          right: "10px",
+        }}
+      >
+        <Interactions
+          addPanel={props.addPanel}
+          selectedObject={selectedObject}
+          interactionsTabType={interactionsTabType}
+          setInteractionsTabType={setInteractionsTabType}
+        />
+      </div>
       {stats}
       {debug}
     </React.Fragment>
@@ -329,6 +397,13 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     refreshMode: "debounce",
   });
 
+  // Create a useCallback wrapper for adding a new panel to the layout, used to open the
+  // "Raw Messages" panel from the object inspector
+  const addPanel = useCallback(
+    (params: Parameters<LayoutActions["addPanel"]>[0]) => context.layout.addPanel(params),
+    [context.layout],
+  );
+
   return (
     <div style={PANEL_STYLE} ref={resizeRef}>
       <CameraListener cameraStore={cameraStore} shiftKeys={true}>
@@ -341,7 +416,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         <canvas ref={setCanvas} style={CANVAS_STYLE} />
       </CameraListener>
       <RendererContext.Provider value={renderer}>
-        <RendererOverlay enableStats={config.scene.enableStats ?? true} />
+        <RendererOverlay addPanel={addPanel} enableStats={config.scene.enableStats ?? true} />
       </RendererContext.Provider>
     </div>
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -32,7 +32,7 @@ import {
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 
 import { DebugGui } from "./DebugGui";
-import Interactions, { OBJECT_TAB_TYPE, TabType } from "./Interactions";
+import Interactions, { InteractionContextMenu, OBJECT_TAB_TYPE, TabType } from "./Interactions";
 import type { InteractionData } from "./Interactions/types";
 import type { Renderable } from "./Renderable";
 import { Renderer, RendererConfig } from "./Renderer";
@@ -116,6 +116,10 @@ function RendererOverlay(props: {
     };
   }, [selectedRenderable]);
 
+  const clickedObjects = useMemo<SelectionObject[]>(() => {
+    return [];
+  }, []);
+
   return (
     <React.Fragment>
       <div
@@ -132,6 +136,13 @@ function RendererOverlay(props: {
           setInteractionsTabType={setInteractionsTabType}
         />
       </div>
+      {clickedObjects.length > 1 && !selectedObject && (
+        <InteractionContextMenu
+          clickedPosition={{ clientX: 0, clientY: 0 }}
+          clickedObjects={[]}
+          selectObject={() => {}}
+        />
+      )}
       {stats}
       {debug}
     </React.Fragment>

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -37,7 +37,7 @@ const DEFAULT_NAMESPACE_SETTINGS: LayerSettingsMarkerNamespace = {
   visible: true,
 };
 
-export type MarkerUserData = BaseUserData & {
+export type MarkerTopicUserData = BaseUserData & {
   topic: string;
   settings: LayerSettingsMarker;
 };
@@ -59,7 +59,7 @@ export class MarkersNamespace {
   }
 }
 
-export class TopicMarkers extends Renderable<MarkerUserData> {
+export class TopicMarkers extends Renderable<MarkerTopicUserData> {
   namespaces = new Map<string, MarkersNamespace>();
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
@@ -15,6 +14,7 @@ import {
   QUAT_IDENTITY,
   SENSOR_FRAME_ID,
 } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
@@ -15,6 +14,7 @@ import {
   QUAT_IDENTITY,
   SENSOR_FRAME_ID,
 } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { CameraInfo, TransformStamped } from "../ros";
 import { BASE_LINK_FRAME_ID, FIXED_FRAME_ID, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Header, Marker } from "../ros";
 import { makeColor, TEST_COLORS } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PolygonStamped, TransformStamped } from "../ros";
 import { QUAT_IDENTITY } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
@@ -15,6 +14,7 @@ import {
   QUAT_IDENTITY,
   SENSOR_FRAME_ID,
 } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Marker, MarkerType, TransformStamped, Vector3 } from "../ros";
 import { makeColor, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -4,12 +4,12 @@
 
 import { fromSec } from "@foxglove/rostime";
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
 import { makeFail, makePass, QUAT_IDENTITY, TEST_COLORS, VEC3_ZERO } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Marker, MarkerType, PointCloud2, TransformStamped } from "../ros";
 import { makeColor, QUAT_IDENTITY, rgba, VEC3_ZERO } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { ColorRGBA, Marker, TransformStamped } from "../ros";
 import { makeColor, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { MessageEvent, Topic } from "@foxglove/studio";
-import useDelayedFixture from "@foxglove/studio-base/panels/ThreeDimensionalViz/stories/useDelayedFixture";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PoseStamped, PoseWithCovarianceStamped, TransformStamped } from "../ros";
 import { BASE_LINK_FRAME_ID, FIXED_FRAME_ID, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/useDelayedFixture.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/useDelayedFixture.ts
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
+
+// useDelayedFixture works around a contract in useMessageReducer which does not re-process an existing
+// frame when topics change.
+//
+// To work around this contract, we delay fixture availability a few cycles giving any users of
+// the fixture time to setup subscribers, etc.
+function useDelayedFixture(fixtureToSet: Fixture): Fixture {
+  const [fixture, setFixture] = useState<Fixture>({});
+  const fixtureRef = useRef<Fixture>(fixtureToSet);
+
+  useLayoutEffect(() => {
+    queueMicrotask(() => {
+      setFixture(fixtureRef.current);
+    });
+  }, []);
+
+  return fixture;
+}
+
+// ts-prune-ignore-next
+export default useDelayedFixture;


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Ports the object inspector UI from Old3D to New3D by copy-pasting the `Interactions/` folder, fixing up import paths, and removing usage of any hooks that rely on contexts not exposed to extension panels.

Currently unsupported:
 - Creating linked global variables
 - Viewing linked global variables
 - Point Cloud details
 - Inline raw message view for non-Marker datatypes
 - Generic scale/color extraction (what is this?)

<img width="1107" alt="Screen Shot 2022-06-21 at 1 39 17 PM" src="https://user-images.githubusercontent.com/195374/174893355-b2f71d02-cc23-41b6-9033-58ec94f2bcc3.png">