### PR TITLE
Bug fix: show settings for `NAV_PATH_DATATYPES`

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -143,7 +143,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (POSE_ARRAY_DATATYPES.has(topic.datatype)) {
+      if (POSE_ARRAY_DATATYPES.has(topic.datatype) || NAV_PATH_DATATYPES.has(topic.datatype)) {
         const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsPoseArray>;
         const displayType = config.type ?? getDefaultType(topic);
         const { axisScale, lineWidth } = config;


### PR DESCRIPTION
**User-Facing Changes**
Settings for `nav_msgs/Path` are made visible in the 3D (beta) panel settings.

**Description**
Previously, `nav_msgs/Path` were rendered in the 3D (beta) panel, but their settings were not displayed in the settings tree. Now, their settings are displayed in the settings tree.

Before:
![pre-bugfix](https://user-images.githubusercontent.com/6638091/178362547-96304d02-acbd-40fe-aefd-c30807076dc5.png)

After:
![post-bugfix](https://user-images.githubusercontent.com/6638091/178362563-d3e380b7-0804-4da3-b044-573c62875489.png)

Bag file:  [path.bag.zip](https://github.com/foxglove/studio/files/9087878/path.bag.zip)

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
