### PR TITLE
[New3D] Fix COLLADA asset loading with Lambertian materials

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -266,6 +266,13 @@ function toStandard(
   const standard = new THREE.MeshStandardMaterial({ name: material.name });
   const shininess = (material as Partial<THREE.MeshPhongMaterial>).shininess ?? 0; // [0-100]
 
+  // MeshStandardMaterial.copy() assumes the normalScale property exists, which
+  // is true for other MeshStandardMaterials or MeshPhongMaterial but not
+  // MeshLambertMaterial. Default initialize this property if needed so the
+  // `standard.copy(material)` below succeeds
+  const maybePhong = material as Partial<THREE.MeshPhongMaterial>;
+  maybePhong.normalScale ??= new THREE.Vector2(1, 1);
+
   standard.copy(material);
   standard.metalness = 0;
   standard.roughness = 1 - shininess / 100;


### PR DESCRIPTION
**User-Facing Changes**

- Fixes a parsing error in `3D (Beta)` for some COLLADA meshes

**Description**

THREE.js doesn't have any defensive checks in Material.copy() so we need to ensure all the right fields exist when copying properties from a phong or lambert material into a standard material. Fixes #3908
