### PR TITLE
Change tab style to have opacity 1 when hovering

### DIFF
--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -425,8 +425,13 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
         root: {
           opacity: 0.8,
 
-          "&$selected": {
+          "&.Mui-selected": {
             opacity: 1,
+          },
+
+          "&:not(.Mui-selected):hover": {
+            opacity: 1,
+            color: theme.palette.action.active,
           },
         },
         selected: {},


### PR DESCRIPTION


**User-Facing Changes**
Visual feedback when hovering a tab.

**Description**
To provide visual indicator to a user when hovering a tab, set the opacity on hover to 1.

Fix a bug with setting the selected item's opacity to 1. Previously it was 0.8 because the style override was not correctly matching the needed css rule.

Fixes: #4142

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
