### PR TITLE
Fix manual looping for experimental player

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -189,9 +189,13 @@ export class IterablePlayer implements Player {
     if (this._isPlaying) {
       return;
     }
+
     this._metricsCollector.play(this._speed);
     this._isPlaying = true;
-    if (this._state === "idle") {
+
+    // If we are idling we can start playing, if we have a next state queued we let that state
+    // finish and it will see that we should be playing
+    if (this._state === "idle" && (!this._nextState || this._nextState === "idle")) {
       this._setState("play");
     }
   }


### PR DESCRIPTION


**User-Facing Changes**
Starting playback when at the end of the experimental player starts from the beginning.

**Description**
When a player reaches the end of playback and the user click play again, the player is suppose to restart from the start. The IterablePlayer was not doing this because the startPlayback call would interrupt the seek backfill state which is responsible for resetting the playback.

Fixes: #3899

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
