### PR TITLE
Persist map zoom level

### DIFF
--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -9,7 +9,7 @@ import { SettingsTreeFields, SettingsTreeNodes } from "@foxglove/studio";
 
 // Persisted panel state
 export type Config = {
-  center: undefined | { lat: number; lon: number };
+  center?: { lat: number; lon: number };
   customTileUrl: string;
   disabledTopics: string[];
   followTopic: string;

--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -9,12 +9,13 @@ import { SettingsTreeFields, SettingsTreeNodes } from "@foxglove/studio";
 
 // Persisted panel state
 export type Config = {
+  center: undefined | { lat: number; lon: number };
   customTileUrl: string;
   disabledTopics: string[];
-  layer: string;
-  zoomLevel?: number;
   followTopic: string;
+  layer: string;
   topicColors: Record<string, string>;
+  zoomLevel?: number;
 };
 
 export function validateCustomUrl(url: string): Error | undefined {


### PR DESCRIPTION
**User-Facing Changes**
Remembers changes in pan and zoom for the map panel.

**Description**
We were already saving zoom level to the panel config but not applying it when loading the panel. This also extends the same logic to the map center.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4225