### PR TITLE
Refactor OpenDialog/Connection to use BuiltinIcon

### DIFF
--- a/packages/studio-base/src/components/BuiltinIcon.tsx
+++ b/packages/studio-base/src/components/BuiltinIcon.tsx
@@ -5,10 +5,13 @@
 import ICONS from "@foxglove/studio-base/theme/icons";
 
 type BuiltinIconProps = {
-  name: keyof typeof ICONS;
+  name?: RegisteredIconNames;
 };
 
 function BuiltinIcon(props: BuiltinIconProps): JSX.Element {
+  if (props.name == undefined) {
+    return <></>;
+  }
   return ICONS[props.name];
 }
 

--- a/packages/studio-base/src/components/BuiltinIcon.tsx
+++ b/packages/studio-base/src/components/BuiltinIcon.tsx
@@ -5,13 +5,10 @@
 import ICONS from "@foxglove/studio-base/theme/icons";
 
 type BuiltinIconProps = {
-  name?: RegisteredIconNames;
+  name: keyof typeof ICONS;
 };
 
 function BuiltinIcon(props: BuiltinIconProps): JSX.Element {
-  if (props.name == undefined) {
-    return <></>;
-  }
   return ICONS[props.name];
 }
 

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -2,10 +2,11 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Icon } from "@fluentui/react";
-import { Alert, Link, Tab, Tabs, Typography, styled as muiStyled } from "@mui/material";
+import { Alert, Link, Tab, Tabs, Typography } from "@mui/material";
 import { useState, useMemo, useCallback, useLayoutEffect } from "react";
+import { makeStyles } from "tss-react/mui";
 
+import { BuiltinIcon } from "@foxglove/studio-base/components/BuiltinIcon";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
   IDataSourceFactory,
@@ -22,14 +23,14 @@ type ConnectionProps = {
   activeSource?: IDataSourceFactory;
 };
 
-const StyledTabs = muiStyled(Tabs)(({ theme }) => ({
-  ".MuiTabs-indicator": {
+const useStyles = makeStyles()((theme) => ({
+  indicator: {
     right: 0,
     width: "100%",
     backgroundColor: theme.palette.action.hover,
     borderRadius: theme.shape.borderRadius,
   },
-  ".MuiTab-root": {
+  tab: {
     textAlign: "right",
     flexDirection: "row",
     justifyContent: "flex-start",
@@ -37,25 +38,25 @@ const StyledTabs = muiStyled(Tabs)(({ theme }) => ({
     minHeight: "auto",
     paddingTop: theme.spacing(1.5),
     paddingBottom: theme.spacing(1.5),
+  },
+  iconWrapper: {
+    marginBottom: 0,
+    marginRight: theme.spacing(1.5),
+    fontSize: theme.typography.pxToRem(24),
+    color: theme.palette.primary.main,
 
-    ".MuiTab-iconWrapper": {
-      marginBottom: 0,
-      marginRight: theme.spacing(1.5),
-      fontSize: theme.typography.pxToRem(24),
-      color: theme.palette.primary.main,
-
-      "> span": {
-        display: "flex",
-      },
-      svg: {
-        fontSize: "inherit",
-      },
+    "> span": {
+      display: "flex",
+    },
+    svg: {
+      fontSize: "inherit",
     },
   },
 }));
 
 export default function Connection(props: ConnectionProps): JSX.Element {
   const { availableSources, activeSource, onCancel, onBack } = props;
+  const { classes } = useStyles();
 
   const { selectSource } = usePlayerSelection();
   const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
@@ -109,7 +110,8 @@ export default function Connection(props: ConnectionProps): JSX.Element {
     <View onBack={onBack} onCancel={onCancel} onOpen={disableOpen ? undefined : onOpen}>
       <Stack direction="row" flexGrow={1} flexWrap="wrap" fullHeight gap={4}>
         <Stack flexBasis={240}>
-          <StyledTabs
+          <Tabs
+            classes={{ indicator: classes.indicator }}
             textColor="inherit"
             orientation="vertical"
             onChange={(_event, newValue: number) => setSelectedConnectionIdx(newValue)}
@@ -118,10 +120,19 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             {enabledSourcesFirst.map((source, idx) => {
               const { id, iconName, displayName } = source;
               return (
-                <Tab value={idx} key={id} icon={<Icon iconName={iconName} />} label={displayName} />
+                <Tab
+                  value={idx}
+                  key={id}
+                  icon={<BuiltinIcon name={iconName} />}
+                  label={displayName}
+                  classes={{
+                    root: classes.tab,
+                    iconWrapper: classes.iconWrapper,
+                  }}
+                />
               );
             })}
-          </StyledTabs>
+          </Tabs>
         </Stack>
         <Stack key={selectedSource?.id} flex="1 0" gap={2}>
           {selectedSource?.warning && <Alert severity="warning">{selectedSource.warning}</Alert>}

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -38,15 +38,13 @@ const useStyles = makeStyles()((theme) => ({
     minHeight: "auto",
     paddingTop: theme.spacing(1.5),
     paddingBottom: theme.spacing(1.5),
-  },
-  iconWrapper: {
-    marginBottom: 0,
-    marginRight: theme.spacing(1.5),
-    fontSize: theme.typography.pxToRem(24),
-    color: theme.palette.primary.main,
 
     "> span": {
       display: "flex",
+      color: theme.palette.primary.main,
+      marginRight: theme.spacing(1.5),
+      height: "auto",
+      width: "auto",
     },
     svg: {
       fontSize: "inherit",
@@ -125,10 +123,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
                   key={id}
                   icon={<BuiltinIcon name={iconName} />}
                   label={displayName}
-                  classes={{
-                    root: classes.tab,
-                    iconWrapper: classes.iconWrapper,
-                  }}
+                  className={classes.tab}
                 />
               );
             })}

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -121,7 +121,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
                 <Tab
                   value={idx}
                   key={id}
-                  icon={<BuiltinIcon name={iconName} />}
+                  icon={<BuiltinIcon name={iconName ?? "Flow"} />}
                   label={displayName}
                   className={classes.tab}
                 />


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Use BuiltinIcon instead of fluentui/Icon in OpenDialog/Connection

Closes #4210

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
