### PR TITLE
Fix missing messages from CachingIterableSource

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -726,7 +726,7 @@ describe("CachingIterableSource", () => {
     }
   });
 
-  it.only("should produce messages that have the same timestamp", async () => {
+  it("should produce messages that have the same timestamp", async () => {
     const source = new TestSource();
     const bufferedSource = new CachingIterableSource(source, {
       maxBlockSize: 100,

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -725,4 +725,101 @@ describe("CachingIterableSource", () => {
       expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
     }
   });
+
+  it.only("should produce messages that have the same timestamp", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source, {
+      maxBlockSize: 100,
+    });
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      for (let i = 0; i < 10; ++i) {
+        yield {
+          msgEvent: {
+            topic: "a",
+            receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
+            message: { value: i },
+            sizeInBytes: 50,
+          },
+          problem: undefined,
+          connectionId: undefined,
+        };
+      }
+    };
+
+    {
+      const messageIterator = bufferedSource.messageIterator({
+        topics: ["a"],
+      });
+
+      // confirm messages are what we expect
+      for (let i = 0; i < 10; ++i) {
+        const iterResult = messageIterator.next();
+        await expect(iterResult).resolves.toEqual({
+          done: false,
+          value: {
+            problem: undefined,
+            connectionId: undefined,
+            msgEvent: {
+              receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
+              message: { value: i },
+              sizeInBytes: 50,
+              topic: "a",
+            },
+          },
+        });
+      }
+
+      // The message iterator should be done since we have no more data to read from the source
+      const iterResult = messageIterator.next();
+      await expect(iterResult).resolves.toEqual({
+        done: true,
+      });
+
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
+    }
+
+    // because we have cached we shouldn't be calling source anymore
+    source.messageIterator = function messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      throw new Error("should not be called");
+    };
+
+    {
+      const messageIterator = bufferedSource.messageIterator({
+        topics: ["a"],
+      });
+
+      // confirm messages are what we expect when reading from the cache
+      for (let i = 0; i < 10; ++i) {
+        const iterResult = messageIterator.next();
+        await expect(iterResult).resolves.toEqual({
+          done: false,
+          value: {
+            problem: undefined,
+            connectionId: undefined,
+            msgEvent: {
+              receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
+              message: { value: i },
+              sizeInBytes: 50,
+              topic: "a",
+            },
+          },
+        });
+      }
+
+      // The message iterator should be done since we have no more data to read from the source
+      const iterResult = messageIterator.next();
+      await expect(iterResult).resolves.toEqual({
+        done: true,
+      });
+
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
+    }
+  });
 });

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -320,7 +320,7 @@ export class IterablePlayer implements Player {
 
     // Support moving between idle (pause) and play and preserving the playback iterator
     if (newState !== "idle" && newState !== "play" && this._playbackIterator) {
-      log.info("Ending playback iterator because next state is not IDLE or PLAY");
+      log.debug("Ending playback iterator because next state is not IDLE or PLAY");
       const oldIterator = this._playbackIterator;
       this._playbackIterator = undefined;
       void oldIterator.return?.().catch((err) => {


### PR DESCRIPTION
**User-Facing Changes**
Fixes messages drops when playing data from data sources which contain multiple messages at the exact same log time (or receive time).

**Description**
When reading from the cache, the CachingIterableSource uses a binary search to deterline where to start reading in a cache block. If a block contained multiple messages at the exact same time as the search parameter, the search algorithm would return a valid index for any time matching the search parameter not necessarily the _first_ occurrence in the block. By not returning an index for the _first_ occurrence, some messages would be skipped during playback.

This change updates `FindStartCacheItemIndex` to handle this case. If an exact match is found in the cache block for the target time, the new logic iterates the block backwards until we find the first occurrence of the target time.

Fixes: #4091

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
