### PR TITLE
[New3D] Add support for glTF meshoptimizer extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,5 @@
     "webpack-dev-server": "4.7.4",
     "webpack-hot-middleware": "2.25.1"
   },
-  "packageManager": "yarn@3.1.0",
-  "dependencies": {
-    "meshoptimizer": "0.18.0"
-  }
+  "packageManager": "yarn@3.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "webpack-dev-server": "4.7.4",
     "webpack-hot-middleware": "2.25.1"
   },
-  "packageManager": "yarn@3.1.0"
+  "packageManager": "yarn@3.1.0",
+  "dependencies": {
+    "meshoptimizer": "0.18.0"
+  }
 }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -148,6 +148,7 @@
     "lodash": "4.17.21",
     "mathjs": "10.1.1",
     "memoize-weak": "1.0.2",
+    "meshoptimizer": "0.18.0",
     "moment": "2.29.4",
     "moment-duration-format": "2.3.2",
     "moment-timezone": "0.5.34",

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { MeshoptDecoder } from "meshoptimizer";
 import * as THREE from "three";
 import dracoDecoderWasmUrl from "three/examples/jsm/../js/libs/draco/draco_decoder.wasm";
 import dracoWasmWrapperJs from "three/examples/jsm/../js/libs/draco/draco_wasm_wrapper.js?raw";
@@ -124,6 +125,7 @@ async function loadGltf(url: string, reportError: ErrorCallback): Promise<Loaded
   const manager = new THREE.LoadingManager(undefined, undefined, onError);
   manager.setURLModifier(rewriteUrl);
   const gltfLoader = new GLTFLoader(manager);
+  gltfLoader.setMeshoptDecoder(MeshoptDecoder);
   gltfLoader.setDRACOLoader(createDracoLoader(manager));
 
   manager.itemStart(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13059,6 +13059,7 @@ __metadata:
     jest: 27.5.1
     jest-canvas-mock: 2.3.1
     license-checker: 25.0.1
+    meshoptimizer: 0.18.0
     playwright: 1.18.1
     pngjs: 6.0.0
     prettier: 2.5.1
@@ -17384,6 +17385,13 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
+  languageName: node
+  linkType: hard
+
+"meshoptimizer@npm:0.18.0":
+  version: 0.18.0
+  resolution: "meshoptimizer@npm:0.18.0"
+  checksum: d9f07b4659315b18f677edea0c7eb25aa0ca8c8ec5d67c7ee3f0d90237144d6bcdc4098dfb5d1de166f5bcd57a735455851b9841fa3f9c52f3aa5cbc2178ecec
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,6 +2633,7 @@ __metadata:
     lodash: 4.17.21
     mathjs: 10.1.1
     memoize-weak: 1.0.2
+    meshoptimizer: 0.18.0
     moment: 2.29.4
     moment-duration-format: 2.3.2
     moment-timezone: 0.5.34
@@ -13059,7 +13060,6 @@ __metadata:
     jest: 27.5.1
     jest-canvas-mock: 2.3.1
     license-checker: 25.0.1
-    meshoptimizer: 0.18.0
     playwright: 1.18.1
     pngjs: 6.0.0
     prettier: 2.5.1


### PR DESCRIPTION
**User-Facing Changes**

- Added support for glTF meshopt-compressed files to `3D (Beta)`

**Description**

Using `meshoptimizer` lib instead of the one shipping with THREE.js since it has TypeScript types

Fixes #4012