### PR TITLE
Shift select ranges of layouts

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -64,6 +64,7 @@
     "@testing-library/dom": "8.11.3",
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
+    "@testing-library/user-event": "14.3.0",
     "@types/amplitude-js": "8.16.0",
     "@types/argparse": "2.0.10",
     "@types/circular-dependency-plugin": "5.0.5",

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -142,14 +142,21 @@ MultiSelect.parameters = {
 MultiSelect.play = async () => {
   const layouts = await screen.findAllByTestId("layout-list-item");
   const user = userEvent.setup();
+
   await user.click(layouts[0]!);
+
   await user.keyboard("{Meta>}");
   await user.click(layouts[1]!);
   await user.click(layouts[3]!);
   await user.keyboard("{/Meta}");
+
   await user.keyboard("{Shift>}");
   await user.click(layouts[6]!);
   await user.keyboard("{/Shift}");
+
+  await user.keyboard("{Meta>}");
+  await user.click(layouts[4]!);
+  await user.keyboard("{/Meta}");
 };
 
 export function MultiDelete(): JSX.Element {

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -4,6 +4,7 @@
 
 import { Story, StoryContext } from "@storybook/react";
 import { fireEvent, screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import { useMemo } from "react";
 
 import AnalyticsProvider from "@foxglove/studio-base/context/AnalyticsProvider";
@@ -128,10 +129,27 @@ export function LayoutList(): JSX.Element {
 export function MultiSelect(): JSX.Element {
   return <LayoutBrowser />;
 }
-MultiSelect.parameters = { colorScheme: "dark" };
+MultiSelect.parameters = {
+  colorScheme: "dark",
+  mockLayouts: Array(8)
+    .fill(undefined)
+    .map((_, idx) => ({
+      id: `layout-${idx + 1}`,
+      name: `Layout ${idx + 1}`,
+      baseline: { data: DEFAULT_LAYOUT_FOR_TESTS, updatedAt: new Date(10).toISOString() },
+    })),
+};
 MultiSelect.play = async () => {
   const layouts = await screen.findAllByTestId("layout-list-item");
-  layouts.forEach((layout) => fireEvent.click(layout, { ctrlKey: true }));
+  const user = userEvent.setup();
+  await user.click(layouts[0]!);
+  await user.keyboard("{Meta>}");
+  await user.click(layouts[1]!);
+  await user.click(layouts[3]!);
+  await user.keyboard("{/Meta}");
+  await user.keyboard("{Shift>}");
+  await user.click(layouts[6]!);
+  await user.keyboard("{/Shift}");
 };
 
 export function MultiDelete(): JSX.Element {

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -210,16 +210,29 @@ export default function LayoutBrowser({
         }
         void analytics.logEvent(AppEvent.LAYOUT_SELECT, { permission: item.permission });
       }
-      if (event?.ctrlKey === true || event?.metaKey === true) {
+      if (event?.ctrlKey === true || event?.metaKey === true || event?.shiftKey === true) {
         if (item.id !== currentLayoutId) {
-          dispatch({ type: "toggle-selected", id: item.id });
+          dispatch({
+            type: "select-id",
+            id: item.id,
+            layouts: layouts.value,
+            modKey: event.ctrlKey || event.metaKey,
+            shiftKey: event.shiftKey,
+          });
         }
       } else {
         setSelectedLayoutId(item.id);
         dispatch({ type: "select-id", id: item.id });
       }
     },
-    [analytics, currentLayoutId, dispatch, promptForUnsavedChanges, setSelectedLayoutId],
+    [
+      analytics,
+      currentLayoutId,
+      dispatch,
+      layouts.value,
+      promptForUnsavedChanges,
+      setSelectedLayoutId,
+    ],
   );
 
   const onRenameLayout = useCallbackWithToast(

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { compact, pull, xor } from "lodash";
+import { compact, pull, union, xor } from "lodash";
 import { Dispatch } from "react";
 import { useImmerReducer } from "use-immer";
 
@@ -53,7 +53,7 @@ function reducer(draft: State, action: Action) {
             const start = Math.min(lastId, thisId);
             const end = Math.max(lastId, thisId);
             for (let i = start; i <= end; i++) {
-              draft.selectedIds.push(layouts[i]!.id);
+              draft.selectedIds = union(draft.selectedIds, [layouts[i]!.id]);
             }
           }
         }

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -6,12 +6,15 @@ import { compact, pull, xor } from "lodash";
 import { Dispatch } from "react";
 import { useImmerReducer } from "use-immer";
 
+import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
+
 type MultiAction = "delete";
 
 type State = {
   busy: boolean;
   error: undefined | Error;
   online: boolean;
+  lastSelectedId: undefined | string;
   multiAction: undefined | { action: MultiAction; ids: string[] };
   selectedIds: string[];
 };
@@ -19,12 +22,17 @@ type State = {
 type Action =
   | { type: "clear-multi-action" }
   | { type: "queue-multi-action"; action: MultiAction }
+  | {
+      type: "select-id";
+      id?: string;
+      layouts?: undefined | { personal: Layout[]; shared: Layout[] };
+      shiftKey?: boolean;
+      modKey?: boolean;
+    }
   | { type: "set-busy"; value: boolean }
   | { type: "set-error"; value: undefined | Error }
   | { type: "set-online"; value: boolean }
-  | { type: "select-id"; id?: string }
-  | { type: "shift-multi-action" }
-  | { type: "toggle-selected"; id: string };
+  | { type: "shift-multi-action" };
 
 function reducer(draft: State, action: Action) {
   switch (action.type) {
@@ -35,8 +43,25 @@ function reducer(draft: State, action: Action) {
       draft.multiAction = { action: action.action, ids: draft.selectedIds };
       break;
     case "select-id":
-      draft.multiAction = undefined;
-      draft.selectedIds = compact([action.id]);
+      if (action.modKey === true) {
+        draft.selectedIds = xor(draft.selectedIds, compact([action.id]));
+      } else if (action.shiftKey === true) {
+        for (const layouts of Object.values(action.layouts ?? {})) {
+          const lastId = layouts.findIndex((layout) => layout.id === draft.lastSelectedId);
+          const thisId = layouts.findIndex((layout) => layout.id === action.id);
+          if (lastId !== -1 && thisId !== -1) {
+            const start = Math.min(lastId, thisId);
+            const end = Math.max(lastId, thisId);
+            for (let i = start; i <= end; i++) {
+              draft.selectedIds.push(layouts[i]!.id);
+            }
+          }
+        }
+      } else {
+        draft.multiAction = undefined;
+        draft.selectedIds = compact([action.id]);
+      }
+      draft.lastSelectedId = action.id;
       break;
     case "set-busy":
       draft.busy = action.value;
@@ -55,14 +80,16 @@ function reducer(draft: State, action: Action) {
       pull(draft.selectedIds, id);
       break;
     }
-    case "toggle-selected":
-      draft.selectedIds = xor(draft.selectedIds, [action.id]);
-      break;
   }
 }
 
 export function useLayoutBrowserReducer(
   props: Pick<State, "busy" | "error" | "online">,
 ): [State, Dispatch<Action>] {
-  return useImmerReducer(reducer, { ...props, selectedIds: [], multiAction: undefined });
+  return useImmerReducer(reducer, {
+    ...props,
+    lastSelectedId: undefined,
+    selectedIds: [],
+    multiAction: undefined,
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,6 +2531,7 @@ __metadata:
     "@testing-library/dom": 8.11.3
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
+    "@testing-library/user-event": 14.3.0
     "@types/amplitude-js": 8.16.0
     "@types/argparse": 2.0.10
     "@types/circular-dependency-plugin": 5.0.5
@@ -5327,6 +5328,15 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: 70b0f7f27c83fe1a33e7df01b1e64850fbab4050c403848d611d852cadaa25ccde58518773002ae569a1350b2282c2ccbcbe5eb6af8b29ab377ab2a8ab573b3b
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:14.3.0":
+  version: 14.3.0
+  resolution: "@testing-library/user-event@npm:14.3.0"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: cbd5954460496519cb2ff3fa506ca598d7e4c2e3d2f2e129b21909758f5ec87573aad7d6c79aebffd4bd0ea843315b3064a2a76e545f196bd4c82489cb3afc1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Enables shift clicking to ranges of layouts in the layout browser.

**Description**
This expands on the existing multi select logic to support selecting ranges by shift clicking.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3960 