### PR TITLE
Allow overrides for map panel topic colors

### DIFF
--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -14,6 +14,7 @@ export type Config = {
   layer: string;
   zoomLevel?: number;
   followTopic: string;
+  topicColors: Record<string, string>;
 };
 
 export function validateCustomUrl(url: string): Error | undefined {
@@ -29,16 +30,38 @@ export function validateCustomUrl(url: string): Error | undefined {
 }
 
 export function buildSettingsTree(config: Config, eligibleTopics: string[]): SettingsTreeNodes {
-  const topics: SettingsTreeFields = transform(
+  const topics: SettingsTreeNodes = transform(
     eligibleTopics,
     (result, topic) => {
+      const coloring = config.topicColors[topic];
       result[topic] = {
         label: topic,
-        input: "boolean",
-        value: !config.disabledTopics.includes(topic),
+        fields: {
+          enabled: {
+            label: "Enabled",
+            input: "boolean",
+            value: !config.disabledTopics.includes(topic),
+          },
+          coloring: {
+            label: "Coloring",
+            input: "select",
+            value: coloring ? "Custom" : "Automatic",
+            options: [
+              { label: "Automatic", value: "Automatic" },
+              { label: "Custom", value: "Custom" },
+            ],
+          },
+          color: coloring
+            ? {
+                label: "Color",
+                input: "rgb",
+                value: coloring,
+              }
+            : undefined,
+        },
       };
     },
-    {} as SettingsTreeFields,
+    {} as SettingsTreeNodes,
   );
 
   const eligibleFollowTopicOptions = filterMap(eligibleTopics, (topic) =>
@@ -88,7 +111,7 @@ export function buildSettingsTree(config: Config, eligibleTopics: string[]): Set
     },
     topics: {
       label: "Topics",
-      fields: topics,
+      children: topics,
     },
   };
 

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -118,7 +118,7 @@ SinglePoint.parameters = {
 };
 
 export const SinglePointWithSettings = (): JSX.Element => {
-  return <MapPanel overrideConfig={{ layer: "custom" }} />;
+  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "pink" } }} />;
 };
 
 SinglePointWithSettings.parameters = {

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -118,28 +118,19 @@ SinglePoint.parameters = {
 };
 
 export const SinglePointWithSettings = (): JSX.Element => {
-  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "pink" } }} />;
+  return <MapPanel overrideConfig={{ layer: "custom" }} />;
+};
+SinglePointWithSettings.parameters = {
+  ...SinglePoint.parameters,
+  includeSettings: true,
 };
 
-SinglePointWithSettings.parameters = {
-  chromatic: {
-    delay: 1000,
-  },
+export const SinglePointWithSettingsOverride = (): JSX.Element => {
+  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "pink" } }} />;
+};
+SinglePointWithSettingsOverride.parameters = {
+  ...SinglePoint.parameters,
   includeSettings: true,
-  panelSetup: {
-    fixture: {
-      topics: [{ name: "/gps", datatype: "sensor_msgs/NavSatFix" }],
-      frame: {
-        "/gps": [
-          {
-            topic: "/gps",
-            receiveTime: { sec: 123, nsec: 456 },
-            message: EMPTY_MESSAGE,
-          },
-        ],
-      },
-    },
-  },
 };
 
 export const MultipleTopics = (): JSX.Element => {

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -126,7 +126,7 @@ SinglePointWithSettings.parameters = {
 };
 
 export const SinglePointWithSettingsOverride = (): JSX.Element => {
-  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "pink" } }} />;
+  return <MapPanel overrideConfig={{ layer: "custom", topicColors: { "/gps": "#ffc0cb" } }} />;
 };
 SinglePointWithSettingsOverride.parameters = {
   ...SinglePoint.parameters,


### PR DESCRIPTION
**User-Facing Changes**
This allows users to override the topic colors in the map panel on a per-topic basis.

**Description**
This expands the settings UI for the map panel to allow users to choose between automatic and custom coloring for each topic and to select a color for each custom topic.

<img width="360" alt="Screen Shot 2022-07-25 at 8 42 37 AM" src="https://user-images.githubusercontent.com/93935560/180804719-6f654934-ce5b-425d-b30f-8e985104a9dc.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3753 
Partially addresses #3786 