### PR TITLE
[New3D] Move measure tool distance into 3D scene

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -130,7 +130,6 @@ function RendererOverlay(props: {
   addPanel: LayoutActions["addPanel"];
   enableStats: boolean;
   measureActive: boolean;
-  measureDistance?: number;
   onClickMeasure: () => void;
   canPublish: boolean;
   publishActive: boolean;
@@ -259,17 +258,6 @@ function RendererOverlay(props: {
             style={{ position: "relative", pointerEvents: "auto" }}
           >
             <RulerIcon style={{ width: 16, height: 16 }} />
-            <div
-              style={{
-                position: "absolute",
-                top: "50%",
-                left: theme.spacing(-0.75),
-                fontSize: "0.75rem",
-                transform: "translate(-100%, -50%)",
-              }}
-            >
-              {props.measureDistance?.toFixed(2)}
-            </div>
           </IconButton>
 
           {props.canPublish && (
@@ -679,17 +667,13 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   );
 
   const [measureActive, setMeasureActive] = useState(false);
-  const [measureDistance, setMeasureDistance] = useState<number | undefined>();
   useEffect(() => {
     const onStart = () => setMeasureActive(true);
-    const onChange = () => setMeasureDistance(renderer?.measurementTool.distance);
     const onEnd = () => setMeasureActive(false);
     renderer?.measurementTool.addEventListener("foxglove.measure-start", onStart);
-    renderer?.measurementTool.addEventListener("foxglove.measure-change", onChange);
     renderer?.measurementTool.addEventListener("foxglove.measure-end", onEnd);
     return () => {
       renderer?.measurementTool.removeEventListener("foxglove.measure-start", onStart);
-      renderer?.measurementTool.removeEventListener("foxglove.measure-change", onChange);
       renderer?.measurementTool.removeEventListener("foxglove.measure-end", onEnd);
     };
   }, [renderer?.measurementTool]);
@@ -832,7 +816,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
             addPanel={addPanel}
             enableStats={config.scene.enableStats ?? false}
             measureActive={measureActive}
-            measureDistance={measureDistance}
             onClickMeasure={onClickMeasure}
             canPublish={context.publish != undefined}
             publishActive={publishActive}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import * as THREE from "three";
 
+import { Label } from "@foxglove/three-text";
+
 import { Renderable, BaseUserData } from "../Renderable";
 import { Renderer } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
@@ -47,10 +49,7 @@ class FixedSizeMeshMaterial extends THREE.ShaderMaterial {
   }
 }
 
-type MeasurementEvent =
-  | { type: "foxglove.measure-start" }
-  | { type: "foxglove.measure-change" }
-  | { type: "foxglove.measure-end" };
+type MeasurementEvent = { type: "foxglove.measure-start" } | { type: "foxglove.measure-end" };
 
 export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, MeasurementEvent> {
   private circleGeometry = new THREE.CircleGeometry(5, 16);
@@ -64,12 +63,13 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     new THREE.LineBasicMaterial({ color: 0xff0000 }),
   );
 
+  private label: Label;
+
   private point1NeedsUpdate = false;
   private point2NeedsUpdate = false;
 
   point1?: THREE.Vector3;
   point2?: THREE.Vector3;
-  distance?: number;
 
   state: MeasurementState = "idle";
 
@@ -80,6 +80,16 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.circle1.userData.picking = false;
     this.circle2.userData.picking = false;
 
+    this.label = renderer.labelPool.acquire();
+    this.label.visible = false;
+    this.label.setBillboard(true);
+    this.label.setSizeAttenuation(false);
+    this.label.setLineHeight(12);
+    this.label.setColor(1, 0, 0);
+    this.label.renderOrder = 9999999;
+    this.label.material.depthTest = false;
+    this.label.material.depthWrite = false;
+
     this.line.frustumCulled = false;
     this.line.geometry.setAttribute("position", this.linePositionAttribute);
     this.circle1.visible = false;
@@ -87,11 +97,13 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.add(this.circle1);
     this.add(this.circle2);
     this.add(this.line);
+    this.add(this.label);
     this._setState("idle");
   }
 
   override dispose(): void {
     super.dispose();
+    this.renderer.labelPool.release(this.label);
     this.circleGeometry.dispose();
     this.circleMaterial.dispose();
     this.line.geometry.dispose();
@@ -105,7 +117,7 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
   }
 
   stopMeasuring(): void {
-    this.point1 = this.point2 = this.distance = undefined;
+    this.point1 = this.point2 = undefined;
     this._setState("idle");
   }
 
@@ -124,7 +136,7 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
         this.dispatchEvent({ type: "foxglove.measure-end" });
         break;
       case "place-first-point":
-        this.point1 = this.point2 = this.distance = undefined;
+        this.point1 = this.point2 = undefined;
         this.renderer.input.addListener("click", this._handleClick);
         this.renderer.input.addListener("mousemove", this._handleMouseMove);
         this.dispatchEvent({ type: "foxglove.measure-start" });
@@ -161,8 +173,9 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
   };
 
   private _updateDistance() {
-    this.distance = this.point1 && this.point2 ? this.point1.distanceTo(this.point2) : undefined;
-    this.dispatchEvent({ type: "foxglove.measure-change" });
+    if (this.point1 && this.point2) {
+      this.label.setText(this.point1.distanceTo(this.point2).toFixed(2));
+    }
   }
 
   private _handleClick = (
@@ -217,7 +230,14 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
       this.circle2.visible = false;
     }
 
-    this.line.visible = this.point1 != undefined && this.point2 != undefined;
+    if (this.point1 && this.point2) {
+      this.line.visible = true;
+      this.label.visible = true;
+      this.label.position.copy(this.point1).lerp(this.point2, 0.5);
+    } else {
+      this.line.visible = false;
+      this.label.visible = false;
+    }
 
     this.renderer.queueAnimationFrame();
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
@@ -86,9 +86,12 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.label.setSizeAttenuation(false);
     this.label.setLineHeight(12);
     this.label.setColor(1, 0, 0);
+
+    // Make the label appear on top of other objects in the scene so it doesn't get clipped/occluded
     this.label.renderOrder = 9999999;
     this.label.material.depthTest = false;
     this.label.material.depthWrite = false;
+    this.label.material.transparent = true;
 
     this.line.frustumCulled = false;
     this.line.geometry.setAttribute("position", this.linePositionAttribute);

--- a/packages/three-text/src/LabelPool.stories.tsx
+++ b/packages/three-text/src/LabelPool.stories.tsx
@@ -74,6 +74,7 @@ export const Basic = Object.assign(BasicTemplate.bind({}), {
     opacity: 1,
     cameraMode: "perspective",
     billboard: false,
+    sizeAttenuation: true,
     anchorPointX: 0.5,
     anchorPointY: 0.5,
     positionX: 0,
@@ -82,7 +83,7 @@ export const Basic = Object.assign(BasicTemplate.bind({}), {
   },
   argTypes: {
     cameraMode: { control: "inline-radio", options: ["perspective", "orthographic"] },
-    lineHeight: { control: { type: "range", min: 0.5, max: 5, step: 0.01 } },
+    lineHeight: { control: { type: "range", min: 0.5, max: 20, step: 0.01 } },
     scaleFactor: { control: { type: "range", min: 0, max: 2, step: 0.01 } },
     opacity: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
     anchorPointX: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
@@ -99,7 +100,8 @@ function BasicTemplate({
   scaleFactor,
   opacity,
   billboard,
-  cameraMode,
+  sizeAttenuation,
+  cameraMode = "perspective",
   anchorPointX,
   anchorPointY,
   positionX,
@@ -112,6 +114,7 @@ function BasicTemplate({
   opacity: number;
   cameraMode: "perspective" | "orthographic";
   billboard: boolean;
+  sizeAttenuation: boolean;
   anchorPointX: number;
   anchorPointY: number;
   positionX: number;
@@ -177,6 +180,13 @@ function BasicTemplate({
       storyScene.render();
     }
   }, [billboard, label, storyScene]);
+
+  useEffect(() => {
+    if (label) {
+      label.setSizeAttenuation(sizeAttenuation);
+      storyScene.render();
+    }
+  }, [sizeAttenuation, label, storyScene]);
 
   useEffect(() => {
     if (label) {

--- a/packages/three-text/src/LabelPool.ts
+++ b/packages/three-text/src/LabelPool.ts
@@ -7,6 +7,8 @@ import { EventDispatcher } from "three";
 
 import { FontManager, FontManagerOptions } from "./FontManager";
 
+const tempVec2 = new THREE.Vector2();
+
 class LabelMaterial extends THREE.RawShaderMaterial {
   constructor(params: { atlasTexture?: THREE.Texture; picking?: boolean }) {
     super({
@@ -17,10 +19,12 @@ precision highp int;
 uniform mat4 projectionMatrix, modelViewMatrix, modelMatrix;
 
 uniform bool uBillboard;
+uniform bool uSizeAttenuation;
 uniform float uScale;
 uniform vec2 uLabelSize;
 uniform vec2 uTextureSize;
 uniform vec2 uAnchorPoint;
+uniform vec2 uCanvasSize;
 
 in vec2 uv;
 in vec2 position;
@@ -37,20 +41,28 @@ void main() {
   vUv = (instanceUv + boxUv * instanceCharSize) / uTextureSize;
   vec2 vertexPos = (instanceBoxPosition + position * instanceBoxSize - uAnchorPoint * uLabelSize) * uScale;
   vPosInLabel = (instanceBoxPosition + position * instanceBoxSize);
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 0.0, 1.0);
 
   // Adapted from THREE.ShaderLib.sprite
   if (uBillboard) {
-    vec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );
-    // vec2 scale;
-    // scale.x = length(modelMatrix[0].xyz);
-    // scale.y = length(modelMatrix[1].xyz);
-    // #ifndef USE_SIZEATTENUATION
-    //   bool isPerspective = isPerspectiveMatrix( projectionMatrix );
-    //   if ( isPerspective ) scale *= - mvPosition.z;
-    // #endif
-    mvPosition.xy += vertexPos;
-    gl_Position = projectionMatrix * mvPosition;
+    if (uSizeAttenuation) {
+      vec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );
+      mvPosition.xy += vertexPos;
+      gl_Position = projectionMatrix * mvPosition;
+    } else {
+      vec4 mvPosition = modelViewMatrix * vec4(0., 0., 0., 1.);
+
+      // Adapted from THREE.ShaderLib.sprite
+      vec2 scale;
+      scale.x = length(vec3(modelMatrix[0].xyz));
+      scale.y = length(vec3(modelMatrix[1].xyz));
+
+      gl_Position = projectionMatrix * mvPosition;
+
+      // Add position after projection to maintain constant pixel size
+      gl_Position.xy += vertexPos * 2. / uCanvasSize * scale * gl_Position.w;
+    }
+  } else {
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPos, 0.0, 1.0);
   }
 }
 `,
@@ -108,7 +120,9 @@ void main() {
         objectId: { value: [NaN, NaN, NaN, NaN] },
         uAnchorPoint: { value: [0.5, 0.5] },
         uBillboard: { value: false },
+        uSizeAttenuation: { value: true },
         uLabelSize: { value: [0, 0] },
+        uCanvasSize: { value: [0, 0] },
         uScale: { value: 0 },
         uTextureSize: {
           value: [params.atlasTexture?.image.width ?? 0, params.atlasTexture?.image.height ?? 0],
@@ -170,6 +184,12 @@ export class Label extends THREE.Object3D {
 
     this.mesh = new THREE.InstancedMesh(this.geometry, this.material, 0);
     this.mesh.userData.pickingMaterial = this.pickingMaterial;
+
+    this.mesh.onBeforeRender = (renderer, _scene, _camera, _geometry, _material, _group) => {
+      renderer.getSize(tempVec2);
+      this.material.uniforms.uCanvasSize!.value[0] = tempVec2.x;
+      this.material.uniforms.uCanvasSize!.value[1] = tempVec2.y;
+    };
 
     this.add(this.mesh);
     this.setOpacity(1);
@@ -281,6 +301,16 @@ export class Label extends THREE.Object3D {
   setBillboard(billboard: boolean): void {
     this.material.uniforms.uBillboard!.value = billboard;
     this.pickingMaterial.uniforms.uBillboard!.value = billboard;
+  }
+
+  /**
+   * Enable or disable size attenuation. Setting this to `false` also requires that billboarding is
+   * enabled.
+   */
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setSizeAttenuation(sizeAttenuation: boolean): void {
+    this.material.uniforms.uSizeAttenuation!.value = sizeAttenuation;
+    this.pickingMaterial.uniforms.uSizeAttenuation!.value = sizeAttenuation;
   }
 
   setAnchorPoint(x: number, y: number): void {

--- a/packages/three-text/src/LabelPool.ts
+++ b/packages/three-text/src/LabelPool.ts
@@ -189,6 +189,8 @@ export class Label extends THREE.Object3D {
       renderer.getSize(tempVec2);
       this.material.uniforms.uCanvasSize!.value[0] = tempVec2.x;
       this.material.uniforms.uCanvasSize!.value[1] = tempVec2.y;
+      this.pickingMaterial.uniforms.uCanvasSize!.value[0] = tempVec2.x;
+      this.pickingMaterial.uniforms.uCanvasSize!.value[1] = tempVec2.y;
     };
 
     this.add(this.mesh);


### PR DESCRIPTION
**User-Facing Changes**
Measured distance in the 3D (Beta) panel is now shown along the measured line instead of next to the measurement tool button.

https://user-images.githubusercontent.com/14237/179317065-ea82f6ef-cf2a-4be5-9f8a-8db94f6cc1fd.mov

**Description**
Added sizeAttenuation=false support to `@foxglove/three-text`