### PR TITLE
Select entire layout name on rename

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -172,13 +172,8 @@ export default React.memo(function LayoutRow({
   }, [layout, onMakePersonalCopy]);
 
   const renameAction = useCallback(() => {
-    // Give the menu time to close before focusing the text field. The MUI Menu auto-focuses itself
-    // which results in an immediate onBlur of the text field if we try to focus it while the menu
-    // is still visible.
-    setTimeout(() => {
-      setEditingName(true);
-      setNameFieldValue(layout.name);
-    }, 0);
+    setNameFieldValue(layout.name);
+    setEditingName(true);
   }, [layout]);
 
   const onClick = useCallback(() => {
@@ -458,6 +453,8 @@ export default React.memo(function LayoutRow({
       <Menu
         id="layout-action-menu"
         open={contextMenuTarget != undefined}
+        disableAutoFocus
+        disableRestoreFocus
         anchorReference={contextMenuTarget?.type === "position" ? "anchorPosition" : "anchorEl"}
         anchorPosition={
           contextMenuTarget?.type === "position"


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the logic to select the entire layout name for convenience when the user chooses `rename` from the layout context menu. Setting the `disableAutoFocus` and `disableRestoreFocus` on the menu fixes the focus interference of the menu and input.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
