### PR TITLE
Fix crash in raw messages panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -63,6 +63,7 @@ export const fixture = {
         receiveTime: { sec: 122, nsec: 456789011 },
         message: {
           some_array: ["a", "b", "c"],
+          some_data_view: new DataView(new ArrayBuffer(10)),
           some_deleted_key: "GONE",
           some_id_example_2: { some_id: 0 },
         },

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -271,7 +271,7 @@ function RawMessages(props: Props) {
       // sample output: Int8Array(331776) [-4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, ...]
       let arrLabel = "";
       if (ArrayBuffer.isView(itemValue)) {
-        const array = itemValue as Uint8Array;
+        const array = Array.isArray(itemValue) ? itemValue : new Uint8Array(itemValue.buffer);
         const itemPart = array.slice(0, DATA_ARRAY_PREVIEW_LIMIT).join(", ");
         const length = array.length;
         arrLabel = `(${length}) [${itemPart}${length >= DATA_ARRAY_PREVIEW_LIMIT ? ", ..." : ""}] `;

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -271,7 +271,7 @@ function RawMessages(props: Props) {
       // sample output: Int8Array(331776) [-4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, ...]
       let arrLabel = "";
       if (ArrayBuffer.isView(itemValue)) {
-        const array = Array.isArray(itemValue) ? itemValue : new Uint8Array(itemValue.buffer);
+        const array = "slice" in itemValue ? itemValue : new Uint8Array(itemValue.buffer);
         const itemPart = array.slice(0, DATA_ARRAY_PREVIEW_LIMIT).join(", ");
         const length = array.length;
         arrLabel = `(${length}) [${itemPart}${length >= DATA_ARRAY_PREVIEW_LIMIT ? ", ..." : ""}] `;


### PR DESCRIPTION
**User-Facing Changes**
Fixes a crash in the raw messages panel.

**Description**
The logic here was trying to cast a `DataView` to an array. We need to check if the object is an array or a `DataView` and if it's a `DataView` wrap it in a sliceable array.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4040