### PR TITLE
Simplify BlockLoader iteration

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -201,16 +201,8 @@ export class BlockLoader {
       let currentBlockId = span.beginId;
 
       let sizeInBytes = 0;
-      for (;;) {
-        const result = await iterator.next();
-        // Code after the for loop handles adding any aggregated messages to the current blockId
-        if (result.done === true) {
-          break;
-        }
-        const iterResult = result.value;
-
+      for await (const iterResult of iterator) {
         if (args.abortSignal.aborted) {
-          await iterator.return?.();
           return;
         }
 


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
When reading an iterator entirely, we can use for await rather than .next(). This handles iterator return semantics for us even when break or returning from the for loop.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
