### PR TITLE
Hide Safari chrome when launched from Home screen on iOS

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -112,6 +112,7 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
   <html>
     <head>
       <meta charset="utf-8">
+      <meta name="apple-mobile-web-app-capable" content="yes">
       <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />


### PR DESCRIPTION
**User-Facing Changes**

When the user saves the web-based Studio to the Home Screen, this causes the shortcut to launch as a separate "app" without Safari chrome, removing the address bar and the user's other tabs for a cleaner look.

**Description**

See here: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW2

To take this further you could specify the status bar color.

```
<meta name="apple-mobile-web-app-status-bar-style" content="black">
```

I understand Safari and touch-based devices are not officially supported but this would be a nicety for users who are experimenting with Studio as, for example, a read-only dashboard.