### PR TITLE
Increase default maxBlockSize for CachingIterableSource

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -88,8 +88,8 @@ class CachingIterableSource implements IIterableSource {
 
   constructor(source: IIterableSource, opt?: Options) {
     this.source = source;
-    this.maxTotalSizeBytes = opt?.maxTotalSize ?? 1e9;
-    this.maxBlockSizeBytes = opt?.maxBlockSize ?? 5000000;
+    this.maxTotalSizeBytes = opt?.maxTotalSize ?? 1073741824; // 1GB
+    this.maxBlockSizeBytes = opt?.maxBlockSize ?? 52428800; // 50MB
   }
 
   async initialize(): Promise<Initalization> {


### PR DESCRIPTION


**User-Facing Changes**
None

Possibly some performance improvements by having to search fewer blocks during playback of larger ranges.

**Description**
The macBlockSize determines how many messages can be in a block before starting a new block. Eviction evicts entire blocks so this is the space freed by evicting a block.

The current default is 5 MB which is an oversight from the original PR that added this default. I meant to set this to something more practical like 50MB since one lidar scan or a few raw images could easily be 5MB. This change updates the default to 50MB

This change also updates the default max total cache size to 1GB in bytes rather than 1e9 bytes.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
