### PR TITLE
Remove OPEN_DIALOG feature flag

### DIFF
--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -76,7 +76,6 @@ async function main() {
     (global as { storageBridge?: Storage }).storageBridge!,
     {
       defaults: {
-        [AppSetting.OPEN_DIALOG]: true,
         [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
         [AppSetting.EXPERIMENTAL_BAG_PLAYER]: false,
         [AppSetting.EXPERIMENTAL_DATA_PLATFORM_PLAYER]: isDevelopment,

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -30,7 +30,6 @@ export enum AppSetting {
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",
   LAUNCH_PREFERENCE = "launchPreference",
-  OPEN_DIALOG = "ui.open-dialog",
   SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
 
   // Dev only

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -188,8 +188,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const isPlayerPresent = playerPresence !== PlayerPresence.NOT_PRESENT;
 
-  const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
-
   const { currentUser } = useCurrentUser();
 
   const { currentUserRequired } = useInitialDeepLinkState(props.deepLinks ?? DEFAULT_DEEPLINKS);
@@ -206,15 +204,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     { view: OpenDialogViews; activeDataSource?: IDataSourceFactory } | undefined
   >(isPlayerPresent || !showOpenDialogOnStartup || showSignInForm ? undefined : { view: "start" });
 
-  const [selectedSidebarItem, setSelectedSidebarItem] = useState<SidebarItemKey | undefined>(() => {
-    // When using the open dialog ui - we always start with the connection sidebar open.
-    // This is to help the user find where to select a connection should they dismiss the open dialog
-    if (enableOpenDialog === true) {
-      return "connection";
-    }
-    // Start with the sidebar open if no connection has been made
-    return isPlayerPresent ? undefined : "connection";
-  });
+  const [selectedSidebarItem, setSelectedSidebarItem] = useState<SidebarItemKey | undefined>(
+    "connection",
+  );
 
   // When a player is present we hide the connection sidebar. To prevent hiding the connection sidebar
   // when the user wants to select a new connection we track whether the sidebar item opened
@@ -568,7 +560,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ]}
     >
       {showSignInForm && <SignInFormModal />}
-      {enableOpenDialog === true && showOpenDialog != undefined && (
+      {showOpenDialog != undefined && (
         <OpenDialog
           activeView={showOpenDialog.view}
           activeDataSource={showOpenDialog.activeDataSource}

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
@@ -14,14 +14,12 @@ import {
 } from "@mui/material";
 import { useState, PropsWithChildren, useEffect, useMemo } from "react";
 
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 
 import { DataSourceInfo } from "./DataSourceInfo";
@@ -88,7 +86,6 @@ const selectPlayerProblems = ({ playerState }: MessagePipelineContext) => player
 
 export default function DataSourceSidebar(props: Props): JSX.Element {
   const { onSelectDataSourceAction } = props;
-  const [enableOpenDialog] = useAppConfigurationValue(AppSetting.OPEN_DIALOG);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems) ?? [];
   const [activeTab, setActiveTab] = useState<number>(0);
@@ -120,16 +117,14 @@ export default function DataSourceSidebar(props: Props): JSX.Element {
             <CircularProgress size={18} variant="indeterminate" />
           </Stack>
         ),
-        enableOpenDialog === true && (
-          <IconButton
-            key="add-connection"
-            color="primary"
-            title="New connection"
-            onClick={onSelectDataSourceAction}
-          >
-            <AddIcon />
-          </IconButton>
-        ),
+        <IconButton
+          key="add-connection"
+          color="primary"
+          title="New connection"
+          onClick={onSelectDataSourceAction}
+        >
+          <AddIcon />
+        </IconButton>,
       ].filter(Boolean)}
     >
       <Stack fullHeight>

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -82,7 +82,6 @@ async function main() {
 
   const appConfiguration = new LocalStorageAppConfiguration({
     defaults: {
-      [AppSetting.OPEN_DIALOG]: true,
       [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
       [AppSetting.EXPERIMENTAL_BAG_PLAYER]: false,
       [AppSetting.EXPERIMENTAL_DATA_PLATFORM_PLAYER]: isDevelopment,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The open dialog has been enabled for some time.
I imagine this fixes https://github.com/foxglove/studio/issues/3502, since the only way I can see that the `+` button would be absent is if this feature flag was false.