### PR TITLE
Abort panel drag within a tab with no destination

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.ts
@@ -692,6 +692,11 @@ const endDrag = (panelsState: PanelsState, dragPayload: EndDragPayload): PanelsS
     return config ? { id, config } : undefined;
   });
 
+  // If dragging within the same tab without position & destination just cancel the drag.
+  if (withinSameTab && position == undefined && destinationPath == undefined) {
+    return { ...panelsState, layout: originalLayout, configById: originalSavedProps };
+  }
+
   if (withinSameTab && sourceTabConfig && position != undefined && destinationPath != undefined) {
     return dragWithinSameTab(panelsState, {
       originalLayout,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with dragging panels within a tab.

**Description**
The fix here is to check if we're dragging within the same tab. If so and we have no position or destination for the drag we simply abort the drop.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3631