### PR TITLE
Update RosDb3IterableSource to list all topics

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.worker.ts
@@ -70,24 +70,25 @@ export class RosDb3IterableSource implements IIterableSource {
     const parsedMessageDefinitionsByTopic: ParsedMessageDefinitionsByTopic = {};
 
     for (const topicDef of topicDefs) {
-      const parsedMsgdef = ROS2_TO_DEFINITIONS.get(topicDef.type);
-      if (parsedMsgdef == undefined) {
-        problems.push({
-          severity: "warn",
-          message: `Topic "${topicDef.name}" has unrecognized datatype "${topicDef.type}"`,
-          tip: "ROS 2 bags don't contain full message definitions, so only well-known ROS types are supported in Studio. As a workaround, you can try using a Rosbridge WebSocket connection. For more information, see: https://github.com/ros2/rosbag2/issues/782",
-        });
-        continue;
-      }
-
-      const fullParsedMessageDefinitions = [parsedMsgdef];
-      const messageDefinition = stringify(fullParsedMessageDefinitions);
       const numMessages = messageCounts.get(topicDef.name);
 
       topics.push({ name: topicDef.name, datatype: topicDef.type });
       if (numMessages != undefined) {
         topicStats.set(topicDef.name, { numMessages });
       }
+
+      const parsedMsgdef = ROS2_TO_DEFINITIONS.get(topicDef.type);
+      if (parsedMsgdef == undefined) {
+        problems.push({
+          severity: "warn",
+          message: `Topic "${topicDef.name}" has unsupported datatype "${topicDef.type}"`,
+          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://foxglove.dev/docs/studio/connection/local-file",
+        });
+        continue;
+      }
+
+      const fullParsedMessageDefinitions = [parsedMsgdef];
+      const messageDefinition = stringify(fullParsedMessageDefinitions);
       datatypes.set(topicDef.type, { name: topicDef.type, definitions: parsedMsgdef.definitions });
       messageDefinitionsByTopic[topicDef.name] = messageDefinition;
       parsedMessageDefinitionsByTopic[topicDef.name] = fullParsedMessageDefinitions;

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.worker.ts
@@ -82,7 +82,7 @@ export class RosDb3IterableSource implements IIterableSource {
         problems.push({
           severity: "warn",
           message: `Topic "${topicDef.name}" has unsupported datatype "${topicDef.type}"`,
-          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://foxglove.dev/docs/studio/connection/local-file",
+          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Foxglove Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://foxglove.dev/docs/studio/connection/local-file",
         });
         continue;
       }


### PR DESCRIPTION


**User-Facing Changes**
Data source info shows all topics found in .db3 files - even those we cannot deserialize.

**Description**
Even if a topic cannot be deserialized (due to missing message definitions), we still show it in the topics results so the user knows it is present in their file.

Fixes: #3967

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
