### PR TITLE
Remove x, y, z fields from Euler in quaternion utility

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/quaternions.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/quaternions.test.ts
@@ -10,9 +10,6 @@ describe("quaternions", () => {
     };
 
     const euler = quaternionToEuler(quaternion);
-    expect(euler.x).toBeCloseTo(10);
-    expect(euler.y).toBeCloseTo(20);
-    expect(euler.z).toBeCloseTo(30);
     expect(euler.roll).toBeCloseTo(10);
     expect(euler.pitch).toBeCloseTo(20);
     expect(euler.yaw).toBeCloseTo(30);

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/quaternions.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/quaternions.ts
@@ -10,9 +10,6 @@ export type Quaternion = {
 };
 
 export type Euler = {
-  x: number;
-  y: number;
-  z: number;
   roll: number;
   pitch: number;
   yaw: number;
@@ -37,9 +34,6 @@ export function quaternionToEuler(quaternion: Quaternion): Euler {
   const pitch = toDegrees * Math.asin(-dcm20);
   const yaw = toDegrees * Math.atan2(dcm10, dcm00);
   return {
-    x: roll,
-    y: pitch,
-    z: yaw,
     roll,
     pitch,
     yaw,


### PR DESCRIPTION
**User-Facing Changes**
This removes the x, y, and z fields from the Euler angle in the `quaternions.ts` user scripts utility.

**Description**
Sounds like these extra fields are not needed.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
