### PR TITLE
Rename ExtensionRegistry

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -31,8 +31,8 @@ import { ConsoleApiCookieCurrentUserProvider } from "./providers/ConsoleApiCooki
 import { ConsoleApiDialogCurrentUserProvider } from "./providers/ConsoleApiDialogCurrentUserProvider";
 import ConsoleApiRemoteLayoutStorageProvider from "./providers/ConsoleApiRemoteLayoutStorageProvider";
 import CurrentLayoutProvider from "./providers/CurrentLayoutProvider";
+import ExtensionCatalogProvider from "./providers/ExtensionCatalogProvider";
 import ExtensionMarketplaceProvider from "./providers/ExtensionMarketplaceProvider";
-import ExtensionRegistryProvider from "./providers/ExtensionRegistryProvider";
 import HelpInfoProvider from "./providers/HelpInfoProvider";
 import LayoutManagerProvider from "./providers/LayoutManagerProvider";
 import PanelCatalogProvider from "./providers/PanelCatalogProvider";
@@ -94,7 +94,7 @@ export function App(props: AppProps): JSX.Element {
     <UserNodeStateProvider />,
     <CurrentLayoutProvider />,
     <ExtensionMarketplaceProvider />,
-    <ExtensionRegistryProvider loaders={extensionLoaders} />,
+    <ExtensionCatalogProvider loaders={extensionLoaders} />,
     <PlayerManager playerSources={dataSources} />,
     /* eslint-enable react/jsx-key */
   ];

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -64,7 +64,7 @@ import {
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext";
 import { useNativeAppMenu } from "@foxglove/studio-base/context/NativeAppMenuContext";
 import {
@@ -348,7 +348,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const { loadFromFile } = useAssets();
 
-  const installExtension = useExtensionRegistry((state) => state.installExtension);
+  const installExtension = useExtensionCatalog((state) => state.installExtension);
 
   const openHandle = useCallback(
     async (handle: FileSystemFileHandle) => {

--- a/packages/studio-base/src/components/ExtensionDetails.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.stories.tsx
@@ -19,7 +19,7 @@ import ExtensionMarketplaceContext, {
   ExtensionMarketplace,
   ExtensionMarketplaceDetail,
 } from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
-import ExtensionRegistryProvider from "@foxglove/studio-base/providers/ExtensionRegistryProvider";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
 import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
 
@@ -71,11 +71,11 @@ export function Details(): JSX.Element {
 
   return (
     <AppConfigurationContext.Provider value={config}>
-      <ExtensionRegistryProvider loaders={[MockExtensionLoader]}>
+      <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
         <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
           <ExtensionDetails extension={extension} onClose={() => {}} installed={false} />
         </ExtensionMarketplaceContext.Provider>
-      </ExtensionRegistryProvider>
+      </ExtensionCatalogProvider>
     </AppConfigurationContext.Provider>
   );
 }

--- a/packages/studio-base/src/components/ExtensionDetails.tsx
+++ b/packages/studio-base/src/components/ExtensionDetails.tsx
@@ -22,11 +22,11 @@ import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent"
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextContent from "@foxglove/studio-base/components/TextContent";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import {
   ExtensionMarketplaceDetail,
   useExtensionMarketplace,
 } from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -42,9 +42,9 @@ export function ExtensionDetails({ extension, onClose, installed }: Props): Reac
   const [isInstalled, setIsInstalled] = useState(installed);
   const [activeTab, setActiveTab] = useState<number>(0);
   const isMounted = useMountedState();
-  const downloadExtension = useExtensionRegistry((state) => state.downloadExtension);
-  const installExtension = useExtensionRegistry((state) => state.installExtension);
-  const uninstallExtension = useExtensionRegistry((state) => state.uninstallExtension);
+  const downloadExtension = useExtensionCatalog((state) => state.downloadExtension);
+  const installExtension = useExtensionCatalog((state) => state.installExtension);
+  const uninstallExtension = useExtensionCatalog((state) => state.uninstallExtension);
   const marketplace = useExtensionMarketplace();
   const { addToast } = useToasts();
   const readmeUrl = extension.readme;

--- a/packages/studio-base/src/components/ExtensionsSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar/index.stories.tsx
@@ -19,7 +19,7 @@ import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurat
 import ExtensionMarketplaceContext, {
   ExtensionMarketplace,
 } from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
-import ExtensionRegistryProvider from "@foxglove/studio-base/providers/ExtensionRegistryProvider";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
 
 export default {
@@ -92,11 +92,11 @@ export function Sidebar(): JSX.Element {
 
   return (
     <AppConfigurationContext.Provider value={config}>
-      <ExtensionRegistryProvider loaders={[MockExtensionLoader]}>
+      <ExtensionCatalogProvider loaders={[MockExtensionLoader]}>
         <ExtensionMarketplaceContext.Provider value={MockExtensionMarketplace}>
           <ExtensionsSidebar />
         </ExtensionMarketplaceContext.Provider>
-      </ExtensionRegistryProvider>
+      </ExtensionCatalogProvider>
     </AppConfigurationContext.Provider>
   );
 }

--- a/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
+++ b/packages/studio-base/src/components/ExtensionsSidebar/index.tsx
@@ -20,11 +20,11 @@ import Log from "@foxglove/log";
 import { ExtensionDetails } from "@foxglove/studio-base/components/ExtensionDetails";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import {
   ExtensionMarketplaceDetail,
   useExtensionMarketplace,
 } from "@foxglove/studio-base/context/ExtensionMarketplaceContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
 
 import helpContent from "./index.help.md";
 
@@ -92,7 +92,7 @@ export default function ExtensionsSidebar(): React.ReactElement {
       }
     | undefined
   >(undefined);
-  const installed = useExtensionRegistry((state) => state.registeredExtensions);
+  const installed = useExtensionCatalog((state) => state.installedExtensions);
   const marketplace = useExtensionMarketplace();
 
   const [marketplaceEntries, refreshMarketplaceEntries] = useAsyncFn(

--- a/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.test.tsx
@@ -8,8 +8,8 @@ import fetchMock from "fetch-mock";
 
 import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
-import ExtensionRegistryProvider from "@foxglove/studio-base/providers/ExtensionRegistryProvider";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
 import { ExtensionInfo } from "@foxglove/studio-base/types/Extensions";
 
@@ -40,7 +40,7 @@ const source = `
 `;
 
 function Wrapper(): JSX.Element {
-  const registeredExtensions = useExtensionRegistry((state) => state.registeredExtensions);
+  const registeredExtensions = useExtensionCatalog((state) => state.installedExtensions);
   return registeredExtensions ? <OrgExtensionRegistrySyncAdapter /> : <></>;
 }
 
@@ -80,9 +80,9 @@ describe("Private registry sync adapter", () => {
     };
 
     render(
-      <ExtensionRegistryProvider loaders={[mockPrivateLoader as ExtensionLoader]}>
+      <ExtensionCatalogProvider loaders={[mockPrivateLoader as ExtensionLoader]}>
         <Wrapper />
-      </ExtensionRegistryProvider>,
+      </ExtensionCatalogProvider>,
     );
 
     await waitFor(() => expect(mockPrivateLoader.installExtension).toHaveBeenCalledTimes(3));

--- a/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.tsx
+++ b/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.tsx
@@ -9,7 +9,7 @@ import { useLatest, useTimeoutFn } from "react-use";
 import Logger from "@foxglove/log";
 import { useConsoleApi } from "@foxglove/studio-base/context/ConsoleApiContext";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 
 const log = Logger.getLogger(__filename);
 
@@ -19,9 +19,9 @@ const SYNC_INTERVAL = 10 * 60 * 1_000; // 10 minutes
  * Implements organization registry extension syncing.
  */
 export function OrgExtensionRegistrySyncAdapter(): ReactNull {
-  const installedExtensions = useExtensionRegistry((state) => state.registeredExtensions);
-  const installExtension = useExtensionRegistry((state) => state.installExtension);
-  const uninstallExtension = useExtensionRegistry((state) => state.uninstallExtension);
+  const installedExtensions = useExtensionCatalog((state) => state.installedExtensions);
+  const installExtension = useExtensionCatalog((state) => state.installExtension);
+  const uninstallExtension = useExtensionCatalog((state) => state.uninstallExtension);
 
   const api = useConsoleApi();
   const user = useCurrentUser();
@@ -44,7 +44,6 @@ export function OrgExtensionRegistrySyncAdapter(): ReactNull {
     [api, installExtension],
   );
 
-  // Use polling for now. To be replaced with some kind of notification mechanism.
   const [_ready, _cancel, resetTimeout] = useTimeoutFn(
     async () => await syncExtensions(),
     SYNC_INTERVAL,

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -41,7 +41,7 @@ import {
   useCurrentLayoutSelector,
   usePanelMosaicId,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
@@ -219,7 +219,7 @@ export default function PanelLayout(): JSX.Element {
   const layoutExists = useCurrentLayoutSelector(selectedLayoutExistsSelector);
   const layoutLoading = useCurrentLayoutSelector(selectedLayoutLoadingSelector);
   const mosaicLayout = useCurrentLayoutSelector(selectedLayoutMosaicSelector);
-  const registeredExtensions = useExtensionRegistry((state) => state.registeredExtensions);
+  const registeredExtensions = useExtensionCatalog((state) => state.installedExtensions);
 
   const onChange = useCallback(
     (newLayout: MosaicNode<string> | undefined) => {

--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -15,7 +15,7 @@ export type RegisteredPanel = {
   registration: ExtensionPanelRegistration;
 };
 
-export type ExtensionRegistry = {
+export type ExtensionCatalog = {
   downloadExtension: (url: string) => Promise<Uint8Array>;
   installExtension: (
     namespace: ExtensionNamespace,
@@ -23,19 +23,20 @@ export type ExtensionRegistry = {
   ) => Promise<ExtensionInfo>;
   loadExtension(id: string): Promise<string>;
   refreshExtensions: () => Promise<void>;
-  registeredExtensions: undefined | ExtensionInfo[];
-  registeredPanels: undefined | Record<string, RegisteredPanel>;
   uninstallExtension: (namespace: ExtensionNamespace, id: string) => Promise<void>;
+
+  installedExtensions: undefined | ExtensionInfo[];
+  installedPanels: undefined | Record<string, RegisteredPanel>;
 };
 
-export const ExtensionRegistryContext = createContext<undefined | StoreApi<ExtensionRegistry>>(
+export const ExtensionCatalogContext = createContext<undefined | StoreApi<ExtensionCatalog>>(
   undefined,
 );
 
-export function useExtensionRegistry<T>(
-  selector: (registry: ExtensionRegistry) => T,
+export function useExtensionCatalog<T>(
+  selector: (registry: ExtensionCatalog) => T,
   equalityFn?: (a: T, b: T) => boolean,
 ): T {
-  const context = useGuaranteedContext(ExtensionRegistryContext);
+  const context = useGuaranteedContext(ExtensionCatalogContext);
   return useStore(context, selector, equalityFn);
 }

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -9,11 +9,11 @@ import { createStore, StoreApi } from "zustand";
 import Logger from "@foxglove/log";
 import { ExtensionContext, ExtensionModule } from "@foxglove/studio";
 import {
-  ExtensionRegistry,
-  ExtensionRegistryContext,
+  ExtensionCatalog,
+  ExtensionCatalogContext,
   RegisteredPanel,
-  useExtensionRegistry,
-} from "@foxglove/studio-base/context/ExtensionRegistryContext";
+  useExtensionCatalog,
+} from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
 import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
 
@@ -83,7 +83,7 @@ async function registerExtensionPanels(
 
 export function createExtensionRegistryStore(
   loaders: readonly ExtensionLoader[],
-): StoreApi<ExtensionRegistry> {
+): StoreApi<ExtensionCatalog> {
   return createStore((set, get) => ({
     downloadExtension: async (url: string) => {
       const res = await fetch(url);
@@ -123,12 +123,12 @@ export function createExtensionRegistryStore(
         extensionList,
         async (id: string) => await get().loadExtension(id),
       );
-      set({ registeredExtensions: extensionList, registeredPanels: panels });
+      set({ installedExtensions: extensionList, installedPanels: panels });
     },
 
-    registeredExtensions: undefined,
+    installedExtensions: undefined,
 
-    registeredPanels: undefined,
+    installedPanels: undefined,
 
     uninstallExtension: async (namespace: ExtensionNamespace, id: string) => {
       const namespacedLoader = loaders.find((loader) => loader.namespace === namespace);
@@ -142,7 +142,7 @@ export function createExtensionRegistryStore(
 }
 
 function InitialRefreshAdapter(): ReactNull {
-  const refreshExtensions = useExtensionRegistry((state) => state.refreshExtensions);
+  const refreshExtensions = useExtensionCatalog((state) => state.refreshExtensions);
   useEffect(() => {
     refreshExtensions().catch((err) => log.error(err));
   }, [refreshExtensions]);
@@ -150,16 +150,16 @@ function InitialRefreshAdapter(): ReactNull {
   return ReactNull;
 }
 
-export default function ExtensionRegistryProvider({
+export default function ExtensionCatalogProvider({
   children,
   loaders,
 }: PropsWithChildren<{ loaders: readonly ExtensionLoader[] }>): JSX.Element {
   const [store] = useState(createExtensionRegistryStore(loaders));
 
   return (
-    <ExtensionRegistryContext.Provider value={store}>
+    <ExtensionCatalogContext.Provider value={store}>
       <InitialRefreshAdapter />
       {children}
-    </ExtensionRegistryContext.Provider>
+    </ExtensionCatalogContext.Provider>
   );
 }

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -7,7 +7,7 @@ import { PropsWithChildren, useMemo } from "react";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelExtensionAdapter from "@foxglove/studio-base/components/PanelExtensionAdapter";
-import { useExtensionRegistry } from "@foxglove/studio-base/context/ExtensionRegistryContext";
+import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
@@ -29,7 +29,7 @@ export default function PanelCatalogProvider(
     AppSetting.ENABLE_LEGACY_PLOT_PANEL,
   );
 
-  const extensionPanels = useExtensionRegistry((state) => state.registeredPanels);
+  const extensionPanels = useExtensionCatalog((state) => state.installedPanels);
 
   const wrappedExtensionPanels = useMemo<PanelInfo[]>(() => {
     return Object.values(extensionPanels ?? {}).map((panel) => {

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -51,7 +51,7 @@ import {
   AdvertiseOptions,
 } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
-import ExtensionRegistryProvider from "@foxglove/studio-base/providers/ExtensionRegistryProvider";
+import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import HelpInfoProvider from "@foxglove/studio-base/providers/HelpInfoProvider";
 import {
   PanelSettingsEditorContextProvider,
@@ -337,13 +337,13 @@ export default function PanelSetup(props: Props): JSX.Element {
       <HoverValueProvider>
         <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
           <PanelSettingsEditorContextProvider>
-            <ExtensionRegistryProvider loaders={[]}>
+            <ExtensionCatalogProvider loaders={[]}>
               <HelpInfoProvider>
                 <ThemeProvider isDark={theme.isInverted}>
                   <UnconnectedPanelSetup {...props} />
                 </ThemeProvider>
               </HelpInfoProvider>
-            </ExtensionRegistryProvider>
+            </ExtensionCatalogProvider>
           </PanelSettingsEditorContextProvider>
         </MockCurrentLayoutProvider>
       </HoverValueProvider>

--- a/packages/studio-base/src/types/Extensions.ts
+++ b/packages/studio-base/src/types/Extensions.ts
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-/**
- * Extensions are installed into separate namespaces enumerated here.
- */
-export type ExtensionNamespace = "local" | "org";
+export type ExtensionNamespace =
+  | "local" // Local extensions installed manually by the user.
+  | "org"; // Extensions managed remotely and provisioned by the organization.
 
 /**
  * Metadata describing an extension.


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The `ExtensionRegistry`, which manages installed extensions, is confusingly named now that we also have a concept of a org-level extension `registry` for provisioning extensions. 

This renames it to `ExtensionCatalog` to mirror the related `PanelCatalog` and also renames the `registeredExtensions` and `registeredPanels` fields to make this distinction  clearer.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
