### PR TITLE
Fix layout browser stories

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -97,7 +97,7 @@ async function deleteLayoutInteraction(index: number) {
 
 async function doMultiAction(action: string) {
   await selectAllAction();
-  await clickMenuButtonAction(0);
+  await clickMenuButtonAction(1);
   const button = await screen.findByText(action);
   fireEvent.click(button);
 }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes layout browser stories. This is a quick fix to get stories working again until the underlying issue with the context menu items is fixed.

The root issue is reported in https://github.com/foxglove/studio/issues/4170.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
