### PR TITLE
Show extension namespace in panel list

### DIFF
--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -11,7 +11,7 @@ import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/E
 
 export type RegisteredPanel = {
   extensionName: string;
-  namespace?: string;
+  extensionNamespace?: ExtensionNamespace;
   registration: ExtensionPanelRegistration;
 };
 

--- a/packages/studio-base/src/context/PanelCatalogContext.ts
+++ b/packages/studio-base/src/context/PanelCatalogContext.ts
@@ -5,6 +5,7 @@
 import { ComponentType, createContext, useContext } from "react";
 
 import { PanelStatics } from "@foxglove/studio-base/components/Panel";
+import { ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 
 export type PanelComponent = ComponentType<{ childId?: string; tabId?: string }> &
@@ -25,6 +26,7 @@ export type PanelInfo = {
   config?: PanelConfig;
   relatedConfigs?: { [panelId: string]: PanelConfig };
   preconfigured?: boolean;
+  extensionNamespace?: ExtensionNamespace;
 };
 
 /** PanelCatalog describes the interface for getting available panels */

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -56,7 +56,7 @@ async function registerExtensionPanels(
 
         panels[fullId] = {
           extensionName: extension.qualifiedName,
-          namespace: extension.namespace,
+          extensionNamespace: extension.namespace,
           registration: params,
         };
       },

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -52,6 +52,7 @@ export default function PanelCatalogProvider(
         title: panel.registration.name,
         type: panelType,
         module: async () => ({ default: Panel(PanelWrapper) }),
+        extensionNamespace: panel.extensionNamespace,
       };
     });
   }, [extensionPanels]);


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This shows the extension namespace from which the panel originated in the panel list, only if there are multiple panels with the same title. This should mainly benefit extension panel authors that are working on local iterations of their panels.

<img width="303" alt="Screen Shot 2022-07-15 at 7 20 37 AM" src="https://user-images.githubusercontent.com/93935560/179232558-1ebe0dfb-a5d8-439a-945e-57fe257e6317.png">

<img width="866" alt="Screen Shot 2022-07-15 at 7 30 09 AM" src="https://user-images.githubusercontent.com/93935560/179233013-f6b3a075-ab13-4394-a3c3-c3ef2945ba0e.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
