### PR TITLE
Add warning to ros2 native connection option

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { ActionButton, useTheme } from "@fluentui/react";
-import { Link, Typography } from "@mui/material";
+import { Alert, Link, Typography } from "@mui/material";
 import { useState, useMemo, useCallback, useLayoutEffect } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -98,6 +98,8 @@ export default function Connection(props: ConnectionProps): JSX.Element {
           })}
         </Stack>
         <Stack key={selectedSource?.id} flex="1 0 240px" gap={2}>
+          {selectedSource?.warning && <Alert severity="warning">{selectedSource.warning}</Alert>}
+
           {selectedSource?.description && (
             <Typography color="text.secondary">{selectedSource.description}</Typography>
           )}

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -46,6 +46,7 @@ export interface IDataSourceFactory {
   disabledReason?: string | JSX.Element;
   badgeText?: string;
   hidden?: boolean;
+  warning?: string;
 
   sampleLayout?: PanelsState;
 

--- a/packages/studio-base/src/dataSources/Ros2SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2SocketDataSourceFactory.tsx
@@ -17,6 +17,8 @@ class Ros2SocketDataSourceFactory implements IDataSourceFactory {
   description =
     "Connect to a running ROS 2 system via a native TCP connection that accesses your ROS nodes directly.";
   docsLink = "https://foxglove.dev/docs/studio/connection/native";
+  warning =
+    "Limitations of ROS 2 prevent Studio from having access to your custom messages. We recommend using the Rosbridge connection for a better experience.";
 
   formConfig = {
     fields: [


### PR DESCRIPTION
**User-Facing Changes**
<img width="836" alt="Screen Shot 2022-07-11 at 8 22 07 AM" src="https://user-images.githubusercontent.com/84792/178301170-6aba462b-d293-4e3b-89e6-d0520ff1734e.png">


**Description**
The ROS 2 native connection does not work with custom messages and generally has more gotchas due to the complexities of DDS. Show a warning and recommend the user use rosbridge instead.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
