### PR TITLE
Update ThreeDeeRender panel to follow the app color scheme

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -27,6 +27,7 @@ import {
   Topic,
 } from "@foxglove/studio";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import { DebugGui } from "./DebugGui";
 import Interactions, {
@@ -425,19 +426,21 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   );
 
   return (
-    <div style={PANEL_STYLE} ref={resizeRef}>
-      <CameraListener cameraStore={cameraStore} shiftKeys={true}>
-        <div
-          // This element forces CameraListener to fill its container. We need this instead of just
-          // the canvas since three.js manages the size of the canvas element and we use
-          // position:absolute
-          style={{ width, height }}
-        />
-        <canvas ref={setCanvas} style={CANVAS_STYLE} />
-      </CameraListener>
-      <RendererContext.Provider value={renderer}>
-        <RendererOverlay addPanel={addPanel} enableStats={config.scene.enableStats ?? false} />
-      </RendererContext.Provider>
-    </div>
+    <ThemeProvider isDark={colorScheme === "dark"}>
+      <div style={PANEL_STYLE} ref={resizeRef}>
+        <CameraListener cameraStore={cameraStore} shiftKeys={true}>
+          <div
+            // This element forces CameraListener to fill its container. We need this instead of just
+            // the canvas since three.js manages the size of the canvas element and we use
+            // position:absolute
+            style={{ width, height }}
+          />
+          <canvas ref={setCanvas} style={CANVAS_STYLE} />
+        </CameraListener>
+        <RendererContext.Provider value={renderer}>
+          <RendererOverlay addPanel={addPanel} enableStats={config.scene.enableStats ?? false} />
+        </RendererContext.Provider>
+      </div>
+    </ThemeProvider>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -8,7 +8,6 @@ import ReactDOM from "react-dom";
 import { PanelExtensionContext } from "@foxglove/studio";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
-import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { ThreeDeeRender } from "./ThreeDeeRender";
@@ -17,9 +16,7 @@ import helpContent from "./index.help.md";
 function initPanel(context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <ThemeProvider isDark>
-        <ThreeDeeRender context={context} />
-      </ThemeProvider>
+      <ThreeDeeRender context={context} />
     </StrictMode>,
     context.panelElement,
   );


### PR DESCRIPTION


**User-Facing Changes**
3D (Beta) floating buttons follow the app color scheme (light or dark).

**Description**
Move ThemeProvider into the ThreeDeeRender component so UI elements inside of it can follow the app color scheme.

Fixes: #3745


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
