### PR TITLE
Show one time tooltip informing users that settings have migrated to the sidebar

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,11 @@ module.exports = {
   core: {
     builder: "webpack5",
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  env: (config: any) => ({
+    ...config,
+    STORYBOOK_MODE: true,
+  }),
 
   // Carefully merge our main webpack config with the Storybook default config.
   // For the most part, our webpack config has already been designed to handle

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -30,6 +30,7 @@ export enum AppSetting {
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",
   LAUNCH_PREFERENCE = "launchPreference",
   SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
+  SHOWN_PANEL_CHANGE_WARNINGS = "ui.shown-panel-change-warnings",
 
   // Dev only
   ENABLE_LAYOUT_DEBUGGING = "enableLayoutDebugging",

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -14,7 +14,8 @@
 import SettingsIcon from "@mui/icons-material/Settings";
 import { useCallback, useContext } from "react";
 
-import PanelContext from "@foxglove/studio-base/components/PanelContext";
+import PanelContext, { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
+import SettingsChangeCallout from "@foxglove/studio-base/components/PanelToolbar/SettingsChangeCallout";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
@@ -42,7 +43,9 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   menuOpen,
   setMenuOpen,
 }: PanelToolbarControlsProps) {
+  const { title } = usePanelContext();
   const panelId = useContext(PanelContext)?.id;
+
   const { setSelectedPanelIds } = useSelectedPanels();
   const { openPanelSettings } = useWorkspace();
 
@@ -61,13 +64,18 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
     }
   }, [setSelectedPanelIds, openPanelSettings, panelId]);
 
+  const settingsHaveRecentlyChanged =
+    title === "3D" || title === "Image" || title === "Map" || title === "URDF Viewer";
+
   return (
     <Stack direction="row" alignItems="center" paddingLeft={1}>
       {additionalIcons}
       {hasSettings && (
-        <ToolbarIconButton title="Settings" onClick={openSettings}>
-          <SettingsIcon />
-        </ToolbarIconButton>
+        <SettingsChangeCallout disabled={!settingsHaveRecentlyChanged}>
+          <ToolbarIconButton title="Settings" onClick={openSettings}>
+            <SettingsIcon />
+          </ToolbarIconButton>
+        </SettingsChangeCallout>
       )}
       <PanelActionsDropdown
         isOpen={menuOpen}

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import SettingsIcon from "@mui/icons-material/Settings";
+import { difference } from "lodash";
 import { useCallback, useContext } from "react";
 import { useLocalStorage } from "react-use";
 
@@ -72,11 +73,12 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
     }
   }, [setSelectedPanelIds, openPanelSettings, panelId]);
 
-  const showRecentChangesTooltip =
-    panelType != undefined &&
-    PanelTypesForChangeWarnings.includes(panelType) &&
-    shownChangeWarnings != undefined &&
-    shownChangeWarnings[panelType] == undefined;
+  const unshownCallouts = difference(
+    PanelTypesForChangeWarnings,
+    Object.keys(shownChangeWarnings ?? {}),
+  );
+
+  const showRecentChangesTooltip = panelType === unshownCallouts[0];
 
   const dismissTooltip = useCallback(() => {
     if (panelType) {

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -78,7 +78,8 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
     Object.keys(shownChangeWarnings ?? {}),
   );
 
-  const showRecentChangesTooltip = panelType === unshownCallouts[0];
+  const showRecentChangesTooltip =
+    panelType === unshownCallouts[0] && process.env.STORYBOOK_MODE == undefined;
 
   const dismissTooltip = useCallback(() => {
     if (panelType) {

--- a/packages/studio-base/src/components/PanelToolbar/SettingsChangeCallout.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/SettingsChangeCallout.tsx
@@ -3,16 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Button, Tooltip, Typography } from "@mui/material";
-import { useState } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 
 export default function SettingsChangeCallout(props: {
   disabled?: boolean;
   children: JSX.Element;
+  dismiss: () => void;
 }): JSX.Element {
-  const { children, disabled = false } = props;
-  const [open, setOpen] = useState<boolean>(!disabled);
+  const { children, disabled = false, dismiss } = props;
 
   if (disabled) {
     return children;
@@ -21,7 +20,7 @@ export default function SettingsChangeCallout(props: {
   return (
     <Tooltip
       arrow
-      open={open}
+      open
       title={
         <div>
           <Stack padding={0.5} gap={0.5}>
@@ -33,7 +32,7 @@ export default function SettingsChangeCallout(props: {
               open the settings sidebar.
             </Typography>
             <Stack direction="row" justifyContent="flex-end" paddingBottom={0.5}>
-              <Button onClick={() => setOpen(false)} size="small" color="info">
+              <Button onClick={dismiss} size="small" color="info">
                 Dismiss
               </Button>
             </Stack>

--- a/packages/studio-base/src/components/PanelToolbar/SettingsChangeCallout.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/SettingsChangeCallout.tsx
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Button, Tooltip, Typography } from "@mui/material";
+import { useState } from "react";
+
+import Stack from "@foxglove/studio-base/components/Stack";
+
+export default function SettingsChangeCallout(props: {
+  disabled?: boolean;
+  children: JSX.Element;
+}): JSX.Element {
+  const { children, disabled = false } = props;
+  const [open, setOpen] = useState<boolean>(!disabled);
+
+  if (disabled) {
+    return children;
+  }
+
+  return (
+    <Tooltip
+      arrow
+      open={open}
+      title={
+        <div>
+          <Stack padding={0.5} gap={0.5}>
+            <Typography variant="body2" color="info.main" fontWeight={600}>
+              We’re making some changes to Panel Settings
+            </Typography>
+            <Typography variant="body2">
+              More panel settings are now available in the settings sidebar. Click the cog icon to
+              open the settings sidebar.
+            </Typography>
+            <Stack direction="row" justifyContent="flex-end" paddingBottom={0.5}>
+              <Button onClick={() => setOpen(false)} size="small" color="info">
+                Dismiss
+              </Button>
+            </Stack>
+          </Stack>
+        </div>
+      }
+    >
+      <div>{children}</div>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
<img width="469" alt="Screen Shot 2022-07-07 at 10 33 00 am" src="https://user-images.githubusercontent.com/924528/177665001-68d8a5ac-02a9-48f8-8333-0a6d715ffc09.png">

**Description**
Show users that things have changed recently on Map, Image, 3D and URDF panel settings.

Fixes https://github.com/foxglove/studio/issues/3676

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
