### PR TITLE
Enable flex-wrap on account sidebar row

### DIFF
--- a/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/AccountInfo.tsx
@@ -62,7 +62,7 @@ export default function AccountInfo(props: { currentUser?: User }): JSX.Element 
   return (
     <Stack fullHeight justifyContent="space-between">
       <Stack gap={2}>
-        <Stack direction="row" alignItems="center" gap={1}>
+        <Stack direction="row" alignItems="center" gap={1} flexWrap="wrap">
           <BlockheadFilledIcon className={classes.icon} />
           <Stack justifyContent="center">
             <Typography variant="subtitle1">{props.currentUser.email}</Typography>


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Fixes https://github.com/foxglove/studio/issues/4194 by enabling flex-wrap

Before: see #4194

After: 
<img width="141" alt="image" src="https://user-images.githubusercontent.com/14237/185525790-fbf04c24-acc2-43f6-ba13-2c54f6aa9b57.png">
