### PR TITLE
[New3D] Bug fix: Create axes/arrows as needed on every PoseArray update

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -345,6 +345,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
    * This is useful when seeking to a new playback position or when a new data source is loaded.
    */
   clear(): void {
+    this.settings.errors.clear();
     this.transformTree.clear();
     for (const extension of this.sceneExtensions.values()) {
       extension.removeAllRenderables();
@@ -843,8 +844,6 @@ export class Renderer extends EventEmitter<RendererEvents> {
         `Frame "${this.renderFrameId}" not found`,
       );
       return;
-    } else {
-      this.settings.errors.remove(FOLLOW_TF_PATH, FRAME_NOT_FOUND);
     }
 
     const rootFrameId = frame.root().id;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -10,7 +10,7 @@ import { SettingsTreeAction } from "@foxglove/studio";
 import { Renderer } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
-import { fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
+import { fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE, SelectEntry } from "../settings";
 import type { FrameAxes } from "./FrameAxes";
 
 export const DEFAULT_LABEL_SCALE_FACTOR = 1;
@@ -41,14 +41,10 @@ export class CoreSettings extends SceneExtension {
     const handler = this.handleSettingsAction;
 
     const followTfOptions = this.renderer.coordinateFrameList;
-    let followTfValue =
-      this.renderer.followFrameId ?? config.followTf ?? this.renderer.renderFrameId;
-    if (
-      followTfValue != undefined &&
-      !followTfOptions.find((option) => option.value === followTfValue)
-    ) {
-      followTfValue = undefined;
-    }
+    const followTfValue = selectBest(
+      [this.renderer.followFrameId, config.followTf, this.renderer.renderFrameId],
+      followTfOptions,
+    );
 
     return [
       {
@@ -288,4 +284,14 @@ export class CoreSettings extends SceneExtension {
   handleCameraMove = (): void => {
     this.updateSettingsTree();
   };
+}
+
+function selectBest(
+  choices: ReadonlyArray<string | undefined>,
+  validEntries: ReadonlyArray<SelectEntry>,
+): string | undefined {
+  const validChoices = choices.filter((choice) =>
+    validEntries.some((entry) => entry.value === choice),
+  );
+  return validChoices[0];
 }


### PR DESCRIPTION
**User-Facing Changes**

- Fixed a crash in `3D (Beta)` when rendering PoseArrays that grew over time as axes or arrows

**Description**

This is a variation of https://github.com/foxglove/studio/pull/3825 (authored by [siddancha](https://github.com/siddancha)) that only grows arrays instead of growing+shrinking to avoid dispose+reallocate in situations where pose arrays are frequently changing lengths. Also includes two minor fixes to the followTf sidebar control.

- [New3D] Bug fix: Create axes/arrows as needed on every PoseArray update
- Fix continuously clearing/resetting followTf sidebar errors
- Show the currently rendered frame_id in fallback cases

![178526172-9692e544-b490-4070-9126-7736b0e148c7](https://user-images.githubusercontent.com/195374/178573895-cc7ab041-7964-49ce-bfe6-614c4e4a38f5.png)