### PR TITLE
Disable context menu for the entire app

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useState, Suspense, Fragment } from "react";
+import { useState, Suspense, Fragment, useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -56,6 +56,16 @@ type AppProps = {
   enableLaunchPreferenceScreen?: boolean;
 };
 
+// Suppress context menu for the entire app except on inputs & textareas.
+function contextMenuHandler(event: MouseEvent) {
+  if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+    return;
+  }
+
+  event.preventDefault();
+  return false;
+}
+
 export function App(props: AppProps): JSX.Element {
   const [assetLoaders] = useState(() => [new URDFAssetLoader()]);
 
@@ -108,6 +118,11 @@ export function App(props: AppProps): JSX.Element {
   }
 
   const MaybeLaunchPreference = enableLaunchPreferenceScreen === true ? LaunchPreference : Fragment;
+
+  useEffect(() => {
+    document.addEventListener("contextmenu", contextMenuHandler);
+    return () => document.removeEventListener("contextmenu", contextMenuHandler);
+  }, []);
 
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -21,6 +21,7 @@ import {
   useMemo,
   useLayoutEffect,
   useContext,
+  MouseEvent,
 } from "react";
 import { useToasts } from "react-toast-notifications";
 
@@ -128,6 +129,12 @@ function keyboardEventHasModifier(event: KeyboardEvent) {
   } else {
     return event.ctrlKey;
   }
+}
+
+// Suppress context menu for the entire app.
+function onContextMenu(event: MouseEvent) {
+  event.preventDefault();
+  return false;
 }
 
 function AddPanel() {
@@ -609,7 +616,12 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       <OrgExtensionRegistrySyncAdapter />
       <URLStateSyncAdapter />
       <KeyListener global keyDownHandlers={keyDownHandlers} />
-      <div className={classes.container} ref={containerRef} tabIndex={0}>
+      <div
+        className={classes.container}
+        ref={containerRef}
+        tabIndex={0}
+        onContextMenu={onContextMenu}
+      >
         <Sidebar
           items={sidebarItems}
           bottomItems={sidebarBottomItems}

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -131,8 +131,12 @@ function keyboardEventHasModifier(event: KeyboardEvent) {
   }
 }
 
-// Suppress context menu for the entire app.
+// Suppress context menu for the entire app except on inputs & textareas.
 function onContextMenu(event: MouseEvent) {
+  if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+    return;
+  }
+
   event.preventDefault();
   return false;
 }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -21,7 +21,6 @@ import {
   useMemo,
   useLayoutEffect,
   useContext,
-  MouseEvent,
 } from "react";
 import { useToasts } from "react-toast-notifications";
 
@@ -129,16 +128,6 @@ function keyboardEventHasModifier(event: KeyboardEvent) {
   } else {
     return event.ctrlKey;
   }
-}
-
-// Suppress context menu for the entire app except on inputs & textareas.
-function onContextMenu(event: MouseEvent) {
-  if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
-    return;
-  }
-
-  event.preventDefault();
-  return false;
 }
 
 function AddPanel() {
@@ -620,12 +609,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       <OrgExtensionRegistrySyncAdapter />
       <URLStateSyncAdapter />
       <KeyListener global keyDownHandlers={keyDownHandlers} />
-      <div
-        className={classes.container}
-        ref={containerRef}
-        tabIndex={0}
-        onContextMenu={onContextMenu}
-      >
+      <div className={classes.container} ref={containerRef} tabIndex={0}>
         <Sidebar
           items={sidebarItems}
           bottomItems={sidebarBottomItems}


### PR DESCRIPTION
**User-Facing Changes**
Disables the right click context menu for the entire app.

**Description**
This just catches the `onContextMenu` event of the root workspace element.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3961 