### PR TITLE
Fix react dom nesting warning in extension sidebar

### DIFF
--- a/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
@@ -43,6 +43,7 @@ function ExtensionListEntry(props: {
     <ListItem disablePadding key={id}>
       <StyledListItemButton onClick={onClick}>
         <ListItemText
+          disableTypography
           primary={
             <Stack direction="row" alignItems="baseline" gap={0.5}>
               <Typography variant="subtitle2" fontWeight={600}>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes a react dom nesting error in the extension sidebar. Looks like the MUI `ListItemText` component by default wraps its children in a `Typography` component which defaults to a `<p>` element that doesn't allow nesting. Looks like setting the `disableTypography` fixes this.

cc @2metres 

<img width="499" alt="Screen Shot 2022-06-23 at 11 53 06 AM" src="https://user-images.githubusercontent.com/93935560/175354430-985ab878-11ae-40d3-86e1-0c5789718834.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
