### PR TITLE
Read and write global variables from extension panels

### DIFF
--- a/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 import { MosaicNode, MosaicPath } from "react-mosaic-component";
 
+import { VariableValue } from "@foxglove/studio";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { LinkedGlobalVariables } from "@foxglove/studio-base/panels/ThreeDimensionalViz/Interactions/useLinkedGlobalVariables";
 import { TabLocation } from "@foxglove/studio-base/types/layouts";
@@ -76,16 +77,12 @@ export type CHANGE_PANEL_LAYOUT = {
 
 export type OVERWRITE_GLOBAL_DATA = {
   type: "OVERWRITE_GLOBAL_DATA";
-  payload: {
-    [key: string]: unknown;
-  };
+  payload: Record<string, VariableValue>;
 };
 
 export type SET_GLOBAL_DATA = {
   type: "SET_GLOBAL_DATA";
-  payload: {
-    [key: string]: unknown;
-  };
+  payload: Record<string, VariableValue>;
 };
 
 export type SET_STUDIO_NODES = { type: "SET_USER_NODES"; payload: Partial<UserNodes> };

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -7,6 +7,7 @@ import { getLeaves } from "react-mosaic-component";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
+import { VariableValue } from "@foxglove/studio";
 import { selectWithUnstableIdentityWarning } from "@foxglove/studio-base/hooks/selectWithUnstableIdentityWarning";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 import useShouldNotChangeOften from "@foxglove/studio-base/hooks/useShouldNotChangeOften";
@@ -74,8 +75,8 @@ export interface ICurrentLayout {
     updatePanelConfigs: (panelType: string, updater: (config: PanelConfig) => PanelConfig) => void;
     createTabPanel: (payload: CreateTabPanelPayload) => void;
     changePanelLayout: (payload: ChangePanelLayoutPayload) => void;
-    overwriteGlobalVariables: (payload: { [key: string]: unknown }) => void;
-    setGlobalVariables: (payload: { [key: string]: unknown }) => void;
+    overwriteGlobalVariables: (payload: Record<string, VariableValue>) => void;
+    setGlobalVariables: (payload: Record<string, VariableValue>) => void;
     setUserNodes: (payload: Partial<UserNodes>) => void;
     setLinkedGlobalVariables: (payload: LinkedGlobalVariables) => void;
     setPlaybackConfig: (payload: Partial<PlaybackConfig>) => void;

--- a/packages/studio-base/src/hooks/useGlobalVariables.ts
+++ b/packages/studio-base/src/hooks/useGlobalVariables.ts
@@ -11,15 +11,16 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import type { VariableValue } from "@foxglove/studio";
 import {
   LayoutState,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 
-export type GlobalVariables = { [key: string]: unknown };
+export type GlobalVariables = { [key: string]: VariableValue };
 
-const EMPTY_GLOBAL_VARIABLES: GlobalVariables = Object.freeze({});
+export const EMPTY_GLOBAL_VARIABLES: GlobalVariables = Object.freeze({});
 
 const globalVariablesSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.globalVariables ?? EMPTY_GLOBAL_VARIABLES;

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
+import { VariableValue } from "@foxglove/studio";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import CurrentLayoutContext, {
   ICurrentLayout,
@@ -284,9 +285,9 @@ export default function CurrentLayoutProvider({
       },
       changePanelLayout: (payload: ChangePanelLayoutPayload) =>
         performAction({ type: "CHANGE_PANEL_LAYOUT", payload }),
-      overwriteGlobalVariables: (payload: { [key: string]: unknown }) =>
+      overwriteGlobalVariables: (payload: Record<string, VariableValue>) =>
         performAction({ type: "OVERWRITE_GLOBAL_DATA", payload }),
-      setGlobalVariables: (payload: { [key: string]: unknown }) =>
+      setGlobalVariables: (payload: Record<string, VariableValue>) =>
         performAction({ type: "SET_GLOBAL_DATA", payload }),
       setUserNodes: (payload: Partial<UserNodes>) =>
         performAction({ type: "SET_USER_NODES", payload }),

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -16,6 +16,17 @@ declare module "@foxglove/studio" {
 
   export type ParameterStruct = Record<string, ParameterValue>;
 
+  // Valid types for global variables
+  export type VariableValue =
+    | undefined
+    | boolean
+    | number
+    | string
+    | VariableValue[]
+    | VariableStruct;
+
+  export type VariableStruct = Record<string, VariableValue>;
+
   // Valid types for application settings
   export type AppSettingValue = string | number | boolean | undefined;
 
@@ -136,9 +147,18 @@ declare module "@foxglove/studio" {
     allFrames?: readonly MessageEvent<unknown>[];
 
     /**
-     * Map of current parameter values.
+     * Map of current parameter values. Parameters are key/value pairs associated with the data
+     * source, and may not be available for all data sources. For example, ROS 1 live connections
+     * support parameters through the Parameter Server <http://wiki.ros.org/Parameter%20Server>.
      */
     parameters?: ReadonlyMap<string, ParameterValue>;
+
+    /**
+     * Map of current Studio variables. Variables are key/value pairs that are globally accessible
+     * to panels and scripts in the current layout. See
+     * <https://foxglove.dev/docs/studio/app-concepts/variables> for more information.
+     */
+    variables?: ReadonlyMap<string, VariableValue>;
 
     /**
      * List of available topics. This list includes subscribed and unsubscribed topics.
@@ -210,6 +230,14 @@ declare module "@foxglove/studio" {
      * @param value The new value of the parameter.
      */
     setParameter: (name: string, value: ParameterValue) => void;
+
+    /**
+     * Set the value of variable name to value.
+     *
+     * @param name The name of the variable to set.
+     * @param value The new value of the variable.
+     */
+    setVariable: (name: string, value: VariableValue) => void;
 
     /**
      * Set the active preview time. Setting the preview time to undefined clears the preview time.


### PR DESCRIPTION
**User-Facing Changes**

- [Extension API] Add global variable support via `RenderState#variables`, `PanelExtensionContext#setVariable(name, value)`

**Description**

This adds global variable support to the extension panel API with a new `setVariable()` method and a `variables` map on RenderState. This pattern mimics the parameters API, although the types are slightly different.
