### PR TITLE
[New3D] Revert camera settings back to degrees, remove @foxglove/regl-worldview dep from New3D, cleanup

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
@@ -14,11 +14,11 @@
 import { useCallback } from "react";
 import styled from "styled-components";
 
-import { MouseEventObject } from "@foxglove/regl-worldview";
 import { getObject } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
 import { BaseMarker } from "@foxglove/studio-base/types/Messages";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+import { MouseEventObject } from "../camera";
 import { Interactive, SelectedObject } from "./types";
 
 type ClickedPosition = { clientX: number; clientY: number };

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -21,7 +21,6 @@ import { DeepPartial } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
 
 import Logger from "@foxglove/log";
-import { CameraState, DEFAULT_CAMERA_STATE, MouseEventObject } from "@foxglove/regl-worldview";
 import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { fromDate, toNanoSec } from "@foxglove/rostime";
 import {
@@ -47,6 +46,7 @@ import type { Renderable } from "./Renderable";
 import { MessageHandler, Renderer, RendererConfig } from "./Renderer";
 import { RendererContext, useRenderer, useRendererEvent } from "./RendererContext";
 import { Stats } from "./Stats";
+import { CameraState, DEFAULT_CAMERA_STATE, MouseEventObject } from "./camera";
 import { FRAME_TRANSFORM_DATATYPES } from "./foxglove";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
 import { TF_DATATYPES, TRANSFORM_STAMPED_DATATYPES } from "./ros";

--- a/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { ColorRGBA, Vector3 } from "./ros";
+import type { Pose } from "./transforms";
+
+export type BaseShape = {
+  pose: Pose;
+  scale: Vector3;
+  color?: ColorRGBA;
+};
+
+export type MouseEventObject = {
+  object: BaseShape;
+  instanceIndex?: number;
+};
+
+export type CameraState = {
+  distance: number;
+  perspective: boolean;
+  phi: number;
+  target: readonly [number, number, number];
+  targetOffset: readonly [number, number, number];
+  targetOrientation: readonly [number, number, number, number];
+  thetaOffset: number;
+  fovy: number;
+  near: number;
+  far: number;
+};
+
+export const DEFAULT_CAMERA_STATE: CameraState = {
+  distance: 75,
+  perspective: true,
+  phi: 45,
+  target: [0, 0, 0],
+  targetOffset: [0, 0, 0],
+  targetOrientation: [0, 0, 0, 1],
+  thetaOffset: 0,
+  fovy: 45,
+  near: 0.01,
+  far: 5000,
+};

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -4,12 +4,12 @@
 
 import { cloneDeep, round, set } from "lodash";
 
-import { DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
 import { SettingsTreeAction } from "@foxglove/studio";
 
 import { Renderer, RendererConfig } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
+import { DEFAULT_CAMERA_STATE } from "../camera";
 import { PRECISION_DEGREES, PRECISION_DISTANCE, SelectEntry } from "../settings";
 import { CoordinateFrame } from "../transforms";
 import { PublishClickType } from "./PublishClickTool";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -6,7 +6,6 @@ import { maxBy } from "lodash";
 
 import { UrdfGeometryMesh, UrdfRobot, UrdfVisual, parseRobot } from "@foxglove/den/urdf";
 import Logger from "@foxglove/log";
-import { Pose } from "@foxglove/regl-worldview";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
 import { eulerToQuaternion } from "@foxglove/studio-base/util/geometry";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
@@ -17,7 +16,7 @@ import { PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { ColorRGBA, Marker, MarkerAction, MarkerType, Quaternion, Vector3 } from "../ros";
 import { BaseSettings, CustomLayerSettings } from "../settings";
-import { makePose } from "../transforms";
+import { Pose, makePose } from "../transforms";
 import { updatePose } from "../updatePose";
 import { RenderableCube } from "./markers/RenderableCube";
 import { RenderableCylinder } from "./markers/RenderableCylinder";

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -12,6 +12,7 @@ import {
   FIXED_FRAME_ID,
   makeColor,
   QUAT_IDENTITY,
+  rad2deg,
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
@@ -143,10 +144,10 @@ export function ArrowMarkers(): JSX.Element {
           cameraState: {
             distance: 4,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: -1,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-1),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -12,6 +12,7 @@ import {
   FIXED_FRAME_ID,
   makeColor,
   QUAT_IDENTITY,
+  rad2deg,
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
@@ -97,10 +98,10 @@ export function AutoSelectFrame(): JSX.Element {
           cameraState: {
             distance: 4,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: -1,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-1),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -7,7 +7,13 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { CameraInfo, TransformStamped } from "../ros";
-import { BASE_LINK_FRAME_ID, FIXED_FRAME_ID, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import {
+  BASE_LINK_FRAME_ID,
+  FIXED_FRAME_ID,
+  QUAT_IDENTITY,
+  rad2deg,
+  SENSOR_FRAME_ID,
+} from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -128,10 +134,10 @@ export function CameraInfoRender(): JSX.Element {
           cameraState: {
             distance: 1.25,
             perspective: true,
-            phi: 0,
+            phi: rad2deg(0),
             targetOffset: [0, 0, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Header, Marker } from "../ros";
-import { makeColor, TEST_COLORS } from "./common";
+import { makeColor, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -70,10 +70,10 @@ export function FramelessMarkers(): JSX.Element {
           cameraState: {
             distance: 5.5,
             perspective: true,
-            phi: 0.5,
+            phi: rad2deg(0.5),
             targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PolygonStamped, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -85,10 +85,10 @@ export function GeometryMsgs_Polygon(): JSX.Element {
           cameraState: {
             distance: 8.25,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [-0.7, 2.1, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -9,7 +9,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PoseArray, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -18,7 +18,6 @@ export default {
 };
 
 type Vec4 = [number, number, number, number];
-
 const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 GeometryMsgs_PoseArray.parameters = { colorScheme: "dark" };
@@ -155,10 +154,10 @@ function GeometryMsgs_PoseArray(): JSX.Element {
           cameraState: {
             distance: 15,
             perspective: true,
-            phi: 0.25,
+            phi: rad2deg(0.25),
             targetOffset: [0, 2, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -4,7 +4,6 @@
 
 import { quat } from "gl-matrix";
 
-import { Vec4, vec4ToOrientation } from "@foxglove/regl-worldview";
 import { MessageEvent, Topic } from "@foxglove/studio";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -17,6 +16,10 @@ export default {
   title: "panels/ThreeDeeRender",
   component: ThreeDeeRender,
 };
+
+type Vec4 = [number, number, number, number];
+
+const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 GeometryMsgs_PoseArray.parameters = { colorScheme: "dark" };
 function GeometryMsgs_PoseArray(): JSX.Element {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -4,7 +4,6 @@
 
 import { quat } from "gl-matrix";
 
-import { Vec4, vec4ToOrientation } from "@foxglove/regl-worldview";
 import { MessageEvent, Topic } from "@foxglove/studio";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -17,6 +16,10 @@ export default {
   title: "panels/ThreeDeeRender",
   component: ThreeDeeRender,
 };
+
+type Vec4 = [number, number, number, number];
+
+const vec4ToOrientation = ([x, y, z, w]: Vec4) => ({ x, y, z, w });
 
 GeometryMsgs_PoseStamped.parameters = { colorScheme: "dark" };
 export function GeometryMsgs_PoseStamped(): JSX.Element {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -9,7 +9,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PoseStamped, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -141,10 +141,10 @@ export function GeometryMsgs_PoseStamped(): JSX.Element {
           cameraState: {
             distance: 15,
             perspective: false,
-            phi: 0,
+            phi: rad2deg(0),
             targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -12,6 +12,7 @@ import {
   FIXED_FRAME_ID,
   PNG_TEST_IMAGE,
   QUAT_IDENTITY,
+  rad2deg,
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
@@ -164,10 +165,10 @@ export function ImageRender(): JSX.Element {
           cameraState: {
             distance: 1.5,
             perspective: true,
-            phi: 0.975,
+            phi: rad2deg(0.975),
             targetOffset: [0, 0.4, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Marker, MarkerType, TransformStamped, Vector3 } from "../ros";
-import { makeColor, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import { makeColor, QUAT_IDENTITY, rad2deg, SENSOR_FRAME_ID } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -108,10 +108,10 @@ export function LabelMarkers(): JSX.Element {
           cameraState: {
             distance: 5.5,
             perspective: true,
-            phi: 0.5,
+            phi: rad2deg(0.5),
             targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
@@ -8,7 +8,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { makePass, QUAT_IDENTITY, TEST_COLORS } from "./common";
+import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -96,10 +96,10 @@ export function LargeTransform(): JSX.Element {
           cameraState: {
             distance: 3,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [0, 0, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -8,7 +8,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { makeFail, makePass, QUAT_IDENTITY, TEST_COLORS, VEC3_ZERO } from "./common";
+import { makeFail, makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -160,10 +160,10 @@ export function MarkerLifetimes(): JSX.Element {
           cameraState: {
             distance: 3,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [0, 0, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Marker, MarkerType, PointCloud2, TransformStamped } from "../ros";
-import { makeColor, QUAT_IDENTITY, rgba, VEC3_ZERO } from "./common";
+import { makeColor, QUAT_IDENTITY, rad2deg, rgba, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -156,10 +156,10 @@ export function Marker_PointCloud2_Alignment(): JSX.Element {
           cameraState: {
             distance: 4,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [-0.22, 2.07, 0],
-            thetaOffset: -0.65,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.65),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { ColorRGBA, Marker, TransformStamped } from "../ros";
-import { makeColor, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import { makeColor, QUAT_IDENTITY, rad2deg, SENSOR_FRAME_ID } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -514,10 +514,10 @@ export function Markers(): JSX.Element {
           cameraState: {
             distance: 5.5,
             perspective: true,
-            phi: 0.5,
+            phi: rad2deg(0.5),
             targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
@@ -8,7 +8,7 @@ import delay from "@foxglove/studio-base/util/delay";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -70,10 +70,10 @@ export function MeasurementTool(): JSX.Element {
           cameraState: {
             distance: 5.5,
             perspective: true,
-            phi: 0.5,
+            phi: rad2deg(0.5),
             targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -140,7 +140,7 @@ f 5/6/6 1/12/6 8/11/6`),
           layers: {
             grid: { layerId: "foxglove.Grid" },
           },
-          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 1 },
+          cameraState: { ...DEFAULT_CAMERA_STATE, distance: 5, thetaOffset: 50 },
           topics: {
             "/markers": { visible: true },
           },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -2,10 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { DEFAULT_CAMERA_STATE } from "@foxglove/regl-worldview";
 import { MessageEvent, Topic } from "@foxglove/studio";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
+import { DEFAULT_CAMERA_STATE } from "../camera";
 import ThreeDeeRender from "../index";
 import { Marker } from "../ros";
 import { makeColor, STL_CUBE_MESH_RESOURCE } from "./common";

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
@@ -9,7 +9,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { NavPath, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -125,10 +125,10 @@ export function NavMsgs_Path(): JSX.Element {
           cameraState: {
             distance: 15,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [0, 2, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -7,7 +7,13 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PoseStamped, PoseWithCovarianceStamped, TransformStamped } from "../ros";
-import { BASE_LINK_FRAME_ID, FIXED_FRAME_ID, QUAT_IDENTITY, SENSOR_FRAME_ID } from "./common";
+import {
+  BASE_LINK_FRAME_ID,
+  FIXED_FRAME_ID,
+  QUAT_IDENTITY,
+  rad2deg,
+  SENSOR_FRAME_ID,
+} from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -161,10 +167,10 @@ export function PoseMarkers(): JSX.Element {
           cameraState: {
             distance: 4,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [-0.6, 0.5, 0],
-            thetaOffset: -1,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-1),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
@@ -10,7 +10,7 @@ import delay from "@foxglove/studio-base/util/delay";
 import ThreeDeeRender from "../index";
 import { PublishClickType } from "../renderables/PublishClickTool";
 import { TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -148,10 +148,10 @@ function PublishClickToolTemplate({ type }: { type: PublishClickType }): JSX.Ele
           cameraState: {
             distance: 5.5,
             perspective: true,
-            phi: 0.5,
+            phi: rad2deg(0.5),
             targetOffset: [-0.5, 0.75, 0],
-            thetaOffset: -0.25,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.25),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -10,7 +10,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { LaserScan, PointCloud2, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -136,10 +136,10 @@ function SensorMsgs_LaserScan({
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 0],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],
@@ -333,10 +333,10 @@ export function ComparisonWithPointCloudColors(): JSX.Element {
           cameraState: {
             distance: 5,
             perspective: false,
-            phi: 0,
+            phi: rad2deg(0),
             targetOffset: [0, 1, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -9,7 +9,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PointCloud2, TransformStamped } from "../ros";
-import { QUAT_IDENTITY } from "./common";
+import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -148,10 +148,10 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 0],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],
@@ -319,10 +319,10 @@ export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 3],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],
@@ -398,10 +398,10 @@ export function SensorMsgs_PointCloud2_TwoDimensions(): JSX.Element {
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 0],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
@@ -7,7 +7,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { makeColor } from "./common";
+import { makeColor, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -112,10 +112,10 @@ export function SphereListPointsTransform(): JSX.Element {
           cameraState: {
             distance: 4,
             perspective: true,
-            phi: 1.2,
+            phi: rad2deg(1.2),
             targetOffset: [0.5, 0, 0],
-            thetaOffset: -0.5,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.5),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -8,7 +8,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { makePass, QUAT_IDENTITY, TEST_COLORS } from "./common";
+import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 const VEC3_ZERO = { x: 0, y: 0, z: 0 };
@@ -97,10 +97,10 @@ export function TransformInterpolation(): JSX.Element {
           cameraState: {
             distance: 3,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [0, 0, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
@@ -75,6 +75,10 @@ facet normal -1 0 0 outer loop vertex -0.5 -0.5 0.5 vertex -0.5 0.5 0.5 vertex -
 facet normal -1 0 0 outer loop vertex -0.5 0.5 -0.5 vertex -0.5 -0.5 -0.5 vertex -0.5 -0.5 0.5 endloop endfacet
 endsolid AssimpScene`);
 
+export function rad2deg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
 // ts-prune-ignore-next
 export function makeColor(hex: string, alpha?: number): ColorRGBA {
   const color = stringToRgba({ r: 0, g: 0, b: 0, a: 1 }, hex);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
@@ -75,6 +75,7 @@ facet normal -1 0 0 outer loop vertex -0.5 -0.5 0.5 vertex -0.5 0.5 0.5 vertex -
 facet normal -1 0 0 outer loop vertex -0.5 0.5 -0.5 vertex -0.5 -0.5 -0.5 vertex -0.5 -0.5 0.5 endloop endfacet
 endsolid AssimpScene`);
 
+// ts-prune-ignore-next
 export function rad2deg(rad: number): number {
   return (rad * 180) / Math.PI;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -9,7 +9,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { LegacyFrameTransform } from "../normalizeMessages";
-import { makePass, QUAT_IDENTITY, TEST_COLORS } from "./common";
+import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 const VEC3_ZERO = { x: 0, y: 0, z: 0 };
@@ -100,10 +100,10 @@ export function FoxgloveFrameTransform(): JSX.Element {
           cameraState: {
             distance: 3,
             perspective: true,
-            phi: 1,
+            phi: rad2deg(1),
             targetOffset: [0, 0, 0],
-            thetaOffset: 0,
-            fovy: 0.75,
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -10,7 +10,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { TransformStamped } from "../ros";
-import { QUAT_IDENTITY, VEC3_ZERO } from "./common";
+import { QUAT_IDENTITY, rad2deg, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -146,10 +146,10 @@ function Foxglove_PointCloud({ rgbaFieldName }: { rgbaFieldName: string }): JSX.
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 0],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],
@@ -314,10 +314,10 @@ export function Foxglove_PointCloud_Intensity(): JSX.Element {
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 3],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],
@@ -390,10 +390,10 @@ export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {
           cameraState: {
             distance: 13.5,
             perspective: true,
-            phi: 1.22,
+            phi: rad2deg(1.22),
             targetOffset: [0.25, -0.5, 0],
-            thetaOffset: -0.33,
-            fovy: 0.75,
+            thetaOffset: rad2deg(-0.33),
+            fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,
             target: [0, 0, 0],


### PR DESCRIPTION
**User-Facing Changes**

- Fixed: Revert `3D (Beta)` camera settings from radians back to degrees

**Description**

This fixes a regression where the user-input camera settings inadvertently changed from degrees to radians, but the input controls still used precision and step values meant for degrees. Users only deal in degrees now (even though the under the hood math uses radians). The DEFAULT_CAMERA_STATE object now lives in this codebase so the values are discoverable by reading the source code and we avoid additional rad2deg confusion, and with this change we also drop all imports of `@foxglove/regl-worldview` from `ThreeDeeRender/*`.

The _updateCameras() method has been streamlined a bit and more comments added.
