### PR TITLE
Fix plot message path scrolling on linux chrome

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -121,14 +121,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: "transparent !important",
     padding: "4px !important",
   },
-  footer: ({ legendDisplay }: StyleProps) => ({
+  footer: ({ showPlotValuesInLegend = false }: StyleProps) => ({
     padding: theme.spacing(0.5),
-    gridColumn: "span 4",
-    ...(legendDisplay !== "floating" && {
-      position: "sticky",
-      right: 0,
-      left: 0,
-    }),
+    gridColumn: showPlotValuesInLegend ? "span 4" : "span 3",
+    position: "sticky",
+    right: 0,
+    left: 0,
   }),
   floatingWrapper: {
     overflow: "hidden",

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -24,7 +24,15 @@ import { Button, IconButton, Theme, alpha, MenuItem, Menu } from "@mui/material"
 import { makeStyles } from "@mui/styles";
 import cx from "classnames";
 import { last } from "lodash";
-import { ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ComponentProps,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useLatest } from "react-use";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -384,9 +392,11 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
     document.removeEventListener("mousemove", handleMouseMove, true);
   };
 
+  const contentRef = useRef<HTMLDivElement>(ReactNull);
+
   const legendContent = useMemo(
     () => (
-      <div className={classes.legendContent}>
+      <div ref={contentRef} className={classes.legendContent}>
         <header className={classes.header}>
           <AxisDropdown
             xAxisVal={xAxisVal}
@@ -467,6 +477,37 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
       xAxisVal,
     ],
   );
+
+  // Hack to fix nested input scrolling on Linux Chrome. Manually scroll content to the
+  // far left or right when the user navigates to the start or end of the
+  // message path input.
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) {
+      return;
+    }
+
+    const listener = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement) {
+        if (event.target.selectionStart === 0) {
+          content.scrollTo(0, 0);
+        }
+        if (event.target.selectionStart === event.target.value.length) {
+          content.scrollTo(content.scrollWidth, 0);
+        }
+      }
+    };
+
+    content.querySelectorAll("input").forEach((input) => {
+      input.addEventListener("keydown", listener);
+    });
+
+    return () => {
+      content.querySelectorAll("input").forEach((input) => {
+        input.removeEventListener("keydown", listener);
+      });
+    };
+  }, []);
 
   return (
     <div className={cx(classes.root, { [classes.rootFloating]: legendDisplay === "floating" })}>


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with long message path inputs in plots on Linux Chrome.

**Description**
This is a somewhat hacky JS fix that synchronizes the plot legend content scroll position with the cursor position on nested message path inputs. At least on Linux Chrome the nested input's scroll container and the parent scroll container don't quite sync up. I tried a variety of CSS solutions but couldn't find any that didn't require functional changes to the plot legend.

This also adds a CSS fix for the sticky positioning of the `Add line` button.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3743 