### PR TITLE
Update ImageCanvas to support React 18

### DIFF
--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -11,14 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import {
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useMemo,
-  useReducer,
-} from "react";
+import { useCallback, useLayoutEffect, useRef, useState, useMemo, useReducer } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useAsync } from "react-use";
 import { makeStyles } from "tss-react/mui";
@@ -98,7 +91,7 @@ const webWorkerManager = new WebWorkerManager(() => {
 }, 1);
 
 type RenderImage = (
-  args: RenderArgs & { canvas: RenderableCanvas },
+  args: RenderArgs & { canvas: RenderableCanvas }
 ) => Promise<Dimensions | undefined>;
 
 const supportsOffscreenCanvas =
@@ -115,7 +108,8 @@ export function ImageCanvas(props: Props): JSX.Element {
   const { mode } = config;
   const { classes, cx } = useStyles();
 
-  const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
+  const renderInMainThread =
+    (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
 
   const [_, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
@@ -140,7 +134,9 @@ export function ImageCanvas(props: Props): JSX.Element {
   });
 
   // The render function dispatches rendering to the main thread or a worker
-  const [doRenderImage, setDoRenderImage] = useState<RenderImage | undefined>(undefined);
+  const [doRenderImage, setDoRenderImage] = useState<RenderImage | undefined>(
+    undefined
+  );
 
   const workerRef = useRef<Rpc | undefined>();
 
@@ -179,21 +175,31 @@ export function ImageCanvas(props: Props): JSX.Element {
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       const workerRender: RenderImage = (args) => {
-        const { geometry, imageMessage, options, rawMarkerData: rawMarkers } = args;
-
-        return worker.send<Dimensions | undefined, RenderArgs & { id: string }>("renderImage", {
+        const {
           geometry,
-          id,
           imageMessage,
           options,
           rawMarkerData: rawMarkers,
-        });
+        } = args;
+
+        return worker.send<Dimensions | undefined, RenderArgs & { id: string }>(
+          "renderImage",
+          {
+            geometry,
+            id,
+            imageMessage,
+            options,
+            rawMarkerData: rawMarkers,
+          }
+        );
       };
 
       const transferredCanvas = newCanvas.transferControlToOffscreen();
 
       worker
-        .send<void>("initialize", { id, canvas: transferredCanvas }, [transferredCanvas])
+        .send<void>("initialize", { id, canvas: transferredCanvas }, [
+          transferredCanvas,
+        ])
         .then(() => {
           if (mounted) {
             setDoRenderImage(() => workerRender);
@@ -335,7 +341,7 @@ export function ImageCanvas(props: Props): JSX.Element {
           }
         });
     },
-    [devicePixelRatio, props.setActivePixelData, workerId],
+    [devicePixelRatio, props.setActivePixelData, workerId]
   );
 
   const resetPanZoom = useCallback(() => {
@@ -371,8 +377,12 @@ export function ImageCanvas(props: Props): JSX.Element {
   return (
     <div ref={rootRef} className={classes.root} tabIndex={0}>
       <KeyListener keyDownHandlers={keyDownHandlers} />
-      {error && <div className={classes.errorMessage}>Error: {error.message}</div>}
-      {renderError && <div className={classes.errorMessage}>Error: {renderError.message}</div>}
+      {error && (
+        <div className={classes.errorMessage}>Error: {error.message}</div>
+      )}
+      {renderError && (
+        <div className={classes.errorMessage}>Error: {renderError.message}</div>
+      )}
       <ZoomMenu
         zoom={scaleValue}
         setZoom={setZoom}

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -91,7 +91,7 @@ const webWorkerManager = new WebWorkerManager(() => {
 }, 1);
 
 type RenderImage = (
-  args: RenderArgs & { canvas: RenderableCanvas }
+  args: RenderArgs & { canvas: RenderableCanvas },
 ) => Promise<Dimensions | undefined>;
 
 const supportsOffscreenCanvas =
@@ -108,8 +108,7 @@ export function ImageCanvas(props: Props): JSX.Element {
   const { mode } = config;
   const { classes, cx } = useStyles();
 
-  const renderInMainThread =
-    (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
+  const renderInMainThread = (props.renderInMainThread ?? false) || !supportsOffscreenCanvas;
 
   const [_, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
@@ -134,9 +133,7 @@ export function ImageCanvas(props: Props): JSX.Element {
   });
 
   // The render function dispatches rendering to the main thread or a worker
-  const [doRenderImage, setDoRenderImage] = useState<RenderImage | undefined>(
-    undefined
-  );
+  const [doRenderImage, setDoRenderImage] = useState<RenderImage | undefined>(undefined);
 
   const workerRef = useRef<Rpc | undefined>();
 
@@ -175,31 +172,21 @@ export function ImageCanvas(props: Props): JSX.Element {
       // Potentially performance-sensitive; await can be expensive
       // eslint-disable-next-line @typescript-eslint/promise-function-async
       const workerRender: RenderImage = (args) => {
-        const {
+        const { geometry, imageMessage, options, rawMarkerData: rawMarkers } = args;
+
+        return worker.send<Dimensions | undefined, RenderArgs & { id: string }>("renderImage", {
           geometry,
+          id,
           imageMessage,
           options,
           rawMarkerData: rawMarkers,
-        } = args;
-
-        return worker.send<Dimensions | undefined, RenderArgs & { id: string }>(
-          "renderImage",
-          {
-            geometry,
-            id,
-            imageMessage,
-            options,
-            rawMarkerData: rawMarkers,
-          }
-        );
+        });
       };
 
       const transferredCanvas = newCanvas.transferControlToOffscreen();
 
       worker
-        .send<void>("initialize", { id, canvas: transferredCanvas }, [
-          transferredCanvas,
-        ])
+        .send<void>("initialize", { id, canvas: transferredCanvas }, [transferredCanvas])
         .then(() => {
           if (mounted) {
             setDoRenderImage(() => workerRender);
@@ -341,7 +328,7 @@ export function ImageCanvas(props: Props): JSX.Element {
           }
         });
     },
-    [devicePixelRatio, props.setActivePixelData, workerId]
+    [devicePixelRatio, props.setActivePixelData, workerId],
   );
 
   const resetPanZoom = useCallback(() => {
@@ -377,12 +364,8 @@ export function ImageCanvas(props: Props): JSX.Element {
   return (
     <div ref={rootRef} className={classes.root} tabIndex={0}>
       <KeyListener keyDownHandlers={keyDownHandlers} />
-      {error && (
-        <div className={classes.errorMessage}>Error: {error.message}</div>
-      )}
-      {renderError && (
-        <div className={classes.errorMessage}>Error: {renderError.message}</div>
-      )}
+      {error && <div className={classes.errorMessage}>Error: {error.message}</div>}
+      {renderError && <div className={classes.errorMessage}>Error: {renderError.message}</div>}
       <ZoomMenu
         zoom={scaleValue}
         setZoom={setZoom}

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -15,10 +15,10 @@ import {
   useCallback,
   useLayoutEffect,
   useRef,
-  MouseEvent,
   useState,
   useMemo,
   useReducer,
+  useEffect,
 } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useAsync } from "react-use";
@@ -74,16 +74,23 @@ const useStyles = makeStyles()((theme) => ({
     justifyContent: "center",
     color: theme.palette.error.main,
   },
-  canvas: {
+  canvasContainer: {
     position: "absolute",
     top: 0,
     left: 0,
     width: "100%",
     height: "100%",
-    imageRendering: "pixelated",
+
+    canvas: {
+      width: "100%",
+      height: "100%",
+      imageRendering: "pixelated",
+    },
   },
   canvasImageRenderingSmooth: {
-    imageRendering: "auto",
+    canvas: {
+      imageRendering: "auto",
+    },
   },
 }));
 
@@ -118,7 +125,8 @@ export function ImageCanvas(props: Props): JSX.Element {
 
   const [zoomMode, setZoomMode] = useState<Config["mode"]>(mode);
 
-  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+  const [canvas, setCanvas] = useState<HTMLCanvasElement | undefined>();
+  const canvasContainerRef = useRef<HTMLDivElement>(ReactNull);
 
   // Use a debounce and 0 refresh rate to avoid triggering a resize observation while handling
   // an existing resize observation.
@@ -135,20 +143,17 @@ export function ImageCanvas(props: Props): JSX.Element {
   // The render function dispatches rendering to the main thread or a worker
   const [doRenderImage, setDoRenderImage] = useState<RenderImage | undefined>(undefined);
 
-  // the canvas can only be transferred once, so we keep the transfer around
-  const transfferedCanvasRef = useRef<OffscreenCanvas | undefined>(undefined);
-
   const workerRef = useRef<Rpc | undefined>();
 
-  const [workerId] = useState(uuidv4());
+  const [workerId] = useState(() => uuidv4());
 
   // setup the render function to render in the main thread or in the worker
   useLayoutEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
+    const newCanvas = document.createElement("canvas");
+    setCanvas(newCanvas);
+    canvasContainerRef.current?.appendChild(newCanvas);
 
+    let mounted = true;
     const id = workerId;
 
     if (renderInMainThread) {
@@ -158,11 +163,11 @@ export function ImageCanvas(props: Props): JSX.Element {
         const targetWidth = args.geometry.viewport.width;
         const targetHeight = args.geometry.viewport.height;
 
-        if (targetWidth !== canvas.width) {
-          canvas.width = targetWidth;
+        if (targetWidth !== newCanvas.width) {
+          newCanvas.width = targetWidth;
         }
-        if (targetHeight !== canvas.height) {
-          canvas.height = targetHeight;
+        if (targetHeight !== newCanvas.height) {
+          newCanvas.height = targetHeight;
         }
         return renderImage({ ...args, hitmapCanvas: undefined });
       };
@@ -186,25 +191,31 @@ export function ImageCanvas(props: Props): JSX.Element {
         });
       };
 
-      transfferedCanvasRef.current ??= canvas.transferControlToOffscreen();
+      const transferredCanvas = newCanvas.transferControlToOffscreen();
 
       worker
-        .send<void>("initialize", { id, canvas: transfferedCanvasRef.current }, [
-          transfferedCanvasRef.current,
-        ])
+        .send<void>("initialize", { id, canvas: transferredCanvas }, [transferredCanvas])
         .then(() => {
-          setDoRenderImage(() => workerRender);
+          if (mounted) {
+            setDoRenderImage(() => workerRender);
+          }
         })
         .catch((err) => {
-          setError(err as Error);
+          if (mounted) {
+            console.error(err);
+            setError(err as Error);
+          }
         });
     }
 
     return () => {
+      mounted = false;
+      newCanvas.remove();
       if (renderInMainThread) {
         return;
       }
 
+      workerRef.current = undefined;
       webWorkerManager.unregisterWorkerListener(id);
     };
   }, [renderInMainThread, workerId]);
@@ -225,10 +236,10 @@ export function ImageCanvas(props: Props): JSX.Element {
   });
 
   useLayoutEffect(() => {
-    if (canvasRef.current) {
-      setContainer(canvasRef.current);
+    if (canvas) {
+      setContainer(canvas);
     }
-  }, [setContainer]);
+  }, [canvas, setContainer]);
 
   const renderOptions = useMemo(() => {
     return {
@@ -240,7 +251,7 @@ export function ImageCanvas(props: Props): JSX.Element {
 
   const devicePixelRatio = window.devicePixelRatio;
   const { error: renderError } = useAsync(async () => {
-    if (!canvasRef.current || !doRenderImage) {
+    if (!canvas || !doRenderImage) {
       return;
     }
 
@@ -263,7 +274,7 @@ export function ImageCanvas(props: Props): JSX.Element {
     const finishRender = onStartRenderImage();
     try {
       return await doRenderImage({
-        canvas: canvasRef.current,
+        canvas,
         geometry: {
           flipHorizontal: config.flipHorizontal ?? false,
           flipVertical: config.flipVertical ?? false,
@@ -280,6 +291,7 @@ export function ImageCanvas(props: Props): JSX.Element {
       finishRender();
     }
   }, [
+    canvas,
     config.flipHorizontal,
     config.flipVertical,
     config.rotation,
@@ -304,24 +316,28 @@ export function ImageCanvas(props: Props): JSX.Element {
     });
   }, [panX, panY, saveConfig, scaleValue]);
 
-  function onCanvasClick(event: MouseEvent<HTMLCanvasElement>) {
-    const boundingRect = event.currentTarget.getBoundingClientRect();
-    const x = event.clientX - boundingRect.x;
-    const y = event.clientY - boundingRect.y;
-    void workerRef.current
-      ?.send<PixelData | undefined>("mouseMove", {
-        id: workerId,
-        x: x * devicePixelRatio,
-        y: y * devicePixelRatio,
-      })
-      .then((r) => {
-        if (r?.marker) {
-          props.setActivePixelData(r);
-        } else {
-          props.setActivePixelData(undefined);
-        }
-      });
-  }
+  const onCanvasClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      const setActivePixelData = props.setActivePixelData;
+      const boundingRect = event.currentTarget.getBoundingClientRect();
+      const x = event.clientX - boundingRect.x;
+      const y = event.clientY - boundingRect.y;
+      void workerRef.current
+        ?.send<PixelData | undefined>("mouseMove", {
+          id: workerId,
+          x: x * devicePixelRatio,
+          y: y * devicePixelRatio,
+        })
+        .then((r) => {
+          if (r?.marker) {
+            setActivePixelData(r);
+          } else {
+            setActivePixelData(undefined);
+          }
+        });
+    },
+    [devicePixelRatio, props.setActivePixelData, workerId],
+  );
 
   const resetPanZoom = useCallback(() => {
     setPan({ x: 0, y: 0 });
@@ -358,19 +374,19 @@ export function ImageCanvas(props: Props): JSX.Element {
       <KeyListener keyDownHandlers={keyDownHandlers} />
       {error && <div className={classes.errorMessage}>Error: {error.message}</div>}
       {renderError && <div className={classes.errorMessage}>Error: {renderError.message}</div>}
-      <canvas
-        {...panZoomHandlers}
-        className={cx(classes.canvas, {
-          [classes.canvasImageRenderingSmooth]: config.smooth === true,
-        })}
-        onClick={onCanvasClick}
-        ref={canvasRef}
-      />
       <ZoomMenu
         zoom={scaleValue}
         setZoom={setZoom}
         setZoomMode={setZoomMode}
         resetPanZoom={resetPanZoom}
+      />
+      <div
+        ref={canvasContainerRef}
+        onClick={onCanvasClick}
+        className={cx(classes.canvasContainer, {
+          [classes.canvasImageRenderingSmooth]: config.smooth === true,
+        })}
+        {...panZoomHandlers}
       />
     </div>
   );

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.tsx
@@ -18,7 +18,6 @@ import {
   useState,
   useMemo,
   useReducer,
-  useEffect,
 } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useAsync } from "react-use";


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Updates to Image panel to make it run under React 18 Strict Mode, where the component will run a mount->unmount->mount cycle when it first mounts (read more about this at https://github.com/reactwg/react-18/discussions/19). Similar to #4064, we dynamically create the canvas element on each mount so we don't have to worry about calling `transferControlToOffscreen()` more than once on the same canvas.