### PR TITLE
[New3D] Add "Opacity" setting for PointCloud's `colormap` and `rgb` modes

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -1306,7 +1306,7 @@ function settingsNode(
           ],
           value: colorMap,
         };
-        fields.opacity = {
+        fields.colorMapAlpha = {
           label: "Opacity",
           input: "number",
           step: 0.1,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -48,7 +48,7 @@ export type LayerSettingsPointCloudAndLaserScan = BaseSettings & {
   colorField: string | undefined;
   gradient: [string, string];
   colorMap: "turbo" | "rainbow";
-  colorMapAlpha: number;
+  explicitAlpha: number;
   rgbByteOrder: "rgba" | "bgra" | "abgr";
   minValue: number | undefined;
   maxValue: number | undefined;
@@ -95,7 +95,7 @@ const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
   colorField: undefined,
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
-  colorMapAlpha: 1,
+  explicitAlpha: 1,
   rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
   minValue: undefined,
   maxValue: undefined,
@@ -1123,9 +1123,8 @@ function colorHasTransparency(settings: LayerSettingsPointCloudAndLaserScan): bo
         stringToRgba(tempColor, settings.gradient[1]).a < 1.0
       );
     case "colormap":
-      return settings.colorMapAlpha < 1.0;
     case "rgb":
-      return false;
+      return settings.explicitAlpha < 1.0;
     case "rgba":
       // It's too expensive to check the alpha value of each color. Just assume it's transparent
       return true;
@@ -1233,7 +1232,7 @@ function settingsNode(
   const colorFieldOptions = msgFields.map((field) => ({ label: field, value: field }));
   const gradient = config.gradient;
   const colorMap = config.colorMap ?? "turbo";
-  const colorMapAlpha = config.colorMapAlpha ?? 1;
+  const explicitAlpha = config.explicitAlpha ?? 1;
   const rgbByteOrder = config.rgbByteOrder ?? "rgba";
   const minValue = config.minValue;
   const maxValue = config.maxValue;
@@ -1306,16 +1305,6 @@ function settingsNode(
           ],
           value: colorMap,
         };
-        fields.colorMapAlpha = {
-          label: "Opacity",
-          input: "number",
-          step: 0.1,
-          placeholder: "1",
-          precision: 3,
-          min: 0,
-          max: 1,
-          value: colorMapAlpha,
-        };
         break;
       case "rgb":
         fields.rgbByteOrder = {
@@ -1341,6 +1330,19 @@ function settingsNode(
           value: rgbByteOrder,
         };
         break;
+    }
+
+    if (colorMode === "colormap" || colorMode === "rgb") {
+      fields.explicitAlpha = {
+        label: "Opacity",
+        input: "number",
+        step: 0.1,
+        placeholder: "1",
+        precision: 3,
+        min: 0,
+        max: 1,
+        value: explicitAlpha,
+      };
     }
 
     fields.minValue = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -48,6 +48,7 @@ export type LayerSettingsPointCloudAndLaserScan = BaseSettings & {
   colorField: string | undefined;
   gradient: [string, string];
   colorMap: "turbo" | "rainbow";
+  colorMapAlpha: number;
   rgbByteOrder: "rgba" | "bgra" | "abgr";
   minValue: number | undefined;
   maxValue: number | undefined;
@@ -94,6 +95,7 @@ const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
   colorField: undefined,
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
+  colorMapAlpha: 1,
   rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
   minValue: undefined,
   maxValue: undefined,
@@ -1121,6 +1123,7 @@ function colorHasTransparency(settings: LayerSettingsPointCloudAndLaserScan): bo
         stringToRgba(tempColor, settings.gradient[1]).a < 1.0
       );
     case "colormap":
+      return settings.colorMapAlpha < 1.0;
     case "rgb":
       return false;
     case "rgba":
@@ -1230,6 +1233,7 @@ function settingsNode(
   const colorFieldOptions = msgFields.map((field) => ({ label: field, value: field }));
   const gradient = config.gradient;
   const colorMap = config.colorMap ?? "turbo";
+  const colorMapAlpha = config.colorMapAlpha ?? 1;
   const rgbByteOrder = config.rgbByteOrder ?? "rgba";
   const minValue = config.minValue;
   const maxValue = config.maxValue;
@@ -1301,6 +1305,16 @@ function settingsNode(
             { label: "Rainbow", value: "rainbow" },
           ],
           value: colorMap,
+        };
+        fields.opacity = {
+          label: "Opacity",
+          input: "number",
+          step: 0.1,
+          placeholder: "1",
+          precision: 3,
+          min: 0,
+          max: 1,
+          value: colorMapAlpha,
         };
         break;
       case "rgb":

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -48,11 +48,13 @@ export function getColorConverter(
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
             turboCached(output, t);
+            output.a = settings.colorMapAlpha;
           };
         case "rainbow":
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
             rainbow(output, t);
+            output.a = settings.colorMapAlpha;
           };
       }
       throw new Error(`Unrecognized color map: ${settings.colorMap}`);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -48,13 +48,13 @@ export function getColorConverter(
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
             turboCached(output, t);
-            output.a = settings.colorMapAlpha;
+            output.a = settings.explicitAlpha;
           };
         case "rainbow":
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
             rainbow(output, t);
-            output.a = settings.colorMapAlpha;
+            output.a = settings.explicitAlpha;
           };
       }
       throw new Error(`Unrecognized color map: ${settings.colorMap}`);
@@ -63,11 +63,20 @@ export function getColorConverter(
       switch (settings.rgbByteOrder) {
         default:
         case "rgba":
-          return getColorRgb;
+          return (output: ColorRGBA, colorValue: number) => {
+            getColorRgb(output, colorValue);
+            output.a = settings.explicitAlpha;
+          };
         case "bgra":
-          return getColorBgr;
+          return (output: ColorRGBA, colorValue: number) => {
+            getColorBgr(output, colorValue);
+            output.a = settings.explicitAlpha;
+          };
         case "abgr":
-          return getColor0bgr;
+          return (output: ColorRGBA, colorValue: number) => {
+            getColor0bgr(output, colorValue);
+            output.a = settings.explicitAlpha;
+          };
       }
     case "rgba":
       switch (settings.rgbByteOrder) {


### PR DESCRIPTION
**User-Facing Changes**
An "Opacity" topic setting now appears when using the `colormap` or `rgb` modes for PointClouds in the 3D (Beta) panel. This lets the user set the opacity (alpha) for the PointCloud.

**Description**
Transparency is very useful for point clouds, especially when the scene is cluttered with many renderables. There are 5 modes for viewing PointClouds in the 3D (Beta) panel. Previously, these were the ways that the user could control their opacity (alpha):

| *Mode* | *Could set alpha?* | *How to set alpha* |
| --- | --- | --- |
| `flat` | ✅ | Using the colorpicker. |
| `gradient` | ✅ | Using the colorpickers of the two gradient endpoints. |
| `rgba` | ✅ | From the alpha field in the PointCloud's user data. |
| `rgb` | ❌ | _Impossible to set alpha_ |
| `colormap` | ❌ | _Impossible to set alpha_ |

This PR adds an "Opacity" setting in the PointCloud's topic settings when the user is in either the `colormap` or `rgb` mode.
- "Opacity" defaults to 1 i.e. the previous behavior (fully opaque / no transparency).
- The explicit "Opacity" setting disappears when the user is not in either the `colormap` or `rgb` modes.

**Before**
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/6638091/183305742-d4e8b382-8b70-4db4-92e2-83be7a2f3e25.png">


**After**
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/6638091/183306865-375d81c9-1e56-4edb-9b34-06cdb46c1900.png">