### PR TITLE
Merge loaded ranges for CachingIterableSource

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -346,10 +346,7 @@ describe("BufferedIterableSource", () => {
 
       await doneYield.wait();
 
-      expect(bufferedSource.loadedRanges()).toEqual([
-        { start: 0, end: 0.4999999999 },
-        { start: 0.5, end: 1 },
-      ]);
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
 
       {
         {
@@ -456,9 +453,6 @@ describe("BufferedIterableSource", () => {
     await messageIterator.next();
     await signal.wait();
     expect(count).toEqual(2);
-    expect(bufferedSource.loadedRanges()).toEqual([
-      { start: 0, end: 0.2 },
-      { start: 0.2000000001, end: 0.4000000001 },
-    ]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.4000000001 }]);
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -302,10 +302,7 @@ describe("CachingIterableSource", () => {
         });
       }
 
-      expect(bufferedSource.loadedRanges()).toEqual([
-        { start: 0, end: 0.4999999999 },
-        { start: 0.5, end: 1 },
-      ]);
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
     }
   });
 
@@ -372,10 +369,7 @@ describe("CachingIterableSource", () => {
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.5000000001, end: 0.9999999999 }]);
 
     await messageIterator.next();
-    expect(bufferedSource.loadedRanges()).toEqual([
-      { start: 0.5000000001, end: 0.9999999999 },
-      { start: 1, end: 1 },
-    ]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.5000000001, end: 1 }]);
   });
 
   it("should return fully cached when there is no data in the source", async () => {
@@ -622,10 +616,7 @@ describe("CachingIterableSource", () => {
         // no-op
       }
 
-      expect(bufferedSource.loadedRanges()).toEqual([
-        { start: 0, end: 0.1999999999 },
-        { start: 0.2, end: 1 },
-      ]);
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
     }
 
     // because we have cached we shouldn't be calling source anymore

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -437,9 +437,32 @@ class CachingIterableSource implements IIterableSource {
       return;
     }
 
-    this.loadedRangesCache = this.cache.map((block) => {
-      const start = Number(toNanoSec(block.start) - sourceStartNs) / rangeNs;
-      const end = Number(toNanoSec(block.end) - sourceStartNs) / rangeNs;
+    // Merge continuous ranges (i.e. a block that starts 1 nanosecond after previous ends)
+    // This avoids float rounding errors when computing loadedRangesCache and produces
+    // continuous ranges for continuous spans
+    const ranges: { start: bigint; end: bigint }[] = [];
+    let prevRange: { start: bigint; end: bigint } | undefined;
+    for (const block of this.cache) {
+      const range = {
+        start: toNanoSec(block.start),
+        end: toNanoSec(block.end),
+      };
+      if (!prevRange) {
+        prevRange = range;
+      } else if (prevRange.end + 1n === range.start) {
+        prevRange.end = range.end;
+      } else {
+        ranges.push(prevRange);
+        prevRange = range;
+      }
+    }
+    if (prevRange) {
+      ranges.push(prevRange);
+    }
+
+    this.loadedRangesCache = ranges.map((item) => {
+      const start = Number(item.start - sourceStartNs) / rangeNs;
+      const end = Number(item.end - sourceStartNs) / rangeNs;
       return { start, end };
     });
   }

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -440,7 +440,7 @@ class CachingIterableSource implements IIterableSource {
     // Merge continuous ranges (i.e. a block that starts 1 nanosecond after previous ends)
     // This avoids float rounding errors when computing loadedRangesCache and produces
     // continuous ranges for continuous spans
-    const ranges: { start: bigint; end: bigint }[] = [];
+    const ranges: { start: number; end: number }[] = [];
     let prevRange: { start: bigint; end: bigint } | undefined;
     for (const block of this.cache) {
       const range = {
@@ -452,19 +452,21 @@ class CachingIterableSource implements IIterableSource {
       } else if (prevRange.end + 1n === range.start) {
         prevRange.end = range.end;
       } else {
-        ranges.push(prevRange);
+        ranges.push({
+          start: Number(prevRange.start - sourceStartNs) / rangeNs,
+          end: Number(prevRange.end - sourceStartNs) / rangeNs,
+        });
         prevRange = range;
       }
     }
     if (prevRange) {
-      ranges.push(prevRange);
+      ranges.push({
+        start: Number(prevRange.start - sourceStartNs) / rangeNs,
+        end: Number(prevRange.end - sourceStartNs) / rangeNs,
+      });
     }
 
-    this.loadedRangesCache = ranges.map((item) => {
-      const start = Number(item.start - sourceStartNs) / rangeNs;
-      const end = Number(item.end - sourceStartNs) / rangeNs;
-      return { start, end };
-    });
+    this.loadedRangesCache = ranges;
   }
 
   // Purge the oldest cache block if adding sizeInBytes to the cache would exceed the maxTotalSizeBytes


### PR DESCRIPTION

**User-Facing Changes**
No more erroneous single black pixel gaps in the playback scrubber when all the data is actually present and there is no gap.

**Description**
When converting the underlying cache blocks to the normalized range [0, 1], each start/end time would be converted to float and normalized. This left "gaps" between consecutive blocks (those separated by only 1 nanosecond).

This change considers consecutive blocks as part of the same range and grows the range to avoid gaps. The final float conversion happens once the merged consecutive ranges are calculated.

Fixes: #4075

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
