### PR TITLE
Fix getBackfillMessages for CachingIterableSource

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
@@ -7,6 +7,7 @@ import { simplify } from "intervals-fn";
 import { useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import { filterMap } from "@foxglove/den/collection";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Range } from "@foxglove/studio-base/util/ranges";
 
@@ -57,11 +58,12 @@ export function ProgressPlot(props: ProgressProps): JSX.Element {
     }
     const mergedRanges = simplify(availableRanges);
 
-    return mergedRanges.map((range, idx) => {
+    return filterMap(mergedRanges, (range, idx) => {
       const width = range.end - range.start;
       if (width === 0) {
-        return <></>;
+        return;
       }
+
       return (
         <div
           className={classes.range}

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -749,7 +749,7 @@ export class IterablePlayer implements Player {
     const tickTimeout = setTimeout(() => {
       this._presence = PlayerPresence.BUFFERING;
       this._emitState();
-    }, 100);
+    }, 500);
 
     try {
       // Read from the iterator through the end of the tick time


### PR DESCRIPTION


**User-Facing Changes**
Better performance when scrubbing or seeking using experimental players

**Description**
getBackfillMessages would return far too many messages and would fail to consider more than one cached block which meant it had to go to the underlying source too often.

This fixes the getBackfillMessages behavior for CachingIterableSource and adds tests to verify the behavior works to return expected messages and avoids going to the source.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
