### PR TITLE
[New3D] Update settings sidebar when toggling 2D/3D mode via panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -233,6 +233,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   input: Input;
   outlineMaterial = new THREE.LineBasicMaterial({ dithering: true });
 
+  coreSettings: CoreSettings;
   measurementTool: MeasurementTool;
   publishClickTool: PublishClickTool;
 
@@ -369,8 +370,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.measurementTool = new MeasurementTool(this);
     this.publishClickTool = new PublishClickTool(this);
+    this.coreSettings = new CoreSettings(this);
 
-    this.addSceneExtension(new CoreSettings(this));
+    this.addSceneExtension(this.coreSettings);
     this.addSceneExtension(new Cameras(this));
     this.addSceneExtension(new FrameAxes(this));
     this.addSceneExtension(new Grids(this));
@@ -451,6 +453,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
   updateConfig(updateHandler: (draft: RendererConfig) => void): void {
     this.config = produce(this.config, updateHandler);
     this.emit("configChange", this);
+  }
+
+  /** Updates the settings tree for core settings to account for any changes in the config. */
+  updateCoreSettings(): void {
+    this.coreSettings.updateSettingsTree();
   }
 
   addDatatypeSubscriptions<T>(

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -463,7 +463,8 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     });
   }, [actionHandler, context, settingsTree]);
 
-  // Update the renderer's reference to `config` when it changes
+  // Update the renderer's reference to `config` when it changes. Note that this does *not*
+  // automatically update the settings tree.
   useEffect(() => {
     if (renderer) {
       renderer.config = config;
@@ -793,7 +794,8 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       ...prevConfig,
       cameraState: { ...prevConfig.cameraState, perspective: !prevConfig.cameraState.perspective },
     }));
-  }, []);
+    setTimeout(() => renderer?.updateCoreSettings(), 0);
+  }, [renderer]);
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -30,8 +30,6 @@ export const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
   poseEstimateThetaDeviation: round(Math.PI / 12, 8),
 };
 
-const ONE_DEGREE = Math.PI / 180;
-
 export class CoreSettings extends SceneExtension {
   constructor(renderer: Renderer) {
     super("foxglove.CoreSettings", renderer);
@@ -145,7 +143,7 @@ export class CoreSettings extends SceneExtension {
                 thetaOffset: {
                   label: "Theta",
                   input: "number",
-                  step: ONE_DEGREE,
+                  step: 1,
                   precision: PRECISION_DEGREES,
                   value: camera.thetaOffset,
                 },
@@ -153,14 +151,14 @@ export class CoreSettings extends SceneExtension {
                   phi: {
                     label: "Phi",
                     input: "number",
-                    step: ONE_DEGREE,
+                    step: 1,
                     precision: PRECISION_DEGREES,
                     value: camera.phi,
                   },
                   fovy: {
                     label: "Y-Axis FOV",
                     input: "number",
-                    step: ONE_DEGREE,
+                    step: 1,
                     precision: PRECISION_DEGREES,
                     value: camera.fovy,
                   },


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug in the 3D (Beta) panel where the settings sidebar would not update when toggling between 2D/3D mode via the panel button or keyboard shortcut.
Fixed an issue with numeric step buttons in 3D (Beta) panel settings not working for Phi, Theta, and Y-Axis FOV.

**Description**
For performance reasons, the New3D panel does not call `updatePanelSettingsEditor` any time its configuration changes, but only when the panel deems necessary (usually in a settings action handler, or when a scene extension notices a change in the underlying data source, after a debounced waiting period). The 2D/3D toggle button & keyboard shortcut were implemented via directly changing the config, and the config change triggers a re-render via useEffect, but that did not trigger an update of the settings tree. (The CoreSettings object updates its settings subtree when it detects a cameraMove event from the panel, but in this case the change did not come from the panel.) The fix is to manually tell the CoreSettings object to update the tree after the setting is toggled.

The `ONE_DEGREE` -> `1` change fixes a regression from https://github.com/foxglove/studio/pull/4043 where we forgot to update the step values in settings tree when the values changed from radians to degrees.