### PR TITLE
Implement min & max for settings vector inputs

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -327,6 +327,8 @@ function FieldInput({
           precision={field.precision}
           disabled={field.disabled}
           readOnly={field.readonly}
+          min={field.min}
+          max={field.max}
           onChange={(value) =>
             actionHandler({ action: "update", payload: { path, input: "vec3", value } })
           }
@@ -340,6 +342,8 @@ function FieldInput({
           precision={field.precision}
           disabled={field.disabled}
           readOnly={field.readonly}
+          min={field.min}
+          max={field.max}
           onChange={(value) =>
             actionHandler({ action: "update", payload: { path, input: "vec2", value } })
           }

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -402,9 +402,7 @@ const PanelExamplesSettings: SettingsTreeNodes = {
     fields: {
       color: { label: "Color", value: "#ffffff", input: "rgb" },
       shaft_length: { label: "Shaft length", value: 1.5, input: "number" },
-      shaft_width: { label: "Shaft width", value: 1.5, input: "number" },
-      head_length: { label: "Head length", value: 2, input: "number" },
-      head_width: { label: "Head width", value: 2, input: "number" },
+      shaft_position: { label: "Shaft Position", value: [1, 2, 3], input: "vec3", min: 0, max: 5 },
     },
   },
 };

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
@@ -15,6 +15,8 @@ export function Vec2Input({
   readOnly = false,
   step,
   value,
+  min,
+  max,
 }: {
   disabled?: boolean;
   onChange: (value: undefined | [undefined | number, undefined | number]) => void;
@@ -22,6 +24,8 @@ export function Vec2Input({
   readOnly?: boolean;
   step?: number;
   value: undefined | readonly [undefined | number, undefined | number];
+  min?: number;
+  max?: number;
 }): JSX.Element {
   const onChangeCallback = useCallback(
     (position: number, inputValue: undefined | number) => {
@@ -49,6 +53,8 @@ export function Vec2Input({
           precision={precision}
           step={step}
           value={pval}
+          min={min}
+          max={max}
           onChange={(newValue) => onChangeCallback(position, newValue)}
         />
       ))}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -15,6 +15,8 @@ export function Vec3Input({
   readOnly = false,
   step,
   value,
+  min,
+  max,
 }: {
   disabled?: boolean;
   onChange: (
@@ -24,6 +26,8 @@ export function Vec3Input({
   readOnly?: boolean;
   step?: number;
   value: undefined | readonly [undefined | number, undefined | number, undefined | number];
+  min?: number;
+  max?: number;
 }): JSX.Element {
   const onChangeCallback = useCallback(
     (position: number, inputValue: undefined | number) => {
@@ -53,6 +57,8 @@ export function Vec3Input({
           precision={precision}
           step={step}
           value={pval}
+          min={min}
+          max={max}
           onChange={(newValue) => onChangeCallback(position, newValue)}
         />
       ))}

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -387,6 +387,8 @@ declare module "@foxglove/studio" {
         step?: number;
         precision?: number;
         labels?: [string, string, string];
+        max?: number;
+        min?: number;
       }
     | {
         input: "vec2";
@@ -394,6 +396,8 @@ declare module "@foxglove/studio" {
         step?: number;
         precision?: number;
         labels?: [string, string];
+        max?: number;
+        min?: number;
       };
 
   export type SettingsTreeField = SettingsTreeFieldValue & {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This implements the `min` & `max` parameters for the vec2 & vec3 settings inputs.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3690 