### PR TITLE
Enable minifySyntax and minifyWhitespace in ESBuildMinifyPlugin config

### DIFF
--- a/desktop/webpack.main.config.ts
+++ b/desktop/webpack.main.config.ts
@@ -68,6 +68,8 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
         new ESBuildMinifyPlugin({
           target: "es2020",
           minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifySyntax: true,
+          minifyWhitespace: true,
         }),
       ],
     },

--- a/desktop/webpack.preload.config.ts
+++ b/desktop/webpack.preload.config.ts
@@ -51,6 +51,8 @@ export default (_: unknown, argv: WebpackArgv): Configuration => {
         new ESBuildMinifyPlugin({
           target: "es2020",
           minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifySyntax: true,
+          minifyWhitespace: true,
         }),
       ],
     },

--- a/desktop/webpack.quicklook.config.ts
+++ b/desktop/webpack.quicklook.config.ts
@@ -74,6 +74,8 @@ export default (_env: unknown, argv: WebpackArgv): Configuration => {
         new ESBuildMinifyPlugin({
           target: "es2020",
           minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifySyntax: true,
+          minifyWhitespace: true,
         }),
       ],
     },

--- a/desktop/webpack.renderer.config.ts
+++ b/desktop/webpack.renderer.config.ts
@@ -78,6 +78,8 @@ export default (env: unknown, argv: WebpackArgv): Configuration => {
         new ESBuildMinifyPlugin({
           target: "es2020",
           minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifySyntax: true,
+          minifyWhitespace: true,
         }),
       ],
     },

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -229,6 +229,8 @@ export function makeConfig(
         new ESBuildMinifyPlugin({
           target: "es2020",
           minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifySyntax: true,
+          minifyWhitespace: true,
         }),
       ],
     },


### PR DESCRIPTION
**User-Facing Changes**
Reduced app bundle size.

**Description**
Alternative to #3860. Apparently when `minifyIdentifiers: false` was added in #1880, it caused the other minify options to also default to false. We need to set them to true explicitly.