### PR TITLE
Feat/snap

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,48 @@
+name: snap
+on:
+  push:
+    tags:
+      - '*'
+    branches: [main, release/*]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        lfs: true
+    - uses: snapcore/action-build@v1
+      id: build-snap
+
+    # Make sure the snap is installable
+    - run: |
+        sudo snap install --dangerous ${{ steps.build-snap.outputs.snap }}
+    # Do some testing with the snap
+    - run: |
+       foxglove-studio.web-server &> tmp.log & sleep 2
+       grep "Caddy serving static files on :8080" tmp.log
+    - uses: actions/upload-artifact@v3
+      with:
+        name: foxglove-studio-snap
+        path: ${{ steps.build-snap.outputs.snap }}
+
+  publish:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: foxglove-studio-snap
+        path: .
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{needs.build.outputs.snap-file}}
+        release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ storybook-static/
 
 # Extensions
 *.foxe
+
+# Snap
+*.snap

--- a/snap/gui/foxglove-studio.desktop
+++ b/snap/gui/foxglove-studio.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Foxglove-studio
+Categories=Robotics;Visualization;
+Icon=${SNAP}/lib/node_modules/foxglove-studio/resources/icon/icon.png
+Exec=foxglove-studio
+Terminal=false
+StartupWMClass=foxglove-studio
+MimeType=application/octet-stream;application/octet-stream;application/zip;text/xml;text/xml;x-scheme-handler/foxglove;
+Categories=Development;

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+snapctl set server-port=8080

--- a/snap/local/web-server
+++ b/snap/local/web-server
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+server_port="$(snapctl get server-port)"
+exec "$SNAP/usr/bin/caddy" file-server -root "$SNAP/foxglove/web/.webpack/" --listen :$server_port

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,8 @@ parts:
     plugin: npm
     npm-node-version: 16.15.0
     source: .
+    build-packages:
+      - git-lfs
     stage-packages:
       - caddy
       - libnss3

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,87 @@
+name: foxglove-studio
+version: git
+summary: Integrated visualization and diagnosis tool for robotics
+description: |
+  Foxglove Studio is an integrated visualization and diagnosis tool for robotics.
+
+  * `server-port`. Port to use for the web server. Change with:
+        $ snap set foxglove-studio server-port="selected port"
+
+contact: https://foxglove.dev/contact
+license: MPL-2.0
+issues: https://github.com/foxglove/studio/issues
+
+# Add caddy
+package-repositories:
+- components: [main]
+  formats: [deb]
+  key-id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
+  key-server: keyserver.ubuntu.com
+  suites: [any-version]
+  type: apt
+  url: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+
+confinement: strict
+base: core20
+grade: stable
+
+parts:
+  foxglove-studio:
+    plugin: npm
+    npm-node-version: 16.15.0
+    source: .
+    stage-packages:
+      - caddy
+      - libnss3
+      - libatk1.0-0
+      - libatk-bridge2.0-0
+      - libcups2
+      - libdrm2
+      - libgtk-3-0
+      - libpango-1.0-0
+      - libcairo2
+      - libgdk-pixbuf2.0-0
+      - libxcomposite1
+      - libxdamage1
+      - libxext6
+      - libxfixes3
+      - libxrandr2
+      - libgbm1
+      - libxkbcommon0
+      - libasound2
+
+    override-pull: |
+        snapcraftctl pull
+        version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
+        [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+        snapcraftctl set-version "$version"
+        snapcraftctl set-grade "$grade"
+
+    override-build: |
+      snapcraftctl build
+      npm install -g yarn
+      yarn install --immutable
+      yarn run web:build:prod
+      yarn run build:prod
+      yarn run package
+      mkdir -p $SNAPCRAFT_PART_INSTALL/foxglove/web
+      mkdir -p $SNAPCRAFT_PART_INSTALL/foxglove/desktop
+      cp -r web/.webpack $SNAPCRAFT_PART_INSTALL/foxglove/web
+      cp -r dist/linux-unpacked/* $SNAPCRAFT_PART_INSTALL/foxglove/desktop
+
+  runner:
+    plugin: dump
+    source: snap/local/
+    organize:
+      '*': usr/bin/
+
+apps:
+  web-server:
+    command: usr/bin/web-server
+    plugs: [network, network-bind, home]
+
+  foxglove-studio:
+    command: foxglove/desktop/foxglove-studio --no-sandbox
+    plugs: [network, network-bind, home, browser-support, unity7]
+    extensions: [gnome-3-38]
+


### PR DESCRIPTION
**User-Facing Changes**
User could download the foxglove-studio [snap and get automatic updates](https://snapcraft.io/about) on many Linux distributions and versions.

**Description**
This PR is adding a snapcraft.yaml as well as a GitHub Action workflow to build and upload the snap.
The snap provide two applications. The web server as well as the electron based app. This could be changed for two different snaps, or even one with only the electron based app.

_snapcraft.yaml_
The [`snapcraft.yaml`](https://snapcraft.io/docs/snapcraft-yaml-reference) is describing how to build foxglove-studio, as well as listing all the dependencies necessary. My knowledge in JS and its environment (npm, yarn etc) is very limited, hence the `override-build` part might need some changes.

_GitHub workflow_
The GitHub workflow (`snap.yaml`), is a complete workflow that builds and publish the snap. I noticed that your CI is currently only publishing packages on releases. For now, the snap workflow is keeping the `main` branch in sync with the `latest/edge` [channel](https://snapcraft.io/docs/channels) and publishing releases on the `latest/candidate` channel. This can be changed to be integrated in your `post-release.yaml`. Note that releasing the snap from `candidate` to `stable` should be done manually on the store after proper testing.

Note that releasing the snap from candidate to stable should be done manually on the store after proper testing

To publish, the Workflow refer to the secret: `STORE_LOGIN`. This secret must be generated by the owner of the snap on the [snapstore](https://snapcraft.io/store). Currently, the name foxglove-studio is owned by [Artivis](https://github.com/artivis) on the store, but he can transfer the ownership to your account.
- Run snapcraft export-login --snaps=micro-ros-agent --acls package_access,package_push,package_update,package_release exported.txt
- You can add the secret to the project by:
  - Going to the "Settings" tab
  - Choosing "Secrets" from the menu on the left, then "Actions"
  - Clicking "New repository secret".
  - Setting the name to STORE_LOGIN, and paste the contents of exported.txt as the value.


Additionally, the snap is defining an [install hook](https://snapcraft.io/docs/supported-snap-hooks) to set the port server that can be changed later: `snap set foxglove-studio server-port="selected port"`

To build and test the snap locally:
- `snapcraft`
- `sudo snap install foxglove-studio*.snap --dangerous`

Additional documentation regarding snap can be found: https://snapcraft.io/docs/robotics
<!-- add `docs` label if this PR requires documentation updates -->
