### PR TITLE
Fix bug with node playground scripts and custom datatypes

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/index.tsx
@@ -110,7 +110,6 @@ const BottomBar = ({ nodeId, isSaved, save, diagnostics, logs }: Props): ReactEl
           paddingRight={1}
         >
           <StyledTabs
-            disableRipple
             textColor="inherit"
             value={bottomBarDisplay !== "closed" ? bottomBarDisplay : false}
             onChange={handleChange}

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -389,7 +389,7 @@ export default class Ros1Player implements Player {
 
       subscription.on("header", (_header, msgdef, _reader) => {
         // We have to create a new object instead of just updating _providerDatatypes to support
-        // shallow memo
+        // shallow memo downstream.
         const newDatatypes = this._getRosDatatypes(datatype, msgdef);
         this._providerDatatypes = new Map([...this._providerDatatypes, ...newDatatypes]);
       });

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -69,6 +69,12 @@ type UserNodeActions = {
   setUserNodeTypesLib: (lib: string) => void;
 };
 
+type NodeRegistrationCacheItem = {
+  nodeId: string;
+  userNode: UserNode;
+  result: NodeRegistration;
+};
+
 function maybePlainObject(rawVal: unknown) {
   if (typeof rawVal === "object" && rawVal && "toJSON" in rawVal) {
     return (rawVal as { toJSON: () => unknown }).toJSON();
@@ -111,11 +117,12 @@ export default class UserNodePlayer implements Player {
   // a node may set its own problem or clear its problem
   private _problemStore = new Map<string, PlayerProblem>();
 
-  private _nodeRegistrationCache: {
-    nodeId: string;
-    userNode: UserNode;
-    result: NodeRegistration;
-  }[] = [];
+  private _nodeRegistrationCache: NodeRegistrationCacheItem[] = [];
+
+  // Map of output topics to input topics. To produce an output we need to know the input topics
+  // that a script requires. When subscribers subscribe to the output topic, the user node player
+  // subscribes to the underlying input topics.
+  private _inputsByOutputTopic = new Map<string, readonly string[]>();
 
   // exposed as a static to allow testing to mock/replace
   static CreateNodeTransformWorker = (): SharedWorker => {
@@ -194,13 +201,13 @@ export default class UserNodePlayer implements Player {
 
   // When updating nodes while paused, we seek to the current time
   // (i.e. invoke _getMessages with an empty array) to refresh messages
-  private _getMessages = async (
+  private async _getMessages(
     parsedMessages: readonly MessageEvent<unknown>[],
     globalVariables: GlobalVariables,
     nodeRegistrations: readonly NodeRegistration[],
   ): Promise<{
     parsedMessages: readonly MessageEvent<unknown>[];
-  }> => {
+  }> {
     if (
       shallowequal(this._lastGetMessagesInput, {
         parsedMessages,
@@ -238,7 +245,7 @@ export default class UserNodePlayer implements Player {
     this._lastGetMessagesInput = { parsedMessages, globalVariables, nodeRegistrations };
     this._lastGetMessagesResult = result;
     return result;
-  };
+  }
 
   setGlobalVariables(globalVariables: GlobalVariables): void {
     this._globalVariables = globalVariables;
@@ -254,7 +261,6 @@ export default class UserNodePlayer implements Player {
     this._nodeRegistrationCache.splice(maxNodeRegistrationCacheCount);
 
     // This code causes us to reset workers twice because the forceSeek resets the workers too
-    // TODO: Only reset workers once
     return await this._resetWorkers().then(() => {
       this.setSubscriptions(this._subscriptions);
       const { currentTime, isPlaying = false } = this._lastPlayerStateActiveData ?? {};
@@ -265,10 +271,10 @@ export default class UserNodePlayer implements Player {
   }
 
   // Defines the inputs/outputs and worker interface of a user node.
-  private _createNodeRegistration = async (
+  private async _createNodeRegistration(
     nodeId: string,
     userNode: UserNode,
-  ): Promise<NodeRegistration> => {
+  ): Promise<NodeRegistration> {
     for (const cacheEntry of this._nodeRegistrationCache) {
       if (nodeId === cacheEntry.nodeId && isEqual(userNode, cacheEntry.userNode)) {
         return cacheEntry.result;
@@ -456,7 +462,7 @@ export default class UserNodePlayer implements Player {
     };
     this._nodeRegistrationCache.push({ nodeId, userNode, result });
     return result;
-  };
+  }
 
   private _getTransformWorker(): Rpc {
     if (!this._nodeTransformRpc) {
@@ -547,19 +553,28 @@ export default class UserNodePlayer implements Player {
     const allNodeOutputs = new Set(
       allNodeRegistrations.map(({ nodeData }) => nodeData.outputTopic),
     );
-    const seenNodeOutputs = new Set<string>();
+
+    // Clear the output -> input map and re-populate it again with with all the node registrations
+    this._inputsByOutputTopic.clear();
 
     for (const nodeRegistration of allNodeRegistrations) {
       const { nodeData, nodeId } = nodeRegistration;
 
-      // Filter out nodes with compilation errors
-      if (hasTransformerErrors(nodeData)) {
-        this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
+      if (!nodeData.outputTopic) {
+        this._setUserNodeDiagnostics(nodeId, [
+          ...nodeData.diagnostics,
+          {
+            severity: DiagnosticSeverity.Error,
+            message: `Output topic cannot be an empty string.`,
+            source: Sources.OutputTopicChecker,
+            code: ErrorCodes.OutputTopicChecker.NOT_UNIQUE,
+          },
+        ]);
         continue;
       }
 
       // Create diagnostic errors if more than one node outputs to the same topic
-      if (seenNodeOutputs.has(nodeData.outputTopic)) {
+      if (this._inputsByOutputTopic.has(nodeData.outputTopic)) {
         this._setUserNodeDiagnostics(nodeId, [
           ...nodeData.diagnostics,
           {
@@ -571,7 +586,9 @@ export default class UserNodePlayer implements Player {
         ]);
         continue;
       }
-      seenNodeOutputs.add(nodeData.outputTopic);
+
+      // Record the required input topics to service this output topic
+      this._inputsByOutputTopic.set(nodeData.outputTopic, nodeData.inputTopics);
 
       // Create diagnostic errors if node outputs overlap with real topics
       if (playerTopics.has(nodeData.outputTopic)) {
@@ -584,6 +601,12 @@ export default class UserNodePlayer implements Player {
             code: ErrorCodes.OutputTopicChecker.EXISTING_TOPIC,
           },
         ]);
+        continue;
+      }
+
+      // Filter out nodes with compilation errors
+      if (hasTransformerErrors(nodeData)) {
+        this._setUserNodeDiagnostics(nodeId, nodeData.diagnostics);
         continue;
       }
 
@@ -609,7 +632,9 @@ export default class UserNodePlayer implements Player {
       this._memoizedNodeDatatypes = nodeDatatypes;
     }
 
-    this._nodeRegistrations.forEach(({ nodeId }) => this._setUserNodeDiagnostics(nodeId, []));
+    for (const nodeRegistration of this._nodeRegistrations) {
+      this._setUserNodeDiagnostics(nodeRegistration.nodeId, []);
+    }
 
     this._pendingResetWorkers = undefined;
     pending.resolve();
@@ -677,6 +702,7 @@ export default class UserNodePlayer implements Player {
           this._nodeRegistrationCache = [];
         }
 
+        //console.log("new data", { shouldReset, activeData });
         this._lastPlayerStateActiveData = activeData;
         if (shouldReset) {
           await this._resetWorkers();
@@ -754,6 +780,10 @@ export default class UserNodePlayer implements Player {
 
     const nodeSubscriptions = new Set<string>();
     const realTopicSubscriptions: SubscribePayload[] = [];
+
+    // For each subscription, identify required input topics by looking up the subscribed topic in
+    // the map of output topics -> inputs. Add these required input topics to the set of topic
+    // subscriptions to the underlying player.
     for (const subscription of subscriptions) {
       // When subscribing to the same node multiple times, only subscribe to the underlying
       // topics once. This is not strictly necessary, but it makes debugging a bit easier.
@@ -761,17 +791,23 @@ export default class UserNodePlayer implements Player {
         continue;
       }
 
-      const nodeRegistration = this._nodeRegistrations.find(
-        (info) => info.output.name === subscription.topic,
-      );
-      if (!nodeRegistration) {
+      const inputs = this._inputsByOutputTopic.get(subscription.topic);
+      if (!inputs) {
+        nodeSubscriptions.add(subscription.topic);
         realTopicSubscriptions.push(subscription);
         continue;
       }
+
+      // If the inputs array is empty then we don't have anything to subscribe to for this output
+      if (inputs.length === 0) {
+        continue;
+      }
+
       nodeSubscriptions.add(subscription.topic);
-      for (const inputTopic of nodeRegistration.inputs) {
+      for (const inputTopic of inputs) {
         realTopicSubscriptions.push({
           topic: inputTopic,
+          preloadType: subscription.preloadType ?? "partial",
         });
       }
     }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -702,7 +702,6 @@ export default class UserNodePlayer implements Player {
           this._nodeRegistrationCache = [];
         }
 
-        //console.log("new data", { shouldReset, activeData });
         this._lastPlayerStateActiveData = activeData;
         if (shouldReset) {
           await this._resetWorkers();

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -104,15 +104,16 @@ describe("pipeline", () => {
       expect(inputTopics).toEqual(expectedTopics);
     });
 
-    it("should not run getInputTopics if there were any compile time errors", () => {
+    it("should run getInputTopics even if there were compile time errors", () => {
       const nodeData = compose(compile, getInputTopics)(
         {
           ...baseNodeData,
-          sourceCode: "const x: string = 41",
+          sourceCode: "export const inputs = ['foo']; const x: DoesNotExist = 41",
         },
         [],
       );
       expect(nodeData.diagnostics.map(({ source }) => source)).toEqual([Sources.Typescript]);
+      expect(nodeData.inputTopics).toEqual(["foo"]);
     });
 
     it.each([


### PR DESCRIPTION

**User-Facing Changes**
Writing node playground scripts using the `./types` module and custom datatypes works even if the user has not separately subscribed to the input topic in another panel.

**Description**
Node playground scripts that used the ./types module and referenced custom datatypes did not work. They would fail to compile because the custom datatypes were missing from the Messages generic (i.e. Message<"my_msgs/Foo"> would be a compile error). Node playground player and transform worker logic would exclude any nodes that failed to compile when building a list of topics to subscribe to. Without subscribing to the input topics of the node script, the compilation step could never get the custom datatypes and the node would never compile successfully.

This change alters the behavior of UserNodePlayer to subscribe to the related input topics of an output topic from node scripts even if the node does not compile (but is able to identify the input topics). By subscribing to the input topics, the underlying player can provide the datatype information for the custom datatype which rebuilds the ./types module and allows the node script to compile successfully.

Prior to this change, a node which did not compile would not cause subscriptions to occur to its input topics since a node that doesn't compile cannot run. After this change, the underlying player will subscribe to "broken" nodes which may result in subscriptions to messages that are not processed by the node since the node is broken. We assume the desired state for node scripts is to be "working", we consider this an acceptable tradeoff to supporting custom datatypes.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
