### PR TITLE
Wait on current emit promise before emitting for tick

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -790,6 +790,11 @@ export class IterablePlayer implements Player {
       return;
     }
 
+    // Wait on any active emit state to finish as part of this tick
+    // Without waiting on the emit state to finish we might drop messages since our emitState
+    // might get debounced
+    await this._emitState.currentPromise;
+
     this._currentTime = end;
     this._messages = msgEvents;
     this._emitState();


### PR DESCRIPTION
**User-Facing Changes**
Messages would be dropped in some situations when using the new latching players. This ensures all messages are delivered.

**Description**
We must wait on the current emit to complete before emitting a tick in the IterablePlayer. If we don't wait for the tick to complete we might drop messages since the emitState call might get debounced.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
