### PR TITLE
Update Chart component to support unmounting/remounting for React 18

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -156,7 +156,7 @@ export const AllowsClickingOnDatalabels: Story = (_args) => {
   const doClick = useCallback(() => {
     if (clickedDatalabel == undefined) {
       const [canvas] = document.getElementsByTagName("canvas");
-      TestUtils.Simulate.click(canvas!, { clientX: 245, clientY: 429 });
+      TestUtils.Simulate.click(canvas!.parentElement!, { clientX: 245, clientY: 429 });
     }
   }, [clickedDatalabel]);
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -119,7 +119,7 @@ export function CanZoomAndUpdate(): JSX.Element {
 
     // Zoom is a continuous event, so we need to simulate wheel multiple times
     for (let i = 0; i < 5; i++) {
-      triggerWheel(canvasEl, 2);
+      triggerWheel(canvasEl.parentElement!, 2);
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
@@ -168,9 +168,12 @@ export function CleansUpTooltipOnUnmount(_args: unknown): JSX.Element | ReactNul
     // wait for chart to render before triggering tooltip
     let tooltip: Element | undefined;
 
-    TestUtils.Simulate.mouseEnter(canvas!);
+    TestUtils.Simulate.mouseEnter(canvas!.parentElement!);
     for (let i = 0; !tooltip && i < 20; i++) {
-      TestUtils.Simulate.mouseMove(canvas!, { clientX: 330 + left, clientY: 339 + top });
+      TestUtils.Simulate.mouseMove(canvas!.parentElement!, {
+        clientX: 330 + left,
+        clientY: 339 + top,
+      });
       await new Promise((resolve) => setTimeout(resolve, 100));
       tooltip = document.querySelector("[data-testid~=TimeBasedChartTooltipContent]") ?? undefined;
     }

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -464,7 +464,7 @@ export function LineGraphAfterZoom(): JSX.Element {
     // Zoom is a continuous event, so we need to simulate wheel multiple times
     if (canvasEl) {
       for (let i = 0; i < 5; i++) {
-        triggerWheel(canvasEl, 1);
+        triggerWheel(canvasEl.parentElement!, 1);
       }
     }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Split from #4052 

Updates the Chart component with changes that will make it work in React 18's Strict Mode, where effects are double-invoked (read more about this at https://github.com/reactwg/react-18/discussions/19). This means the component has to survive mount → unmount (useEffect cleanups) → remount, which is similar to what happens during hot reloading.

Changed to dynamically create a new canvas element on each mount, which was much easier than getting the OffscreenCanvas _back_ from the worker when unmounting.