### PR TITLE
Allow user to delete the initial slash in plot x path

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -394,7 +394,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
           />
           {(xAxisVal === "custom" || xAxisVal === "currentCustom") && (
             <MessagePathInput
-              path={xAxisPath?.value ? xAxisPath.value : "/"}
+              path={xAxisPath?.value ?? "/"}
               onChange={(newXAxisPath) =>
                 saveConfig({
                   xAxisPath: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This is a partial fix for https://github.com/foxglove/studio/issues/3713. It allows the user to manually delete the initial `/` for the x-path in the plot panel. Unfortunately clearing the subsequent "mismatched messages" error described in https://github.com/foxglove/studio/issues/3713 is going to require a more significant reworking of the messaging logic here.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially fixes https://github.com/foxglove/studio/issues/3713