### PR TITLE
Process preloaded messages with node playground

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -38,9 +38,11 @@ export default class FakePlayer implements Player {
   async emit({
     activeData,
     presence,
+    progress,
   }: {
     activeData?: PlayerStateActiveData;
     presence?: PlayerPresence;
+    progress?: PlayerState["progress"];
   } = {}): Promise<void> {
     if (!this.listener) {
       return undefined;
@@ -51,7 +53,7 @@ export default class FakePlayer implements Player {
       presence: presence ?? PlayerPresence.PRESENT,
       capabilities: this._capabilities,
       profile: this._profile,
-      progress: {},
+      progress: progress ?? {},
       activeData,
     });
   }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { isEqual, pick, uniq } from "lodash";
+import { isEqual, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import shallowequal from "shallowequal";
 import { v4 as uuidv4 } from "uuid";

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -294,8 +294,8 @@ export default class UserNodePlayer implements Player {
       // Flatten and re-sort block messages so that nodes see them in the same order
       // as the non-block nodes.
       const messagesByTopic = { ...block.messagesByTopic };
-      const blockMessages = Object.values(pick(messagesByTopic, allInputTopics))
-        .flat()
+      const blockMessages = allInputTopics
+        .flatMap((topic) => messagesByTopic[topic] ?? [])
         .sort((a, b) => compare(a.receiveTime, b.receiveTime));
       for (const nodeRegistration of fullRegistrations) {
         const outTopic = nodeRegistration.output.name;

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -310,6 +310,9 @@ export default class UserNodePlayer implements Player {
         }
       }
 
+      // Note that this size doesn't include the new processed messqges. We may need
+      // to recalculate this if it turns out to be important for good cache eviction
+      // behavior.
       outputBlocks.push({
         messagesByTopic,
         sizeInBytes: block.sizeInBytes,

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { isEqual } from "lodash";
+import { isEqual, pick, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import shallowequal from "shallowequal";
 import { v4 as uuidv4 } from "uuid";
@@ -282,6 +282,8 @@ export default class UserNodePlayer implements Player {
       return blocks;
     }
 
+    const allInputTopics = uniq(fullRegistrations.flatMap((reg) => reg.inputs));
+
     const outputBlocks: (MessageBlock | undefined)[] = [];
     for (const block of blocks) {
       if (!block) {
@@ -292,7 +294,7 @@ export default class UserNodePlayer implements Player {
       // Flatten and re-sort block messages so that nodes see them in the same order
       // as the non-block nodes.
       const messagesByTopic = { ...block.messagesByTopic };
-      const blockMessages = Object.values(messagesByTopic)
+      const blockMessages = Object.values(pick(messagesByTopic, allInputTopics))
         .flat()
         .sort((a, b) => compare(a.receiveTime, b.receiveTime));
       for (const nodeRegistration of fullRegistrations) {

--- a/packages/studio-base/src/players/UserNodePlayer/types.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/types.ts
@@ -103,6 +103,10 @@ export type NodeRegistration = {
   nodeData: NodeData;
   inputs: readonly string[];
   output: Topic;
+  processBlockMessage: (
+    messageEvent: MessageEvent<unknown>,
+    globalVariables: GlobalVariables,
+  ) => Promise<MessageEvent<unknown> | undefined>;
   processMessage: (
     messageEvent: MessageEvent<unknown>,
     globalVariables: GlobalVariables,


### PR DESCRIPTION
**User-Facing Changes**
Adds support for plotting the outputs of node playground scripts.

**Description**
Node playground scripts are also run on preloaded messages. Panels like plot benefit from showing the entire loaded dataset when possible. Prior to this change, node playground scripts would only run "during playback" which meant that a plot panel could not show the output of a node playground script against the entire range of data.

This change alters this behavior by running the scripts on preloaded messages and playback messages.

This implementation works by creating two instances of the shared worker for each node and running blocks through the second instance. In order for the block instance to see messages in the same order we have to flatten and re-sort the block messages. Hopefully memoization will minimize the performance hit.

Fixes: #3714

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
