### PR TITLE
Fix style injection order

### DIFF
--- a/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
+++ b/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
@@ -2,11 +2,18 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import createCache from "@emotion/cache";
+import { CacheProvider } from "@emotion/react";
 import { useMedia } from "react-use";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+export const muiCache = createCache({
+  key: "mui",
+  prepend: true,
+});
 
 export function ColorSchemeThemeProvider({
   children,
@@ -14,5 +21,9 @@ export function ColorSchemeThemeProvider({
   const [colorScheme = "dark"] = useAppConfigurationValue<string>(AppSetting.COLOR_SCHEME);
   const systemSetting = useMedia("(prefers-color-scheme: dark)");
   const isDark = colorScheme === "dark" || (colorScheme === "system" && systemSetting);
-  return <ThemeProvider isDark={isDark}>{children}</ThemeProvider>;
+  return (
+    <CacheProvider value={muiCache}>
+      <ThemeProvider isDark={isDark}>{children}</ThemeProvider>
+    </CacheProvider>
+  );
 }

--- a/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
+++ b/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
@@ -2,18 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import createCache from "@emotion/cache";
-import { CacheProvider } from "@emotion/react";
 import { useMedia } from "react-use";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
-
-export const muiCache = createCache({
-  key: "mui",
-  prepend: true,
-});
 
 export function ColorSchemeThemeProvider({
   children,
@@ -21,9 +14,5 @@ export function ColorSchemeThemeProvider({
   const [colorScheme = "dark"] = useAppConfigurationValue<string>(AppSetting.COLOR_SCHEME);
   const systemSetting = useMedia("(prefers-color-scheme: dark)");
   const isDark = colorScheme === "dark" || (colorScheme === "system" && systemSetting);
-  return (
-    <CacheProvider value={muiCache}>
-      <ThemeProvider isDark={isDark}>{children}</ThemeProvider>
-    </CacheProvider>
-  );
+  return <ThemeProvider isDark={isDark}>{children}</ThemeProvider>;
 }

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -12,9 +12,6 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 const useStyles = makeStyles()(({ palette, typography }) => ({
   root: {
-    "*,*:before,*:after": {
-      boxSizing: "inherit",
-    },
     "code, pre, tt": {
       fontFamily: fonts.MONOSPACE,
       overflowWrap: "break-word",

--- a/packages/studio-base/src/panels/Parameters/ParametersTable.tsx
+++ b/packages/studio-base/src/panels/Parameters/ParametersTable.tsx
@@ -2,52 +2,56 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { styled as muiStyled } from "@mui/material";
+import { PropsWithChildren } from "react";
+import { makeStyles } from "tss-react/mui";
 
-const ParametersTable = muiStyled("div")`
-  display: flex;
-  flex-direction: column;
-  white-space: nowrap;
-  color: ${({ theme }) => theme.palette.text.primary};
-  flex: auto;
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    whiteSpace: "nowrap",
+    color: theme.palette.text.primary,
+    flex: "auto",
+    table: {
+      width: "calc(100% + 1px)",
+    },
 
-  table {
-    width: calc(100% + 1px);
-  }
+    thead: {
+      userSelect: "none",
+      borderBottom: `1px solid ${theme.palette.divider}`,
+    },
 
-  thead {
-    user-select: none;
-    border-bottom: 1px solid ${({ theme }) => theme.palette.divider};
-  }
+    "& table th, & table td": {
+      padding: "6px 16px",
+      lineHeight: "100%",
+      border: "none",
+    },
 
-  th,
-  td {
-    padding: 6px 16px;
-    line-height: 100%;
-    border: none;
-  }
+    "tr:first-child th": {
+      padding: "6px 16px",
+      border: "none",
+      textAlign: "left",
+      color: theme.palette.text.secondary,
+      minWidth: "120px",
+    },
 
-  tr:first-child th {
-    padding: 6px 16px;
-    border: none;
-    text-align: left;
-    color: ${({ theme }) => theme.palette.text.secondary};
-    min-width: 120px;
-  }
+    td: {
+      input: {
+        background: "none !important",
+        color: "inherit",
+        width: "100%",
+        paddingLeft: 0,
+        paddingRight: 0,
+        minWidth: "40px",
+      },
+      "&:last-child": {
+        color: theme.palette.text.secondary,
+      },
+    },
+  },
+}));
 
-  td {
-    input {
-      background: none !important;
-      color: inherit;
-      width: 100%;
-      padding-left: 0;
-      padding-right: 0;
-      min-width: 40px;
-    }
-    &:last-child {
-      color: ${({ theme }) => theme.palette.text.secondary};
-    }
-  }
-`;
-
-export default ParametersTable;
+export default function ParametersTable(props: PropsWithChildren<unknown>): JSX.Element {
+  const { classes } = useStyles();
+  return <div className={classes.root}>{props.children}</div>;
+}

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import { ThemeProvider as FluentThemeProvider } from "@fluentui/react";
@@ -15,7 +16,7 @@ import icons from "./icons";
 
 // Make sure mui styles are loaded first so that our makeStyles customizations
 // take precedence.
-export const muiCache = createCache({
+const muiCache = createCache({
   key: "mui",
   prepend: true,
 });

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -1,6 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import createCache from "@emotion/cache";
+import { CacheProvider } from "@emotion/react";
 import { ThemeProvider as FluentThemeProvider } from "@fluentui/react";
 import { registerIcons, unregisterIcons } from "@fluentui/style-utilities";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material";
@@ -10,6 +12,11 @@ import { ThemeProvider as StyledThemeProvider } from "styled-components";
 import { createMuiTheme, createFluentTheme } from "@foxglove/studio-base/theme";
 
 import icons from "./icons";
+
+export const muiCache = createCache({
+  key: "mui",
+  prepend: true,
+});
 
 // By default the ThemeProvider adds an extra div to the DOM tree. We can disable this with a
 // custom `as` component to FluentThemeProvider. The component must support a `ref` property
@@ -40,19 +47,21 @@ export default function ThemeProvider({
   }
 
   return (
-    <MuiThemeProvider theme={muiTheme}>
-      <FluentThemeProvider
-        as={ThemeContainer}
-        applyTo="none" // skip default global styles for now
-        theme={fluentTheme}
-      >
-        <StyledThemeProvider
-          // Expose the same theme to styled-components - see types/styled-components.d.ts for type definitions
+    <CacheProvider value={muiCache}>
+      <MuiThemeProvider theme={muiTheme}>
+        <FluentThemeProvider
+          as={ThemeContainer}
+          applyTo="none" // skip default global styles for now
           theme={fluentTheme}
         >
-          {children}
-        </StyledThemeProvider>
-      </FluentThemeProvider>
-    </MuiThemeProvider>
+          <StyledThemeProvider
+            // Expose the same theme to styled-components - see types/styled-components.d.ts for type definitions
+            theme={fluentTheme}
+          >
+            {children}
+          </StyledThemeProvider>
+        </FluentThemeProvider>
+      </MuiThemeProvider>
+    </CacheProvider>
   );
 }

--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -13,6 +13,8 @@ import { createMuiTheme, createFluentTheme } from "@foxglove/studio-base/theme";
 
 import icons from "./icons";
 
+// Make sure mui styles are loaded first so that our makeStyles customizations
+// take precedence.
 export const muiCache = createCache({
   key: "mui",
   prepend: true,

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -363,6 +363,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
     MuiOutlinedInput: {
       styleOverrides: {
         input: {
+          boxSizing: "content-box",
           padding: theme.spacing(1, 1.25),
         },
         inputSizeSmall: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes the order of style injection so that our customizations in `makeStyles` are loaded after the stock MUI styles and take precedence.

See https://docs.tss-react.dev/readme-1

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
