### PR TITLE
Update post-release to publish snap to stable channel

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -217,4 +217,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
         with:
           snap: ci/apt/packages/foxglove-studio-${{ steps.studio-version.outputs.version }}-linux-amd64.snap
-          release: candidate
+          release: stable


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Publish our snap package to the stable channel on release. This will make it available to users without a manual promotion from candidate.

We don't do manual vetting on each OS specific release today and would prefer our releases go out to users once we cut them rather than more manual steps.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
