### PR TITLE
Improve PanelLayout story interactions

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -140,8 +140,8 @@ export const RemoveUnknownPanel = (): JSX.Element => {
   );
 };
 RemoveUnknownPanel.play = async () => {
-  await openPanelMenu();
-  fireEvent.click(screen.getByRole("panel-menu-remove")!);
+  (await screen.findAllByRole("panel-menu")).forEach((button) => fireEvent.click(button));
+  (await screen.findAllByRole("panel-menu-remove")).forEach((button) => fireEvent.click(button));
 };
 
 export const PanelLoading = (): JSX.Element => {

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -30,7 +30,7 @@ async function openPanelMenu() {
 
 async function goFullScreen() {
   await openPanelMenu();
-  fireEvent.click(screen.getByTestId("panel-menu-fullscreen")!);
+  fireEvent.click(screen.getAllByTestId("panel-menu-fullscreen")[0]!);
 }
 
 const allPanels: readonly PanelInfo[] = [

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { fireEvent, screen } from "@testing-library/dom";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -72,8 +73,6 @@ class MockPanelCatalog implements PanelCatalog {
   }
 }
 
-const DEFAULT_CLICK_DELAY = 100;
-
 export default {
   title: "components/PanelLayout",
 };
@@ -82,11 +81,6 @@ export const PanelNotFound = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <PanelSetup
-        onMount={() => {
-          setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
-          }, DEFAULT_CLICK_DELAY);
-        }}
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
         omitDragAndDrop
       >
@@ -101,6 +95,10 @@ PanelNotFound.parameters = { colorScheme: "dark" };
 export const PanelNotFoundLight = Object.assign(PanelNotFound.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
+PanelNotFound.play = async () => {
+  const buttons = await screen.findAllByRole("panel-menu");
+  fireEvent.click(buttons[0]!);
+};
 
 export const PanelWithError = (): JSX.Element => {
   return (
@@ -122,12 +120,6 @@ export const RemoveUnknownPanel = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
       <PanelSetup
-        onMount={() => {
-          setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
-            (document.querySelectorAll("[data-test=panel-menu-remove]")[0] as any).click();
-          }, DEFAULT_CLICK_DELAY);
-        }}
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
         omitDragAndDrop
       >
@@ -137,6 +129,11 @@ export const RemoveUnknownPanel = (): JSX.Element => {
       </PanelSetup>
     </DndProvider>
   );
+};
+RemoveUnknownPanel.play = async () => {
+  const buttons = await screen.findAllByRole("panel-menu");
+  fireEvent.click(buttons[0]!);
+  fireEvent.click(screen.getByRole("panel-menu-remove")!);
 };
 
 export const PanelLoading = (): JSX.Element => {
@@ -155,6 +152,12 @@ export const PanelLoading = (): JSX.Element => {
   );
 };
 
+async function goFullScreen() {
+  const buttons = await screen.findAllByRole("panel-menu");
+  fireEvent.click(buttons[0]!);
+  fireEvent.click(screen.getByRole("panel-menu-fullscreen")!);
+}
+
 export const FullScreen = (): JSX.Element => {
   return (
     <DndProvider backend={HTML5Backend}>
@@ -171,14 +174,6 @@ export const FullScreen = (): JSX.Element => {
           },
         }}
         omitDragAndDrop
-        onMount={() => {
-          setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-menu]")[0] as any).click();
-          }, DEFAULT_CLICK_DELAY);
-          setTimeout(() => {
-            (document.querySelectorAll("[data-test=panel-menu-fullscreen]")[0] as any).click();
-          }, DEFAULT_CLICK_DELAY);
-        }}
       >
         <MockPanelContextProvider>
           <PanelLayout />
@@ -188,6 +183,9 @@ export const FullScreen = (): JSX.Element => {
   );
 };
 FullScreen.parameters = { colorScheme: "dark" };
+FullScreen.play = goFullScreen;
+
 export const FullScreenLight = Object.assign(FullScreen.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
+FullScreenLight.play = goFullScreen;

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -23,6 +23,16 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import PanelLayout from "./PanelLayout";
 
+async function openPanelMenu() {
+  const buttons = await screen.findAllByRole("panel-menu");
+  fireEvent.click(buttons[0]!);
+}
+
+async function goFullScreen() {
+  await openPanelMenu();
+  fireEvent.click(screen.getByRole("panel-menu-fullscreen")!);
+}
+
 const allPanels: readonly PanelInfo[] = [
   { title: "Some Panel", type: "Sample1", module: async () => await new Promise(() => {}) },
   {
@@ -92,13 +102,12 @@ export const PanelNotFound = (): JSX.Element => {
   );
 };
 PanelNotFound.parameters = { colorScheme: "dark" };
+PanelNotFound.play = openPanelMenu;
+
 export const PanelNotFoundLight = Object.assign(PanelNotFound.bind(undefined), {
   parameters: { colorScheme: "light" },
 });
-PanelNotFound.play = async () => {
-  const buttons = await screen.findAllByRole("panel-menu");
-  fireEvent.click(buttons[0]!);
-};
+PanelNotFoundLight.play = openPanelMenu;
 
 export const PanelWithError = (): JSX.Element => {
   return (
@@ -131,8 +140,7 @@ export const RemoveUnknownPanel = (): JSX.Element => {
   );
 };
 RemoveUnknownPanel.play = async () => {
-  const buttons = await screen.findAllByRole("panel-menu");
-  fireEvent.click(buttons[0]!);
+  await openPanelMenu();
   fireEvent.click(screen.getByRole("panel-menu-remove")!);
 };
 
@@ -151,12 +159,6 @@ export const PanelLoading = (): JSX.Element => {
     </DndProvider>
   );
 };
-
-async function goFullScreen() {
-  const buttons = await screen.findAllByRole("panel-menu");
-  fireEvent.click(buttons[0]!);
-  fireEvent.click(screen.getByRole("panel-menu-fullscreen")!);
-}
 
 export const FullScreen = (): JSX.Element => {
   return (

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -24,13 +24,13 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import PanelLayout from "./PanelLayout";
 
 async function openPanelMenu() {
-  const buttons = await screen.findAllByRole("panel-menu");
+  const buttons = await screen.findAllByTestId("panel-menu");
   fireEvent.click(buttons[0]!);
 }
 
 async function goFullScreen() {
   await openPanelMenu();
-  fireEvent.click(screen.getByRole("panel-menu-fullscreen")!);
+  fireEvent.click(screen.getByTestId("panel-menu-fullscreen")!);
 }
 
 const allPanels: readonly PanelInfo[] = [
@@ -140,8 +140,8 @@ export const RemoveUnknownPanel = (): JSX.Element => {
   );
 };
 RemoveUnknownPanel.play = async () => {
-  (await screen.findAllByRole("panel-menu")).forEach((button) => fireEvent.click(button));
-  (await screen.findAllByRole("panel-menu-remove")).forEach((button) => fireEvent.click(button));
+  (await screen.findAllByTestId("panel-menu")).forEach((button) => fireEvent.click(button));
+  (await screen.findAllByTestId("panel-menu-remove")).forEach((button) => fireEvent.click(button));
 };
 
 export const PanelLoading = (): JSX.Element => {

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -162,7 +162,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
           iconName: "FullScreenMaximize",
           styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
         },
-        "data-test": "panel-menu-fullscreen",
+        role: "panel-menu-fullscreen",
       });
     }
 
@@ -171,7 +171,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
       text: "Remove panel",
       onClick: close,
       iconProps: { iconName: "Delete" },
-      "data-test": "panel-menu-remove",
+      role: "panel-menu-remove",
     });
 
     return items;
@@ -202,7 +202,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         target={buttonRef}
         onDismiss={() => setIsOpen(false)}
       />
-      <ToolbarIconButton title="More" data-test="panel-menu" onClick={() => setIsOpen(!isOpen)}>
+      <ToolbarIconButton title="More" role="panel-menu" onClick={() => setIsOpen(!isOpen)}>
         <MoreVertIcon />
       </ToolbarIconButton>
     </div>

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -202,7 +202,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
         target={buttonRef}
         onDismiss={() => setIsOpen(false)}
       />
-      <ToolbarIconButton title="More" role="panel-menu" onClick={() => setIsOpen(!isOpen)}>
+      <ToolbarIconButton title="More" data-testid="panel-menu" onClick={() => setIsOpen(!isOpen)}>
         <MoreVertIcon />
       </ToolbarIconButton>
     </div>

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -162,7 +162,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
           iconName: "FullScreenMaximize",
           styles: { root: { height: 24, marginLeft: 2, marginRight: 6 } },
         },
-        role: "panel-menu-fullscreen",
+        "data-testid": "panel-menu-fullscreen",
       });
     }
 
@@ -171,7 +171,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
       text: "Remove panel",
       onClick: close,
       iconProps: { iconName: "Delete" },
-      role: "panel-menu-remove",
+      "data-testid": "panel-menu-remove",
     });
 
     return items;

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -74,7 +74,7 @@ class PanelToolbarWithOpenMenu extends React.PureComponent {
           if (el) {
             // wait for Dimensions
             setTimeout(() => {
-              const gearIcon = el.querySelector("[role=panel-menu] > svg");
+              const gearIcon = el.querySelector("[data-testid=panel-menu] > svg");
               gearIcon?.parentElement?.click();
             }, 100);
           }

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -74,7 +74,7 @@ class PanelToolbarWithOpenMenu extends React.PureComponent {
           if (el) {
             // wait for Dimensions
             setTimeout(() => {
-              const gearIcon = el.querySelector("[data-test=panel-menu] > svg");
+              const gearIcon = el.querySelector("[role=panel-menu] > svg");
               gearIcon?.parentElement?.click();
             }, 100);
           }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This makes the interactions in the `PanelLayout` stories more idiomatic and robust by using the built-in `play` function and replacing the click timeouts with the storybook `findAllById` and `getAllById` functions.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
