### PR TITLE
Add alpha in point cloud settings for old 3D panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
@@ -32,7 +32,7 @@ export default function CommonPointSettings({
   settings: {
     pointSize?: number;
     pointShape?: string;
-    alpha?: number;
+    opacity?: number;
   };
   onFieldChange: (name: string, value: unknown) => void;
 }): JSX.Element {
@@ -41,7 +41,7 @@ export default function CommonPointSettings({
   const pointShape = settings.pointShape;
   const pointShapeVal = pointShape ?? defaultPointShape;
 
-  const alphaVal = settings.alpha ?? 1;  // 1 should always be the default for alpha
+  const opacityVal = settings.opacity ?? 1;
 
   return (
     <Stack flex="auto" gap={1}>
@@ -84,11 +84,11 @@ export default function CommonPointSettings({
       </FormControl>
 
       <TextField
-        label="Alpha"
-        data-test="alpha"
+        label="Opacity"
+        data-test="opacity"
         type="number"
         placeholder="1.0"
-        value={alphaVal}
+        value={opacityVal}
         variant="filled"
         inputProps={{
           min: 0.0,
@@ -97,7 +97,7 @@ export default function CommonPointSettings({
         }}
         onChange={(e) => {
           const isInputValid = !isNaN(parseFloat(e.target.value));
-          onFieldChange("alpha", isInputValid ? parseFloat(e.target.value) : undefined);
+          onFieldChange("opacity", isInputValid ? parseFloat(e.target.value) : undefined);
         }}
       />
     </Stack>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
@@ -41,7 +41,7 @@ export default function CommonPointSettings({
   const pointShape = settings.pointShape;
   const pointShapeVal = pointShape ?? defaultPointShape;
 
-  const alphaVal = settings.alpha ?? 1.0;  // 1 should always be the default for alpha
+  const alphaVal = settings.alpha ?? 1;  // 1 should always be the default for alpha
 
   return (
     <Stack flex="auto" gap={1}>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/CommonPointSettings.tsx
@@ -32,6 +32,7 @@ export default function CommonPointSettings({
   settings: {
     pointSize?: number;
     pointShape?: string;
+    alpha?: number;
   };
   onFieldChange: (name: string, value: unknown) => void;
 }): JSX.Element {
@@ -39,6 +40,8 @@ export default function CommonPointSettings({
 
   const pointShape = settings.pointShape;
   const pointShapeVal = pointShape ?? defaultPointShape;
+
+  const alphaVal = settings.alpha ?? 1.0;  // 1 should always be the default for alpha
 
   return (
     <Stack flex="auto" gap={1}>
@@ -79,6 +82,24 @@ export default function CommonPointSettings({
           <MenuItem value="square">Square</MenuItem>
         </Select>
       </FormControl>
+
+      <TextField
+        label="Alpha"
+        data-test="alpha"
+        type="number"
+        placeholder="1.0"
+        value={alphaVal}
+        variant="filled"
+        inputProps={{
+          min: 0.0,
+          max: 1.0,
+          step: 0.01,
+        }}
+        onChange={(e) => {
+          const isInputValid = !isNaN(parseFloat(e.target.value));
+          onFieldChange("alpha", isInputValid ? parseFloat(e.target.value) : undefined);
+        }}
+      />
     </Stack>
   );
 }

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { TopicSettingsEditorProps } from "./types";
 export type PointCloudSettings = {
   pointSize?: number;
   pointShape?: string;
+  alpha?: number;
   decayTime?: number;
   colorMode?: ColorMode;
 };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PointCloudSettingsEditor.tsx
@@ -51,7 +51,7 @@ import { TopicSettingsEditorProps } from "./types";
 export type PointCloudSettings = {
   pointSize?: number;
   pointShape?: string;
-  alpha?: number;
+  opacity?: number;
   decayTime?: number;
   colorMode?: ColorMode;
 };

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -51,6 +51,7 @@ enum ShaderColorMode {
 type Uniforms = {
   pointSize: number;
   isCircle: boolean;
+  alpha: number;
   colorMode: ShaderColorMode;
   flatColor: [number, number, number, number];
   minGradientColor: [number, number, number, number];
@@ -76,6 +77,7 @@ attribute float color; // color values in range [0-255]
 
 uniform float pointSize;
 uniform lowp int colorMode;
+uniform float alpha;
 uniform vec4 flatColor;
 uniform vec4 minGradientColor;
 uniform vec4 maxGradientColor;
@@ -155,13 +157,13 @@ void main () {
   gl_Position = projection * view * vec4(p, 1);
 
   if (colorMode == ${ShaderColorMode.GRADIENT}) {
-    fragColor = vec4(gradientColor(), 1.0);
+    fragColor = vec4(gradientColor(), alpha);
   } else if (colorMode == ${ShaderColorMode.RAINBOW}) {
-    fragColor = vec4(rainbowColor(), 1.0);
+    fragColor = vec4(rainbowColor(), alpha);
   } else if (colorMode == ${ShaderColorMode.TURBO}) {
-    fragColor = vec4(turboColor(), 1.0);
+    fragColor = vec4(turboColor(), alpha);
   } else {
-    fragColor = vec4(flatColor.rgb, 1.0);
+    fragColor = vec4(flatColor.rgb, alpha);
   }
 }
 `;
@@ -194,6 +196,7 @@ void main () {
 const fragmentShader = `
 precision mediump float;
 varying vec4 fragColor;
+uniform float alpha;
 uniform bool isCircle;
 uniform lowp int colorMode;
 void main () {
@@ -211,7 +214,7 @@ void main () {
   if (colorMode == ${ShaderColorMode.RGBA}) {
     gl_FragColor = vec4(fragColor / 255.0);
   } else {
-    gl_FragColor = vec4(fragColor.rgb / 255.0, 1.0);
+    gl_FragColor = vec4(fragColor.rgb / 255.0, alpha);
   }
 }
 `;
@@ -358,6 +361,9 @@ const makePointCloudCommand = () => {
           return props.settings.pointShape != undefined
             ? props.settings.pointShape === "circle"
             : true;
+        },
+        alpha: (_context, props) => {
+          return props.settings.alpha ?? 1.0;
         },
         colorMode: (_context, props) => getEffectiveColorMode(props),
         flatColor: (_context, props) => {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -51,7 +51,7 @@ enum ShaderColorMode {
 type Uniforms = {
   pointSize: number;
   isCircle: boolean;
-  alpha: number;
+  opacity: number;
   colorMode: ShaderColorMode;
   flatColor: [number, number, number, number];
   minGradientColor: [number, number, number, number];
@@ -77,7 +77,7 @@ attribute float color; // color values in range [0-255]
 
 uniform float pointSize;
 uniform lowp int colorMode;
-uniform float alpha;
+uniform float opacity;
 uniform vec4 flatColor;
 uniform vec4 minGradientColor;
 uniform vec4 maxGradientColor;
@@ -157,13 +157,13 @@ void main () {
   gl_Position = projection * view * vec4(p, 1);
 
   if (colorMode == ${ShaderColorMode.GRADIENT}) {
-    fragColor = vec4(gradientColor(), alpha);
+    fragColor = vec4(gradientColor(), opacity);
   } else if (colorMode == ${ShaderColorMode.RAINBOW}) {
-    fragColor = vec4(rainbowColor(), alpha);
+    fragColor = vec4(rainbowColor(), opacity);
   } else if (colorMode == ${ShaderColorMode.TURBO}) {
-    fragColor = vec4(turboColor(), alpha);
+    fragColor = vec4(turboColor(), opacity);
   } else {
-    fragColor = vec4(flatColor.rgb, alpha);
+    fragColor = vec4(flatColor.rgb, opacity);
   }
 }
 `;
@@ -196,7 +196,7 @@ void main () {
 const fragmentShader = `
 precision mediump float;
 varying vec4 fragColor;
-uniform float alpha;
+uniform float opacity;
 uniform bool isCircle;
 uniform lowp int colorMode;
 void main () {
@@ -214,7 +214,7 @@ void main () {
   if (colorMode == ${ShaderColorMode.RGBA}) {
     gl_FragColor = vec4(fragColor / 255.0);
   } else {
-    gl_FragColor = vec4(fragColor.rgb / 255.0, alpha);
+    gl_FragColor = vec4(fragColor.rgb / 255.0, opacity);
   }
 }
 `;
@@ -362,8 +362,8 @@ const makePointCloudCommand = () => {
             ? props.settings.pointShape === "circle"
             : true;
         },
-        alpha: (_context, props) => {
-          return props.settings.alpha ?? 1.0;
+        opacity: (_context, props) => {
+          return props.settings.opacity ?? 1.0;
         },
         colorMode: (_context, props) => getEffectiveColorMode(props),
         flatColor: (_context, props) => {


### PR DESCRIPTION
**User-Facing Changes**
Add an option called "Alpha" in user settings for point clouds in the old 3D panel. This represents the opacity of the point cloud. It defaults to 1, but the user can set it to any value between 0 and 1.

**Description**
Transparency is very useful for point clouds, especially when the scene is cluttered with many renderables. There is currently no way to make point clouds transparent in the user settings. This PR adds transparency.

**Before**:
<img src="https://user-images.githubusercontent.com/6638091/180291279-7538b5d4-6c39-4e92-8e0a-6e529a860d96.png" width=200 />
<img src="https://user-images.githubusercontent.com/6638091/180291651-ef081335-e0d5-4873-8a0f-c38aa031e569.png" width=700/>


**After**:
<img src="https://user-images.githubusercontent.com/6638091/180289300-8eafdef7-331e-49db-8d7e-446788ab3d66.png" width=200 />
<img src="https://user-images.githubusercontent.com/6638091/180289422-af44f35d-0cf3-4a97-a74b-cfdc620b42c0.png" width=700/>



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
