### PR TITLE
Show one time dialog informing users that settings have migrated to the sidebar

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -34,4 +34,6 @@ export enum AppSetting {
   // Dev only
   ENABLE_LAYOUT_DEBUGGING = "enableLayoutDebugging",
   ENABLE_REACT_STRICT_MODE = "enableReactStrictMode",
+
+  SETTINGS_CHANGE_DIALOG_SHOWN = "settings.changeDialogShown",
 }

--- a/packages/studio-base/src/components/SettingsChangeNotificationDialog.tsx
+++ b/packages/studio-base/src/components/SettingsChangeNotificationDialog.tsx
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import CloseIcon from "@mui/icons-material/Close";
+import SettingsIcon from "@mui/icons-material/Settings";
+import {
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  styled as muiStyled,
+  useTheme,
+} from "@mui/material";
+import { useCallback, useState } from "react";
+import { useLocalStorage } from "react-use";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import Stack from "@foxglove/studio-base/components/Stack";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+const STORAGE_KEY = "studio.app-configuration.settings-change-update-shown";
+
+const Root = muiStyled("div")(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  maxWidth: "30rem",
+  position: "absolute",
+  top: "50%",
+  right: "50%",
+  transform: "translate(50%, -50%)",
+  zIndex: 1_000,
+}));
+
+export function SettingsChangeNotificationDialog({
+  panelType,
+}: {
+  panelType: string;
+}): ReactNull | JSX.Element {
+  // We can't use useAppConfigurationValue here because we're not in the context.
+  const [dialogShown, setDialogShown, _removeDialogShown] = useLocalStorage(
+    [STORAGE_KEY, panelType].join("."),
+    false,
+  );
+  const [colorScheme] = useLocalStorage(`studio.app-configuration.${AppSetting.COLOR_SCHEME}`);
+
+  const theme = useTheme();
+
+  const [_, setOpen] = useState(dialogShown !== true);
+
+  const handleClose = useCallback(() => {
+    setDialogShown(true);
+    setOpen(false);
+  }, [setDialogShown]);
+
+  if (dialogShown === true) {
+    return ReactNull;
+  }
+
+  return (
+    <ThemeProvider isDark={colorScheme === colorScheme}>
+      <Root>
+        <Stack
+          alignItems="center"
+          direction="row"
+          fullWidth
+          style={{ backgroundColor: theme.palette.background.default }}
+        >
+          <DialogTitle style={{ flex: 1, color: theme.palette.text.primary }}>
+            Things have changed
+          </DialogTitle>
+          <IconButton onClick={handleClose} color="primary">
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+        <DialogContent
+          style={{ backgroundColor: theme.palette.background.paper, padding: theme.spacing(2) }}
+        >
+          <DialogContentText>
+            <div>Many panel settings are now available in the settings sidebar.</div>
+            <div>
+              To open the sidebar click the settings cog icon{" "}
+              <SettingsIcon fontSize="small" style={{ marginBottom: -3 }} /> in the toolbar on the
+              upper right: ; of thw panel.
+            </div>
+          </DialogContentText>
+        </DialogContent>
+      </Root>
+    </ThemeProvider>
+  );
+}

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -26,6 +26,7 @@ import {
   PanelContextMenuItem,
 } from "@foxglove/studio-base/components/PanelContextMenu";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import { SettingsChangeNotificationDialog } from "@foxglove/studio-base/components/SettingsChangeNotificationDialog";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
@@ -306,6 +307,7 @@ function ImageView(props: Props) {
         )}
       </Stack>
       <Toolbar pixelData={activePixelData} />
+      <SettingsChangeNotificationDialog panelType="ImagePanel" />
     </Stack>
   );
 }

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -19,6 +19,7 @@ import { useDebouncedCallback } from "use-debounce";
 
 import { toSec } from "@foxglove/rostime";
 import { PanelExtensionContext, MessageEvent, SettingsTreeAction } from "@foxglove/studio";
+import { SettingsChangeNotificationDialog } from "@foxglove/studio-base/components/SettingsChangeNotificationDialog";
 import Stack from "@foxglove/studio-base/components/Stack";
 import FilteredPointLayer, {
   POINT_MARKER_RADIUS,
@@ -606,6 +607,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
           visibility: center ? "visible" : "hidden",
         }}
       />
+      <SettingsChangeNotificationDialog panelType="MapPanel" />
     </Stack>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -26,6 +26,7 @@ import {
   SettingsTreeNodes,
   Topic,
 } from "@foxglove/studio";
+import { SettingsChangeNotificationDialog } from "@foxglove/studio-base/components/SettingsChangeNotificationDialog";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
@@ -441,6 +442,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
           <RendererOverlay addPanel={addPanel} enableStats={config.scene.enableStats ?? false} />
         </RendererContext.Provider>
       </div>
+      <SettingsChangeNotificationDialog panelType="New3D" />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
This lets users know that some settings that were previously managed in the panel have moved to the new settings sidebar. 

**Description**
For now this is shown only once and only for the map, image and new 3d panel.

<img width="437" alt="Screen Shot 2022-07-06 at 2 34 37 PM" src="https://user-images.githubusercontent.com/93935560/177629048-30d9e539-1893-4f61-a90a-f45bc974e73a.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
