### PR TITLE
Run rosbridge topic graph setup queries in parallel

### DIFF
--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { isEqual, sortBy } from "lodash";
+import { isEqual, sortBy, transform } from "lodash";
 import roslib from "roslib";
 import { v4 as uuidv4 } from "uuid";
 
@@ -44,6 +44,27 @@ const log = Log.getLogger(__dirname);
 
 const CAPABILITIES = [PlayerCapabilities.advertise, PlayerCapabilities.callServices];
 
+type RosNodeDetails = {
+  subcriptions: [string, string[]];
+  publications: [string, string[]];
+  services: [string, string[]];
+};
+
+function collateNodeDetails(details: Array<[string, string[]]>): Map<string, Set<string>> {
+  return transform(
+    details,
+    (acc, [node, values]) => {
+      for (const value of values) {
+        if (!acc.has(value)) {
+          acc.set(value, new Set());
+        }
+        acc.get(value)?.add(node);
+      }
+    },
+    new Map<string, Set<string>>(),
+  );
+}
+
 function isClockMessage(topic: string, msg: unknown): msg is { clock: Time } {
   const maybeClockMsg = msg as { clock?: Time };
   return topic === "/clock" && maybeClockMsg.clock != undefined && !isNaN(maybeClockMsg.clock.sec);
@@ -51,6 +72,26 @@ function isClockMessage(topic: string, msg: unknown): msg is { clock: Time } {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value != undefined;
+}
+
+function isFulfilledPromise<T>(value: PromiseSettledResult<T>): value is PromiseFulfilledResult<T> {
+  return value.status === "fulfilled";
+}
+
+async function makeGetNodeDetailsPromise(rosClient: roslib.Ros, node: string) {
+  return await new Promise<RosNodeDetails>((resolve, reject) => {
+    rosClient.getNodeDetails(
+      node,
+      (subscriptions, publications, services) => {
+        resolve({
+          publications: [node, publications],
+          services: [node, services],
+          subcriptions: [node, subscriptions],
+        });
+      },
+      reject,
+    );
+  });
 }
 
 // Connects to `rosbridge_server` instance using `roslibjs`. Currently doesn't support seeking or
@@ -678,59 +719,36 @@ export default class RosbridgePlayer implements Player {
   // Refreshes the full system state graph. Runs in the background so we don't
   // block app startup while mapping large node graphs.
   private _refreshSystemState(): void {
-    if (this._isRefreshing) {
+    const rosClient = this._rosClient;
+    if (this._isRefreshing || rosClient == undefined) {
       return;
     }
 
-    this._isRefreshing = true;
-    const publishers = new Map<string, Set<string>>();
-    const subscribers = new Map<string, Set<string>>();
-    const services = new Map<string, Set<string>>();
-
-    const addError = (error: Error) => {
-      this._problems.addProblem("requestTopics:system-state", {
-        severity: "error",
-        message: "Failed to fetch node details from rosbridge",
-        error,
-      });
-      this._isRefreshing = false;
-    };
-
-    const addEntry = (map: Map<string, Set<string>>, key: string, value: string) => {
-      let entries = map.get(key);
-      if (entries == undefined) {
-        entries = new Set<string>();
-        map.set(key, entries);
-      }
-      entries.add(value);
-    };
-
-    const makeGetNodeDetailsPromise = async (node: string) =>
-      await new Promise<void>((resolve, reject) => {
-        this._rosClient?.getNodeDetails(
-          node,
-          (newSubscriptions, newPublications, newServices) => {
-            newSubscriptions.forEach((pub) => addEntry(publishers, pub, node));
-            newPublications.forEach((sub) => addEntry(subscribers, sub, node));
-            newServices.forEach((srv) => addEntry(services, srv, node));
-            resolve();
-          },
-          reject,
-        );
-      });
-
     new Promise<string[]>((resolve, reject) => {
+      this._isRefreshing = true;
       this._rosClient?.getNodes((nodes) => resolve(nodes), reject);
     })
-      .then((nodes) => nodes.map(makeGetNodeDetailsPromise))
+      .then((nodes) => nodes.map(async (node) => await makeGetNodeDetailsPromise(rosClient, node)))
       .then(async (promises) => await Promise.allSettled(promises))
-      .then(() => {
-        this._publishedTopics = publishers;
-        this._subscribedTopics = subscribers;
-        this._services = services;
+      .then((items) => {
+        const fulfilledItems = items.filter(isFulfilledPromise);
+        this._publishedTopics = collateNodeDetails(
+          fulfilledItems.map((item) => item.value.publications),
+        );
+        this._subscribedTopics = collateNodeDetails(
+          fulfilledItems.map((item) => item.value.subcriptions),
+        );
+        this._services = collateNodeDetails(fulfilledItems.map((item) => item.value.services));
         this._isRefreshing = false;
         this._emitState();
       })
-      .catch(addError);
+      .catch((error) => {
+        this._problems.addProblem("requestTopics:system-state", {
+          severity: "error",
+          message: "Failed to fetch node details from rosbridge",
+          error,
+        });
+        this._isRefreshing = false;
+      });
   }
 }

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -79,22 +79,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value != undefined;
 }
 
-async function makeGetNodeDetailsPromise(rosClient: roslib.Ros, node: string) {
-  return await new Promise<RosNodeDetails>((resolve, reject) => {
-    rosClient.getNodeDetails(
-      node,
-      (subscriptions, publications, services) => {
-        resolve({
-          publications: [node, publications],
-          services: [node, services],
-          subscriptions: [node, subscriptions],
-        });
-      },
-      reject,
-    );
-  });
-}
-
 // Connects to `rosbridge_server` instance using `roslibjs`. Currently doesn't support seeking or
 // showing simulated time, so current time from Date.now() is always used instead. Also doesn't yet
 // support raw ROS messages; instead we use the CBOR compression provided by roslibjs, which
@@ -342,7 +326,7 @@ export default class RosbridgePlayer implements Player {
       this.setSubscriptions(this._requestedSubscriptions);
 
       // Refresh the full graph topology
-      this._refreshSystemState();
+      this._refreshSystemState().catch((error) => log.error(error));
     } catch (error) {
       log.error(error);
       clearTimeout(topicsStallWarningTimeout);
@@ -719,36 +703,53 @@ export default class RosbridgePlayer implements Player {
 
   // Refreshes the full system state graph. Runs in the background so we don't
   // block app startup while mapping large node graphs.
-  private _refreshSystemState(): void {
+  private async _refreshSystemState(): Promise<void> {
     const rosClient = this._rosClient;
     if (this._isRefreshing || rosClient == undefined) {
       return;
     }
 
-    new Promise<string[]>((resolve, reject) => {
+    try {
       this._isRefreshing = true;
-      this._rosClient?.getNodes((nodes) => resolve(nodes), reject);
-    })
-      .then((nodes) => nodes.map(async (node) => await makeGetNodeDetailsPromise(rosClient, node)))
-      .then(async (promises) => await Promise.allSettled(promises))
-      .then((items) => {
-        const fulfilled = filterMap(items, (item) =>
-          item.status === "fulfilled" ? item.value : undefined,
-        );
-        this._publishedTopics = collateNodeDetails(fulfilled, "publications");
-        this._subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
-        this._services = collateNodeDetails(fulfilled, "services");
-        this._emitState();
-      })
-      .catch((error) => {
-        this._problems.addProblem("requestTopics:system-state", {
-          severity: "error",
-          message: "Failed to fetch node details from rosbridge",
-          error,
-        });
-      })
-      .finally(() => {
-        this._isRefreshing = false;
+
+      const nodes = await new Promise<string[]>((resolve, reject) => {
+        this._rosClient?.getNodes((fetchedNodes) => resolve(fetchedNodes), reject);
       });
+
+      const promises = nodes.map(async (node) => {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        return await new Promise<RosNodeDetails>((resolve, reject) => {
+          rosClient.getNodeDetails(
+            node,
+            (subscriptions, publications, services) => {
+              resolve({
+                publications: [node, publications],
+                services: [node, services],
+                subscriptions: [node, subscriptions],
+              });
+            },
+            reject,
+          );
+        });
+      });
+
+      const results = await Promise.allSettled(promises);
+      const fulfilled = filterMap(results, (item) =>
+        item.status === "fulfilled" ? item.value : undefined,
+      );
+      this._publishedTopics = collateNodeDetails(fulfilled, "publications");
+      this._subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
+      this._services = collateNodeDetails(fulfilled, "services");
+
+      this._emitState();
+    } catch (error) {
+      this._problems.addProblem("requestTopics:system-state", {
+        severity: "error",
+        message: "Failed to fetch node details from rosbridge",
+        error,
+      });
+    } finally {
+      this._isRefreshing = false;
+    }
   }
 }

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -62,6 +62,7 @@ export default class RosbridgePlayer implements Player {
   private _url: string; // WebSocket URL.
   private _rosClient?: roslib.Ros; // The roslibjs client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player.
+  private _isRefreshing = false; // True if currently refreshing the node graph.
   private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
   private _closed: boolean = false; // Whether the player has been completely closed using close().
   private _providerTopics?: Topic[]; // Topics as published by the WebSocket.
@@ -299,22 +300,8 @@ export default class RosbridgePlayer implements Player {
       // Try subscribing again, since we might now be able to subscribe to some new topics.
       this.setSubscriptions(this._requestedSubscriptions);
 
-      // Fetch the full graph topology
-      try {
-        const graph = await this._getSystemState();
-        this._publishedTopics = graph.publishers;
-        this._subscribedTopics = graph.subscribers;
-        this._services = graph.services;
-      } catch (error) {
-        this._problems.addProblem("requestTopics:system-state", {
-          severity: "error",
-          message: "Failed to fetch node details from rosbridge",
-          error,
-        });
-        this._publishedTopics = new Map();
-        this._subscribedTopics = new Map();
-        this._services = new Map();
-      }
+      // Refresh the full graph topology
+      this._refreshSystemState();
     } catch (error) {
       log.error(error);
       clearTimeout(topicsStallWarningTimeout);
@@ -689,11 +676,27 @@ export default class RosbridgePlayer implements Player {
     return this._clockTime ?? fromMillis(Date.now());
   }
 
-  private async _getSystemState(): Promise<RosGraph> {
-    const output: RosGraph = {
-      publishers: new Map<string, Set<string>>(),
-      subscribers: new Map<string, Set<string>>(),
-      services: new Map<string, Set<string>>(),
+  private _refreshSystemState(): void {
+    if (this._isRefreshing) {
+      return;
+    }
+
+    this._isRefreshing = true;
+    let error: undefined | Error = undefined;
+    const publishers = new Map<string, Set<string>>();
+    const subscribers = new Map<string, Set<string>>();
+    const services = new Map<string, Set<string>>();
+
+    const addError = (newError: Error) => {
+      if (!error) {
+        error = newError;
+        this._isRefreshing = false;
+        this._problems.addProblem("requestTopics:system-state", {
+          severity: "error",
+          message: "Failed to fetch node details from rosbridge",
+          error,
+        });
+      }
     };
 
     const addEntry = (map: Map<string, Set<string>>, key: string, value: string) => {
@@ -705,30 +708,30 @@ export default class RosbridgePlayer implements Player {
       entries.add(value);
     };
 
-    // Note that we're calling two layers of nested callbacks here so we need to make sure
-    // we wrap each layer in indepedent promises and resolve them all before returning
-    // or we will immediately resolve `output` before it's initialized and downstream
-    // clients will never register the eventual update. This could probably be
-    // simplified with a promisfy utility.
-    return await new Promise((outerResolve, outerReject) => {
-      this._rosClient?.getNodes(async (nodes) => {
-        const promises = nodes.map(async (node) => {
-          return await new Promise((innerResolve, innerReject) => {
-            this._rosClient?.getNodeDetails(
-              node,
-              (subscriptions, publications, services) => {
-                publications.forEach((pub) => addEntry(output.publishers, pub, node));
-                subscriptions.forEach((sub) => addEntry(output.subscribers, sub, node));
-                services.forEach((srv) => addEntry(output.services, srv, node));
-                innerResolve(undefined);
-              },
-              innerReject,
-            );
-          });
-        });
-        await Promise.allSettled(promises);
-        outerResolve(output);
-      }, outerReject);
-    });
+    this._rosClient?.getNodes((nodes) => {
+      nodes.forEach((node, index) => {
+        if (error) {
+          return;
+        }
+
+        this._rosClient?.getNodeDetails(
+          node,
+          (newSubscriptions, newPublications, newServices) => {
+            newSubscriptions.forEach((pub) => addEntry(publishers, pub, node));
+            newPublications.forEach((sub) => addEntry(subscribers, sub, node));
+            newServices.forEach((srv) => addEntry(services, srv, node));
+
+            if (index === nodes.length - 1) {
+              this._publishedTopics = publishers;
+              this._subscribedTopics = subscribers;
+              this._services = services;
+              this._isRefreshing = false;
+              this._emitState();
+            }
+          },
+          addError,
+        );
+      });
+    }, addError);
   }
 }

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -45,11 +45,10 @@ const log = Log.getLogger(__dirname);
 
 const CAPABILITIES = [PlayerCapabilities.advertise, PlayerCapabilities.callServices];
 
-type RosNodeDetails = {
-  subscriptions: [node: string, values: string[]];
-  publications: [node: string, values: string[]];
-  services: [node: string, values: string[]];
-};
+type RosNodeDetails = Record<
+  "subscriptions" | "publications" | "services",
+  { node: string; values: string[] }
+>;
 
 function collateNodeDetails(
   details: RosNodeDetails[],
@@ -58,7 +57,7 @@ function collateNodeDetails(
   return transform(
     details,
     (acc, detail) => {
-      const [node, values] = detail[key];
+      const { node, values } = detail[key];
       for (const value of values) {
         if (!acc.has(value)) {
           acc.set(value, new Set());
@@ -704,8 +703,7 @@ export default class RosbridgePlayer implements Player {
   // Refreshes the full system state graph. Runs in the background so we don't
   // block app startup while mapping large node graphs.
   private async _refreshSystemState(): Promise<void> {
-    const rosClient = this._rosClient;
-    if (this._isRefreshing || rosClient == undefined) {
+    if (this._isRefreshing) {
       return;
     }
 
@@ -717,15 +715,14 @@ export default class RosbridgePlayer implements Player {
       });
 
       const promises = nodes.map(async (node) => {
-        await new Promise((resolve) => setTimeout(resolve, 5000));
         return await new Promise<RosNodeDetails>((resolve, reject) => {
-          rosClient.getNodeDetails(
+          this._rosClient?.getNodeDetails(
             node,
             (subscriptions, publications, services) => {
               resolve({
-                publications: [node, publications],
-                services: [node, services],
-                subscriptions: [node, subscriptions],
+                publications: { node, values: publications },
+                services: { node, values: services },
+                subscriptions: { node, values: subscriptions },
               });
             },
             reject,

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -676,27 +676,25 @@ export default class RosbridgePlayer implements Player {
     return this._clockTime ?? fromMillis(Date.now());
   }
 
+  // Refreshes the full system state graph. Runs in the background so we don't
+  // block app startup while mapping large node graphs.
   private _refreshSystemState(): void {
     if (this._isRefreshing) {
       return;
     }
 
     this._isRefreshing = true;
-    let error: undefined | Error = undefined;
     const publishers = new Map<string, Set<string>>();
     const subscribers = new Map<string, Set<string>>();
     const services = new Map<string, Set<string>>();
 
-    const addError = (newError: Error) => {
-      if (!error) {
-        error = newError;
-        this._isRefreshing = false;
-        this._problems.addProblem("requestTopics:system-state", {
-          severity: "error",
-          message: "Failed to fetch node details from rosbridge",
-          error,
-        });
-      }
+    const addError = (error: Error) => {
+      this._problems.addProblem("requestTopics:system-state", {
+        severity: "error",
+        message: "Failed to fetch node details from rosbridge",
+        error,
+      });
+      this._isRefreshing = false;
     };
 
     const addEntry = (map: Map<string, Set<string>>, key: string, value: string) => {
@@ -708,30 +706,32 @@ export default class RosbridgePlayer implements Player {
       entries.add(value);
     };
 
-    this._rosClient?.getNodes((nodes) => {
-      nodes.forEach((node, index) => {
-        if (error) {
-          return;
-        }
-
+    const makeGetNodeDetailsPromise = async (node: string) =>
+      await new Promise<void>((resolve, reject) => {
         this._rosClient?.getNodeDetails(
           node,
           (newSubscriptions, newPublications, newServices) => {
             newSubscriptions.forEach((pub) => addEntry(publishers, pub, node));
             newPublications.forEach((sub) => addEntry(subscribers, sub, node));
             newServices.forEach((srv) => addEntry(services, srv, node));
-
-            if (index === nodes.length - 1) {
-              this._publishedTopics = publishers;
-              this._subscribedTopics = subscribers;
-              this._services = services;
-              this._isRefreshing = false;
-              this._emitState();
-            }
+            resolve();
           },
-          addError,
+          reject,
         );
       });
-    }, addError);
+
+    new Promise<string[]>((resolve, reject) => {
+      this._rosClient?.getNodes((nodes) => resolve(nodes), reject);
+    })
+      .then((nodes) => nodes.map(makeGetNodeDetailsPromise))
+      .then(async (promises) => await Promise.allSettled(promises))
+      .then(() => {
+        this._publishedTopics = publishers;
+        this._subscribedTopics = subscribers;
+        this._services = services;
+        this._isRefreshing = false;
+        this._emitState();
+      })
+      .catch(addError);
   }
 }

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -712,8 +712,8 @@ export default class RosbridgePlayer implements Player {
     // simplified with a promisfy utility.
     return await new Promise((outerResolve, outerReject) => {
       this._rosClient?.getNodes(async (nodes) => {
-        for (const node of nodes) {
-          await new Promise((innerResolve, innerReject) => {
+        const promises = nodes.map(async (node) => {
+          return await new Promise((innerResolve, innerReject) => {
             this._rosClient?.getNodeDetails(
               node,
               (subscriptions, publications, services) => {
@@ -725,7 +725,8 @@ export default class RosbridgePlayer implements Player {
               innerReject,
             );
           });
-        }
+        });
+        await Promise.allSettled(promises);
         outerResolve(output);
       }, outerReject);
     });

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -17,7 +17,6 @@ import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@foxglove/den/async";
 import Log from "@foxglove/log";
-import type { RosGraph } from "@foxglove/ros1";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -16,6 +16,7 @@ import roslib from "roslib";
 import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@foxglove/den/async";
+import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
@@ -45,15 +46,19 @@ const log = Log.getLogger(__dirname);
 const CAPABILITIES = [PlayerCapabilities.advertise, PlayerCapabilities.callServices];
 
 type RosNodeDetails = {
-  subcriptions: [string, string[]];
-  publications: [string, string[]];
-  services: [string, string[]];
+  subscriptions: [node: string, values: string[]];
+  publications: [node: string, values: string[]];
+  services: [node: string, values: string[]];
 };
 
-function collateNodeDetails(details: Array<[string, string[]]>): Map<string, Set<string>> {
+function collateNodeDetails(
+  details: RosNodeDetails[],
+  key: keyof RosNodeDetails,
+): Map<string, Set<string>> {
   return transform(
     details,
-    (acc, [node, values]) => {
+    (acc, detail) => {
+      const [node, values] = detail[key];
       for (const value of values) {
         if (!acc.has(value)) {
           acc.set(value, new Set());
@@ -74,10 +79,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value != undefined;
 }
 
-function isFulfilledPromise<T>(value: PromiseSettledResult<T>): value is PromiseFulfilledResult<T> {
-  return value.status === "fulfilled";
-}
-
 async function makeGetNodeDetailsPromise(rosClient: roslib.Ros, node: string) {
   return await new Promise<RosNodeDetails>((resolve, reject) => {
     rosClient.getNodeDetails(
@@ -86,7 +87,7 @@ async function makeGetNodeDetailsPromise(rosClient: roslib.Ros, node: string) {
         resolve({
           publications: [node, publications],
           services: [node, services],
-          subcriptions: [node, subscriptions],
+          subscriptions: [node, subscriptions],
         });
       },
       reject,
@@ -731,15 +732,12 @@ export default class RosbridgePlayer implements Player {
       .then((nodes) => nodes.map(async (node) => await makeGetNodeDetailsPromise(rosClient, node)))
       .then(async (promises) => await Promise.allSettled(promises))
       .then((items) => {
-        const fulfilledItems = items.filter(isFulfilledPromise);
-        this._publishedTopics = collateNodeDetails(
-          fulfilledItems.map((item) => item.value.publications),
+        const fulfilled = filterMap(items, (item) =>
+          item.status === "fulfilled" ? item.value : undefined,
         );
-        this._subscribedTopics = collateNodeDetails(
-          fulfilledItems.map((item) => item.value.subcriptions),
-        );
-        this._services = collateNodeDetails(fulfilledItems.map((item) => item.value.services));
-        this._isRefreshing = false;
+        this._publishedTopics = collateNodeDetails(fulfilled, "publications");
+        this._subscribedTopics = collateNodeDetails(fulfilled, "subscriptions");
+        this._services = collateNodeDetails(fulfilled, "services");
         this._emitState();
       })
       .catch((error) => {
@@ -748,6 +746,8 @@ export default class RosbridgePlayer implements Player {
           message: "Failed to fetch node details from rosbridge",
           error,
         });
+      })
+      .finally(() => {
         this._isRefreshing = false;
       });
   }


### PR DESCRIPTION
**User-Facing Changes**
Improves startup time of rosbridge sessions with large topic graphs.

**Description**
This runs the topic graph queries in parallel to speed them up.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4123 