### PR TITLE
Update rosmsg-serialization package

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -44,7 +44,7 @@
     "@foxglove/rosbag2-web": "4.0.4",
     "@foxglove/rosmsg": "3.0.0",
     "@foxglove/rosmsg-msgs-common": "1.1.0",
-    "@foxglove/rosmsg-serialization": "1.3.0",
+    "@foxglove/rosmsg-serialization": "1.5.0",
     "@foxglove/rosmsg2-serialization": "1.0.6",
     "@foxglove/rostime": "1.1.2",
     "@foxglove/schemas": "0.3.0",

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
@@ -319,7 +319,7 @@ describe("MemoryCacheDataProvider", () => {
       inputMessages.map((item) => ({
         topic: item.topic,
         receiveTime: item.receiveTime,
-        message: { _offset: 0, _view: new DataView(new ArrayBuffer(0)) },
+        message: {},
         sizeInBytes: 0,
       })),
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,21 +2431,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-serialization@npm:1.5.0":
+"@foxglove/rosmsg-serialization@npm:1.5.0, @foxglove/rosmsg-serialization@npm:^1.2.3, @foxglove/rosmsg-serialization@npm:^1.3.0":
   version: 1.5.0
   resolution: "@foxglove/rosmsg-serialization@npm:1.5.0"
   dependencies:
     "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
   checksum: ff56cc0b5643ec847ee8799e239b2f861eb63496ef9fcc174816e7fdc5e48178207a2b396f9f86f92e9c0101bda15bdb0bbb497b457ecf018b97527e213f3e8b
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg-serialization@npm:^1.2.3, @foxglove/rosmsg-serialization@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@foxglove/rosmsg-serialization@npm:1.3.0"
-  dependencies:
-    "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
-  checksum: 7e5875a96607aa70dc51e0e9d605016c89f4dde23e275d382133dcd02496cb320ff82a2e9d1c8e6e6957cc9d3ad7ee6434e30d7b9930e2a67ba6de7785823fb4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,7 +2431,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg-serialization@npm:1.3.0, @foxglove/rosmsg-serialization@npm:^1.2.3, @foxglove/rosmsg-serialization@npm:^1.3.0":
+"@foxglove/rosmsg-serialization@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@foxglove/rosmsg-serialization@npm:1.5.0"
+  dependencies:
+    "@foxglove/rosmsg": ^2.0.0 || ^3.0.0
+  checksum: ff56cc0b5643ec847ee8799e239b2f861eb63496ef9fcc174816e7fdc5e48178207a2b396f9f86f92e9c0101bda15bdb0bbb497b457ecf018b97527e213f3e8b
+  languageName: node
+  linkType: hard
+
+"@foxglove/rosmsg-serialization@npm:^1.2.3, @foxglove/rosmsg-serialization@npm:^1.3.0":
   version: 1.3.0
   resolution: "@foxglove/rosmsg-serialization@npm:1.3.0"
   dependencies:
@@ -2529,7 +2538,7 @@ __metadata:
     "@foxglove/rosbag2-web": 4.0.4
     "@foxglove/rosmsg": 3.0.0
     "@foxglove/rosmsg-msgs-common": 1.1.0
-    "@foxglove/rosmsg-serialization": 1.3.0
+    "@foxglove/rosmsg-serialization": 1.5.0
     "@foxglove/rosmsg2-serialization": 1.0.6
     "@foxglove/rostime": 1.1.2
     "@foxglove/schemas": 0.3.0


### PR DESCRIPTION
**User-Facing Changes**
This fixes a bug in message diffing in the raw messages panel

**Description**
This updates the rosmsg-serialization library to fix an issue with message diffs. The diffs no longer try to diff private fields since message private fields are now completely hidden as `#private` fields.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4040