### PR TITLE
Fix error in preferences timezone input

### DIFF
--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -135,7 +135,7 @@ function TimezoneSettings(): React.ReactElement {
   const allItems = useMemo(() => [...fixedItems, ...timezoneItems], [fixedItems, timezoneItems]);
 
   const selectedItem = useMemo(
-    () => (timezone != undefined && allItems.find((item) => item.data === timezone)) || detectItem,
+    () => (timezone != undefined && allItems.find((item) => item.key === timezone)) || detectItem,
     [allItems, detectItem, timezone],
   );
 

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -148,7 +148,13 @@ function TimezoneSettings(): React.ReactElement {
         options={[...fixedItems, ...timezoneItems]}
         value={selectedItem}
         renderOption={(props, option: Option) =>
-          option.divider === true ? <Divider /> : <li {...props}>{option.label}</li>
+          option.divider === true ? (
+            <Divider />
+          ) : (
+            <li {...props} key={option.key}>
+              {option.label}
+            </li>
+          )
         }
         renderInput={(params) => (
           <TextField


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the timezone selector in the preferences sidebar.

**Description**
The autocomplete was looking at the wrong field to determine the currently selected timezone.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes regression from https://github.com/foxglove/studio/pull/4026