### PR TITLE
Distinguish between un-indexed and empty mcap files

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -25,9 +25,9 @@ async function tryCreateIndexedReader(readable: Mcap0Types.IReadable) {
 
   if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0) {
     if (reader.summaryOffsetsByOpcode.size > 0) {
-      throw new Error("The mcap file is empty or has an incomplete summary section.");
+      throw new Error("The MCAP file is empty or has an incomplete summary section.");
     } else {
-      throw new Error("The mcap file is unindexed. Only indexed files are supported.");
+      throw new Error("The MCAP file is unindexed. Only indexed files are supported.");
     }
   }
   return reader;

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -4,7 +4,6 @@
 
 import { Mcap0IndexedReader, Mcap0Types } from "@mcap/core";
 
-import Logger from "@foxglove/log";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
 import { FileReadable } from "@foxglove/studio-base/players/IterablePlayer/Mcap/FileReadable";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
@@ -18,24 +17,18 @@ import {
 } from "../IIterableSource";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
 
-const log = Logger.getLogger(__filename);
-
 type McapSource = { type: "file"; file: File };
 
 async function tryCreateIndexedReader(readable: Mcap0Types.IReadable) {
   const decompressHandlers = await loadDecompressHandlers();
   const reader = await Mcap0IndexedReader.Initialize({ readable, decompressHandlers });
 
-  let hasMissingSchemas = false;
-  for (const channel of reader.channelsById.values()) {
-    if (channel.schemaId !== 0 && !reader.schemasById.has(channel.schemaId)) {
-      hasMissingSchemas = true;
-      break;
+  if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0) {
+    if (reader.summaryOffsetsByOpcode.size > 0) {
+      throw new Error("The mcap file is empty or has an incomplete summary section.");
+    } else {
+      throw new Error("The mcap file is unindexed. Only indexed files are supported.");
     }
-  }
-  if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0 || hasMissingSchemas) {
-    log.info("Summary does not contain chunk indexes, schemas, and channels");
-    return undefined;
   }
   return reader;
 }
@@ -52,9 +45,6 @@ export class McapIterableSource implements IIterableSource {
     const source = this._source;
     const readable = new FileReadable(source.file);
     const reader = await tryCreateIndexedReader(readable);
-    if (!reader) {
-      throw new Error("The mcap file is unindexed. Only indexed files are supported.");
-    }
 
     this._sourceImpl = new McapIndexedIterableSource(reader);
     return await this._sourceImpl.initialize();


### PR DESCRIPTION

**User-Facing Changes**
Users of the experimental mcap player are given a more detailed error message if their mcap file cannot be opened with the indexed reader.

**Description**
Mcap files may have summary records but be missing chunkindex records (as a result of not having any messages). We distinguish between files with no summary information and those that might have some summary information but are missing the summary information we need.

Fixes: #3731

----
I'm open to other suggestion in the language here. A more robust check would be for the Mcap0IndexedReader to report from `Initialize()` on whether it will make an attempt at reading the file (i.e. whether initialize succeeds) rather than the caller of Initialize having to guess at the failure modes since those are internal to the reader.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
