### PR TITLE
MemoryCacheDataProvider: send notification on parse error

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -569,7 +569,14 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
         topics.length > 0
           ? await this._provider.getMessages(startTime, endTime, { parsedMessages: topics })
           : { parsedMessages: [] };
-      const { parsedMessages = [] } = messages;
+      const { parsedMessages = [], problems } = messages;
+
+      if (problems != undefined && problems.length > 0) {
+        for (const { error, message, severity } of problems) {
+          console.error(error);
+          sendNotification(`Failure parsing messages: ${message}`, error, "user", severity);
+        }
+      }
 
       // If we're not current any more, discard the messages, because otherwise we might write duplicate messages.
       if (!isCurrent()) {


### PR DESCRIPTION
**User-Facing Changes**
Users see an error rather than missing messages when they attempt to play malformed JSON messages.

**Description**
Previously when using the legacy MCAP player, any errors parsing
messages would be ignored from the `_provider.getMessages` result.

This PR logs these errors to console, and also sends a notification
including the error details. This uses the legacy `sendNotification`
API that we're trying to remove the use of, which is not ideal.
However:

1. This problem is fixed already with the new buffered iterable player.
2. Once we switch over to the buffered iterable player, we can happily
   delete this code and never think about it again.


<!-- link relevant github issues -->
addresses #3804.
<!-- add `docs` label if this PR requires documentation updates -->
