### PR TITLE
Unbreak JSON MCAP/ws support

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -75,9 +75,8 @@ export function parseChannel(channel: Channel): ParsedChannel {
         channel.schema.name,
       );
       datatypes = parsedDatatypes;
-      deserializer = (data) => {
+      deserializer = (data) =>
         postprocessValue(JSON.parse(textDecoder.decode(data)) as Record<string, unknown>);
-      };
     }
     return { fullSchemaName: channel.schema.name, deserializer, datatypes };
   }


### PR DESCRIPTION
Accidentally made a flyby "improvement" to the syntax in #3465 that
was actually behavioral.

Should really have tests for this....

**User-Facing Changes**

MCAP files using JSON encoding and foxglove websocket connectors using JSON will actually work again.

**Description**

In #3465, I incidentally added some braces in a spot that caused the JSON deserializer to no longer have a return value.

Don't have the bandwidth to write tests or add more explicit type checking for this right this instant, but should probably do so.