### PR TITLE
Delete unlimited memory cache setting

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -18,7 +18,6 @@ export enum AppSetting {
   CRASH_REPORTING_ENABLED = "telemetry.crashReportingEnabled",
 
   // Experimental features
-  UNLIMITED_MEMORY_CACHE = "experimental.unlimited-memory-cache",
   SHOW_DEBUG_PANELS = "showDebugPanels",
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
   EXPERIMENTAL_BAG_PLAYER = "experimental.bag-player",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -26,16 +26,6 @@ type Feature = {
 
 const features: Feature[] = [
   {
-    key: AppSetting.UNLIMITED_MEMORY_CACHE,
-    name: "Unlimited in-memory cache",
-    description: (
-      <>
-        Fully buffer a bag into memory. This may use up a lot of system memory. Changing this
-        setting requires a restart.
-      </>
-    ),
-  },
-  {
     key: AppSetting.SHOW_DEBUG_PANELS,
     name: "Studio debug panels",
     description: <>Show Foxglove Studio debug panels in the &ldquo;Add panel&rdquo; list.</>,

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -86,13 +86,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   const analytics = useAnalytics();
   const metricsCollector = useMemo(() => new AnalyticsMetricsCollector(analytics), [analytics]);
 
-  // When we implmenent per-data-connector UI settings we will move this into the appropriate
-  // data sources. We might also consider this a studio responsibility and handle generically for
-  // all data sources.
-  const [unlimitedMemoryCache = false] = useAppConfigurationValue<boolean>(
-    AppSetting.UNLIMITED_MEMORY_CACHE,
-  );
-
   // Use the default message ordering unless this experimental flag is enabled
   const [enableMessageOrdering = false] = useAppConfigurationValue<boolean>(
     AppSetting.EXPERIMENTAL_MESSAGE_ORDER,
@@ -162,7 +155,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         const newPlayer = foundSource.initialize({
           consoleApi,
           metricsCollector,
-          unlimitedMemoryCache,
         });
 
         setBasePlayer(newPlayer);
@@ -202,7 +194,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
               ...args.params,
               consoleApi,
               metricsCollector,
-              unlimitedMemoryCache,
             });
             setBasePlayer(newPlayer);
 
@@ -239,7 +230,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
                 file: multiFile ? undefined : file,
                 files: multiFile ? fileList : undefined,
                 metricsCollector,
-                unlimitedMemoryCache,
               });
 
               setBasePlayer(newPlayer);
@@ -265,7 +255,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
               const newPlayer = foundSource.initialize({
                 file,
                 metricsCollector,
-                unlimitedMemoryCache,
               });
 
               setBasePlayer(newPlayer);
@@ -295,7 +284,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       metricsCollector,
       playerSources,
       setSelectedLayoutId,
-      unlimitedMemoryCache,
     ],
   );
 

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -10,7 +10,6 @@ import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 
 export type DataSourceFactoryInitializeArgs = {
   metricsCollector: PlayerMetricsCollectorInterface;
-  unlimitedMemoryCache: boolean;
   folder?: FileSystemDirectoryHandle;
   file?: File;
   files?: File[];

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -44,9 +44,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
     }
 
     const mcapProvider = new McapDataProvider({ source: { type: "file", file } });
-    const messageCacheProvider = new MemoryCacheDataProvider(mcapProvider, {
-      unlimitedCache: args.unlimitedMemoryCache,
-    });
+    const messageCacheProvider = new MemoryCacheDataProvider(mcapProvider);
 
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
@@ -28,9 +28,7 @@ export default class McapRemoteDataSourceFactory implements IDataSourceFactory {
     }
 
     const mcapProvider = new McapDataProvider({ source: { type: "remote", url } });
-    const messageCacheProvider = new MemoryCacheDataProvider(mcapProvider, {
-      unlimitedCache: args.unlimitedMemoryCache,
-    });
+    const messageCacheProvider = new MemoryCacheDataProvider(mcapProvider);
 
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.tsx
@@ -43,9 +43,7 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "file", file });
-      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider, {
-        unlimitedCache: args.unlimitedMemoryCache,
-      });
+      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider);
 
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1RemoteBagDataSourceFactory.tsx
@@ -50,9 +50,7 @@ class Ros1RemoteBagDataSourceFactory implements IDataSourceFactory {
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url });
-      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider, {
-        unlimitedCache: args.unlimitedMemoryCache,
-      });
+      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider);
 
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.tsx
@@ -27,9 +27,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
         files: args.files ?? [],
       });
 
-      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider, {
-        unlimitedCache: args.unlimitedMemoryCache,
-      });
+      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider);
 
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,
@@ -42,9 +40,7 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
         file: args.file,
       });
 
-      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider, {
-        unlimitedCache: args.unlimitedMemoryCache,
-      });
+      const messageCacheProvider = new MemoryCacheDataProvider(bagWorkerDataProvider);
 
       return new RandomAccessPlayer(messageCacheProvider, {
         metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -45,9 +45,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
       });
     } else {
       const bagWorkerDataProvider = new WorkerBagDataProvider({ type: "remote", url: bagUrl });
-      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider, {
-        unlimitedCache: args.unlimitedMemoryCache,
-      });
+      const messageCacheProvider = new Ros1MemoryCacheDataProvider(bagWorkerDataProvider);
 
       return new RandomAccessPlayer(messageCacheProvider, {
         isSampleDataSource: true,

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.tsx
@@ -26,9 +26,7 @@ class UlogLocalDataSourceFactory implements IDataSourceFactory {
     }
 
     const ulogDataProvider = new UlogDataProvider({ file });
-    const messageCacheProvider = new MemoryCacheDataProvider(ulogDataProvider, {
-      unlimitedCache: args.unlimitedMemoryCache,
-    });
+    const messageCacheProvider = new MemoryCacheDataProvider(ulogDataProvider);
 
     return new RandomAccessPlayer(messageCacheProvider, {
       metricsCollector: args.metricsCollector,

--- a/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/MemoryCacheDataProvider.ts
@@ -274,9 +274,8 @@ export default class MemoryCacheDataProvider implements RandomAccessDataProvider
   private _readAheadBlocks: number = 0;
   private _memCacheBlockSizeNs: number = 0;
 
-  constructor(provider: RandomAccessDataProvider, options: { unlimitedCache?: boolean }) {
-    const { unlimitedCache = false } = options;
-    this._cacheSizeBytes = unlimitedCache ? Infinity : DEFAULT_CACHE_SIZE_BYTES;
+  constructor(provider: RandomAccessDataProvider) {
+    this._cacheSizeBytes = DEFAULT_CACHE_SIZE_BYTES;
     this._provider = provider;
   }
 

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
@@ -76,10 +76,7 @@ function generateMessagesForLongInput(): MessageEvent<ArrayBuffer>[] {
   ]);
 }
 
-function getProvider(
-  messages: MessageEvent<ArrayBuffer>[],
-  { unlimitedCache = false }: { unlimitedCache?: boolean } = {},
-) {
+function getProvider(messages: MessageEvent<ArrayBuffer>[]) {
   const memoryDataProvider = new MemoryDataProvider({
     messages: { parsedMessages: undefined, encodedMessages: messages },
     topicStats: new Map(),
@@ -91,7 +88,7 @@ function getProvider(
     },
   });
   return {
-    provider: new Ros1MemoryCacheDataProvider(memoryDataProvider, { unlimitedCache }),
+    provider: new Ros1MemoryCacheDataProvider(memoryDataProvider),
     memoryDataProvider,
   };
 }
@@ -237,29 +234,6 @@ describe("MemoryCacheDataProvider", () => {
     expect(last(mockProgressCallback.mock.calls)).toEqual([
       {
         fullyLoadedFractionRanges: [{ start: 0, end: 81 / 201 }],
-        messageCache: {
-          startTime: { sec: 0, nsec: 0 },
-          blocks: expect.arrayContaining([]),
-        },
-      },
-    ]);
-  });
-
-  it("does not stop prefetching with unlimitedCache", async () => {
-    const { provider } = getProvider(generateLargeMessages(), { unlimitedCache: true });
-    const { extensionPoint } = mockExtensionPoint();
-    const mockProgressCallback = jest.spyOn(extensionPoint, "progressCallback");
-
-    await provider.initialize(extensionPoint);
-    await provider.getMessages(
-      { sec: 0, nsec: 0 },
-      { sec: 0, nsec: 0 },
-      { parsedMessages: ["/foo"] },
-    );
-    await delay(10);
-    expect(last(mockProgressCallback.mock.calls)).toEqual([
-      {
-        fullyLoadedFractionRanges: [{ start: 0, end: 1 }],
         messageCache: {
           startTime: { sec: 0, nsec: 0 },
           blocks: expect.arrayContaining([]),

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.ts
@@ -288,11 +288,8 @@ export default class Ros1MemoryCacheDataProvider implements RandomAccessDataProv
 
   private _lazyMessageReadersByTopic = new Map<string, LazyMessageReader>();
 
-  constructor(
-    provider: RandomAccessDataProvider,
-    { unlimitedCache = false }: { unlimitedCache?: boolean },
-  ) {
-    this._cacheSizeBytes = unlimitedCache ? Infinity : DEFAULT_CACHE_SIZE_BYTES;
+  constructor(provider: RandomAccessDataProvider) {
+    this._cacheSizeBytes = DEFAULT_CACHE_SIZE_BYTES;
     this._provider = provider;
   }
 


### PR DESCRIPTION


**User-Facing Changes**
The unlimited memory cache setting is removed.

**Description**
This setting is not practically useful since the app is likely to crash or slow-down substantially when trying to use too much memory in a browser environment. This is an old setting carried over from webviz and not something we want to encourage for Studio users right now.

Fixes: #3903

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
