### PR TITLE
[New3D] Recompute defaultFrameId when frames change

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -978,6 +978,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
     return selectedRenderable;
   }
 
+  /** Tracks the number of frames so we can recompute the defaultFrameId when frames are added. */
+  private _lastTransformFrameCount = 0;
+
   private _updateFrames(): void {
     if (
       this.followFrameId != undefined &&
@@ -988,11 +991,13 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.renderFrameId = this.followFrameId;
     } else if (
       this.renderFrameId == undefined ||
+      this.transformTree.frames().size !== this._lastTransformFrameCount ||
       !this.transformTree.hasFrame(this.renderFrameId)
     ) {
-      // No valid renderFrameId set, fall back to selecting the heuristically
-      // most valid frame (if any frames are present)
+      // No valid renderFrameId set, or new frames have been added, fall back to selecting the
+      // heuristically most valid frame (if any frames are present)
       this.renderFrameId = this.defaultFrameId();
+      this._lastTransformFrameCount = this.transformTree.frames().size;
 
       if (this.renderFrameId == undefined) {
         this.settings.errors.add(FOLLOW_TF_PATH, NO_FRAME_SELECTED, `No coordinate frames found`);


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug in the 3D (Beta) panel where seeking would sometimes result in orientation changes if a transform frame had not been manually selected.

**Description**
Fixes https://github.com/foxglove/studio/issues/3790 by re-selecting a render frame using `defaultFrameId` whenever the number of frames changes. This only applies if a `followFrameId` was not chosen in the config.