### PR TITLE
Add manual limits for x axis

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -477,18 +477,10 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       max = datasetBounds.x.max;
     }
 
-    // if we are syncing and have global bounds there are two possibilities
-    // 1. the global bounds are from user interaction, we use that unconditionally
-    // 2. the global bounds are min/max with our dataset bounds
-    if (globalBounds) {
-      if (globalBounds.userInteraction) {
-        min = globalBounds.min;
-        max = globalBounds.max;
-      } else if (defaultView?.type === "following") {
-        // If following and no user interaction - min/max with globalBounds.
-        min = Math.min(min ?? globalBounds.min, globalBounds.min);
-        max = Math.max(max ?? globalBounds.max, globalBounds.max);
-      }
+    // If the global bounds are from user interaction, we use that unconditionally.
+    if (globalBounds?.userInteraction === true) {
+      min = globalBounds.min;
+      max = globalBounds.max;
     }
 
     // if the min/max are the same, use undefined to fall-back to chart component auto-scales

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -484,7 +484,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       if (globalBounds.userInteraction) {
         min = globalBounds.min;
         max = globalBounds.max;
-      } else if (defaultView?.type !== "following") {
+      } else if (defaultView?.type !== "fixed") {
         // if following and no user interaction - we leave our bounds as they are
         min = Math.min(min ?? globalBounds.min, globalBounds.min);
         max = Math.max(max ?? globalBounds.max, globalBounds.max);

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -484,8 +484,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       if (globalBounds.userInteraction) {
         min = globalBounds.min;
         max = globalBounds.max;
-      } else if (defaultView?.type !== "fixed") {
-        // if following and no user interaction - we leave our bounds as they are
+      } else if (defaultView?.type === "following") {
+        // If following and no user interaction - min/max with globalBounds.
         min = Math.min(min ?? globalBounds.min, globalBounds.min);
         max = Math.max(max ?? globalBounds.max, globalBounds.max);
       }

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -379,6 +379,21 @@ LineGraph.parameters = {
   useReadySignal: true,
 };
 
+LineGraphWithXMinMax.storyName = "line graph with x min & max";
+export function LineGraphWithXMinMax(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  return (
+    <PlotWrapper
+      pauseFrame={pauseFrame}
+      config={{ ...exampleConfig, minXValue: 1, maxXValue: 2 }}
+    />
+  );
+}
+LineGraphWithXMinMax.parameters = {
+  useReadySignal: true,
+};
+
 LineGraphWithNoTitle.storyName = "line graph with no title";
 export function LineGraphWithNoTitle(): JSX.Element {
   const readySignal = useReadySignal({ count: 3 });

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -411,12 +411,13 @@ export function LineGraphWithSettings(): JSX.Element {
   return (
     <PlotWrapper
       pauseFrame={pauseFrame}
-      config={{ ...exampleConfig, minYValue: 1, maxYValue: -1 }}
+      config={{ ...exampleConfig, minYValue: 1, maxYValue: -1, minXValue: 0, maxXValue: 3 }}
       includeSettings
     />
   );
 }
 LineGraphWithSettings.parameters = {
+  colorScheme: "light",
   useReadySignal: true,
 };
 
@@ -886,6 +887,36 @@ export function CustomXAxisTopic(): JSX.Element {
 CustomXAxisTopic.parameters = {
   useReadySignal: true,
 };
+
+export function CustomXAxisTopicWithXLimits(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+
+  return (
+    <PlotWrapper
+      pauseFrame={pauseFrame}
+      config={{
+        ...exampleConfig,
+        xAxisVal: "custom",
+        minXValue: 1.3,
+        maxXValue: 1.8,
+        paths: [
+          {
+            value: "/some_topic/location.pose.acceleration",
+            enabled: true,
+            timestampMethod: "receiveTime",
+          },
+        ],
+        xAxisPath: { value: "/some_topic/location.pose.velocity", enabled: true },
+      }}
+    />
+  );
+}
+CustomXAxisTopicWithXLimits.parameters = {
+  colorScheme: "light",
+  useReadySignal: true,
+};
+CustomXAxisTopicWithXLimits.storyName = "custom x-axis topic with x limits";
 
 CurrentCustomXAxisTopic.storyName = "current custom x-axis topic";
 export function CurrentCustomXAxisTopic(): JSX.Element {

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -391,8 +391,26 @@ export function LineGraphWithXMinMax(): JSX.Element {
   );
 }
 LineGraphWithXMinMax.parameters = {
+  colorScheme: "light",
   useReadySignal: true,
 };
+
+export function LineGraphWithXRange(): JSX.Element {
+  const readySignal = useReadySignal({ count: 3 });
+  const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  return (
+    <PlotWrapper
+      pauseFrame={pauseFrame}
+      config={{ ...exampleConfig, followingViewWidth: 3 }}
+      includeSettings
+    />
+  );
+}
+LineGraphWithXRange.parameters = {
+  colorScheme: "light",
+  useReadySignal: true,
+};
+LineGraphWithXRange.storyName = "line graph with x range";
 
 LineGraphWithNoTitle.storyName = "line graph with no title";
 export function LineGraphWithNoTitle(): JSX.Element {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -13,7 +13,7 @@
 
 import DownloadIcon from "@mui/icons-material/Download";
 import { Typography, useTheme } from "@mui/material";
-import { compact, isEmpty, uniq } from "lodash";
+import { compact, isEmpty, isNumber, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { useEffect, useCallback, useMemo, ComponentProps } from "react";
 
@@ -224,11 +224,12 @@ function Plot(props: Props) {
 
   const endTimeSinceStart = timeSincePreloadedStart(endTime);
   const fixedView = useMemo<ChartDefaultView | undefined>(() => {
-    if (minXValue != undefined && maxXValue != undefined) {
+    // Apply min/max x-value if either min or max or both is defined.
+    if ((isNumber(minXValue) && isNumber(endTimeSinceStart)) || isNumber(maxXValue)) {
       return {
         type: "fixed",
-        minXValue: Number(minXValue),
-        maxXValue: Number(maxXValue),
+        minXValue: isNumber(minXValue) ? minXValue : 0,
+        maxXValue: isNumber(maxXValue) ? maxXValue : endTimeSinceStart ?? 0,
       };
     }
     if (xAxisVal === "timestamp" && startTime && endTimeSinceStart != undefined) {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -13,8 +13,7 @@
 
 import DownloadIcon from "@mui/icons-material/Download";
 import { Typography, useTheme } from "@mui/material";
-import produce from "immer";
-import { compact, isEmpty, set, uniq } from "lodash";
+import { compact, isEmpty, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { useEffect, useCallback, useMemo, ComponentProps } from "react";
 
@@ -27,7 +26,7 @@ import {
   subtract as subtractTimes,
   toSec,
 } from "@foxglove/rostime";
-import { MessageEvent, SettingsTreeAction } from "@foxglove/studio";
+import { MessageEvent } from "@foxglove/studio";
 import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
 import parseRosPath, {
@@ -53,7 +52,6 @@ import {
   ChartDefaultView,
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
@@ -64,7 +62,7 @@ import { downloadCSV } from "./csv";
 import { getDatasets } from "./datasets";
 import helpContent from "./index.help.md";
 import { PlotDataByPath, PlotDataItem } from "./internalTypes";
-import { buildSettingsTree } from "./settings";
+import { usePlotPanelSettings } from "./settings";
 import { PlotConfig } from "./types";
 
 export { plotableRosTypes } from "./types";
@@ -177,6 +175,8 @@ function Plot(props: Props) {
     title,
     followingViewWidth,
     paths: yAxisPaths,
+    minXValue,
+    maxXValue,
     minYValue,
     maxYValue,
     showXAxisLabels,
@@ -224,11 +224,18 @@ function Plot(props: Props) {
 
   const endTimeSinceStart = timeSincePreloadedStart(endTime);
   const fixedView = useMemo<ChartDefaultView | undefined>(() => {
+    if (minXValue != undefined && maxXValue != undefined) {
+      return {
+        type: "fixed",
+        minXValue: Number(minXValue),
+        maxXValue: Number(maxXValue),
+      };
+    }
     if (xAxisVal === "timestamp" && startTime && endTimeSinceStart != undefined) {
       return { type: "fixed", minXValue: 0, maxXValue: endTimeSinceStart };
     }
     return undefined;
-  }, [endTimeSinceStart, startTime, xAxisVal]);
+  }, [maxXValue, minXValue, endTimeSinceStart, startTime, xAxisVal]);
 
   // following view and fixed view are split to keep defaultView identity stable when possible
   const defaultView = useMemo<ChartDefaultView | undefined>(() => {
@@ -436,29 +443,7 @@ function Plot(props: Props) {
     [messagePipeline, xAxisVal],
   );
 
-  const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
-
-  const actionHandler = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
-        return;
-      }
-
-      const { path, value } = action.payload;
-      saveConfig(
-        produce((draft) => {
-          set(draft, path.slice(1), value);
-        }),
-      );
-    },
-    [saveConfig],
-  );
-  useEffect(() => {
-    updatePanelSettingsTree({
-      actionHandler,
-      nodes: buildSettingsTree(config),
-    });
-  }, [actionHandler, config, updatePanelSettingsTree]);
+  usePlotPanelSettings(config, saveConfig);
 
   const stackDirection = useMemo(
     () => (legendDisplay === "top" ? "column" : "row"),

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -73,7 +73,7 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
     xAxis: {
       label: "X Axis",
       fields: {
-        showYAxisLabels: {
+        showXAxisLabels: {
           label: "Show labels",
           input: "boolean",
           value: config.showXAxisLabels,

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -2,16 +2,25 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { isNumber } from "lodash";
+import produce from "immer";
+import { isNumber, set } from "lodash";
+import { useCallback, useEffect } from "react";
 
-import { SettingsTreeNodes } from "@foxglove/studio";
+import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { PlotConfig } from "./types";
 
-export function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
+function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
   const maxYError =
     isNumber(config.minYValue) && isNumber(config.maxYValue) && config.minYValue >= config.maxYValue
       ? "Y max must be greater than Y min."
+      : undefined;
+
+  const maxXError =
+    isNumber(config.minXValue) && isNumber(config.maxXValue) && config.minXValue >= config.maxXValue
+      ? "X max must be greater than X min."
       : undefined;
 
   return {
@@ -36,24 +45,24 @@ export function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
           input: "boolean",
           value: config.showPlotValuesInLegend,
         },
-        showXAxisLabels: {
-          label: "Show X axis labels",
-          input: "boolean",
-          value: config.showXAxisLabels,
-        },
+      },
+    },
+    yAxis: {
+      label: "Y Axis",
+      fields: {
         showYAxisLabels: {
-          label: "Show Y axis labels",
+          label: "Show labels",
           input: "boolean",
           value: config.showYAxisLabels,
         },
         minYValue: {
-          label: "Y min",
+          label: "Min",
           input: "number",
           value: config.minYValue != undefined ? Number(config.minYValue) : undefined,
           placeholder: "auto",
         },
         maxYValue: {
-          label: "Y max",
+          label: "Max",
           input: "number",
           error: maxYError,
           value: config.maxYValue != undefined ? Number(config.maxYValue) : undefined,
@@ -61,11 +70,29 @@ export function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
         },
       },
     },
-    timeSeriesOnly: {
-      label: "Time series only",
+    xAxis: {
+      label: "X Axis",
       fields: {
+        showYAxisLabels: {
+          label: "Show labels",
+          input: "boolean",
+          value: config.showXAxisLabels,
+        },
+        minXValue: {
+          label: "Min",
+          input: "number",
+          value: config.minXValue != undefined ? Number(config.minXValue) : undefined,
+          placeholder: "auto",
+        },
+        maxXValue: {
+          label: "Max",
+          input: "number",
+          error: maxXError,
+          value: config.maxXValue != undefined ? Number(config.maxXValue) : undefined,
+          placeholder: "auto",
+        },
         followingViewWidth: {
-          label: "X range (seconds)",
+          label: "Range (seconds)",
           input: "number",
           placeholder: "auto",
           value: config.followingViewWidth,
@@ -73,4 +100,39 @@ export function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
       },
     },
   };
+}
+
+export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<PlotConfig>): void {
+  const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+
+  const actionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action !== "update") {
+        return;
+      }
+
+      const { path, value } = action.payload;
+      saveConfig(
+        produce((draft) => {
+          set(draft, path.slice(1), value);
+
+          // X min/max and following width are mutually exclusive.
+          if (path[1] === "followingViewWidth") {
+            draft.minXValue = undefined;
+            draft.maxXValue = undefined;
+          } else if (path[1] === "minXValue" || path[1] === "maxXValue") {
+            draft.followingViewWidth = undefined;
+          }
+        }),
+      );
+    },
+    [saveConfig],
+  );
+
+  useEffect(() => {
+    updatePanelSettingsTree({
+      actionHandler,
+      nodes: buildSettingsTree(config),
+    });
+  }, [actionHandler, config, updatePanelSettingsTree]);
 }

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -18,6 +18,8 @@ type DeprecatedPlotConfig = {
 export type PlotConfig = DeprecatedPlotConfig & {
   title?: string;
   paths: PlotPath[];
+  minXValue?: string | number;
+  maxXValue?: string | number;
   minYValue?: string | number;
   maxYValue?: string | number;
   showLegend: boolean;

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -18,8 +18,8 @@ type DeprecatedPlotConfig = {
 export type PlotConfig = DeprecatedPlotConfig & {
   title?: string;
   paths: PlotPath[];
-  minXValue?: string | number;
-  maxXValue?: string | number;
+  minXValue?: number;
+  maxXValue?: number;
   minYValue?: string | number;
   maxYValue?: string | number;
   showLegend: boolean;


### PR DESCRIPTION
**User-Facing Changes**
This adds new plot panel settings to manually specify the min and max X axis values.

**Description**
This adds new settings and new logic to clamp the X axis when both min and max are specified.

It also separates X & Y related settings into their own nodes in the settings sidebar.

<img width="1244" alt="Screen Shot 2022-08-16 at 3 07 33 PM" src="https://user-images.githubusercontent.com/93935560/184962037-5ec0fbe7-f0dc-4f7b-a3aa-c11a04e4c36b.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #3991
Fixes #4251