### PR TITLE
[New3D] Bug fix: Create/remove axes/arrows on every `PoseArray` update

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -298,7 +298,6 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     renderable: PoseArrayRenderable,
     poseArrayMessage: PoseArray,
     topic: string,
-    arrowScale: [number, number, number],
     colorStart: ColorRGBA,
     colorEnd: ColorRGBA
   ): void {
@@ -306,7 +305,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     const createArrowMarkerFromIndex = (i: number): Marker => {
       const t = i / (poseArrayMessage.poses.length - 1);
       const color = rgbaGradient(tempColor3, colorStart, colorEnd, t);
-      return createArrowMarker(arrowScale, color);
+      return createArrowMarker(renderable.userData.settings.arrowScale, color);
     }
 
     // Update the arrowMarker of existing RenderableArrow as needed
@@ -412,9 +411,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         }
         break;
       case "arrow":
-        this._createOrRemoveArrowsToMatchPoses(
-          renderable, poseArrayMessage, topic, settings.arrowScale, colorStart, colorEnd
-        );
+        this._createOrRemoveArrowsToMatchPoses(renderable, poseArrayMessage, topic, colorStart, colorEnd);
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.arrows[i]!, poseArrayMessage.poses[i]!);
         }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -318,9 +318,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
             renderable.removeArrows();
             renderable.removeLineStrip();
 
-            this._createOrRemoveAxesToMatchPoses(renderable, poseArrayMessage, topic);
-
-            // Update the scale for each axis
+            // Update the scale for each existing axis
             const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
             for (const axis of renderable.userData.axes) {
               axis.scale.set(scale, scale, scale);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -275,7 +275,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     }
 
     // Create any AxisRenderables as needed
-    while (renderable.userData.axes.length < poseArrayMessage.poses.length) {
+    for (let i = renderable.userData.axes.length; i < poseArrayMessage.poses.length; i++) {
       const axis = new Axis(topic, this.renderer);
       renderable.userData.axes.push(axis);
       renderable.add(axis);
@@ -292,6 +292,47 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     }
 
     renderable.userData.axes.length = poseArrayMessage.poses.length;
+  }
+
+  _createOrRemoveArrowsToMatchPoses(
+    renderable: PoseArrayRenderable,
+    poseArrayMessage: PoseArray,
+    topic: string,
+    arrowScale: [number, number, number],
+    colorStart: ColorRGBA,
+    colorEnd: ColorRGBA
+  ): void {
+    // Generate a Marker with the right scale and color
+    const createArrowMarkerFromIndex = (i: number): Marker => {
+      const t = i / (poseArrayMessage.poses.length - 1);
+      const color = rgbaGradient(tempColor3, colorStart, colorEnd, t);
+      return createArrowMarker(arrowScale, color);
+    }
+
+    // Update the arrowMarker of existing RenderableArrow as needed
+    const existingUpdateCount = Math.min(renderable.userData.arrows.length, poseArrayMessage.poses.length);
+    for (let i = 0; i < existingUpdateCount; i++) {
+      const arrowMarker = createArrowMarkerFromIndex(i);
+      const arrow = renderable.userData.arrows[i]!;
+      arrow.update(arrowMarker, undefined);
+    }
+
+    // Create any RenderableArrow as needed
+    for (let i = renderable.userData.arrows.length; i < poseArrayMessage.poses.length; i++) {
+      const arrowMarker = createArrowMarkerFromIndex(i);
+      const arrow = new RenderableArrow(topic, arrowMarker, undefined, this.renderer);
+      renderable.userData.arrows.push(arrow);
+      renderable.add(arrow);
+    }
+
+    // Remove any RenderableArrow as needed
+    for (let i = poseArrayMessage.poses.length; i < renderable.userData.arrows.length; i++) {
+      const arrow = renderable.userData.arrows[i]!;
+      renderable.remove(arrow);
+      arrow.dispose();
+    }
+
+    renderable.userData.arrows.length = poseArrayMessage.poses.length;
   }
 
   _updatePoseArrayRenderable(
@@ -330,23 +371,6 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
           {
             renderable.removeAxes();
             renderable.removeLineStrip();
-
-            for (let i = 0; i < poseArrayMessage.poses.length; i++) {
-              // Update the scale and color for each arrow by regenerating a Marker
-              const t = i / (poseArrayMessage.poses.length - 1);
-              const color = rgbaGradient(tempColor3, colorStart, colorEnd, t);
-              const arrowMarker = createArrowMarker(settings.arrowScale, color);
-
-              // Create this RenderableArrow if needed
-              if (i >= renderable.userData.arrows.length) {
-                const arrow = new RenderableArrow(topic, arrowMarker, undefined, this.renderer);
-                renderable.userData.arrows.push(arrow);
-                renderable.add(arrow);
-              }
-
-              const arrow = renderable.userData.arrows[i]!;
-              arrow.update(arrowMarker, undefined);
-            }
           }
           break;
         case "line":
@@ -388,6 +412,9 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         }
         break;
       case "arrow":
+        this._createOrRemoveArrowsToMatchPoses(
+          renderable, poseArrayMessage, topic, settings.arrowScale, colorStart, colorEnd
+        );
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.arrows[i]!, poseArrayMessage.poses[i]!);
         }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -263,12 +263,15 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   _createOrRemoveAxesToMatchPoses(
     renderable: PoseArrayRenderable,
     poseArrayMessage: PoseArray,
-    topic: string
+    topic: string,
   ): void {
     const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
 
     // Update the scale of existing AxisRenderables as needed
-    const existingUpdateCount = Math.min(renderable.userData.axes.length, poseArrayMessage.poses.length);
+    const existingUpdateCount = Math.min(
+      renderable.userData.axes.length,
+      poseArrayMessage.poses.length
+    );
     for (let i = 0; i < existingUpdateCount; i++) {
       const axis = renderable.userData.axes[i]!;
       axis.scale.set(scale, scale, scale);
@@ -281,7 +284,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
       renderable.add(axis);
 
       // Set the scale for each new axis
-      axis.scale.set(scale, scale, scale)
+      axis.scale.set(scale, scale, scale);
     }
 
     // Remove any AxisRenderables as needed
@@ -299,17 +302,20 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     poseArrayMessage: PoseArray,
     topic: string,
     colorStart: ColorRGBA,
-    colorEnd: ColorRGBA
+    colorEnd: ColorRGBA,
   ): void {
     // Generate a Marker with the right scale and color
     const createArrowMarkerFromIndex = (i: number): Marker => {
       const t = i / (poseArrayMessage.poses.length - 1);
       const color = rgbaGradient(tempColor3, colorStart, colorEnd, t);
       return createArrowMarker(renderable.userData.settings.arrowScale, color);
-    }
+    };
 
     // Update the arrowMarker of existing RenderableArrow as needed
-    const existingUpdateCount = Math.min(renderable.userData.arrows.length, poseArrayMessage.poses.length);
+    const existingUpdateCount = Math.min(
+      renderable.userData.arrows.length,
+      poseArrayMessage.poses.length
+    );
     for (let i = 0; i < existingUpdateCount; i++) {
       const arrowMarker = createArrowMarkerFromIndex(i);
       const arrow = renderable.userData.arrows[i]!;
@@ -411,7 +417,13 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         }
         break;
       case "arrow":
-        this._createOrRemoveArrowsToMatchPoses(renderable, poseArrayMessage, topic, colorStart, colorEnd);
+        this._createOrRemoveArrowsToMatchPoses(
+          renderable,
+          poseArrayMessage,
+          topic,
+          colorStart,
+          colorEnd
+        );
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.arrows[i]!, poseArrayMessage.poses[i]!);
         }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -270,7 +270,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     // Update the scale of existing AxisRenderables as needed
     const existingUpdateCount = Math.min(
       renderable.userData.axes.length,
-      poseArrayMessage.poses.length
+      poseArrayMessage.poses.length,
     );
     for (let i = 0; i < existingUpdateCount; i++) {
       const axis = renderable.userData.axes[i]!;
@@ -314,7 +314,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     // Update the arrowMarker of existing RenderableArrow as needed
     const existingUpdateCount = Math.min(
       renderable.userData.arrows.length,
-      poseArrayMessage.poses.length
+      poseArrayMessage.poses.length,
     );
     for (let i = 0; i < existingUpdateCount; i++) {
       const arrowMarker = createArrowMarkerFromIndex(i);
@@ -422,7 +422,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
           poseArrayMessage,
           topic,
           colorStart,
-          colorEnd
+          colorEnd,
         );
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.arrows[i]!, poseArrayMessage.poses[i]!);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -267,6 +267,13 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
   ): void {
     const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
 
+    // Update the scale of existing AxisRenderables as needed
+    const existingUpdateCount = Math.min(renderable.userData.axes.length, poseArrayMessage.poses.length);
+    for (let i = 0; i < existingUpdateCount; i++) {
+      const axis = renderable.userData.axes[i]!;
+      axis.scale.set(scale, scale, scale);
+    }
+
     // Create any AxisRenderables as needed
     while (renderable.userData.axes.length < poseArrayMessage.poses.length) {
       const axis = new Axis(topic, this.renderer);
@@ -317,12 +324,6 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
           {
             renderable.removeArrows();
             renderable.removeLineStrip();
-
-            // Update the scale for each existing axis
-            const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
-            for (const axis of renderable.userData.axes) {
-              axis.scale.set(scale, scale, scale);
-            }
           }
           break;
         case "arrow":

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -260,6 +260,33 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     );
   }
 
+  _createOrRemoveAxesToMatchPoses(
+    renderable: PoseArrayRenderable,
+    poseArrayMessage: PoseArray,
+    topic: string
+  ): void {
+    const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
+
+    // Create any AxisRenderables as needed
+    while (renderable.userData.axes.length < poseArrayMessage.poses.length) {
+      const axis = new Axis(topic, this.renderer);
+      renderable.userData.axes.push(axis);
+      renderable.add(axis);
+
+      // Set the scale for each new axis
+      axis.scale.set(scale, scale, scale)
+    }
+
+    // Remove any AxisRenderables as needed
+    for (let i = poseArrayMessage.poses.length; i < renderable.userData.axes.length; i++) {
+      const axis = renderable.userData.axes[i]!;
+      renderable.remove(axis);
+      axis.dispose();
+    }
+
+    renderable.userData.axes.length = poseArrayMessage.poses.length;
+  }
+
   _updatePoseArrayRenderable(
     renderable: PoseArrayRenderable,
     poseArrayMessage: PoseArray,
@@ -291,12 +318,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
             renderable.removeArrows();
             renderable.removeLineStrip();
 
-            // Create any AxisRenderables needed
-            while (renderable.userData.axes.length < poseArrayMessage.poses.length) {
-              const axis = new Axis(topic, this.renderer);
-              renderable.userData.axes.push(axis);
-              renderable.add(axis);
-            }
+            this._createOrRemoveAxesToMatchPoses(renderable, poseArrayMessage, topic);
 
             // Update the scale for each axis
             const scale = renderable.userData.settings.axisScale * (1 / AXIS_LENGTH);
@@ -361,6 +383,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
     // Update the pose for each pose renderable
     switch (settings.type) {
       case "axis":
+        this._createOrRemoveAxesToMatchPoses(renderable, poseArrayMessage, topic);
         for (let i = 0; i < poseArrayMessage.poses.length; i++) {
           setObjectPose(renderable.userData.axes[i]!, poseArrayMessage.poses[i]!);
         }


### PR DESCRIPTION
**User-Facing Changes**
Previously, rendering `PoseArrays` in the 3D (beta) panel crashed for the `Axis` or `Arrow` display types when the length of the `PoseArray` changed. Rendering now works.

**Description**
Previously, new `Axis`/`RenderableArrow` were only created when the settings changed, not on every `PoseArray` update. Therefore, whenever the length of the `PoseArray` increased, elements out of bounds of the `Axis`/`RenderableArrow` buffers were accessed, throwing an error. Now, `Axis`/`RenderableArrow` objects are added (or extra objects removed) from the buffers on every `PoseArray` update.

**Before:**

ROS bag containing `nav_msgs/Path` messages with increasing length:  [path.bag.zip](https://github.com/foxglove/studio/files/9094447/path.bag.zip)

Using "Axis": TypeError -- `Cannot read properties of undefined (reading 'position')`
Using "Arrow": TypeError -- `Cannot read properties of undefined (reading 'position')`

```
Call Stack
 setObjectPose
  packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts:300:12
 PoseArrays._updatePoseArrayRenderable
  packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts:275:21
 PoseArrays.addPoseArray
  packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts:195:14
 PoseArrays.handleNavPath
  packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts:125:18
 Renderer.addMessageEvent
  packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts:537:17
 eval
  packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx:306:22
 invokePassiveEffectCreate
  node_modules/react-dom/cjs/react-dom.development.js:23484:20
 HTMLUnknownElement.callCallback
  node_modules/react-dom/cjs/react-dom.development.js:3947:14
 Object.invokeGuardedCallbackDev
  node_modules/react-dom/cjs/react-dom.development.js:3996:16
 invokeGuardedCallback
  node_modules/react-dom/cjs/react-dom.development.js:4058:31
```

**After:**
Using "Axis":
![image](https://user-images.githubusercontent.com/6638091/178526172-9692e544-b490-4070-9126-7736b0e148c7.png)

Using "Arrow":
![image](https://user-images.githubusercontent.com/6638091/178526399-d8d362d8-b45e-4443-97f3-fe28c6158438.png)

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
