### PR TITLE
Update useConfirm and usePrompt Dialogs to submit if Enter key is pressed

### DIFF
--- a/packages/studio-base/src/hooks/useConfirm.tsx
+++ b/packages/studio-base/src/hooks/useConfirm.tsx
@@ -13,6 +13,7 @@
 
 import { Dialog, DialogContent, DialogTitle, DialogActions, Button } from "@mui/material";
 import { useCallback, useEffect, useContext, useRef } from "react";
+import { useKeyPressEvent } from "react-use";
 
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
 
@@ -50,6 +51,8 @@ function ConfirmModal(props: ConfirmModalProps) {
     },
     [originalOnComplete],
   );
+
+  useKeyPressEvent("Enter", () => onComplete("ok"));
 
   // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
   // called already

--- a/packages/studio-base/src/hooks/useConfirm.tsx
+++ b/packages/studio-base/src/hooks/useConfirm.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Dialog, DialogContent, DialogTitle, DialogActions, Button } from "@mui/material";
-import { useCallback, useEffect, useContext, useRef } from "react";
+import { useCallback, useContext, useRef } from "react";
 import { useKeyPressEvent } from "react-use";
 
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
@@ -53,12 +53,6 @@ function ConfirmModal(props: ConfirmModalProps) {
   );
 
   useKeyPressEvent("Enter", () => onComplete("ok"));
-
-  // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
-  // called already
-  useEffect(() => {
-    return () => onComplete("cancel");
-  }, [onComplete]);
 
   const buttons = [
     props.cancel !== false && (

--- a/packages/studio-base/src/hooks/useConfirm.tsx
+++ b/packages/studio-base/src/hooks/useConfirm.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Dialog, DialogContent, DialogTitle, DialogActions, Button } from "@mui/material";
-import { useCallback, useContext, useRef } from "react";
+import { useCallback, useContext, useEffect, useRef } from "react";
 import { useKeyPressEvent } from "react-use";
 
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
@@ -53,6 +53,12 @@ function ConfirmModal(props: ConfirmModalProps) {
   );
 
   useKeyPressEvent("Enter", () => onComplete("ok"));
+
+  // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
+  // called already
+  useEffect(() => {
+    return () => onComplete("cancel");
+  }, [onComplete]);
 
   const buttons = [
     props.cancel !== false && (

--- a/packages/studio-base/src/hooks/usePrompt.tsx
+++ b/packages/studio-base/src/hooks/usePrompt.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Button, Dialog, DialogActions, DialogContent, TextField, Typography } from "@mui/material";
-import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useKeyPressEvent } from "react-use";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -59,7 +59,14 @@ function ModalPrompt({
     },
     [originalOnComplete],
   );
+
   useKeyPressEvent("Enter", () => onComplete("ok"));
+
+  // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
+  // called already
+  useEffect(() => {
+    return () => onComplete("cancel");
+  }, [onComplete]);
 
   return (
     <Dialog open maxWidth="xs" fullWidth onClose={() => onComplete(undefined)}>

--- a/packages/studio-base/src/hooks/usePrompt.tsx
+++ b/packages/studio-base/src/hooks/usePrompt.tsx
@@ -4,6 +4,7 @@
 
 import { Button, Dialog, DialogActions, DialogContent, TextField, Typography } from "@mui/material";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useKeyPressEvent } from "react-use";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import ModalContext from "@foxglove/studio-base/context/ModalContext";
@@ -58,6 +59,8 @@ function ModalPrompt({
     },
     [originalOnComplete],
   );
+  useKeyPressEvent("Enter", () => onComplete("ok"));
+
   // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
   // called already
   useEffect(() => {

--- a/packages/studio-base/src/hooks/usePrompt.tsx
+++ b/packages/studio-base/src/hooks/usePrompt.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Button, Dialog, DialogActions, DialogContent, TextField, Typography } from "@mui/material";
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useMemo, useRef, useState } from "react";
 import { useKeyPressEvent } from "react-use";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -60,12 +60,6 @@ function ModalPrompt({
     [originalOnComplete],
   );
   useKeyPressEvent("Enter", () => onComplete("ok"));
-
-  // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
-  // called already
-  useEffect(() => {
-    return () => onComplete(undefined);
-  }, [onComplete]);
 
   return (
     <Dialog open maxWidth="xs" fullWidth onClose={() => onComplete(undefined)}>

--- a/packages/studio-base/src/hooks/usePrompt.tsx
+++ b/packages/studio-base/src/hooks/usePrompt.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Button, Dialog, DialogActions, DialogContent, TextField, Typography } from "@mui/material";
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useKeyPressEvent } from "react-use";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -49,6 +49,19 @@ function ModalPrompt({
     }
   }, [transformer, value]);
 
+  const onConfirmAction = () => {
+    try {
+      onComplete(transformer ? transformer(value) : value);
+    } catch (err) {
+      onComplete(undefined);
+    }
+  };
+
+  const onSubmitAction = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onConfirmAction();
+  };
+
   const completed = useRef(false);
   const onComplete = useCallback(
     (result: string | undefined) => {
@@ -60,26 +73,17 @@ function ModalPrompt({
     [originalOnComplete],
   );
 
-  useKeyPressEvent("Enter", () => onComplete("ok"));
+  useKeyPressEvent("Enter", onConfirmAction);
 
   // Ensure we still call onComplete(undefined) when the component unmounts, if it hasn't been
   // called already
   useEffect(() => {
-    return () => onComplete("cancel");
+    return () => onComplete(undefined);
   }, [onComplete]);
 
   return (
     <Dialog open maxWidth="xs" fullWidth onClose={() => onComplete(undefined)}>
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          try {
-            onComplete(transformer ? transformer(value) : value);
-          } catch (err) {
-            onComplete(undefined);
-          }
-        }}
-      >
+      <form onSubmit={onSubmitAction}>
         <Stack paddingX={3} paddingTop={2}>
           <Typography variant="h4" fontWeight={600} gutterBottom>
             {title}


### PR DESCRIPTION
**User-Facing Changes**
useConfirm Dialog submit's when the 'Enter' key is pressed

**Description**
Resolves #3858

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
