### PR TITLE
Add BGRA8 support for Image Panel

### DIFF
--- a/packages/studio-base/src/panels/Image/lib/decodings.ts
+++ b/packages/studio-base/src/panels/Image/lib/decodings.ts
@@ -88,6 +88,28 @@ export function decodeRGBA8(
   }
 }
 
+export function decodeBGRA8(
+  rgba: Uint8Array,
+  width: number,
+  height: number,
+  output: Uint8ClampedArray,
+): void {
+  let inIdx = 0;
+  let outIdx = 0;
+
+  for (let i = 0; i < width * height; i++) {
+    const b = rgba[inIdx++]!;
+    const g = rgba[inIdx++]!;
+    const r = rgba[inIdx++]!;
+    const a = rgba[inIdx++]!;
+
+    output[outIdx++] = r;
+    output[outIdx++] = g;
+    output[outIdx++] = b;
+    output[outIdx++] = a;
+  }
+}
+
 export function decodeBGR8(
   bgr: Uint8Array,
   width: number,

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -34,6 +34,7 @@ import {
   decodeYUV,
   decodeRGB8,
   decodeRGBA8,
+  decodeBGRA8,
   decodeBGR8,
   decodeFloat1c,
   decodeBayerRGGB8,
@@ -142,6 +143,9 @@ function decodeMessageToBitmap(
           break;
         case "rgba8":
           decodeRGBA8(rawData, width, height, image.data);
+          break;
+        case "bgra8":
+          decodeBGRA8(rawData, width, height, image.data);
           break;
         case "bgr8":
         case "8UC3":


### PR DESCRIPTION
**User-Facing Changes**
Added support for images with `bgra8` format in the Image panel.

**Description**
Adresses the part of #1273, which #3536 has not adressed.
