### PR TITLE
Fix map panel settings field order

### DIFF
--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -56,12 +56,6 @@ export function buildSettingsTree(config: Config, eligibleTopics: string[]): Set
         { label: "Custom", value: "custom" },
       ],
     },
-    followTopic: {
-      label: "Follow topic",
-      input: "select",
-      value: config.followTopic,
-      options: followTopicOptions,
-    },
   };
 
   // Only show the custom url input when the user selects the custom layer
@@ -78,6 +72,13 @@ export function buildSettingsTree(config: Config, eligibleTopics: string[]): Set
       error,
     };
   }
+
+  generalSettings.followTopic = {
+    label: "Follow topic",
+    input: "select",
+    value: config.followTopic,
+    options: followTopicOptions,
+  };
 
   const settings: SettingsTreeNodes = {
     general: {

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -78,7 +78,10 @@ export default {
   decorators: [
     (StoryComponent: Story, { parameters }: StoryContext): JSX.Element => {
       return (
-        <PanelSetup fixture={parameters.panelSetup?.fixture}>
+        <PanelSetup
+          fixture={parameters.panelSetup?.fixture}
+          includeSettings={parameters.includeSettings}
+        >
           <StoryComponent />
         </PanelSetup>
       );
@@ -98,6 +101,31 @@ SinglePoint.parameters = {
   chromatic: {
     delay: 1000,
   },
+  panelSetup: {
+    fixture: {
+      topics: [{ name: "/gps", datatype: "sensor_msgs/NavSatFix" }],
+      frame: {
+        "/gps": [
+          {
+            topic: "/gps",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: EMPTY_MESSAGE,
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const SinglePointWithSettings = (): JSX.Element => {
+  return <MapPanel overrideConfig={{ layer: "custom" }} />;
+};
+
+SinglePointWithSettings.parameters = {
+  chromatic: {
+    delay: 1000,
+  },
+  includeSettings: true,
   panelSetup: {
     fixture: {
       topics: [{ name: "/gps", datatype: "sensor_msgs/NavSatFix" }],


### PR DESCRIPTION
**User-Facing Changes**
This fixes the order of settings fields for the map panel so that the custom tile url follows the tile layer selector.

**Description**
It also adds a story to render the map panel with settings open.

<img width="397" alt="Screen Shot 2022-07-07 at 1 39 33 PM" src="https://user-images.githubusercontent.com/93935560/177845641-8e9ebce0-360b-4247-ab36-551603e09a68.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3673 