### PR TITLE
Animate sidebar opening/closing

### DIFF
--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -10,10 +10,11 @@ import {
   ResizeGroup,
   ResizeGroupDirection,
 } from "@fluentui/react";
-import { Theme, useTheme } from "@mui/material";
+import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { MosaicNode, MosaicWithoutDragDropContext } from "react-mosaic-component";
+import { Transition } from "react-transition-group";
 
 import { filterMap } from "@foxglove/den/collection";
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
@@ -34,15 +35,24 @@ export type SidebarItem = {
   url?: string;
 };
 
+const SIDEBAR_TRANSITION_DURATION_MS = 300;
+
 const useStyles = makeStyles((theme: Theme) => ({
   nav: {
     width: BUTTON_SIZE,
     boxSizing: "content-box",
     borderRight: `1px solid ${theme.palette.divider}`,
     backgroundColor: theme.palette.background.paper,
+    zIndex: 2, // overlap mosaic border-left during transition
+  },
+  contentWrapper: {
+    position: "relative",
+    flex: "1 1 100%",
   },
   mosaicWrapper: {
-    flex: "1 1 100%",
+    position: "absolute",
+    inset: 0,
+    borderLeft: `0px solid ${theme.palette.divider}`,
 
     // Root drop targets in this top level sidebar mosaic interfere with drag/mouse events from the
     // PanelList. We don't allow users to edit the mosaic since it's just used for the sidebar, so we
@@ -50,6 +60,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     "& > .mosaic > .drop-target-container": {
       display: "none !important",
     },
+  },
+  sidebarContentWrapper: {
+    backgroundColor: theme.palette.background.paper,
+    position: "absolute",
+    inset: 0,
   },
   resizeGroup: {
     height: "100%",
@@ -77,27 +92,29 @@ export default function Sidebar<K extends string>({
   selectedKey: K | undefined;
   onSelectKey: (key: K | undefined) => void;
 }>): JSX.Element {
-  const [mosaicValue, setMosaicValue] = useState<MosaicNode<"sidebar" | "children">>("children");
-
-  const theme = useTheme();
   const classes = useStyles();
 
-  const prevSelectedKey = useRef<string | undefined>(undefined);
-  useLayoutEffect(() => {
-    if (prevSelectedKey.current !== selectedKey) {
-      if (selectedKey == undefined) {
-        setMosaicValue("children");
-      } else if (prevSelectedKey.current == undefined) {
-        setMosaicValue({
-          direction: "row",
-          first: "sidebar",
-          second: "children",
-          splitPercentage: defaultInitialSidebarPercentage(),
-        });
-      }
-      prevSelectedKey.current = selectedKey;
+  const [splitPercentage, setSplitPercentage] = useState(() => defaultInitialSidebarPercentage());
+  const lastSelectedKey = useRef(selectedKey);
+  useEffect(() => {
+    if (lastSelectedKey.current == undefined && selectedKey != undefined) {
+      setSplitPercentage(defaultInitialSidebarPercentage());
     }
+    lastSelectedKey.current = selectedKey;
   }, [selectedKey]);
+
+  const mosaicValue: MosaicNode<"sidebar" | "children"> = useMemo(() => {
+    if (selectedKey == undefined) {
+      return "children";
+    } else {
+      return {
+        direction: "row",
+        first: "sidebar",
+        second: "children",
+        splitPercentage,
+      };
+    }
+  }, [selectedKey, splitPercentage]);
 
   const onItemClick = useCallback(
     (key: K) => {
@@ -110,7 +127,16 @@ export default function Sidebar<K extends string>({
     [onSelectKey, selectedKey],
   );
 
-  const SelectedComponent = (selectedKey != undefined && items.get(selectedKey)?.component) || Noop;
+  // Keep track of the last selected key so we can continue displaying the component during the exit transition
+  const lastNonnullSelectedKey = useRef(selectedKey);
+  useLayoutEffect(() => {
+    if (selectedKey != undefined) {
+      lastNonnullSelectedKey.current = selectedKey;
+    }
+  }, [selectedKey]);
+
+  const keyToRender = selectedKey ?? lastNonnullSelectedKey.current;
+  const SelectedComponent = (keyToRender != undefined && items.get(keyToRender)?.component) || Noop;
 
   type OverflowSetItem = IOverflowSetItemProps & { key: K };
 
@@ -203,6 +229,19 @@ export default function Sidebar<K extends string>({
     [numNonBottomItems],
   );
 
+  const transitionNodeRef = useRef<HTMLDivElement>(ReactNull);
+
+  // This state is set to true just *after* the Transition state turns to "exiting". This allows us
+  // to make an exit transition before fully switching to the "exited" state (at which time we need
+  // to remove the sidebar content from the DOM).
+  const [afterExiting, setAfterExiting] = useState(false);
+  const onExiting = useCallback(() => {
+    // Force a repaint to allow transition to start immediately
+    // See: https://github.com/reactjs/react-transition-group/blob/5007303e729a74be66a21c3e2205e4916821524b/src/CSSTransition.js#L208-L215
+    void transitionNodeRef.current?.scrollTop;
+    setAfterExiting(true);
+  }, []);
+
   return (
     <Stack direction="row" fullHeight overflow="hidden">
       <Stack className={classes.nav} flexShrink={0} justifyContent="space-between">
@@ -220,29 +259,73 @@ export default function Sidebar<K extends string>({
         // By always rendering the mosaic, even if we are only showing children, we can prevent the
         // children from having to re-mount each time the sidebar is opened/closed.
       }
-      <div className={classes.mosaicWrapper}>
-        <MosaicWithoutDragDropContext<"sidebar" | "children">
-          className=""
-          value={mosaicValue}
-          onChange={(value) => value != undefined && setMosaicValue(value)}
-          renderTile={(id) => (
-            <ErrorBoundary>
-              {id === "children" ? (
-                (children as JSX.Element)
-              ) : (
-                <div
-                  style={{
-                    backgroundColor: theme.palette.background.paper,
-                  }}
-                >
+      <Transition
+        nodeRef={transitionNodeRef}
+        in={selectedKey != undefined}
+        timeout={SIDEBAR_TRANSITION_DURATION_MS}
+        onExiting={onExiting}
+        onExited={() => setAfterExiting(false)}
+      >
+        {(state) => (
+          <div className={classes.contentWrapper} ref={transitionNodeRef}>
+            {state !== "exited" && (
+              <div
+                className={classes.sidebarContentWrapper}
+                style={{
+                  right: `${100 - splitPercentage}%`,
+                  // Mosaic should be on top during transition (since it has a border that slightly
+                  // overlaps the sidebar) but the sidebar needs to be clickable after the
+                  // transition.
+                  zIndex: state === "entered" ? 1 : undefined,
+                  // Set a transform to create a stacking context so elements inside the sidebar
+                  // with z-index don't escape outside the sidebar
+                  transform: "scale(1)",
+                }}
+              >
+                <ErrorBoundary>
                   <SelectedComponent />
-                </div>
-              )}
-            </ErrorBoundary>
-          )}
-          resize={{ minimumPaneSizePercentage: 10 }}
-        />
-      </div>
+                </ErrorBoundary>
+              </div>
+            )}
+            <div
+              className={classes.mosaicWrapper}
+              style={{
+                transition:
+                  state === "entering" || afterExiting
+                    ? `left ${SIDEBAR_TRANSITION_DURATION_MS}ms`
+                    : undefined,
+                left:
+                  state === "entering" || (state === "exiting" && !afterExiting)
+                    ? `calc(${splitPercentage}% - 2px)`
+                    : state === "exiting"
+                    ? -2
+                    : 0,
+                borderLeftWidth: state === "entering" || state === "exiting" ? 2 : 0,
+              }}
+            >
+              <MosaicWithoutDragDropContext<"sidebar" | "children">
+                className=""
+                value={state === "entering" ? "children" : mosaicValue}
+                onChange={(value) =>
+                  typeof value === "object" &&
+                  value != undefined &&
+                  setSplitPercentage(value.splitPercentage ?? defaultInitialSidebarPercentage())
+                }
+                renderTile={(id) => (
+                  <ErrorBoundary>
+                    {id === "children"
+                      ? (children as JSX.Element)
+                      : // Don't actually render sidebar inside the mosaic -- it's always rendered outside
+                        // to support the animated transition
+                        ReactNull}
+                  </ErrorBoundary>
+                )}
+                resize={{ minimumPaneSizePercentage: 10 }}
+              />
+            </div>
+          </div>
+        )}
+      </Transition>
     </Stack>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Added animation when opening/closing the sidebar.

**Description**
The sidebar opening/closing is a major UI shift. An animation helps the eye track what is changing and reduce confusion.

https://user-images.githubusercontent.com/14237/175134214-666d2071-cce8-414b-8c90-6ce4bb31b507.mov
