### PR TITLE
Fix plot panel issue with externally added paths

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -24,7 +24,8 @@ import { Button, IconButton, Theme, alpha, MenuItem, Menu } from "@mui/material"
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import { last } from "lodash";
-import { ComponentProps, useCallback, useMemo, useRef, useState } from "react";
+import { ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLatest } from "react-use";
 import { useDebouncedCallback } from "use-debounce";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
@@ -334,6 +335,13 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
   );
 
   const lastPath = last(localPaths);
+
+  // The set of paths we plot can be changed externally by other panels so
+  // we replace our local path state with the config path state when this happens.
+  const latestPropsPaths = useLatest(props.paths);
+  useEffect(() => {
+    setLocalPaths(latestPropsPaths.current);
+  }, [latestPropsPaths, props.paths.length]);
 
   const toggleLegend = useCallback(
     () => saveConfig({ showLegend: !showLegend }),


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with plot paths added from the raw messages panel.

**Description**
#3629 used local path state in the plot panel to improve interactivity but it didn't account for changes to the plot paths made externally to the plot panel by things like the click to plot feature of the raw messages panel.

The fix here is to replace the local plot path state with the layouts state when the number of plot paths changes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3672 