### PR TITLE
Gracefully handle un-indexed mcap files with experimental player

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -40,6 +40,8 @@ async function tryCreateIndexedReader(readable: Mcap0Types.IReadable) {
   return reader;
 }
 
+async function* noopMessageIterator(): AsyncIterator<Readonly<IteratorResult>> {}
+
 export class McapIterableSource implements IIterableSource {
   private _source: McapSource;
   private _sourceImpl: IIterableSource | undefined;
@@ -76,7 +78,7 @@ export class McapIterableSource implements IIterableSource {
 
   messageIterator(opt: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>> {
     if (!this._sourceImpl) {
-      throw new Error("Invariant: uninitialized");
+      return noopMessageIterator();
     }
 
     return this._sourceImpl.messageIterator(opt);
@@ -84,7 +86,7 @@ export class McapIterableSource implements IIterableSource {
 
   async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
     if (!this._sourceImpl) {
-      throw new Error("Invariant: uninitialized");
+      return [];
     }
 
     return await this._sourceImpl.getBackfillMessages(args);

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -40,8 +40,6 @@ async function tryCreateIndexedReader(readable: Mcap0Types.IReadable) {
   return reader;
 }
 
-async function* noopMessageIterator(): AsyncIterator<Readonly<IteratorResult>> {}
-
 export class McapIterableSource implements IIterableSource {
   private _source: McapSource;
   private _sourceImpl: IIterableSource | undefined;
@@ -55,21 +53,7 @@ export class McapIterableSource implements IIterableSource {
     const readable = new FileReadable(source.file);
     const reader = await tryCreateIndexedReader(readable);
     if (!reader) {
-      return {
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 0, nsec: 0 },
-        topics: [],
-        datatypes: new Map(),
-        profile: undefined,
-        problems: [
-          {
-            severity: "error",
-            message: "The mcap file is unindexed. Only indexed files are supported.",
-          },
-        ],
-        publishersByTopic: new Map(),
-        topicStats: new Map(),
-      };
+      throw new Error("The mcap file is unindexed. Only indexed files are supported.");
     }
 
     this._sourceImpl = new McapIndexedIterableSource(reader);
@@ -78,7 +62,7 @@ export class McapIterableSource implements IIterableSource {
 
   messageIterator(opt: MessageIteratorArgs): AsyncIterator<Readonly<IteratorResult>> {
     if (!this._sourceImpl) {
-      return noopMessageIterator();
+      throw new Error("Invariant: uninitialized");
     }
 
     return this._sourceImpl.messageIterator(opt);
@@ -86,7 +70,7 @@ export class McapIterableSource implements IIterableSource {
 
   async getBackfillMessages(args: GetBackfillMessagesArgs): Promise<MessageEvent<unknown>[]> {
     if (!this._sourceImpl) {
-      return [];
+      throw new Error("Invariant: uninitialized");
     }
 
     return await this._sourceImpl.getBackfillMessages(args);


### PR DESCRIPTION

**User-Facing Changes**
Loading an un-indexed mcap file with the experimental player no longer shows an un-actionable "invariant" error.

**Description**
Rather than throwing an invariant error for un-indexed files, throw in initialize() which puts the IterablePlayer in an error state and avoids trying to read messages which triggered the invariant throws.

Fixes: #3730

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
