### PR TITLE
Make GlobalCss usable outside of <App>

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -5,25 +5,26 @@
 import { useMemo, useEffect, useState } from "react";
 
 import {
-  IDataSourceFactory,
-  Ros1LocalBagDataSourceFactory,
-  Ros2LocalBagDataSourceFactory,
-  RosbridgeDataSourceFactory,
-  VelodyneDataSourceFactory,
-  Ros1RemoteBagDataSourceFactory,
-  Ros1SocketDataSourceFactory,
-  Ros2SocketDataSourceFactory,
+  App,
+  AppSetting,
+  ConsoleApi,
   FoxgloveDataPlatformDataSourceFactory,
   FoxgloveWebSocketDataSourceFactory,
-  UlogLocalDataSourceFactory,
-  McapLocalDataSourceFactory,
-  SampleNuscenesDataSourceFactory,
-  McapRemoteDataSourceFactory,
+  GlobalCss,
   IAppConfiguration,
-  AppSetting,
-  App,
-  ConsoleApi,
+  IDataSourceFactory,
   IdbExtensionLoader,
+  McapLocalDataSourceFactory,
+  McapRemoteDataSourceFactory,
+  Ros1LocalBagDataSourceFactory,
+  Ros1RemoteBagDataSourceFactory,
+  Ros1SocketDataSourceFactory,
+  Ros2LocalBagDataSourceFactory,
+  Ros2SocketDataSourceFactory,
+  RosbridgeDataSourceFactory,
+  SampleNuscenesDataSourceFactory,
+  UlogLocalDataSourceFactory,
+  VelodyneDataSourceFactory,
 } from "@foxglove/studio-base";
 
 import { Desktop, NativeMenuBridge, Storage } from "../common/types";
@@ -97,16 +98,19 @@ export default function Root({
   });
 
   return (
-    <App
-      enableDialogAuth
-      deepLinks={deepLinks}
-      dataSources={dataSources}
-      appConfiguration={appConfiguration}
-      consoleApi={consoleApi}
-      layoutStorage={layoutStorage}
-      extensionLoaders={extensionLoaders}
-      nativeAppMenu={nativeAppMenu}
-      nativeWindow={nativeWindow}
-    />
+    <>
+      <GlobalCss />
+      <App
+        enableDialogAuth
+        deepLinks={deepLinks}
+        dataSources={dataSources}
+        appConfiguration={appConfiguration}
+        consoleApi={consoleApi}
+        layoutStorage={layoutStorage}
+        extensionLoaders={extensionLoaders}
+        nativeAppMenu={nativeAppMenu}
+        nativeWindow={nativeWindow}
+      />
+    </>
   );
 }

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -15,7 +15,6 @@ import { ColorSchemeThemeProvider } from "./components/ColorSchemeThemeProvider"
 import CssBaseline from "./components/CssBaseline";
 import DocumentTitleAdapter from "./components/DocumentTitleAdapter";
 import ErrorBoundary from "./components/ErrorBoundary";
-import GlobalCss from "./components/GlobalCss";
 import MultiProvider from "./components/MultiProvider";
 import PlayerManager from "./components/PlayerManager";
 import SendNotificationToastAdapter from "./components/SendNotificationToastAdapter";
@@ -134,7 +133,6 @@ export function App(props: AppProps): JSX.Element {
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>
       <ColorSchemeThemeProvider>
-        <GlobalCss />
         <CssBaseline>
           <ErrorBoundary>
             <MaybeLaunchPreference>

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -13,6 +13,38 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 const useStyles = makeStyles()(({ palette, typography }) => ({
   root: {
+    // container styling
+    height: "100%",
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    position: "relative",
+    flex: "1 1 100%",
+    overflow: "hidden",
+    background: palette.background.default,
+    color: palette.text.primary,
+    font: "inherit",
+    fontSize: typography.body2.fontSize,
+    fontFeatureSettings: fonts.SANS_SERIF_FEATURE_SETTINGS,
+    fontFamily: typography.body2.fontFamily,
+    fontWeight: typography.body2.fontWeight,
+    zIndex: 0,
+    boxSizing: "border-box",
+
+    // Prevent scroll "bouncing" since the app workspace is not scrollable. Allows individual
+    // scrollable elements to be scrolled without the whole page moving (even if they don't
+    // preventDefault on scroll events).
+    overscrollBehavior: "none",
+
+    // https://github.com/necolas/normalize.css/blob/master/normalize.css#L12
+    lineHeight: 1.15,
+
+    /// --- child and element styling follows ---
+
+    "*, *:before, *:after": {
+      boxSizing: "inherit",
+    },
+
     "code, pre, tt": {
       fontFamily: fonts.MONOSPACE,
       overflowWrap: "break-word",
@@ -46,20 +78,6 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     canvas: {
       outline: "none",
     },
-
-    // container styling
-    height: "100%",
-    width: "100%",
-    display: "flex",
-    flexDirection: "column",
-    position: "relative",
-    flex: "1 1 100%",
-    overflow: "hidden",
-    background: palette.background.default,
-    color: palette.text.primary,
-    font: "inherit",
-    fontSize: typography.body2.fontSize,
-    fontFeatureSettings: fonts.SANS_SERIF_FEATURE_SETTINGS,
 
     // mosaic styling
     ".mosaic": {

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -29,7 +29,6 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     fontFamily: typography.body2.fontFamily,
     fontWeight: typography.body2.fontWeight,
     zIndex: 0,
-    boxSizing: "border-box",
 
     // Prevent scroll "bouncing" since the app workspace is not scrollable. Allows individual
     // scrollable elements to be scrolled without the whole page moving (even if they don't
@@ -40,11 +39,6 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     lineHeight: 1.15,
 
     /// --- child and element styling follows ---
-
-    "*, *:before, *:after": {
-      boxSizing: "inherit",
-    },
-
     "code, pre, tt": {
       fontFamily: fonts.MONOSPACE,
       overflowWrap: "break-word",

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -33,6 +33,7 @@ export { IdbExtensionLoader } from "./services/IdbExtensionLoader";
 export type { ExtensionLoader } from "./services/ExtensionLoader";
 export type { ExtensionInfo, ExtensionNamespace } from "./types/Extensions";
 export { AppSetting } from "./AppSetting";
+export { default as GlobalCss } from "./components/GlobalCss";
 export { default as FoxgloveDataPlatformDataSourceFactory } from "./dataSources/FoxgloveDataPlatformDataSourceFactory";
 export { default as FoxgloveWebSocketDataSourceFactory } from "./dataSources/FoxgloveWebSocketDataSourceFactory";
 export { default as Ros1LocalBagDataSourceFactory } from "./dataSources/Ros1LocalBagDataSourceFactory";

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -20,6 +20,7 @@ import {
   McapRemoteDataSourceFactory,
   App,
   ConsoleApi,
+  GlobalCss,
 } from "@foxglove/studio-base";
 
 import Ros1UnavailableDataSourceFactory from "./dataSources/Ros1UnavailableDataSourceFactory";
@@ -63,16 +64,19 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
   const disableSignin = process.env.FOXGLOVE_DISABLE_SIGN_IN != undefined;
 
   return (
-    <App
-      disableSignin={disableSignin}
-      enableDialogAuth={enableDialogAuth}
-      enableLaunchPreferenceScreen
-      deepLinks={[window.location.href]}
-      dataSources={dataSources}
-      appConfiguration={appConfiguration}
-      layoutStorage={layoutStorage}
-      consoleApi={consoleApi}
-      extensionLoaders={extensionLoaders}
-    />
+    <>
+      <GlobalCss />
+      <App
+        disableSignin={disableSignin}
+        enableDialogAuth={enableDialogAuth}
+        enableLaunchPreferenceScreen
+        deepLinks={[window.location.href]}
+        dataSources={dataSources}
+        appConfiguration={appConfiguration}
+        layoutStorage={layoutStorage}
+        consoleApi={consoleApi}
+        extensionLoaders={extensionLoaders}
+      />
+    </>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Using `<App>` from `@foxglove/studio-base` no longer takes over your html and body styling.

**Description**
The styling for the `<App>` component is now fully scoped to the container the app runs in. The `<GlobalCss>` component is removed from App and applied within `desktop` and `web` respectively to remove some padding and apply fallback colors and fonts for the body - tho these are not strictly necessary.

We are able to do this now that fluentui is removed from our UI. MUI properly places context menu and tooltip elements within the component tree of our <App> and those elements receive the correct styling.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
