### PR TITLE
Fix vertexShaderKey multiple define error during development

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -194,12 +194,16 @@ Object.defineProperty(LabelMaterial.prototype, "vertexShaderKey", {
   get() {
     return "LabelMaterial-VertexShader";
   },
+  enumerable: true,
+  configurable: true,
 });
 Object.defineProperty(LabelMaterial.prototype, "fragmentShaderKey", {
   get() {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     return this.picking ? "LabelMaterial-FragmentShader-picking" : "LabelMaterial-FragmentShader";
   },
+  enumerable: true,
+  configurable: true,
 });
 
 /**


### PR DESCRIPTION
**User-Facing Changes**

- None (dev mode only fix)

**Description**

HMR can execute Renderer.ts multiple times in the same context, causing an error on the Object.defineProperty() calls unless configurable is set to true
