### PR TITLE
Wait for previous emit state in tick

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -733,6 +733,9 @@ export class IterablePlayer implements Player {
     if (this._lastMessage) {
       // If the last message we saw is still ahead of the tick end time, we don't emit anything
       if (compare(this._lastMessage.receiveTime, end) > 0) {
+        // Wait for the previous render frame to finish
+        await this._emitState.currentPromise;
+
         this._currentTime = end;
         this._messages = msgEvents;
         this._emitState();


### PR DESCRIPTION


**User-Facing Changes**
Fixes bugs in the latching player when using a slow framerate or looping.

**Description**
In the iterable player, when the previous message is still past the target tick time, the logic would override the messages and current time without waiting on the current emitState to finish. This would result in overriding outgoing messages.

This change fixes this behavior to wait on any active emit state to finish before proceeding to emit state for the new message data.

Fixes: #4073
Fixes: #4057

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
