### PR TITLE
Improve full preload handling for iterable player

### DIFF
--- a/packages/den/async/Condvar.test.ts
+++ b/packages/den/async/Condvar.test.ts
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Condvar } from "./Condvar";
+
+describe("Condvar", () => {
+  it("should notifyAll waiting", async () => {
+    const condvar = new Condvar();
+
+    const wait1 = condvar.wait();
+    const wait2 = condvar.wait();
+
+    const start = Date.now();
+    setTimeout(() => {
+      condvar.notifyAll();
+    }, 500);
+
+    await wait1;
+    await wait2;
+    expect(Date.now() - start).toBeGreaterThan(500);
+  });
+
+  it("should notifyOne waiting", async () => {
+    const condvar = new Condvar();
+
+    const wait1 = condvar.wait();
+    const wait2 = condvar.wait();
+
+    condvar.notifyOne();
+    await wait1;
+
+    // Notify another after 500 milliseconds and verify 500 milliseconds time passed
+    const start = Date.now();
+    setTimeout(() => {
+      condvar.notifyOne();
+    }, 500);
+
+    await wait2;
+    expect(Date.now() - start).toBeGreaterThan(500);
+  });
+});

--- a/packages/den/async/Condvar.test.ts
+++ b/packages/den/async/Condvar.test.ts
@@ -18,7 +18,7 @@ describe("Condvar", () => {
 
     await wait1;
     await wait2;
-    expect(Date.now() - start).toBeGreaterThan(500);
+    expect(Date.now() - start).toBeGreaterThan(480);
   });
 
   it("should notifyOne waiting", async () => {
@@ -37,6 +37,6 @@ describe("Condvar", () => {
     }, 500);
 
     await wait2;
-    expect(Date.now() - start).toBeGreaterThan(500);
+    expect(Date.now() - start).toBeGreaterThan(480);
   });
 });

--- a/packages/den/async/Condvar.ts
+++ b/packages/den/async/Condvar.ts
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Condvar provides a condition variable interface for async code
+ *
+ * Callers can wait on the condition variable and other callers can notify any
+ * waiters. An example use case could be a producer/consumer queue where the consumer
+ * waits for the producer to notify it that there are items to consume.
+ *
+ * See: https://en.wikipedia.org/wiki/Monitor_(synchronization)#Condition_variables_2
+ */
+class Condvar {
+  private waitQueue: Array<() => void> = [];
+
+  /**
+   * Wait on a notification.
+   *
+   * @return a promise which resolves when notified.
+   *
+   * ```
+   * await condvar.wait();
+   * ```
+   */
+  async wait(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.waitQueue.push(resolve);
+    });
+  }
+
+  /**
+   * Notify one wait.
+   */
+  notifyOne(): void {
+    const item = this.waitQueue.shift();
+    item?.();
+  }
+
+  /**
+   * Notify all waiting.
+   */
+  notifyAll(): void {
+    for (const item of this.waitQueue) {
+      item();
+    }
+    this.waitQueue.length = 0;
+  }
+}
+
+export { Condvar };

--- a/packages/den/async/index.ts
+++ b/packages/den/async/index.ts
@@ -6,3 +6,4 @@ export { default as LazilyInitialized } from "./LazilyInitialized";
 export { default as MutexLocked } from "./MutexLocked";
 export { default as signal, type Signal } from "./signal";
 export { default as debouncePromise } from "./debouncePromise";
+export * from "./Condvar";

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -267,117 +267,6 @@ describe("BlockLoader", () => {
     const source = new TestSource();
 
     const loader = new BlockLoader({
-      maxBlocks: 5,
-      cacheSizeBytes: 1,
-      minBlockDurationNs: 1,
-      source,
-      start: { sec: 0, nsec: 0 },
-      end: { sec: 9, nsec: 0 },
-      problemManager: new PlayerProblemManager(),
-    });
-
-    const msgEvents: MessageEvent<unknown>[] = [];
-    for (let i = 0; i < 5; ++i) {
-      msgEvents.push({
-        topic: "a",
-        receiveTime: { sec: i, nsec: 0 },
-        message: undefined,
-        sizeInBytes: 0,
-      });
-    }
-
-    source.messageIterator = async function* messageIterator(
-      args: MessageIteratorArgs,
-    ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      for (let i = 0; i < msgEvents.length; ++i) {
-        const msgEvent = msgEvents[i]!;
-        if (args.start && compare(msgEvent.receiveTime, args.start) < 0) {
-          continue;
-        }
-        if (args.end && compare(msgEvent.receiveTime, args.end) > 0) {
-          continue;
-        }
-
-        yield {
-          msgEvent,
-          problem: undefined,
-          connectionId: undefined,
-        };
-      }
-    };
-
-    loader.setTopics(new Set("a"));
-
-    let count = 0;
-    await loader.startLoading({
-      progress: async (progress) => {
-        count += 1;
-        if (count >= 1) {
-          loader.setActiveTime({ sec: 5, nsec: 0 });
-        }
-
-        // when progress matches what we want we've finished loading
-        if (progress.messageCache?.blocks.every((item) => item != undefined) === true) {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(progress).toEqual({
-            fullyLoadedFractionRanges: [
-              {
-                start: 0,
-                end: 1,
-              },
-            ],
-            messageCache: {
-              blocks: [
-                {
-                  messagesByTopic: {
-                    a: [msgEvents[0], msgEvents[1]],
-                  },
-                  sizeInBytes: 0,
-                },
-                {
-                  messagesByTopic: {
-                    a: [msgEvents[2], msgEvents[3]],
-                  },
-                  sizeInBytes: 0,
-                },
-                {
-                  messagesByTopic: {
-                    a: [msgEvents[4]],
-                  },
-                  sizeInBytes: 0,
-                },
-                {
-                  messagesByTopic: {
-                    a: [],
-                  },
-                  sizeInBytes: 0,
-                },
-                {
-                  messagesByTopic: {
-                    a: [],
-                  },
-                  sizeInBytes: 0,
-                },
-              ],
-              startTime: { sec: 0, nsec: 0 },
-            },
-          });
-          await loader.stopLoading();
-        }
-      },
-    });
-
-    expect.assertions(1);
-  });
-
-  // fixme - loading not from start, then going back to start and loading seemed to not realize some area had already been loaded...
-  // basically when loading reaches a section that has already loaded, it doesn't seem like it realizes that
-
-  // fixme - better name
-  it.only("should reset loading when active time moves to an unloaded region2", async () => {
-    const source = new TestSource();
-
-    const loader = new BlockLoader({
       maxBlocks: 6,
       cacheSizeBytes: 1,
       minBlockDurationNs: 1,
@@ -397,10 +286,11 @@ describe("BlockLoader", () => {
       });
     }
 
+    const messageIteratorCallArgs: MessageIteratorArgs[] = [];
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      console.log(args);
+      messageIteratorCallArgs.push(args);
       for (let i = 0; i < msgEvents.length; ++i) {
         const msgEvent = msgEvents[i]!;
         if (args.start && compare(msgEvent.receiveTime, args.start) < 0) {
@@ -424,12 +314,122 @@ describe("BlockLoader", () => {
     await loader.startLoading({
       progress: async (progress) => {
         count += 1;
+
         if (count === 1) {
           loader.setActiveTime({ sec: 6, nsec: 0 });
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(progress).toEqual({
+            fullyLoadedFractionRanges: [
+              {
+                start: 0,
+                end: 0.16666666666666666,
+              },
+            ],
+            messageCache: {
+              blocks: [
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[0], msgEvents[1]],
+                  },
+                  sizeInBytes: 0,
+                },
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+              ],
+              startTime: { sec: 0, nsec: 0 },
+            },
+          });
         } else if (count === 3) {
           loader.setActiveTime({ sec: 1, nsec: 0 });
+
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(progress).toEqual({
+            fullyLoadedFractionRanges: [
+              {
+                start: 0,
+                end: 0.16666666666666666,
+              },
+              {
+                start: 0.5,
+                end: 0.8333333333333334,
+              },
+            ],
+            messageCache: {
+              blocks: [
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[0], msgEvents[1]],
+                  },
+                  sizeInBytes: 0,
+                },
+                undefined,
+                undefined,
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[5], msgEvents[6]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[7]],
+                  },
+                  sizeInBytes: 0,
+                },
+                undefined,
+              ],
+              startTime: { sec: 0, nsec: 0 },
+            },
+          });
+        } else if (count === 4) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(progress).toEqual({
+            fullyLoadedFractionRanges: [
+              {
+                start: 0,
+                end: 0.3333333333333333,
+              },
+              {
+                start: 0.5,
+                end: 0.8333333333333334,
+              },
+            ],
+            messageCache: {
+              blocks: [
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[0], msgEvents[1]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[2], msgEvents[3]],
+                  },
+                  sizeInBytes: 0,
+                },
+                undefined,
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[5], msgEvents[6]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[7]],
+                  },
+                  sizeInBytes: 0,
+                },
+                undefined,
+              ],
+              startTime: { sec: 0, nsec: 0 },
+            },
+          });
         }
-        console.log(progress);
 
         // when progress matches what we want we've finished loading
         if (progress.messageCache?.blocks.every((item) => item != undefined) === true) {
@@ -463,13 +463,19 @@ describe("BlockLoader", () => {
                 },
                 {
                   messagesByTopic: {
-                    a: [],
+                    a: [msgEvents[5], msgEvents[6]],
                   },
                   sizeInBytes: 0,
                 },
                 {
                   messagesByTopic: {
-                    a: [],
+                    a: [msgEvents[7]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[8], msgEvents[9]],
                   },
                   sizeInBytes: 0,
                 },
@@ -482,7 +488,30 @@ describe("BlockLoader", () => {
       },
     });
 
-    expect.assertions(1);
+    expect(messageIteratorCallArgs).toEqual([
+      {
+        topics: ["a"],
+        start: { sec: 0, nsec: 0 },
+        end: { sec: 9, nsec: 0 },
+      },
+      {
+        topics: ["a"],
+        start: { sec: 4, nsec: 500000003 },
+        end: { sec: 9, nsec: 0 },
+      },
+      {
+        topics: ["a"],
+        start: { sec: 1, nsec: 500000001 },
+        end: { sec: 4, nsec: 500000002 },
+      },
+      {
+        topics: ["a"],
+        start: { sec: 7, nsec: 500000005 },
+        end: { sec: 9, nsec: 0 },
+      },
+    ]);
+
+    expect.assertions(6);
   });
 
   // fixme

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
@@ -50,10 +49,7 @@ describe("BlockLoader", () => {
       problemManager: new PlayerProblemManager(),
     });
 
-    const abort = new AbortController();
-    await loader.load({
-      abortSignal: abort.signal,
-      startTime: { sec: 0, nsec: 0 },
+    await loader.startLoading({
       progress: async (progress) => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [],
@@ -79,10 +75,7 @@ describe("BlockLoader", () => {
       problemManager: new PlayerProblemManager(),
     });
 
-    const abort = new AbortController();
-    await loader.load({
-      abortSignal: abort.signal,
-      startTime: { sec: 0, nsec: 0 },
+    await loader.startLoading({
       progress: async (progress) => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [],
@@ -110,10 +103,7 @@ describe("BlockLoader", () => {
 
     loader.setTopics(new Set(["foo"]));
 
-    const abort = new AbortController();
-    await loader.load({
-      abortSignal: abort.signal,
-      startTime: { sec: 0, nsec: 0 },
+    await loader.startLoading({
       progress: async (progress) => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -514,8 +514,12 @@ describe("BlockLoader", () => {
     expect.assertions(6);
   });
 
+  // fixme - jumping forward in time while loading doesn't work
+
   // fixme
   // when changing the active time and all blocks are loaded, we still emit progress several times?
   // strange because we didn't actually change anything...
   // as active time continues to change we continue to emit progress - again nothing changed...
+
+  // fixme - sometimes it looks like blocks are evicted even tho we don't need to evict?
 });

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -2,8 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { compare } from "@foxglove/rostime";
+import { MessageEvent } from "@foxglove/studio";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
-import { MessageEvent } from "@foxglove/studio-base/players/types";
 
 import { BlockLoader } from "./BlockLoader";
 import {
@@ -18,7 +19,7 @@ class TestSource implements IIterableSource {
   async initialize(): Promise<Initalization> {
     return {
       start: { sec: 0, nsec: 0 },
-      end: { sec: 1, nsec: 0 },
+      end: { sec: 10, nsec: 0 },
       topics: [],
       topicStats: new Map(),
       problems: [],
@@ -40,12 +41,12 @@ class TestSource implements IIterableSource {
 describe("BlockLoader", () => {
   it("should make an empty block loader", async () => {
     const loader = new BlockLoader({
-      maxBlocks: 1,
+      maxBlocks: 4,
       cacheSizeBytes: 1,
       minBlockDurationNs: 1,
       source: new TestSource(),
       start: { sec: 0, nsec: 0 },
-      end: { sec: 0, nsec: 0 },
+      end: { sec: 2, nsec: 0 },
       problemManager: new PlayerProblemManager(),
     });
 
@@ -54,57 +55,61 @@ describe("BlockLoader", () => {
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [],
           messageCache: {
-            blocks: [undefined],
+            blocks: [undefined, undefined, undefined, undefined],
             startTime: { sec: 0, nsec: 0 },
           },
         });
+        await loader.stopLoading();
       },
     });
 
     expect.assertions(1);
   });
 
-  it("should limit to min block duration ns", async () => {
-    const loader = new BlockLoader({
-      maxBlocks: 5,
-      cacheSizeBytes: 1,
-      minBlockDurationNs: 2000000000,
-      source: new TestSource(),
-      start: { sec: 0, nsec: 0 },
-      end: { sec: 5, nsec: 0 },
-      problemManager: new PlayerProblemManager(),
-    });
+  it("should load the source into blocks", async () => {
+    const source = new TestSource();
 
-    await loader.startLoading({
-      progress: async (progress) => {
-        expect(progress).toEqual({
-          fullyLoadedFractionRanges: [],
-          messageCache: {
-            blocks: [undefined, undefined, undefined],
-            startTime: { sec: 0, nsec: 0 },
-          },
-        });
-      },
-    });
-
-    expect.assertions(1);
-  });
-
-  it("should mark blocks as loaded when there are no messages", async () => {
     const loader = new BlockLoader({
       maxBlocks: 5,
       cacheSizeBytes: 1,
       minBlockDurationNs: 1,
-      source: new TestSource(),
+      source,
       start: { sec: 0, nsec: 0 },
-      end: { sec: 5, nsec: 0 },
+      end: { sec: 9, nsec: 0 },
       problemManager: new PlayerProblemManager(),
     });
 
-    loader.setTopics(new Set(["foo"]));
+    const msgEvents: MessageEvent<unknown>[] = [];
+    for (let i = 0; i < 5; ++i) {
+      msgEvents.push({
+        topic: "a",
+        receiveTime: { sec: i, nsec: 0 },
+        message: undefined,
+        sizeInBytes: 0,
+      });
+    }
 
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < msgEvents.length; ++i) {
+        const msgEvent = msgEvents[i]!;
+        yield {
+          msgEvent,
+          problem: undefined,
+          connectionId: undefined,
+        };
+      }
+    };
+
+    loader.setTopics(new Set("a"));
+    let count = 0;
     await loader.startLoading({
       progress: async (progress) => {
+        if (++count < 4) {
+          return;
+        }
+
         expect(progress).toEqual({
           fullyLoadedFractionRanges: [
             {
@@ -116,31 +121,31 @@ describe("BlockLoader", () => {
             blocks: [
               {
                 messagesByTopic: {
-                  foo: [],
+                  a: [msgEvents[0], msgEvents[1]],
                 },
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
-                  foo: [],
+                  a: [msgEvents[2], msgEvents[3]],
                 },
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
-                  foo: [],
+                  a: [msgEvents[4]],
                 },
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
-                  foo: [],
+                  a: [],
                 },
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
-                  foo: [],
+                  a: [],
                 },
                 sizeInBytes: 0,
               },
@@ -148,9 +153,228 @@ describe("BlockLoader", () => {
             startTime: { sec: 0, nsec: 0 },
           },
         });
+
+        await loader.stopLoading();
+      },
+    });
+    expect.assertions(1);
+  });
+
+  it("should load the source into blocks when starting partially through the source", async () => {
+    const source = new TestSource();
+
+    const loader = new BlockLoader({
+      maxBlocks: 5,
+      cacheSizeBytes: 1,
+      minBlockDurationNs: 1,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 9, nsec: 0 },
+      problemManager: new PlayerProblemManager(),
+    });
+
+    const msgEvents: MessageEvent<unknown>[] = [];
+    for (let i = 0; i < 5; ++i) {
+      msgEvents.push({
+        topic: "a",
+        receiveTime: { sec: i, nsec: 0 },
+        message: undefined,
+        sizeInBytes: 0,
+      });
+    }
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < msgEvents.length; ++i) {
+        const msgEvent = msgEvents[i]!;
+        if (args.start && compare(msgEvent.receiveTime, args.start) < 0) {
+          continue;
+        }
+        if (args.end && compare(msgEvent.receiveTime, args.end) > 0) {
+          continue;
+        }
+
+        yield {
+          msgEvent,
+          problem: undefined,
+          connectionId: undefined,
+        };
+      }
+    };
+
+    loader.setTopics(new Set("a"));
+    loader.setActiveTime({ sec: 3, nsec: 10 });
+    let count = 0;
+    await loader.startLoading({
+      progress: async (progress) => {
+        if (++count < 3) {
+          return;
+        }
+
+        expect(progress).toEqual({
+          fullyLoadedFractionRanges: [
+            {
+              start: 0,
+              end: 1,
+            },
+          ],
+          messageCache: {
+            blocks: [
+              {
+                messagesByTopic: {
+                  a: [msgEvents[0], msgEvents[1]],
+                },
+                sizeInBytes: 0,
+              },
+              {
+                messagesByTopic: {
+                  a: [msgEvents[2], msgEvents[3]],
+                },
+                sizeInBytes: 0,
+              },
+              {
+                messagesByTopic: {
+                  a: [msgEvents[4]],
+                },
+                sizeInBytes: 0,
+              },
+              {
+                messagesByTopic: {
+                  a: [],
+                },
+                sizeInBytes: 0,
+              },
+              {
+                messagesByTopic: {
+                  a: [],
+                },
+                sizeInBytes: 0,
+              },
+            ],
+            startTime: { sec: 0, nsec: 0 },
+          },
+        });
+
+        await loader.stopLoading();
       },
     });
 
     expect.assertions(1);
   });
+
+  it("should reset loading when active time moves to an unloaded region", async () => {
+    const source = new TestSource();
+
+    const loader = new BlockLoader({
+      maxBlocks: 5,
+      cacheSizeBytes: 1,
+      minBlockDurationNs: 1,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 9, nsec: 0 },
+      problemManager: new PlayerProblemManager(),
+    });
+
+    const msgEvents: MessageEvent<unknown>[] = [];
+    for (let i = 0; i < 5; ++i) {
+      msgEvents.push({
+        topic: "a",
+        receiveTime: { sec: i, nsec: 0 },
+        message: undefined,
+        sizeInBytes: 0,
+      });
+    }
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < msgEvents.length; ++i) {
+        const msgEvent = msgEvents[i]!;
+        if (args.start && compare(msgEvent.receiveTime, args.start) < 0) {
+          continue;
+        }
+        if (args.end && compare(msgEvent.receiveTime, args.end) > 0) {
+          continue;
+        }
+
+        yield {
+          msgEvent,
+          problem: undefined,
+          connectionId: undefined,
+        };
+      }
+    };
+
+    loader.setTopics(new Set("a"));
+
+    let count = 0;
+    await loader.startLoading({
+      progress: async (progress) => {
+        count += 1;
+        if (count >= 1) {
+          loader.setActiveTime({ sec: 5, nsec: 0 });
+        }
+
+        // when progress matches what we want we've finished loading
+        if (progress.messageCache?.blocks.every((item) => item != undefined) === true) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(progress).toEqual({
+            fullyLoadedFractionRanges: [
+              {
+                start: 0,
+                end: 1,
+              },
+            ],
+            messageCache: {
+              blocks: [
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[0], msgEvents[1]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[2], msgEvents[3]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[4]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [],
+                  },
+                  sizeInBytes: 0,
+                },
+              ],
+              startTime: { sec: 0, nsec: 0 },
+            },
+          });
+          await loader.stopLoading();
+        }
+      },
+    });
+
+    expect.assertions(1);
+  });
+
+  // fixme - loading not from start, then going back to start and loading seemed to not realize some area had already been loaded...
+  // basically when loading reaches a section that has already loaded, it doesn't seem like it realizes that
+
+  // fixme
+  // when changing the active time and all blocks are loaded, we still emit progress several times?
+  // strange because we didn't actually change anything...
+  // as active time continues to change we continue to emit progress - again nothing changed...
 });

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -123,30 +123,35 @@ describe("BlockLoader", () => {
                 messagesByTopic: {
                   a: [msgEvents[0], msgEvents[1]],
                 },
+                needTopics: new Set(),
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
                   a: [msgEvents[2], msgEvents[3]],
                 },
+                needTopics: new Set(),
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
                   a: [msgEvents[4]],
                 },
+                needTopics: new Set(),
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
                   a: [],
                 },
+                needTopics: new Set(),
                 sizeInBytes: 0,
               },
               {
                 messagesByTopic: {
                   a: [],
                 },
+                needTopics: new Set(),
                 sizeInBytes: 0,
               },
             ],
@@ -226,30 +231,35 @@ describe("BlockLoader", () => {
                   a: [msgEvents[0], msgEvents[1]],
                 },
                 sizeInBytes: 0,
+                needTopics: new Set(),
               },
               {
                 messagesByTopic: {
                   a: [msgEvents[2], msgEvents[3]],
                 },
                 sizeInBytes: 0,
+                needTopics: new Set(),
               },
               {
                 messagesByTopic: {
                   a: [msgEvents[4]],
                 },
                 sizeInBytes: 0,
+                needTopics: new Set(),
               },
               {
                 messagesByTopic: {
                   a: [],
                 },
                 sizeInBytes: 0,
+                needTopics: new Set(),
               },
               {
                 messagesByTopic: {
                   a: [],
                 },
                 sizeInBytes: 0,
+                needTopics: new Set(),
               },
             ],
             startTime: { sec: 0, nsec: 0 },
@@ -331,6 +341,7 @@ describe("BlockLoader", () => {
                   messagesByTopic: {
                     a: [msgEvents[0], msgEvents[1]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 undefined,
@@ -363,6 +374,7 @@ describe("BlockLoader", () => {
                   messagesByTopic: {
                     a: [msgEvents[0], msgEvents[1]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 undefined,
@@ -371,12 +383,14 @@ describe("BlockLoader", () => {
                   messagesByTopic: {
                     a: [msgEvents[5], msgEvents[6]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[7]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 undefined,
@@ -403,12 +417,14 @@ describe("BlockLoader", () => {
                   messagesByTopic: {
                     a: [msgEvents[0], msgEvents[1]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[2], msgEvents[3]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 undefined,
@@ -416,12 +432,14 @@ describe("BlockLoader", () => {
                   messagesByTopic: {
                     a: [msgEvents[5], msgEvents[6]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[7]],
                   },
+                  needTopics: new Set(),
                   sizeInBytes: 0,
                 },
                 undefined,
@@ -448,36 +466,42 @@ describe("BlockLoader", () => {
                     a: [msgEvents[0], msgEvents[1]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[2], msgEvents[3]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[4]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[5], msgEvents[6]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[7]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[8], msgEvents[9]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
               ],
               startTime: { sec: 0, nsec: 0 },
@@ -575,12 +599,14 @@ describe("BlockLoader", () => {
                     a: [msgEvents[0], msgEvents[1], msgEvents[2]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
                 {
                   messagesByTopic: {
                     a: [msgEvents[3]],
                   },
                   sizeInBytes: 0,
+                  needTopics: new Set(),
                 },
               ],
               startTime: { sec: 0, nsec: 0 },

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -106,7 +106,7 @@ describe("BlockLoader", () => {
     let count = 0;
     await loader.startLoading({
       progress: async (progress) => {
-        if (++count < 4) {
+        if (++count < 3) {
           return;
         }
 
@@ -511,15 +511,100 @@ describe("BlockLoader", () => {
       },
     ]);
 
-    expect.assertions(6);
+    expect.assertions(5);
   });
 
-  // fixme - jumping forward in time while loading doesn't work
+  it("should avoid emitting progress when nothing changed", async () => {
+    const source = new TestSource();
 
-  // fixme
-  // when changing the active time and all blocks are loaded, we still emit progress several times?
-  // strange because we didn't actually change anything...
-  // as active time continues to change we continue to emit progress - again nothing changed...
+    const loader = new BlockLoader({
+      maxBlocks: 2,
+      cacheSizeBytes: 1,
+      minBlockDurationNs: 1,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 5, nsec: 0 },
+      problemManager: new PlayerProblemManager(),
+    });
 
-  // fixme - sometimes it looks like blocks are evicted even tho we don't need to evict?
+    const msgEvents: MessageEvent<unknown>[] = [];
+    for (let i = 0; i < 4; ++i) {
+      msgEvents.push({
+        topic: "a",
+        receiveTime: { sec: i, nsec: 0 },
+        message: undefined,
+        sizeInBytes: 0,
+      });
+    }
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < msgEvents.length; ++i) {
+        const msgEvent = msgEvents[i]!;
+        yield {
+          msgEvent,
+          problem: undefined,
+          connectionId: undefined,
+        };
+      }
+    };
+
+    loader.setTopics(new Set("a"));
+    let count = 0;
+    await loader.startLoading({
+      progress: async (progress) => {
+        count += 1;
+        if (count > 2) {
+          throw new Error("Too many progress callbacks");
+        }
+
+        if (count === 2) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(progress).toEqual({
+            fullyLoadedFractionRanges: [
+              {
+                start: 0,
+                end: 1,
+              },
+            ],
+            messageCache: {
+              blocks: [
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[0], msgEvents[1], msgEvents[2]],
+                  },
+                  sizeInBytes: 0,
+                },
+                {
+                  messagesByTopic: {
+                    a: [msgEvents[3]],
+                  },
+                  sizeInBytes: 0,
+                },
+              ],
+              startTime: { sec: 0, nsec: 0 },
+            },
+          });
+
+          // eslint-disable-next-line require-yield
+          source.messageIterator = async function* messageIterator(
+            _args: MessageIteratorArgs,
+          ): AsyncIterableIterator<Readonly<IteratorResult>> {
+            throw new Error("Should not call iterator");
+          };
+
+          // Everything has loaded so now we seek to a new time
+          // We should not get any more progress updates
+          setTimeout(() => {
+            loader.setActiveTime({ sec: 4, nsec: 0 });
+          }, 0);
+
+          setTimeout(async () => {
+            await loader.stopLoading();
+          }, 500);
+        }
+      },
+    });
+  });
 });

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -196,7 +196,6 @@ export class BlockLoader {
         // we've found a block that needs fetching
         // now build a continuous span of the next blocks
         for (let endIdx = fetchBlockId + 1; endIdx < this.blocks.length; ++endIdx) {
-          console.log({ endIdx });
           const nextBlock = this.blocks[endIdx];
           const nextBlockTopics = nextBlock ? Object.keys(nextBlock.messagesByTopic) : [];
 
@@ -204,8 +203,6 @@ export class BlockLoader {
           for (const topic of nextBlockTopics) {
             nextTopicsToFetch.delete(topic);
           }
-
-          console.log({ topicsToFetch, nextTopicsToFetch });
 
           // Topics no longer match, either block is loaded or we'll need to load in another pass
           if (!isEqual(topicsToFetch, nextTopicsToFetch)) {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -162,12 +162,15 @@ export class BlockLoader {
     for (const segment of segments) {
       const [beginBlockId, lastBlockId] = segment;
 
+      console.log({ beginBlockId, lastBlockId });
+
       // starting at beginBlockId, identify the first block we need to load
       // this is our start block, from the start block identify to _load to_ block
       // this is our end block
       // load from start block up to end block
       // if end block is at end, go back to 0 and keep going until we reach beginBlockId
       for (let i = beginBlockId; i < lastBlockId; ++i) {
+        // fixme - fetchBlockId can be looked up onces before beginBlockId
         const fetchBlockId = i;
 
         // Topics we will fetch for this range
@@ -193,6 +196,7 @@ export class BlockLoader {
         // we've found a block that needs fetching
         // now build a continuous span of the next blocks
         for (let endIdx = fetchBlockId + 1; endIdx < this.blocks.length; ++endIdx) {
+          console.log({ endIdx });
           const nextBlock = this.blocks[endIdx];
           const nextBlockTopics = nextBlock ? Object.keys(nextBlock.messagesByTopic) : [];
 
@@ -201,11 +205,17 @@ export class BlockLoader {
             nextTopicsToFetch.delete(topic);
           }
 
-          // Our topics are equal to the next block, we can load them as one long range
-          if (isEqual(topicsToFetch, nextTopicsToFetch)) {
-            endBlockId = endIdx;
+          console.log({ topicsToFetch, nextTopicsToFetch });
+
+          // Topics no longer match, either block is loaded or we'll need to load in another pass
+          if (!isEqual(topicsToFetch, nextTopicsToFetch)) {
+            break;
           }
+
+          endBlockId = endIdx;
         }
+
+        console.log({ fetchBlockId, endBlockId });
 
         // we have a fetchBlockId which is the first block to fetch
         // and we have an endBlockId which is the last block to fetch

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -34,7 +34,11 @@ type BlockLoaderArgs = {
   problemManager: PlayerProblemManager;
 };
 
-type Blocks = (MessageBlock | undefined)[];
+type CacheBlock = MessageBlock & {
+  needTopics: Set<string>;
+};
+
+type Blocks = (CacheBlock | undefined)[];
 
 type LoadArgs = {
   progress: (progress: Progress) => void;
@@ -98,14 +102,24 @@ export class BlockLoader {
 
     this.topics = topics;
     this.activeChangeCondvar.notifyAll();
+
+    // Update all the blocks with any missing topics
+    for (const block of this.blocks) {
+      if (block) {
+        const blockTopics = Object.keys(block.messagesByTopic);
+        const needTopics = new Set(topics);
+        for (const topic of blockTopics) {
+          needTopics.delete(topic);
+        }
+        block.needTopics = needTopics;
+      }
+    }
   }
 
   async stopLoading(): Promise<void> {
     log.debug("Stop loading blocks");
     this.stopped = true;
     this.activeChangeCondvar.notifyAll();
-
-    // fixme - should this be async and wait on loading to actually stop?
   }
 
   async startLoading(args: LoadArgs): Promise<void> {
@@ -136,15 +150,11 @@ export class BlockLoader {
   private async load(args: { progress: LoadArgs["progress"] }): Promise<void> {
     const topics = this.topics;
 
-    let progress = this.calculateProgress(topics);
-
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
-      args.progress(progress);
+      args.progress(this.calculateProgress(topics));
       return;
     }
-
-    let totalBlockSizeBytes = this.cacheSize();
 
     // We prioritize loading from the active block id to the end, then we load from the start to active block id
     const segments: [number, number][] = [
@@ -155,239 +165,222 @@ export class BlockLoader {
     for (const segment of segments) {
       const [beginBlockId, lastBlockId] = segment;
 
-      console.log({ beginBlockId, lastBlockId });
-
       // Note: lastBlockId is actually 1-past-last block so we can skip this loop if the begin and last are the same
       if (beginBlockId === lastBlockId) {
         continue;
       }
 
-      // starting at beginBlockId, identify the first block we need to load
-      // this is our start block, from the start block identify to _load to_ block
-      // this is our end block
-      // load from start block up to end block
-      // if end block is at end, go back to 0 and keep going until we reach beginBlockId
-      for (let i = beginBlockId; i < lastBlockId; ++i) {
-        const fetchBlockId = i;
-
-        // Topics we will fetch for this range
-        const topicsToFetch = new Set(topics);
-
-        // fixme - track the needed topics for a block to avoid re-computing
-        {
-          const existingBlock = this.blocks[fetchBlockId];
-          const blockTopics = existingBlock ? Object.keys(existingBlock.messagesByTopic) : [];
-
-          for (const topic of blockTopics) {
-            topicsToFetch.delete(topic);
-          }
-
-          // This block is fully fetched, move on
-          if (topicsToFetch.size === 0) {
-            continue;
-          }
-        }
-
-        let endBlockId = fetchBlockId;
-
-        // we've found a block that needs fetching
-        // now build a continuous span of the next blocks
-        for (let endIdx = fetchBlockId + 1; endIdx < this.blocks.length; ++endIdx) {
-          const nextBlock = this.blocks[endIdx];
-          const nextBlockTopics = nextBlock ? Object.keys(nextBlock.messagesByTopic) : [];
-
-          const nextTopicsToFetch = new Set(topics);
-          for (const topic of nextBlockTopics) {
-            nextTopicsToFetch.delete(topic);
-          }
-
-          // Topics no longer match, either block is loaded or we'll need to load in another pass
-          if (!isEqual(topicsToFetch, nextTopicsToFetch)) {
-            break;
-          }
-
-          endBlockId = endIdx;
-        }
-
-        console.log({ fetchBlockId, endBlockId });
-
-        // we have a fetchBlockId which is the first block to fetch
-        // and we have an endBlockId which is the last block to fetch
-        // make a request to the source
-
-        const iteratorStartTime = this.blockIdToStartTime(fetchBlockId);
-        const iteratorEndTime = clampTime(this.blockIdToEndTime(endBlockId), this.start, this.end);
-
-        const iterator = this.source.messageIterator({
-          topics: Array.from(topicsToFetch),
-          start: iteratorStartTime,
-          end: iteratorEndTime,
-        });
-
-        let messagesByTopic: Record<string, MessageEvent<unknown>[]> = {};
-        // Set all topic arrays to empty to indicate we've read this topic
-        for (const topic of topicsToFetch) {
-          messagesByTopic[topic] = [];
-        }
-
-        let currentBlockId = fetchBlockId;
-
-        let sizeInBytes = 0;
-        for await (const iterResult of iterator) {
-          if (iterResult.problem) {
-            this.problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
-            continue;
-          }
-
-          const messageBlockId = this.timeToBlockId(iterResult.msgEvent.receiveTime);
-
-          if (messageBlockId < currentBlockId) {
-            log.error("Invariant: received a message for a block in the past");
-            throw new Error("Invariant: received a message for a block in the past");
-          }
-
-          // Message is for a different block.
-          // 1. Close out the current block.
-          // 2. Fill in any block gaps.
-          // 3. start a new block.
-          if (messageBlockId !== currentBlockId) {
-            // Close out the current block with the aggregated messages. Fill any blocks between
-            // current and the new block with empty topic arrays. We can use empty arrays because we
-            // know these blocks have no messages since messages arrive in time order.
-            for (let idx = currentBlockId; idx < messageBlockId; ++idx) {
-              const existingBlock = this.blocks[idx];
-
-              this.blocks[idx] = {
-                messagesByTopic: {
-                  ...existingBlock?.messagesByTopic,
-                  ...messagesByTopic,
-                },
-                sizeInBytes: sizeInBytes + (existingBlock?.sizeInBytes ?? 0),
-              };
-
-              // setup a new block cache for the next block
-              messagesByTopic = {};
-              // Set all topic arrays to empty to indicate we've read this topic
-              for (const topic of topicsToFetch) {
-                messagesByTopic[topic] = [];
-              }
-            }
-
-            // Set the new block to the id of our latest message
-            currentBlockId = messageBlockId;
-
-            progress = this.calculateProgress(topics);
-            args.progress(progress);
-          }
-
-          // When the topics change we re bail and will re-load
-          // Since topics changing is in-frequent and usually indicates we need to reload blocks
-          if (topics !== this.topics) {
-            log.debug("topics changed, aborting load instance");
-            return;
-          }
-
-          const msgTopic = iterResult.msgEvent.topic;
-          const events = messagesByTopic[msgTopic];
-
-          const problemKey = `unexpected-topic-${msgTopic}`;
-          if (!events) {
-            this.problemManager.addProblem(problemKey, {
-              severity: "error",
-              message: `Received a messaged on an unexpected topic: ${msgTopic}.`,
-            });
-
-            continue;
-          }
-          this.problemManager.removeProblem(problemKey);
-
-          const messageSizeInBytes = iterResult.msgEvent.sizeInBytes;
-          sizeInBytes += messageSizeInBytes;
-
-          while (totalBlockSizeBytes + messageSizeInBytes > this.maxCacheSize) {
-            const evictedSize = this.evictBlock({
-              startId: this.activeBlockId,
-              endId: currentBlockId,
-            });
-            // If we could not evict any blocks to bring our size down, then we stop loading more data
-            if (evictedSize === 0) {
-              return;
-            }
-
-            totalBlockSizeBytes -= evictedSize;
-          }
-
-          // When the active block id changes, we need to check whether the active block
-          // is loaded through where we are loading (or the end if active block is after currentBlockId)
-          if (beginBlockId !== this.activeBlockId) {
-            // minus one because the currentBlockIdx is now the next block we are loading
-            // we don't need to compare to that sine we know it hasn't loaded yet but is about to be
-            let scanToBlockIdx = currentBlockId - 1;
-
-            // If the active block id > the block we scan to, then we need to scan to end
-            if (this.activeBlockId > scanToBlockIdx) {
-              scanToBlockIdx = this.blocks.length - 1;
-            }
-
-            // scan from active to scanToBlockId
-            for (let scanIdx = this.activeBlockId; scanIdx <= scanToBlockIdx; ++scanIdx) {
-              // figure out the needed topics for scanIdx
-
-              const scanTopics = new Set(topicsToFetch);
-
-              // if any scanIdx block needs topics, then we need to bail
-              const existingBlock = this.blocks[scanIdx];
-              const blockTopics = existingBlock ? Object.keys(existingBlock.messagesByTopic) : [];
-
-              for (const topic of blockTopics) {
-                scanTopics.delete(topic);
-              }
-
-              // Our active block needs loading, we abort our existing loading loop
-              // and start working on active.
-              if (scanTopics.size > 0) {
-                return;
-              }
-            }
-          }
-
-          totalBlockSizeBytes += messageSizeInBytes;
-          events.push(iterResult.msgEvent);
-        }
-
-        // Close out the current block with the aggregated messages. Fill any blocks between
-        // current and the new block with empty topic arrays. We can use empty arrays because we
-        // know these blocks have no messages since messages arrive in time order.
-        for (let idx = currentBlockId; idx <= endBlockId; ++idx) {
-          const existingBlock = this.blocks[idx];
-
-          this.blocks[idx] = {
-            messagesByTopic: {
-              ...existingBlock?.messagesByTopic,
-              ...messagesByTopic,
-            },
-            sizeInBytes: sizeInBytes + (existingBlock?.sizeInBytes ?? 0),
-          };
-
-          messagesByTopic = {};
-          // Set all topic arrays to empty to indicate we've read this topic
-          for (const topic of topicsToFetch) {
-            messagesByTopic[topic] = [];
-          }
-        }
-
-        if (currentBlockId <= endBlockId) {
-          progress = this.calculateProgress(topics);
-          args.progress(progress);
-        }
-
-        // We've processed through endBlockId now, next cycle can skip all those blocks
-        i = endBlockId + 1;
-      }
+      await this.loadBlockRange(beginBlockId, lastBlockId, args.progress);
     }
   }
 
   /// ---- private
+
+  // Load the blocks from [beginBlockId, lastBlockId)
+  private async loadBlockRange(
+    beginBlockId: number,
+    lastBlockId: number,
+    progress: LoadArgs["progress"],
+  ): Promise<void> {
+    const topics = this.topics;
+
+    let totalBlockSizeBytes = this.cacheSize();
+
+    for (let blockId = beginBlockId; blockId < lastBlockId; ++blockId) {
+      // Topics we will fetch for this range
+      let topicsToFetch = new Set<string>();
+
+      // Keep looking for a block that needs loading
+      {
+        const existingBlock = this.blocks[blockId];
+
+        // The current block has everything, so we can move to the next block
+        if (existingBlock?.needTopics.size === 0) {
+          continue;
+        }
+
+        // The current block needs some topics so those will be come the topics we need to fetch
+        topicsToFetch = existingBlock?.needTopics ?? topics;
+      }
+
+      // blockId is the first block that needs loading
+      // Now we look for the last block. We do this by finding blocks that need the same topics to fetch.
+      // This creates a continuous span of the same topics to fetch
+      let endBlockId = blockId;
+      for (let endIdx = blockId + 1; endIdx < this.blocks.length; ++endIdx) {
+        const nextBlock = this.blocks[endIdx];
+
+        const needTopics = nextBlock?.needTopics ?? topics;
+
+        // if needtopics is undefined cause there's no block, then needTopics is all topics
+
+        // The topics we need to fetch no longer match the topics we need so we stop the range
+        if (!isEqual(topicsToFetch, needTopics)) {
+          break;
+        }
+
+        endBlockId = endIdx;
+      }
+
+      const iteratorStartTime = this.blockIdToStartTime(blockId);
+      const iteratorEndTime = clampTime(this.blockIdToEndTime(endBlockId), this.start, this.end);
+
+      const iterator = this.source.messageIterator({
+        topics: Array.from(topicsToFetch),
+        start: iteratorStartTime,
+        end: iteratorEndTime,
+      });
+
+      let messagesByTopic: Record<string, MessageEvent<unknown>[]> = {};
+      // Set all topic arrays to empty to indicate we've read this topic
+      for (const topic of topicsToFetch) {
+        messagesByTopic[topic] = [];
+      }
+
+      let currentBlockId = blockId;
+
+      let sizeInBytes = 0;
+      for await (const iterResult of iterator) {
+        if (iterResult.problem) {
+          this.problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+          continue;
+        }
+
+        const messageBlockId = this.timeToBlockId(iterResult.msgEvent.receiveTime);
+
+        if (messageBlockId < currentBlockId) {
+          log.error("Invariant: received a message for a block in the past");
+          throw new Error("Invariant: received a message for a block in the past");
+        }
+
+        // Message is for a different block.
+        // 1. Close out the current block.
+        // 2. Fill in any block gaps.
+        // 3. start a new block.
+        if (messageBlockId !== currentBlockId) {
+          // Close out the current block with the aggregated messages. Fill any blocks between
+          // current and the new block with empty topic arrays. We can use empty arrays because we
+          // know these blocks have no messages since messages arrive in time order.
+          for (let idx = currentBlockId; idx < messageBlockId; ++idx) {
+            const existingBlock = this.blocks[idx];
+
+            this.blocks[idx] = {
+              needTopics: new Set(),
+              messagesByTopic: {
+                ...existingBlock?.messagesByTopic,
+                ...messagesByTopic,
+              },
+              sizeInBytes: sizeInBytes + (existingBlock?.sizeInBytes ?? 0),
+            };
+
+            // setup a new block cache for the next block
+            messagesByTopic = {};
+            // Set all topic arrays to empty to indicate we've read this topic
+            for (const topic of topicsToFetch) {
+              messagesByTopic[topic] = [];
+            }
+          }
+
+          // Set the new block to the id of our latest message
+          currentBlockId = messageBlockId;
+
+          progress(this.calculateProgress(topics));
+        }
+
+        // When the topics change we re bail and will re-load
+        // Since topics changing is in-frequent and usually indicates we need to reload blocks
+        if (topics !== this.topics) {
+          log.debug("topics changed, aborting load instance");
+          return;
+        }
+
+        const msgTopic = iterResult.msgEvent.topic;
+        const events = messagesByTopic[msgTopic];
+
+        const problemKey = `unexpected-topic-${msgTopic}`;
+        if (!events) {
+          this.problemManager.addProblem(problemKey, {
+            severity: "error",
+            message: `Received a messaged on an unexpected topic: ${msgTopic}.`,
+          });
+
+          continue;
+        }
+        this.problemManager.removeProblem(problemKey);
+
+        const messageSizeInBytes = iterResult.msgEvent.sizeInBytes;
+        sizeInBytes += messageSizeInBytes;
+
+        // Evict blocks until we have space for our new message
+        while (totalBlockSizeBytes + messageSizeInBytes > this.maxCacheSize) {
+          const evictedSize = this.evictBlock({
+            startId: this.activeBlockId,
+            endId: currentBlockId,
+          });
+          // If we could not evict any blocks to bring our size down, then we stop loading more data
+          if (evictedSize === 0) {
+            return;
+          }
+
+          totalBlockSizeBytes -= evictedSize;
+        }
+
+        // When the active block id changes, we need to check whether the active block
+        // is loaded through where we are loading (or the end if active block is after currentBlockId)
+        if (beginBlockId !== this.activeBlockId) {
+          // minus one because the currentBlockIdx is now the next block we are loading
+          // we don't need to compare to that sine we know it hasn't loaded yet but is about to be
+          let scanToBlockIdx = currentBlockId - 1;
+
+          // If the active block id > the block we scan to, then we need to scan to end
+          if (this.activeBlockId > scanToBlockIdx) {
+            scanToBlockIdx = this.blocks.length - 1;
+          }
+
+          // scan from active to scanToBlockId
+          for (let scanIdx = this.activeBlockId; scanIdx <= scanToBlockIdx; ++scanIdx) {
+            // There's a block between active and current that needs loading, we bail and restart loading
+            const existingBlock = this.blocks[scanIdx];
+            if (!existingBlock || existingBlock.needTopics.size > 0) {
+              return;
+            }
+          }
+        }
+
+        totalBlockSizeBytes += messageSizeInBytes;
+        events.push(iterResult.msgEvent);
+      }
+
+      // Close out the current block with the aggregated messages. Fill any blocks between
+      // current and the new block with empty topic arrays. We can use empty arrays because we
+      // know these blocks have no messages since messages arrive in time order.
+      for (let idx = currentBlockId; idx <= endBlockId; ++idx) {
+        const existingBlock = this.blocks[idx];
+
+        this.blocks[idx] = {
+          needTopics: new Set(),
+          messagesByTopic: {
+            ...existingBlock?.messagesByTopic,
+            ...messagesByTopic,
+          },
+          sizeInBytes: sizeInBytes + (existingBlock?.sizeInBytes ?? 0),
+        };
+
+        messagesByTopic = {};
+        // Set all topic arrays to empty to indicate we've read this topic
+        for (const topic of topicsToFetch) {
+          messagesByTopic[topic] = [];
+        }
+      }
+
+      if (currentBlockId <= endBlockId) {
+        progress(this.calculateProgress(topics));
+      }
+
+      // We've processed through endBlockId now, next cycle can skip all those blocks
+      blockId = endBlockId + 1;
+    }
+  }
 
   // Evict a block while preserving blocks in the block id range (inclusive)
   private evictBlock(range: { startId: number; endId: number }): number {

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -34,13 +34,6 @@ type BlockLoaderArgs = {
   problemManager: PlayerProblemManager;
 };
 
-// A BlockSpan is a continuous set of blocks and topics to load for those blocks
-type BlockSpan = {
-  beginId: number;
-  endId: number;
-  topics: Set<string>;
-};
-
 type Blocks = (MessageBlock | undefined)[];
 
 type LoadArgs = {
@@ -164,13 +157,17 @@ export class BlockLoader {
 
       console.log({ beginBlockId, lastBlockId });
 
+      // Note: lastBlockId is actually 1-past-last block so we can skip this loop if the begin and last are the same
+      if (beginBlockId === lastBlockId) {
+        continue;
+      }
+
       // starting at beginBlockId, identify the first block we need to load
       // this is our start block, from the start block identify to _load to_ block
       // this is our end block
       // load from start block up to end block
       // if end block is at end, go back to 0 and keep going until we reach beginBlockId
       for (let i = beginBlockId; i < lastBlockId; ++i) {
-        // fixme - fetchBlockId can be looked up onces before beginBlockId
         const fetchBlockId = i;
 
         // Topics we will fetch for this range
@@ -276,11 +273,10 @@ export class BlockLoader {
               }
             }
 
-            progress = this.calculateProgress(topics);
-
             // Set the new block to the id of our latest message
             currentBlockId = messageBlockId;
 
+            progress = this.calculateProgress(topics);
             args.progress(progress);
           }
 
@@ -380,12 +376,14 @@ export class BlockLoader {
           }
         }
 
+        if (currentBlockId <= endBlockId) {
+          progress = this.calculateProgress(topics);
+          args.progress(progress);
+        }
+
         // We've processed through endBlockId now, next cycle can skip all those blocks
         i = endBlockId + 1;
       }
-
-      progress = this.calculateProgress(topics);
-      args.progress(progress);
     }
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -148,6 +148,10 @@ describe("IterablePlayer", () => {
         ...baseState,
         presence: PlayerPresence.PRESENT,
         activeData: { ...baseState.activeData, currentTime: { sec: 0, nsec: 99000000 } },
+        progress: {
+          fullyLoadedFractionRanges: [{ start: 0, end: 0 }],
+          messageCache: undefined,
+        },
       },
     ]);
 
@@ -169,7 +173,7 @@ describe("IterablePlayer", () => {
     await store.done;
 
     // Reset store to get state from the seeks
-    store.reset(2);
+    store.reset(3);
 
     // replace the message iterator with our own implementation
     // This implementation performs a seekPlayback during backfill.
@@ -217,7 +221,10 @@ describe("IterablePlayer", () => {
       capabilities: [PlayerCapabilities.setSpeed, PlayerCapabilities.playbackControl],
       profile: undefined,
       presence: PlayerPresence.PRESENT,
-      progress: {},
+      progress: {
+        fullyLoadedFractionRanges: [{ start: 0, end: 1 }],
+        messageCache: undefined,
+      },
       filePath: undefined,
       urlState: {
         sourceId: "test",
@@ -246,7 +253,7 @@ describe("IterablePlayer", () => {
     // The state order:
     // 1. a state update completing the second seek
     // 1. a state update for moving to idle
-    expect(playerStates).toEqual([withMessages, baseState]);
+    expect(playerStates).toEqual([withMessages, baseState, baseState]);
 
     player.close();
   });

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -641,6 +641,7 @@ export class IterablePlayer implements Player {
   }
 
   /** Emit the player state to the registered listener */
+  // fixme - debouncePromise
   private async _emitState() {
     if (!this._listener) {
       return;
@@ -938,6 +939,7 @@ export class IterablePlayer implements Player {
 
     await this._blockLoader?.startLoading({
       progress: async (progress) => {
+        console.log({ progress });
         this._progress = {
           fullyLoadedFractionRanges: this._progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -138,7 +138,6 @@ export class IterablePlayer implements Player {
   private _receivedBytes: number = 0;
   private _hasError = false;
   private _lastRangeMillis?: number;
-  private _closed: boolean = false;
   private _lastMessage?: MessageEvent<unknown>;
   private _publishedTopics = new Map<string, Set<string>>();
   private _seekTarget?: Time;
@@ -892,7 +891,6 @@ export class IterablePlayer implements Player {
 
   private async _stateClose() {
     this._isPlaying = false;
-    this._closed = true;
     this._metricsCollector.close();
     await this._bufferedSource.stopProducer();
     await this._playbackIterator?.return?.();

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -5,6 +5,7 @@
 import { isEqual } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
+import { debouncePromise } from "@foxglove/den/async";
 import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import {
@@ -160,7 +161,8 @@ export class IterablePlayer implements Player {
 
   private _blockLoader?: BlockLoader;
   private _blockLoadingProcess?: Promise<void>;
-  private _emitting: boolean = false;
+
+  private _emitState: ReturnType<typeof debouncePromise>;
 
   private readonly _sourceId: string;
 
@@ -175,6 +177,10 @@ export class IterablePlayer implements Player {
     this._metricsCollector.playerConstructed();
     this._enablePreload = enablePreload ?? true;
     this._sourceId = sourceId;
+
+    // Wrap emitStateImpl in a debouncePromise for our states to call. Since we can emit from states
+    // or from block loading updates we use debouncePromise to guard against concurrent emits.
+    this._emitState = debouncePromise(this._emitStateImpl.bind(this));
   }
 
   setListener(listener: (playerState: PlayerState) => Promise<void>): void {
@@ -345,7 +351,7 @@ export class IterablePlayer implements Player {
 
         switch (state) {
           case "preinit":
-            await this._emitState();
+            this._emitState();
             break;
           case "initialize":
             await this._stateInitialize();
@@ -375,7 +381,7 @@ export class IterablePlayer implements Player {
     } catch (err) {
       log.error(err);
       this._setError((err as Error).message, err);
-      await this._emitState();
+      this._emitState();
     } finally {
       this._runningState = false;
     }
@@ -394,7 +400,7 @@ export class IterablePlayer implements Player {
   // Initialize the source and player members
   private async _stateInitialize(): Promise<void> {
     // emit state indicating start of initialization
-    await this._emitState();
+    this._emitState();
 
     try {
       const { start, end, topics, profile, topicStats, problems, publishersByTopic, datatypes } =
@@ -448,7 +454,7 @@ export class IterablePlayer implements Player {
     } catch (error) {
       this._setError(`Error initializing: ${error.message}`, error);
     }
-    await this._emitState();
+    this._emitState();
 
     if (!this._hasError) {
       // Wait a bit until panels have had the chance to subscribe to topics before we start
@@ -521,10 +527,9 @@ export class IterablePlayer implements Player {
 
     // If we take too long to read the data, we set the player into a BUFFERING presence. This
     // indicates that the player is waiting to load more data.
-    let tickEmit: Promise<void> | undefined;
     const tickTimeout = setTimeout(() => {
       this._presence = PlayerPresence.BUFFERING;
-      tickEmit = this._emitState();
+      this._emitState();
     }, 100);
 
     try {
@@ -554,17 +559,12 @@ export class IterablePlayer implements Player {
       }
     } finally {
       clearTimeout(tickTimeout);
-      await tickEmit;
     }
 
     this._currentTime = stopTime;
     this._messages = messageEvents;
     this._presence = PlayerPresence.PRESENT;
-    await this._emitState();
-
-    if (this._nextState) {
-      return;
-    }
+    this._emitState();
     this._setState("idle");
   }
 
@@ -579,10 +579,6 @@ export class IterablePlayer implements Player {
     this._lastMessage = undefined;
     this._seekTarget = undefined;
 
-    // If the seekAckTimeout emits a state, _stateSeekBackfill must wait for it to complete.
-    // It would be invalid to allow the _stateSeekBackfill to finish prior to completion
-    let seekAckWait: Promise<void> | undefined;
-
     // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
     // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
     const seekAckTimeout = setTimeout(() => {
@@ -590,8 +586,7 @@ export class IterablePlayer implements Player {
       this._messages = [];
       this._currentTime = targetTime;
       this._lastSeekEmitTime = Date.now();
-
-      seekAckWait = this._emitState();
+      this._emitState();
     }, 100);
 
     const topics = Array.from(this._allTopics);
@@ -617,11 +612,6 @@ export class IterablePlayer implements Player {
     // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
     clearTimeout(seekAckTimeout);
 
-    // timeout may have triggered, so we need to wait for any emit that happened
-    if (seekAckWait) {
-      await seekAckWait;
-    }
-
     if (this._nextState) {
       return;
     }
@@ -629,28 +619,14 @@ export class IterablePlayer implements Player {
     this._currentTime = targetTime;
     this._lastSeekEmitTime = Date.now();
     this._presence = PlayerPresence.PRESENT;
-    console.log("emit");
-    await this._emitState();
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-    if (this._nextState) {
-      return;
-    }
-
+    this._emitState();
     await this.resetPlaybackIterator();
     this._setState(this._isPlaying ? "play" : "idle");
   }
 
   /** Emit the player state to the registered listener */
-  // fixme - debouncePromise
-  private async _emitState() {
+  private async _emitStateImpl() {
     if (!this._listener) {
-      return;
-    }
-
-    if (this._emitting) {
-      // fixme - the blocks backfill update means we are already emitting
-      // need debouncePromise :'(
-      console.log("already emitting");
       return;
     }
 
@@ -709,12 +685,7 @@ export class IterablePlayer implements Player {
       },
     };
 
-    try {
-      this._emitting = true;
-      return await this._listener(data);
-    } finally {
-      this._emitting = false;
-    }
+    return await this._listener(data);
   }
 
   /**
@@ -764,7 +735,7 @@ export class IterablePlayer implements Player {
       if (compare(this._lastMessage.receiveTime, end) > 0) {
         this._currentTime = end;
         this._messages = msgEvents;
-        await this._emitState();
+        this._emitState();
         return;
       }
 
@@ -775,10 +746,9 @@ export class IterablePlayer implements Player {
     // If we take too long to read the tick data, we set the player into a BUFFERING presence. This
     // indicates that the player is waiting to load more data. When the tick finally finishes, we
     // clear this timeout.
-    let tickEmit: Promise<void> | undefined;
     const tickTimeout = setTimeout(() => {
       this._presence = PlayerPresence.BUFFERING;
-      tickEmit = this._emitState();
+      this._emitState();
     }, 100);
 
     try {
@@ -811,7 +781,6 @@ export class IterablePlayer implements Player {
       }
     } finally {
       clearTimeout(tickTimeout);
-      await tickEmit;
     }
 
     // Set the presence back to PRESENT since we are no longer buffering
@@ -823,25 +792,16 @@ export class IterablePlayer implements Player {
 
     this._currentTime = end;
     this._messages = msgEvents;
-    await this._emitState();
+    this._emitState();
   }
 
   private async _stateIdle() {
     this._presence = PlayerPresence.PRESENT;
-    await this._emitState();
-    if (this._nextState) {
-      return;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-    if (this._nextState) {
-      return;
-    }
+    this._emitState();
 
     if (this._abort) {
       throw new Error("Invariant: some other abort controller exists");
     }
-
     const abort = (this._abort = new AbortController());
 
     const aborted = new Promise<void>((resolve) => {
@@ -855,13 +815,12 @@ export class IterablePlayer implements Player {
         fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
         messageCache: this._progress.messageCache,
       };
-      await this._emitState();
+      this._emitState();
 
       // When idling nothing is querying the source, but our buffered source might be
       // buffering behind the scenes. Every second we emit state with an update to show that
       // buffering is happening.
       await Promise.race([delay(1000), aborted]);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
       if (this._nextState) {
         break;
       }
@@ -900,12 +859,6 @@ export class IterablePlayer implements Player {
           return;
         }
 
-        // Eslint doesn't understand that this._nextState could change
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-        if (this._nextState) {
-          return;
-        }
-
         this._progress = {
           fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
           messageCache: this._progress.messageCache,
@@ -920,7 +873,7 @@ export class IterablePlayer implements Player {
       }
     } catch (err) {
       this._setError((err as Error).message, err);
-      await this._emitState();
+      this._emitState();
     }
   }
 
@@ -935,23 +888,14 @@ export class IterablePlayer implements Player {
   }
 
   private async startBlockLoading() {
-    let nextEmit = 0;
-
     await this._blockLoader?.startLoading({
       progress: async (progress) => {
-        console.log({ progress });
         this._progress = {
           fullyLoadedFractionRanges: this._progress.fullyLoadedFractionRanges,
           messageCache: progress.messageCache,
         };
 
-        // We throttle emitting the state since we could be loading blocks faster than 60fps and it
-        // is actually slower to try rendering with each new block compared to spacing out the
-        // rendering.
-        if (Date.now() >= nextEmit) {
-          await this._emitState();
-          nextEmit = Date.now() + 100;
-        }
+        this._emitState();
       },
     });
   }


### PR DESCRIPTION
**User-Facing Changes**
Better handling of preloading topics for users on experimental players

**Description**
The BlockLoader is responsible for loading subscriptions with the "full" subscriber option. These are topics which a panel has indicated it wants all the messages across the entire data source range. When there is not enough memory to hold the entire dataset, the loader attempts to prioritize showing the data at and after the current time.

The existing behavior of BlockLoader had some drawbacks:

- When switching from idle -> play (and vice versa) the loader would stop and restart.
- When loading blocks the loader would not consider the position of the playhead for which blocks to evict vs keep which resulted in evicting blocks relevant to the current playhead.

This change addresses these issues by making the loader a "background" task of the iterable player. Rather than starting/stopping the loader during state changes, the iterable player updates the loader with the current time and the current full subscriber topic set. The loader uses these inputs to manage the full preload. When these inputs allow, the loader keeps loading rather than starting and stopping. When these inputs change in a way that the loader needs to start loading another region (i.e. seeking to an un-loaded region), the loader stops and restarts itself to always ensure it is loading the region with the playhead.

This change adds additional tests to verify that the loader loads the expected regions under playback and seeking.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
