### PR TITLE
Fix setRenderDone call for new3d

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -510,7 +510,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         }
 
         // Set the done callback into a state variable to trigger a re-render
-        setRenderDone(done);
+        setRenderDone(() => done);
 
         // Keep UI elements and the renderer aware of the current color scheme
         setColorScheme(renderState.colorScheme);


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Calling a react `setState` function with a function argument will call that function argument immediately. The behavior we want here is to set `renderDone` to a function we can later call to indicate rendering is done.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
