### PR TITLE
Use context menu for multiple deletes

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -223,15 +223,15 @@ export default React.memo(function LayoutRow({
   }, []);
 
   const confirmDelete = useCallback(() => {
+    const layoutWarning =
+      !multiSelection && layoutIsShared(layout)
+        ? "Team members will no longer be able to access this layout. "
+        : "";
+    const prompt = `${layoutWarning}This action cannot be undone.`;
+    const title = multiSelection ? "Delete selected layouts?" : `Delete “${layout.name}”?`;
     void confirm({
-      title: multiSelection ? "Delete selected layouts?" : `Delete “${layout.name}”?`,
-      prompt: multiSelection
-        ? "This action cannot be undone."
-        : `${
-            layoutIsShared(layout)
-              ? "Team members will no longer be able to access this layout."
-              : ""
-          } This action cannot be undone.`,
+      title,
+      prompt,
       ok: "Delete",
       variant: "danger",
     }).then((response) => {

--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -110,7 +110,7 @@ export type LayoutActionMenuItem =
 
 export default React.memo(function LayoutRow({
   layout,
-  multiSelected,
+  multiSelectedIds,
   selected,
   onSelect,
   onRename,
@@ -123,7 +123,7 @@ export default React.memo(function LayoutRow({
   onMakePersonalCopy,
 }: {
   layout: Layout;
-  multiSelected: boolean;
+  multiSelectedIds: readonly string[];
   selected: boolean;
   onSelect: (item: Layout, params?: { selectedViaClick?: boolean; event?: MouseEvent }) => void;
   onRename: (item: Layout, newName: string) => void;
@@ -151,6 +151,7 @@ export default React.memo(function LayoutRow({
 
   const deletedOnServer = layout.syncInfo?.status === "remotely-deleted";
   const hasModifications = layout.working != undefined;
+  const multiSelection = multiSelectedIds.length > 1;
 
   useLayoutEffect(() => {
     const onlineListener = () => setIsOnline(layoutManager.isOnline);
@@ -223,10 +224,14 @@ export default React.memo(function LayoutRow({
 
   const confirmDelete = useCallback(() => {
     void confirm({
-      title: `Delete “${layout.name}”?`,
-      prompt: `${
-        layoutIsShared(layout) ? "Team members will no longer be able to access this layout." : ""
-      } This action cannot be undone.`,
+      title: multiSelection ? "Delete selected layouts?" : `Delete “${layout.name}”?`,
+      prompt: multiSelection
+        ? "This action cannot be undone."
+        : `${
+            layoutIsShared(layout)
+              ? "Team members will no longer be able to access this layout."
+              : ""
+          } This action cannot be undone.`,
       ok: "Delete",
       variant: "danger",
     }).then((response) => {
@@ -234,7 +239,7 @@ export default React.memo(function LayoutRow({
         onDelete(layout);
       }
     });
-  }, [confirm, isMounted, layout, onDelete]);
+  }, [confirm, isMounted, layout, multiSelection, onDelete]);
 
   const handleContextMenu = useCallback((event: React.MouseEvent) => {
     event.preventDefault();
@@ -263,7 +268,7 @@ export default React.memo(function LayoutRow({
       text: "Rename",
       onClick: renameAction,
       "data-test": "rename-layout",
-      disabled: layoutIsShared(layout) && !isOnline,
+      disabled: (layoutIsShared(layout) && !isOnline) || multiSelection,
       secondaryText: layoutIsShared(layout) && !isOnline ? "Offline" : undefined,
     },
     // For shared layouts, duplicate first requires saving or discarding changes
@@ -275,6 +280,7 @@ export default React.memo(function LayoutRow({
           ? "Make a personal copy"
           : "Duplicate",
       onClick: duplicateAction,
+      disabled: multiSelection,
       "data-test": "duplicate-layout",
     },
     layoutManager.supportsSharing &&
@@ -283,13 +289,14 @@ export default React.memo(function LayoutRow({
         key: "share",
         text: "Share with team…",
         onClick: shareAction,
-        disabled: !isOnline,
+        disabled: !isOnline || multiSelection,
         secondaryText: !isOnline ? "Offline" : undefined,
       },
     {
       type: "item",
       key: "export",
       text: "Export…",
+      disabled: multiSelection,
       onClick: exportAction,
     },
     { key: "divider_1", type: "divider" },
@@ -309,7 +316,7 @@ export default React.memo(function LayoutRow({
         key: "overwrite",
         text: "Save changes",
         onClick: overwriteAction,
-        disabled: deletedOnServer || (layoutIsShared(layout) && !isOnline),
+        disabled: deletedOnServer || (layoutIsShared(layout) && !isOnline) || multiSelection,
         secondaryText: layoutIsShared(layout) && !isOnline ? "Offline" : undefined,
       },
       {
@@ -317,7 +324,7 @@ export default React.memo(function LayoutRow({
         key: "revert",
         text: "Revert",
         onClick: revertAction,
-        disabled: deletedOnServer,
+        disabled: deletedOnServer || multiSelection,
       },
     ];
     if (layoutIsShared(layout)) {
@@ -325,6 +332,7 @@ export default React.memo(function LayoutRow({
         type: "item",
         key: "copy_to_personal",
         text: "Make a personal copy",
+        disabled: multiSelection,
         onClick: makePersonalCopyAction,
       });
     }
@@ -428,7 +436,7 @@ export default React.memo(function LayoutRow({
     >
       <ListItemButton
         data-testid="layout-list-item"
-        selected={selected || multiSelected}
+        selected={selected || multiSelectedIds.includes(layout.id)}
         onSubmit={onSubmit}
         onClick={editingName ? undefined : onClick}
         onContextMenu={editingName ? undefined : handleContextMenu}

--- a/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -60,7 +60,7 @@ export default function LayoutSection({
         )}
         {items?.map((layout) => (
           <LayoutRow
-            multiSelected={multiSelectedIds.includes(layout.id)}
+            multiSelectedIds={multiSelectedIds}
             selected={layout.id === selectedId}
             key={layout.id}
             layout={layout}

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -280,6 +280,9 @@ DeleteSelectedLayout.play = async () => {
     fireEvent.click(layouts[1]);
   }
   await deleteLayoutInteraction(1);
+  if (layouts[0]) {
+    fireEvent.click(layouts[0]);
+  }
 };
 DeleteSelectedLayout.parameters = { colorScheme: "dark" };
 

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -141,10 +141,12 @@ MultiDelete.parameters = { colorScheme: "dark" };
 MultiDelete.play = async () => {
   const layouts = await screen.findAllByTestId("layout-list-item");
   layouts.forEach((layout) => fireEvent.click(layout, { ctrlKey: true }));
-  const deleteButton = await screen.findAllByTitle("Delete Selected");
-  if (deleteButton[0]) {
-    fireEvent.click(deleteButton[0]);
+  const actions = await screen.findAllByTestId("layout-actions");
+  if (actions[0]) {
+    fireEvent.click(actions[0]!);
   }
+  const deleteButton = await screen.findByText("Delete");
+  fireEvent.click(deleteButton);
   const confirmButton = await screen.findByText("Delete");
   fireEvent.click(confirmButton);
 };

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -81,7 +81,9 @@ export default function LayoutBrowser({
   });
 
   useLayoutEffect(() => {
-    const busyListener = () => dispatch({ type: "set-busy", value: layoutManager.isBusy });
+    const busyListener = () => {
+      dispatch({ type: "set-busy", value: layoutManager.isBusy });
+    };
     const onlineListener = () => dispatch({ type: "set-online", value: layoutManager.isOnline });
     const errorListener = () => dispatch({ type: "set-error", value: layoutManager.error });
     busyListener();
@@ -453,7 +455,7 @@ export default function LayoutBrowser({
 
   const showSignInPrompt = supportsSignIn && !layoutManager.supportsSharing && !hideSignInPrompt;
 
-  const pendingMultiAction = state.multiAction != undefined;
+  const pendingMultiAction = state.multiAction?.ids != undefined;
 
   return (
     <SidebarContent

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -4,7 +4,6 @@
 
 import AddIcon from "@mui/icons-material/Add";
 import CloudOffIcon from "@mui/icons-material/CloudOff";
-import DeleteIcon from "@mui/icons-material/Delete";
 import FileOpenOutlinedIcon from "@mui/icons-material/FileOpenOutlined";
 import {
   Button,
@@ -113,36 +112,30 @@ export default function LayoutBrowser({
     { loading: true },
   );
 
-  const queueMultipleLayoutsForDelete = useCallback(async () => {
-    const response = await confirm({
-      title: `Delete multiple layouts?`,
-      prompt: `Are you sure you want to delete ${state.selectedIds.length} layouts?. This cannot be undone.`,
-      ok: "Delete",
-      variant: "danger",
-    });
-    if (response !== "ok") {
-      return;
-    }
-
-    dispatch({ type: "queue-deletes" });
-  }, [confirm, dispatch, state.selectedIds.length]);
-
   useEffect(() => {
-    const deleteLayouts = async () => {
-      const toDelete = state.queuedDeleteIds[0];
-      if (toDelete) {
+    const processAction = async () => {
+      if (!state.multiAction) {
+        return;
+      }
+
+      const id = state.multiAction.ids[0];
+      if (id) {
         try {
-          await layoutManager.deleteLayout({ id: toDelete as LayoutID });
-          dispatch({ type: "shift-queued-deletes" });
+          switch (state.multiAction.action) {
+            case "delete":
+              await layoutManager.deleteLayout({ id: id as LayoutID });
+              dispatch({ type: "shift-multi-action" });
+              break;
+          }
         } catch (err) {
           addToast(`Error deleting layouts: ${err.message}`, { appearance: "error" });
-          dispatch({ type: "clear-queued-deletes" });
+          dispatch({ type: "clear-multi-action" });
         }
       }
     };
 
-    deleteLayouts().catch((err) => log.error(err));
-  }, [addToast, dispatch, layoutManager, state.queuedDeleteIds]);
+    processAction().catch((err) => log.error(err));
+  }, [addToast, dispatch, layoutManager, state.multiAction]);
 
   useEffect(() => {
     const listener = () => void reloadLayouts();
@@ -253,6 +246,11 @@ export default function LayoutBrowser({
 
   const onDeleteLayout = useCallbackWithToast(
     async (item: Layout) => {
+      if (state.selectedIds.length > 0) {
+        dispatch({ type: "queue-multi-action", action: "delete" });
+        return;
+      }
+
       void analytics.logEvent(AppEvent.LAYOUT_DELETE, { permission: item.permission });
 
       // If the layout was selected, select a different available layout.
@@ -268,7 +266,14 @@ export default function LayoutBrowser({
       }
       await layoutManager.deleteLayout({ id: item.id });
     },
-    [analytics, currentLayoutId, dispatch, layoutManager, setSelectedLayoutId],
+    [
+      analytics,
+      currentLayoutId,
+      dispatch,
+      layoutManager,
+      setSelectedLayoutId,
+      state.selectedIds.length,
+    ],
   );
 
   const createNewLayout = useCallbackWithToast(async () => {
@@ -448,7 +453,7 @@ export default function LayoutBrowser({
 
   const showSignInPrompt = supportsSignIn && !layoutManager.supportsSharing && !hideSignInPrompt;
 
-  const queuedMultiActions = state.queuedDeleteIds.length > 0;
+  const pendingMultiAction = state.multiAction != undefined;
 
   return (
     <SidebarContent
@@ -456,21 +461,10 @@ export default function LayoutBrowser({
       helpContent={helpContent}
       disablePadding
       trailingItems={[
-        (layouts.loading || state.busy || queuedMultiActions) && (
+        (layouts.loading || state.busy || pendingMultiAction) && (
           <Stack key="loading" alignItems="center" justifyContent="center" padding={1}>
             <CircularProgress size={18} variant="indeterminate" />
           </Stack>
-        ),
-        state.selectedIds.length > 1 && (
-          <IconButton
-            color="primary"
-            key="delete"
-            disabled={queuedMultiActions}
-            title="Delete Selected"
-            onClick={queueMultipleLayoutsForDelete}
-          >
-            <DeleteIcon />
-          </IconButton>
         ),
         (!state.online || state.error != undefined) && (
           <IconButton color="primary" key="offline" disabled title="Offline">
@@ -499,7 +493,7 @@ export default function LayoutBrowser({
       ].filter(Boolean)}
     >
       {unsavedChangesPrompt}
-      <Stack fullHeight gap={2} style={{ pointerEvents: queuedMultiActions ? "none" : "auto" }}>
+      <Stack fullHeight gap={2} style={{ pointerEvents: pendingMultiAction ? "none" : "auto" }}>
         <LayoutSection
           title={layoutManager.supportsSharing ? "Personal" : undefined}
           emptyText="Add a new layout to get started with Foxglove Studio!"

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -6,34 +6,36 @@ import { compact, pull, xor } from "lodash";
 import { Dispatch } from "react";
 import { useImmerReducer } from "use-immer";
 
+type MultiAction = "delete";
+
 type State = {
   busy: boolean;
   error: undefined | Error;
   online: boolean;
+  multiAction: undefined | { action: MultiAction; ids: string[] };
   selectedIds: string[];
-  queuedDeleteIds: string[];
 };
 
 type Action =
-  | { type: "clear-queued-deletes" }
-  | { type: "queue-deletes" }
+  | { type: "clear-multi-action" }
+  | { type: "queue-multi-action"; action: MultiAction }
   | { type: "set-busy"; value: boolean }
   | { type: "set-error"; value: undefined | Error }
   | { type: "set-online"; value: boolean }
   | { type: "select-id"; id?: string }
-  | { type: "shift-queued-deletes" }
+  | { type: "shift-multi-action" }
   | { type: "toggle-selected"; id: string };
 
 function reducer(draft: State, action: Action) {
   switch (action.type) {
-    case "clear-queued-deletes":
-      draft.queuedDeleteIds = [];
+    case "clear-multi-action":
+      draft.multiAction = undefined;
       break;
-    case "queue-deletes":
-      draft.queuedDeleteIds = draft.selectedIds;
+    case "queue-multi-action":
+      draft.multiAction = { action: action.action, ids: draft.selectedIds };
       break;
     case "select-id":
-      draft.queuedDeleteIds = [];
+      draft.multiAction = undefined;
       draft.selectedIds = compact([action.id]);
       break;
     case "set-busy":
@@ -45,9 +47,9 @@ function reducer(draft: State, action: Action) {
     case "set-online":
       draft.online = action.value;
       break;
-    case "shift-queued-deletes": {
-      const toDelete = draft.queuedDeleteIds.shift();
-      pull(draft.selectedIds, toDelete);
+    case "shift-multi-action": {
+      const id = draft.multiAction?.ids.shift();
+      pull(draft.selectedIds, id);
       break;
     }
     case "toggle-selected":
@@ -59,5 +61,5 @@ function reducer(draft: State, action: Action) {
 export function useLayoutBrowserReducer(
   props: Pick<State, "busy" | "error" | "online">,
 ): [State, Dispatch<Action>] {
-  return useImmerReducer(reducer, { ...props, selectedIds: [], queuedDeleteIds: [] });
+  return useImmerReducer(reducer, { ...props, selectedIds: [], multiAction: undefined });
 }

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -49,6 +49,9 @@ function reducer(draft: State, action: Action) {
       break;
     case "shift-multi-action": {
       const id = draft.multiAction?.ids.shift();
+      if (draft.multiAction?.ids.length === 0) {
+        draft.multiAction = undefined;
+      }
       pull(draft.selectedIds, id);
       break;
     }


### PR DESCRIPTION
**User-Facing Changes**
This replaces the multi-delete icon in the layout browser header with the context menu delete item.

**Description**
Instead of having a special icon for deleting multiple layouts this just uses the existing context menu delete item to delete whichever layouts are selected.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #3962 