### PR TITLE
Add Immutable definition to studio-base

### DIFF
--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -16,8 +16,8 @@ import {
 import { useCallback, useState } from "react";
 import { useToasts } from "react-toast-notifications";
 import { useAsync, useMountedState } from "react-use";
-import { DeepReadonly } from "ts-essentials";
 
+import { Immutable } from "@foxglove/studio-base";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextContent from "@foxglove/studio-base/components/TextContent";
@@ -32,7 +32,7 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 type Props = {
   installed: boolean;
-  extension: DeepReadonly<ExtensionMarketplaceDetail>;
+  extension: Immutable<ExtensionMarketplaceDetail>;
   onClose: () => void;
 };
 

--- a/packages/studio-base/src/typings/immutable.d.ts
+++ b/packages/studio-base/src/typings/immutable.d.ts
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+declare module "@foxglove/studio-base" {
+  export type Immutable<T> = import("ts-essentials").DeepReadonly<T>;
+}

--- a/packages/studio-base/src/typings/immutable.d.ts
+++ b/packages/studio-base/src/typings/immutable.d.ts
@@ -5,3 +5,5 @@
 declare module "@foxglove/studio-base" {
   export type Immutable<T> = import("ts-essentials").DeepReadonly<T>;
 }
+
+export {};

--- a/packages/studio-base/src/typings/index.d.ts
+++ b/packages/studio-base/src/typings/index.d.ts
@@ -7,6 +7,7 @@
 import "./extensions";
 import "./react";
 import "./fluentui";
+import "./immutable";
 import "./overrides";
 import "./styled-components";
 import "./web";


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Immutability is a very useful concept for code correctness but `DeepReadonly` is syntactically awkward and a proliferation of imports from `ts-essentials` all over the codebase seems undesirable.  `Immutable` from immerjs is syntactically cleaner but we don't want to add dependencies on immer just for this definition to code that doesn't otherwise use immer.

This adds an `Immutable` definition to `@foxglove/studio-base` that for now is just an alias to the `ts-essentials` `DeepReadonly` definition but is nicer to read and more convenient to import.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
