### PR TITLE
Add builtin_interfaces/Time and builtin_interfaces/Duration types to Ros2Player

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/messagePathsForDatatype.ts
@@ -84,28 +84,30 @@ export function messagePathStructures(
   lastDatatypes = undefined;
   const structureFor = memoize(
     (datatype: string, seenDatatypes: string[]): MessagePathStructureItemMessage => {
-      if (datatype === "time" || datatype === "duration") {
-        return {
-          structureType: "message",
-          nextByName: {
-            sec: {
-              structureType: "primitive",
-              primitiveType: "uint32",
-              datatype: "",
-            },
-            nsec: {
-              structureType: "primitive",
-              primitiveType: "uint32",
-              datatype: "",
-            },
-          },
-          datatype,
-        };
-      }
-
       const nextByName: Record<string, MessagePathStructureItem> = {};
       const rosDatatype = datatypes.get(datatype);
       if (!rosDatatype) {
+        // "time" and "duration" are considered "built-in" types in ROS
+        // If we can't find a datatype in our datatypes list we fall-back to our hard-coded versions
+        if (datatype === "time" || datatype === "duration") {
+          return {
+            structureType: "message",
+            nextByName: {
+              sec: {
+                structureType: "primitive",
+                primitiveType: "uint32",
+                datatype: "",
+              },
+              nsec: {
+                structureType: "primitive",
+                primitiveType: "uint32",
+                datatype: "",
+              },
+            },
+            datatype,
+          };
+        }
+
         throw new Error(`datatype not found: "${datatype}"`);
       }
       rosDatatype.definitions.forEach((msgField) => {

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -131,6 +131,23 @@ export default class Ros2Player implements Player {
       name: "std_msgs/msg/Header",
       definitions,
     });
+
+    // Add Time and Duration builtin interfaces
+    this._providerDatatypes.set("builtin_interfaces/Time", {
+      name: "builtin_interfaces/Time",
+      definitions: [
+        { name: "sec", type: "int32" },
+        { name: "nanosec", type: "uint32" },
+      ],
+    });
+
+    this._providerDatatypes.set("builtin_interfaces/Duration", {
+      name: "builtin_interfaces/Duration",
+      definitions: [
+        { name: "sec", type: "int32" },
+        { name: "nanosec", type: "uint32" },
+      ],
+    });
   }
 
   private _open = async (): Promise<void> => {


### PR DESCRIPTION


**User-Facing Changes**
Ros2 native connections work again.

**Description**
https://github.com/foxglove/studio/pull/3532 updated foxglove/schemas. These new schemas reference the builtin_interfaces/Time type within the schema datatypes. This complex type was never provided explicitly in the Ros2Player provider datatypes. As a result, the messagePathsForDatatypes would error when trying to create a structure for fields having the builtin_interfaces/Time type.

This change fixes this behavior by manually adding these two builtin interfaces to the datatypes within Ros2Player.

Fixes: #3645

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
