### PR TITLE
Remove use of fluent color utils in favor of tinycolor2

### DIFF
--- a/desktop/main/getDevModeIcon.ts
+++ b/desktop/main/getDevModeIcon.ts
@@ -1,8 +1,9 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-import { rgb2hsv, hsv2rgb } from "@fluentui/react";
+
 import { NativeImage, nativeImage } from "electron";
+import tinycolor from "tinycolor2";
 
 const ROTATION_DEGREES = 270;
 
@@ -14,9 +15,13 @@ export default function getDevModeIcon(): NativeImage | undefined {
 
     const buffer = originalIcon.toBitmap();
     for (let i = 0; i + 3 < buffer.length; i += 4) {
-      const hsv = rgb2hsv(buffer[i]!, buffer[i + 1]!, buffer[i + 2]!);
+      const hsv = tinycolor({ r: buffer[i]!, g: buffer[i + 1]!, b: buffer[i + 2]! }).toHsv();
       hsv.h = (hsv.h + ROTATION_DEGREES) % 360;
-      ({ r: buffer[i], g: buffer[i + 1], b: buffer[i + 2] } = hsv2rgb(hsv.h, hsv.s, hsv.v));
+      ({
+        r: buffer[i],
+        g: buffer[i + 1],
+        b: buffer[i + 2],
+      } = tinycolor({ h: hsv.h, s: hsv.s, v: hsv.v }).toRgb());
     }
 
     return nativeImage.createFromBuffer(buffer, originalIcon.getSize());


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Dependency on fluentui/react `hsv2rgb` and `rgb2hsv`

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
