### PR TITLE
Allow file:// URIs in mesh markers and URDFs

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -250,7 +250,7 @@ function main() {
       "script-src": `'self' 'unsafe-inline' 'unsafe-eval'`,
       "worker-src": `'self' blob:`,
       "style-src": "'self' 'unsafe-inline'",
-      "connect-src": "'self' ws: wss: http: https: package: blob:",
+      "connect-src": "'self' ws: wss: http: https: package: blob: file:",
       "font-src": "'self' data:",
       // Include http in the CSP to allow loading images (i.e. map tiles) from http endpoints like localhost
       "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http:",


### PR DESCRIPTION
**User-Facing Changes**

- `file://` URIs can be used in MESH_RESOURCE markers and URDFs

**Description**

Although file:// URIs in markers or URDFs are generally not a best practice, it can be convenient for rapid iteration to reference local files without worrying about web hosting or ROS_PACKAGE_PATH (especially in non-ROS environments). This change allows fetch() requests in the Electron desktop app to retrieve file:// URIs.
