### PR TITLE
fixes for PointsAnnotation handling

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -21,7 +21,7 @@
     "prepack": "tsc -b"
   },
   "devDependencies": {
-    "@foxglove/schemas": "0.3.0",
+    "@foxglove/schemas": "0.4.0",
     "@types/zstd-codec": "workspace:*",
     "typescript": "4.6.2"
   },

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -47,7 +47,7 @@
     "@foxglove/rosmsg-serialization": "1.5.0",
     "@foxglove/rosmsg2-serialization": "1.0.6",
     "@foxglove/rostime": "1.1.2",
-    "@foxglove/schemas": "0.3.0",
+    "@foxglove/schemas": "0.4.0",
     "@foxglove/studio": "workspace:*",
     "@foxglove/three-text": "workspace:*",
     "@foxglove/ulog": "2.1.2",

--- a/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.test.ts
+++ b/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.test.ts
@@ -4,6 +4,7 @@
 
 import { AVLTree } from "@foxglove/avl";
 import { Time, compare as compareTime, toNanoSec } from "@foxglove/rostime";
+import { ImageAnnotations } from "@foxglove/schemas/schemas/typescript";
 import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 
 import { synchronizedAddMessage, SynchronizationItem } from "./useImagePanelMessages";
@@ -23,17 +24,19 @@ function GenerateImage(stamp: Time): FoxgloveMessages["foxglove.CompressedImage"
   };
 }
 
-function GenerateAnnotations(stamp: Time): FoxgloveMessages["foxglove.ImageAnnotations"] {
+function GenerateAnnotations(stamp: Time): ImageAnnotations {
   return {
     circles: [
       {
-        timestamp: toNanoSec(stamp),
+        timestamp: stamp,
         diameter: 1,
         position: { x: 0, y: 0 },
         thickness: 1,
         outline_color: { r: 0, g: 0, b: 0, a: 1 },
+        fill_color: { r: 0, g: 0, b: 0, a: 1 },
       },
     ],
+    points: [],
   };
 }
 
@@ -178,22 +181,11 @@ describe("synchronizedAddMessage", () => {
           Object.entries({
             "/annotation": [
               {
-                fillColor: undefined,
-                outlineColor: {
-                  a: 1,
-                  b: 0,
-                  g: 0,
-                  r: 0,
-                },
-                position: {
-                  x: 0,
-                  y: 0,
-                },
+                fillColor: { r: 0, g: 0, b: 0, a: 1 },
+                outlineColor: { a: 1, b: 0, g: 0, r: 0 },
+                position: { x: 0, y: 0 },
                 radius: 0.5,
-                stamp: {
-                  nsec: 0,
-                  sec: 2,
-                },
+                stamp: { nsec: 0, sec: 2 },
                 thickness: 1,
                 type: "circle",
               },

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -4,31 +4,37 @@
 
 import { filterMap } from "@foxglove/den/collection";
 import { fromNanoSec } from "@foxglove/rostime";
+import { ImageAnnotations, type PointsAnnotationType } from "@foxglove/schemas/schemas/typescript";
 import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 import {
   ImageMarker,
   ImageMarkerArray,
   ImageMarkerType,
 } from "@foxglove/studio-base/types/Messages";
+import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
 import type { Annotation, PointsAnnotation } from "../types";
 
-function foxglovePointTypeToStyle(type: number): PointsAnnotation["style"] | undefined {
+function foxglovePointTypeToStyle(
+  type: PointsAnnotationType,
+): PointsAnnotation["style"] | undefined {
   switch (type) {
-    case 0:
+    // casting required for now because enum imports don't work: https://github.com/foxglove/schemas/issues/41
+    case 0 as PointsAnnotationType.UNKNOWN:
+    case 1 as PointsAnnotationType.POINTS:
       return "points";
-    case 1:
+    case 2 as PointsAnnotationType.LINE_LOOP:
       return "polygon";
-    case 2:
+    case 3 as PointsAnnotationType.LINE_STRIP:
       return "line_strip";
-    case 3:
+    case 4 as PointsAnnotationType.LINE_LIST:
       return "line_list";
   }
   return undefined;
 }
 
 function normalizeFoxgloveImageAnnotations(
-  message: FoxgloveMessages["foxglove.ImageAnnotations"],
+  message: Partial<ImageAnnotations>,
 ): Annotation[] | undefined {
   if (!message.circles && !message.points) {
     return undefined;
@@ -66,8 +72,8 @@ function normalizeFoxgloveImageAnnotations(
       style,
       points: point.points,
       outlineColors: point.outline_colors,
-      outlineColor: point.outline_color,
-      thickness: point.thickness,
+      outlineColor: mightActuallyBePartial(point).outline_color ?? { r: 1, g: 1, b: 1, a: 1 },
+      thickness: mightActuallyBePartial(point).thickness ?? 1,
       fillColor: point.fill_color,
     });
   }

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -5,7 +5,6 @@
 import { filterMap } from "@foxglove/den/collection";
 import { fromNanoSec } from "@foxglove/rostime";
 import { ImageAnnotations, type PointsAnnotationType } from "@foxglove/schemas/schemas/typescript";
-import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 import {
   ImageMarker,
   ImageMarkerArray,
@@ -198,9 +197,7 @@ function normalizeAnnotations(
     case "foxglove_msgs/ImageAnnotations":
     case "foxglove_msgs/msg/ImageAnnotations":
     case "foxglove.ImageAnnotations": {
-      return normalizeFoxgloveImageAnnotations(
-        message as FoxgloveMessages["foxglove.ImageAnnotations"],
-      );
+      return normalizeFoxgloveImageAnnotations(message as ImageAnnotations);
     }
   }
 

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -5,7 +5,8 @@
 import { Story } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useCompressedImage, cameraInfo, annotations } from "../storySupport";
+import { useCompressedImage, cameraInfo, annotations, foxgloveAnnotations } from "../storySupport";
+import { normalizeAnnotations } from "./normalizeAnnotations";
 import { renderImage } from "./renderImage";
 
 export default {
@@ -124,3 +125,45 @@ export const MarkersWithRotations: Story = (_args) => {
     </div>
   );
 };
+
+export function FoxgloveAnnotations(): JSX.Element {
+  const imageMessage = useCompressedImage();
+  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+
+  const width = 400;
+  const height = 300;
+
+  useEffect(() => {
+    if (!canvasRef.current) {
+      return;
+    }
+
+    canvasRef.current.width = 2 * width;
+    canvasRef.current.height = 2 * height;
+
+    void renderImage({
+      canvas: canvasRef.current,
+      hitmapCanvas: undefined,
+      geometry: {
+        flipHorizontal: false,
+        flipVertical: false,
+        panZoom: { x: 0, y: 0, scale: 1 },
+        rotation: 0,
+        viewport: { width, height },
+        zoomMode: "fill",
+      },
+      imageMessage,
+      rawMarkerData: {
+        markers: normalizeAnnotations(foxgloveAnnotations, "foxglove.ImageAnnotations")!,
+        cameraInfo,
+        transformMarkers: false,
+      },
+    });
+  }, [imageMessage]);
+
+  return (
+    <div style={{ backgroundColor: "white", padding: "1rem" }}>
+      <canvas ref={canvasRef} style={{ width, height }} />
+    </div>
+  );
+}

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -388,8 +388,6 @@ function paintPointsAnnotation(
   cameraModel: PinholeCameraModel | undefined,
   panZoom: PanZoom,
 ) {
-  const thickness = annotation.thickness ?? 1;
-
   switch (annotation.style) {
     case "points": {
       for (let i = 0; i < annotation.points.length; i++) {
@@ -407,11 +405,27 @@ function paintPointsAnnotation(
 
         // For points small enough to be visually indistinct at our current zoom level
         // we do a fast render.
-        const size = thickness * panZoom.scale;
+        const size = annotation.thickness * panZoom.scale;
         if (size <= FAST_POINT_SIZE_THRESHOlD) {
-          paintFastPoint(ctx, point, thickness, thickness, undefined, fillColor, cameraModel);
+          paintFastPoint(
+            ctx,
+            point,
+            annotation.thickness,
+            annotation.thickness,
+            undefined,
+            fillColor,
+            cameraModel,
+          );
         } else {
-          paintCircle(ctx, point, thickness, thickness, undefined, fillColor, cameraModel);
+          paintCircle(
+            ctx,
+            point,
+            annotation.thickness,
+            annotation.thickness,
+            undefined,
+            fillColor,
+            cameraModel,
+          );
         }
       }
       break;
@@ -435,12 +449,7 @@ function paintPointsAnnotation(
           ctx.fill();
         }
       }
-      if (
-        annotation.outlineColor &&
-        annotation.outlineColor.a > 0 &&
-        annotation.thickness != undefined &&
-        annotation.thickness > 0
-      ) {
+      if (annotation.outlineColor && annotation.outlineColor.a > 0 && annotation.thickness > 0) {
         ctx.strokeStyle = toRGBA(annotation.outlineColor);
         ctx.lineWidth = annotation.thickness;
         ctx.stroke();
@@ -448,10 +457,6 @@ function paintPointsAnnotation(
       break;
     }
     case "line_list": {
-      if (annotation.points.length % 2 !== 0) {
-        break;
-      }
-
       const hasExactColors = annotation.outlineColors.length === annotation.points.length / 2;
 
       for (let i = 0; i < annotation.points.length; i += 2) {
@@ -468,7 +473,7 @@ function paintPointsAnnotation(
           ctx,
           annotation.points[i]!,
           annotation.points[i + 1]!,
-          thickness,
+          annotation.thickness,
           outlineColor ?? { r: 0, g: 0, b: 0, a: 1 },
           cameraModel,
         );

--- a/packages/studio-base/src/panels/Image/storySupport/annotations.ts
+++ b/packages/studio-base/src/panels/Image/storySupport/annotations.ts
@@ -198,6 +198,7 @@ const outlineColors = [
   { r: 1, g: 0, b: 1, a: 1 },
 ];
 export const foxgloveAnnotations: ImageAnnotations = {
+  circles: [],
   points: [
     {
       timestamp: { sec: 0, nsec: 0 },

--- a/packages/studio-base/src/panels/Image/storySupport/annotations.ts
+++ b/packages/studio-base/src/panels/Image/storySupport/annotations.ts
@@ -4,6 +4,7 @@
 
 import { range } from "lodash";
 
+import { ImageAnnotations } from "@foxglove/schemas/schemas/typescript";
 import { normalizeAnnotations } from "@foxglove/studio-base/panels/Image/lib/normalizeAnnotations";
 import { ImageMarker, ImageMarkerType } from "@foxglove/studio-base/types/Messages";
 
@@ -179,6 +180,60 @@ const markers: ImageMarker[] = [
   }),
 ];
 
-const annotations = normalizeAnnotations({ markers }, "foxglove_msgs/ImageMarkerArray") ?? [];
+export const annotations =
+  normalizeAnnotations({ markers }, "foxglove_msgs/ImageMarkerArray") ?? [];
 
-export { annotations };
+const points = [
+  { x: 40, y: 40 },
+  { x: 70, y: 80 },
+  { x: 40, y: 120 },
+  { x: 110, y: 90 },
+  { x: 150, y: 50 },
+];
+const outlineColors = [
+  { r: 1, g: 0, b: 0, a: 1 },
+  { r: 0, g: 1, b: 0, a: 1 },
+  { r: 0, g: 0, b: 1, a: 1 },
+  { r: 1, g: 1, b: 0, a: 1 },
+  { r: 1, g: 0, b: 1, a: 1 },
+];
+export const foxgloveAnnotations: ImageAnnotations = {
+  points: [
+    {
+      timestamp: { sec: 0, nsec: 0 },
+      type: 1,
+      points,
+      outline_colors: outlineColors,
+      outline_color: { r: 1, g: 0.5, b: 0, a: 1 },
+      fill_color: { r: 1, g: 0, b: 0, a: 1 },
+      thickness: 10,
+    },
+    {
+      timestamp: { sec: 0, nsec: 0 },
+      type: 2,
+      points: points.map(({ x, y }) => ({ x: x + 130, y })),
+      outline_colors: outlineColors,
+      outline_color: { r: 1, g: 0.5, b: 0, a: 1 },
+      fill_color: { r: 1, g: 0, b: 0, a: 1 },
+      thickness: 5,
+    },
+    {
+      timestamp: { sec: 0, nsec: 0 },
+      type: 3,
+      points: points.map(({ x, y }) => ({ x, y: y + 100 })),
+      outline_colors: outlineColors,
+      outline_color: { r: 1, g: 0.5, b: 0, a: 1 },
+      fill_color: { r: 1, g: 0, b: 0, a: 1 },
+      thickness: 5,
+    },
+    {
+      timestamp: { sec: 0, nsec: 0 },
+      type: 4,
+      points: points.map(({ x, y }) => ({ x: x + 130, y: y + 100 })),
+      outline_colors: outlineColors,
+      outline_color: { r: 1, g: 0.5, b: 0, a: 1 },
+      fill_color: { r: 1, g: 0, b: 0, a: 1 },
+      thickness: 5,
+    },
+  ],
+};

--- a/packages/studio-base/src/panels/Image/types.ts
+++ b/packages/studio-base/src/panels/Image/types.ts
@@ -106,7 +106,7 @@ export type PointsAnnotation = {
   points: readonly Point2D[];
   outlineColors: readonly Color[];
   outlineColor?: Color;
-  thickness?: number;
+  thickness: number;
   fillColor?: Color;
 };
 

--- a/packages/studio-base/src/types/FoxgloveMessages.ts
+++ b/packages/studio-base/src/types/FoxgloveMessages.ts
@@ -34,20 +34,6 @@ export type FoxgloveMessages = {
     R?: readonly number[];
   };
 
-  "foxglove.ImageAnnotations": {
-    circles?: Array<FoxgloveMessages["foxglove.ImageAnnotations.Circle"]>;
-    points?: Array<FoxgloveMessages["foxglove.ImageAnnotations.Points"]>;
-  };
-
-  "foxglove.ImageAnnotations.Circle": {
-    timestamp: bigint | { sec: number; nsec: number };
-    position: FoxgloveMessages["foxglove.ImageAnnotations.Point2D"];
-    diameter: number;
-    thickness: number;
-    fill_color?: FoxgloveMessages["foxglove.Color"];
-    outline_color: FoxgloveMessages["foxglove.Color"];
-  };
-
   "foxglove.Color": {
     r: number;
     g: number;
@@ -57,21 +43,6 @@ export type FoxgloveMessages = {
 
   "foxglove.GeoJSON": {
     geojson: string;
-  };
-
-  "foxglove.ImageAnnotations.Point2D": {
-    x: number;
-    y: number;
-  };
-
-  "foxglove.ImageAnnotations.Points": {
-    timestamp: bigint | { sec: number; nsec: number };
-    type: number;
-    points: Array<FoxgloveMessages["foxglove.ImageAnnotations.Point2D"]>;
-    outline_colors: Array<FoxgloveMessages["foxglove.Color"]>;
-    outline_color?: FoxgloveMessages["foxglove.Color"];
-    fill_color?: FoxgloveMessages["foxglove.Color"];
-    thickness: number;
   };
 
   "foxglove.RawImage": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2489,6 +2489,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/schemas@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@foxglove/schemas@npm:0.4.0"
+  dependencies:
+    "@foxglove/rosmsg-msgs-common": ^1.0.4
+    tslib: ^2
+  checksum: 76abd73451cbbf0885c3ab834b17f0d3ed9bb59b0201f48790ececf1b4d2b6a69dbffb0e081ee055e760418924ade2403f2078889b015094cf0fb92b123168f8
+  languageName: node
+  linkType: hard
+
 "@foxglove/schemas@npm:^0.2.0":
   version: 0.2.0
   resolution: "@foxglove/schemas@npm:0.2.0"
@@ -2532,7 +2542,7 @@ __metadata:
     "@foxglove/rosmsg-serialization": 1.5.0
     "@foxglove/rosmsg2-serialization": 1.0.6
     "@foxglove/rostime": 1.1.2
-    "@foxglove/schemas": 0.3.0
+    "@foxglove/schemas": 0.4.0
     "@foxglove/studio": "workspace:*"
     "@foxglove/three-text": "workspace:*"
     "@foxglove/ulog": 2.1.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,7 +2315,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
-    "@foxglove/schemas": 0.3.0
+    "@foxglove/schemas": 0.4.0
     "@foxglove/wasm-bz2": 0.1.0
     "@protobufjs/base64": 1.1.2
     "@types/zstd-codec": "workspace:*"
@@ -2476,16 +2476,6 @@ __metadata:
     avl: ^1.5.3
     eventemitter3: ^4.0.7
   checksum: d109eaf5bef135afe0f7c8636c6147ede65999e50cb9c7c5b9016bacaf87d2a603eb0a258a57c9e2003ec3e2baa6334789076fe3b4bf397bb92154ba8cb1a27d
-  languageName: node
-  linkType: hard
-
-"@foxglove/schemas@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@foxglove/schemas@npm:0.3.0"
-  dependencies:
-    "@foxglove/rosmsg-msgs-common": ^1.0.4
-    tslib: ^2
-  checksum: d0cdcaf9ec264f5395b3636b5fd11925f8893d31dbe9ed1d4de7c988b8aa6d7b6580728d9cbe0b4504c511324835f8bfea02656facb1f0a5c66f4fd4be043b39
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed issues with the Image panel's handling of `foxglove.PointsAnnotation` messages.

**Description**
- Allow odd number of points with LINE_LIST
- Handle missing outline_color and thickness properties since these were not documented as part of the schema
- Fix interpretation of `type` values

Fixes https://github.com/foxglove/studio/issues/4080