### PR TITLE
Improve error message when user script errors during runtime

### DIFF
--- a/packages/studio-base/src/components/NotificationModal.stories.tsx
+++ b/packages/studio-base/src/components/NotificationModal.stories.tsx
@@ -25,7 +25,7 @@ export default {
   title: "components/NotificationModal",
 };
 
-export const ErrorModal = (): JSX.Element => {
+export const ErrorNoSubtextWithDetails = (): JSX.Element => {
   return (
     <NotificationModal
       onRequestClose={() => {}}
@@ -33,18 +33,17 @@ export const ErrorModal = (): JSX.Element => {
         id: "1",
         message: "Error 1",
         details: fakeError(),
-        read: false,
         created: new Date(),
         severity: "error",
       }}
     />
   );
 };
-ErrorModal.parameters = { colorScheme: "light" };
-export const ErrorModalDark = ErrorModal.bind(undefined);
-ErrorModalDark.parameters = { colorScheme: "dark" };
+ErrorNoSubtextWithDetails.parameters = { colorScheme: "light" };
+export const ErrorNoSubtextWithDetailsDark = ErrorNoSubtextWithDetails.bind(undefined);
+ErrorNoSubtextWithDetailsDark.parameters = { colorScheme: "dark" };
 
-export const ErrorModalWithSubtext = (): JSX.Element => {
+export const ErrorWithSubtextAndDetails = (): JSX.Element => {
   return (
     <NotificationModal
       onRequestClose={() => {}}
@@ -52,7 +51,6 @@ export const ErrorModalWithSubtext = (): JSX.Element => {
         id: "1",
         message: "Error 1",
         details: fakeError(),
-        read: false,
         created: new Date(),
         severity: "error",
         subText: "This error has a subtext.",
@@ -60,7 +58,24 @@ export const ErrorModalWithSubtext = (): JSX.Element => {
     />
   );
 };
-ErrorModalWithSubtext.parameters = { colorScheme: "light" };
+ErrorWithSubtextAndDetails.parameters = { colorScheme: "light" };
+
+export const ErrorWithSubtextNoDetails = (): JSX.Element => {
+  return (
+    <NotificationModal
+      onRequestClose={() => {}}
+      notification={{
+        id: "1",
+        message: "Error 1",
+        details: undefined,
+        created: new Date(),
+        severity: "error",
+        subText: "This error has a subtext.",
+      }}
+    />
+  );
+};
+ErrorWithSubtextNoDetails.parameters = { colorScheme: "light" };
 
 export const Warning = (): JSX.Element => {
   return (
@@ -70,7 +85,6 @@ export const Warning = (): JSX.Element => {
         id: "1",
         message: "Warning 1",
         details: "Some error details",
-        read: false,
         created: new Date(),
         severity: "warn",
       }}
@@ -79,7 +93,7 @@ export const Warning = (): JSX.Element => {
 };
 Warning.parameters = { colorScheme: "dark" };
 
-export const ErrorWithoutDetails = (): JSX.Element => {
+export const ErrorNoDetailsOrSubtext = (): JSX.Element => {
   return (
     <NotificationModal
       onRequestClose={() => {}}
@@ -87,14 +101,13 @@ export const ErrorWithoutDetails = (): JSX.Element => {
         id: "1",
         message: "Error 1",
         details: undefined,
-        read: false,
         created: new Date(),
         severity: "error",
       }}
     />
   );
 };
-ErrorWithoutDetails.parameters = { colorScheme: "dark" };
+ErrorNoDetailsOrSubtext.parameters = { colorScheme: "dark" };
 
 export const ErrorWithJsxElementDetails = (): JSX.Element => {
   return (
@@ -108,7 +121,6 @@ export const ErrorWithJsxElementDetails = (): JSX.Element => {
             This is <b style={{ color: "red" }}>customized</b> error detail.
           </p>
         ),
-        read: false,
         created: new Date(),
         severity: "error",
       }}
@@ -127,7 +139,6 @@ export const ErrorWithNewlineDetails = (): JSX.Element => {
         id: "1",
         message: "Error 1",
         details: "Some details.\n\nWith a newline.",
-        read: false,
         created: new Date(),
         severity: "error",
       }}

--- a/packages/studio-base/src/components/NotificationModal.tsx
+++ b/packages/studio-base/src/components/NotificationModal.tsx
@@ -4,6 +4,7 @@
 
 import CloseIcon from "@mui/icons-material/Close";
 import { Box, Dialog, DialogTitle, IconButton, Typography, useTheme } from "@mui/material";
+import { useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { NotificationMessage } from "@foxglove/studio-base/util/sendNotification";
@@ -45,22 +46,28 @@ export default function NotificationModal({
     info: theme.palette.info.main,
   };
 
+  const detailsElement = useMemo(() => {
+    if (details instanceof Error) {
+      return <Box className={classes.text}>{details.stack}</Box>;
+    } else if (details != undefined && details !== "") {
+      return (
+        <Typography style={{ whiteSpace: "pre-line" /* allow newlines in the details message */ }}>
+          {details}
+        </Typography>
+      );
+    } else if (subText) {
+      return undefined;
+    }
+
+    return "No details provided";
+  }, [classes, details, subText]);
+
   return (
     <Dialog classes={{ paper: classes.paper }} fullWidth open onClose={() => onRequestClose?.()}>
       <DialogTitle color={displayPropsBySeverity[severity]}>{message}</DialogTitle>
       <Box className={classes.container}>
         {subText && <Typography mb={3}>{subText}</Typography>}
-        {details instanceof Error ? (
-          <Box className={classes.text}>{details.stack}</Box>
-        ) : details != undefined && details !== "" ? (
-          <Typography
-            style={{ whiteSpace: "pre-line" /* allow newlines in the details message */ }}
-          >
-            {details}
-          </Typography>
-        ) : (
-          "No details provided"
-        )}
+        {detailsElement}
       </Box>
       <IconButton
         aria-label="close"

--- a/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/BottomBar/DiagnosticsSection.tsx
@@ -63,10 +63,12 @@ const DiagnosticsSection = ({ diagnostics }: Props): ReactElement => {
           (invert(DiagnosticSeverity) as Record<string, keyof typeof DiagnosticSeverity>)[
             severity
           ] ?? "Error";
+
         const errorLoc =
           startLineNumber != undefined && startColumn != undefined
             ? `[${startLineNumber + 1},${startColumn + 1}]`
-            : undefined;
+            : "";
+
         return (
           <StyledListItem key={`${message}_${i}`}>
             <ListItemIcon>{severityIcons[severityLabel]}</ListItemIcon>

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -485,26 +485,34 @@ export default class UserNodePlayer implements Player {
           return;
         }
 
-        const diagnostics =
-          result.error != undefined
-            ? [
-                {
-                  source: Sources.Runtime,
-                  severity: DiagnosticSeverity.Error,
-                  message: result.error,
-                  code: ErrorCodes.RUNTIME,
-                },
-              ]
-            : [];
-        if (diagnostics.length > 0) {
-          this._setUserNodeDiagnostics(nodeId, diagnostics);
+        const allDiagnostics = result.userNodeDiagnostics;
+        if (result.error) {
+          allDiagnostics.push({
+            source: Sources.Runtime,
+            severity: DiagnosticSeverity.Error,
+            message: result.error,
+            code: ErrorCodes.RUNTIME,
+          });
         }
+
         this._addUserNodeLogs(nodeId, result.userNodeLogs);
+
+        if (allDiagnostics.length > 0) {
+          this._problemStore.set(problemKey, {
+            severity: "error",
+            message: `User Script ${nodeId} suffered an error.`,
+            tip: "Open the User Scripts panel and check the Problems tab for errors.",
+          });
+
+          this._setUserNodeDiagnostics(nodeId, allDiagnostics);
+          return;
+        }
 
         if (!result.message) {
           this._problemStore.set(problemKey, {
             severity: "warn",
-            message: `User Script ${nodeId} did not produce a message`,
+            message: `User Script ${nodeId} did not produce a message.`,
+            tip: "Check that all code paths in the user script return a message.",
           });
           return;
         }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -500,7 +500,7 @@ export default class UserNodePlayer implements Player {
         if (allDiagnostics.length > 0) {
           this._problemStore.set(problemKey, {
             severity: "error",
-            message: `User Script ${nodeId} suffered an error.`,
+            message: `User Script ${nodeId} encountered an error.`,
             tip: "Open the User Scripts panel and check the Problems tab for errors.",
           });
 

--- a/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/registry.ts
@@ -15,8 +15,11 @@ import path from "path";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   Diagnostic,
+  DiagnosticSeverity,
+  ErrorCodes,
   ProcessMessageOutput,
   RegistrationOutput,
+  Sources,
   UserNodeLog,
 } from "@foxglove/studio-base/players/UserNodePlayer/types";
 import { DEFAULT_STUDIO_NODE_PREFIX } from "@foxglove/studio-base/util/globalConstants";
@@ -157,11 +160,18 @@ export const processMessage = ({
     return { message: newMessage, error: undefined, userNodeLogs, userNodeDiagnostics };
   } catch (err) {
     const error: string = err.toString();
+    const diagnostic: Diagnostic = {
+      source: Sources.Runtime,
+      severity: DiagnosticSeverity.Error,
+      message: error.length > 0 ? error : "Unknown error encountered running this node.",
+      code: ErrorCodes.RUNTIME,
+    };
+
     return {
       message: undefined,
-      error: error.length > 0 ? error : "Unknown error encountered running this node.",
+      error: undefined,
       userNodeLogs,
-      userNodeDiagnostics,
+      userNodeDiagnostics: [diagnostic],
     };
   }
 };

--- a/packages/studio-base/src/util/sendNotification.ts
+++ b/packages/studio-base/src/util/sendNotification.ts
@@ -37,7 +37,6 @@ export type NotificationMessage = {
   readonly message: string;
   readonly details: DetailsType;
   readonly subText?: string;
-  readonly read?: boolean;
   readonly created?: Date;
   readonly severity: NotificationSeverity;
 };


### PR DESCRIPTION


**User-Facing Changes**
When a user script errors, the new message displayed to the user is the following:

<img width="721" alt="Screen Shot 2022-08-17 at 6 09 36 PM" src="https://user-images.githubusercontent.com/84792/185270252-031756ad-9239-41c7-a593-3c8907fb2bda.png">

Additionally, the `Problems` tab diagnostics list is fixed to removed the `undefined` text that would show up after `Runtime`.

<img width="433" alt="Screen Shot 2022-08-17 at 5 45 12 PM" src="https://user-images.githubusercontent.com/84792/185270249-7c5ea170-5a65-48dd-ad04-1e315ab66b37.png">


**Description**
When a user script errors during runtime and fails to produce a message, the previous error displayed would only indicate that a script failed to produce a message. This warning did not make it obvious that the user script in fact errored during runtime.

This change improves the error to be clear that the script errored during runtime when there is an error rather than only a missing message.

Fixes: #4084

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
