### PR TITLE
Allow string ordering values and sort new3d topics by topic name

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/utils.ts
@@ -15,7 +15,9 @@ export function prepareSettingsNodes(
 ): DeepReadonly<Array<[string, SettingsTreeNode]>> {
   // Use sortBy here for stable sorting.
   return sortBy(
-    Object.entries(roots).filter((kv): kv is [string, SettingsTreeNode] => kv[1] != undefined),
-    (kv) => kv[1].order ?? Number.MAX_SAFE_INTEGER,
+    Object.entries(roots).filter(
+      (entry): entry is [string, SettingsTreeNode] => entry[1] != undefined,
+    ),
+    (entry) => entry[1].order,
   );
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Cameras.ts
@@ -95,7 +95,13 @@ export class Cameras extends SceneExtension<CameraInfoRenderable> {
 
         entries.push({
           path: ["topics", topic.name],
-          node: { icon: "Camera", fields, visible: config.visible ?? true, handler },
+          node: {
+            icon: "Camera",
+            fields,
+            visible: config.visible ?? true,
+            handler,
+            order: topic.name.toLocaleLowerCase(),
+          },
         });
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -118,7 +118,13 @@ export class Images extends SceneExtension<ImageRenderable> {
 
         entries.push({
           path: ["topics", topic.name],
-          node: { icon: "ImageProjection", fields, visible: config.visible ?? true, handler },
+          node: {
+            icon: "ImageProjection",
+            fields,
+            visible: config.visible ?? true,
+            order: topic.name.toLocaleLowerCase(),
+            handler,
+          },
         });
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -51,6 +51,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
         const node: SettingsTreeNodeWithActionHandler = {
           label: topic.name,
           icon: "Shapes",
+          order: topic.name.toLocaleLowerCase(),
           visible: config.visible ?? true,
           handler: this.handleSettingsActionTopic,
         };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -105,6 +105,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
             icon: "Cells",
             fields,
             visible: config.visible ?? true,
+            order: topic.name.toLocaleLowerCase(),
             handler,
           },
         });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -664,7 +664,7 @@ function settingsNode(
     };
   }
 
-  return { icon: "Points", fields };
+  return { icon: "Points", fields, order: topic.name.toLocaleLowerCase() };
 }
 
 function pointFieldTypeName(type: PointFieldType): string {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -121,6 +121,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
             icon: "Flag",
             fields,
             visible: config.visible ?? true,
+            order: topic.name.toLocaleLowerCase(),
             handler,
           },
         });

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -507,7 +507,7 @@ declare module "@foxglove/studio" {
      *
      * https://262.ecma-international.org/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
      */
-    order?: number;
+    order?: number | string;
 
     /**
      * An optional visibility status. If this is not undefined, the node


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This allows sorting settings tree nodes by numeric or string values and uses string values to sort topics alphabetically in the new 3d panel settings.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3663 