### PR TITLE
Implement tss-react linter and remove @mui/styles (JSS)

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -13,6 +13,7 @@ ignorePatterns:
 
 plugins:
   - file-progress
+  - tss-unused-classes
 
 extends:
   - plugin:@foxglove/base
@@ -24,6 +25,8 @@ settings:
 
 rules:
   "@foxglove/license-header": error
+
+  tss-unused-classes/unused-classes: error
 
   # show progress while linting
   file-progress/activate: warn
@@ -147,7 +150,14 @@ overrides:
       - "**/*.test.ts"
 
   - rules:
-      "no-restricted-imports": off
+      tss-unused-classes/unused-classes: off
+    files:
+      # Using @fluentui/makeStyles expecting deletion soon
+      - packages/studio-base/src/components/Menu/Item.tsx
+      - packages/studio-base/src/components/Menu/Menu.tsx
+
+  - rules:
+      no-restricted-imports: off
     files:
       # Ignore existing implementations of fluentui, styled-components, and @mui/styled
       - "web/src/VersionBanner.tsx"

--- a/desktop/quicklook/FileInfoDisplay.tsx
+++ b/desktop/quicklook/FileInfoDisplay.tsx
@@ -100,7 +100,7 @@ const useStyles = makeStyles()(() => ({
       "@media (prefers-color-scheme: dark)": {
         "--zebra-color": "rgba(255, 255, 255, 5%)",
       },
-      "& > :first-child": {
+      "& > :first-of-type": {
         background: "var(--zebra-color)",
 
         [`@media (min-width: ${NARROW_MIN_WIDTH}px)`]: {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "eslint-plugin-react": "7.30.0",
     "eslint-plugin-react-hooks": "4.3.0",
+    "eslint-plugin-tss-unused-classes": "0.0.3",
     "html-webpack-plugin": "5.5.0",
     "jest": "27.5.1",
     "jest-canvas-mock": "2.3.1",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -58,7 +58,6 @@
     "@mdi/svg": "6.5.95",
     "@mui/icons-material": "5.4.1",
     "@mui/material": "5.4.1",
-    "@mui/styles": "5.4.1",
     "@mui/x-data-grid": "5.15.1",
     "@protobufjs/base64": "1.1.2",
     "@sentry/core": "7.10.0",

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -10,8 +10,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Box, Link, Typography, useTheme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Link, Typography } from "@mui/material";
 import { extname } from "path";
 import {
   useState,
@@ -23,6 +22,7 @@ import {
   useContext,
 } from "react";
 import { useToasts } from "react-toast-notifications";
+import { makeStyles } from "tss-react/mui";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
@@ -85,7 +85,7 @@ import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/provid
 
 const log = Logger.getLogger(__filename);
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   container: {
     width: "100%",
     height: "100%",
@@ -133,7 +133,6 @@ function keyboardEventHasModifier(event: KeyboardEvent) {
 function AddPanel() {
   const addPanel = useAddPanel();
   const { openLayoutBrowser } = useWorkspace();
-  const theme = useTheme();
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
 
   return (
@@ -147,7 +146,7 @@ function AddPanel() {
           <Link onClick={openLayoutBrowser}>Select a layout</Link> to get started!
         </Typography>
       ) : (
-        <PanelList onPanelSelect={addPanel} backgroundColor={theme.palette.background.default} />
+        <PanelList onPanelSelect={addPanel} />
       )}
     </SidebarContent>
   );
@@ -172,7 +171,7 @@ const selectPlayUntil = (ctx: MessagePipelineContext) => ctx.playUntil;
 const selectSetHelpInfo = (store: HelpInfoStore) => store.setHelpInfo;
 
 export default function Workspace(props: WorkspaceProps): JSX.Element {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const containerRef = useRef<HTMLDivElement>(ReactNull);
   const { availableSources, selectSource } = usePlayerSelection();
   const playerPresence = useMessagePipeline(selectPlayerPresence);
@@ -621,7 +620,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
             <Stack>
               <PanelLayout />
               {play && pause && seek && (
-                <Box flexShrink={0}>
+                <div style={{ flexShrink: 0 }}>
                   <PlaybackControls
                     play={play}
                     pause={pause}
@@ -630,7 +629,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
                     isPlaying={isPlaying}
                     getTimeInfo={getTimeInfo}
                   />
-                </Box>
+                </div>
               )}
             </Stack>
           </RemountOnValueChange>

--- a/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
+++ b/packages/studio-base/src/components/AccountSettingsSidebar/SigninForm.tsx
@@ -2,14 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Button, Theme, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Button, Typography } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 
 import AccountSyncGraphic from "./AccountSyncGraphic";
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
     display: "flex",
     flexDirection: "column",
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export default function SigninForm(): JSX.Element {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { signIn } = useCurrentUser();
 
   return (

--- a/packages/studio-base/src/components/BlockheadFilledIcon.tsx
+++ b/packages/studio-base/src/components/BlockheadFilledIcon.tsx
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   // trying to match the wrapper provided by @fluentui here
   root: {
     display: "inline-block",
@@ -17,7 +16,7 @@ const useStyles = makeStyles({
 });
 
 export default function BlockheadFilledIcon({ className }: { className?: string }): JSX.Element {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
 
   return (
     <span className={cx(classes.root, className)}>

--- a/packages/studio-base/src/components/BlockheadIcon.tsx
+++ b/packages/studio-base/src/components/BlockheadIcon.tsx
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   // trying to match the wrapper provided by @fluentui here
   root: {
     display: "inline-block",
@@ -17,7 +16,7 @@ const useStyles = makeStyles({
 });
 
 export default function BlockheadIcon({ className }: { className?: string }): JSX.Element {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
 
   return (
     <span className={cx(classes.root, className)}>

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -76,7 +76,7 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
       ".mosaic-tile": {
         margin: 0,
       },
-      ".mosaic-tile:first-child": {
+      ".mosaic-tile:first-of-type": {
         // make room for splitters - unfortunately this means the background color will show
         // through even if the tile has its own background color set
         gap: 1,

--- a/packages/studio-base/src/components/ErrorDisplay.tsx
+++ b/packages/studio-base/src/components/ErrorDisplay.tsx
@@ -2,13 +2,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Theme, Typography, Link, Divider, styled as muiStyled } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Typography, Link, Divider } from "@mui/material";
 import { ErrorInfo, useMemo, useState } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
+  grid: {
+    display: "grid",
+    gridTemplateRows: "auto 1fr auto",
+    height: "100%",
+    padding: theme.spacing(2),
+  },
   errorDetailStack: {
     fontSize: theme.typography.body2.fontSize,
     lineHeight: "1.3em",
@@ -25,14 +31,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: "right",
   },
 }));
-
-const Container = muiStyled("div")(({ theme }) => ({
-  display: "grid",
-  gridTemplateRows: "auto 1fr auto",
-  height: "100%",
-  padding: theme.spacing(2),
-}));
-
 /**
  * Remove source locations (which often include file hashes) so storybook screenshots can be
  * deterministic.
@@ -48,14 +46,14 @@ function ErrorStacktrace({
   stack: string;
   hideSourceLocations: boolean;
 }) {
-  const styles = useStyles();
+  const { classes } = useStyles();
   const lines = (hideSourceLocations ? sanitizeStack(stack) : stack)
     .trim()
     .replace(/^\s*at /gm, "")
     .split("\n")
     .map((line) => line.trim());
   return (
-    <pre className={styles.errorDetailStack}>
+    <pre className={classes.errorDetailStack}>
       {lines.map((line, i) => {
         const match = /^(.+)\s(\(.+$)/.exec(line);
         if (!match) {
@@ -84,7 +82,7 @@ type ErrorDisplayProps = {
 };
 
 function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
-  const styles = useStyles();
+  const { classes } = useStyles();
   const { error, errorInfo, hideErrorSourceLocations = false } = props;
 
   const [showErrorDetails, setShowErrorDetails] = useState(props.showErrorDetails ?? false);
@@ -121,7 +119,7 @@ function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
   }, [error, errorInfo, hideErrorSourceLocations, showErrorDetails]);
 
   return (
-    <Container>
+    <div className={classes.grid}>
       <Stack gap={2} paddingBottom={2}>
         <Stack>
           <Typography variant="h4" gutterBottom>
@@ -139,10 +137,10 @@ function ErrorDisplay(props: ErrorDisplayProps): JSX.Element {
           {showErrorDetails ? "Hide" : "Show"} details
         </Link>
       </Stack>
-      {errorDetails && <div className={styles.errorDetailContainer}>{errorDetails}</div>}
+      {errorDetails && <div className={classes.errorDetailContainer}>{errorDetails}</div>}
       {!errorDetails && <div />}
-      <div className={styles.actions}>{props.actions}</div>
-    </Container>
+      <div className={classes.actions}>{props.actions}</div>
+    </div>
   );
 }
 

--- a/packages/studio-base/src/components/Icon.tsx
+++ b/packages/studio-base/src/components/Icon.tsx
@@ -11,9 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
 import { ComponentProps, CSSProperties, ReactNode, MouseEvent } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import Tooltip, { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import { colors } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -36,7 +35,7 @@ function makeIconStyle(size: number) {
   };
 }
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   icon: {
     "& > svg": {
       fill: "currentColor",
@@ -97,7 +96,7 @@ type Props = {
 };
 
 const Icon = (props: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
   const {
     children,
     size,
@@ -158,7 +157,7 @@ const Icon = (props: Props): JSX.Element => {
 Icon.displayName = "Icon";
 
 export const WrappedIcon = (props: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
   return (
     <Icon
       {...props}

--- a/packages/studio-base/src/components/LegacyStyledComponents.tsx
+++ b/packages/studio-base/src/components/LegacyStyledComponents.tsx
@@ -44,7 +44,7 @@ export const LegacyTable = styled.table`
   th {
     color: ${({ theme }) => theme.semanticColors.bodyText};
 
-    tr:first-child & {
+    tr:first-of-type & {
       padding-top: 4px;
       padding-bottom: 4px;
     }

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -14,7 +14,6 @@
 import CloseIcon from "@mui/icons-material/Close";
 import SearchIcon from "@mui/icons-material/Search";
 import {
-  Theme,
   Card,
   CardActionArea,
   CardContent,
@@ -25,16 +24,15 @@ import {
   ListItemButton,
   ListItemText,
   Typography,
-  styled as muiStyled,
   TextField,
   IconButton,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import fuzzySort from "fuzzysort";
 import { countBy, isEmpty } from "lodash";
 import { useCallback, useEffect, useMemo } from "react";
 import { useDrag } from "react-dnd";
 import { MosaicDragType, MosaicPath } from "react-mosaic-component";
+import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextHighlight from "@foxglove/studio-base/components/TextHighlight";
@@ -53,7 +51,7 @@ import {
 } from "@foxglove/studio-base/types/panels";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
 
-const useStyles = makeStyles((theme: Theme) => {
+const useStyles = makeStyles()((theme) => {
   return {
     fullHeight: {
       height: "100%",
@@ -73,20 +71,19 @@ const useStyles = makeStyles((theme: Theme) => {
       gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
       gap: theme.spacing(2),
     },
+    toolbar: {
+      position: "sticky",
+      top: -0.5, // yep that's a half pixel to avoid a gap between the appbar and panel top
+      zIndex: 100,
+      display: "flex",
+      padding: theme.spacing(2),
+      justifyContent: "stretch",
+      backgroundImage: `linear-gradient(to top, transparent, ${
+        theme.palette.background.paper
+      } ${theme.spacing(1.5)}) !important`,
+    },
   };
 });
-
-const StickyToolbar = muiStyled("div")(({ theme }) => ({
-  position: "sticky",
-  top: -0.5, // yep that's a half pixel to avoid a gap between the appbar and panel top
-  zIndex: 100,
-  display: "flex",
-  padding: theme.spacing(2),
-  justifyContent: "stretch",
-  backgroundImage: `linear-gradient(to top, transparent, ${
-    theme.palette.background.paper
-  } ${theme.spacing(1.5)}) !important`,
-}));
 
 type DropDescription = {
   type: string;
@@ -134,7 +131,7 @@ function DraggablePanelItem({
   highlighted = false,
   mosaicId,
 }: PanelItemProps) {
-  const classes = useStyles({});
+  const { classes } = useStyles();
   const scrollRef = React.useRef<HTMLElement>(ReactNull);
   const [, connectDragSource] = useDrag<unknown, MosaicDropResult, never>({
     type: MosaicDragType.WINDOW,
@@ -271,7 +268,6 @@ type Props = {
   mode?: "grid" | "list";
   onPanelSelect: (arg0: PanelSelection) => void;
   selectedPanelType?: string;
-  backgroundColor?: string;
 };
 
 // sanity checks to help panel authors debug issues
@@ -300,8 +296,8 @@ function verifyPanels(panels: readonly PanelInfo[]) {
 function PanelList(props: Props): JSX.Element {
   const [searchQuery, setSearchQuery] = React.useState("");
   const [highlightedPanelIdx, setHighlightedPanelIdx] = React.useState<number | undefined>();
-  const { mode, onPanelSelect, selectedPanelType, backgroundColor } = props;
-  const classes = useStyles({ backgroundColor });
+  const { mode, onPanelSelect, selectedPanelType } = props;
+  const { classes } = useStyles();
 
   const { dropPanel } = useCurrentLayoutActions();
   const mosaicId = usePanelMosaicId();
@@ -467,7 +463,7 @@ function PanelList(props: Props): JSX.Element {
 
   return (
     <div className={classes.fullHeight}>
-      <StickyToolbar>
+      <div className={classes.toolbar}>
         <TextField
           fullWidth
           placeholder="Search panels"
@@ -485,7 +481,7 @@ function PanelList(props: Props): JSX.Element {
             ),
           }}
         />
-      </StickyToolbar>
+      </div>
       {mode === "grid" ? (
         <Container className={classes.grid} maxWidth={false}>
           {allFilteredPanels.map(displayPanelListItem)}

--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { ContextualMenu, IContextualMenuItem, useTheme } from "@fluentui/react";
+import { ContextualMenu, IContextualMenuItem } from "@fluentui/react";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useCallback, useContext, useMemo, useRef } from "react";
 import { MosaicContext, MosaicNode, MosaicWindowContext } from "react-mosaic-component";
@@ -95,8 +95,6 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
     [mosaicActions, mosaicWindowActions, panelContext?.type, setIsOpen, swapPanel, tabId],
   );
 
-  const theme = useTheme();
-
   const menuItems: IContextualMenuItem[] = useMemo(() => {
     const items: IContextualMenuItem[] = [
       {
@@ -124,7 +122,6 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
             <PanelList
               selectedPanelType={panelContext?.type}
               onPanelSelect={swap(panelContext?.id)}
-              backgroundColor={theme.semanticColors.menuBackground}
             />
           ),
         },
@@ -175,17 +172,7 @@ export function PanelActionsDropdown({ isOpen, setIsOpen, isUnknownPanel }: Prop
     });
 
     return items;
-  }, [
-    close,
-    isUnknownPanel,
-    panelContext?.enterFullscreen,
-    panelContext?.id,
-    panelContext?.isFullscreen,
-    panelContext?.type,
-    split,
-    swap,
-    theme.semanticColors.menuBackground,
-  ]);
+  }, [close, isUnknownPanel, panelContext, split, swap]);
 
   const buttonRef = useRef<HTMLDivElement>(ReactNull);
 

--- a/packages/studio-base/src/components/TextContent.tsx
+++ b/packages/studio-base/src/components/TextContent.tsx
@@ -36,7 +36,7 @@ const TextContentRoot = withStyles("div", (theme) => {
       "h1, h2, h3, h4, h5, h6": {
         color: palette.text.primary,
 
-        "&:first-of-type": { marginTop: 0 },
+        "&:first-child": { marginTop: 0 },
       },
       h1: {
         fontFamily: typography.h4.fontFamily,

--- a/packages/studio-base/src/components/TextContent.tsx
+++ b/packages/studio-base/src/components/TextContent.tsx
@@ -36,7 +36,7 @@ const TextContentRoot = withStyles("div", (theme) => {
       "h1, h2, h3, h4, h5, h6": {
         color: palette.text.primary,
 
-        "&:first-child": { marginTop: 0 },
+        "&:first-of-type": { marginTop: 0 },
       },
       h1: {
         fontFamily: typography.h4.fontFamily,

--- a/packages/studio-base/src/components/TimestampMethodDropdown.tsx
+++ b/packages/studio-base/src/components/TimestampMethodDropdown.tsx
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { AccessTime as AccessTimeIcon, Check as CheckIcon } from "@mui/icons-material";
-import { IconButton, IconButtonProps, Menu, MenuItem, Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { IconButton, IconButtonProps, Menu, MenuItem } from "@mui/material";
 import { useCallback, useMemo } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import {
@@ -41,7 +41,7 @@ type Props = {
   onTimestampMethodChange?: (arg0: TimestampMethod, index?: number) => void;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   iconButton: {
     "&.MuiIconButton-root": {
       color: theme.palette.text.secondary,
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export default function TimestampMethodDropdown(props: Props): JSX.Element {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
   const open = Boolean(anchorEl);
 

--- a/packages/studio-base/src/panels/Log/FilterTagInput.tsx
+++ b/packages/studio-base/src/panels/Log/FilterTagInput.tsx
@@ -20,9 +20,6 @@ const useStyles = makeStyles()((theme) => ({
       margin: 0,
     },
   },
-  ".MuiAutocomplete-tag": {
-    margin: theme.spacing(0),
-  },
 }));
 
 export function FilterTagInput({

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -13,7 +13,6 @@
 
 import { IconButton, IList, List } from "@fluentui/react";
 import { Box } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import produce from "immer";
 import { set } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -52,17 +51,7 @@ const SUPPORTED_DATATYPES = [
   "foxglove.Log",
 ];
 
-const useStyles = makeStyles({
-  scrollArea: {
-    height: "100%",
-    overflow: "auto",
-    display: "flex",
-    flexDirection: "column-reverse",
-  },
-});
-
 const LogPanel = React.memo(({ config, saveConfig }: Props) => {
-  const classes = useStyles();
   const { topics } = useDataSourceInfo();
   const { minLogLevel, searchTerms } = config;
   const { timeFormat, timeZone } = useAppTimeFormat();
@@ -194,7 +183,7 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
         />
       </PanelToolbar>
       <Stack flexGrow={1} overflow="hidden">
-        <div ref={divRef} className={classes.scrollArea}>
+        <Stack ref={divRef} fullHeight overflow="auto" direction="column-reverse">
           {/* items property wants a mutable array but filteredMessages is readonly */}
           <List
             componentRef={listRef}
@@ -219,7 +208,7 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
               );
             }}
           />
-        </div>
+        </Stack>
       </Stack>
       {hasUserScrolled && (
         <Box position="absolute" bottom={10} right={10}>

--- a/packages/studio-base/src/panels/Log/useLogStyles.ts
+++ b/packages/studio-base/src/panels/Log/useLogStyles.ts
@@ -5,6 +5,7 @@
 import { makeStyles } from "tss-react/mui";
 
 export default makeStyles()(({ palette }) => ({
+  /* eslint-disable tss-unused-classes/unused-classes */
   fatal: {
     color: palette.error.main,
     fontWeight: "bold",
@@ -21,4 +22,5 @@ export default makeStyles()(({ palette }) => ({
   debug: {
     color: palette.text.secondary,
   },
+  /* eslint-enable tss-unused-classes/unused-classes */
 }));

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -83,7 +83,16 @@ type StyleProps = {
 };
 
 const useStyles = makeStyles<StyleProps>()(
-  (theme, { legendDisplay, sidebarDimension, showLegend, showPlotValuesInLegend = false }) => ({
+  (
+    theme,
+    // prettier-ignore
+    {
+      legendDisplay,
+      sidebarDimension,
+      showLegend,
+      showPlotValuesInLegend = false,
+    },
+  ) => ({
     addButton: {
       minWidth: 100,
       backgroundColor: `${theme.palette.action.hover} !important`,

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -20,9 +20,7 @@ import {
   KeyboardArrowDown as KeyboardArrowDownIcon,
   ArrowDropDown as ArrowDropDownIcon,
 } from "@mui/icons-material";
-import { Button, IconButton, Theme, alpha, MenuItem, Menu } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { alpha, Button, IconButton, Menu, MenuItem } from "@mui/material";
 import { last } from "lodash";
 import {
   ComponentProps,
@@ -34,6 +32,7 @@ import {
   useState,
 } from "react";
 import { useLatest } from "react-use";
+import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
@@ -83,63 +82,63 @@ type StyleProps = {
   sidebarDimension: PlotLegendProps["sidebarDimension"];
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  addButton: {
-    minWidth: 100,
-    backgroundColor: `${theme.palette.action.hover} !important`,
-  },
-  dragHandle: ({ legendDisplay }: StyleProps) => ({
-    userSelect: "none",
-    border: `0px solid ${theme.palette.action.hover}`,
-    ...(legendDisplay === "left"
-      ? {
-          cursor: "ew-resize",
-          borderRightWidth: 2,
-          height: "100%",
-          width: theme.spacing(0.5),
-        }
-      : {
-          cursor: "ns-resize",
-          borderBottomWidth: 2,
-          height: theme.spacing(0.5),
-          width: "100%",
-        }),
-
-    "&:hover": {
-      borderColor: theme.palette.action.selected,
+const useStyles = makeStyles<StyleProps>()(
+  (theme, { legendDisplay, sidebarDimension, showLegend, showPlotValuesInLegend = false }) => ({
+    addButton: {
+      minWidth: 100,
+      backgroundColor: `${theme.palette.action.hover} !important`,
     },
-  }),
-  dropdownWrapper: {
-    zIndex: 4,
-    height: 20,
+    dragHandle: {
+      userSelect: "none",
+      border: `0px solid ${theme.palette.action.hover}`,
+      ...(legendDisplay === "left"
+        ? {
+            cursor: "ew-resize",
+            borderRightWidth: 2,
+            height: "100%",
+            width: theme.spacing(0.5),
+          }
+        : {
+            cursor: "ns-resize",
+            borderBottomWidth: 2,
+            height: theme.spacing(0.5),
+            width: "100%",
+          }),
 
-    "&:hover": {
-      backgroundColor: theme.palette.action.hover,
+      "&:hover": {
+        borderColor: theme.palette.action.selected,
+      },
     },
-  },
-  dropdown: {
-    backgroundColor: "transparent !important",
-    padding: "4px !important",
-  },
-  footer: ({ showPlotValuesInLegend = false }: StyleProps) => ({
-    padding: theme.spacing(0.5),
-    gridColumn: showPlotValuesInLegend ? "span 4" : "span 3",
-    position: "sticky",
-    right: 0,
-    left: 0,
-  }),
-  floatingWrapper: {
-    overflow: "hidden",
-    display: "flex",
-    flexDirection: "column",
-    height: "100%",
-  },
-  grid: {
-    alignItems: "stretch",
-    position: "relative",
-    display: "grid",
-    gridTemplateColumns: ({ showPlotValuesInLegend = false }: StyleProps) =>
-      [
+    // dropdownWrapper: {
+    //   zIndex: 4,
+    //   height: 20,
+
+    //   "&:hover": {
+    //     backgroundColor: theme.palette.action.hover,
+    //   },
+    // },
+    // dropdown: {
+    //   backgroundColor: "transparent !important",
+    //   padding: "4px !important",
+    // },
+    footer: {
+      padding: theme.spacing(0.5),
+      gridColumn: showPlotValuesInLegend ? "span 4" : "span 3",
+      position: "sticky",
+      right: 0,
+      left: 0,
+    },
+    floatingWrapper: {
+      overflow: "hidden",
+      display: "flex",
+      flexDirection: "column",
+      height: "100%",
+    },
+    grid: {
+      alignItems: "stretch",
+      position: "relative",
+      display: "grid",
+      gridTemplateColumns: [
         "auto",
         "minmax(max-content, 1fr)",
         showPlotValuesInLegend && "minmax(max-content, 1fr)",
@@ -147,92 +146,93 @@ const useStyles = makeStyles((theme: Theme) => ({
       ]
         .filter(Boolean)
         .join(" "),
-  },
-  header: {
-    display: "flex",
-    alignItems: "center",
-    padding: theme.spacing(0.25),
-    height: 26,
-    position: "sticky",
-    top: 0,
-    left: 0,
-    right: 0,
-    backgroundColor: theme.palette.background.paper,
-    zIndex: theme.zIndex.mobileStepper + 1,
-  },
-  legendContent: ({ legendDisplay }: StyleProps) => ({
-    display: "flex",
-    flexDirection: "column",
-    backgroundColor: alpha(theme.palette.background.paper, 0.8),
-    overflow: "auto",
-    pointerEvents: "auto",
-    [legendDisplay !== "floating" ? "height" : "maxHeight"]: "100%",
-    position: "relative",
-  }),
-  toggleButton: ({ legendDisplay }: StyleProps) => ({
-    cursor: "pointer",
-    userSelect: "none",
-    pointerEvents: "auto",
-    ...{
-      left: { height: "100%", padding: "0px !important" },
-      top: { width: "100%", padding: "0px !important" },
-      floating: undefined,
-    }[legendDisplay],
-
-    "&:hover": {
-      backgroundColor: theme.palette.action.focus,
     },
-  }),
-  toggleButtonFloating: {
-    marginRight: theme.spacing(0.25),
-    borderRadius: theme.shape.borderRadius,
-    backgroundColor: `${theme.palette.action.focus} !important`,
-    visibility: ({ showLegend }: StyleProps) => (showLegend ? "visible" : "hidden"),
-
-    "&:hover": {
+    header: {
+      display: "flex",
+      alignItems: "center",
+      padding: theme.spacing(0.25),
+      height: 26,
+      position: "sticky",
+      top: 0,
+      left: 0,
+      right: 0,
       backgroundColor: theme.palette.background.paper,
+      zIndex: theme.zIndex.mobileStepper + 1,
     },
-    ".mosaic-window:hover &": {
-      visibility: "initial",
+    legendContent: {
+      display: "flex",
+      flexDirection: "column",
+      backgroundColor: alpha(theme.palette.background.paper, 0.8),
+      overflow: "auto",
+      pointerEvents: "auto",
+      [legendDisplay !== "floating" ? "height" : "maxHeight"]: "100%",
+      position: "relative",
     },
-  },
-  root: {
-    display: "flex",
-    alignItems: "flex-start",
-    position: "relative",
-    color: theme.palette.text.secondary,
-    backgroundColor: theme.palette.background.paper,
-    borderTop: `${theme.palette.background.default} solid 1px`,
-    flexDirection: ({ legendDisplay }: StyleProps) => (legendDisplay === "top" ? "column" : "row"),
-  },
-  rootFloating: {
-    cursor: "pointer",
-    position: "absolute",
-    left: theme.spacing(4),
-    top: `calc(${theme.spacing(1)} + ${PANEL_TOOLBAR_MIN_HEIGHT}px)`,
-    bottom: theme.spacing(3),
-    maxWidth: `calc(100% - ${theme.spacing(8)})`,
-    backgroundColor: "transparent",
-    borderTop: "none",
-    pointerEvents: "none",
-    zIndex: theme.zIndex.mobileStepper,
-    gap: theme.spacing(0.5),
-  },
-  wrapper: ({ legendDisplay }: StyleProps) => ({
-    display: "flex",
-    flexDirection: legendDisplay === "left" ? "row" : "column",
-    width: legendDisplay === "top" ? "100%" : undefined,
-    height: legendDisplay === "left" ? "100%" : undefined,
+    toggleButton: {
+      cursor: "pointer",
+      userSelect: "none",
+      pointerEvents: "auto",
+      ...{
+        left: { height: "100%", padding: "0px !important" },
+        top: { width: "100%", padding: "0px !important" },
+        floating: undefined,
+      }[legendDisplay],
+
+      "&:hover": {
+        backgroundColor: theme.palette.action.focus,
+      },
+    },
+    toggleButtonFloating: {
+      marginRight: theme.spacing(0.25),
+      borderRadius: theme.shape.borderRadius,
+      backgroundColor: `${theme.palette.action.focus} !important`,
+      visibility: showLegend ? "visible" : "hidden",
+
+      "&:hover": {
+        backgroundColor: theme.palette.background.paper,
+      },
+      ".mosaic-window:hover &": {
+        visibility: "initial",
+      },
+    },
+    root: {
+      display: "flex",
+      alignItems: "flex-start",
+      position: "relative",
+      color: theme.palette.text.secondary,
+      backgroundColor: theme.palette.background.paper,
+      borderTop: `${theme.palette.background.default} solid 1px`,
+      flexDirection: legendDisplay === "top" ? "column" : "row",
+    },
+    rootFloating: {
+      cursor: "pointer",
+      position: "absolute",
+      left: theme.spacing(4),
+      top: `calc(${theme.spacing(1)} + ${PANEL_TOOLBAR_MIN_HEIGHT}px)`,
+      bottom: theme.spacing(3),
+      maxWidth: `calc(100% - ${theme.spacing(8)})`,
+      backgroundColor: "transparent",
+      borderTop: "none",
+      pointerEvents: "none",
+      zIndex: theme.zIndex.mobileStepper,
+      gap: theme.spacing(0.5),
+    },
+    wrapper: {
+      display: "flex",
+      flexDirection: legendDisplay === "left" ? "row" : "column",
+      width: legendDisplay === "top" ? "100%" : undefined,
+      height: legendDisplay === "left" ? "100%" : undefined,
+    },
+    wrapperContent: {
+      display: "flex",
+      flexDirection: "column",
+      flexGrow: 1,
+      gap: theme.spacing(0.5),
+      overflow: "auto",
+      [legendDisplay === "left" ? "width" : "height"]: sidebarDimension,
+    },
   }),
-  wrapperContent: ({ legendDisplay, sidebarDimension }: StyleProps) => ({
-    display: "flex",
-    flexDirection: "column",
-    flexGrow: 1,
-    gap: theme.spacing(0.5),
-    overflow: "auto",
-    [legendDisplay === "left" ? "width" : "height"]: sidebarDimension,
-  }),
-}));
+);
 
 function AxisDropdown({
   xAxisVal,
@@ -316,7 +316,7 @@ export default function PlotLegend(props: PlotLegendProps): JSX.Element {
     xAxisPath,
     xAxisVal,
   } = props;
-  const classes = useStyles({
+  const { classes, cx } = useStyles({
     legendDisplay,
     sidebarDimension,
     showLegend,

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -8,9 +8,9 @@ import {
   Remove as RemoveIcon,
   MoreVert as MoreVertIcon,
 } from "@mui/icons-material";
-import { IconButton, Theme, Tooltip, Typography, useTheme } from "@mui/material";
-import { createStyles, makeStyles } from "@mui/styles";
+import { IconButton, Tooltip, Typography, useTheme } from "@mui/material";
 import { ComponentProps, useCallback, useMemo, useState } from "react";
+import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
 
 import MessagePathInput from "@foxglove/studio-base/components/MessagePathSyntax/MessagePathInput";
@@ -34,72 +34,70 @@ type PlotLegendRowProps = {
   showPlotValuesInLegend: boolean;
 };
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      display: "contents",
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    display: "contents",
 
-      "&:hover, &:focus-within": {
-        "& .MuiIconButton-root": {
-          backgroundColor: theme.palette.action.hover,
-        },
-        "& > *:last-child": {
-          opacity: 1,
-        },
-        "& > *": {
-          backgroundColor: theme.palette.action.hover,
-        },
+    "&:hover, &:focus-within": {
+      "& .MuiIconButton-root": {
+        backgroundColor: theme.palette.action.hover,
       },
-    },
-    listIcon: {
-      padding: theme.spacing(0.25),
-      position: "sticky",
-      left: 0,
-      // creates an opaque background for the sticky element
-      backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper})`,
-      backgroundBlendMode: "overlay",
-    },
-    legendIconButton: {
-      padding: `${theme.spacing(0.125)} !important`,
-      marginLeft: theme.spacing(0.25),
-    },
-    inputWrapper: {
-      display: "flex",
-      alignItems: "center",
-      padding: theme.spacing(0.25),
-    },
-    plotValue: {
-      display: "flex",
-      alignItems: "center",
-      padding: theme.spacing(0.25),
-    },
-    actionButton: {
-      padding: `${theme.spacing(0.25)} !important`,
-      color: theme.palette.text.secondary,
-
-      "&:hover": {
-        color: theme.palette.text.primary,
-      },
-    },
-    actions: {
-      display: "flex",
-      flexDirection: "row",
-      alignItems: "center",
-      padding: theme.spacing(0.25),
-      gap: theme.spacing(0.25),
-      position: "sticky",
-      right: 0,
-      opacity: 0,
-      // creates an opaque background for the sticky element
-      backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper})`,
-      backgroundBlendMode: "overlay",
-
-      "&:hover": {
+      "& > *:last-child": {
         opacity: 1,
       },
+      "& > *": {
+        backgroundColor: theme.palette.action.hover,
+      },
     },
-  }),
-);
+  },
+  listIcon: {
+    padding: theme.spacing(0.25),
+    position: "sticky",
+    left: 0,
+    // creates an opaque background for the sticky element
+    backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper})`,
+    backgroundBlendMode: "overlay",
+  },
+  legendIconButton: {
+    padding: `${theme.spacing(0.125)} !important`,
+    marginLeft: theme.spacing(0.25),
+  },
+  inputWrapper: {
+    display: "flex",
+    alignItems: "center",
+    padding: theme.spacing(0.25),
+  },
+  plotValue: {
+    display: "flex",
+    alignItems: "center",
+    padding: theme.spacing(0.25),
+  },
+  actionButton: {
+    padding: `${theme.spacing(0.25)} !important`,
+    color: theme.palette.text.secondary,
+
+    "&:hover": {
+      color: theme.palette.text.primary,
+    },
+  },
+  actions: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    padding: theme.spacing(0.25),
+    gap: theme.spacing(0.25),
+    position: "sticky",
+    right: 0,
+    opacity: 0,
+    // creates an opaque background for the sticky element
+    backgroundImage: `linear-gradient(${theme.palette.background.paper}, ${theme.palette.background.paper})`,
+    backgroundBlendMode: "overlay",
+
+    "&:hover": {
+      opacity: 1,
+    },
+  },
+}));
 
 export default function PlotLegendRow({
   index,
@@ -153,7 +151,7 @@ export default function PlotLegendRow({
     ? getLineColor(path.color, index)
     : theme.palette.text.secondary;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const isReferenceLinePlotPath = isReferenceLinePlotPathType(path);
 

--- a/packages/studio-base/src/panels/Table/Table.tsx
+++ b/packages/studio-base/src/panels/Table/Table.tsx
@@ -52,7 +52,7 @@ export const StyledTable = muiStyled("table")(({ theme }) => ({
   th: {
     color: theme.palette.text.primary,
 
-    "tr:first-child &": {
+    "tr:first-of-type &": {
       paddingTop: theme.spacing(0.5),
       paddingBottom: theme.spacing(0.5),
     },

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
@@ -11,9 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { useContext, useRef } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { WorldviewReactContext, WorldviewContextType } from "@foxglove/regl-worldview";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -28,7 +27,7 @@ type Stats = {
   getTotalBufferSize(): number;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
     position: "absolute",
     bottom: theme.spacing(2),
@@ -75,7 +74,7 @@ function validate(stats: Stats) {
 // Shows debug regl stats in the 3d panel.  Crashes the panel if regl stats drift outside of acceptable ranges.
 // TODO(bmc): move to regl-worldview at some point
 export default function DebugStats(): JSX.Element | ReactNull {
-  const classes = useStyles();
+  const { classes } = useStyles();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const context = useContext<WorldviewContextType>(WorldviewReactContext);
   const renderCount = useRef(0);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/FollowTFControl.tsx
@@ -14,11 +14,11 @@
 import { IButtonStyles, IconButton, useTheme } from "@fluentui/react";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import NavigationIcon from "@mui/icons-material/Navigation";
-import { Paper, IconButton as MuiIconButton, Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Paper, IconButton as MuiIconButton } from "@mui/material";
 import { sortBy } from "lodash";
 import { memo, useCallback, useMemo, useRef } from "react";
 import shallowequal from "shallowequal";
+import { makeStyles } from "tss-react/mui";
 
 import Autocomplete, { IAutocomplete } from "@foxglove/studio-base/components/Autocomplete";
 import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
@@ -123,7 +123,7 @@ type StyleProps = {
   followTf?: Props["followTf"];
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles<StyleProps>()((theme, { followTf }) => ({
   root: {
     pointerEvents: "auto",
   },
@@ -132,7 +132,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     alignItems: "center",
     // see also ExpandingToolbar styles
-    color: ({ followTf }: StyleProps) => (followTf ? undefined : theme.palette.text.disabled),
+    color: followTf ? undefined : theme.palette.text.disabled,
     position: "relative",
   },
   icon: {
@@ -143,7 +143,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const FollowTFControl = memo<Props>(function FollowTFControl(props: Props) {
   const { transforms, followTf, followMode, onFollowChange } = props;
   const theme = useTheme();
-  const classes = useStyles({ followTf });
+  const { classes } = useStyles({ followTf });
 
   const iconButtonStyles = useMemo(
     (): Partial<IButtonStyles> => ({

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -12,10 +12,10 @@
 //   You may not use this file except in compliance with the License.
 
 import { useTheme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { groupBy } from "lodash";
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
 import { useImmerReducer } from "use-immer";
 
@@ -142,7 +142,7 @@ export type ColorOverride = {
 };
 export type ColorOverrideByVariable = Record<GlobalVariableName, ColorOverride>;
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   container: {
     display: "flex",
     flexDirection: "column",
@@ -264,7 +264,7 @@ export default function Layout({
     ignoreColladaUpAxis = false,
   },
 }: Props): React.ReactElement {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [filterText, setFilterText] = useState(""); // Topic tree text for filtering to see certain topics.
   const containerRef = useRef<HTMLDivElement>(ReactNull);
   const { linkedGlobalVariables } = useLinkedGlobalVariables();

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/LayoutToolbar.tsx
@@ -11,8 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
 import { MouseEventObject } from "@foxglove/regl-worldview";
 import { Time } from "@foxglove/rostime";
@@ -59,7 +58,7 @@ type Props = LayoutToolbarSharedProps &
     showCrosshair?: boolean;
   };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   controls: {
     position: "absolute",
     top: `calc(${PANEL_TOOLBAR_MIN_HEIGHT}px + ${theme.spacing(1.5)})`,
@@ -108,7 +107,7 @@ function LayoutToolbar({
   toggleSearchTextOpen,
   transforms,
 }: Props) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <>
       <div className={classes.controls}>

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/MainToolbar.tsx
@@ -14,12 +14,11 @@ import {
   MenuItem,
   MenuItemProps,
   Paper,
-  Theme,
   Typography,
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { ReactNode, useCallback, useContext, useRef, useState } from "react";
 import { useLongPress } from "react-use";
+import { makeStyles } from "tss-react/mui";
 
 import {
   MessagePipelineContext,
@@ -47,7 +46,7 @@ type Props = {
   perspective: boolean;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
     pointerEvents: "auto",
     display: "flex",
@@ -65,10 +64,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       },
     },
   },
-  row: {
-    display: "flex",
-    position: "relative",
-  },
+  // row: {
+  //   display: "flex",
+  //   position: "relative",
+  // },
   expandIndicator: {
     content: "''",
     borderBottom: "6px solid currentColor",
@@ -125,7 +124,7 @@ type PopupMenuItemProps = {
 } & MenuItemProps;
 
 function PopupMenuItem({ icon, text, selected = false, ...rest }: PopupMenuItemProps): JSX.Element {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <MenuItem className={classes.menuItem} selected={selected} {...rest}>
       <div className={classes.menuItemIcon}>{icon != undefined && icon}</div>
@@ -147,7 +146,7 @@ function MainToolbar({
   onToggleDebug,
   perspective = false,
 }: Props) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const canPublish = useMessagePipeline(canPublishSelector);
 
   const [clickMenuExpanded, setClickMenuExpanded] = useState(false);

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SearchText.tsx
@@ -17,10 +17,10 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import SearchIcon from "@mui/icons-material/Search";
 import { Paper, IconButton, ToggleButton, ToggleButtonGroup } from "@mui/material";
-import { makeStyles } from "@mui/styles";
 import { vec3 } from "gl-matrix";
 import { range, throttle } from "lodash";
 import { useState, useRef, useEffect, useCallback, KeyboardEvent } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { CameraState, cameraStateSelectors } from "@foxglove/regl-worldview";
 import { Time } from "@foxglove/rostime";
@@ -224,7 +224,7 @@ export const useSearchMatches = ({
   ]);
 };
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   root: {
     pointerEvents: "auto",
     display: "flex",
@@ -253,7 +253,7 @@ const SearchText = React.memo<SearchTextComponentProps>(function SearchText({
   fixedFrameId,
   currentTime,
 }: SearchTextComponentProps) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const theme = useTheme();
   const currentMatch = searchTextMatches[selectedMatchIndex];
   const iterateCurrentIndex = useCallback(

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/VisibilityToggle.tsx
@@ -3,19 +3,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import BlockIcon from "@mui/icons-material/Block";
-import { IconButton, SvgIcon, Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { IconButton, SvgIcon } from "@mui/material";
 import { MouseEvent, KeyboardEvent, useCallback } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { Color } from "@foxglove/regl-worldview";
 import { defaultedRGBStringFromColorObj } from "@foxglove/studio-base/util/colorUtils";
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles<StyleProps>()((theme, { checked, overrideRGB, visibleInScene }) => ({
   unavailable: {
     cursor: "not-allowed",
   },
-  button: ({ overrideRGB }: StyleProps) => ({
+  button: {
     fontSize: `10px !important`,
     color: `${theme.palette.text.secondary} !important`,
     position: "relative",
@@ -35,14 +34,14 @@ const useStyles = makeStyles((theme: Theme) => ({
         backgroundColor: theme.palette.action.focus,
       },
     },
-  }),
-  circle: ({ checked, overrideRGB, visibleInScene }: StyleProps) => ({
+  },
+  circle: {
     color: overrideRGB ?? "currentcolor",
     stroke: "currentcolor",
     strokeWidth: 2,
     fill: "currentcolor",
     fillOpacity: checked ? (visibleInScene ? 1 : theme.palette.action.disabledOpacity) : 0,
-  }),
+  },
 }));
 
 type VisibilityToggleProps = {
@@ -80,7 +79,7 @@ export default function VisibilityToggle(props: VisibilityToggleProps): JSX.Elem
   } = props;
   const overrideRGB = overrideColor ? defaultedRGBStringFromColorObj(overrideColor) : undefined;
 
-  const classes = useStyles({
+  const { classes, cx } = useStyles({
     checked,
     overrideRGB,
     visibleInScene,

--- a/packages/studio-base/src/panels/TopicGraph/index.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.tsx
@@ -16,12 +16,11 @@ import ArrowUpDownIcon from "@mdi/svg/svg/arrow-up-down.svg";
 import FitToPageIcon from "@mdi/svg/svg/fit-to-page-outline.svg";
 import ServiceIcon from "@mdi/svg/svg/rectangle-outline.svg";
 import TopicIcon from "@mdi/svg/svg/rhombus.svg";
-import { FormControlLabel, IconButton, Paper, Radio, RadioGroup, Theme } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import cx from "classnames";
+import { FormControlLabel, IconButton, Paper, Radio, RadioGroup } from "@mui/material";
 import Cytoscape from "cytoscape";
 import { useCallback, useMemo, useRef, useState } from "react";
 import textMetrics from "text-metrics";
+import { makeStyles } from "tss-react/mui";
 
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import ExpandingToolbar, { ToolGroup } from "@foxglove/studio-base/components/ExpandingToolbar";
@@ -104,7 +103,7 @@ const STYLESHEET: Cytoscape.Stylesheet[] = [
   },
 ];
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
     display: "flex",
     flexDirection: "column",
@@ -119,7 +118,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   stack: {
     "& > .MuiIconButton-root": {
-      "&:not(:first-child)": {
+      "&:not(:first-of-type)": {
         borderTopRightRadius: 0,
         borderTopLeftRadius: 0,
       },
@@ -172,7 +171,7 @@ function unionInto<T>(dest: Set<T>, ...iterables: Set<T>[]): void {
 }
 
 function TopicGraph() {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
   const [selectedTab, setSelectedTab] = useState<"Topics" | undefined>(undefined);
 
   const publishedTopics = useMessagePipeline(

--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -3,11 +3,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { IDropdownOption } from "@fluentui/react";
-import { makeStyles } from "@mui/styles";
 import produce from "immer";
 import { isEmpty, set } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
+import { makeStyles } from "tss-react/mui";
 
 import { filterMap } from "@foxglove/den/collection";
 import {
@@ -55,18 +55,18 @@ const DATA_TYPES = Object.freeze([
   "ros.sensor_msgs.JointState",
 ]);
 
-const useStyles = makeStyles({
+const useStyles = makeStyles()({
   root: {
     display: "flex",
     flexDirection: "column",
     flex: "auto",
     overflow: "hidden",
   },
-  toolbar: {
-    display: "flex",
-    flexGrow: 1,
-    alignItems: "baseline",
-  },
+  // toolbar: {
+  //   display: "flex",
+  //   flexGrow: 1,
+  //   alignItems: "baseline",
+  // },
   content: {
     display: "flex",
     flexDirection: "column",
@@ -88,7 +88,7 @@ const useStyles = makeStyles({
 });
 
 function URDFViewer({ config, saveConfig }: Props) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { customJointValues, jointStatesTopic, opacity } = config;
   const [canvas, setCanvas] = useState<HTMLCanvasElement | ReactNull>(ReactNull);
 

--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -62,11 +62,6 @@ const useStyles = makeStyles()({
     flex: "auto",
     overflow: "hidden",
   },
-  // toolbar: {
-  //   display: "flex",
-  //   flexGrow: 1,
-  //   alignItems: "baseline",
-  // },
   content: {
     display: "flex",
     flexDirection: "column",

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -3,19 +3,19 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { CompoundButton, Checkbox, IButtonStyles } from "@fluentui/react";
-import { Card, Theme, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Card, Typography } from "@mui/material";
 import { ReactElement, useState } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.default,
-  },
+const useStyles = makeStyles()((theme) => ({
+  // root: {
+  //   backgroundColor: theme.palette.background.default,
+  // },
   card: {
     display: "flex",
     flexDirection: "column",
@@ -32,7 +32,7 @@ const buttonStyles = {
 } as Partial<IButtonStyles>;
 
 export function LaunchPreferenceScreen(): ReactElement {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const [globalPreference, setGlobalPreference] = useAppConfigurationValue<string | undefined>(
     AppSetting.LAUNCH_PREFERENCE,

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -13,9 +13,6 @@ import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 
 const useStyles = makeStyles()((theme) => ({
-  // root: {
-  //   backgroundColor: theme.palette.background.default,
-  // },
   card: {
     display: "flex",
     flexDirection: "column",

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -4,8 +4,8 @@
 
 import type {} from "@mui/x-data-grid/themeAugmentation";
 
-import { alpha, Theme, ThemeOptions } from "@mui/material/styles";
-import { CSSProperties } from "@mui/styles";
+import { alpha, Theme, ThemeOptions } from "@mui/material";
+import { CSSProperties } from "react";
 
 type MuiLabComponents = {
   MuiFocusVisible?: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,7 +1558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.3.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.11.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.16.7, @babel/runtime@npm:^7.17.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.3.4, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.18.9
   resolution: "@babel/runtime@npm:7.18.9"
   dependencies:
@@ -2518,7 +2518,6 @@ __metadata:
     "@mdi/svg": 6.5.95
     "@mui/icons-material": 5.4.1
     "@mui/material": 5.4.1
-    "@mui/styles": 5.4.1
     "@mui/x-data-grid": 5.15.1
     "@protobufjs/base64": 1.1.2
     "@sentry/core": 7.10.0
@@ -3303,37 +3302,6 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: a376bbeb75becdb01c262d73aef6a1229caf50bebcc6f616c3ca0c9bc70b4f35a49ba081dcc157e1acd39a77c8eda679c0eedb387e2a6d135f3c57416627931a
-  languageName: node
-  linkType: hard
-
-"@mui/styles@npm:5.4.1":
-  version: 5.4.1
-  resolution: "@mui/styles@npm:5.4.1"
-  dependencies:
-    "@babel/runtime": ^7.17.0
-    "@emotion/hash": ^0.8.0
-    "@mui/private-theming": ^5.4.1
-    "@mui/types": ^7.1.1
-    "@mui/utils": ^5.4.1
-    clsx: ^1.1.1
-    csstype: ^3.0.10
-    hoist-non-react-statics: ^3.3.2
-    jss: ^10.8.2
-    jss-plugin-camel-case: ^10.8.2
-    jss-plugin-default-unit: ^10.8.2
-    jss-plugin-global: ^10.8.2
-    jss-plugin-nested: ^10.8.2
-    jss-plugin-props-sort: ^10.8.2
-    jss-plugin-rule-value-function: ^10.8.2
-    jss-plugin-vendor-prefixer: ^10.8.2
-    prop-types: ^15.7.2
-  peerDependencies:
-    "@types/react": ^16.8.6 || ^17.0.0
-    react: ^17.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 17f9262f977ec3b012319789f4f58006ead570b487e4bd856c0ad88a12d2e654b36d1b83c9cbff839e59f47348fc66b800448ed5f2368fd44529db2497b9698f
   languageName: node
   linkType: hard
 
@@ -10098,16 +10066,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-vendor@npm:^2.0.8":
-  version: 2.0.8
-  resolution: "css-vendor@npm:2.0.8"
-  dependencies:
-    "@babel/runtime": ^7.8.3
-    is-in-browser: ^1.0.2
-  checksum: 647cd4ea5e401c65c59376255aa2b708e92bf84fba9ce2b3ff5ecb94bf51d74ac374052b1cf9956ef7419b8ebf07fcea9a7683d2d2459127b2ca747ab5b98745
-  languageName: node
-  linkType: hard
-
 "css-what@npm:^3.2.1":
   version: 3.4.2
   resolution: "css-what@npm:3.4.2"
@@ -11938,6 +11896,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-tss-unused-classes@npm:0.0.3":
+  version: 0.0.3
+  resolution: "eslint-plugin-tss-unused-classes@npm:0.0.3"
+  peerDependencies:
+    eslint: ^7.14.0
+  checksum: 6ff956c2a97b640e30aa96ae40499dc1b6dfdf59037d68fcf5a3d30a07cc116ef1ed017af31c2f78989e6fda34e5c1f9abb7ec55078c78f4bc4fc43c617444ae
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -12930,6 +12897,7 @@ __metadata:
     eslint-plugin-prettier: 4.0.0
     eslint-plugin-react: 7.30.0
     eslint-plugin-react-hooks: 4.3.0
+    eslint-plugin-tss-unused-classes: 0.0.3
     html-webpack-plugin: 5.5.0
     jest: 27.5.1
     jest-canvas-mock: 2.3.1
@@ -14297,7 +14265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hyphenate-style-name@npm:^1.0.2, hyphenate-style-name@npm:^1.0.3":
+"hyphenate-style-name@npm:^1.0.2":
   version: 1.0.4
   resolution: "hyphenate-style-name@npm:1.0.4"
   checksum: 4f5bf4b055089754924babebaa23c17845937bcca6aee95d5d015f8fa1e6814279002bd6a9e541e3fac2cd02519fc76305396727066c57c8e21a7e73e7a12137
@@ -14990,13 +14958,6 @@ __metadata:
   version: 2.0.1
   resolution: "is-hexadecimal@npm:2.0.1"
   checksum: 66a2ea85994c622858f063f23eda506db29d92b52580709eb6f4c19550552d4dcf3fb81952e52f7cf972097237959e00adc7bb8c9400cd12886e15bf06145321
-  languageName: node
-  linkType: hard
-
-"is-in-browser@npm:^1.0.2, is-in-browser@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "is-in-browser@npm:1.1.3"
-  checksum: 178491f97f6663c0574565701b76f41633dbe065e4bd8d518ce017a8fa25e5109ecb6a3bd8bd55c0aba11b208f86b9f0f9c91f3664e148ebf618b74a74fcaf09
   languageName: node
   linkType: hard
 
@@ -16281,92 +16242,6 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
-  languageName: node
-  linkType: hard
-
-"jss-plugin-camel-case@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-camel-case@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    hyphenate-style-name: ^1.0.3
-    jss: 10.9.0
-  checksum: 435c7e3111f1e23b369f7a78bdadb09e91f100215b3156a0e46edad5801c2c002f8029d2afa71c9eafc1cb340988b5d9b81fed633bd63983371d21e3d5be2a4c
-  languageName: node
-  linkType: hard
-
-"jss-plugin-default-unit@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-default-unit@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    jss: 10.9.0
-  checksum: 5ff18061b1bf3afb0ae2d435dd2253159fc1927ce9ffd3457692df5b949f2ca39e01f752b728c584dd17dac5457963179ac3e71303bab8344fa8eee0352e8e5c
-  languageName: node
-  linkType: hard
-
-"jss-plugin-global@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-global@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    jss: 10.9.0
-  checksum: 1ff11b47131fec7b156cac057d3b749abff778b7ebd219649ef7a8988187e2a9b2c6cbd27f4b3c294df66378d688dc9e14a67e2ef9396a9c76ee2e720d6e224c
-  languageName: node
-  linkType: hard
-
-"jss-plugin-nested@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-nested@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    jss: 10.9.0
-    tiny-warning: ^1.0.2
-  checksum: 46dc4977d014bc67e9348642cd642a09864707ea70b7eac06a20f8505b0c995402199a6895d02faa9bb5282a3429b0e6814a41fe852da2a3b85543e75e60f271
-  languageName: node
-  linkType: hard
-
-"jss-plugin-props-sort@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-props-sort@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    jss: 10.9.0
-  checksum: 87eb054d4afa0d8db86ea5d7ace40d9883a11c7cbeada54c4a515da73a92178d777d3cef48b2b2bb52e0eab11212c8a15b9c29ec3d327ab256aaff943fd77c9d
-  languageName: node
-  linkType: hard
-
-"jss-plugin-rule-value-function@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-rule-value-function@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    jss: 10.9.0
-    tiny-warning: ^1.0.2
-  checksum: b8d0f4f8b2620f084e5e9e6f2cf54c9ce5857d1a15c4eb9d0f1d7fc4ee79452dba877c8c4039eeb163b132cbaff04ea958df54150fb41d9a9f9e86b93a54813f
-  languageName: node
-  linkType: hard
-
-"jss-plugin-vendor-prefixer@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss-plugin-vendor-prefixer@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    css-vendor: ^2.0.8
-    jss: 10.9.0
-  checksum: 8248908d9788fea2e2060ec82a61c07549935e57de3682a319927b3ee2256867a26c7af95e2169ceffe3712520ebd4b518c84485606b9838340f50d561a6cd22
-  languageName: node
-  linkType: hard
-
-"jss@npm:10.9.0, jss@npm:^10.8.2":
-  version: 10.9.0
-  resolution: "jss@npm:10.9.0"
-  dependencies:
-    "@babel/runtime": ^7.3.1
-    csstype: ^3.0.2
-    is-in-browser: ^1.1.3
-    tiny-warning: ^1.0.2
-  checksum: 29d3f133afc45ac8b392c1cda697ca0dc62b8a8b1f6a445054b9801f93c6beb95af81ef9c2f7c1583f99517234229adfc16067d163a29334a1d072cbd25df1b7
   languageName: node
   linkType: hard
 
@@ -23259,13 +23134,6 @@ __metadata:
   version: 2.1.0
   resolution: "tiny-emitter@npm:2.1.0"
   checksum: fbcfb5145751a0e3b109507a828eb6d6d4501352ab7bb33eccef46e22e9d9ad3953158870a6966a59e57ab7c3f9cfac7cab8521db4de6a5e757012f4677df2dd
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add linter to show us when there are unused classNames then realize that there are style `@mui/makeStyles` hanging out, which causes issues with the linter so removing them too

Removes JSS (MUI v4 style libs) #3628

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
