### PR TITLE
NodePlayground: Use empty datatype definition for unknown datatypes

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateTypesLib.test.ts.snap
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateTypesLib.test.ts.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateTypesLib full 1`] = `
-"// NOTE:
-// This file is generated from the current data source.
-// It contains helper types for looking up message definitions by schema name or topic.
-//
-// You likely want to use the higher-level types in \`./types\` rather than the types in this file directly.
-
-type Time = {
-  sec: number;
-  nsec: number;
-};
-
-type Duration = Time;
-
-/**
- * MessageTypeBySchemaName enumerates the message types for for all the schema names
- * in the current data source.
- *
- * You probably want to use Message<...> instead.
- */
-export type MessageTypeBySchemaName = {
-  \\"std_msgs/ColorRGBA\\": {
-    r: number;
-  };
-};
-
-/**
- * MessageTypeByTopic enumerates the Messages types for all the topics in
- * the current data source.
- *
- * You probably want to use Input<\\"/my-topic\\"> instead of MessageTypeByTopic.
- */
-export type MessageTypeByTopic = {
-  \\"/my_topic\\": MessageTypeBySchemaName[\\"std_msgs/ColorRGBA\\"];
-};
-"
-`;
-
 exports[`generateTypesLib generateDatatypesInterface should generate basic Datatypes interface 1`] = `
 "/**
  * MessageTypeBySchemaName enumerates the message types for for all the schema names

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateTypesLib.test.ts.snap
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/__snapshots__/generateTypesLib.test.ts.snap
@@ -88,3 +88,81 @@ export type MessageTypeBySchemaName = {
 };
 "
 `;
+
+exports[`generateTypesLib should generate types lib 1`] = `
+"// NOTE:
+// This file is generated from the current data source.
+// It contains helper types for looking up message definitions by schema name or topic.
+//
+// You likely want to use the higher-level types in \`./types\` rather than the types in this file directly.
+
+type Time = {
+  sec: number;
+  nsec: number;
+};
+
+type Duration = Time;
+
+/**
+ * MessageTypeBySchemaName enumerates the message types for for all the schema names
+ * in the current data source.
+ *
+ * You probably want to use Message<...> instead.
+ */
+export type MessageTypeBySchemaName = {
+  \\"std_msgs/ColorRGBA\\": {
+    r: number;
+  };
+};
+
+/**
+ * MessageTypeByTopic enumerates the Messages types for all the topics in
+ * the current data source.
+ *
+ * You probably want to use Input<\\"/my-topic\\"> instead of MessageTypeByTopic.
+ */
+export type MessageTypeByTopic = {
+  \\"/my_topic\\": MessageTypeBySchemaName[\\"std_msgs/ColorRGBA\\"];
+};
+"
+`;
+
+exports[`generateTypesLib should work when a datatype is not known 1`] = `
+"// NOTE:
+// This file is generated from the current data source.
+// It contains helper types for looking up message definitions by schema name or topic.
+//
+// You likely want to use the higher-level types in \`./types\` rather than the types in this file directly.
+
+type Time = {
+  sec: number;
+  nsec: number;
+};
+
+type Duration = Time;
+
+/**
+ * MessageTypeBySchemaName enumerates the message types for for all the schema names
+ * in the current data source.
+ *
+ * You probably want to use Message<...> instead.
+ */
+export type MessageTypeBySchemaName = {
+  \\"std_msgs/ColorRGBA\\": {
+    r: number;
+  };
+  unknown_datatype: {};
+};
+
+/**
+ * MessageTypeByTopic enumerates the Messages types for all the topics in
+ * the current data source.
+ *
+ * You probably want to use Input<\\"/my-topic\\"> instead of MessageTypeByTopic.
+ */
+export type MessageTypeByTopic = {
+  \\"/my_topic\\": MessageTypeBySchemaName[\\"std_msgs/ColorRGBA\\"];
+  \\"/another_topic\\": MessageTypeBySchemaName[\\"unknown_datatype\\"];
+};
+"
+`;

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateTypesLib.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateTypesLib.test.ts
@@ -88,12 +88,43 @@ describe("generateTypesLib", () => {
     });
   });
 
-  it("full", async () => {
+  it("should generate types lib", async () => {
     const src = generateTypesLib({
       topics: [
         {
           name: "/my_topic",
           datatype: "std_msgs/ColorRGBA",
+        },
+      ],
+      datatypes: new Map(
+        Object.entries({
+          "std_msgs/ColorRGBA": {
+            definitions: [{ type: "float32", name: "r", isArray: false, isComplex: false }],
+          },
+        }),
+      ),
+    });
+
+    const prettified = await getPrettifiedCode(src);
+
+    const { diagnostics } = compile({ ...baseNodeData, sourceCode: src });
+    expect(diagnostics).toEqual([]);
+
+    expect(prettified).toMatchSnapshot();
+  });
+
+  // A topic may reference a datatype which is not yet known (hasn't been subscribed or won't be)
+  // The types library must still compile.
+  it("should work when a datatype is not known", async () => {
+    const src = generateTypesLib({
+      topics: [
+        {
+          name: "/my_topic",
+          datatype: "std_msgs/ColorRGBA",
+        },
+        {
+          name: "/another_topic",
+          datatype: "unknown_datatype",
         },
       ],
       datatypes: new Map(

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateTypesLib.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateTypesLib.ts
@@ -123,7 +123,23 @@ function generateTypesByTopicInterface(topics: Topic[]): string {
 
 function generateTypesLib(args: Args): string {
   const typesByTopic = generateTypesByTopicInterface(args.topics);
-  const typesBySchemaName = generateTypesInterface(args.datatypes);
+
+  // A topic may reference a datatype that we don't have in args.datatypes.
+  // This happens for some data sources if nothing's subscribe to a topic and we never get info
+  // about the specific datatype.
+  //
+  // We want the types library to still generate and compile so we use empty placeholders for such datatypes.
+  const allDatatypes = new Map(args.datatypes);
+  for (const topic of args.topics) {
+    if (!allDatatypes.has(topic.datatype)) {
+      allDatatypes.set(topic.datatype, {
+        name: topic.datatype,
+        definitions: [],
+      });
+    }
+  }
+
+  const typesBySchemaName = generateTypesInterface(allDatatypes);
 
   const src = `
 // NOTE:


### PR DESCRIPTION


**User-Facing Changes**
Node playground scripts work in more situations where custom datatype are involved.

**Description**
When a topic references a datatype that is not yet known to the data source, the types library would fail to compile and run. The user would need to manually add a subscriber (some panel) for a topic of the missing datatype to unblock node playground.

This changes fixes this requirement by using empty datatype placeholders for unknown datatypes so the user script compiles and runs.

Fixes: #3784

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
