### PR TITLE
Use full size color input in settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -611,6 +611,19 @@ const FilterSettings: SettingsTreeNodes = {
   },
 };
 
+const ColorSettings: SettingsTreeNodes = {
+  colors: {
+    fields: {
+      hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
+      hex8: { label: "Hex 8", input: "rgb", value: "#ffaa0088" },
+      rgb: { label: "RGB", input: "rgb", value: "rgb(255, 128, 0)" },
+      rgba: { label: "RGBA", input: "rgba", value: "rgba(0, 128, 255, 0.5)" },
+      rgbaBlack: { label: "RGBA Black", input: "rgba", value: "rgba(0, 0, 0, 1)" },
+      rgbaWhite: { label: "RGBA White", input: "rgba", value: "rgba(255, 255, 255, 1)" },
+    },
+  },
+};
+
 function updateSettingsTreeNodes(
   previous: SettingsTreeNodes,
   path: readonly string[],
@@ -792,3 +805,7 @@ Filter.play = () => {
     fireEvent.change(node, { target: { value: "matcha" } });
   }
 };
+
+export function Colors(): JSX.Element {
+  return <Wrapper nodes={ColorSettings} />;
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -5,25 +5,31 @@
 import { ColorPicker } from "@fluentui/react";
 import { TextField, styled as muiStyled, Popover } from "@mui/material";
 import { useCallback, MouseEvent, useState } from "react";
+import { CSSProperties } from "styled-components";
 import tinycolor from "tinycolor2";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
-
-import { ColorSwatch } from "./ColorSwatch";
 
 const StyledTextField = muiStyled(TextField)({
   ".MuiInputBase-formControl.MuiInputBase-root": {
     padding: 0,
   },
   ".MuiInputBase-input": {
-    fontFamily: fonts.MONOSPACE,
     alignItems: "center",
+    color: "white",
+    cursor: "pointer",
+    fontFamily: fonts.MONOSPACE,
+    mixBlendMode: "difference",
   },
 });
 
-const Root = muiStyled("div", { shouldForwardProp: (prop) => prop !== "disabled" })<{
+const Root = muiStyled("div", {
+  shouldForwardProp: (prop) => prop !== "backgroundColor" && prop !== "disabled",
+})<{
+  backgroundColor: CSSProperties["backgroundColor"];
   disabled: boolean;
-}>(({ disabled }) => ({
+}>(({ backgroundColor, disabled }) => ({
+  backgroundColor,
   position: "relative",
   pointerEvents: disabled ? "none" : "auto",
 }));
@@ -34,12 +40,11 @@ type ColorPickerInputProps = {
   value: undefined | string;
   onChange: (value: undefined | string) => void;
   placeholder?: string;
-  swatchOrientation?: "start" | "end";
   readOnly?: boolean;
 };
 
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
-  const { disabled, onChange, readOnly, swatchOrientation = "start", value } = props;
+  const { disabled, onChange, readOnly, value } = props;
 
   const [anchorElement, setAnchorElement] = useState<undefined | HTMLDivElement>(undefined);
 
@@ -57,7 +62,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const swatchColor = isValidColor ? tinycolor(value).toHex8String() : "#00000044";
 
   return (
-    <Root disabled={disabled === true || readOnly === true}>
+    <Root backgroundColor={swatchColor} disabled={disabled === true || readOnly === true}>
       <StyledTextField
         fullWidth
         disabled={disabled}
@@ -66,14 +71,9 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
         size="small"
         value={value ?? ""}
         variant="filled"
+        onClick={handleClick}
         InputProps={{
-          readOnly,
-          startAdornment: swatchOrientation === "start" && (
-            <ColorSwatch color={swatchColor} onClick={handleClick} />
-          ),
-          endAdornment: swatchOrientation === "end" && (
-            <ColorSwatch color={swatchColor} onClick={handleClick} />
-          ),
+          readOnly: true,
         }}
       />
       <Popover


### PR DESCRIPTION
**User-Facing Changes**
This improves the color input in the settings editor.

**Description**
This fills the entire background of the color field with the selected color and requires the user to open the color picker to manually enter a value. 

This has a few benefits:

1. `rgba` values are no longer clipped.
2. We no longer have the problem of handing text input in arbitrary format.s
3. The chosen color is more visible than it is in the small swatch we have now.
4. The resulting input looks more like the gradient input.

<img width="491" alt="Screen Shot 2022-06-30 at 11 34 08 AM" src="https://user-images.githubusercontent.com/93935560/176747632-ef986372-651a-47cd-9012-eaaccaa93eac.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3684 