### PR TITLE
Apply custom topic colors to geoJSON messages

### DIFF
--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -268,9 +268,8 @@ SinglePointFullCovariance.parameters = {
 };
 
 export const GeoJSON = (): JSX.Element => {
-  return <MapPanel />;
+  return <MapPanel overrideConfig={{ topicColors: { "/geo": "#00ffaa", "/gps": "#ffc0cb" } }} />;
 };
-
 GeoJSON.parameters = {
   chromatic: {
     delay: 1000,


### PR DESCRIPTION
**User-Facing Changes**
Apply custom colors to geoJSON messages in the map panel.

**Description**
This applies custom colors to geoJSON messages in the map panel.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4111