### PR TITLE
Fix plot panel auto-complete from incomplete topic

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -13,6 +13,7 @@
 
 import { Stack } from "@mui/material";
 import { storiesOf } from "@storybook/react";
+import TestUtils from "react-dom/test-utils";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import { Topic } from "@foxglove/studio-base/players/types";
@@ -45,6 +46,18 @@ const clickInput = (el: HTMLDivElement) => {
   }
 };
 
+const clickInputAndSelectNthResult = (el: HTMLDivElement, selectIndex: number) => {
+  clickInput(el);
+  setTimeout(() => {
+    const select: HTMLDivElement | undefined = document.querySelectorAll("[data-test-auto-item]")[
+      selectIndex
+    ] as any;
+    if (select) {
+      TestUtils.Simulate.click(select);
+    }
+  });
+};
+
 function MessagePathInputStory(props: { path: string; prioritizedDatatype?: string }) {
   const [path, setPath] = React.useState(props.path);
 
@@ -56,6 +69,33 @@ function MessagePathInputStory(props: { path: string; prioritizedDatatype?: stri
             autoSize={false}
             path={path}
             prioritizedDatatype={props.prioritizedDatatype}
+            onChange={(newPath) => setPath(newPath)}
+          />
+        </Stack>
+      </PanelSetup>
+    </MockPanelContextProvider>
+  );
+}
+
+function MessagePathInputSelectionStory(props: {
+  path: string;
+  validTypes: string[];
+  selectInput: number;
+}) {
+  const [path, setPath] = React.useState(props.path);
+
+  const onMount = (el: HTMLDivElement) => {
+    clickInputAndSelectNthResult(el, props.selectInput);
+  };
+
+  return (
+    <MockPanelContextProvider>
+      <PanelSetup fixture={MessagePathInputStoryFixture} onFirstMount={onMount}>
+        <Stack direction="row" flex="auto" margin={1.25}>
+          <MessagePathInput
+            autoSize={false}
+            path={path}
+            validTypes={props.validTypes}
             onChange={(newPath) => setPath(newPath)}
           />
         </Stack>
@@ -90,6 +130,20 @@ storiesOf("components/MessagePathInput", module)
   })
   .add("autocomplete topics", () => {
     return <MessagePathInputStory path="/" />;
+  })
+  .add("autocomplete scalar from topic", () => {
+    return (
+      <MessagePathInputSelectionStory path="/some_logs_" validTypes={["int32"]} selectInput={1} />
+    );
+  })
+  .add("autocomplete scalar from full topic", () => {
+    return (
+      <MessagePathInputSelectionStory
+        path="/some_logs_topic"
+        validTypes={["int32"]}
+        selectInput={0}
+      />
+    );
   })
   .add("autocomplete messagePath", () => {
     return <MessagePathInputStory path="/some_topic/location.po" />;

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -225,7 +225,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
       // Check if accepting this completion would result in a path to a non-complex field.
       const completedPath = completeStart + rawValue + completeEnd;
       const completedField = topicFields.get(completedPath);
-      const isSimpleField = completedField?.isComplex === false;
+      const isSimpleField = completedField?.isComplex == undefined || !completedField.isComplex;
 
       // If we're dealing with a topic name, and we cannot validly end in a message type,
       // add a "." so the user can keep typing to autocomplete the message path.


### PR DESCRIPTION
Previously, if you created a plot panel, and e.g. wanted to plot a topic
named `"/drivetrain frc971.control_loops.drivetrain.Output".left_high`
and then typed `output` into the legend, the aforementioned field might
be listed in the auto-complete options, but if you selected it then
it would append a `.` and auto-complete to `"/drivetrain frc971.control_loops.drivetrain.Output".left_high.`.
This was a consequence of the logic checking against this exact scenario
being broken--in particular, at least the JSON and flatbuffer
parsers for MCAP files set `isComplex` to undefined rather than to false.
Given that multiple tests seem to duplicate this assumption, I am
assuming that this is the fault of the MessagePathInput and not the MCAP
parser.

Added a small extra story to sanity check for regressions in this code.

**User-Facing Changes**

Fixes autocomplete in certain scenarios.
