### PR TITLE
[New3D] Do not load lights from COLLADA files

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -98,9 +98,12 @@ export class RenderableMeshResource extends RenderableMarker {
       return;
     }
 
-    const mesh = opts.useEmbeddedMaterials
-      ? cachedModel.clone(true)
-      : replaceMaterials(cachedModel.clone(true), this.material);
+    const mesh = cachedModel.clone(true);
+    removeLights(mesh);
+    if (!opts.useEmbeddedMaterials) {
+      replaceMaterials(mesh, this.material);
+    }
+
     this.mesh = mesh;
     this.add(mesh);
 
@@ -111,7 +114,21 @@ export class RenderableMeshResource extends RenderableMarker {
   }
 }
 
-function replaceMaterials(model: LoadedModel, material: THREE.MeshStandardMaterial): LoadedModel {
+function removeLights(model: LoadedModel): void {
+  // Remove lights from the model
+  const lights: THREE.Light[] = [];
+  model.traverse((child: THREE.Object3D) => {
+    const maybeLight = child as Partial<THREE.Light>;
+    if (maybeLight.isLight === true) {
+      lights.push(maybeLight as THREE.Light);
+    }
+  });
+  for (const light of lights) {
+    light.removeFromParent();
+  }
+}
+
+function replaceMaterials(model: LoadedModel, material: THREE.MeshStandardMaterial): void {
   model.traverse((child: THREE.Object3D) => {
     if (!(child instanceof THREE.Mesh)) {
       return;
@@ -129,7 +146,6 @@ function replaceMaterials(model: LoadedModel, material: THREE.MeshStandardMateri
     }
     meshChild.material = material;
   });
-  return model;
 }
 
 /** Generic MeshStandardMaterial dispose function for materials loaded from an external source */


### PR DESCRIPTION
**User-Facing Changes**

- Fixed visualization of COLLADA files containing lights in `3D (Beta)` panel

**Description**

If a COLLADA (.dae) mesh included its own lights, those were getting loaded into the scene which would generally blow out the lighting since we already include two scene lights. This change removes any embedded lights in COLLADA scene graphs
