### PR TITLE
Graceful chart component unmounting

### DIFF
--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -144,10 +144,11 @@ function Chart(props: Props): JSX.Element {
     return () => {
       log.info(`Unregister chart ${id}`);
       rpcSendRef.current = undefined;
-      void sendWrapper("destroy");
-      if (supportsOffscreenCanvas) {
-        webWorkerManager.unregisterWorkerListener(id);
-      }
+      sendWrapper("destroy").finally(() => {
+        if (supportsOffscreenCanvas) {
+          webWorkerManager.unregisterWorkerListener(id);
+        }
+      });
     };
   }, [id]);
 

--- a/packages/studio-base/src/util/Rpc.ts
+++ b/packages/studio-base/src/util/Rpc.ts
@@ -138,7 +138,12 @@ export default class Rpc {
       callback({
         topic: RESPONSE,
         id,
-        data: { [ERROR]: true, name: "Error", message: "Rpc terminated", stack: "" },
+        data: {
+          [ERROR]: true,
+          name: "Error",
+          message: "Rpc terminated",
+          stack: new Error().stack,
+        },
       });
     }
   }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
In dev the Chart component was constantly throwing rpc errors when loading data sources or changing panels. The Chart component sends an rpc command to destroy when shutting down but doesn't wait for the response before removing the rpc id from the worker pool.

This change fixes this the crash behavior by removing the rpc id in a finally that happens after the rpc call completes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
