### PR TITLE
Allow data: URLs for connect-src

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -250,7 +250,7 @@ function main() {
       "script-src": `'self' 'unsafe-inline' 'unsafe-eval'`,
       "worker-src": `'self' blob:`,
       "style-src": "'self' 'unsafe-inline'",
-      "connect-src": "'self' ws: wss: http: https: package: blob: file:",
+      "connect-src": "'self' ws: wss: http: https: package: blob: data: file:",
       "font-src": "'self' data:",
       // Include http in the CSP to allow loading images (i.e. map tiles) from http endpoints like localhost
       "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http:",


### PR DESCRIPTION
**User-Facing Changes**

- Unclear, let's go with "none"

**Description**

If we allow `file:`, there should be no concern with `data:`. During local development I encountered a CSP error about a `data:` URL. I wasn't able to track down the source of the fetch request, but this seems like an innocuous change.
