### PR TITLE
Make Open dialog layout more responsive

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/ActionList.tsx
+++ b/packages/studio-base/src/components/OpenDialog/ActionList.tsx
@@ -11,10 +11,11 @@ import Stack from "@foxglove/studio-base/components/Stack";
 type IActionListProps = {
   title?: ReactNode;
   items: IButtonProps[];
+  gridColumn?: number | string;
 };
 
 export default function ActionList(props: IActionListProps): JSX.Element {
-  const { items, title } = props;
+  const { items, title, gridColumn } = props;
   const theme = useTheme();
 
   const actionButtonStyles = useMemo(
@@ -23,7 +24,7 @@ export default function ActionList(props: IActionListProps): JSX.Element {
         root: {
           padding: 0,
           color: theme.palette.themePrimary,
-          minWidth: 320,
+          // minWidth: 320,
           height: 24,
         },
         flexContainer: {
@@ -47,7 +48,7 @@ export default function ActionList(props: IActionListProps): JSX.Element {
   );
 
   return (
-    <Stack gap={1}>
+    <Stack gap={1} style={{ gridColumn }}>
       {title != undefined && (
         <Typography variant="h5" color="text.secondary">
           {title}

--- a/packages/studio-base/src/components/OpenDialog/ActionList.tsx
+++ b/packages/studio-base/src/components/OpenDialog/ActionList.tsx
@@ -24,7 +24,6 @@ export default function ActionList(props: IActionListProps): JSX.Element {
         root: {
           padding: 0,
           color: theme.palette.themePrimary,
-          // minWidth: 320,
           height: 24,
         },
         flexContainer: {

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -76,8 +76,8 @@ export default function Connection(props: ConnectionProps): JSX.Element {
 
   return (
     <View onBack={onBack} onCancel={onCancel} onOpen={disableOpen ? undefined : onOpen}>
-      <Stack direction="row" flexGrow={1} fullHeight gap={4}>
-        <Stack fullHeight>
+      <Stack direction="row" flexGrow={1} flexWrap="wrap" fullHeight gap={4}>
+        <Stack flex="0 0 240px">
           {enabledSourcesFirst.map((source, idx) => {
             const { id, iconName, displayName } = source;
             return (
@@ -87,7 +87,6 @@ export default function Connection(props: ConnectionProps): JSX.Element {
                 iconProps={{ iconName }}
                 onClick={() => setSelectedConnectionIdx(idx)}
                 styles={{
-                  root: { minWidth: 240 },
                   rootChecked: { backgroundColor: theme.semanticColors.bodyBackgroundHovered },
                   icon: { "> span": { display: "flex" } },
                   iconChecked: { color: theme.palette.themePrimary },
@@ -98,7 +97,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             );
           })}
         </Stack>
-        <Stack key={selectedSource?.id} flex="auto" fullHeight gap={2} overflowX="auto">
+        <Stack key={selectedSource?.id} flex="1 0 240px" gap={2}>
           {selectedSource?.description && (
             <Typography color="text.secondary">{selectedSource.description}</Typography>
           )}

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -142,8 +142,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   return (
     <Dialog
       hidden={false}
-      maxWidth={800}
-      minWidth={800}
+      maxWidth="calc(min(800px, 100% - 32px))"
       modalProps={{
         layerProps: {
           // We enable event bubbling so a user can drag&drop files or folders onto the app even when
@@ -168,29 +167,24 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
         title: view.title,
         styles: {
           content: {
-            overflow: "hidden",
-            // Keep a consistent height for the dialog so changing views does not change the height
+            overflow: "visible",
             display: "flex",
             flexDirection: "column",
-            minHeight: 520,
+            // Keep a consistent height for the dialog so changing views does not change the height
+            flexBasis: 520,
+            maxHeight: 520,
             padding: theme.spacing.l1,
-
-            "@media (max-height: 552px)": { overflowY: "auto" },
           },
           inner: {
             flex: 1,
             display: "flex",
             flexDirection: "column",
-
-            "@media (min-height: 552px)": { overflow: "hidden" },
           },
           innerContent: {
             height: "100%",
             display: "flex",
             flexDirection: "column",
             flex: 1,
-
-            "@media (min-height: 552px)": { overflow: "hidden" },
           },
         },
       }}

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -62,6 +62,17 @@ const RecentStack = muiStyled(Stack)(({ theme }) => ({
   "&:hover": { color: theme.palette.primary.dark },
 }));
 
+const Grid = muiStyled("div")(({ theme }) => ({
+  // See comment below for explanation of grid properties
+  display: "grid",
+  gap: theme.spacing(2.5, 4),
+  gridTemplateRows: "repeat(2, auto) 1fr",
+  "@media(max-width: 800px)": {
+    display: "flex",
+    flexDirection: "column",
+  },
+}));
+
 export default function Start(props: IStartProps): JSX.Element {
   const {
     supportedLocalFileExtensions = [],
@@ -78,7 +89,7 @@ export default function Start(props: IStartProps): JSX.Element {
   const buttonStyles = useMemo(
     () => ({
       root: {
-        width: 340,
+        width: "100%",
         maxWidth: "none",
       },
       rootHovered: { backgroundColor: theme.palette.neutralLighterAlt },
@@ -171,11 +182,18 @@ export default function Start(props: IStartProps): JSX.Element {
     });
   }, [recentSources, selectRecent, theme]);
 
+  // This layout uses `display: grid` at large widths, and `display: flex` at small widths. When
+  // using flex, the elements flow in source order within the column.
+  //
+  // At the larger width (when using grid), `gridColumn: 2` makes the Recent, Help, and Contact
+  // items go in the 2nd column, while the larger "Open data source" section occupies the first
+  // column. `gridTemplateRows: "repeat(2, auto) 1fr"` and `gridRow: "1 / 4"` makes it so the Open
+  // section doesn't affect the heights of the Recent and Help sections.
   return (
     <Stack gap={2.5}>
-      <Stack direction="row" gap={4}>
-        {/* Left column */}
-        <Stack flex="1 1 50%" gap={2}>
+      <Grid>
+        {recentItems.length > 0 && <ActionList gridColumn={2} title="Recent" items={recentItems} />}
+        <Stack flex="1 1 0" gap={2} style={{ minWidth: 340, gridRow: "1 / 4" }}>
           <Typography variant="h5" color="text.secondary">
             Open data source
           </Typography>
@@ -185,14 +203,9 @@ export default function Start(props: IStartProps): JSX.Element {
             ))}
           </Stack>
         </Stack>
-
-        {/* Right column */}
-        <Stack flex="1 1 50%" gap={2.5} zeroMinWidth>
-          {recentItems.length > 0 && <ActionList title="Recent" items={recentItems} />}
-          <ActionList title="Help" items={HELP_ITEMS} />
-          <ActionList title="Contact" items={CONTACT_ITEMS} />
-        </Stack>
-      </Stack>
+        <ActionList gridColumn={2} title="Help" items={HELP_ITEMS} />
+        <ActionList gridColumn={2} title="Contact" items={CONTACT_ITEMS} />
+      </Grid>
       <Checkbox
         label="Show on startup"
         checked={showOnStartup}


### PR DESCRIPTION
**User-Facing Changes**
Improved Open dialog layout for smaller screens.

**Description**
Fixes https://github.com/foxglove/studio/issues/3216
Fixes https://github.com/foxglove/studio/issues/2506

<table><tr><th>Before</th><th>After</th></tr>
<tr>
<td>

- Extra scrollbars on some screens
- Unusable on narrow screens

https://user-images.githubusercontent.com/14237/175203989-32ed05f0-c60a-424a-b32d-452eb15d7833.mov

</td>
<td>

- Only one scrollbar per page
- Responsive layout to support narrower screens using grid/flexbox

https://user-images.githubusercontent.com/14237/175204069-b0ff1d9a-58c3-4c9b-9c93-013374cee321.mov

</td></tr></table>