### PR TITLE
[New3D] MarkerPool

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Labels.ts
@@ -83,6 +83,15 @@ export class Labels extends THREE.Object3D {
     this.renderer = renderer;
   }
 
+  dispose(): void {
+    for (const sprite of this.sprites.values()) {
+      sprite.material.map?.dispose();
+      sprite.material.dispose();
+    }
+    this.children.length = 0;
+    this.sprites.clear();
+  }
+
   setLabel(id: string, label: LabelOptions): LabelRenderable {
     const extraScale = scaleFactor(this.renderer.maxLod);
     const scale = window.devicePixelRatio + extraScale;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -43,6 +43,7 @@ import { PointCloudsAndLaserScans } from "./renderables/PointCloudsAndLaserScans
 import { Polygons } from "./renderables/Polygons";
 import { PoseArrays } from "./renderables/PoseArrays";
 import { Poses } from "./renderables/Poses";
+import { MarkerPool } from "./renderables/markers/MarkerPool";
 import {
   Header,
   TFMessage,
@@ -191,6 +192,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   renderFrameId: string | undefined;
 
   labels = new Labels(this);
+  markerPool = new MarkerPool(this);
 
   constructor(canvas: HTMLCanvasElement, config: RendererConfig) {
     super();
@@ -301,6 +303,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
     this.sceneExtensions.clear();
 
+    this.markerPool.dispose();
     this.labels.dispose();
     this.picker.dispose();
     this.input.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -390,6 +390,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
   }
 
   defaultFrameId(): string | undefined {
+    const allFrames = this.transformTree.frames();
+    if (allFrames.size === 0) {
+      return undefined;
+    }
+
     // Prefer frames from [REP-105](https://www.ros.org/reps/rep-0105.html)
     for (const frameId of DEFAULT_FRAME_IDS) {
       const frame = this.transformTree.frame(frameId);
@@ -400,7 +405,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     // Choose the root frame with the most children
     const rootsToCounts = new Map<string, number>();
-    for (const frame of this.transformTree.frames().values()) {
+    for (const frame of allFrames.values()) {
       const rootId = frame.root().id;
       rootsToCounts.set(rootId, (rootsToCounts.get(rootId) ?? 0) + 1);
     }
@@ -726,7 +731,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   };
 
   private _updateFrames(): void {
-    if (this.renderFrameId == undefined) {
+    if (this.renderFrameId == undefined || !this.transformTree.hasFrame(this.renderFrameId)) {
       this.renderFrameId = this.defaultFrameId();
 
       if (this.renderFrameId == undefined) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -301,6 +301,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
     this.sceneExtensions.clear();
 
+    this.labels.dispose();
     this.picker.dispose();
     this.input.dispose();
     this.gl.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -190,6 +190,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   currentTime: bigint | undefined;
   fixedFrameId: string | undefined;
   renderFrameId: string | undefined;
+  followFrameId: string | undefined;
 
   labels = new Labels(this);
   markerPool = new MarkerPool(this);
@@ -272,7 +273,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.selectionBackdrop.visible = false;
     this.scene.add(this.selectionBackdrop);
 
-    this.renderFrameId = config.followTf;
+    this.followFrameId = config.followTf;
 
     const samples = msaaSamples(this.maxLod, this.gl.capabilities);
     const renderSize = this.gl.getDrawingBufferSize(tempVec2);
@@ -393,6 +394,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
     const allFrames = this.transformTree.frames();
     if (allFrames.size === 0) {
       return undefined;
+    }
+
+    // Top priority is the followFrameId
+    if (this.followFrameId != undefined && this.transformTree.hasFrame(this.followFrameId)) {
+      return this.followFrameId;
     }
 
     // Prefer frames from [REP-105](https://www.ros.org/reps/rep-0105.html)
@@ -731,11 +737,23 @@ export class Renderer extends EventEmitter<RendererEvents> {
   };
 
   private _updateFrames(): void {
-    if (this.renderFrameId == undefined || !this.transformTree.hasFrame(this.renderFrameId)) {
+    if (
+      this.followFrameId != undefined &&
+      this.renderFrameId !== this.followFrameId &&
+      this.transformTree.hasFrame(this.followFrameId)
+    ) {
+      // followFrameId is set and is a valid frame, use it
+      this.renderFrameId = this.followFrameId;
+    } else if (
+      this.renderFrameId == undefined ||
+      !this.transformTree.hasFrame(this.renderFrameId)
+    ) {
+      // No valid renderFrameId set, fall back to selecting the heuristically
+      // most valid frame (if any frames are present)
       this.renderFrameId = this.defaultFrameId();
 
       if (this.renderFrameId == undefined) {
-        this.settings.errors.add(FOLLOW_TF_PATH, NO_FRAME_SELECTED, `No frame selected`);
+        this.settings.errors.add(FOLLOW_TF_PATH, NO_FRAME_SELECTED, `No coordinate frames found`);
         this.fixedFrameId = undefined;
         return;
       } else {
@@ -745,6 +763,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     const frame = this.transformTree.frame(this.renderFrameId);
     if (!frame) {
+      this.renderFrameId = undefined;
       this.fixedFrameId = undefined;
       this.settings.errors.add(
         FOLLOW_TF_PATH,

--- a/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Stats.tsx
@@ -5,7 +5,7 @@
 import { useEffect, useState } from "react";
 
 import { Renderer } from "./Renderer";
-import { useRenderer, useRendererEvent } from "./RendererContext";
+import { useRendererEvent } from "./RendererContext";
 
 let stats: THREEStats | undefined;
 let drawCallsPanel: Panel | undefined;
@@ -32,15 +32,8 @@ function update(renderer: Renderer) {
 
 export function Stats(): JSX.Element {
   const [div, setDiv] = useState<HTMLDivElement | ReactNull>(ReactNull);
-  const renderer = useRenderer();
 
-  useRendererEvent("startFrame", () => stats?.begin());
-  useRendererEvent("endFrame", () => {
-    stats?.end();
-    if (renderer) {
-      update(renderer);
-    }
-  });
+  useRendererEvent("endFrame", (_curTime, curRenderer) => update(curRenderer));
 
   useEffect(() => {
     if (!div) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -203,7 +203,7 @@ export class CoreSettings extends SceneExtension {
           draft.followTf = followTf;
         });
 
-        this.renderer.renderFrameId = followTf;
+        this.renderer.followFrameId = followTf;
       }
     } else if (category === "scene") {
       // Update the configuration

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
@@ -1,0 +1,82 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { Renderer } from "../../Renderer";
+import { MarkerType, Marker } from "../../ros";
+import { RenderableArrow } from "./RenderableArrow";
+import { RenderableCube } from "./RenderableCube";
+import { RenderableCubeList } from "./RenderableCubeList";
+import { RenderableCylinder } from "./RenderableCylinder";
+import { RenderableLineList } from "./RenderableLineList";
+import { RenderableLineStrip } from "./RenderableLineStrip";
+import { RenderableMarker } from "./RenderableMarker";
+import { RenderableMeshResource } from "./RenderableMeshResource";
+import { RenderablePoints } from "./RenderablePoints";
+import { RenderableSphereList } from "./RenderableSphereList";
+import { RenderableTextViewFacing } from "./RenderableTextViewFacing";
+import { RenderableTriangleList } from "./RenderableTriangleList";
+
+const CONSTRUCTORS = {
+  [MarkerType.ARROW]: RenderableArrow,
+  [MarkerType.CUBE]: RenderableCube,
+  [MarkerType.SPHERE]: RenderableMarker,
+  [MarkerType.CYLINDER]: RenderableCylinder,
+  [MarkerType.LINE_STRIP]: RenderableLineStrip,
+  [MarkerType.LINE_LIST]: RenderableLineList,
+  [MarkerType.CUBE_LIST]: RenderableCubeList,
+  [MarkerType.SPHERE_LIST]: RenderableSphereList,
+  [MarkerType.POINTS]: RenderablePoints,
+  [MarkerType.TEXT_VIEW_FACING]: RenderableTextViewFacing,
+  [MarkerType.MESH_RESOURCE]: RenderableMeshResource,
+  [MarkerType.TRIANGLE_LIST]: RenderableTriangleList,
+};
+
+/**
+ * An object pool for RenderableMarker subclass objects.
+ */
+export class MarkerPool {
+  private renderablesByType = new Map<MarkerType, RenderableMarker[]>();
+
+  constructor(private renderer: Renderer) {}
+
+  acquire<T extends MarkerType>(
+    type: T,
+    topic: string,
+    marker: Marker,
+    receiveTime: bigint | undefined,
+  ): RenderableMarker {
+    const renderables = this.renderablesByType.get(type);
+    if (renderables) {
+      const renderable = renderables.pop();
+      if (renderable) {
+        renderable.userData.settingsPath = ["topics", topic, marker.ns, String(marker.id)];
+        renderable.userData.settings = { visible: true, frameLocked: marker.frame_locked };
+        renderable.userData.topic = topic;
+        renderable.update(marker, receiveTime);
+        return renderable;
+      }
+    }
+    const renderable = new CONSTRUCTORS[type](topic, marker, receiveTime, this.renderer);
+    return renderable;
+  }
+
+  release(renderable: RenderableMarker): void {
+    const type = renderable.userData.marker.type as MarkerType;
+    const renderables = this.renderablesByType.get(type);
+    if (!renderables) {
+      this.renderablesByType.set(type, [renderable]);
+    } else {
+      renderables.push(renderable);
+    }
+  }
+
+  dispose(): void {
+    for (const renderables of this.renderablesByType.values()) {
+      for (const renderable of renderables) {
+        renderable.dispose();
+      }
+    }
+    this.renderablesByType.clear();
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
@@ -13,6 +13,7 @@ import { RenderableLineStrip } from "./RenderableLineStrip";
 import { RenderableMarker } from "./RenderableMarker";
 import { RenderableMeshResource } from "./RenderableMeshResource";
 import { RenderablePoints } from "./RenderablePoints";
+import { RenderableSphere } from "./RenderableSphere";
 import { RenderableSphereList } from "./RenderableSphereList";
 import { RenderableTextViewFacing } from "./RenderableTextViewFacing";
 import { RenderableTriangleList } from "./RenderableTriangleList";
@@ -20,7 +21,7 @@ import { RenderableTriangleList } from "./RenderableTriangleList";
 const CONSTRUCTORS = {
   [MarkerType.ARROW]: RenderableArrow,
   [MarkerType.CUBE]: RenderableCube,
-  [MarkerType.SPHERE]: RenderableMarker,
+  [MarkerType.SPHERE]: RenderableSphere,
   [MarkerType.CYLINDER]: RenderableCylinder,
   [MarkerType.LINE_STRIP]: RenderableLineStrip,
   [MarkerType.LINE_LIST]: RenderableLineList,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -11,8 +11,8 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 
 export class RenderableCube extends RenderableMarker {
-  private static geometry: THREE.BoxGeometry | undefined;
-  private static edgesGeometry: THREE.EdgesGeometry | undefined;
+  private static cubeGeometry: THREE.BoxGeometry | undefined;
+  private static cubeEdgesGeometry: THREE.EdgesGeometry | undefined;
 
   mesh: THREE.Mesh<THREE.BoxGeometry, THREE.MeshStandardMaterial>;
   outline: THREE.LineSegments | undefined;
@@ -55,18 +55,18 @@ export class RenderableCube extends RenderableMarker {
   }
 
   static Geometry(): THREE.BoxGeometry {
-    if (!RenderableCube.geometry) {
-      RenderableCube.geometry = new THREE.BoxGeometry(1, 1, 1);
-      RenderableCube.geometry.computeBoundingSphere();
+    if (!RenderableCube.cubeGeometry) {
+      RenderableCube.cubeGeometry = new THREE.BoxGeometry(1, 1, 1);
+      RenderableCube.cubeGeometry.computeBoundingSphere();
     }
-    return RenderableCube.geometry;
+    return RenderableCube.cubeGeometry;
   }
 
   static EdgesGeometry(): THREE.EdgesGeometry {
-    if (!RenderableCube.edgesGeometry) {
-      RenderableCube.edgesGeometry = new THREE.EdgesGeometry(RenderableCube.Geometry(), 40);
-      RenderableCube.edgesGeometry.computeBoundingSphere();
+    if (!RenderableCube.cubeEdgesGeometry) {
+      RenderableCube.cubeEdgesGeometry = new THREE.EdgesGeometry(RenderableCube.Geometry(), 40);
+      RenderableCube.cubeEdgesGeometry.computeBoundingSphere();
     }
-    return RenderableCube.edgesGeometry;
+    return RenderableCube.cubeEdgesGeometry;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -13,8 +13,8 @@ import { makeStandardMaterial } from "./materials";
 
 export class RenderableCylinder extends RenderableMarker {
   private static lod: DetailLevel | undefined;
-  private static geometry: THREE.CylinderGeometry | undefined;
-  private static edgesGeometry: THREE.EdgesGeometry | undefined;
+  private static cylinderGeometry: THREE.CylinderGeometry | undefined;
+  private static cylinderEdgesGeometry: THREE.EdgesGeometry | undefined;
 
   mesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
   outline: THREE.LineSegments | undefined;
@@ -60,22 +60,22 @@ export class RenderableCylinder extends RenderableMarker {
   }
 
   static Geometry(lod: DetailLevel): THREE.CylinderGeometry {
-    if (!RenderableCylinder.geometry || lod !== RenderableCylinder.lod) {
+    if (!RenderableCylinder.cylinderGeometry || lod !== RenderableCylinder.lod) {
       const subdivisions = cylinderSubdivisions(lod);
-      RenderableCylinder.geometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivisions);
-      RenderableCylinder.geometry.rotateX(Math.PI / 2); // Make the cylinder geometry stand upright
-      RenderableCylinder.geometry.computeBoundingSphere();
+      RenderableCylinder.cylinderGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivisions);
+      RenderableCylinder.cylinderGeometry.rotateX(Math.PI / 2); // Make the cylinder geometry stand upright
+      RenderableCylinder.cylinderGeometry.computeBoundingSphere();
       RenderableCylinder.lod = lod;
     }
-    return RenderableCylinder.geometry;
+    return RenderableCylinder.cylinderGeometry;
   }
 
   static EdgesGeometry(lod: DetailLevel): THREE.EdgesGeometry {
-    if (!RenderableCylinder.edgesGeometry) {
+    if (!RenderableCylinder.cylinderEdgesGeometry) {
       const geometry = RenderableCylinder.Geometry(lod);
-      RenderableCylinder.edgesGeometry = new THREE.EdgesGeometry(geometry, 40);
-      RenderableCylinder.edgesGeometry.computeBoundingSphere();
+      RenderableCylinder.cylinderEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
+      RenderableCylinder.cylinderEdgesGeometry.computeBoundingSphere();
     }
-    return RenderableCylinder.edgesGeometry;
+    return RenderableCylinder.cylinderEdgesGeometry;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -55,8 +55,9 @@ export class RenderableLineList extends RenderableMarker {
   }
 
   override update(marker: Marker, receiveTime: bigint | undefined): void {
-    if (marker.points.length % 2 !== 0) {
-      throw new Error(`LineList marker has odd number of points (${marker.points.length})`);
+    let pointsLength = marker.points.length;
+    if (pointsLength % 2 !== 0) {
+      pointsLength--;
     }
 
     const prevMarker = this.userData.marker;
@@ -77,17 +78,17 @@ export class RenderableLineList extends RenderableMarker {
     this.linePrepass.material.linewidth = lineWidth;
     this.line.material.linewidth = lineWidth;
 
-    this._setPositions(marker);
-    this._setColors(marker);
+    this._setPositions(marker, pointsLength);
+    this._setColors(marker, pointsLength);
 
     // These both update the same `LineSegmentsGeometry` reference, so no need to call both
     // this.linePrepass.computeLineDistances();
     this.line.computeLineDistances();
   }
 
-  private _setPositions(marker: Marker): void {
-    const linePositions = new Float32Array(3 * marker.points.length);
-    for (let i = 0; i < marker.points.length; i++) {
+  private _setPositions(marker: Marker, pointsLength: number): void {
+    const linePositions = new Float32Array(3 * pointsLength);
+    for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
       linePositions[i * 3 + 0] = point.x;
       linePositions[i * 3 + 1] = point.y;
@@ -97,10 +98,10 @@ export class RenderableLineList extends RenderableMarker {
     this.geometry.setPositions(linePositions);
   }
 
-  private _setColors(marker: Marker): void {
+  private _setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to a flattened typed array
-    const rgbaData = new Float32Array(4 * marker.points.length);
-    this._markerColorsToLinear(marker, (color, i) => {
+    const rgbaData = new Float32Array(4 * pointsLength);
+    this._markerColorsToLinear(marker, pointsLength, (color, i) => {
       rgbaData[4 * i + 0] = color[0];
       rgbaData[4 * i + 1] = color[1];
       rgbaData[4 * i + 2] = color[2];

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -72,16 +72,17 @@ export class RenderableLineStrip extends RenderableMarker {
     this.linePrepass.material.linewidth = lineWidth;
     this.line.material.linewidth = lineWidth;
 
-    this._setPositions(marker);
-    this._setColors(marker);
+    const pointsLength = marker.points.length;
+    this._setPositions(marker, pointsLength);
+    this._setColors(marker, pointsLength);
 
     this.linePrepass.computeLineDistances();
     this.line.computeLineDistances();
   }
 
-  private _setPositions(marker: Marker): void {
-    const linePositions = new Float32Array(3 * marker.points.length);
-    for (let i = 0; i < marker.points.length; i++) {
+  private _setPositions(marker: Marker, pointsLength: number): void {
+    const linePositions = new Float32Array(3 * pointsLength);
+    for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
       linePositions[i * 3 + 0] = point.x;
       linePositions[i * 3 + 1] = point.y;
@@ -91,11 +92,11 @@ export class RenderableLineStrip extends RenderableMarker {
     this.geometry.setPositions(linePositions);
   }
 
-  private _setColors(marker: Marker): void {
+  private _setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to pairs format in a flattened typed array
-    const rgbaData = new Float32Array(8 * marker.points.length);
+    const rgbaData = new Float32Array(8 * pointsLength);
     const color1: THREE.Vector4Tuple = [0, 0, 0, 0];
-    this._markerColorsToLinear(marker, (color2, ii) => {
+    this._markerColorsToLinear(marker, pointsLength, (color2, ii) => {
       if (ii === 0) {
         copyTuple4(color2, color1);
         return;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
@@ -59,12 +59,12 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
   // Convert sRGB values to linear
   protected _markerColorsToLinear(
     marker: Marker,
+    pointsLength: number,
     callback: (color: THREE.Vector4Tuple, i: number) => void,
   ): void {
     rgbToThreeColor(tempColor, marker.color);
 
-    const length = marker.points.length;
-    for (let i = 0; i < length; i++) {
+    for (let i = 0; i < pointsLength; i++) {
       const srgb = marker.colors[i];
       if (srgb) {
         // Per-point color

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
@@ -44,15 +44,16 @@ export class RenderablePoints extends RenderableMarker {
 
     this.points.material.size = marker.scale.x;
 
-    this.geometry.resize(marker.points.length);
-    this._setPositions(marker);
-    this._setColors(marker);
+    const pointsLength = marker.points.length;
+    this.geometry.resize(pointsLength);
+    this._setPositions(marker, pointsLength);
+    this._setColors(marker, pointsLength);
   }
 
-  private _setPositions(marker: Marker): void {
+  private _setPositions(marker: Marker, pointsLength: number): void {
     const attribute = this.geometry.getAttribute("position") as THREE.BufferAttribute;
     const positions = attribute.array as Float32Array;
-    for (let i = 0; i < marker.points.length; i++) {
+    for (let i = 0; i < pointsLength; i++) {
       const point = marker.points[i]!;
       positions[i * 3 + 0] = point.x;
       positions[i * 3 + 1] = point.y;
@@ -61,11 +62,11 @@ export class RenderablePoints extends RenderableMarker {
     attribute.needsUpdate = true;
   }
 
-  private _setColors(marker: Marker): void {
+  private _setColors(marker: Marker, pointsLength: number): void {
     // Converts color-per-point to a flattened typed array
     const attribute = this.geometry.getAttribute("color") as THREE.BufferAttribute;
     const rgbaData = attribute.array as Float32Array;
-    this._markerColorsToLinear(marker, (color, i) => {
+    this._markerColorsToLinear(marker, pointsLength, (color, i) => {
       rgbaData[4 * i + 0] = color[0];
       rgbaData[4 * i + 1] = color[1];
       rgbaData[4 * i + 2] = color[2];

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -13,7 +13,7 @@ import { makeStandardMaterial } from "./materials";
 
 export class RenderableSphere extends RenderableMarker {
   private static lod: DetailLevel | undefined;
-  private static geometry: THREE.SphereGeometry | undefined;
+  private static sphereGeometry: THREE.SphereGeometry | undefined;
 
   mesh: THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
 
@@ -51,12 +51,12 @@ export class RenderableSphere extends RenderableMarker {
   }
 
   static Geometry(lod: DetailLevel): THREE.SphereGeometry {
-    if (!RenderableSphere.geometry || lod !== RenderableSphere.lod) {
+    if (!RenderableSphere.sphereGeometry || lod !== RenderableSphere.lod) {
       const subdivisions = sphereSubdivisions(lod);
-      RenderableSphere.geometry = new THREE.SphereGeometry(0.5, subdivisions, subdivisions);
-      RenderableSphere.geometry.computeBoundingSphere();
+      RenderableSphere.sphereGeometry = new THREE.SphereGeometry(0.5, subdivisions, subdivisions);
+      RenderableSphere.sphereGeometry.computeBoundingSphere();
       RenderableSphere.lod = lod;
     }
-    return RenderableSphere.geometry;
+    return RenderableSphere.sphereGeometry;
   }
 }


### PR DESCRIPTION
**User-Facing Changes**

- Improved performance in `3D (Beta)` when marker IDs change frequently
- Autoselect a new rendering frame when switching between data sources in `3D (Beta)`

**Description**

Adds a MarkerPool class, accessible as `Renderer#markerPool` that reuses subclasses of `RenderableMarker` keyed by `MarkerType`. This avoids expensive dispose() + creation when marker IDs change frequently, and fixes a bug when a marker ID changes marker type.

Other misc fixes:

- Labels#dispose()
- Rename static members to avoid type collisions
- Fix <Stats> to not double-update
- Support iterating points[] with a different range than points.length
