### PR TITLE
- fix camera info story camerastate

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -136,7 +136,7 @@ export function CameraInfoRender(): JSX.Element {
             perspective: true,
             phi: rad2deg(0),
             targetOffset: [0, 0, 0],
-            thetaOffset: rad2deg(0),
+            thetaOffset: rad2deg(Math.PI),
             fovy: rad2deg(0.75),
             near: 0.01,
             far: 5000,


### PR DESCRIPTION
**User-Facing Changes**
 - n/a


**Description**
 - setting the theta offset to Math.PI gets rid of the camera switching 180 degrees when first interacted with

