### PR TITLE
Fix uncontrolled component react warning

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -91,7 +91,7 @@ function ExperimentalFeatureItem(props: { feature: Feature }) {
       control={
         <Checkbox
           className={classes.checkbox}
-          checked={enabled}
+          checked={enabled ?? false}
           onChange={(_, checked) => void setEnabled(checked)}
         />
       }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes a react warning triggered by checkboxes in the experimental features preferences section.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4117