### PR TITLE
Add remote mcap file support for experimental mcap player.

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -65,7 +65,7 @@ export default function Root({
       }),
       new SampleNuscenesDataSourceFactory({ useIterablePlayer: enableExperimentalBagPlayer }),
       new McapLocalDataSourceFactory({ useIterablePlayer: enableExperimentalMcapPlayer }),
-      new McapRemoteDataSourceFactory(),
+      new McapRemoteDataSourceFactory({ useIterablePlayer: enableExperimentalMcapPlayer }),
     ];
 
     return sources;

--- a/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapRemoteDataSourceFactory.ts
@@ -6,6 +6,8 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { IterablePlayer } from "@foxglove/studio-base/players/IterablePlayer";
+import { McapIterableSource } from "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSource";
 import RandomAccessPlayer from "@foxglove/studio-base/players/RandomAccessPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import McapDataProvider from "@foxglove/studio-base/randomAccessDataProviders/McapDataProvider";
@@ -21,10 +23,26 @@ export default class McapRemoteDataSourceFactory implements IDataSourceFactory {
   description = "Fetch and load pre-recorded MCAP files from a remote location.";
   docsLink = "https://foxglove.dev/docs/studio/connection/mcap";
 
+  private enableIterablePlayer = false;
+
+  constructor(opt?: { useIterablePlayer: boolean }) {
+    this.enableIterablePlayer = opt?.useIterablePlayer ?? false;
+  }
+
   initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     const url = args.url;
     if (!url) {
       return;
+    }
+
+    if (this.enableIterablePlayer) {
+      const source = new McapIterableSource({ type: "url", url });
+      return new IterablePlayer({
+        metricsCollector: args.metricsCollector,
+        source,
+        name: url,
+        sourceId: this.id,
+      });
     }
 
     const mcapProvider = new McapDataProvider({ source: { type: "remote", url } });

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/RemoteFileReadable.ts
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import BrowserHttpReader from "@foxglove/studio-base/util/BrowserHttpReader";
+import CachedFilelike from "@foxglove/studio-base/util/CachedFilelike";
+
+export class RemoteFileReadable {
+  private remoteReader: CachedFilelike;
+
+  constructor(url: string) {
+    const fileReader = new BrowserHttpReader(url);
+    this.remoteReader = new CachedFilelike({
+      fileReader,
+      cacheSizeInBytes: 1024 * 1024 * 200, // 200MiB
+    });
+  }
+
+  async open(): Promise<void> {
+    await this.remoteReader.open(); // Important that we call this first, because it might throw an error if the file can't be read.
+  }
+
+  async size(): Promise<bigint> {
+    return BigInt(this.remoteReader.size());
+  }
+  async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    if (offset + size > Number.MAX_SAFE_INTEGER) {
+      throw new Error(`Read too large: offset ${offset}, size ${size}`);
+    }
+    return await this.remoteReader.read(Number(offset), Number(size));
+  }
+}

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -53,7 +53,7 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
       }),
       new SampleNuscenesDataSourceFactory({ useIterablePlayer: enableExperimentalBagPlayer }),
       new McapLocalDataSourceFactory({ useIterablePlayer: enableExperimentalMcapPlayer }),
-      new McapRemoteDataSourceFactory(),
+      new McapRemoteDataSourceFactory({ useIterablePlayer: enableExperimentalMcapPlayer }),
     ];
 
     return sources;


### PR DESCRIPTION


**User-Facing Changes**
When the experimental mcap player flag is on, remote mcap files are handled via the new player.

**Description**

Fixes: #3949

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
