### PR TITLE
Support saving, reverting, and duplicating multiple layouts

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -166,9 +166,19 @@ export default React.memo(function LayoutRow({
     onOverwrite(layout);
   }, [layout, onOverwrite]);
 
-  const revertAction = useCallback(() => {
+  const confirmRevert = useCallback(async () => {
+    const response = await confirm({
+      title: multiSelection ? `Revert layouts` : `Revert “${layout.name}”?`,
+      prompt: "Your changes will be permantly discarded. This cannot be undone.",
+      ok: "Discard changes",
+      variant: "danger",
+    });
+    if (response !== "ok") {
+      return;
+    }
+
     onRevert(layout);
-  }, [layout, onRevert]);
+  }, [confirm, layout, multiSelection, onRevert]);
 
   const makePersonalCopyAction = useCallback(() => {
     onMakePersonalCopy(layout);
@@ -280,7 +290,6 @@ export default React.memo(function LayoutRow({
           ? "Make a personal copy"
           : "Duplicate",
       onClick: duplicateAction,
-      disabled: multiSelection,
       "data-testid": "duplicate-layout",
     },
     layoutManager.supportsSharing &&
@@ -316,15 +325,15 @@ export default React.memo(function LayoutRow({
         key: "overwrite",
         text: "Save changes",
         onClick: overwriteAction,
-        disabled: deletedOnServer || (layoutIsShared(layout) && !isOnline) || multiSelection,
+        disabled: deletedOnServer || (layoutIsShared(layout) && !isOnline),
         secondaryText: layoutIsShared(layout) && !isOnline ? "Offline" : undefined,
       },
       {
         type: "item",
         key: "revert",
         text: "Revert",
-        onClick: revertAction,
-        disabled: deletedOnServer || multiSelection,
+        onClick: confirmRevert,
+        disabled: deletedOnServer,
       },
     ];
     if (layoutIsShared(layout)) {

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -8,7 +8,7 @@ import { useImmerReducer } from "use-immer";
 
 import { Layout } from "@foxglove/studio-base/services/ILayoutStorage";
 
-type MultiAction = "delete";
+type MultiAction = "delete" | "duplicate" | "revert" | "save";
 
 type State = {
   busy: boolean;


### PR DESCRIPTION
**User-Facing Changes**
Support saving, reverting, and duplicating multiple layouts at once.

**Description**
This expands the existing multiple action support for layouts to include save, revert, and duplicate.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3962