### PR TITLE
Benchmark: Add sinewave plot and synthetic player

### DIFF
--- a/benchmark/src/Root.tsx
+++ b/benchmark/src/Root.tsx
@@ -6,11 +6,9 @@ import { useMemo, useState } from "react";
 
 import { App, IDataSourceFactory, ConsoleApi, AppSetting } from "@foxglove/studio-base";
 
-import McapLocalBenchmarkDataSourceFactory from "./dataSources/McapLocalBenchmarkDataSourceFactory";
+import { McapLocalBenchmarkDataSourceFactory, SyntheticDataSourceFactory } from "./dataSources";
 import { LAYOUTS } from "./layouts";
 import { PredefinedLayoutStorage, MemoryAppConfiguration } from "./services";
-
-const BENCHMARK_NAME = "benchmark-3d-panel"; // see layouts.ts
 
 export function Root(): JSX.Element {
   const [appConfiguration] = useState(
@@ -18,12 +16,13 @@ export function Root(): JSX.Element {
       new MemoryAppConfiguration({
         defaults: {
           [AppSetting.LAUNCH_PREFERENCE]: "web",
+          [AppSetting.MESSAGE_RATE]: 240,
         },
       }),
   );
 
   const dataSources: IDataSourceFactory[] = useMemo(() => {
-    const sources = [new McapLocalBenchmarkDataSourceFactory()];
+    const sources = [new McapLocalBenchmarkDataSourceFactory(), new SyntheticDataSourceFactory()];
 
     return sources;
   }, []);
@@ -33,7 +32,6 @@ export function Root(): JSX.Element {
   const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL ?? ""), []);
 
   const url = new URL(window.location.href);
-  url.searchParams.set("layoutId", BENCHMARK_NAME);
 
   return (
     <App

--- a/benchmark/src/dataSources/McapLocalBenchmarkDataSourceFactory.ts
+++ b/benchmark/src/dataSources/McapLocalBenchmarkDataSourceFactory.ts
@@ -29,4 +29,4 @@ class McapLocalBenchmarkDataSourceFactory implements IDataSourceFactory {
   }
 }
 
-export default McapLocalBenchmarkDataSourceFactory;
+export { McapLocalBenchmarkDataSourceFactory };

--- a/benchmark/src/dataSources/SyntheticDataSourceFactory.ts
+++ b/benchmark/src/dataSources/SyntheticDataSourceFactory.ts
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  IDataSourceFactory,
+  DataSourceFactoryInitializeArgs,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { Player } from "@foxglove/studio-base/players/types";
+
+import { SinewavePlayer } from "../players";
+
+class SyntheticDataSourceFactory implements IDataSourceFactory {
+  id = "synthetic";
+  type: IDataSourceFactory["type"] = "connection";
+  displayName = "Synthetic";
+  iconName: IDataSourceFactory["iconName"] = "FileASPX";
+
+  initialize(_args: DataSourceFactoryInitializeArgs): Player | undefined {
+    return new SinewavePlayer();
+  }
+}
+
+export { SyntheticDataSourceFactory };

--- a/benchmark/src/dataSources/index.ts
+++ b/benchmark/src/dataSources/index.ts
@@ -2,5 +2,5 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export * from "./BenchmarkPlayer";
-export * from "./SinewavePlayer";
+export * from "./SyntheticDataSourceFactory";
+export * from "./McapLocalBenchmarkDataSourceFactory";

--- a/benchmark/src/layouts.ts
+++ b/benchmark/src/layouts.ts
@@ -212,7 +212,32 @@ const LAYOUTS = new Map<string, Layout>([
               title: "10 second window",
               paths: [
                 {
-                  value: "sinewave.value",
+                  value: "sinewave_0.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+                {
+                  value: "sinewave_1.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+                {
+                  value: "sinewave_2.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+                {
+                  value: "sinewave_3.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+                {
+                  value: "sinewave_4.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+                {
+                  value: "sinewave_5.value",
                   enabled: true,
                   timestampMethod: "receiveTime",
                 },

--- a/benchmark/src/layouts.ts
+++ b/benchmark/src/layouts.ts
@@ -199,6 +199,49 @@ const LAYOUTS = new Map<string, Layout>([
       syncInfo: undefined,
     },
   ],
+  [
+    "benchmark-single-plot",
+    {
+      id: "benchmark-single-plot" as LayoutID,
+      name: "Benchmark - Single Plot",
+      permission: "CREATOR_WRITE",
+      baseline: {
+        data: {
+          configById: {
+            "Plot!a": {
+              title: "10 second window",
+              paths: [
+                {
+                  value: "sinewave.value",
+                  enabled: true,
+                  timestampMethod: "receiveTime",
+                },
+              ],
+              showXAxisLabels: true,
+              showYAxisLabels: true,
+              showLegend: true,
+              legendDisplay: "floating",
+              showPlotValuesInLegend: false,
+              isSynced: true,
+              xAxisVal: "timestamp",
+              sidebarDimension: 240,
+              followingViewWidth: 10,
+            },
+          },
+          globalVariables: {},
+          userNodes: {},
+          linkedGlobalVariables: [],
+          playbackConfig: {
+            speed: 1,
+          },
+          layout: "Plot!a",
+        },
+        savedAt: new Date().toISOString() as ISO8601Timestamp,
+      },
+      working: undefined,
+      syncInfo: undefined,
+    },
+  ],
 ]);
 
 export { LAYOUTS };

--- a/benchmark/src/layouts.ts
+++ b/benchmark/src/layouts.ts
@@ -234,7 +234,11 @@ const LAYOUTS = new Map<string, Layout>([
           playbackConfig: {
             speed: 1,
           },
-          layout: "Plot!a",
+          layout: {
+            first: "Plot!a",
+            second: "PlaybackPerformance!1fz1hnn",
+            direction: "column",
+          },
         },
         savedAt: new Date().toISOString() as ISO8601Timestamp,
       },

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -15,6 +15,7 @@ import {
   PublishPayload,
   SubscribePayload,
   Topic,
+  TopicStats,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -26,7 +27,6 @@ class SinewavePlayer implements Player {
   private name: string = "sinewave";
   private startTime: Time = rostime.fromDate(new Date());
   private listener?: (state: PlayerState) => Promise<void>;
-  private topicStats = new Map();
   private datatypes: RosDatatypes = new Map();
 
   constructor() {
@@ -88,20 +88,43 @@ class SinewavePlayer implements Player {
       },
     });
 
-    const topics: Topic[] = [{ name: "sinewave", datatype: "Sinewave" }];
+    const sinewaveCount = 100;
 
+    const topics: Topic[] = [];
+
+    const startTime = rostime.fromDate(new Date());
+
+    for (let i = 0; i < sinewaveCount; ++i) {
+      const topicName = `sinewave_${i}`;
+      topics.push({ name: topicName, datatype: "Sinewave" });
+    }
+
+    let messageCount = 0;
     for (;;) {
+      messageCount += 1;
+
+      const topicStats = new Map<string, TopicStats>();
+
       const now = rostime.fromDate(new Date());
       const value = Math.sin(rostime.toSec(now));
 
-      const messages: MessageEvent<unknown>[] = [
-        {
+      const messages: MessageEvent<unknown>[] = [];
+
+      for (let i = 0; i < sinewaveCount; ++i) {
+        const topicName = `sinewave_${i}`;
+        messages.push({
           receiveTime: now,
-          topic: "sinewave",
-          message: { value },
+          topic: topicName,
+          message: { value: value + i * 0.1 },
           sizeInBytes: 0,
-        },
-      ];
+        });
+
+        topicStats.set(topicName, {
+          numMessages: messageCount,
+          firstMessageTime: startTime,
+          lastMessageTime: now,
+        });
+      }
 
       await listener({
         profile: undefined,
@@ -120,7 +143,7 @@ class SinewavePlayer implements Player {
           lastSeekTime: 1,
           endTime: now,
           topics,
-          topicStats: this.topicStats,
+          topicStats,
           datatypes: this.datatypes,
         },
       });

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Log from "@foxglove/log";
+import * as rostime from "@foxglove/rostime";
+import { Time } from "@foxglove/rostime";
+import { MessageEvent } from "@foxglove/studio";
+import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
+import {
+  AdvertiseOptions,
+  Player,
+  PlayerPresence,
+  PlayerState,
+  PublishPayload,
+  SubscribePayload,
+  Topic,
+} from "@foxglove/studio-base/players/types";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+
+const log = Log.getLogger(__filename);
+
+const CAPABILITIES: string[] = [];
+
+class SinewavePlayer implements Player {
+  private name: string = "sinewave";
+  private startTime: Time = rostime.fromDate(new Date());
+  private listener?: (state: PlayerState) => Promise<void>;
+  private topicStats = new Map();
+  private datatypes: RosDatatypes = new Map();
+
+  constructor() {
+    this.datatypes.set("Sinewave", {
+      name: "Sinewave",
+      definitions: [
+        {
+          name: "value",
+          type: "float32",
+        },
+      ],
+    });
+  }
+
+  setListener(listener: (state: PlayerState) => Promise<void>): void {
+    this.listener = listener;
+    void this.run();
+  }
+  close(): void {
+    // no-op
+  }
+  setSubscriptions(_subscriptions: SubscribePayload[]): void {}
+  setPublishers(_publishers: AdvertiseOptions[]): void {
+    // no-op
+  }
+  setParameter(_key: string, _value: unknown): void {
+    throw new Error("Method not implemented.");
+  }
+  publish(_request: PublishPayload): void {
+    throw new Error("Method not implemented.");
+  }
+  async callService(_service: string, _request: unknown): Promise<unknown> {
+    throw new Error("Method not implemented.");
+  }
+  requestBackfill(): void {
+    // no-op
+  }
+  setGlobalVariables(_globalVariables: GlobalVariables): void {
+    throw new Error("Method not implemented.");
+  }
+
+  private async run() {
+    const listener = this.listener;
+    if (!listener) {
+      throw new Error("Invariant: listener is not set");
+    }
+
+    log.info("Initializing benchmark player");
+
+    await listener({
+      profile: undefined,
+      presence: PlayerPresence.PRESENT,
+      name: this.name,
+      playerId: this.name,
+      capabilities: CAPABILITIES,
+      progress: {},
+      urlState: {
+        sourceId: "synthetic",
+      },
+    });
+
+    const topics: Topic[] = [{ name: "sinewave", datatype: "Sinewave" }];
+
+    for (;;) {
+      const now = rostime.fromDate(new Date());
+      const value = Math.sin(rostime.toSec(now));
+
+      const messages: MessageEvent<unknown>[] = [
+        {
+          receiveTime: now,
+          topic: "sinewave",
+          message: { value },
+          sizeInBytes: 0,
+        },
+      ];
+
+      await listener({
+        profile: undefined,
+        presence: PlayerPresence.PRESENT,
+        name: this.name,
+        playerId: this.name,
+        capabilities: CAPABILITIES,
+        progress: {},
+        activeData: {
+          messages,
+          totalBytesReceived: 0,
+          currentTime: now,
+          startTime: this.startTime,
+          isPlaying: false,
+          speed: 1,
+          lastSeekTime: 1,
+          endTime: now,
+          topics,
+          topicStats: this.topicStats,
+          datatypes: this.datatypes,
+        },
+      });
+    }
+  }
+}
+
+export { SinewavePlayer };

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -115,7 +115,7 @@ class SinewavePlayer implements Player {
           totalBytesReceived: 0,
           currentTime: now,
           startTime: this.startTime,
-          isPlaying: false,
+          isPlaying: true,
           speed: 1,
           lastSeekTime: 1,
           endTime: now,

--- a/benchmark/src/services/PredefinedLayoutStorage.tsx
+++ b/benchmark/src/services/PredefinedLayoutStorage.tsx
@@ -24,6 +24,9 @@ class PredefinedLayoutStorage implements ILayoutStorage {
   }
 
   async put(_namespace: string, layout: Layout): Promise<Layout> {
+    if (!this.layouts.get(layout.id)) {
+      throw new Error("Benchmark app only allows updating existing layouts.");
+    }
     return layout;
   }
 

--- a/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
+++ b/packages/studio-base/src/panels/PlaybackPerformance/index.tsx
@@ -100,12 +100,12 @@ export function UnconnectedPlaybackPerformance({
       lastPlaybackInfo.activeData.lastSeekTime === activeData.lastSeekTime &&
       lastPlaybackInfo.activeData.currentTime !== activeData.currentTime
     ) {
-      const bagTimeMs =
+      const elapsedPlayerTime =
         toSec(subtractTimes(activeData.currentTime, lastPlaybackInfo.activeData.currentTime)) *
         1000;
-      perfPoints.current.speed.push({ value: bagTimeMs / renderTimeMs, timestamp });
+      perfPoints.current.speed.push({ value: elapsedPlayerTime / renderTimeMs, timestamp });
       perfPoints.current.framerate.push({ value: 1000 / renderTimeMs, timestamp });
-      perfPoints.current.bagTimeMs.push({ value: bagTimeMs, timestamp });
+      perfPoints.current.bagTimeMs.push({ value: elapsedPlayerTime, timestamp });
     }
     const newBytesReceived =
       activeData.totalBytesReceived - lastPlaybackInfo.activeData.totalBytesReceived;


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
The synthetic player produces a sinewave as fast as the message pipeline allows it to produce new messages.

```
yarn benchmark:serve
```

Then open:
http://localhost:8080/?ds=synthetic&layoutId=benchmark-single-plot


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
