### PR TITLE
Scope global styles to the #root container

### DIFF
--- a/packages/studio-base/src/components/GlobalCss.tsx
+++ b/packages/studio-base/src/components/GlobalCss.tsx
@@ -6,20 +6,9 @@ import { createGlobalStyle } from "styled-components";
 
 /** GlobalCss component configures html, body, and #root with theme elements */
 const GlobalCss = createGlobalStyle`
-html, body {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  width: 100%;
-
-  // https://github.com/necolas/normalize.css/blob/master/normalize.css#L12
+#root {
   line-height: 1.15;
-}
-*, *:before, *:after {
-  box-sizing: inherit;
-}
-body {
+  box-sizing: border-box;
   background: ${({ theme }) => theme.semanticColors.bodyBackground};
   color: ${({ theme }) => theme.semanticColors.bodyText};
   font: inherit;
@@ -32,8 +21,7 @@ body {
   // scrollable elements to be scrolled without the whole page moving (even if they don't
   // preventDefault on scroll events).
   overscroll-behavior: none;
-}
-#root {
+
   height: 100%;
   width: 100%;
   display: flex;
@@ -43,6 +31,9 @@ body {
   outline: none;
   overflow: hidden;
   z-index: 0;
+}
+#root *, #root *:before, #root *:after {
+  box-sizing: inherit;
 }
 `;
 

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -117,6 +117,12 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
       <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
       <title>Foxglove Studio</title>
     </head>
+    <style>
+      html, body {
+        margin: 0;
+        height: 100%;
+      }
+    </style>
     <script>
       global = globalThis;
     </script>


### PR DESCRIPTION
**User-Facing Changes**

None

**Description**

Scopes the global styles to the #root container so embedding Studio within another app doesn't affect things outside its parent node.