### PR TITLE
Toggle settings on panel gear icon click

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -498,6 +498,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const workspaceActions = useMemo(
     () => ({
       panelSettingsOpen: selectedSidebarItem === "panel-settings",
+      closePanelSettings: () => setSelectedSidebarItem(undefined),
       openPanelSettings: () => setSelectedSidebarItem("panel-settings"),
       openHelp: () => setSelectedSidebarItem("help"),
       openAccountSettings: () => supportsAccountSettings && setSelectedSidebarItem("account"),

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -43,8 +43,8 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   setMenuOpen,
 }: PanelToolbarControlsProps) {
   const panelId = useContext(PanelContext)?.id;
-  const { setSelectedPanelIds } = useSelectedPanels();
-  const { openPanelSettings } = useWorkspace();
+  const { selectedPanelIds, setSelectedPanelIds } = useSelectedPanels();
+  const { closePanelSettings, openPanelSettings } = useWorkspace();
 
   const hasSettingsSelector = useCallback(
     (store: PanelSettingsEditorStore) =>
@@ -55,11 +55,17 @@ export const PanelToolbarControls = React.memo(function PanelToolbarControls({
   const hasSettings = usePanelSettingsEditorStore(hasSettingsSelector);
 
   const openSettings = useCallback(() => {
-    if (panelId) {
+    if (!panelId) {
+      return;
+    }
+
+    if (selectedPanelIds.includes(panelId)) {
+      closePanelSettings();
+    } else {
       setSelectedPanelIds([panelId]);
       openPanelSettings();
     }
-  }, [setSelectedPanelIds, openPanelSettings, panelId]);
+  }, [closePanelSettings, openPanelSettings, panelId, selectedPanelIds, setSelectedPanelIds]);
 
   return (
     <Stack direction="row" alignItems="center" paddingLeft={1}>

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -6,6 +6,9 @@ import { createContext, useContext } from "react";
 
 export const WorkspaceContext = createContext({
   panelSettingsOpen: false,
+  closePanelSettings: (): void => {
+    throw new Error("Must be in a WorkspaceContext.Provider to close panel settings");
+  },
   openPanelSettings: (): void => {
     throw new Error("Must be in a WorkspaceContext.Provider to open panel settings");
   },
@@ -23,6 +26,7 @@ WorkspaceContext.displayName = "WorkspaceContext";
 
 export function useWorkspace(): {
   panelSettingsOpen: boolean;
+  closePanelSettings: () => void;
   openPanelSettings: () => void;
   openHelp: () => void;
   openAccountSettings: () => void;


### PR DESCRIPTION
**User-Facing Changes**
Close panel settings sidebar on second panel toolbar settings button click.

**Description**
This modifies the behavior of the settings button in the panel toolbar to close the settings sidebar if it is currently displaying the settings for the clicked panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3956