### PR TITLE
[New3D] fix crash when updating line strip to be empty

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -66,6 +66,14 @@ export class RenderableLineStrip extends RenderableMarker {
 
   override update(marker: Marker, receiveTime: bigint | undefined): void {
     const pointsLength = marker.points.length;
+    if (pointsLength === 0) {
+      this.linePrepass.visible = false;
+      this.line.visible = false;
+      return;
+    } else {
+      this.linePrepass.visible = true;
+      this.line.visible = true;
+    }
 
     const prevMarker = this.userData.marker;
     super.update(marker, receiveTime);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineStrip.ts
@@ -67,6 +67,8 @@ export class RenderableLineStrip extends RenderableMarker {
   override update(marker: Marker, receiveTime: bigint | undefined): void {
     const pointsLength = marker.points.length;
     if (pointsLength === 0) {
+      // THREE.LineGeometry.setPositions crashes when given an empty array:
+      // https://github.com/foxglove/studio/issues/3954
       this.linePrepass.visible = false;
       this.line.visible = false;
       return;


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash in the 3D (Beta) when a line strip marker was updated to have 0 points.

**Description**
Fixes #3954.

THREE.LineGeometry.setPositions does not handle an empty array: https://github.com/mrdoob/three.js/blob/38273fb9b2acde3f6046301757d9f1e5428f7d9d/examples/jsm/lines/LineGeometry.js#L15-L20

Avoid the crash by hiding the renderables and adding an early return when the new length is zero.