### PR TITLE
[New3D] convert output color to srgb for LaserScan material

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -646,8 +646,7 @@ class LaserScanMaterial extends THREE.RawShaderMaterial {
             vec2 cxy = 2.0 * gl_PointCoord - 1.0;
             if (dot(cxy, cxy) > 1.0) { discard; }
           }
-          ${picking ? "outColor = objectId;" : "outColor = vColor;"}
-          outColor = LinearTosRGB(outColor);
+          ${picking ? "outColor = objectId;" : "outColor = LinearTosRGB(vColor);"}
         }
       `,
     });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -638,12 +638,16 @@ class LaserScanMaterial extends THREE.RawShaderMaterial {
         uniform bool isCircle;
         ${picking ? "uniform vec4 objectId;" : "in mediump vec4 vColor;"}
         out vec4 outColor;
+
+        ${THREE.ShaderChunk.encodings_pars_fragment /* for LinearTosRGB() */}
+
         void main() {
           if (isCircle) {
             vec2 cxy = 2.0 * gl_PointCoord - 1.0;
             if (dot(cxy, cxy) > 1.0) { discard; }
           }
           ${picking ? "outColor = objectId;" : "outColor = vColor;"}
+          outColor = LinearTosRGB(outColor);
         }
       `,
     });


### PR DESCRIPTION
**User-Facing Changes**
Fixed incorrect color conversion for LaserScan points in the 3D (Beta) panel.

**Description**
Since this is a raw shader, we need to manually include the linear→sRGB conversion step in the fragment shader.