### PR TITLE
Fix panel toolbar inputs drag interaction

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -85,12 +85,20 @@ export default React.memo<Props>(function PanelToolbar({
     );
   }, [additionalIcons, isFullscreen, exitFullscreen]);
 
+  // If we have children then we limit the drag area to the controls. Otherwise the entire
+  // toolbar is draggable.
+  const rootDragRef =
+    isUnknownPanel || children != undefined ? undefined : panelContext?.connectToolbarDragHandle;
+
+  const controlsDragRef =
+    isUnknownPanel || children == undefined ? undefined : panelContext?.connectToolbarDragHandle;
+
   return (
     <PanelToolbarRoot
       backgroundColor={backgroundColor}
       data-testid="mosaic-drag-handle"
       enableDrag={panelContext?.connectToolbarDragHandle != undefined}
-      ref={isUnknownPanel ? undefined : panelContext?.connectToolbarDragHandle}
+      ref={rootDragRef}
     >
       {children ??
         (panelContext != undefined && (
@@ -98,12 +106,14 @@ export default React.memo<Props>(function PanelToolbar({
             {panelContext.title}
           </Typography>
         ))}
-      <PanelToolbarControls
-        additionalIcons={additionalIconsWithHelp}
-        isUnknownPanel={!!isUnknownPanel}
-        menuOpen={menuOpen}
-        setMenuOpen={setMenuOpen}
-      />
+      <div ref={controlsDragRef}>
+        <PanelToolbarControls
+          additionalIcons={additionalIconsWithHelp}
+          isUnknownPanel={!!isUnknownPanel}
+          menuOpen={menuOpen}
+          setMenuOpen={setMenuOpen}
+        />
+      </div>
     </PanelToolbarRoot>
   );
 });

--- a/packages/studio-base/src/hooks/usePanelDrag.tsx
+++ b/packages/studio-base/src/hooks/usePanelDrag.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import _ from "lodash";
+import { defer } from "lodash";
 import { useContext } from "react";
 import { useDrag, ConnectDragSource, ConnectDragPreview } from "react-dnd";
 import { MosaicDragType, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
@@ -63,7 +63,7 @@ export default function usePanelDrag(props: {
 
       // The defer is necessary as the element must be present on start for HTML DnD to not cry
       const path = mosaicWindowActions.getPath();
-      const deferredHide = _.defer(() => {
+      const deferredHide = defer(() => {
         startDrag({ path, sourceTabId });
       });
       return { mosaicId, deferredHide, originalLayout, originalConfigById };


### PR DESCRIPTION
**User-Facing Changes**
This fixes interaction conflicts with inputs embedded in the panel toolbars and drag and drop.

**Description**
The fix here is to restrict the drag and drop area to the controls at the end of the toolbar if we have any children embedded in the toolbar.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4019