### PR TITLE
[New3D] Resize canvas immediately when devicePixelRatio changes

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -289,8 +289,22 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addSceneExtension(new Poses(this));
     this.addSceneExtension(new PoseArrays(this));
 
+    this._watchDevicePixelRatio();
+
     this._updateCameras(config.cameraState);
     this.animationFrame();
+  }
+
+  private _watchDevicePixelRatio() {
+    window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`).addEventListener(
+      "change",
+      () => {
+        log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
+        this.resizeHandler(this.input.canvasSize);
+        this._watchDevicePixelRatio();
+      },
+      { once: true },
+    );
   }
 
   dispose(): void {


### PR DESCRIPTION
**User-Facing Changes**
Improved 3D (Beta) panel behavior when moving the app between displays of different resolutions.

**Description**
Listener code taken from https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio#monitoring_screen_resolution_or_zoom_level_changes &  https://stackoverflow.com/a/71774031/23649