### PR TITLE
Support batch deleting layouts in the layout browser

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -17,7 +17,7 @@ import {
   TextField,
   styled as muiStyled,
 } from "@mui/material";
-import { useCallback, useContext, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useContext, useLayoutEffect, useMemo, useState, MouseEvent } from "react";
 import { useMountedState } from "react-use";
 
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
@@ -110,6 +110,7 @@ export type LayoutActionMenuItem =
 
 export default React.memo(function LayoutRow({
   layout,
+  multiSelected,
   selected,
   onSelect,
   onRename,
@@ -122,8 +123,9 @@ export default React.memo(function LayoutRow({
   onMakePersonalCopy,
 }: {
   layout: Layout;
+  multiSelected: boolean;
   selected: boolean;
-  onSelect: (item: Layout, params?: { selectedViaClick?: boolean }) => void;
+  onSelect: (item: Layout, params?: { selectedViaClick?: boolean; event?: MouseEvent }) => void;
   onRename: (item: Layout, newName: string) => void;
   onDuplicate: (item: Layout) => void;
   onDelete: (item: Layout) => void;
@@ -176,11 +178,12 @@ export default React.memo(function LayoutRow({
     setEditingName(true);
   }, [layout]);
 
-  const onClick = useCallback(() => {
-    if (!selected) {
-      onSelect(layout, { selectedViaClick: true });
-    }
-  }, [layout, onSelect, selected]);
+  const onClick = useCallback(
+    (event: MouseEvent) => {
+      onSelect(layout, { selectedViaClick: true, event });
+    },
+    [layout, onSelect],
+  );
 
   const duplicateAction = useCallback(() => onDuplicate(layout), [layout, onDuplicate]);
   const shareAction = useCallback(() => onShare(layout), [layout, onShare]);
@@ -424,7 +427,7 @@ export default React.memo(function LayoutRow({
       }
     >
       <ListItemButton
-        selected={selected}
+        selected={selected || multiSelected}
         onSubmit={onSubmit}
         onClick={editingName ? undefined : onClick}
         onContextMenu={editingName ? undefined : handleContextMenu}

--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -427,6 +427,7 @@ export default React.memo(function LayoutRow({
       }
     >
       <ListItemButton
+        data-testid="layout-list-item"
         selected={selected || multiSelected}
         onSubmit={onSubmit}
         onClick={editingName ? undefined : onClick}

--- a/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Typography, List } from "@mui/material";
+import { MouseEvent } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
@@ -13,6 +14,7 @@ export default function LayoutSection({
   title,
   emptyText,
   items,
+  multiSelectedIds,
   selectedId,
   onSelect,
   onRename,
@@ -27,8 +29,9 @@ export default function LayoutSection({
   title: string | undefined;
   emptyText: string | undefined;
   items: readonly Layout[] | undefined;
+  multiSelectedIds: readonly string[];
   selectedId?: string;
-  onSelect: (item: Layout, params?: { selectedViaClick?: boolean }) => void;
+  onSelect: (item: Layout, params?: { selectedViaClick?: boolean; event?: MouseEvent }) => void;
   onRename: (item: Layout, newName: string) => void;
   onDuplicate: (item: Layout) => void;
   onDelete: (item: Layout) => void;
@@ -57,6 +60,7 @@ export default function LayoutSection({
         )}
         {items?.map((layout) => (
           <LayoutRow
+            multiSelected={multiSelectedIds.includes(layout.id)}
             selected={layout.id === selectedId}
             key={layout.id}
             layout={layout}

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Story, StoryContext } from "@storybook/react";
+import { createEvent, fireEvent, screen } from "@testing-library/dom";
 import { useEffect, useMemo } from "react";
 import TestUtils from "react-dom/test-utils";
 import { useAsync } from "react-use";
@@ -128,6 +129,28 @@ Empty.parameters = { mockLayouts: [] };
 export function LayoutList(): JSX.Element {
   return <LayoutBrowser />;
 }
+
+export function MultiSelect(): JSX.Element {
+  return <LayoutBrowser />;
+}
+MultiSelect.play = async () => {
+  const layouts = await screen.findAllByTestId("layout-list-item");
+  layouts.forEach((layout) => fireEvent.click(layout, { ctrlKey: true }));
+};
+
+export function MultiDelete(): JSX.Element {
+  return <LayoutBrowser />;
+}
+MultiDelete.play = async () => {
+  const layouts = await screen.findAllByTestId("layout-list-item");
+  layouts.forEach((layout) => fireEvent.click(layout, { ctrlKey: true }));
+  const deleteButton = await screen.findAllByTitle("Delete Selected");
+  if (deleteButton[0]) {
+    fireEvent.click(deleteButton[0]);
+  }
+  const confirmButton = await screen.findByText("Delete");
+  fireEvent.click(confirmButton);
+};
 
 TruncatedLayoutName.parameters = {
   mockLayouts: [

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Story, StoryContext } from "@storybook/react";
-import { createEvent, fireEvent, screen } from "@testing-library/dom";
+import { fireEvent, screen } from "@testing-library/dom";
 import { useEffect, useMemo } from "react";
 import TestUtils from "react-dom/test-utils";
 import { useAsync } from "react-use";

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -215,16 +215,7 @@ export default function LayoutBrowser({
         }
         void analytics.logEvent(AppEvent.LAYOUT_SELECT, { permission: item.permission });
       }
-      const selectedIsShared =
-        layouts.value?.shared.some((layout) => layout.id === item.id) === true;
-      const currentIsShared =
-        currentLayoutId != undefined &&
-        layouts.value?.shared.some((layout) => layout.id === currentLayoutId) === true;
-      if (
-        (event?.ctrlKey === true || event?.metaKey === true) &&
-        !selectedIsShared &&
-        !currentIsShared
-      ) {
+      if (event?.ctrlKey === true || event?.metaKey === true) {
         if (item.id !== currentLayoutId) {
           dispatch({ type: "toggle-selected", id: item.id });
         }
@@ -233,14 +224,7 @@ export default function LayoutBrowser({
         dispatch({ type: "select-id", id: item.id });
       }
     },
-    [
-      analytics,
-      currentLayoutId,
-      dispatch,
-      layouts.value?.shared,
-      promptForUnsavedChanges,
-      setSelectedLayoutId,
-    ],
+    [analytics, currentLayoutId, dispatch, promptForUnsavedChanges, setSelectedLayoutId],
   );
 
   const onRenameLayout = useCallbackWithToast(

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -4,6 +4,7 @@
 
 import AddIcon from "@mui/icons-material/Add";
 import CloudOffIcon from "@mui/icons-material/CloudOff";
+import DeleteIcon from "@mui/icons-material/Delete";
 import FileOpenOutlinedIcon from "@mui/icons-material/FileOpenOutlined";
 import {
   Button,
@@ -17,11 +18,12 @@ import {
 import { partition } from "lodash";
 import moment from "moment";
 import path from "path";
-import { useCallback, useContext, useEffect, useLayoutEffect, useState } from "react";
+import { MouseEvent, useCallback, useContext, useEffect, useLayoutEffect } from "react";
 import { useToasts } from "react-toast-notifications";
 import { useMountedState } from "react-use";
 import useAsyncFn from "react-use/lib/useAsyncFn";
 
+import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import SignInPrompt from "@foxglove/studio-base/components/LayoutBrowser/SignInPrompt";
 import { useUnsavedChangesPrompt } from "@foxglove/studio-base/components/LayoutBrowser/UnsavedChangesPrompt";
@@ -43,13 +45,16 @@ import { useConfirm } from "@foxglove/studio-base/hooks/useConfirm";
 import { usePrompt } from "@foxglove/studio-base/hooks/usePrompt";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
-import { Layout, layoutIsShared } from "@foxglove/studio-base/services/ILayoutStorage";
+import { Layout, LayoutID, layoutIsShared } from "@foxglove/studio-base/services/ILayoutStorage";
 import { downloadTextFile } from "@foxglove/studio-base/util/download";
 import showOpenFilePicker from "@foxglove/studio-base/util/showOpenFilePicker";
 
 import LayoutSection from "./LayoutSection";
 import helpContent from "./index.help.md";
+import { useLayoutBrowserReducer } from "./reducer";
 import { debugBorder } from "./styles";
+
+const log = Logger.getLogger(__filename);
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 
@@ -70,13 +75,16 @@ export default function LayoutBrowser({
   const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
   const { setSelectedLayoutId } = useCurrentLayoutActions();
 
-  const [isBusy, setIsBusy] = useState(layoutManager.isBusy);
-  const [isOnline, setIsOnline] = useState(layoutManager.isOnline);
-  const [error, setError] = useState(layoutManager.error);
+  const [state, dispatch] = useLayoutBrowserReducer({
+    busy: layoutManager.isBusy,
+    error: layoutManager.error,
+    online: layoutManager.isOnline,
+  });
+
   useLayoutEffect(() => {
-    const busyListener = () => setIsBusy(layoutManager.isBusy);
-    const onlineListener = () => setIsOnline(layoutManager.isOnline);
-    const errorListener = () => setError(layoutManager.error);
+    const busyListener = () => dispatch({ type: "set-busy", value: layoutManager.isBusy });
+    const onlineListener = () => dispatch({ type: "set-online", value: layoutManager.isOnline });
+    const errorListener = () => dispatch({ type: "set-error", value: layoutManager.error });
     busyListener();
     onlineListener();
     errorListener();
@@ -88,7 +96,7 @@ export default function LayoutBrowser({
       layoutManager.off("onlinechange", onlineListener);
       layoutManager.off("errorchange", errorListener);
     };
-  }, [layoutManager]);
+  }, [dispatch, layoutManager]);
 
   const [layouts, reloadLayouts] = useAsyncFn(
     async () => {
@@ -105,6 +113,37 @@ export default function LayoutBrowser({
     { loading: true },
   );
 
+  const queueMultipleLayoutsForDelete = useCallback(async () => {
+    const response = await confirm({
+      title: `Delete multiple layouts?`,
+      prompt: `Are you sure you want to delete ${state.selectedIds.length} layouts?. This cannot be undone.`,
+      ok: "Delete",
+      variant: "danger",
+    });
+    if (response !== "ok") {
+      return;
+    }
+
+    dispatch({ type: "queue-deletes" });
+  }, [confirm, dispatch, state.selectedIds.length]);
+
+  useEffect(() => {
+    const deleteLayouts = async () => {
+      const toDelete = state.queuedDeleteIds[0];
+      if (toDelete) {
+        try {
+          await layoutManager.deleteLayout({ id: toDelete as LayoutID });
+          dispatch({ type: "shift-queued-deletes" });
+        } catch (err) {
+          addToast(`Error deleting layouts: ${err.message}`, { appearance: "error" });
+          dispatch({ type: "clear-queued-deletes" });
+        }
+      }
+    };
+
+    deleteLayouts().catch((err) => log.error(err));
+  }, [addToast, dispatch, layoutManager, state.queuedDeleteIds]);
+
   useEffect(() => {
     const listener = () => void reloadLayouts();
     layoutManager.on("change", listener);
@@ -113,7 +152,7 @@ export default function LayoutBrowser({
 
   // Start loading on first mount
   useEffect(() => {
-    void reloadLayouts();
+    reloadLayouts().catch((err) => log.error(err));
   }, [reloadLayouts]);
 
   /**
@@ -161,22 +200,47 @@ export default function LayoutBrowser({
           });
           return true;
       }
-      return false;
     }
     return true;
   }, [analytics, currentLayoutId, layoutManager, openUnsavedChangesPrompt]);
 
   const onSelectLayout = useCallbackWithToast(
-    async (item: Layout, { selectedViaClick = false }: { selectedViaClick?: boolean } = {}) => {
+    async (
+      item: Layout,
+      { selectedViaClick = false, event }: { selectedViaClick?: boolean; event?: MouseEvent } = {},
+    ) => {
       if (selectedViaClick) {
         if (!(await promptForUnsavedChanges())) {
           return;
         }
         void analytics.logEvent(AppEvent.LAYOUT_SELECT, { permission: item.permission });
       }
-      setSelectedLayoutId(item.id);
+      const selectedIsShared =
+        layouts.value?.shared.some((layout) => layout.id === item.id) === true;
+      const currentIsShared =
+        currentLayoutId != undefined &&
+        layouts.value?.shared.some((layout) => layout.id === currentLayoutId) === true;
+      if (
+        (event?.ctrlKey === true || event?.metaKey === true) &&
+        !selectedIsShared &&
+        !currentIsShared
+      ) {
+        if (item.id !== currentLayoutId) {
+          dispatch({ type: "toggle-selected", id: item.id });
+        }
+      } else {
+        setSelectedLayoutId(item.id);
+        dispatch({ type: "select-id", id: item.id });
+      }
     },
-    [analytics, promptForUnsavedChanges, setSelectedLayoutId],
+    [
+      analytics,
+      currentLayoutId,
+      dispatch,
+      layouts.value?.shared,
+      promptForUnsavedChanges,
+      setSelectedLayoutId,
+    ],
   );
 
   const onRenameLayout = useCallbackWithToast(
@@ -216,10 +280,11 @@ export default function LayoutBrowser({
         const storedLayouts = await layoutManager.getLayouts();
         const targetLayout = storedLayouts.find((layout) => layout.id !== currentLayoutId);
         setSelectedLayoutId(targetLayout?.id);
+        dispatch({ type: "select-id", id: targetLayout?.id });
       }
       await layoutManager.deleteLayout({ id: item.id });
     },
-    [analytics, currentLayoutId, layoutManager, setSelectedLayoutId],
+    [analytics, currentLayoutId, dispatch, layoutManager, setSelectedLayoutId],
   );
 
   const createNewLayout = useCallbackWithToast(async () => {
@@ -229,7 +294,7 @@ export default function LayoutBrowser({
     const name = `Unnamed layout ${moment(currentDateForStorybook).format("l")} at ${moment(
       currentDateForStorybook,
     ).format("LT")}`;
-    const state: Omit<PanelsState, "name" | "id"> = {
+    const panelState: Omit<PanelsState, "name" | "id"> = {
       configById: {},
       globalVariables: {},
       userNodes: {},
@@ -238,7 +303,7 @@ export default function LayoutBrowser({
     };
     const newLayout = await layoutManager.saveNewLayout({
       name,
-      data: state as PanelsState,
+      data: panelState as PanelsState,
       permission: "CREATOR_WRITE",
     });
     void onSelectLayout(newLayout);
@@ -399,18 +464,31 @@ export default function LayoutBrowser({
 
   const showSignInPrompt = supportsSignIn && !layoutManager.supportsSharing && !hideSignInPrompt;
 
+  const queuedMultiActions = state.queuedDeleteIds.length > 0;
+
   return (
     <SidebarContent
       title="Layouts"
       helpContent={helpContent}
       disablePadding
       trailingItems={[
-        (layouts.loading || isBusy) && (
+        (layouts.loading || state.busy || queuedMultiActions) && (
           <Stack key="loading" alignItems="center" justifyContent="center" padding={1}>
             <CircularProgress size={18} variant="indeterminate" />
           </Stack>
         ),
-        (!isOnline || error != undefined) && (
+        state.selectedIds.length > 1 && (
+          <IconButton
+            color="primary"
+            key="delete"
+            disabled={queuedMultiActions}
+            title="Delete Selected"
+            onClick={queueMultipleLayoutsForDelete}
+          >
+            <DeleteIcon />
+          </IconButton>
+        ),
+        (!state.online || state.error != undefined) && (
           <IconButton color="primary" key="offline" disabled title="Offline">
             <CloudOffIcon />
           </IconButton>
@@ -437,11 +515,12 @@ export default function LayoutBrowser({
       ].filter(Boolean)}
     >
       {unsavedChangesPrompt}
-      <Stack fullHeight gap={2}>
+      <Stack fullHeight gap={2} style={{ pointerEvents: queuedMultiActions ? "none" : "auto" }}>
         <LayoutSection
           title={layoutManager.supportsSharing ? "Personal" : undefined}
           emptyText="Add a new layout to get started with Foxglove Studio!"
           items={layouts.value?.personal}
+          multiSelectedIds={state.selectedIds}
           selectedId={currentLayoutId}
           onSelect={onSelectLayout}
           onRename={onRenameLayout}
@@ -458,6 +537,7 @@ export default function LayoutBrowser({
             title="Team"
             emptyText="Your organization doesn’t have any shared layouts yet. Share a personal layout to collaborate with other team members."
             items={layouts.value?.shared}
+            multiSelectedIds={state.selectedIds}
             selectedId={currentLayoutId}
             onSelect={onSelectLayout}
             onRename={onRenameLayout}

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { compact, pull, xor } from "lodash";
+import { Dispatch } from "react";
+import { useImmerReducer } from "use-immer";
+
+type State = {
+  busy: boolean;
+  error: undefined | Error;
+  online: boolean;
+  selectedIds: string[];
+  queuedDeleteIds: string[];
+};
+
+type Action =
+  | { type: "clear-queued-deletes" }
+  | { type: "queue-deletes" }
+  | { type: "set-busy"; value: boolean }
+  | { type: "set-error"; value: undefined | Error }
+  | { type: "set-online"; value: boolean }
+  | { type: "select-id"; id?: string }
+  | { type: "shift-queued-deletes" }
+  | { type: "toggle-selected"; id: string };
+
+function reducer(draft: State, action: Action) {
+  switch (action.type) {
+    case "clear-queued-deletes":
+      draft.queuedDeleteIds = [];
+      break;
+    case "queue-deletes":
+      draft.queuedDeleteIds = draft.selectedIds;
+      break;
+    case "select-id":
+      draft.queuedDeleteIds = [];
+      draft.selectedIds = compact([action.id]);
+      break;
+    case "set-busy":
+      draft.busy = action.value;
+      break;
+    case "set-error":
+      draft.error = action.value;
+      break;
+    case "set-online":
+      draft.online = action.value;
+      break;
+    case "shift-queued-deletes": {
+      const toDelete = draft.queuedDeleteIds.shift();
+      pull(draft.selectedIds, toDelete);
+      break;
+    }
+    case "toggle-selected":
+      draft.selectedIds = xor(draft.selectedIds, [action.id]);
+      break;
+  }
+}
+
+export function useLayoutBrowserReducer(
+  props: Pick<State, "busy" | "error" | "online">,
+): [State, Dispatch<Action>] {
+  return useImmerReducer(reducer, { ...props, selectedIds: [], queuedDeleteIds: [] });
+}


### PR DESCRIPTION
**User-Facing Changes**
This makes it possible to batch delete layouts in the layout browser.

**Description**
This implementation allows the user to select multiple layouts by holding the `Ctrl/Cmd` key while selecting layouts. When more than one layout is selected a delete icon appears in the layout browser header that will delete all selected layouts when clicked. 

The implementation here deletes one layout at a time. We could expand this to support transactional deletes of multiple layouts but that would require much more extensive changes.

Another enhancement would be supporting selecting ranges of layouts via `shift` clicking, similar to the Mac finder or Windows explorer.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3615 