### PR TITLE
[New3D] Fix topic links from selected object dialog

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
@@ -66,11 +66,15 @@ const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseCom
         <ToolGroupFixedSizePane>
           {originalMessage ? (
             <>
-              <SRow>
-                <SValue>
-                  <TopicLink addPanel={addPanel} topic={selectedInteractionData.topic} />
-                </SValue>
-              </SRow>
+              {selectedInteractionData.topic ? (
+                <SRow>
+                  <SValue>
+                    <TopicLink addPanel={addPanel} topic={selectedInteractionData.topic} />
+                  </SValue>
+                </SRow>
+              ) : (
+                <></>
+              )}
               <ObjectDetails
                 selectedObject={originalMessage}
                 interactionData={selectedInteractionData}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/types.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/types.ts
@@ -15,7 +15,7 @@ import { RosObject } from "@foxglove/studio-base/players/types";
 import { Marker } from "@foxglove/studio-base/types/Messages";
 
 export type InteractionData = {
-  readonly topic: string;
+  readonly topic: string | undefined;
   highlighted?: boolean;
   readonly originalMessage: RosObject;
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -205,7 +205,7 @@ function RendererOverlay(props: {
             object: {
               pose: selectedRenderable.userData.pose,
               interactionData: {
-                topic: selectedRenderable.name,
+                topic: (selectedRenderable.userData as { topic?: string }).topic,
                 highlighted: true,
                 originalMessage: selectedRenderable.details(),
               },


### PR DESCRIPTION
**User-Facing Changes**

- Fixed `3D (Beta)` selection dialog topic link to use the correct topic name

**Description**

Only put topic names in the topic links, don't show topic links for renderables that do not have a topic name
