### PR TITLE
Make panel titles editable

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -14,7 +14,7 @@
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
-import { IconButton, InputBase, styled as muiStyled, Typography } from "@mui/material";
+import { InputBase, styled as muiStyled, Typography } from "@mui/material";
 import { useContext, useState, useMemo, CSSProperties, useCallback } from "react";
 
 import PanelContext from "@foxglove/studio-base/components/PanelContext";


### PR DESCRIPTION
**User-Facing Changes**
This implements editable panel titles for all standard panels.

**Description**
This makes panel titles editable. This implementation adds a pencil icon to put the titlebar in editing mode. If we feel this adds too much clutter to the titlebar then another option is a new item in the context menu that toggles title editing mode.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3806 