### PR TITLE
Refactor PanelRoot to use tss-react/mui

### DIFF
--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -15,7 +15,7 @@ import BorderAllIcon from "@mui/icons-material/BorderAll";
 import DeleteForeverOutlinedIcon from "@mui/icons-material/DeleteForeverOutlined";
 import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
 import TabIcon from "@mui/icons-material/Tab";
-import { Button, styled as muiStyled } from "@mui/material";
+import { Button, styled as muiStyled, useTheme } from "@mui/material";
 import { last } from "lodash";
 import React, {
   useState,
@@ -47,10 +47,7 @@ import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import PanelErrorBoundary from "@foxglove/studio-base/components/PanelErrorBoundary";
-import {
-  FULLSCREEN_TRANSITION_DURATION_MS,
-  PanelRoot,
-} from "@foxglove/studio-base/components/PanelRoot";
+import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
 import {
   useCurrentLayoutActions,
   useSelectedPanels,
@@ -166,7 +163,7 @@ export default function Panel<
 ): ComponentType<Props<Config> & Omit<PanelProps, "config" | "saveConfig">> & PanelStatics<Config> {
   function ConnectedPanel(props: Props<Config>) {
     const { childId, overrideConfig, tabId, ...otherProps } = props;
-
+    const theme = useTheme();
     const isMounted = useMountedState();
 
     const { mosaicActions } = useContext(MosaicContext);
@@ -557,7 +554,7 @@ export default function Panel<
           {fullscreen && <KeyListener global keyDownHandlers={fullScreenKeyHandlers} />}
           <Transition
             in={fullscreen}
-            timeout={{ exit: FULLSCREEN_TRANSITION_DURATION_MS }}
+            timeout={{ exit: theme.transitions.duration.shorter }}
             onExited={() => setHasFullscreenDescendant(false)}
             nodeRef={panelRootRef}
           >

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -554,9 +554,12 @@ export default function Panel<
           {fullscreen && <KeyListener global keyDownHandlers={fullScreenKeyHandlers} />}
           <Transition
             in={fullscreen}
-            timeout={{ exit: theme.transitions.duration.shorter }}
             onExited={() => setHasFullscreenDescendant(false)}
             nodeRef={panelRootRef}
+            timeout={{
+              // match to transition duration inside PanelRoot
+              exit: theme.transitions.duration.shorter,
+            }}
           >
             {(fullscreenState) => (
               <PanelRoot

--- a/packages/studio-base/src/components/PanelContextMenu.tsx
+++ b/packages/studio-base/src/components/PanelContextMenu.tsx
@@ -13,7 +13,7 @@ import {
 import { DeepReadonly } from "ts-essentials";
 
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
-import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
+import { PANEL_ROOT_CLASS_NAME } from "@foxglove/studio-base/components/PanelRoot";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 
 /**
@@ -98,7 +98,7 @@ export function PanelContextMenu(props: PanelContextMenuProps): JSX.Element {
       return;
     }
 
-    const parent: HTMLElement | ReactNull = element.closest(PanelRoot);
+    const parent: HTMLElement | ReactNull = element.closest(`.${PANEL_ROOT_CLASS_NAME}`);
     parent?.addEventListener("contextmenu", listener);
 
     return () => {

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -21,6 +21,7 @@ export const usePanelRootStyles = makeStyles<
 >()((theme, props) => {
   const { palette, transitions } = theme;
   const { sourceRect, hasFullscreenDescendant } = props;
+  const duration = transitions.duration.shorter;
 
   return {
     root: {
@@ -30,7 +31,9 @@ export const usePanelRootStyles = makeStyles<
       overflow: "hidden",
       backgroundColor: palette.background.default,
       border: `0px solid ${alpha(palette.primary.main, 0.67)}`,
-      transition: transitions.create("border-width", { duration: transitions.duration.shorter }),
+      transition: transitions.create("border-width", {
+        duration, // match to timeout duration inside Panel component
+      }),
 
       "::after": {
         content: "''",
@@ -59,7 +62,7 @@ export const usePanelRootStyles = makeStyles<
       left: sourceRect?.left ?? 0,
       right: sourceRect ? window.innerWidth - sourceRect.right : 0,
       bottom: sourceRect ? window.innerHeight - sourceRect.bottom : 0,
-      zIndex: 10000, // zIndex?
+      zIndex: 10000,
     },
     entered: {
       borderWidth: 4,
@@ -67,10 +70,10 @@ export const usePanelRootStyles = makeStyles<
       top: 0,
       left: 0,
       right: 0,
-      bottom: 50, // plabackbar.height?
-      zIndex: 10000, // zIndex?
+      bottom: 50, // match PlaybackBar height
+      zIndex: 10000,
       transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
-        duration: transitions.duration.shorter,
+        duration, // match to timeout duration inside Panel component
       }),
     },
     exiting: {
@@ -81,7 +84,7 @@ export const usePanelRootStyles = makeStyles<
       bottom: sourceRect ? window.innerHeight - sourceRect.bottom : 0,
       zIndex: 10000,
       transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
-        duration: transitions.duration.shorter,
+        duration, // match to timeout duration inside Panel component
       }),
     },
     exited: {

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -101,10 +101,11 @@ export const usePanelRootStyles = makeStyles<
 
 export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootProps>>(
   function PanelRoot(props, ref): JSX.Element {
-    const { fullscreenState, selected, sourceRect, hasFullscreenDescendant } = props;
+    const { fullscreenState, selected, sourceRect, hasFullscreenDescendant, className, ...rest } =
+      props;
     const { classes, cx } = usePanelRootStyles({ sourceRect, hasFullscreenDescendant });
 
-    const className = cx(PANEL_ROOT_CLASS_NAME, classes.root, {
+    const classNames = cx(PANEL_ROOT_CLASS_NAME, className, classes.root, {
       [classes.entering]: fullscreenState === "entering",
       [classes.entered]: fullscreenState === "entered",
       [classes.exiting]: fullscreenState === "exiting",
@@ -113,7 +114,7 @@ export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootP
     });
 
     return (
-      <div ref={ref} className={className}>
+      <div ref={ref} className={classNames} {...rest}>
         {props.children}
       </div>
     );

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -2,95 +2,120 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { alpha } from "@mui/material";
+import { forwardRef, HTMLAttributes, PropsWithChildren } from "react";
 import { TransitionStatus } from "react-transition-group";
-import styled, { css } from "styled-components";
+import { makeStyles } from "tss-react/mui";
 
-export const FULLSCREEN_TRANSITION_DURATION_MS = 200;
+export const PANEL_ROOT_CLASS_NAME = "FoxglovePanelRoot-root";
 
-// This is in a separate file to prevent circular import issues.
-export const PanelRoot = styled.div<{
+type PanelRootProps = {
   fullscreenState: TransitionStatus;
   selected: boolean;
   sourceRect: DOMRectReadOnly | undefined;
   hasFullscreenDescendant: boolean;
-}>`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
-  overflow: hidden;
-  background-color: ${({ theme }) => theme.semanticColors.bodyBackground};
-  border: 0px solid rgba(110, 81, 238, 0.3);
-  transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
+} & HTMLAttributes<HTMLDivElement>;
 
-  ${({ fullscreenState, sourceRect, hasFullscreenDescendant }) => {
-    switch (fullscreenState) {
-      case "entering":
-        return css`
-          position: fixed;
-          top: ${sourceRect?.top ?? 0}px;
-          left: ${sourceRect?.left ?? 0}px;
-          right: ${sourceRect ? window.innerWidth - sourceRect.right : 0}px;
-          bottom: ${sourceRect ? window.innerHeight - sourceRect.bottom : 0}px;
-          z-index: 10000;
-        `;
-      case "entered":
-        return css`
-          transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            top ${FULLSCREEN_TRANSITION_DURATION_MS}ms, left ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            right ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            bottom ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
-          border-width: 4px;
-          position: fixed;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 50px;
-          z-index: 10000;
-        `;
-      case "exiting":
-        return css`
-          transition: border-width ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            top ${FULLSCREEN_TRANSITION_DURATION_MS}ms, left ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            right ${FULLSCREEN_TRANSITION_DURATION_MS}ms,
-            bottom ${FULLSCREEN_TRANSITION_DURATION_MS}ms;
-          position: fixed;
-          top: ${sourceRect?.top ?? 0}px;
-          left: ${sourceRect?.left ?? 0}px;
-          right: ${sourceRect ? window.innerWidth - sourceRect.right : 0}px;
-          bottom: ${sourceRect ? window.innerHeight - sourceRect.bottom : 0}px;
-          z-index: 10000;
-        `;
-      case "exited":
-        return css`
-          position: relative;
-          top: 0;
-          left: 0;
-          right: 0;
-          bottom: 0;
-          // "z-index: 1" makes panel drag & drop work more reliably (see
-          // https://github.com/foxglove/studio/pull/3355), but it also makes fullscreen panels get
-          // overlapped by other parts of the panel layout. So we turn it back to auto when a
-          // descendant is fullscreen.
-          z-index: ${hasFullscreenDescendant ? "auto" : 1};
-        `;
-      case "unmounted":
-        return css``;
-    }
-  }}
+export const usePanelRootStyles = makeStyles<
+  Omit<PanelRootProps, "fullscreenState" | "selected">
+>()((theme, props) => {
+  const { palette, transitions } = theme;
+  const { sourceRect, hasFullscreenDescendant } = props;
 
-  :after {
-    content: "";
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    inset: 1px;
-    opacity: ${({ selected }) => (selected ? 1 : 0)};
-    border: 1px solid ${({ theme }) => theme.palette.themePrimary};
-    position: absolute;
-    pointer-events: none;
-    transition: ${({ selected }) =>
-      selected ? "opacity 0.125s ease-out" : "opacity 0.05s ease-out"};
-    z-index: 100000;
-  }
-`;
+  return {
+    root: {
+      display: "flex",
+      flexDirection: "column",
+      flex: "1 1 auto",
+      overflow: "hidden",
+      backgroundColor: palette.background.default,
+      border: `0px solid ${alpha(palette.primary.main, 0.67)}`,
+      transition: transitions.create("border-width", { duration: transitions.duration.shorter }),
+
+      "::after": {
+        content: "''",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        inset: 1,
+        opacity: 0,
+        border: `1px solid ${palette.primary.main}`,
+        position: "absolute",
+        pointerEvents: "none",
+        transition: "opacity 0.05s ease-out",
+        zIndex: 10000 + 1,
+      },
+    },
+    rootSelected: {
+      "::after": {
+        opacity: 1,
+        transition: "opacity 0.125s ease-out",
+      },
+    },
+    entering: {
+      position: "fixed",
+      top: sourceRect?.top ?? 0,
+      left: sourceRect?.left ?? 0,
+      right: sourceRect ? window.innerWidth - sourceRect.right : 0,
+      bottom: sourceRect ? window.innerHeight - sourceRect.bottom : 0,
+      zIndex: 10000, // zIndex?
+    },
+    entered: {
+      borderWidth: 4,
+      position: "fixed",
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 50, // plabackbar.height?
+      zIndex: 10000, // zIndex?
+      transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
+        duration: transitions.duration.shorter,
+      }),
+    },
+    exiting: {
+      position: "fixed",
+      top: sourceRect?.top ?? 0,
+      left: sourceRect?.left ?? 0,
+      right: sourceRect ? window.innerWidth - sourceRect.right : 0,
+      bottom: sourceRect ? window.innerHeight - sourceRect.bottom : 0,
+      zIndex: 10000,
+      transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
+        duration: transitions.duration.shorter,
+      }),
+    },
+    exited: {
+      position: "relative",
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      // "z-index: 1" makes panel drag & drop work more reliably (see
+      // https://github.com/foxglove/studio/pull/3355), but it also makes fullscreen panels get
+      // overlapped by other parts of the panel layout. So we turn it back to auto when a
+      // descendant is fullscreen.
+      zIndex: hasFullscreenDescendant ? "auto" : 1,
+    },
+  };
+});
+
+export const PanelRoot = forwardRef<HTMLDivElement, PropsWithChildren<PanelRootProps>>(
+  function PanelRoot(props, ref): JSX.Element {
+    const { fullscreenState, selected, sourceRect, hasFullscreenDescendant } = props;
+    const { classes, cx } = usePanelRootStyles({ sourceRect, hasFullscreenDescendant });
+
+    const className = cx(PANEL_ROOT_CLASS_NAME, classes.root, {
+      [classes.entering]: fullscreenState === "entering",
+      [classes.entered]: fullscreenState === "entered",
+      [classes.exiting]: fullscreenState === "exiting",
+      [classes.exited]: fullscreenState === "exited",
+      [classes.rootSelected]: selected,
+    });
+
+    return (
+      <div ref={ref} className={className}>
+        {props.children}
+      </div>
+    );
+  },
+);

--- a/packages/studio-base/src/hooks/usePanelMousePresence.tsx
+++ b/packages/studio-base/src/hooks/usePanelMousePresence.tsx
@@ -4,7 +4,7 @@
 
 import { MutableRefObject, useCallback, useEffect, useState } from "react";
 
-import { PanelRoot } from "@foxglove/studio-base/components/PanelRoot";
+import { PANEL_ROOT_CLASS_NAME } from "@foxglove/studio-base/components/PanelRoot";
 
 /**
  * Tracks the presence of the mouse in the parent panel.
@@ -36,7 +36,7 @@ export function usePanelMousePresence(ref: MutableRefObject<HTMLElement | ReactN
       return;
     }
 
-    const parent: HTMLElement | ReactNull = element.closest(PanelRoot);
+    const parent: HTMLElement | ReactNull = element.closest(`.${PANEL_ROOT_CLASS_NAME}`);
     parent?.addEventListener("mouseenter", listener);
     parent?.addEventListener("mouseleave", listener);
 

--- a/packages/studio-base/src/theme/createMuiTheme.ts
+++ b/packages/studio-base/src/theme/createMuiTheme.ts
@@ -17,9 +17,6 @@ export default function createMuiTheme(
     palette: palette[themePreference],
     shape: { borderRadius: 2 },
     typography,
-    transitions: {
-      create: () => "none",
-    },
   });
 
   // add name for storybook


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Removes styled-components and fluentui/react from PanelRoot styles

Closes #4246

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
