### PR TITLE
Fix layout context menu logic

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutRow.tsx
@@ -119,6 +119,7 @@ export type LayoutActionMenuItem =
 
 export default React.memo(function LayoutRow({
   layout,
+  anySelectedModifiedLayouts,
   multiSelectedIds,
   selected,
   onSelect,
@@ -132,6 +133,7 @@ export default React.memo(function LayoutRow({
   onMakePersonalCopy,
 }: {
   layout: Layout;
+  anySelectedModifiedLayouts: boolean;
   multiSelectedIds: readonly string[];
   selected: boolean;
   onSelect: (item: Layout, params?: { selectedViaClick?: boolean; event?: MouseEvent }) => void;
@@ -325,7 +327,7 @@ export default React.memo(function LayoutRow({
     },
   ];
 
-  if (hasModifications) {
+  if (hasModifications || anySelectedModifiedLayouts) {
     const sectionItems: LayoutActionMenuItem[] = [
       {
         type: "item",
@@ -352,13 +354,16 @@ export default React.memo(function LayoutRow({
         onClick: makePersonalCopyAction,
       });
     }
+
+    const unsavedChangesMessage = anySelectedModifiedLayouts
+      ? "These layouts have unsaved changes"
+      : "This layout has unsaved changes";
+
     menuItems.unshift(
       {
         key: "changes",
         type: "header",
-        text: deletedOnServer
-          ? "Someone else has deleted this layout"
-          : "This layout has unsaved changes",
+        text: deletedOnServer ? "Someone else has deleted this layout" : unsavedChangesMessage,
       },
       ...sectionItems,
       { key: "changes_divider", type: "divider" },

--- a/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/LayoutSection.tsx
@@ -14,6 +14,7 @@ export default function LayoutSection({
   title,
   emptyText,
   items,
+  anySelectedModifiedLayouts,
   multiSelectedIds,
   selectedId,
   onSelect,
@@ -29,6 +30,7 @@ export default function LayoutSection({
   title: string | undefined;
   emptyText: string | undefined;
   items: readonly Layout[] | undefined;
+  anySelectedModifiedLayouts: boolean;
   multiSelectedIds: readonly string[];
   selectedId?: string;
   onSelect: (item: Layout, params?: { selectedViaClick?: boolean; event?: MouseEvent }) => void;
@@ -60,6 +62,7 @@ export default function LayoutSection({
         )}
         {items?.map((layout) => (
           <LayoutRow
+            anySelectedModifiedLayouts={anySelectedModifiedLayouts}
             multiSelectedIds={multiSelectedIds}
             selected={layout.id === selectedId}
             key={layout.id}

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -97,7 +97,7 @@ async function deleteLayoutInteraction(index: number) {
 
 async function doMultiAction(action: string) {
   await selectAllAction();
-  await clickMenuButtonAction(1);
+  await clickMenuButtonAction(0);
   const button = await screen.findByText(action);
   fireEvent.click(button);
 }

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -17,7 +17,7 @@ import {
 import { partition } from "lodash";
 import moment from "moment";
 import path from "path";
-import { MouseEvent, useCallback, useContext, useEffect, useLayoutEffect } from "react";
+import { MouseEvent, useCallback, useContext, useEffect, useLayoutEffect, useMemo } from "react";
 import { useToasts } from "react-toast-notifications";
 import { useMountedState } from "react-use";
 import useAsyncFn from "react-use/lib/useAsyncFn";
@@ -506,6 +506,12 @@ export default function LayoutBrowser({
 
   const pendingMultiAction = state.multiAction?.ids != undefined;
 
+  const anySelectedModifiedLayouts = useMemo(() => {
+    return [layouts.value?.personal ?? [], layouts.value?.shared ?? []]
+      .flat()
+      .some((layout) => layout.working != undefined && state.selectedIds.includes(layout.id));
+  }, [layouts, state.selectedIds]);
+
   return (
     <SidebarContent
       title="Layouts"
@@ -549,6 +555,7 @@ export default function LayoutBrowser({
           title={layoutManager.supportsSharing ? "Personal" : undefined}
           emptyText="Add a new layout to get started with Foxglove Studio!"
           items={layouts.value?.personal}
+          anySelectedModifiedLayouts={anySelectedModifiedLayouts}
           multiSelectedIds={state.selectedIds}
           selectedId={currentLayoutId}
           onSelect={onSelectLayout}
@@ -566,6 +573,7 @@ export default function LayoutBrowser({
             title="Team"
             emptyText="Your organization doesn’t have any shared layouts yet. Share a personal layout to collaborate with other team members."
             items={layouts.value?.shared}
+            anySelectedModifiedLayouts={anySelectedModifiedLayouts}
             multiSelectedIds={state.selectedIds}
             selectedId={currentLayoutId}
             onSelect={onSelectLayout}


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue in the layout browser context menu logic.

**Description**
The fix is to consider the saved/unsaved state of all selected layouts instead of just the clicked layout when determining whether or not to show the save and revert items in the context menu.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4170 