### PR TITLE
[New3D] Make camera_info topic matching more lenient

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/color.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/color.ts
@@ -8,7 +8,11 @@ import tinycolor from "tinycolor2";
 import { lerp } from "./math";
 import { ColorRGB, ColorRGBA } from "./ros";
 
-export const SRGBToLinear = THREE.SRGBToLinear;
+// From https://github.com/mrdoob/three.js/blob/dev/src/math/ColorManagement.js
+// which is not exported
+export function SRGBToLinear(c: number): number {
+  return c < 0.04045 ? c * 0.0773993808 : Math.pow(c * 0.9478672986 + 0.0521327014, 2.4);
+}
 
 export function stringToRgba(output: ColorRGBA, colorStr: string): ColorRGBA {
   const color = tinycolor(colorStr);
@@ -64,9 +68,9 @@ export function rgbaToCssString(color: ColorRGBA): string {
 }
 
 export function rgbaToLinear(output: ColorRGBA, color: ColorRGBA): ColorRGBA {
-  output.r = THREE.SRGBToLinear(color.r);
-  output.g = THREE.SRGBToLinear(color.g);
-  output.b = THREE.SRGBToLinear(color.b);
+  output.r = SRGBToLinear(color.r);
+  output.g = SRGBToLinear(color.g);
+  output.b = SRGBToLinear(color.b);
   output.a = color.a;
   return output;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/color.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/color.ts
@@ -2,14 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { SRGBToLinear } from "three/src/math/ColorManagement";
-import { clamp } from "three/src/math/MathUtils";
+import * as THREE from "three";
 import tinycolor from "tinycolor2";
 
 import { lerp } from "./math";
 import { ColorRGB, ColorRGBA } from "./ros";
 
-export { SRGBToLinear } from "three/src/math/ColorManagement";
+export const SRGBToLinear = THREE.SRGBToLinear;
 
 export function stringToRgba(output: ColorRGBA, colorStr: string): ColorRGBA {
   const color = tinycolor(colorStr);
@@ -50,10 +49,10 @@ export function rgbToThreeColor(output: THREE.Color, rgb: ColorRGB): THREE.Color
 // ts-prune-ignore-next
 export function rgbaToHexString(color: ColorRGBA): string {
   const rgba =
-    (clamp(color.r * 255, 0, 255) << 24) ^
-    (clamp(color.g * 255, 0, 255) << 16) ^
-    (clamp(color.b * 255, 0, 255) << 8) ^
-    (clamp(color.a * 255, 0, 255) << 0);
+    (THREE.MathUtils.clamp(color.r * 255, 0, 255) << 24) ^
+    (THREE.MathUtils.clamp(color.g * 255, 0, 255) << 16) ^
+    (THREE.MathUtils.clamp(color.b * 255, 0, 255) << 8) ^
+    (THREE.MathUtils.clamp(color.a * 255, 0, 255) << 0);
   return ("00000000" + rgba.toString(16)).slice(-8);
 }
 
@@ -65,9 +64,9 @@ export function rgbaToCssString(color: ColorRGBA): string {
 }
 
 export function rgbaToLinear(output: ColorRGBA, color: ColorRGBA): ColorRGBA {
-  output.r = SRGBToLinear(color.r);
-  output.g = SRGBToLinear(color.g);
-  output.b = SRGBToLinear(color.b);
+  output.r = THREE.SRGBToLinear(color.r);
+  output.g = THREE.SRGBToLinear(color.g);
+  output.b = THREE.SRGBToLinear(color.b);
   output.a = color.a;
   return output;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { cameraInfoTopicMatches } from "./Images";
+
+describe("cameraInfoTopicMatches", () => {
+  it("matches topics with common namespace conventions", () => {
+    expect(cameraInfoTopicMatches("/a/image_raw", "/a/camera_info")).toBe(true);
+    expect(cameraInfoTopicMatches("/a/image", "/a/camera_info")).toBe(true);
+
+    expect(cameraInfoTopicMatches("/camera/image_raw/compressed", "/camera/camera_info")).toBe(
+      true,
+    );
+    expect(
+      cameraInfoTopicMatches(
+        "/camera/image_raw/compressed",
+        "/camera/image_raw/compressed/camera_info",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -510,14 +510,11 @@ function multiplyScalar(vec: MutablePoint, scalar: number): void {
   vec.z *= scalar;
 }
 
-function cameraInfoTopicMatches(topic: string, cameraInfoTopic: string): boolean {
+export function cameraInfoTopicMatches(topic: string, cameraInfoTopic: string): boolean {
   const imageParts = topic.split("/");
   const infoParts = cameraInfoTopic.split("/");
-  if (imageParts.length !== infoParts.length) {
-    return false;
-  }
 
-  for (let i = 0; i < imageParts.length - 1; i++) {
+  for (let i = 0; i < imageParts.length - 1 && i < infoParts.length - 1; i++) {
     if (imageParts[i] !== infoParts[i]) {
       return false;
     }


### PR DESCRIPTION
**User-Facing Changes**
Improved the automatic matching between camera images and camera info topics in the 3D (Beta) panel.

**Description**
Fixes https://github.com/foxglove/studio/issues/3898