### PR TITLE
Add support for new FrameTransform definition while keeping backwards compatibility

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -21,7 +21,7 @@
     "prepack": "tsc -b"
   },
   "devDependencies": {
-    "@foxglove/schemas": "0.2.0",
+    "@foxglove/schemas": "0.3.0",
     "@types/zstd-codec": "workspace:*",
     "typescript": "4.6.2"
   },

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -46,7 +46,7 @@
     "@foxglove/rosmsg-serialization": "1.3.0",
     "@foxglove/rosmsg2-serialization": "1.0.6",
     "@foxglove/rostime": "1.1.2",
-    "@foxglove/schemas": "0.2.0",
+    "@foxglove/schemas": "0.3.0",
     "@foxglove/studio": "workspace:*",
     "@foxglove/three-text": "workspace:*",
     "@foxglove/ulog": "2.1.2",

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -749,8 +749,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
     // top-level timestamp for now until the ambiguity is resolved. See
     // <https://github.com/foxglove/schemas/issues/45>
     const stamp = toNanoSec(transform.timestamp);
-    const t = transform.transform.translation;
-    const q = transform.transform.rotation;
+    const t = transform.translation;
+    const q = transform.rotation;
 
     this.addTransform(parentId, childId, stamp, t, q);
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/normalizeMessages.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/normalizeMessages.ts
@@ -3,10 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import type { Time } from "@foxglove/rostime";
-import type {
-  FrameTransform,
-  Transform as TransformWithTime,
-} from "@foxglove/schemas/schemas/typescript";
+import type { FrameTransform } from "@foxglove/schemas/schemas/typescript";
 
 import type { PartialMessage } from "./SceneExtension";
 import {
@@ -36,6 +33,20 @@ enum NumericType {
   FLOAT32 = 7,
   FLOAT64 = 8,
 }
+
+// Legacy foxglove.Transform type -- see https://github.com/foxglove/schemas/pull/46
+type LegacyTransform = {
+  timestamp: Time;
+  translation: Vector3;
+  rotation: Quaternion;
+};
+// Legacy foxglove.FrameTransform type -- see https://github.com/foxglove/schemas/pull/46
+type LegacyFrameTransform = {
+  timestamp: Time;
+  parent_frame_id: string;
+  child_frame_id: string;
+  transform: LegacyTransform;
+};
 
 export function normalizeTime(time: Partial<Time> | undefined): Time {
   if (!time) {
@@ -153,16 +164,6 @@ export function normalizeTransform(transform: PartialMessage<Transform> | undefi
   };
 }
 
-export function normalizeTransformWithTime(
-  transform: PartialMessage<TransformWithTime> | undefined,
-): TransformWithTime {
-  return {
-    timestamp: normalizeTime(transform?.timestamp),
-    translation: normalizeVector3(transform?.translation),
-    rotation: normalizeQuaternion(transform?.rotation),
-  };
-}
-
 export function normalizeTransformStamped(
   transform: PartialMessage<TransformStamped> | undefined,
 ): TransformStamped {
@@ -180,13 +181,18 @@ export function normalizeTFMessage(tfMessage: PartialMessage<TFMessage> | undefi
 }
 
 export function normalizeFrameTransform(
-  frameTransform: PartialMessage<FrameTransform> | undefined,
+  frameTransform:
+    | (PartialMessage<FrameTransform> & PartialMessage<LegacyFrameTransform>)
+    | undefined,
 ): FrameTransform {
   return {
     timestamp: normalizeTime(frameTransform?.timestamp),
     parent_frame_id: frameTransform?.parent_frame_id ?? "",
     child_frame_id: frameTransform?.child_frame_id ?? "",
-    transform: normalizeTransformWithTime(frameTransform?.transform),
+    translation: normalizeVector3(
+      frameTransform?.translation ?? frameTransform?.transform?.translation,
+    ),
+    rotation: normalizeQuaternion(frameTransform?.rotation ?? frameTransform?.transform?.rotation),
   };
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/normalizeMessages.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/normalizeMessages.ts
@@ -41,7 +41,7 @@ type LegacyTransform = {
   rotation: Quaternion;
 };
 // Legacy foxglove.FrameTransform type -- see https://github.com/foxglove/schemas/pull/46
-type LegacyFrameTransform = {
+export type LegacyFrameTransform = {
   timestamp: Time;
   parent_frame_id: string;
   child_frame_id: string;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -8,6 +8,7 @@ import { MessageEvent, Topic } from "@foxglove/studio";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
+import { LegacyFrameTransform } from "../normalizeMessages";
 import { makePass, QUAT_IDENTITY, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
@@ -31,15 +32,13 @@ export function FoxgloveFrameTransform(): JSX.Element {
       timestamp: { sec: 1, nsec: 0 },
       parent_frame_id: "map",
       child_frame_id: "base_link",
-      transform: {
-        timestamp: { sec: 1, nsec: 0 },
-        translation: VEC3_ZERO,
-        rotation: QUAT_IDENTITY,
-      },
+      translation: VEC3_ZERO,
+      rotation: QUAT_IDENTITY,
     },
     sizeInBytes: 0,
   };
-  const tf_t3: MessageEvent<FrameTransform> = {
+  // backwards compatibility with legacy message format
+  const tf_t3: MessageEvent<LegacyFrameTransform> = {
     topic: "/tf",
     receiveTime: { sec: 10, nsec: 0 },
     message: {

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/useTransforms.ts
@@ -57,7 +57,11 @@ function consumeFoxgloveFrameTransform(
   transformTree: TransformTree,
 ): void {
   for (const { message } of msgEvents) {
-    const { translation, rotation } = message.transform;
+    const translation = message.translation ?? message.transform?.translation;
+    const rotation = message.rotation ?? message.transform?.rotation;
+    if (!translation || !rotation) {
+      continue;
+    }
     const transform = new Transform(
       vec3FromValues(translation.x, translation.y, translation.z),
       quatFromValues(rotation.x, rotation.y, rotation.z, rotation.w),

--- a/packages/studio-base/src/types/FoxgloveMessages.ts
+++ b/packages/studio-base/src/types/FoxgloveMessages.ts
@@ -105,10 +105,12 @@ export type FoxgloveMessages = {
     };
     parent_frame_id: string;
     child_frame_id: string;
-    transform: {
+    transform?: {
       translation: { x: number; y: number; z: number };
       rotation: { x: number; y: number; z: number; w: number };
     };
+    translation?: { x: number; y: number; z: number };
+    rotation?: { x: number; y: number; z: number; w: number };
   };
 
   "foxglove.Pose": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,7 +2307,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
-    "@foxglove/schemas": 0.2.0
+    "@foxglove/schemas": 0.3.0
     "@foxglove/wasm-bz2": 0.1.0
     "@protobufjs/base64": 1.1.2
     "@types/zstd-codec": "workspace:*"
@@ -2471,7 +2471,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/schemas@npm:0.2.0, @foxglove/schemas@npm:^0.2.0":
+"@foxglove/schemas@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@foxglove/schemas@npm:0.3.0"
+  dependencies:
+    "@foxglove/rosmsg-msgs-common": ^1.0.4
+    tslib: ^2
+  checksum: d0cdcaf9ec264f5395b3636b5fd11925f8893d31dbe9ed1d4de7c988b8aa6d7b6580728d9cbe0b4504c511324835f8bfea02656facb1f0a5c66f4fd4be043b39
+  languageName: node
+  linkType: hard
+
+"@foxglove/schemas@npm:^0.2.0":
   version: 0.2.0
   resolution: "@foxglove/schemas@npm:0.2.0"
   dependencies:
@@ -2513,7 +2523,7 @@ __metadata:
     "@foxglove/rosmsg-serialization": 1.3.0
     "@foxglove/rosmsg2-serialization": 1.0.6
     "@foxglove/rostime": 1.1.2
-    "@foxglove/schemas": 0.2.0
+    "@foxglove/schemas": 0.3.0
     "@foxglove/studio": "workspace:*"
     "@foxglove/three-text": "workspace:*"
     "@foxglove/ulog": 2.1.2


### PR DESCRIPTION
**User-Facing Changes**
Added support for new definition of `foxglove.FrameTransform` schema (https://github.com/foxglove/schemas/pull/46)

**Description**
Fixes https://github.com/foxglove/studio/issues/3850