### PR TITLE
[New3D] Create coordinate frames from all <link>s when loading URDFs

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -808,7 +808,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     return frameId.slice(1);
   }
 
-  private addCoordinateFrame(frameId: string): void {
+  public addCoordinateFrame(frameId: string): void {
     const normalizedFrameId = this.normalizeFrameId(frameId);
     if (!this.transformTree.hasFrame(normalizedFrameId)) {
       this.transformTree.getOrCreateFrame(normalizedFrameId);


### PR DESCRIPTION
**User-Facing Changes**

- `3D (Beta)` panel can now visualize URDF files that define one or more `<link>`s but no `<joint>`s

**Description**

Previously, we would only recognize new coordinate frames in URDFs from joints (which define a parent/child relationship between two links). If a URDF defined a single <link> with no <joint>, or a link that was disconnected from any joint, it would not end up defining a coordinate frame in Studio and the URDF could not be rendered.
