### PR TITLE
Catch datatype construction errors in user scripts

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.ts
@@ -396,14 +396,21 @@ export const extractDatatypes = (nodeData: NodeData): NodeData => {
       return { ...nodeData, diagnostics: [...nodeData.diagnostics, error.diagnostic] };
     }
 
-    throw error;
+    return {
+      ...nodeData,
+      diagnostics: [
+        ...nodeData.diagnostics,
+        {
+          message: error.message,
+          severity: DiagnosticSeverity.Error,
+          source: Sources.DatatypeExtraction,
+          code: ErrorCodes.DatatypeExtraction.UNKNOWN_ERROR,
+        },
+      ],
+    };
   }
 };
 
-/*
-TODO:
-  - what happens when the `register` portion of the node pipeline fails to instantiate the code? can we get the stack trace?
-*/
 export const compose = (...transformers: NodeDataTransformer[]): NodeDataTransformer => {
   return (nodeData: NodeData, topics: Topic[]) => {
     let newNodeData = nodeData;


### PR DESCRIPTION


**User-Facing Changes**
Users can still playback their data even if a user script has a return type that is not able to be handled.

**Description**
Rather than throwing an error when a user script cannot detect the return type, catch the error and report it as an unknown diagnostic. This allows other user scripts to run and also allows the player to run. Prior to this change, a failure in the detection would "lock up" any playback.

Fixes: #3862

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
