### PR TITLE
Graduate the experimental latching feature to general availability

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -41,8 +41,7 @@ export default function Root({
 }: {
   appConfiguration: IAppConfiguration;
 }): JSX.Element {
-  const enableExperimentalLatching: boolean =
-    (appConfiguration.get(AppSetting.EXPERIMENTAL_LATCHING) as boolean | undefined) ?? true;
+  const enableExperimentalLatching = true;
 
   const dataSources: IDataSourceFactory[] = useMemo(() => {
     const sources = [

--- a/desktop/renderer/index.tsx
+++ b/desktop/renderer/index.tsx
@@ -77,7 +77,6 @@ async function main() {
     {
       defaults: {
         [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
-        [AppSetting.EXPERIMENTAL_LATCHING]: true,
       },
     },
   );

--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -20,7 +20,6 @@ export enum AppSetting {
   // Experimental features
   SHOW_DEBUG_PANELS = "showDebugPanels",
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
-  EXPERIMENTAL_LATCHING = "experimental.latching",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -49,11 +49,6 @@ const features: Feature[] = [
     description: <>Enable the Legacy Plot panel.</>,
   },
   {
-    key: AppSetting.EXPERIMENTAL_LATCHING,
-    name: "Latching",
-    description: <>Enable message latching for bag, mcap, and data platform sources.</>,
-  },
-  {
     key: AppSetting.ENABLE_MEMORY_USE_INDICATOR,
     name: "Memory use indicator",
     description: <>Show the app memory use in the sidebar.</>,

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -6,7 +6,6 @@ import { useMemo, useState } from "react";
 
 import {
   IDataSourceFactory,
-  AppSetting,
   Ros1LocalBagDataSourceFactory,
   Ros2LocalBagDataSourceFactory,
   RosbridgeDataSourceFactory,

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -29,8 +29,7 @@ import VelodyneUnavailableDataSourceFactory from "./dataSources/VelodyneUnavaila
 import { IdbLayoutStorage } from "./services/IdbLayoutStorage";
 
 export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration }): JSX.Element {
-  const enableExperimentalLatching: boolean =
-    (appConfiguration.get(AppSetting.EXPERIMENTAL_LATCHING) as boolean | undefined) ?? true;
+  const enableExperimentalLatching = true;
 
   const dataSources: IDataSourceFactory[] = useMemo(() => {
     const sources = [

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -83,7 +83,6 @@ async function main() {
   const appConfiguration = new LocalStorageAppConfiguration({
     defaults: {
       [AppSetting.ENABLE_REACT_STRICT_MODE]: isDevelopment,
-      [AppSetting.EXPERIMENTAL_LATCHING]: true,
     },
   });
   const enableStrictMode = appConfiguration.get(AppSetting.ENABLE_REACT_STRICT_MODE) as boolean;


### PR DESCRIPTION


**User-Facing Changes**
The latching feature is removed from experimental and now a default part of app playback.

**Description**
This feature is now the default and uses the new iterable players for playback on all supported data sources.

Fixes: #4162

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
