### PR TITLE
Order new3d custom layers by creation order

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { maxBy } from "lodash";
+
 import Logger from "@foxglove/log";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
 
@@ -122,6 +124,7 @@ export class Grids extends SceneExtension<GridRenderable> {
           fields,
           visible: config.visible ?? true,
           actions: [{ type: "action", id: "delete", label: "Delete" }],
+          order: layerConfig.order,
           handler,
         },
       });
@@ -184,7 +187,9 @@ export class Grids extends SceneExtension<GridRenderable> {
 
     // Add this instance to the config
     this.renderer.updateConfig((draft) => {
-      draft.layers[instanceId] = config;
+      const maxOrderLayer = maxBy(Object.values(draft.layers), (entry) => entry?.order);
+      const order = 1 + (maxOrderLayer?.order ?? 0);
+      draft.layers[instanceId] = { ...config, order };
     });
 
     // Add a renderable

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -187,7 +187,7 @@ export class Grids extends SceneExtension<GridRenderable> {
 
     // Add this instance to the config
     this.renderer.updateConfig((draft) => {
-      const maxOrderLayer = maxBy(Object.values(draft.layers), (entry) => entry?.order);
+      const maxOrderLayer = maxBy(Object.values(draft.layers), (layer) => layer?.order);
       const order = 1 + (maxOrderLayer?.order ?? 0);
       draft.layers[instanceId] = { ...config, order };
     });

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -25,7 +25,7 @@ export type CustomLayerSettings = BaseSettings & {
   layerId: string;
   /** The label to use for this layer in the settings tree, under "Custom Layers". */
   label: string;
-  /** Optional id specifying order in the custom layer list */
+  /** Optional value specifying order in the custom layer list */
   order?: number;
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -25,6 +25,8 @@ export type CustomLayerSettings = BaseSettings & {
   layerId: string;
   /** The label to use for this layer in the settings tree, under "Custom Layers". */
   label: string;
+  /** Optional id specifying order in the custom layer list */
+  order?: number;
 };
 
 export const PRECISION_DISTANCE = 3; // [1mm]


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This adds an `order` field to the `CustomLayerSettings` type, sets the order to be the max order + 1 for new grids, and sorts grids by this order in the settings tree.

If we add new custom layer types besides grids we'll have to duplicate or refactor this max order logic.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3663 