### PR TITLE
Fix placeholder handling for settings input types

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -323,6 +323,7 @@ function FieldInput({
       return (
         <Vec3Input
           step={field.step}
+          placeholder={field.placeholder}
           value={field.value}
           precision={field.precision}
           disabled={field.disabled}
@@ -339,6 +340,7 @@ function FieldInput({
         <Vec2Input
           step={field.step}
           value={field.value}
+          placeholder={field.placeholder}
           precision={field.precision}
           disabled={field.disabled}
           readOnly={field.readonly}

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -811,3 +811,75 @@ Filter.play = () => {
 export function Colors(): JSX.Element {
   return <Wrapper nodes={ColorSettings} />;
 }
+
+export function Vec2(): JSX.Element {
+  const settings: SettingsTreeNodes = {
+    fields: {
+      fields: {
+        basic: {
+          label: "Basic",
+          input: "vec2",
+        },
+        labels: {
+          label: "Custom Labels",
+          input: "vec2",
+          labels: ["A", "B"],
+        },
+        values: {
+          label: "Values",
+          input: "vec2",
+          value: [1.1111, 2.2222],
+        },
+        someValues: {
+          label: "Some values",
+          input: "vec2",
+          value: [1.1111, undefined],
+        },
+        placeholder: {
+          label: "Placeholder",
+          input: "vec2",
+          placeholder: ["foo", "bar"],
+          value: [1.1111, undefined],
+        },
+      },
+    },
+  };
+
+  return <Wrapper nodes={settings} />;
+}
+
+export function Vec3(): JSX.Element {
+  const settings: SettingsTreeNodes = {
+    fields: {
+      fields: {
+        basic: {
+          label: "Basic",
+          input: "vec3",
+        },
+        labels: {
+          label: "Custom Labels",
+          input: "vec3",
+          labels: ["A", "B", "C"],
+        },
+        values: {
+          label: "Values",
+          input: "vec3",
+          value: [1.1111, 2.2222, 3.333],
+        },
+        someValues: {
+          label: "Some values",
+          input: "vec3",
+          value: [1.1111, undefined, 2.222],
+        },
+        placeholder: {
+          label: "Placeholder",
+          input: "vec3",
+          placeholder: ["foo", "bar", "baz"],
+          value: [1.1111, undefined, undefined],
+        },
+      },
+    },
+  };
+
+  return <Wrapper nodes={settings} />;
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
@@ -8,25 +8,31 @@ import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NumberInput } from "./NumberInput";
 
-export function Vec2Input({
-  disabled = false,
-  onChange,
-  precision,
-  readOnly = false,
-  step,
-  value,
-  min,
-  max,
-}: {
+type Vec2Props = {
   disabled?: boolean;
   onChange: (value: undefined | [undefined | number, undefined | number]) => void;
   precision?: number;
   readOnly?: boolean;
   step?: number;
+  placeholder?: readonly [undefined | string, undefined | string];
   value: undefined | readonly [undefined | number, undefined | number];
   min?: number;
   max?: number;
-}): JSX.Element {
+};
+
+export function Vec2Input(props: Vec2Props): JSX.Element {
+  const {
+    disabled = false,
+    onChange,
+    precision,
+    readOnly = false,
+    step,
+    value,
+    min,
+    max,
+    placeholder,
+  } = props;
+
   const onChangeCallback = useCallback(
     (position: number, inputValue: undefined | number) => {
       const newValue: [undefined | number, undefined | number] = [...(value ?? [0, 0])];
@@ -36,28 +42,36 @@ export function Vec2Input({
     [onChange, value],
   );
 
-  if (value == undefined) {
-    return <div />;
-  }
-
   return (
     <Stack gap={0.25}>
-      {value.map((pval, position) => (
-        <NumberInput
-          key={position}
-          size="small"
-          disabled={disabled}
-          readOnly={readOnly}
-          variant="filled"
-          fullWidth
-          precision={precision}
-          step={step}
-          value={pval}
-          min={min}
-          max={max}
-          onChange={(newValue) => onChangeCallback(position, newValue)}
-        />
-      ))}
+      <NumberInput
+        size="small"
+        disabled={disabled}
+        readOnly={readOnly}
+        variant="filled"
+        fullWidth
+        precision={precision}
+        step={step}
+        placeholder={placeholder?.[0]}
+        value={value?.[0]}
+        min={min}
+        max={max}
+        onChange={(newValue) => onChangeCallback(0, newValue)}
+      />
+      <NumberInput
+        size="small"
+        disabled={disabled}
+        readOnly={readOnly}
+        variant="filled"
+        fullWidth
+        precision={precision}
+        step={step}
+        placeholder={placeholder?.[1]}
+        value={value?.[1]}
+        min={min}
+        max={max}
+        onChange={(newValue) => onChangeCallback(1, newValue)}
+      />
     </Stack>
   );
 }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -8,16 +8,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NumberInput } from "./NumberInput";
 
-export function Vec3Input({
-  disabled = false,
-  onChange,
-  precision,
-  readOnly = false,
-  step,
-  value,
-  min,
-  max,
-}: {
+type Vec3Props = {
   disabled?: boolean;
   onChange: (
     value: undefined | [undefined | number, undefined | number, undefined | number],
@@ -25,10 +16,25 @@ export function Vec3Input({
   precision?: number;
   readOnly?: boolean;
   step?: number;
+  placeholder?: readonly [undefined | string, undefined | string, undefined | string];
   value: undefined | readonly [undefined | number, undefined | number, undefined | number];
   min?: number;
   max?: number;
-}): JSX.Element {
+};
+
+export function Vec3Input(props: Vec3Props): JSX.Element {
+  const {
+    disabled = false,
+    onChange,
+    precision,
+    readOnly = false,
+    step,
+    value,
+    min,
+    max,
+    placeholder,
+  } = props;
+
   const onChangeCallback = useCallback(
     (position: number, inputValue: undefined | number) => {
       const newValue: [undefined | number, undefined | number, undefined | number] = [
@@ -40,28 +46,50 @@ export function Vec3Input({
     [onChange, value],
   );
 
-  if (value == undefined) {
-    return <div />;
-  }
-
   return (
     <Stack gap={0.25}>
-      {value.map((pval, position) => (
-        <NumberInput
-          key={position}
-          size="small"
-          disabled={disabled}
-          readOnly={readOnly}
-          variant="filled"
-          fullWidth
-          precision={precision}
-          step={step}
-          value={pval}
-          min={min}
-          max={max}
-          onChange={(newValue) => onChangeCallback(position, newValue)}
-        />
-      ))}
+      <NumberInput
+        size="small"
+        disabled={disabled}
+        readOnly={readOnly}
+        variant="filled"
+        fullWidth
+        precision={precision}
+        step={step}
+        placeholder={placeholder?.[0]}
+        value={value?.[0]}
+        min={min}
+        max={max}
+        onChange={(newValue) => onChangeCallback(0, newValue)}
+      />
+      <NumberInput
+        size="small"
+        disabled={disabled}
+        readOnly={readOnly}
+        variant="filled"
+        fullWidth
+        precision={precision}
+        step={step}
+        placeholder={placeholder?.[1]}
+        value={value?.[1]}
+        min={min}
+        max={max}
+        onChange={(newValue) => onChangeCallback(1, newValue)}
+      />
+      <NumberInput
+        size="small"
+        disabled={disabled}
+        readOnly={readOnly}
+        variant="filled"
+        fullWidth
+        precision={precision}
+        step={step}
+        placeholder={placeholder?.[2]}
+        value={value?.[2]}
+        min={min}
+        max={max}
+        onChange={(newValue) => onChangeCallback(2, newValue)}
+      />
     </Stack>
   );
 }

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -394,8 +394,24 @@ declare module "@foxglove/studio" {
   export type SettingsTreeFieldValue =
     | { input: "autocomplete"; value?: string; items: string[] }
     | { input: "boolean"; value?: boolean }
-    | { input: "rgb"; value?: string }
-    | { input: "rgba"; value?: string }
+    | {
+        input: "rgb";
+        value?: string;
+
+        /**
+         * Optional placeholder text displayed in the field input when value is undefined
+         */
+        placeholder?: string;
+      }
+    | {
+        input: "rgba";
+        value?: string;
+
+        /**
+         * Optional placeholder text displayed in the field input when value is undefined
+         */
+        placeholder?: string;
+      }
     | { input: "gradient"; value?: [string, string] }
     | { input: "messagepath"; value?: string; validTypes?: string[] }
     | {
@@ -405,6 +421,11 @@ declare module "@foxglove/studio" {
         max?: number;
         min?: number;
         precision?: number;
+
+        /**
+         * Optional placeholder text displayed in the field input when value is undefined
+         */
+        placeholder?: string;
       }
     | {
         input: "select";
@@ -416,11 +437,20 @@ declare module "@foxglove/studio" {
         value?: string | string[];
         options: Array<{ label: string; value: undefined | string }>;
       }
-    | { input: "string"; value?: string }
+    | {
+        input: "string";
+        value?: string;
+
+        /**
+         * Optional placeholder text displayed in the field input when value is undefined
+         */
+        placeholder?: string;
+      }
     | { input: "toggle"; value?: string; options: string[] }
     | {
         input: "vec3";
         value?: [undefined | number, undefined | number, undefined | number];
+        placeholder?: [undefined | string, undefined | string, undefined | string];
         step?: number;
         precision?: number;
         labels?: [string, string, string];
@@ -430,6 +460,7 @@ declare module "@foxglove/studio" {
     | {
         input: "vec2";
         value?: [undefined | number, undefined | number];
+        placeholder?: [undefined | string, undefined | string];
         step?: number;
         precision?: number;
         labels?: [string, string];
@@ -452,12 +483,6 @@ declare module "@foxglove/studio" {
      * The label displayed alongside the field.
      */
     label: string;
-
-    /**
-     * Optional placeholder text displayed in the field input in the
-     * absence of a value.
-     */
-    placeholder?: string;
 
     /**
      * True if the field is readonly.


### PR DESCRIPTION


**User-Facing Changes**
The type information for panel settings api is more accurate for the placeholder property.

vec2 and vec3 input fields support a new `placeholder` property that is an array of placeholder values

**Description**

Prior to this change the `placeholder` field was present for all settings input types. This change alters the type defunitions to include `placeholder` only in the input types that support it.

This change also adds placeholder array support to vec2 and vec3 input types. It also fixes a bug where vec2 and vec3 would not show the NumericInput elements if values was not specified.

Stories added to test the new behaviors.

Fixes: #3822
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
