### PR TITLE
Remove `seq` from ThreeDeeRender and ThreeDimensionalViz publish messages

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/publish.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/publish.ts
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
+import { fromDate } from "@foxglove/rostime";
+import { Point, makeCovarianceArray } from "@foxglove/studio-base/util/geometry";
+
+import { Pose } from "./transforms/geometry";
+
+export const PublishDatatypes = new Map(
+  (
+    [
+      "geometry_msgs/Point",
+      "geometry_msgs/PointStamped",
+      "geometry_msgs/Pose",
+      "geometry_msgs/PoseStamped",
+      "geometry_msgs/PoseWithCovariance",
+      "geometry_msgs/PoseWithCovarianceStamped",
+      "geometry_msgs/Quaternion",
+      "std_msgs/Header",
+    ] as Array<keyof typeof commonDefs>
+  ).map((type) => [type, commonDefs[type]]),
+);
+
+export function makePointMessage(point: Point, frameId: string): unknown {
+  const time = fromDate(new Date());
+  return {
+    // seq is omitted since it is not present in ros2
+    header: { stamp: time, frame_id: frameId },
+    point: { x: point.x, y: point.y, z: 0 },
+  };
+}
+
+export function makePoseMessage(pose: Pose, frameId: string): unknown {
+  const time = fromDate(new Date());
+  return {
+    // seq is omitted since it is not present in ros2
+    header: { stamp: time, frame_id: frameId },
+    pose,
+  };
+}
+
+export function makePoseEstimateMessage(
+  pose: Pose,
+  frameId: string,
+  xDev: number,
+  yDev: number,
+  thetaDev: number,
+): unknown {
+  const time = fromDate(new Date());
+  return {
+    // seq is omitted since it is not present in ros2
+    header: { stamp: time, frame_id: frameId },
+    pose: {
+      covariance: makeCovarianceArray(xDev, yDev, thetaDev),
+      pose,
+    },
+  };
+}

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/PublishClickTool.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/PublishClickTool.tsx
@@ -50,7 +50,7 @@ function makePointMessage(topic: string, point: Point, frameId: string) {
   return {
     topic,
     msg: {
-      header: { seq: 0, stamp: time, frame_id: frameId },
+      header: { stamp: time, frame_id: frameId },
       point: { x: point.x, y: point.y, z: 0 },
     },
   };
@@ -61,7 +61,7 @@ function makePoseMessage(topic: string, start: Point, end: Point, frameId: strin
   return {
     topic,
     msg: {
-      header: { seq: 0, stamp: time, frame_id: frameId },
+      header: { stamp: time, frame_id: frameId },
       pose: {
         position: { x: start.x, y: start.y, z: 0 },
         orientation: quaternionFromPoints(start, end),
@@ -83,7 +83,7 @@ function makePoseEstimateMessage(
   return {
     topic,
     msg: {
-      header: { seq: 0, stamp: time, frame_id: frameId },
+      header: { stamp: time, frame_id: frameId },
       pose: {
         covariance: makeCovarianceArray(x, y, theta),
         pose: {


### PR DESCRIPTION


**User-Facing Changes**
Publishing via the 3d and 3d (beta) panel works for ROS2 data sources if the connection supports publishing (rosbridge supports publishing to both ros1 and ros2).

**Description**
When publishing messages to a ROS 2 source (rosbridge), the `seq` field would cause the rosbridge to fail because headers in ROS2 do not have a `seq` field.

This change removes the `seq` field from ThreeDeeRender and ThreeDimensionalViz so those messages are valid to publish.

Fixes: #2834

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
