### PR TITLE
Fix ros2 getMessages end time calculation

### DIFF
--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -107,13 +107,9 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
     }
 
-    // Add 1 nsec to the end time because rosbag2 treats the time range as non-inclusive
-    // of the exact end time.
-    const inclusiveEndTime = { sec: end.sec, nsec: end.nsec + 1 };
-
     return {
       start,
-      end: inclusiveEndTime,
+      end,
       topics,
       topicStats,
       connections,
@@ -143,8 +139,15 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
       return {};
     }
 
+    // Add 1 nsec to the end time because rosbag2 treats the time range as non-inclusive
+    // of the exact end time.
+    const inclusiveEndTime = { sec: end.sec, nsec: end.nsec + 1 };
     const parsedMessages: MessageEvent<unknown>[] = [];
-    for await (const msg of this.bag_.readMessages({ startTime: start, endTime: end, topics })) {
+    for await (const msg of this.bag_.readMessages({
+      startTime: start,
+      endTime: inclusiveEndTime,
+      topics,
+    })) {
       parsedMessages.push({
         topic: msg.topic.name,
         receiveTime: msg.timestamp,

--- a/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Rosbag2DataProvider.ts
@@ -107,9 +107,13 @@ export default class Rosbag2DataProvider implements RandomAccessDataProvider {
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;
     }
 
+    // Add 1 nsec to the end time because rosbag2 treats the time range as non-inclusive
+    // of the exact end time.
+    const inclusiveEndTime = { sec: end.sec, nsec: end.nsec + 1 };
+
     return {
       start,
-      end,
+      end: inclusiveEndTime,
       topics,
       topicStats,
       connections,


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with ros2 bag message reading.

**Description**
The fix here is to add 1 nsec to our calculation of the time range of the messages to fetch since the rosbag2-web implementation of `readMessages` returns messages with end time < the specified time, not <=.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3826 