### PR TITLE
Search on panel description as well as title in panel list

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelList/index.stories.tsx
@@ -47,6 +47,7 @@ const allPanels: PanelInfo[] = [
   {
     title: "Preconfigured Panel AAA",
     type: "Sample1",
+    description: "Panel description",
     module: async () => ({ default: MockPanel1 }),
     config: { text: "def" },
   },
@@ -146,6 +147,9 @@ storiesOf("components/PanelList", module)
   })
   .add("filtered panel list", () => <PanelListWithInteractions inputValue="AAA" />)
   .add("filtered panel grid", () => <PanelListWithInteractions mode="grid" inputValue="AAA" />)
+  .add("filtered panel grid with description", () => (
+    <PanelListWithInteractions mode="grid" inputValue="description" />
+  ))
   .add("filtered panel list light", () => <PanelListWithInteractions inputValue="AAA" />, {
     colorScheme: "light",
   })

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -227,7 +227,7 @@ function DraggablePanelItem({
                   </span>
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {panel.description}
+                  <TextHighlight targetStr={panel.description ?? ""} searchText={searchQuery} />
                 </Typography>
               </CardContent>
             </Stack>
@@ -368,7 +368,7 @@ function PanelList(props: Props): JSX.Element {
     (panels: PanelInfo[]) => {
       return searchQuery.length > 0
         ? fuzzySort
-            .go(searchQuery, panels, { key: "title" })
+            .go(searchQuery, panels, { keys: ["title", "description"] })
             .map((searchResult) => searchResult.obj)
         : panels;
     },

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -372,6 +372,7 @@ function PanelList(props: Props): JSX.Element {
               keys: ["title", "description"],
               // Weigh title matches more heavily than description matches.
               scoreFn: (a) => Math.max(a[0] ? a[0].score : -1000, a[1] ? a[1].score - 100 : -1000),
+              threshold: -900,
             })
             .map((searchResult) => searchResult.obj)
         : panels;

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -368,7 +368,11 @@ function PanelList(props: Props): JSX.Element {
     (panels: PanelInfo[]) => {
       return searchQuery.length > 0
         ? fuzzySort
-            .go(searchQuery, panels, { keys: ["title", "description"] })
+            .go(searchQuery, panels, {
+              keys: ["title", "description"],
+              // Weigh title matches more heavily than description matches.
+              scoreFn: (a) => Math.max(a[0] ? a[0].score : -1000, a[1] ? a[1].score - 100 : -1000),
+            })
             .map((searchResult) => searchResult.obj)
         : panels;
     },

--- a/packages/studio-base/src/components/TextHighlight.tsx
+++ b/packages/studio-base/src/components/TextHighlight.tsx
@@ -32,11 +32,13 @@ export default function TextHighlight({ targetStr = "", searchText = "" }: Props
   if (searchText.length === 0) {
     return <>{targetStr}</>;
   }
-  const result = fuzzySort.highlight(
-    fuzzySort.single(searchText, targetStr) ?? undefined,
-    "<span class='TextHighlight-highlight'>",
-    "</span>",
-  );
+
+  const match = fuzzySort.single(searchText, targetStr);
+
+  const result = match
+    ? fuzzySort.highlight(match, "<span class='TextHighlight-highlight'>", "</span>")
+    : undefined;
+
   // TODO(Audrey): compute highlighted parts separately in order to avoid dangerouslySetInnerHTML
   return (
     <STextHighlight>

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -202,7 +202,8 @@ const builtin: PanelInfo[] = [
   {
     title: "User Scripts",
     type: "NodePlayground",
-    description: "Write custom data transformations in TypeScript.",
+    description:
+      "Write custom data transformations in TypeScript. Previously known as Node Playground.",
     help: NodePlaygroundHelp,
     thumbnail: nodePlaygroundThumbnail,
     module: async () => await import("./NodePlayground"),


### PR DESCRIPTION
**User-Facing Changes**
Search by panel description as well as title in the panel list.

**Description**
This expands search matching to panel descriptions and also adds `Previously known as Node Playground` to the user scripts panel so users searching for `node playground` will still get a match.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3985 