### PR TITLE
fix(New3D): Fix topic subscriptions logic

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -569,9 +569,9 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       } else if (
         // prettier-ignore
         (topicHandlers.get(topic.name)?.length ?? 0) +
-        (datatypeHandlers.get(topic.datatype)?.length ?? 0) > 1
+        (datatypeHandlers.get(topic.datatype)?.length ?? 0) > 0
       ) {
-        // Subscribe if there are multiple handlers registered for this topic
+        // Subscribe if there are handlers registered for this topic
         subscriptions.add(topic.name);
       }
     }


### PR DESCRIPTION
**Description**

After the latest rebase, our custom `SceneExtension` stopped working. On a closer look, it turned out the subscription messages were not going through even though `SceneExtension` subscribed through `addTopicSubscription`. The culprit was that `ThreeDeeRender` requires _both_ `topicHandlers` and `datatypeHandlers` to be present while we only had a single `topicHandler`. This PR fixes the logic so that a single handler is sufficient.
