### PR TITLE
Limit ROS Diagnostic panels to DiagnosticStatusArray topics

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -25,7 +25,6 @@ import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
-import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 
 import DiagnosticStatus from "./DiagnosticStatus";
 import helpContent from "./DiagnosticStatusPanel.help.md";
@@ -61,10 +60,16 @@ function DiagnosticStatusPanel(props: Props) {
       .map((topic) => topic.name);
 
     // Keeps only the first occurrence of each topic.
-    return uniq([DIAGNOSTIC_TOPIC, ...filtered, topicToRender]);
-  }, [topics, topicToRender]);
+    return uniq([...filtered]);
+  }, [topics]);
 
-  const availableDiagnostics = useAvailableDiagnostics(topicToRender);
+  // If the topicToRender is not in the availableTopics, then we should not try to use it
+  const diagnosticTopic = useMemo(() => {
+    return availableTopics.includes(topicToRender) ? topicToRender : undefined;
+  }, [availableTopics, topicToRender]);
+
+  const diagnostics = useDiagnostics(diagnosticTopic);
+  const availableDiagnostics = useAvailableDiagnostics(diagnosticTopic);
 
   // generate Autocomplete entries from the available diagnostics
   const autocompleteOptions = useMemo(() => {
@@ -99,8 +104,6 @@ function DiagnosticStatusPanel(props: Props) {
       }) ?? ReactNull
     );
   }, [autocompleteOptions, selectedDisplayName]);
-
-  const diagnostics = useDiagnostics(topicToRender);
 
   const filteredDiagnostics = useMemo(() => {
     const diagnosticsByName = diagnostics.get(selectedHardwareId ?? "");
@@ -203,7 +206,7 @@ function DiagnosticStatusPanel(props: Props) {
   );
 }
 
-const defaultConfig: Config = { topicToRender: DIAGNOSTIC_TOPIC };
+const defaultConfig: Config = { topicToRender: "/diagnostics" };
 
 export default Panel(
   Object.assign(DiagnosticStatusPanel, {

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -39,7 +39,6 @@ import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSumm
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
-import { DIAGNOSTIC_TOPIC } from "@foxglove/studio-base/util/globalConstants";
 import toggle from "@foxglove/studio-base/util/toggle";
 
 import { buildSummarySettingsTree } from "./settings";
@@ -204,10 +203,15 @@ function DiagnosticSummary(props: Props): JSX.Element {
       .map((topic) => topic.name);
 
     // Keeps only the first occurrence of each topic.
-    return uniq([DIAGNOSTIC_TOPIC, ...filtered, topicToRender]);
-  }, [topics, topicToRender]);
+    return uniq([...filtered]);
+  }, [topics]);
 
-  const diagnostics = useDiagnostics(topicToRender);
+  // If the topicToRender is not in the availableTopics, then we should not try to use it
+  const diagnosticTopic = useMemo(() => {
+    return availableTopics.includes(topicToRender) ? topicToRender : undefined;
+  }, [availableTopics, topicToRender]);
+
+  const diagnostics = useDiagnostics(diagnosticTopic);
 
   const summary = useMemo(() => {
     if (diagnostics.size === 0) {
@@ -323,7 +327,7 @@ const defaultConfig: DiagnosticSummaryConfig = {
   minLevel: 0,
   pinnedIds: [],
   hardwareIdFilter: "",
-  topicToRender: DIAGNOSTIC_TOPIC,
+  topicToRender: "/diagnostics",
   sortByLevel: true,
 };
 

--- a/packages/studio-base/src/panels/diagnostics/useAvailableDiagnostics.ts
+++ b/packages/studio-base/src/panels/diagnostics/useAvailableDiagnostics.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useMemo } from "react";
+
 import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
@@ -11,8 +13,7 @@ import { DiagnosticStatusArrayMsg } from "./util";
 type DiagnosticNameSet = Set<string>;
 type UseAvailableDiagnosticResult = Map<string, DiagnosticNameSet>;
 
-// Exported for tests
-export function addMessages(
+function addMessages(
   previousAvailableDiagnostics: UseAvailableDiagnosticResult,
   messages: readonly MessageEvent<unknown>[],
 ): UseAvailableDiagnosticResult {
@@ -46,9 +47,16 @@ export function addMessages(
 
 const EmptyMap = () => new Map();
 
-export default function useAvailableDiagnostics(topic: string): UseAvailableDiagnosticResult {
+export default function useAvailableDiagnostics(topic?: string): UseAvailableDiagnosticResult {
+  const topics = useMemo(() => {
+    if (topic) {
+      return [topic];
+    }
+    return [];
+  }, [topic]);
+
   return useMessageReducer<UseAvailableDiagnosticResult>({
-    topics: [topic],
+    topics,
     restore: EmptyMap,
     addMessages,
   });

--- a/packages/studio-base/src/panels/diagnostics/useDiagnostics.ts
+++ b/packages/studio-base/src/panels/diagnostics/useDiagnostics.ts
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { useMemo } from "react";
+
 import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
@@ -23,9 +25,7 @@ export function addMessages(
   prevResult: UseDiagnosticsResult,
   msgEvents: readonly MessageEvent<unknown>[],
 ): UseDiagnosticsResult {
-  // maybeAddMessageToBuffer mutates the buffer instead of doing an immutable update for performance
-  // reasons. There are large numbers of diagnostics messages, and often many diagnostics panels in
-  // a layout.
+  // Mutates the previous value since there might be many diagnostic messages
   let modified = false;
   for (const msgEvent of msgEvents as MessageEvent<DiagnosticStatusArrayMsg>[]) {
     const { header, status: statusArray }: DiagnosticStatusArrayMsg = msgEvent.message;
@@ -49,9 +49,16 @@ export function addMessages(
 
 const EmptyMap = () => new Map();
 
-export default function useDiagnostics(topic: string): UseDiagnosticsResult {
+export default function useDiagnostics(topic?: string): UseDiagnosticsResult {
+  const topics = useMemo(() => {
+    if (topic) {
+      return [topic];
+    }
+    return [];
+  }, [topic]);
+
   return useMessageReducer<UseDiagnosticsResult>({
-    topics: [topic],
+    topics,
     restore: EmptyMap,
     addMessages,
   });

--- a/packages/studio-base/src/util/globalConstants.ts
+++ b/packages/studio-base/src/util/globalConstants.ts
@@ -15,8 +15,6 @@ import type { Base16Theme } from "base16";
 
 export const DEFAULT_STUDIO_NODE_PREFIX = "/studio_node/";
 
-export const DIAGNOSTIC_TOPIC = "/diagnostics";
-
 export const FOXGLOVE_GRID_TOPIC = "/foxglove/grid";
 export const FOXGLOVE_GRID_DATATYPE = "foxglove/Grid";
 


### PR DESCRIPTION


**User-Facing Changes**
The diagnostic panels don't crash when an unsupported datatype is sent on the /diagnostic topic.

**Description**
Prior to this change, the Diagnostic panels would always subscribe to the /diagnostics topic regardless of the datatype. This resulted in the panels crashing when a user sent a message that is not a DiagnosticStatusArray on this topic.

This change fixes the panel logic to avoid subscribing to the topic unless it publishes a supported datatype.

Fixes: #3785

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
