### PR TITLE
render order being disabled causing transparency fighting

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -295,7 +295,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.gl.info.autoReset = false;
     this.gl.shadowMap.enabled = false;
     this.gl.shadowMap.type = THREE.VSMShadowMap;
-    this.gl.sortObjects = false;
+    this.gl.sortObjects = true;
     this.gl.setPixelRatio(window.devicePixelRatio);
 
     let width = canvas.width;


### PR DESCRIPTION
Fixes #4082 - Enable threejs object sorting

**User-Facing Changes**
 - Transparent object ordering in the new 3D view has been fixed so that their colors can be properly stacked in order away from the camera
 
**Description**
 - enable sortObjects on the threejs renderer
 - doesn't seem to affect the render order or lines and text markers/labels


<!-- link relevant github issues -->
https://github.com/foxglove/studio/issues/4082
<!-- add `docs` label if this PR requires documentation updates -->
