### PR TITLE
Fix new layouts created while offline being deleted when online

### DIFF
--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -416,9 +416,10 @@ export default class LayoutManager implements ILayoutManager {
               savedAt: now,
             },
             working: undefined,
-            syncInfo: this.remote
-              ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
-              : localLayout.syncInfo,
+            syncInfo:
+              this.remote && localLayout.syncInfo?.status !== "new"
+                ? { status: "updated", lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt }
+                : localLayout.syncInfo,
           }),
       );
       this.notifyChangeListeners({ type: "change", updatedLayout: result });
@@ -542,6 +543,9 @@ export default class LayoutManager implements ILayoutManager {
           }
 
           case "delete-local":
+            log.debug(
+              `Deleting local layout ${operation.localLayout.id}, whose sync status was ${operation.localLayout.syncInfo?.status}`,
+            );
             await local.delete(operation.localLayout.id);
             this.notifyChangeListeners({ type: "delete", layoutId: operation.localLayout.id });
             break;


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where a layout created while offline would be deleted when going back online, if the user chose to "Save changes" to the new layout while offline.

**Description**
The save operation was changing the status from `"new"` to `"updated"`. And `"updated"` status indicates that the layout has been seen on the server, so the fact that it's _not_ present on the server when internet is restored means that it should be deleted locally. The fix is to keep the `"new"` status when the user saves the layout so we know it still needs to be uploaded.

Fixes https://github.com/foxglove/studio/issues/3810