### PR TITLE
Fix import of SampleNuscenesLayout to avoid saving stray data in layout storage

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -13,7 +13,7 @@ import Ros1MemoryCacheDataProvider from "@foxglove/studio-base/randomAccessDataP
 import WorkerBagDataProvider from "@foxglove/studio-base/randomAccessDataProviders/WorkerBagDataProvider";
 import { getSeekToTime } from "@foxglove/studio-base/util/time";
 
-import * as SampleNuscenesLayout from "./SampleNuscenesLayout.json";
+import SampleNuscenesLayout from "./SampleNuscenesLayout.json";
 
 class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
   id = "sample-nuscenes";


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
I noticed that when I used the Export button on the sample layout, I got some extra data in a `default` key that looked like another copy of the layout:

<img width="316" alt="image" src="https://user-images.githubusercontent.com/14237/175422718-ffc84fa5-b09e-4fe9-963a-04faae06cb79.png">

This was due to the use of `import * as SampleNuscenesLayout` rather than just `import SampleNuscenesLayout`.