### PR TITLE
Always show visibility toggle on untoggled settings nodes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -49,7 +49,9 @@ const EditButton = muiStyled(IconButton)(({ theme }) => ({
   padding: theme.spacing(0.5),
 }));
 
-const NodeHeader = muiStyled("div")(({ theme }) => {
+const NodeHeader = muiStyled("div", {
+  shouldForwardProp: (prop) => prop !== "visible",
+})<{ visible: boolean }>(({ theme, visible }) => {
   return {
     display: "flex",
     gridColumn: "span 2",
@@ -58,7 +60,7 @@ const NodeHeader = muiStyled("div")(({ theme }) => {
 
     "@media (pointer: fine)": {
       ".MuiCheckbox-root": {
-        visibility: "hidden",
+        visibility: visible ? "hidden" : "visible",
       },
 
       "[data-node-function=edit-label]": {
@@ -205,7 +207,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
 
   return (
     <>
-      <NodeHeader>
+      <NodeHeader visible={visible}>
         <NodeHeaderToggle
           hasProperties={hasProperties}
           indent={indent}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The visibility toggle is always shown for nodes that have been toggled off to make it clearer to the user that they're not disabled.

Personally I think the meaning of the closed eye icon is not obvious and this might be better:

https://mui.com/material-ui/material-icons/?query=vis&selected=VisibilityOff

<img width="378" alt="Screen Shot 2022-06-27 at 10 40 21 AM" src="https://user-images.githubusercontent.com/93935560/175979755-813fb90a-86fe-4c0d-b2a3-ba0aef041d62.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3509 