### PR TITLE
Allow users to clear settings color fields

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -4,7 +4,7 @@
 
 import { ColorPicker } from "@fluentui/react";
 import ClearIcon from "@mui/icons-material/Clear";
-import { TextField, Popover, Button, IconButton } from "@mui/material";
+import { TextField, Popover, IconButton } from "@mui/material";
 import { useCallback, MouseEvent, useState } from "react";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -50,12 +50,11 @@ type ColorPickerInputProps = {
   value: undefined | string;
   onChange: (value: undefined | string) => void;
   placeholder?: string;
-  swatchOrientation?: "start" | "end";
   readOnly?: boolean;
 };
 
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
-  const { alphaType, disabled, onChange, readOnly, swatchOrientation = "start", value } = props;
+  const { alphaType, disabled, onChange, readOnly, value } = props;
 
   const { classes, cx } = useStyles();
 
@@ -96,17 +95,19 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
         variant="filled"
         InputProps={{
           readOnly: true,
-          startAdornment: swatchOrientation === "start" && (
-            <ColorSwatch color={swatchColor} onClick={handleClick} />
-          ),
-          endAdornment: swatchOrientation === "end" && (
-            <ColorSwatch color={swatchColor} onClick={handleClick} />
+          startAdornment: <ColorSwatch color={swatchColor} onClick={handleClick} />,
+          endAdornment: (
+            <IconButton
+              className={classes.clearButton}
+              onClick={clearValue}
+              size="small"
+              color="primary"
+            >
+              <ClearIcon />
+            </IconButton>
           ),
         }}
       />
-      <IconButton className={classes.clearButton} onClick={clearValue} size="small" color="primary">
-        <ClearIcon />
-      </IconButton>
       <Popover
         open={open}
         anchorEl={anchorElement}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -3,33 +3,46 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { ColorPicker } from "@fluentui/react";
-import { TextField, styled as muiStyled, Popover } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+import { TextField, Popover, Button, IconButton } from "@mui/material";
 import { useCallback, MouseEvent, useState } from "react";
 import tinycolor from "tinycolor2";
+import { makeStyles } from "tss-react/mui";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { ColorSwatch } from "./ColorSwatch";
 
-const StyledTextField = muiStyled(TextField)({
-  ".MuiInputBase-formControl.MuiInputBase-root": {
-    padding: 0,
+const useStyles = makeStyles()({
+  clearButton: {
+    "&.MuiIconButton-root": {
+      cursor: "pointer",
+      position: "absolute",
+      right: 0,
+      top: "50%",
+      transform: "translate(0, -50%)",
+    },
   },
-  ".MuiInputBase-root": {
-    cursor: "pointer",
+  root: {
+    position: "relative",
+    pointerEvents: "auto",
   },
-  ".MuiInputBase-input": {
-    fontFamily: fonts.MONOSPACE,
-    alignItems: "center",
+  rootDisabled: {
+    pointerEvents: "none",
+  },
+  textField: {
+    ".MuiInputBase-formControl.MuiInputBase-root": {
+      padding: 0,
+    },
+    ".MuiInputBase-root": {
+      cursor: "pointer",
+    },
+    ".MuiInputBase-input": {
+      fontFamily: fonts.MONOSPACE,
+      alignItems: "center",
+    },
   },
 });
-
-const Root = muiStyled("div", { shouldForwardProp: (prop) => prop !== "disabled" })<{
-  disabled: boolean;
-}>(({ disabled }) => ({
-  position: "relative",
-  pointerEvents: disabled ? "none" : "auto",
-}));
 
 type ColorPickerInputProps = {
   alphaType: "none" | "alpha";
@@ -44,6 +57,8 @@ type ColorPickerInputProps = {
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const { alphaType, disabled, onChange, readOnly, swatchOrientation = "start", value } = props;
 
+  const { classes, cx } = useStyles();
+
   const [anchorElement, setAnchorElement] = useState<undefined | HTMLDivElement>(undefined);
 
   const handleClick = useCallback((event: MouseEvent<HTMLDivElement>) => {
@@ -54,6 +69,10 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
     setAnchorElement(undefined);
   }, []);
 
+  const clearValue = useCallback(() => {
+    onChange(undefined);
+  }, [onChange]);
+
   const open = Boolean(anchorElement);
 
   const parsedValue = value ? tinycolor(value) : undefined;
@@ -62,13 +81,18 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
   const swatchColor = displayValue ?? "#00000044";
 
   return (
-    <Root disabled={disabled === true || readOnly === true}>
-      <StyledTextField
+    <div
+      className={cx(classes.root, {
+        [classes.rootDisabled]: disabled === true || readOnly === true,
+      })}
+    >
+      <TextField
+        className={classes.textField}
         fullWidth
         disabled={disabled}
         placeholder={props.placeholder}
         size="small"
-        value={displayValue}
+        value={displayValue ?? ""}
         variant="filled"
         InputProps={{
           readOnly: true,
@@ -80,6 +104,9 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
           ),
         }}
       />
+      <IconButton className={classes.clearButton} onClick={clearValue} size="small" color="primary">
+        <ClearIcon />
+      </IconButton>
       <Popover
         open={open}
         anchorEl={anchorElement}
@@ -108,6 +135,6 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
           onChange={(_event, newValue) => onChange(newValue.str)}
         />
       </Popover>
-    </Root>
+    </div>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Adds a button to clear the value of a color field in the settings UI.

**Description**
This adds a clear button to the right of the color value.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4053 