### PR TITLE
Flash variable when changed by slider

### DIFF
--- a/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
@@ -21,7 +21,7 @@ import {
   InputBase,
 } from "@mui/material";
 import { pick } from "lodash";
-import { useMemo, useCallback, useState } from "react";
+import { useMemo, useCallback, useState, useRef } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import JsonInput from "@foxglove/studio-base/components/JsonInput";
@@ -183,8 +183,14 @@ export default function Variable({
 
   const nameIsInError = name !== editedName && globalVariables[editedName] != undefined;
 
+  const rootRef = useRef<HTMLDivElement>(ReactNull);
+
+  const activeElementIsChild = rootRef.current?.contains(document.activeElement) === true;
+
+  const isSelected = selected && !activeElementIsChild;
+
   return (
-    <Stack className={classes.root}>
+    <Stack className={classes.root} ref={rootRef}>
       <ListItem
         dense
         disablePadding
@@ -210,7 +216,7 @@ export default function Variable({
                   )
                 }
               >
-                <LinkIcon color={selected ? "primary" : "info"} style={{ opacity: 0.8 }} />
+                <LinkIcon color={isSelected ? "primary" : "info"} style={{ opacity: 0.8 }} />
               </Tooltip>
             )}
             <IconButton
@@ -259,7 +265,7 @@ export default function Variable({
       >
         <ListItemButton
           className={classes.listItemButton}
-          selected={selected}
+          selected={isSelected}
           onClick={() => setOpen(!open)}
         >
           <ListItemText

--- a/packages/studio-base/src/components/VariablesSidebar/index.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/index.tsx
@@ -19,16 +19,6 @@ import helpContent from "./index.help.md";
 
 const ANIMATION_RESET_DELAY_MS = 1500;
 
-function isActiveElementEditable(): boolean {
-  const activeEl = document.activeElement;
-  return (
-    activeEl != undefined &&
-    ((activeEl as HTMLElement).isContentEditable ||
-      activeEl.tagName === "INPUT" ||
-      activeEl.tagName === "TEXTAREA")
-  );
-}
-
 export default function VariablesSidebar(): ReactElement {
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
   const { linkedGlobalVariablesByName } = useLinkedGlobalVariables();
@@ -50,7 +40,7 @@ export default function VariablesSidebar(): ReactElement {
   const [changedVariables, setChangedVariables] = useState<string[]>([]);
 
   useEffect(() => {
-    if (skipAnimation.current || isActiveElementEditable()) {
+    if (skipAnimation.current) {
       previousGlobalVariablesRef.current = globalVariables;
       return;
     }


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with animation in the variables sidebar.

**Description**
The fix here is to only skip the animation when the active element is a child of the variable, not any input in the app.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4090