### PR TITLE
Fix outdated links to docs

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/help.md
+++ b/packages/studio-base/src/components/DataSourceSidebar/help.md
@@ -1,1 +1,1 @@
-Foxglove Studio can inspect robotics data from various [sources](https://foxglove.dev/docs/app-concepts/data-sources).
+Foxglove Studio can inspect robotics data from various [sources](https://foxglove.dev/docs/studio/connection/data-sources).

--- a/packages/studio-base/src/components/EmptyPanelLayout.tsx
+++ b/packages/studio-base/src/components/EmptyPanelLayout.tsx
@@ -83,11 +83,7 @@ export const EmptyPanelLayout = ({ tabId }: Props): JSX.Element => {
         <Stack paddingBottom={2}>
           <Typography variant="body2" paddingX={2} paddingTop={2}>
             Select a panel below to add it to your layout.{" "}
-            <Link
-              color="primary"
-              target="_blank"
-              href="https://foxglove.dev/docs/app-concepts/layouts"
-            >
+            <Link color="primary" target="_blank" href="https://foxglove.dev/docs/studio/layouts">
               Learn more
             </Link>
           </Typography>

--- a/packages/studio-base/src/components/LayoutBrowser/index.help.md
+++ b/packages/studio-base/src/components/LayoutBrowser/index.help.md
@@ -1,1 +1,1 @@
-Arrange Foxglove Studio panels into custom workspaces, called [layouts](https://foxglove.dev/docs/app-concepts/layouts), for your unique visualization and debugging workflows.
+Arrange Foxglove Studio panels into custom workspaces, called [layouts](https://foxglove.dev/docs/studio/layouts), for your unique visualization and debugging workflows.

--- a/packages/studio-base/src/components/MessagePathSyntax/index.help.md
+++ b/packages/studio-base/src/components/MessagePathSyntax/index.help.md
@@ -34,4 +34,4 @@ Message path syntax is used throughout Studio to help you drill down to the exac
 - Multiple filters
   - `/some_topic.many_values[:]{some_str_field=="abc"}{some_num_field==5}{some_boolean_field==false}.x`
 
-[View docs](https://foxglove.dev/docs/app-concepts/message-path-syntax).
+[View docs](https://foxglove.dev/docs/studio/app-concepts/message-path-syntax).

--- a/packages/studio-base/src/components/PanelList/index.help.md
+++ b/packages/studio-base/src/components/PanelList/index.help.md
@@ -1,1 +1,1 @@
-[Panels](https://foxglove.dev/docs/app-concepts/panels) are modular visualization interfaces that can be configured and arranged into layouts.
+[Panels](https://foxglove.dev/docs/studio/panels/introduction) are modular visualization interfaces that can be configured and arranged into layouts.

--- a/packages/studio-base/src/components/VariablesSidebar/index.help.md
+++ b/packages/studio-base/src/components/VariablesSidebar/index.help.md
@@ -1,3 +1,3 @@
-[Variables](https://foxglove.dev/docs/app-concepts/variables) can be set to any primitive value for a given layout.
+[Variables](https://foxglove.dev/docs/studio/app-concepts/variables) can be set to any primitive value for a given layout.
 
 Reference variables in any panel that supports [message path syntax](#help:message-path-syntax) to switch quickly between subsets of your data.

--- a/packages/studio-base/src/panels/NodePlayground/index.help.md
+++ b/packages/studio-base/src/panels/NodePlayground/index.help.md
@@ -12,6 +12,6 @@ Check out the _templates_ within the editor for sample nodes.
 
 To debug your code, call `log(someValue, anotherValue)` to print values to the Logs section at the bottom of the editor panel.
 
-You can write more complex nodes that output custom datatypes or listen to multiple input topics. You can even reference [variables](https://foxglove.dev/docs/app-concepts/variables) or import the utility functions listed in the sidebar's "Utilities" tab.
+You can write more complex nodes that output custom datatypes or listen to multiple input topics. You can even reference [variables](https://foxglove.dev/docs/studio/app-concepts/variables) or import the utility functions listed in the sidebar's "Utilities" tab.
 
-[View docs](https://foxglove.dev/docs/panels/node-playground).
+[View docs](https://foxglove.dev/docs/studio/panels/user-scripts).


### PR DESCRIPTION

**User-Facing Changes**
Clicking the updated links takes users to the correct docs pages.

**Description**
Fixes: #4168


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
