### PR TITLE
Continue loading MCAP file if some channels have errors

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -67,7 +67,17 @@ export class McapIndexedIterableSource implements IIterableSource {
         continue;
       }
 
-      const parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
+      let parsedChannel;
+      try {
+        parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
+      } catch (error) {
+        problems.push({
+          severity: "error",
+          message: `Error in topic ${channel.topic} (channel ${channel.id}): ${error.message}`,
+          error,
+        });
+        continue;
+      }
       this.channelInfoById.set(channel.id, { channel, parsedChannel });
 
       let topic = topicsByName.get(channel.topic);

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0IndexedDataProvider.ts
@@ -68,7 +68,17 @@ export default class Mcap0IndexedDataProvider implements RandomAccessDataProvide
         continue;
       }
 
-      const parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
+      let parsedChannel;
+      try {
+        parsedChannel = parseChannel({ messageEncoding: channel.messageEncoding, schema });
+      } catch (error) {
+        problems.push({
+          severity: "error",
+          message: `Error in topic ${channel.topic} (channel ${channel.id}): ${error.message}`,
+          error,
+        });
+        continue;
+      }
       this.channelInfoById.set(channel.id, { channel, parsedChannel });
 
       let topic = topicsByName.get(channel.topic);

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
@@ -14,7 +14,12 @@ import {
   isTimeInRangeInclusive,
   fromNanoSec,
 } from "@foxglove/rostime";
-import { MessageEvent, Topic, TopicStats } from "@foxglove/studio-base/players/types";
+import {
+  MessageEvent,
+  PlayerProblem,
+  Topic,
+  TopicStats,
+} from "@foxglove/studio-base/players/types";
 import {
   RandomAccessDataProvider,
   ExtensionPoint,
@@ -44,6 +49,9 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
     const decompressHandlers = await loadDecompressHandlers();
 
     const streamReader = this.options.stream.getReader();
+
+    const problems: PlayerProblem[] = [];
+    const channelIdsWithErrors = new Set<number>();
 
     const messagesByChannel = new Map<number, MessageEvent<unknown>[]>();
     const schemasById = new Map<number, Mcap0Types.TypedMcapRecords["Schema"]>();
@@ -84,6 +92,9 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
             }
             break;
           }
+          if (channelIdsWithErrors.has(record.id)) {
+            break;
+          }
           if (record.schemaId === 0) {
             throw new Error(
               `Channel ${record.id} has no schema; channels without schemas are not supported`,
@@ -96,9 +107,18 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
             );
           }
 
-          const parsedChannel = parseChannel({ messageEncoding: record.messageEncoding, schema });
-          channelInfoById.set(record.id, { channel: record, parsedChannel });
-          messagesByChannel.set(record.id, []);
+          try {
+            const parsedChannel = parseChannel({ messageEncoding: record.messageEncoding, schema });
+            channelInfoById.set(record.id, { channel: record, parsedChannel });
+            messagesByChannel.set(record.id, []);
+          } catch (error) {
+            channelIdsWithErrors.add(record.id);
+            problems.push({
+              severity: "error",
+              message: `Error in topic ${record.topic} (channel ${record.id}): ${error.message}`,
+              error,
+            });
+          }
           break;
         }
 
@@ -107,6 +127,9 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
           const channelInfo = channelInfoById.get(channelId);
           const messages = messagesByChannel.get(channelId);
           if (!channelInfo || !messages) {
+            if (channelIdsWithErrors.has(channelId)) {
+              break; // error has already been reported
+            }
             throw new Error(`message for channel ${channelId} with no prior channel info`);
           }
           const receiveTime = fromNanoSec(record.logTime);
@@ -170,7 +193,7 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
         messageDefinitionsByTopic: {},
         parsedMessageDefinitionsByTopic: {},
       },
-      problems: [],
+      problems,
     };
   }
 

--- a/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Mcap0StreamedDataProvider.ts
@@ -14,12 +14,7 @@ import {
   isTimeInRangeInclusive,
   fromNanoSec,
 } from "@foxglove/rostime";
-import {
-  MessageEvent,
-  PlayerProblem,
-  Topic,
-  TopicStats,
-} from "@foxglove/studio-base/players/types";
+import { MessageEvent, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import {
   RandomAccessDataProvider,
   ExtensionPoint,
@@ -27,6 +22,7 @@ import {
   GetMessagesTopics,
   InitializationResult,
   Connection,
+  RandomAccessDataProviderProblem,
 } from "@foxglove/studio-base/randomAccessDataProviders/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -50,7 +46,7 @@ export default class Mcap0StreamedDataProvider implements RandomAccessDataProvid
 
     const streamReader = this.options.stream.getReader();
 
-    const problems: PlayerProblem[] = [];
+    const problems: RandomAccessDataProviderProblem[] = [];
     const channelIdsWithErrors = new Set<number>();
 
     const messagesByChannel = new Map<number, MessageEvent<unknown>[]>();

--- a/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/McapDataProvider.ts
@@ -151,12 +151,12 @@ export default class McapDataProvider implements RandomAccessDataProvider {
           return {
             ...result,
             problems: [
-              ...result.problems,
               {
                 message: "MCAP file is unindexed, falling back to streamed reading",
                 severity: "warn",
                 error,
               },
+              ...result.problems,
             ],
           };
         }


### PR DESCRIPTION
**User-Facing Changes**
Improved handling of MCAP files with errors on some channels. (other channels can still be loaded in the app).

**Description**
Improves https://github.com/foxglove/studio/issues/3546 for experimental and non-experimental players. After merging, that ticket can be turned into a feature request for array-of-bytes support.