### PR TITLE
Fix erroreneous "&:" causing body background to have hover state

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -195,7 +195,7 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: theme.semanticColors.bodyBackground,
       color: theme.semanticColors.disabledBodyText,
 
-      "&:hover": {
+      ":hover": {
         backgroundColor: theme.semanticColors.bodyBackgroundHovered,
       },
     },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Removes body background hover state introduced in #3650 

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
