### PR TITLE
Tweak mosaic drag overlay colors

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -10,6 +10,8 @@ import "@foxglove/studio-base/styles/assets/plex-mono.css";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
+import { alpha } from "@mui/material";
+
 const useStyles = makeStyles()(({ palette, typography }) => ({
   root: {
     "code, pre, tt": {
@@ -67,10 +69,10 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
 
         ".drop-target-container .drop-target": {
           backgroundColor: palette.action.hover,
-          border: `2px solid ${palette.divider}`,
+          border: `2px solid ${alpha(palette.divider, 0.5)}`,
         },
         ".drop-target-container .drop-target-hover": {
-          opacity: 0.3,
+          opacity: 1,
         },
       },
       ".mosaic-tile": {

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { alpha } from "@mui/material";
 import { PropsWithChildren } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -9,8 +10,6 @@ import "@foxglove/studio-base/styles/assets/inter.css";
 import "@foxglove/studio-base/styles/assets/plex-mono.css";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
-
-import { alpha } from "@mui/material";
 
 const useStyles = makeStyles()(({ palette, typography }) => ({
   root: {


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Fixes #4186, a color regression from https://github.com/foxglove/studio/pull/3987.

Before: see #4186

https://user-images.githubusercontent.com/14237/185695020-786a27cc-20e0-4404-8639-b13b45b0e31a.mov


