### PR TITLE
Improve datasource sidebar performance

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -3,7 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Skeleton, Typography } from "@mui/material";
+import { useDebounce } from "use-debounce";
 
+import { Time } from "@foxglove/rostime";
 import Duration from "@foxglove/studio-base/components/Duration";
 import {
   MessagePipelineContext,
@@ -21,13 +23,14 @@ const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeDat
 const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
 
-function DataSourceInfo(): JSX.Element {
-  const startTime = useMessagePipeline(selectStartTime);
-  const endTime = useMessagePipeline(selectEndTime);
-  const playerName = useMessagePipeline(selectPlayerName);
-  const playerPresence = useMessagePipeline(selectPlayerPresence);
-
-  const duration = startTime && endTime ? subtractTimes(endTime, startTime) : undefined;
+function DataSourceInfoContent(props: {
+  duration?: Time;
+  endTime?: Time;
+  playerName?: string;
+  playerPresence: PlayerPresence;
+  startTime?: Time;
+}): JSX.Element {
+  const { duration, endTime, playerName, playerPresence, startTime } = props;
 
   return (
     <Stack gap={1.5} paddingX={2} paddingBottom={2}>
@@ -93,6 +96,30 @@ function DataSourceInfo(): JSX.Element {
         )}
       </Stack>
     </Stack>
+  );
+}
+
+const MemoDataSourceInfoContent = React.memo(DataSourceInfoContent);
+
+function DataSourceInfo(): JSX.Element {
+  const startTime = useMessagePipeline(selectStartTime);
+  const endTime = useMessagePipeline(selectEndTime);
+  const playerName = useMessagePipeline(selectPlayerName);
+  const playerPresence = useMessagePipeline(selectPlayerPresence);
+
+  const [debouncedTimes] = useDebounce(
+    { endTime, duration: startTime && endTime ? subtractTimes(endTime, startTime) : undefined },
+    500,
+    { maxWait: 500 },
+  );
+
+  return (
+    <MemoDataSourceInfoContent
+      duration={debouncedTimes.duration}
+      endTime={debouncedTimes.endTime}
+      playerName={playerName}
+      playerPresence={playerPresence}
+    />
   );
 }
 

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -109,8 +109,8 @@ function DataSourceInfo(): JSX.Element {
 
   const [debouncedTimes] = useDebounce(
     { endTime, duration: startTime && endTime ? subtractTimes(endTime, startTime) : undefined },
-    500,
-    { maxWait: 500 },
+    100,
+    { maxWait: 100 },
   );
 
   return (

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -110,7 +110,7 @@ function DataSourceInfo(): JSX.Element {
   const [debouncedTimes] = useDebounce(
     { endTime, duration: startTime && endTime ? subtractTimes(endTime, startTime) : undefined },
     100,
-    { maxWait: 100 },
+    { leading: true, maxWait: 100 },
   );
 
   return (

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceInfo.tsx
@@ -119,6 +119,7 @@ function DataSourceInfo(): JSX.Element {
       endTime={debouncedTimes.endTime}
       playerName={playerName}
       playerPresence={playerPresence}
+      startTime={startTime}
     />
   );
 }

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
@@ -18,7 +18,9 @@ import {
   TypographyProps,
 } from "@mui/material";
 import { Fzf, FzfResultItem } from "fzf";
+import { cloneDeep } from "lodash";
 import { useMemo, useState } from "react";
+import { useDebounce } from "use-debounce";
 
 import { areEqual, subtract as subtractTimes, Time, toSec } from "@foxglove/rostime";
 import {
@@ -151,6 +153,54 @@ const messageFrequency = (topic: TopicWithStats, duration: Time | undefined) => 
   return `${value.toFixed(digits)} Hz`;
 };
 
+function TopicListItem({
+  item,
+  messageCount,
+  messageHz,
+  positions,
+}: {
+  item: TopicWithStats;
+  messageCount?: number;
+  messageHz?: string;
+  positions: Set<number>;
+}): JSX.Element {
+  return (
+    <StyledListItem
+      divider
+      key={item.name}
+      secondaryAction={
+        (messageCount != undefined || messageHz != undefined) && (
+          <Stack style={{ textAlign: "right" }}>
+            <Typography variant="caption" color="text.secondary">
+              {messageCount ?? "–"}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {messageHz ?? "–"}
+            </Typography>
+          </Stack>
+        )
+      }
+    >
+      <ListItemText
+        primary={<HighlightChars str={item.name} indices={positions} />}
+        primaryTypographyProps={{ noWrap: true, title: item.name }}
+        secondary={
+          <HighlightChars str={item.datatype} indices={positions} offset={item.name.length + 1} />
+        }
+        secondaryTypographyProps={{
+          variant: "caption",
+          fontFamily: fonts.MONOSPACE,
+          noWrap: true,
+          title: item.datatype,
+        }}
+        style={{ marginRight: "48px" }}
+      />
+    </StyledListItem>
+  );
+}
+
+const MemoTopicListItem = React.memo(TopicListItem);
+
 export function TopicList(): JSX.Element {
   const [filterText, setFilterText] = useState<string>("");
 
@@ -168,19 +218,26 @@ export function TopicList(): JSX.Element {
     [topics, topicStats],
   );
 
-  const duration =
-    endTime != undefined && startTime != undefined ? subtractTimes(endTime, startTime) : undefined;
+  // Clone deep is necessary here because players mutate the stats directly and
+  // break memoization.
+  const [debouncedItems] = useDebounce(cloneDeep(items), 1000, { maxWait: 1000 });
+
+  const [duration] = useDebounce(
+    endTime != undefined && startTime != undefined ? subtractTimes(endTime, startTime) : undefined,
+    500,
+    { maxWait: 500 },
+  );
 
   const filteredTopics: FzfResultItem<TopicWithStats>[] = useMemo(
     () =>
       filterText
-        ? new Fzf(items, {
+        ? new Fzf(debouncedItems, {
             fuzzy: filterText.length > 2 ? "v2" : false,
             sort: true,
             selector: (item) => `${item.name}|${item.datatype}`,
           }).find(filterText)
-        : items.map((item) => topicToFzfResult(item)),
-    [filterText, items],
+        : debouncedItems.map((item) => topicToFzfResult(item)),
+    [filterText, debouncedItems],
   );
 
   if (playerPresence === PlayerPresence.ERROR) {
@@ -257,41 +314,13 @@ export function TopicList(): JSX.Element {
             const messageHz = messageFrequency(item, duration);
 
             return (
-              <StyledListItem
-                divider
+              <MemoTopicListItem
                 key={item.name}
-                secondaryAction={
-                  (messageCount != undefined || messageHz != undefined) && (
-                    <Stack style={{ textAlign: "right" }}>
-                      <Typography variant="caption" color="text.secondary">
-                        {messageCount ?? "–"}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {messageHz ?? "–"}
-                      </Typography>
-                    </Stack>
-                  )
-                }
-              >
-                <ListItemText
-                  primary={<HighlightChars str={item.name} indices={positions} />}
-                  primaryTypographyProps={{ noWrap: true, title: item.name }}
-                  secondary={
-                    <HighlightChars
-                      str={item.datatype}
-                      indices={positions}
-                      offset={item.name.length + 1}
-                    />
-                  }
-                  secondaryTypographyProps={{
-                    variant: "caption",
-                    fontFamily: fonts.MONOSPACE,
-                    noWrap: true,
-                    title: item.datatype,
-                  }}
-                  style={{ marginRight: "48px" }}
-                />
-              </StyledListItem>
+                item={item}
+                messageCount={messageCount}
+                messageHz={messageHz}
+                positions={positions}
+              />
             );
           })}
         </List>

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
@@ -220,24 +220,28 @@ export function TopicList(): JSX.Element {
 
   // Clone deep is necessary here because players mutate the stats directly and
   // break memoization.
-  const [debouncedItems] = useDebounce(cloneDeep(items), 1000, { maxWait: 1000 });
-
-  const [duration] = useDebounce(
-    endTime != undefined && startTime != undefined ? subtractTimes(endTime, startTime) : undefined,
-    500,
-    { maxWait: 500 },
+  const [debouncedData] = useDebounce(
+    {
+      items: cloneDeep(items),
+      duration:
+        endTime != undefined && startTime != undefined
+          ? subtractTimes(endTime, startTime)
+          : undefined,
+    },
+    1000,
+    { maxWait: 1000 },
   );
 
   const filteredTopics: FzfResultItem<TopicWithStats>[] = useMemo(
     () =>
       filterText
-        ? new Fzf(debouncedItems, {
+        ? new Fzf(debouncedData.items, {
             fuzzy: filterText.length > 2 ? "v2" : false,
             sort: true,
             selector: (item) => `${item.name}|${item.datatype}`,
           }).find(filterText)
-        : debouncedItems.map((item) => topicToFzfResult(item)),
-    [filterText, debouncedItems],
+        : debouncedData.items.map((item) => topicToFzfResult(item)),
+    [filterText, debouncedData.items],
   );
 
   if (playerPresence === PlayerPresence.ERROR) {
@@ -311,7 +315,7 @@ export function TopicList(): JSX.Element {
         <List key="topics" dense disablePadding>
           {filteredTopics.map(({ item, positions }) => {
             const messageCount = item.numMessages;
-            const messageHz = messageFrequency(item, duration);
+            const messageHz = messageFrequency(item, debouncedData.duration);
 
             return (
               <MemoTopicListItem

--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.tsx
@@ -229,7 +229,7 @@ export function TopicList(): JSX.Element {
           : undefined,
     },
     1000,
-    { maxWait: 1000 },
+    { leading: true, maxWait: 1000 },
   );
 
   const filteredTopics: FzfResultItem<TopicWithStats>[] = useMemo(


### PR DESCRIPTION
**User-Facing Changes**
This improves performance of the datasource sidebar.

**Description**
This uses a combination of debouncing updates to 2fps for the info panel and 1fps for the topics and memoizing some components to improve the performance of the datasource info sidebar. On my machine this brings the fps of the app from about 28 on the sinewave benchmark to ~58.

Would could possibly make this a little bit smarter and make the debounce time for the topics a function of the number of topics. For the sinewave benchmark reducing the debounce from 1000ms to 500ms costs about 10fps overall for the app but we could afford to debounce for a shorter time with fewer topics.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses #4173 