### PR TITLE
[New3D] Position frame axis labels based on axis length and label size

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -40,6 +40,9 @@ export class CoreSettings extends SceneExtension {
       "foxglove.publish-type-change",
       this.handlePublishToolChange,
     );
+
+    renderer.labelPool.scaleFactor =
+      renderer.config.scene.labelScaleFactor ?? DEFAULT_LABEL_SCALE_FACTOR;
   }
 
   public override dispose(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -18,7 +18,7 @@ import { SettingsTreeEntry } from "../SettingsManager";
 import { getLuminance, stringToRgb } from "../color";
 import { BaseSettings, fieldSize } from "../settings";
 import { Duration, Transform, makePose, CoordinateFrame, MAX_DURATION } from "../transforms";
-import { Axis } from "./Axis";
+import { Axis, AXIS_LENGTH } from "./Axis";
 import {
   DEFAULT_AXIS_SCALE,
   DEFAULT_LINE_COLOR_STR,
@@ -31,7 +31,6 @@ export type LayerSettingsTransform = BaseSettings;
 
 const PICKING_LINE_SIZE = 6;
 const PI_2 = Math.PI / 2;
-const LABEL_OFFSET = new THREE.Vector3(0, 0, 0.4);
 
 const DEFAULT_SETTINGS: LayerSettingsTransform = {
   visible: true,
@@ -63,6 +62,7 @@ class FrameAxisRenderable extends Renderable<FrameAxisUserData> {
   }
 }
 
+const labelOffset = new THREE.Vector3();
 const tempVec = new THREE.Vector3();
 const tempVecB = new THREE.Vector3();
 const tempLower: [Duration, Transform] = [0n, Transform.Identity()];
@@ -200,6 +200,13 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
     super.startFrame(currentTime, renderFrameId, fixedFrameId);
 
+    // Compute the label offset based on the axis length and label size. We want the label
+    // to float a little above the up axis arrow, proportional to the height of the label
+    const axisScale = this.renderer.config.scene.transforms?.axisScale ?? DEFAULT_AXIS_SCALE;
+    const axisLength = AXIS_LENGTH * axisScale;
+    const labelSize = this.renderer.config.scene.transforms?.labelSize ?? DEFAULT_TF_LABEL_SIZE;
+    labelOffset.set(0, 0, axisLength + labelSize * 1.5);
+
     // Update the lines and labels between coordinate frames
     for (const renderable of this.renderables.values()) {
       const label = renderable.userData.label;
@@ -226,7 +233,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       }
 
       // Add the label offset in "world" coordinates (in the render frame)
-      worldPosition.add(LABEL_OFFSET);
+      worldPosition.add(labelOffset);
       // Transform worldPosition back to the local coordinate frame of the
       // renderable, which the label is a child of
       renderable.worldToLocal(worldPosition);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -21,6 +21,7 @@ import { Duration, Transform, makePose, CoordinateFrame, MAX_DURATION } from "..
 import { Axis, AXIS_LENGTH } from "./Axis";
 import {
   DEFAULT_AXIS_SCALE,
+  DEFAULT_LABEL_SCALE_FACTOR,
   DEFAULT_LINE_COLOR_STR,
   DEFAULT_LINE_WIDTH_PX,
   DEFAULT_TF_LABEL_SIZE,
@@ -204,7 +205,8 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const axisScale = this.renderer.config.scene.transforms?.axisScale ?? DEFAULT_AXIS_SCALE;
     const axisLength = AXIS_LENGTH * axisScale;
     const labelSize = this.renderer.config.scene.transforms?.labelSize ?? DEFAULT_TF_LABEL_SIZE;
-    const labelOffsetZ = axisLength + labelSize * 1.5;
+    const labelScale = this.renderer.config.scene.labelScaleFactor ?? DEFAULT_LABEL_SCALE_FACTOR;
+    const labelOffsetZ = axisLength + labelSize * labelScale * 1.5;
 
     // Update the lines and labels between coordinate frames
     for (const renderable of this.renderables.values()) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -62,7 +62,6 @@ class FrameAxisRenderable extends Renderable<FrameAxisUserData> {
   }
 }
 
-const labelOffset = new THREE.Vector3();
 const tempVec = new THREE.Vector3();
 const tempVecB = new THREE.Vector3();
 const tempLower: [Duration, Transform] = [0n, Transform.Identity()];
@@ -205,7 +204,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const axisScale = this.renderer.config.scene.transforms?.axisScale ?? DEFAULT_AXIS_SCALE;
     const axisLength = AXIS_LENGTH * axisScale;
     const labelSize = this.renderer.config.scene.transforms?.labelSize ?? DEFAULT_TF_LABEL_SIZE;
-    labelOffset.set(0, 0, axisLength + labelSize * 1.5);
+    const labelOffsetZ = axisLength + labelSize * 1.5;
 
     // Update the lines and labels between coordinate frames
     for (const renderable of this.renderables.values()) {
@@ -233,7 +232,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       }
 
       // Add the label offset in "world" coordinates (in the render frame)
-      worldPosition.add(labelOffset);
+      worldPosition.z += labelOffsetZ;
       // Transform worldPosition back to the local coordinate frame of the
       // renderable, which the label is a child of
       renderable.worldToLocal(worldPosition);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -162,6 +162,9 @@ export function ImageRender(): JSX.Element {
         overrideConfig={{
           ...ThreeDeeRender.defaultConfig,
           followTf: SENSOR_FRAME_ID,
+          scene: {
+            labelScaleFactor: 0,
+          },
           cameraState: {
             distance: 1.5,
             perspective: true,


### PR DESCRIPTION
**User-Facing Changes**

- Improve coordinate frame label positioning in `3D (Beta)` panel

**Description**

Compute the label offset based on the axis length and label size. We want the label to float a little above the up axis arrow, proportional to the height of the label. This makes the label position look consistent regardless of user scale settings

Before:
<img width="1137" alt="Screen Shot 2022-08-24 at 1 29 20 PM" src="https://user-images.githubusercontent.com/195374/186517189-baf2b167-624b-40c8-85a3-7b9f8e979182.png">
After:
<img width="1137" alt="Screen Shot 2022-08-24 at 1 28 01 PM" src="https://user-images.githubusercontent.com/195374/186517224-ef0dc695-0811-431a-866c-50d4d2f3e392.png">