### PR TITLE
Remove duplicate nodeSubscriptions filter in UserNodePlayer

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/usePlayerState.ts
+++ b/packages/studio-base/src/components/MessagePipeline/usePlayerState.ts
@@ -58,7 +58,13 @@ function updateSubscriberAction(
   }
 
   const newSubscriptionsById = new Map(previousSubscriptionsById);
-  newSubscriptionsById.set(action.id, action.payloads);
+
+  if (action.payloads.length === 0) {
+    // When a subscription id has no topics we removed it from our map
+    newSubscriptionsById.delete(action.id);
+  } else {
+    newSubscriptionsById.set(action.id, action.payloads);
+  }
 
   const subscriberIdsByTopic: InternalState["subscriberIdsByTopic"] = new Map();
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -784,13 +784,6 @@ export default class UserNodePlayer implements Player {
     // the map of output topics -> inputs. Add these required input topics to the set of topic
     // subscriptions to the underlying player.
     for (const subscription of subscriptions) {
-      // When subscribing to the same node multiple times, only subscribe to the underlying
-      // topics once. This is not strictly necessary, but it makes debugging a bit easier.
-      // fixme - should subscribe to full and partial for each topic
-      //if (nodeSubscriptions.has(subscription.topic)) {
-      //  continue;
-      //}
-
       const inputs = this._inputsByOutputTopic.get(subscription.topic);
       if (!inputs) {
         nodeSubscriptions.add(subscription.topic);

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -786,9 +786,10 @@ export default class UserNodePlayer implements Player {
     for (const subscription of subscriptions) {
       // When subscribing to the same node multiple times, only subscribe to the underlying
       // topics once. This is not strictly necessary, but it makes debugging a bit easier.
-      if (nodeSubscriptions.has(subscription.topic)) {
-        continue;
-      }
+      // fixme - should subscribe to full and partial for each topic
+      //if (nodeSubscriptions.has(subscription.topic)) {
+      //  continue;
+      //}
 
       const inputs = this._inputsByOutputTopic.get(subscription.topic);
       if (!inputs) {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
UserNodePlayer setSubscriptions creates a set of subscriptions for its child player. These set of subscriptions is a merger of the subscriptions from the setSubscriptions call and the required topics from user node scripts.

The logic it used would limit each topic to one subscription entry. Unfortunately, since we support "partial" and "full" subscriptions on topics this meant that subscription information was lost.

This change removes the topic filtering and passes through all requested subscriptions to the underlying player.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
