### PR TITLE
Add terminate() to cancel outstanding Rpc send requests when worker is terminated

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerBagDataProvider.ts
@@ -103,6 +103,7 @@ export default class WorkerBagDataProvider implements RandomAccessDataProvider {
       await this.rpc?.send("close");
     } finally {
       this.worker?.terminate();
+      this.rpc?.terminate();
     }
   }
 }

--- a/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/WorkerRosbag2DataProvider.ts
@@ -103,6 +103,7 @@ export default class WorkerRosbag2DataProvider implements RandomAccessDataProvid
       await this.rpc?.send("close");
     } finally {
       this.worker?.terminate();
+      this.rpc?.terminate();
     }
   }
 }

--- a/packages/studio-base/src/util/Rpc.test.ts
+++ b/packages/studio-base/src/util/Rpc.test.ts
@@ -153,4 +153,18 @@ describe("Rpc", () => {
       }),
     ).toThrow();
   });
+
+  it("rejects when terminated", async () => {
+    const { local, remote } = createLinkedChannels();
+
+    const worker = new Rpc(remote);
+    worker.receive("foo", async () => {
+      return await new Promise(() => {});
+    });
+
+    const rpc = new Rpc(local);
+    const sendPromise = rpc.send("foo", 1);
+    rpc.terminate();
+    await expect(sendPromise).rejects.toThrow("Rpc terminated");
+  });
 });

--- a/packages/studio-base/src/util/Rpc.ts
+++ b/packages/studio-base/src/util/Rpc.ts
@@ -132,6 +132,17 @@ export default class Rpc {
       });
   };
 
+  /** Call this when the channel has been terminated to reject any outstanding send callbacks. */
+  terminate(): void {
+    for (const [id, callback] of Object.entries(this._pendingCallbacks)) {
+      callback({
+        topic: RESPONSE,
+        id,
+        data: { [ERROR]: true, name: "Error", message: "Rpc terminated", stack: "" },
+      });
+    }
+  }
+
   // send a message across the rpc boundary to a receiver on the other side
   // this returns a promise for the receiver's response.  If there is no registered
   // receiver for the given topic, this method throws

--- a/packages/studio-base/src/util/WebWorkerManager.test.ts
+++ b/packages/studio-base/src/util/WebWorkerManager.test.ts
@@ -17,6 +17,7 @@ import WebWorkerManager from "./WebWorkerManager";
 
 jest.mock("@foxglove/studio-base/util/Rpc", () => {
   return class FakeRpc {
+    terminate() {}
     receive() {
       // no-op
     }

--- a/packages/studio-base/src/util/WebWorkerManager.ts
+++ b/packages/studio-base/src/util/WebWorkerManager.ts
@@ -89,6 +89,7 @@ export default class WebWorkerManager<W extends Channel> {
       if (workerState.listenerIds.length === 0) {
         this._workerStates[workerStateIndex] = undefined;
         workerState.worker.terminate();
+        workerState.rpc.terminate();
       }
     }
   }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where the app would temporarily stop displaying data when panels were hidden or removed from the layout.

**Description**
When an underlying worker is terminated, the Rpc object might be left with callbacks in the `_pendingCallbacks` map that never get resolved or rejected. This PR adds an explicit `Rpc.terminate()` method to reject any outstanding callbacks.

This bug would cause the app to freeze for [5 seconds](https://github.com/foxglove/studio/blob/256512561ec2139f95e173835ead5435a6489b35/packages/studio-base/src/components/MessagePipeline/pauseFrameForPromise.ts#L19-L20) if a `pauseFrame` was triggered but the call to resume was waiting on a promise that never resolved. This would happen with e.g. an active Image panel, when switching away to a different tab — a certain percentage of the time the image panel wouldn't complete its latest render before the worker was terminated.

Relates to https://github.com/foxglove/studio/issues/3682, but not sure if it completely fixes it.