### PR TITLE
Example: Remove <PanelToolbar>

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -11,14 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
-import { styled as muiStyled, Typography } from "@mui/material";
-import { useContext, useState, useMemo, CSSProperties } from "react";
-
-import PanelContext from "@foxglove/studio-base/components/PanelContext";
-import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
-
-import { PanelToolbarControls } from "./PanelToolbarControls";
+import { CSSProperties } from "react";
 
 export const PANEL_TOOLBAR_MIN_HEIGHT = 30;
 
@@ -28,82 +21,13 @@ type Props = {
   children?: React.ReactNode;
   // Keeping this prop for now in case we decide to expose it via some other mechanism
   // like a context menu item.
-  // eslint-disable-next-line react/no-unused-prop-types
   helpContent?: React.ReactNode;
   isUnknownPanel?: boolean;
 };
 
-const PanelToolbarRoot = muiStyled("div", {
-  shouldForwardProp: (prop) => prop !== "backgroundColor" && prop !== "enableDrag",
-})<{ backgroundColor?: CSSProperties["backgroundColor"]; enableDrag: boolean }>(
-  ({ theme, backgroundColor, enableDrag }) => ({
-    transition: "transform 80ms ease-in-out, opacity 80ms ease-in-out",
-    cursor: enableDrag ? "grab" : "auto",
-    flex: "0 0 auto",
-    alignItems: "center",
-    justifyContent: "flex-end",
-    padding: theme.spacing(0.25, 0.75),
-    display: "flex",
-    minHeight: PANEL_TOOLBAR_MIN_HEIGHT,
-    backgroundColor: backgroundColor ?? theme.palette.background.paper,
-    width: "100%",
-    left: 0,
-    zIndex: theme.zIndex.appBar,
-  }),
-);
-
 // Panel toolbar should be added to any panel that's part of the
 // react-mosaic layout.  It adds a drag handle, remove/replace controls
 // and has a place to add custom controls via it's children property
-export default React.memo<Props>(function PanelToolbar({
-  additionalIcons,
-  backgroundColor,
-  children,
-  isUnknownPanel = false,
-}: Props) {
-  const { isFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
-  const [menuOpen, setMenuOpen] = useState(false);
-
-  const panelContext = useContext(PanelContext);
-
-  // Help-shown state must be hoisted outside the controls container so the modal can remain visible
-  // when the panel is no longer hovered.
-  const additionalIconsWithHelp = useMemo(() => {
-    return (
-      <>
-        {additionalIcons}
-        {isFullscreen === true && (
-          <ToolbarIconButton
-            value="exit-fullscreen"
-            title="Exit fullscreen"
-            onClick={exitFullscreen}
-          >
-            <FullscreenExitIcon />
-          </ToolbarIconButton>
-        )}
-      </>
-    );
-  }, [additionalIcons, isFullscreen, exitFullscreen]);
-
-  return (
-    <PanelToolbarRoot
-      backgroundColor={backgroundColor}
-      data-test="mosaic-drag-handle"
-      enableDrag={panelContext?.connectToolbarDragHandle != undefined}
-      ref={isUnknownPanel ? undefined : panelContext?.connectToolbarDragHandle}
-    >
-      {children ??
-        (panelContext != undefined && (
-          <Typography noWrap variant="body2" color="text.secondary" flex="auto">
-            {panelContext.title}
-          </Typography>
-        ))}
-      <PanelToolbarControls
-        additionalIcons={additionalIconsWithHelp}
-        isUnknownPanel={!!isUnknownPanel}
-        menuOpen={menuOpen}
-        setMenuOpen={setMenuOpen}
-      />
-    </PanelToolbarRoot>
-  );
+export default React.memo<Props>(function PanelToolbar() {
+  return <></>;
 });


### PR DESCRIPTION
**User-Facing Changes**

- Removes panel toolbars entirely. Functionality is removed from panels such as Raw Messages

**Description**

This demonstrates how to fully remove panel toolbars. Note that this will remove functionality from some panels such as Raw Messages.
