### PR TITLE
Replace signal with Condvar

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import { Story, StoryContext } from "@storybook/react";
 import { useMemo, useRef } from "react";
 import { ToastProvider } from "react-toast-notifications";
 
-import { signal } from "@foxglove/den/async";
+import { Condvar } from "@foxglove/den/async";
 import CssBaseline from "@foxglove/studio-base/components/CssBaseline";
 import GlobalCss from "@foxglove/studio-base/components/GlobalCss";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
@@ -55,10 +55,10 @@ function StudioContextProviders({
   ctx,
 }: React.PropsWithChildren<{ ctx: StoryContext }>): JSX.Element {
   if (ctx.parameters.useReadySignal === true) {
-    const sig = signal();
-    ctx.parameters.storyReady = sig;
+    const condvar = new Condvar();
+    ctx.parameters.storyReady = condvar.wait();
     ctx.parameters.readySignal = () => {
-      sig.resolve();
+      condvar.notifyAll();
     };
   }
 

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -13,7 +13,7 @@
 
 import { debounce, flatten } from "lodash";
 
-import { signal } from "@foxglove/den/async";
+import { Condvar } from "@foxglove/den/async";
 import { useShallowMemo } from "@foxglove/hooks";
 import { Time } from "@foxglove/rostime";
 import { MessageEvent, ParameterValue } from "@foxglove/studio";
@@ -224,10 +224,10 @@ export function MessagePipelineProvider({
     [player, capabilities],
   );
   const pauseFrame = useCallback((name: string) => {
-    const promise = signal();
-    promisesToWaitForRef.current.push({ name, promise });
+    const condvar = new Condvar();
+    promisesToWaitForRef.current.push({ name, promise: condvar.wait() });
     return () => {
-      promise.resolve();
+      condvar.notifyAll();
     };
   }, []);
   const requestBackfill = useMemo(


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Replace some instances of signal() with Condvar

- UserNodePlayer
- CurrentLayoutProvider
- storybook/preview
- MessagePipeline

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
