### PR TITLE
Add keyboard shortcut to close the sidebar

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -36,6 +36,7 @@ import variablesHelpContent from "@foxglove/studio-base/components/GlobalVariabl
 import HelpSidebar, {
   MESSAGE_PATH_SYNTAX_HELP_INFO,
 } from "@foxglove/studio-base/components/HelpSidebar";
+import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import LayoutBrowser from "@foxglove/studio-base/components/LayoutBrowser";
 import {
   MessagePipelineContext,
@@ -114,6 +115,13 @@ type SidebarItemKey =
   | "help";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+
+function activeElementIsInput() {
+  return (
+    document.activeElement instanceof HTMLInputElement ||
+    document.activeElement instanceof HTMLTextAreaElement
+  );
+}
 
 function AddPanel() {
   const addPanel = useAddPanel();
@@ -213,7 +221,12 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   // when the user wants to select a new connection we track whether the sidebar item opened
   const userSelectSidebarItem = useRef(false);
 
+  const lastSelectedSidebarItem = useRef<SidebarItemKey | undefined>(undefined);
+
   const selectSidebarItem = useCallback((item: SidebarItemKey | undefined) => {
+    if (item != undefined) {
+      lastSelectedSidebarItem.current = item;
+    }
     userSelectSidebarItem.current = true;
     setSelectedSidebarItem(item);
   }, []);
@@ -546,6 +559,19 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     return supportsAccountSettings ? ["help", "account", "preferences"] : ["help", "preferences"];
   }, [supportsAccountSettings]);
 
+  const keyDownHandlers = useMemo(
+    () => ({
+      b: (ev: KeyboardEvent) => {
+        if (!ev.ctrlKey || activeElementIsInput() || selectedSidebarItem == undefined) {
+          return;
+        }
+
+        setSelectedSidebarItem(undefined);
+      },
+    }),
+    [selectedSidebarItem],
+  );
+
   const play = useMessagePipeline(selectPlay);
   const pause = useMessagePipeline(selectPause);
   const seek = useMessagePipeline(selectSeek);
@@ -581,6 +607,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       </DocumentDropListener>
       <OrgExtensionRegistrySyncAdapter />
       <URLStateSyncAdapter />
+      <KeyListener global keyDownHandlers={keyDownHandlers} />
       <div className={classes.container} ref={containerRef} tabIndex={0}>
         <Sidebar
           items={sidebarItems}

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -221,12 +221,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   // when the user wants to select a new connection we track whether the sidebar item opened
   const userSelectSidebarItem = useRef(false);
 
-  const lastSelectedSidebarItem = useRef<SidebarItemKey | undefined>(undefined);
-
   const selectSidebarItem = useCallback((item: SidebarItemKey | undefined) => {
-    if (item != undefined) {
-      lastSelectedSidebarItem.current = item;
-    }
     userSelectSidebarItem.current = true;
     setSelectedSidebarItem(item);
   }, []);

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -123,6 +123,14 @@ function activeElementIsInput() {
   );
 }
 
+function keyboardEventHasModifier(event: KeyboardEvent) {
+  if (navigator.userAgent.includes("Mac")) {
+    return event.metaKey;
+  } else {
+    return event.ctrlKey;
+  }
+}
+
 function AddPanel() {
   const addPanel = useAddPanel();
   const { openLayoutBrowser } = useWorkspace();
@@ -557,7 +565,11 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const keyDownHandlers = useMemo(
     () => ({
       b: (ev: KeyboardEvent) => {
-        if (!ev.ctrlKey || activeElementIsInput() || selectedSidebarItem == undefined) {
+        if (
+          !keyboardEventHasModifier(ev) ||
+          activeElementIsInput() ||
+          selectedSidebarItem == undefined
+        ) {
           return;
         }
 

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -573,6 +573,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           return;
         }
 
+        ev.preventDefault();
         setSelectedSidebarItem(undefined);
       },
     }),


### PR DESCRIPTION
**User-Facing Changes**
This adds a global keyboard shortcut for closing the sidebar, mapped to `ctrl-b`.

**Description**
This just adds a global key handler to close the sidebar. It's not a toggle and doesn't reopen the sidebar its previous state but just mirrors the process of clicking on sidebar button. We could expand on this to maintain or restore the previous sidebar state when the shortcut is used when the sidebar is closed but that would require more extensive changes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3873 