### PR TITLE
Expand state transition color palette

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.stories.tsx
@@ -17,6 +17,7 @@ import TestUtils from "react-dom/test-utils";
 import { BlockCache } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+import { expandedLineColors } from "@foxglove/studio-base/util/plotColors";
 
 import StateTransitions from "./index";
 
@@ -75,6 +76,7 @@ const fixture = {
   ),
   topics: [
     { name: "/some/topic/with/state", datatype: "msgs/SystemState" },
+    { name: "/some/topic/with/string_state", datatype: "msgs/SystemState" },
     { name: "/blocks", datatype: "msgs/SystemState" },
   ],
   activeData: {
@@ -90,6 +92,15 @@ const fixture = {
       message: { ...message, data: { value: idx } },
       sizeInBytes: 0,
     })),
+    "/some/topic/with/string_state": systemStateMessages.map((message, idx) => {
+      const values = "abcdefghijklmnopqrstuvwxyz".split("");
+      return {
+        topic: "/some/topic/with/string_state",
+        receiveTime: message.header.stamp,
+        message: { ...message, data: { value: values[idx % values.length] } },
+        sizeInBytes: 0,
+      };
+    }),
   },
 };
 
@@ -102,6 +113,16 @@ export default {
     },
   },
 };
+
+export function ColorPalette(): JSX.Element {
+  return (
+    <div style={{ width: "100%", padding: "1rem" }}>
+      {expandedLineColors.map((color) => (
+        <div key={color} style={{ backgroundColor: color, height: "1rem" }} />
+      ))}
+    </div>
+  );
+}
 
 OnePath.parameters = { useReadySignal: true };
 export function OnePath(): JSX.Element {
@@ -188,6 +209,23 @@ export function JsonPath(): JSX.Element {
       <StateTransitions
         overrideConfig={{
           paths: [{ value: "/some/topic/with/state.data.value", timestampMethod: "receiveTime" }],
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+ColorClash.parameters = { useReadySignal: true };
+export function ColorClash(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  return (
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
+      <StateTransitions
+        overrideConfig={{
+          paths: [
+            { value: "/some/topic/with/string_state.data.value", timestampMethod: "receiveTime" },
+          ],
         }}
       />
     </PanelSetup>

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -8,7 +8,7 @@ import { Time, toSec, subtract as subtractTimes } from "@foxglove/rostime";
 import { ChartData } from "@foxglove/studio-base/components/Chart";
 import { MessageAndData } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { TimeBasedChartTooltipData } from "@foxglove/studio-base/components/TimeBasedChart";
-import { darkColor, lineColors } from "@foxglove/studio-base/util/plotColors";
+import { darkColor, expandedLineColors } from "@foxglove/studio-base/util/plotColors";
 import { getTimestampForMessageEvent } from "@foxglove/studio-base/util/time";
 import { grey } from "@foxglove/studio-base/util/toolsColorScheme";
 
@@ -20,7 +20,7 @@ type DatasetInfo = {
   tooltips: TimeBasedChartTooltipData[];
 };
 
-const baseColors = [grey, ...lineColors];
+const baseColors = [grey, ...expandedLineColors];
 
 type Args = {
   path: StateTransitionPath;

--- a/packages/studio-base/src/util/plotColors.ts
+++ b/packages/studio-base/src/util/plotColors.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { memoize } from "lodash";
+import { memoize, range, uniq } from "lodash";
 import tinycolor from "tinycolor2";
 
 import { toolsColorScheme } from "@foxglove/studio-base/util/toolsColorScheme";
@@ -28,6 +28,19 @@ export const lineColors = [
   toolsColorScheme.paleGreen.medium,
   "#DDDDDD",
 ];
+
+const colorExpansion = lineColors.map((color) => [
+  color,
+  ...tinycolor(color)
+    .tetrad()
+    .map((acolor) => acolor.toHexString()),
+]);
+
+export const expandedLineColors = uniq(
+  range(0, colorExpansion[0]!.length)
+    .map((i) => colorExpansion.map((colors) => colors[i]!))
+    .flat(),
+);
 
 export const lightColor: (_: string) => string = memoize((color: string): string =>
   tinycolor(color).brighten(15).toString(),


### PR DESCRIPTION
**User-Facing Changes**
Improve state transition pane's color selection.

**Description**
This expands on the set of colors the state transition panel uses to color items to reduce the likelihood of clashes.

Before:
<img width="513" alt="Screen Shot 2022-08-12 at 1 21 30 PM" src="https://user-images.githubusercontent.com/93935560/184429316-87402b8b-b624-4cc3-b6be-098831249696.png">

After:
<img width="512" alt="Screen Shot 2022-08-12 at 1 22 05 PM" src="https://user-images.githubusercontent.com/93935560/184429331-cc2674f5-c37e-4414-8e23-7ce9fb02f0fc.png">

It looks like our hash function does pretty well on single char values so it seems like it should be enough to just make sure we have enough colors to accommodate them:

<img width="110" alt="Screen Shot 2022-08-12 at 1 23 57 PM" src="https://user-images.githubusercontent.com/93935560/184429435-327797e8-ba58-4141-ab09-f2f2ba39a717.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4118