### PR TITLE
clean up workarounds for webpack bug that has been fixed

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "@types/copy-webpack-plugin": "10.1.0",
     "copy-webpack-plugin": "10.2.4",
-    "webpack": "5.68.0"
+    "webpack": "5.74.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "typescript": "4.6.2",
     "typescript-plugin-css-modules": "3.4.0",
     "utif": "3.1.0",
-    "webpack": "5.68.0",
+    "webpack": "5.74.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-server": "4.7.4",
     "webpack-hot-middleware": "2.25.1"

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -212,7 +212,7 @@
     "use-pan-and-zoom": "0.6.5",
     "uuid": "8.3.2",
     "wasm-lz4": "2.0.0",
-    "webpack": "5.68.0",
+    "webpack": "5.74.0",
     "xacro-parser": "0.3.8",
     "zustand": "4.0.0"
   }

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -31,8 +31,6 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const MESSAGE_RATES = [1, 3, 5, 10, 15, 20, 30, 60];
 
-const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
-
 const useStyles = makeStyles()({
   autocompleteInput: {
     "&.MuiOutlinedInput-input": {
@@ -279,7 +277,10 @@ function RosPackagePath(): React.ReactElement {
     AppSetting.ROS_PACKAGE_PATH,
   );
 
-  const rosPackagePathPlaceholder = useMemo(() => os?.getEnvVar("ROS_PACKAGE_PATH"), []);
+  const rosPackagePathPlaceholder = useMemo(
+    () => OsContextSingleton?.getEnvVar("ROS_PACKAGE_PATH"),
+    [],
+  );
 
   return (
     <TextField
@@ -305,7 +306,7 @@ export default function Preferences(): React.ReactElement {
   // electron-updater does not provide a way to detect if we are on a supported update platform
   // so we hard-code linux as an _unsupported_ auto-update platform since we cannot auto-update
   // with our .deb package install method on linux.
-  const supportsAppUpdates = isDesktopApp() && os?.platform !== "linux";
+  const supportsAppUpdates = isDesktopApp() && OsContextSingleton?.platform !== "linux";
 
   const { classes } = useStyles();
 

--- a/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
@@ -11,8 +11,6 @@ import {
 import Ros1Player from "@foxglove/studio-base/players/Ros1Player";
 import { Player } from "@foxglove/studio-base/players/types";
 
-const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
-
 class Ros1SocketDataSourceFactory implements IDataSourceFactory {
   id = "ros1-socket";
   type: IDataSourceFactory["type"] = "connection";
@@ -27,14 +25,18 @@ class Ros1SocketDataSourceFactory implements IDataSourceFactory {
       {
         id: "url",
         label: "ROS_MASTER_URI",
-        defaultValue: os?.getEnvVar("ROS_MASTER_URI") ?? "http://localhost:11311",
+        defaultValue: OsContextSingleton?.getEnvVar("ROS_MASTER_URI") ?? "http://localhost:11311",
         description: "Tells ROS nodes where they can locate the master",
       },
       {
         id: "hostname",
         label: "ROS_HOSTNAME",
-        defaultValue: os
-          ? RosNode.GetRosHostname(os.getEnvVar, os.getHostname, os.getNetworkInterfaces)
+        defaultValue: OsContextSingleton
+          ? RosNode.GetRosHostname(
+              OsContextSingleton.getEnvVar,
+              OsContextSingleton.getHostname,
+              OsContextSingleton.getNetworkInterfaces,
+            )
           : "localhost",
         description: "Acts as the declared network address of a ROS node or tool",
       },

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -149,8 +149,7 @@ export default class Ros2Player implements Player {
   }
 
   private _open = async (): Promise<void> => {
-    const os = OsContextSingleton;
-    if (this._closed || os == undefined) {
+    if (this._closed || OsContextSingleton == undefined) {
       return;
     }
     this._presence = PlayerPresence.INITIALIZING;
@@ -161,10 +160,10 @@ export default class Ros2Player implements Player {
 
     if (this._rosNode == undefined) {
       const rosNode = new RosNode({
-        name: `/foxglovestudio_${os.pid}`,
+        name: `/foxglovestudio_${OsContextSingleton.pid}`,
         domainId: this._domainId,
         udpSocketCreate,
-        getNetworkInterfaces: os.getNetworkInterfaces,
+        getNetworkInterfaces: OsContextSingleton.getNetworkInterfaces,
         log: rosLog,
       });
       this._rosNode = rosNode;

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -18,14 +18,12 @@ import IAnalytics, {
 
 const log = Logger.getLogger("Analytics");
 
-const os = OsContextSingleton; // workaround for https://github.com/webpack/webpack/issues/12960
-
 export class AmplitudeAnalytics implements IAnalytics {
   private _amp?: AmplitudeClient;
 
   constructor(options: { enableTelemetry: boolean; amplitudeApiKey?: string }) {
     const platform = getPlatformName();
-    const appVersion = os?.getAppVersion();
+    const appVersion = OsContextSingleton?.getAppVersion();
     const { glVendor, glRenderer } = getWebGLInfo() ?? {
       glVendor: "(unknown)",
       glRenderer: "(unknown)",
@@ -94,7 +92,7 @@ export class AmplitudeAnalytics implements IAnalytics {
 }
 
 function getPlatformName(): string {
-  const platform = os?.platform ?? "web";
+  const platform = OsContextSingleton?.platform ?? "web";
   switch (platform) {
     case "darwin":
       return "macOS";

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,6 @@
   "devDependencies": {
     "@types/copy-webpack-plugin": "10.1.0",
     "copy-webpack-plugin": "10.2.4",
-    "webpack": "5.68.0"
+    "webpack": "5.74.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,7 +2697,7 @@ __metadata:
     use-pan-and-zoom: 0.6.5
     uuid: 8.3.2
     wasm-lz4: 2.0.0
-    webpack: 5.68.0
+    webpack: 5.74.0
     xacro-parser: 0.3.8
     zustand: 4.0.0
   languageName: unknown
@@ -5690,13 +5690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.0":
-  version: 3.7.1
-  resolution: "@types/eslint-scope@npm:3.7.1"
+"@types/eslint-scope@npm:^3.7.3":
+  version: 3.7.4
+  resolution: "@types/eslint-scope@npm:3.7.4"
   dependencies:
     "@types/eslint": "*"
     "@types/estree": "*"
-  checksum: 4271c9adad19ad8a1d23062d9020468a51c7f81594b12b8e68f7d460c09e14d57cae3e82b077c402766369c0c17e2de72da72c405fa465d18a46c0b14ce92530
+  checksum: ea6a9363e92f301cd3888194469f9ec9d0021fe0a397a97a6dd689e7545c75de0bd2153dfb13d3ab532853a278b6572c6f678ce846980669e41029d205653460
   languageName: node
   linkType: hard
 
@@ -5710,10 +5710,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^0.0.50":
-  version: 0.0.50
-  resolution: "@types/estree@npm:0.0.50"
-  checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
+"@types/estree@npm:*, @types/estree@npm:^0.0.51":
+  version: 0.0.51
+  resolution: "@types/estree@npm:0.0.51"
+  checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
   languageName: node
   linkType: hard
 
@@ -7241,12 +7241,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.7.0":
-  version: 8.7.0
-  resolution: "acorn@npm:8.7.0"
+"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.7.0, acorn@npm:^8.7.1":
+  version: 8.8.0
+  resolution: "acorn@npm:8.8.0"
   bin:
     acorn: bin/acorn
-  checksum: e0f79409d68923fbf1aa6d4166f3eedc47955320d25c89a20cc822e6ba7c48c5963d5bc657bc242d68f7a4ac9faf96eef033e8f73656da6c640d4219935fdfd0
+  checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
   languageName: node
   linkType: hard
 
@@ -11412,13 +11412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.8.3":
-  version: 5.8.3
-  resolution: "enhanced-resolve@npm:5.8.3"
+"enhanced-resolve@npm:^5.0.0, enhanced-resolve@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "enhanced-resolve@npm:5.10.0"
   dependencies:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
-  checksum: d79fbe531106448b768bb0673fb623ec0202d7ee70373ab7d4f4745d5dfe0806f38c9db7e7da8c941288fe475ab3d538db3791fce522056eeea40ca398c9e287
+  checksum: 0bb9830704db271610f900e8d79d70a740ea16f251263362b0c91af545576d09fe50103496606c1300a05e588372d6f9780a9bc2e30ce8ef9b827ec8f44687ff
   languageName: node
   linkType: hard
 
@@ -13052,7 +13052,7 @@ __metadata:
     typescript: 4.6.2
     typescript-plugin-css-modules: 3.4.0
     utif: 3.1.0
-    webpack: 5.68.0
+    webpack: 5.74.0
     webpack-cli: 4.9.2
     webpack-dev-server: 4.7.4
     webpack-hot-middleware: 2.25.1
@@ -16292,7 +16292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.0":
+"json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
@@ -24992,13 +24992,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.2.0, watchpack@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "watchpack@npm:2.3.1"
+"watchpack@npm:^2.2.0, watchpack@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "watchpack@npm:2.4.0"
   dependencies:
     glob-to-regexp: ^0.4.1
     graceful-fs: ^4.1.2
-  checksum: 70a34f92842d94b5d842980f866d568d7a467de667c96ae5759c759f46587e49265863171f4650bdbafc5f3870a28f2b4453e9e847098ec4b718b38926d47d22
+  checksum: 23d4bc58634dbe13b86093e01c6a68d8096028b664ab7139d58f0c37d962d549a940e98f2f201cecdabd6f9c340338dc73ef8bf094a2249ef582f35183d1a131
   languageName: node
   linkType: hard
 
@@ -25041,7 +25041,7 @@ __metadata:
     "@foxglove/studio-base": "workspace:*"
     "@types/copy-webpack-plugin": 10.1.0
     copy-webpack-plugin: 10.2.4
-    webpack: 5.68.0
+    webpack: 5.74.0
   languageName: unknown
   linkType: soft
 
@@ -25319,40 +25319,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.68.0, webpack@npm:^5.1.0, webpack@npm:^5.9.0":
-  version: 5.68.0
-  resolution: "webpack@npm:5.68.0"
+"webpack@npm:5.74.0, webpack@npm:^5.1.0, webpack@npm:^5.9.0":
+  version: 5.74.0
+  resolution: "webpack@npm:5.74.0"
   dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.50
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
     "@webassemblyjs/ast": 1.11.1
     "@webassemblyjs/wasm-edit": 1.11.1
     "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.4.1
+    acorn: ^8.7.1
     acorn-import-assertions: ^1.7.6
     browserslist: ^4.14.5
     chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.8.3
+    enhanced-resolve: ^5.10.0
     es-module-lexer: ^0.9.0
     eslint-scope: 5.1.1
     events: ^3.2.0
     glob-to-regexp: ^0.4.1
     graceful-fs: ^4.2.9
-    json-parse-better-errors: ^1.0.2
+    json-parse-even-better-errors: ^2.3.1
     loader-runner: ^4.2.0
     mime-types: ^2.1.27
     neo-async: ^2.6.2
     schema-utils: ^3.1.0
     tapable: ^2.1.1
     terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.3.1
+    watchpack: ^2.4.0
     webpack-sources: ^3.2.3
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: ac6efd861a0bfb35d8a467fba0d87f905ef6e1a9a9f7e3db42ea459cf191268094cedd025d3eb36a1464e2208a0c193f3f4a92531ba58850246f3c6b8f210b03
+  checksum: 320c41369a75051b19e18c63f408b3dcc481852e992f83d311771c5ec0f05f2946385e8ebef62030cf3587f0a3d2f12779ffdb191569a966847289ba7313f946
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Upgrades webpack and removes the workaround for https://github.com/webpack/webpack/issues/12960 introduced in https://github.com/foxglove/studio/pull/1638. The bug was fixed upstream in webpack 5.71.0.
