### PR TITLE
Dialog contrast tweaks

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/ActionList.tsx
+++ b/packages/studio-base/src/components/OpenDialog/ActionList.tsx
@@ -24,7 +24,7 @@ type ActionListProps = {
 export default function ActionList(props: ActionListProps): JSX.Element {
   const { items, title, gridColumn } = props;
   return (
-    <Stack gap={1} style={{ gridColumn }}>
+    <Stack gap={1} overflow="hidden" style={{ gridColumn }}>
       {title != undefined && (
         <Typography variant="h5" color="text.secondary">
           {title}

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.stories.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.stories.tsx
@@ -21,7 +21,7 @@ const playerSelection: PlayerSelection = {
   recentSources: [
     {
       id: "1111",
-      title: "NuScenes-v1.0-mini-scene-0655.bag",
+      title: "NuScenes-v1.0-mini-scene-0655-reallllllllly-long-name-8829908290831091.bag",
     },
     {
       id: "2222",

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Theme, ThemeOptions } from "@mui/material/styles";
+import { alpha, Theme, ThemeOptions } from "@mui/material/styles";
 import { CSSProperties } from "@mui/styles";
 
 type MuiLabComponents = {
@@ -192,6 +192,13 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       defaultProps: {
         PaperProps: {
           elevation: 4,
+        },
+      },
+    },
+    MuiBackdrop: {
+      styleOverrides: {
+        root: {
+          backgroundColor: alpha(theme.palette.common.black, 0.4),
         },
       },
     },
@@ -387,6 +394,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       defaultProps: {
         elevation: 2,
         square: true,
+      },
+      styleOverrides: {
+        elevation: {
+          backgroundImage: "none !important",
+        },
       },
     },
     MuiRadio: {

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -194,11 +194,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
           elevation: 4,
         },
       },
-    },
-    MuiBackdrop: {
       styleOverrides: {
         root: {
-          backgroundColor: alpha(theme.palette.common.black, 0.4),
+          ".MuiBackdrop-root": {
+            backgroundColor: alpha(theme.palette.common.black, 0.4),
+          },
         },
       },
     },


### PR DESCRIPTION
**User-Facing Changes**

TLDR: Darker paper, lighter backdrop

MUI follows the [Material UI](https://material.io/design/color/dark-theme.html#properties) dark elevation guidlines. by lightening the background of surfaces when increasing the elevation. We have managed to not notice this as we don't really use elevation that much but the Dialog have a default elevation higher than the rest of the elements.

Before
<img width="1912" alt="Screen Shot 2022-07-16 at 9 57 04 am" src="https://user-images.githubusercontent.com/924528/179325753-34018029-2378-49aa-86ca-afd73b16c842.png">

After
<img width="1912" alt="Screen Shot 2022-07-16 at 9 56 52 am" src="https://user-images.githubusercontent.com/924528/179325756-dc451fbf-3808-4da1-ba94-22e0d983dc14.png">

**Description**
Resolve contrast issues created by #3774

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
