### PR TITLE
[New3D] Don't auto-select a different frame if the user-configured render frame doesn't exist

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -495,8 +495,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
 
     // Top priority is the followFrameId
-    if (this.followFrameId != undefined && this.transformTree.hasFrame(this.followFrameId)) {
-      return this.followFrameId;
+    if (this.followFrameId != undefined) {
+      return this.transformTree.hasFrame(this.followFrameId) ? this.followFrameId : undefined;
     }
 
     // Prefer frames from [REP-105](https://www.ros.org/reps/rep-0105.html)
@@ -998,7 +998,15 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this._lastTransformFrameCount = this.transformTree.frames().size;
 
       if (this.renderFrameId == undefined) {
-        this.settings.errors.add(FOLLOW_TF_PATH, NO_FRAME_SELECTED, `No coordinate frames found`);
+        if (this.followFrameId != undefined) {
+          this.settings.errors.add(
+            FOLLOW_TF_PATH,
+            FRAME_NOT_FOUND,
+            `Frame "${this.followFrameId}" not found`,
+          );
+        } else {
+          this.settings.errors.add(FOLLOW_TF_PATH, NO_FRAME_SELECTED, `No coordinate frames found`);
+        }
         this.fixedFrameId = undefined;
         return;
       } else {
@@ -1031,15 +1039,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.fixedFrameId = rootFrameId;
     }
 
-    if (this.followFrameId != undefined && this.renderFrameId !== this.followFrameId) {
-      this.settings.errors.add(
-        FOLLOW_TF_PATH,
-        FRAME_NOT_FOUND,
-        `Frame "${this.followFrameId}" not found, rendering in "${this.renderFrameId}"`,
-      );
-    } else {
-      this.settings.errors.clearPath(FOLLOW_TF_PATH);
-    }
+    this.settings.errors.clearPath(FOLLOW_TF_PATH);
   }
 
   private _updateResolution(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -11,6 +11,7 @@ import { Renderer, RendererConfig } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { PRECISION_DEGREES, PRECISION_DISTANCE, SelectEntry } from "../settings";
+import { CoordinateFrame } from "../transforms";
 import { PublishClickType } from "./PublishClickTool";
 
 export const DEFAULT_LABEL_SCALE_FACTOR = 1;
@@ -58,7 +59,17 @@ export class CoreSettings extends SceneExtension {
     const { cameraState: camera, publish } = config;
     const handler = this.handleSettingsAction;
 
-    const followTfOptions = this.renderer.coordinateFrameList;
+    // If the user-selected frame does not exist, show it in the dropdown
+    // anyways. A settings node error will be displayed
+    let followTfOptions = this.renderer.coordinateFrameList;
+    const followFrameId = this.renderer.followFrameId;
+    if (followFrameId != undefined && !this.renderer.transformTree.hasFrame(followFrameId)) {
+      followTfOptions = [
+        { label: CoordinateFrame.DisplayName(followFrameId), value: followFrameId },
+        ...followTfOptions,
+      ];
+    }
+
     const followTfValue = selectBest(
       [this.renderer.followFrameId, config.followTf, this.renderer.renderFrameId],
       followTfOptions,


### PR DESCRIPTION
**User-Facing Changes**

- `3D (Beta)` panel will no longer auto-select a different frame if the user-selected frame does not exist

**Description**

Fixes https://github.com/foxglove/studio/issues/3863
