### PR TITLE
Switch BufferedIterableSource to a VecQueue

### DIFF
--- a/packages/den/collection/VecQueue.test.ts
+++ b/packages/den/collection/VecQueue.test.ts
@@ -1,0 +1,98 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { VecQueue } from "./VecQueue";
+
+describe("VecQueue", () => {
+  it("should make an empty queue", () => {
+    const queue = new VecQueue();
+    expect(queue.size()).toEqual(0);
+    expect(queue.dequeue()).toEqual(undefined);
+  });
+
+  it("should add and remove one item", () => {
+    const queue = new VecQueue<string>();
+    queue.enqueue("a");
+    expect(queue.size()).toEqual(1);
+    expect(queue.dequeue()).toEqual("a");
+    expect(queue.size()).toEqual(0);
+  });
+
+  it("should add many items and remove them", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+    }
+    expect(queue.size()).toEqual(10);
+    for (let i = 0; i < 10; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(0);
+  });
+
+  it("should add and remove items interleaves", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+      expect(queue.size()).toEqual(1);
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(0);
+  });
+
+  it("should clear", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+    }
+    for (let i = 0; i < 3; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    queue.clear();
+    expect(queue.size()).toEqual(0);
+  });
+
+  it("should read then write without growing", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+    }
+    expect(queue.size()).toEqual(10);
+    expect(queue.capacity()).toEqual(16);
+
+    for (let i = 0; i < 3; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(7);
+    expect(queue.capacity()).toEqual(16);
+
+    for (let i = 10; i < 12; ++i) {
+      queue.enqueue(i);
+    }
+    expect(queue.size()).toEqual(9);
+
+    for (let i = 3; i < 12; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(0);
+    expect(queue.capacity()).toEqual(16);
+  });
+
+  it("should stop reading when no more items", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+    }
+    for (let i = 0; i < 10; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(0);
+    for (let i = 0; i < 2; ++i) {
+      expect(queue.dequeue()).toEqual(undefined);
+    }
+
+    queue.enqueue(11);
+    expect(queue.dequeue()).toEqual(11);
+  });
+});

--- a/packages/den/collection/VecQueue.test.ts
+++ b/packages/den/collection/VecQueue.test.ts
@@ -101,4 +101,58 @@ describe("VecQueue", () => {
     queue.enqueue(11);
     expect(queue.dequeue()).toEqual(11);
   });
+
+  it("should grow when write is before read and is less than half capacity", () => {
+    const queue = new VecQueue<number>();
+    queue.enqueue(1);
+    queue.enqueue(2);
+    queue.enqueue(3);
+    queue.enqueue(4);
+
+    expect(queue.size()).toEqual(4);
+    expect(queue.capacity()).toEqual(4);
+
+    expect(queue.dequeue()).toEqual(1);
+    expect(queue.dequeue()).toEqual(2);
+    queue.enqueue(5);
+    expect(queue.capacity()).toEqual(4);
+
+    queue.enqueue(6);
+    expect(queue.capacity()).toEqual(8);
+
+    queue.enqueue(7);
+    expect(queue.capacity()).toEqual(8);
+
+    expect(queue.dequeue()).toEqual(3);
+    expect(queue.dequeue()).toEqual(4);
+    expect(queue.dequeue()).toEqual(5);
+    expect(queue.dequeue()).toEqual(6);
+    expect(queue.dequeue()).toEqual(7);
+  });
+
+  it("should grow when write before read and is greater than half capacity", () => {
+    const queue = new VecQueue<number>();
+    for (let i = 0; i < 8; ++i) {
+      queue.enqueue(i);
+    }
+
+    expect(queue.size()).toEqual(8);
+    expect(queue.capacity()).toEqual(8);
+
+    for (let i = 0; i < 6; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+
+    expect(queue.size()).toEqual(2);
+    for (let i = 8; i < 14; ++i) {
+      queue.enqueue(i);
+    }
+    expect(queue.capacity()).toEqual(16);
+
+    queue.enqueue(14);
+    for (let i = 6; i < 15; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
+    expect(queue.size()).toEqual(0);
+  });
 });

--- a/packages/den/collection/VecQueue.test.ts
+++ b/packages/den/collection/VecQueue.test.ts
@@ -37,8 +37,8 @@ describe("VecQueue", () => {
       queue.enqueue(i);
       expect(queue.size()).toEqual(1);
       expect(queue.dequeue()).toEqual(i);
+      expect(queue.size()).toEqual(0);
     }
-    expect(queue.size()).toEqual(0);
   });
 
   it("should clear", () => {
@@ -51,6 +51,12 @@ describe("VecQueue", () => {
     }
     queue.clear();
     expect(queue.size()).toEqual(0);
+    for (let i = 0; i < 10; ++i) {
+      queue.enqueue(i);
+    }
+    for (let i = 0; i < 3; ++i) {
+      expect(queue.dequeue()).toEqual(i);
+    }
   });
 
   it("should read then write without growing", () => {

--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -2,11 +2,21 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+/**
+ * VecQueue provides an interface for a FIFO queue backed by a growing circular buffer.
+ *
+ * `enqueue` inserts items at the end of the queue (possibly growing the underlying buffer)
+ * `dequeue` removes items from the front of the queue
+ */
 export class VecQueue<T> {
   private readPos = 0;
   private writePos = 0;
   private buffer: Array<T | undefined> = new Array(4);
 
+  /**
+   * Add an item at the end of the queue. If the queue is full the underlying buffer is grown.
+   * @param item the item to insert into the queue
+   */
   enqueue(item: T): void {
     // When the write position is past the buffer end, we need to take one of two actions:
     // 1. If read position is at 0, we grow the array and write to the end
@@ -15,12 +25,9 @@ export class VecQueue<T> {
       // Read head is at the start, we will write at the end
       if (this.readPos === 0) {
         this.addCapacity();
-        this.buffer[this.writePos] = item;
-        this.writePos += 1;
-        return;
+      } else {
+        this.writePos = this.writePos % this.buffer.length;
       }
-
-      this.writePos = this.writePos % this.buffer.length;
     }
 
     // Read is only 1 away from write, so once the item is written our write head would be at the read head
@@ -34,6 +41,10 @@ export class VecQueue<T> {
     this.writePos++;
   }
 
+  /**
+   * Remove an item from the front of the queue and return it.
+   * @returns the first item in the queue or undefined if the queue is empty
+   */
   dequeue(): T | undefined {
     if (this.readPos === this.writePos) {
       return undefined;
@@ -51,6 +62,9 @@ export class VecQueue<T> {
     return item;
   }
 
+  /**
+   * @returns the number of items in the queue
+   */
   size(): number {
     if (this.writePos >= this.readPos) {
       return this.writePos - this.readPos;
@@ -59,10 +73,16 @@ export class VecQueue<T> {
     return this.buffer.length - this.readPos + this.writePos;
   }
 
+  /**
+   * @returns the capacity of the underlying circular buffer
+   */
   capacity(): number {
     return this.buffer.length;
   }
 
+  /**
+   * Clear the queue.
+   */
   clear(): void {
     this.buffer.length = 0;
     this.writePos = 0;

--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -95,13 +95,30 @@ export class VecQueue<T> {
 
     // if the read head is before write, then there's no change to index management and write can continue at end
     // if the read head is ahead of write, then we can un-wrap the write bytes
-    if (this.readPos > this.writePos) {
+    if (this.readPos <= this.writePos) {
+      return;
+    }
+
+    const newLen = this.buffer.length;
+
+    // if writePos is past half it is cheaper to move the read elements
+    if (this.writePos >= oldLen / 2) {
+      const oldCount = oldLen - this.readPos;
+      // move the read elements to the end giving us the most room to write
+      const offset = newLen - oldCount;
+      for (let i = 0; i < oldCount; ++i) {
+        this.buffer[offset + i] = this.buffer[this.readPos + i];
+        this.buffer[this.readPos + i] = undefined;
+      }
+      this.readPos = offset;
+    } else {
       // copy all the elements from start to writePos - 1 to the end of the extended buffer
       for (let i = 0; i < this.writePos; ++i) {
         this.buffer[oldLen + i] = this.buffer[i];
         this.buffer[i] = undefined;
       }
-      this.writePos = oldLen;
+
+      this.writePos = oldLen + this.writePos;
     }
   }
 }

--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -8,24 +8,19 @@ export class VecQueue<T> {
   private buffer: Array<T | undefined> = new Array(4);
 
   enqueue(item: T): void {
-    // When the write head is ahead of the read head we can grow the array at the end
-    if (this.writePos >= this.readPos) {
-      // Write position is past the buffer end, we could wrap around to the front if readPos is > 0
-      if (this.writePos >= this.buffer.length) {
-        // Read head is at the start, we will write at the end
-        if (this.readPos > 0) {
-          this.writePos = this.writePos % this.buffer.length;
-        } else {
-          this.addCapacity();
-          this.buffer[this.writePos] = item;
-          this.writePos += 1;
-          return;
-        }
-      } else {
+    // When the write position is past the buffer end, we need to take one of two actions:
+    // 1. If read position is at 0, we grow the array and write to the end
+    // 2. Otherwise, we wrap write to the front and continue writing
+    if (this.writePos >= this.buffer.length) {
+      // Read head is at the start, we will write at the end
+      if (this.readPos === 0) {
+        this.addCapacity();
         this.buffer[this.writePos] = item;
         this.writePos += 1;
         return;
       }
+
+      this.writePos = this.writePos % this.buffer.length;
     }
 
     // Read is only 1 away from write, so once the item is written our write head would be at the read head

--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export class VecQueue<T> {
+  private readPos = 0;
+  private writePos = 0;
+  private buffer: Array<T | undefined> = new Array(4);
+
+  enqueue(item: T): void {
+    // When the write head is ahead of the read head we can grow the array at the end
+    if (this.writePos >= this.readPos) {
+      // Write position is past the buffer end, we could wrap around to the front if readPos is > 0
+      if (this.writePos >= this.buffer.length) {
+        // Read head is at the start, we will write at the end
+        if (this.readPos > 0) {
+          this.writePos = this.writePos % this.buffer.length;
+        } else {
+          this.addCapacity();
+          this.buffer[this.writePos] = item;
+          this.writePos += 1;
+          return;
+        }
+      } else {
+        this.buffer[this.writePos] = item;
+        this.writePos += 1;
+        return;
+      }
+    }
+
+    // Read is only 1 away from write, so once the item is written our write head would be at the read head
+    // we can't allow that so we need to add capacity
+    if (this.readPos - this.writePos === 1) {
+      this.addCapacity();
+    }
+
+    // write to position and increment
+    this.buffer[this.writePos] = item;
+    this.writePos++;
+  }
+
+  dequeue(): T | undefined {
+    if (this.readPos === this.writePos) {
+      return undefined;
+    }
+
+    // Read position may have incremented from a previous read
+    // and we need to maybe wrap it to our size
+    if (this.readPos >= this.buffer.length) {
+      this.readPos = this.readPos % this.buffer.length;
+    }
+
+    const item = this.buffer[this.readPos];
+    this.buffer[this.readPos] = undefined;
+    this.readPos += 1;
+    return item;
+  }
+
+  size(): number {
+    if (this.writePos >= this.readPos) {
+      return this.writePos - this.readPos;
+    }
+
+    return this.buffer.length - this.readPos + this.writePos;
+  }
+
+  capacity(): number {
+    return this.buffer.length;
+  }
+
+  clear(): void {
+    this.buffer.length = 0;
+    this.writePos = 0;
+    this.readPos = 0;
+  }
+
+  private addCapacity() {
+    const oldLen = this.buffer.length;
+    this.buffer.length = this.buffer.length * 2;
+
+    // if the read head is before write, then there's no change to index management and write can continue at end
+    // if the read head is ahead of write, then we can un-wrap the write bytes
+    if (this.readPos > this.writePos) {
+      // copy all the elements from start to writePos - 1 to the end of the extended buffer
+      for (let i = 0; i < this.writePos; ++i) {
+        this.buffer[oldLen + i] = this.buffer[i];
+        this.buffer[i] = undefined;
+      }
+      this.writePos = oldLen;
+    }
+  }
+}

--- a/packages/den/collection/index.ts
+++ b/packages/den/collection/index.ts
@@ -6,3 +6,4 @@ export { default as filterMap } from "./filterMap";
 export * from "./ArrayMap";
 export * from "./minIndexBy";
 export * from "./binarySearch";
+export * from "./VecQueue";


### PR DESCRIPTION
**User-Facing Changes**
Better performance during playback.

**Description**
The BufferedIterableSource uses a producer/consumer architecture. The producer inserts new messages into a FIFO queue and the consumer reads from the queue. The existing code used an array with `push` and `shift`. When calling `shift`, all the items in the array need to move down one. This was causing large and noticeable performance impact when playing back files with many messages.

Here is a video with the `shift` playback and a file containing ~100k messages.

https://user-images.githubusercontent.com/84792/182458834-bba18805-a2ee-4062-ab89-8bef2d9de358.mov

When viewing the performance traces there would be large amount of time spent in the bufferedIterator message generator (where the `shift` call happens).

<img width="303" alt="Screen Shot 2022-08-02 at 12 29 30 PM" src="https://user-images.githubusercontent.com/84792/182458922-c8fe3e7a-318b-4178-aeb3-0a9a6572b319.png">

By replacing the array with a queue implementation based on a circular buffer, the `shift` operations are removed. The dequeue operation avoids any re-allocations of the array. The message generator no longer represents a large amount of time spent.

https://user-images.githubusercontent.com/84792/182459336-584d1bac-99f1-483b-8415-fd5a079543e0.mov



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
