### PR TITLE
Set _this.messages alongside _lastSeekEmitTime in stateSeekBackfill

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -115,7 +115,6 @@ class MessageOrderTracker {
             `Processed a message on ${message.topic} at ${formattedTime} which is earlier than ` +
             `last processed message on ${this.lastMessageTopic} at ${lastMessageTime}.`;
 
-          log.error(errorMessage);
           problems.push({
             severity: "warn",
             message: "Data went back in time",

--- a/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
+++ b/packages/studio-base/src/components/MessagePipeline/MessageOrderTracker.ts
@@ -115,6 +115,7 @@ class MessageOrderTracker {
             `Processed a message on ${message.topic} at ${formattedTime} which is earlier than ` +
             `last processed message on ${this.lastMessageTopic} at ${lastMessageTime}.`;
 
+          log.error(errorMessage);
           problems.push({
             severity: "warn",
             message: "Data went back in time",


### PR DESCRIPTION
**User-Facing Changes**
Quickly scrubbing back and forth does not cause a "Data went back in time" error to appear in data source problems.

**Description**
`stateSeekBackfill` would set `this._messages` after loading the backfill messages separately from setting `this._lastSeekEmitTime` which results in emitting a set of messages with no seekEmitTime making it look like the emit is a regular message playback rather than a seek. This would trip the message order tracker when a batch of older messages from a seek backfill (seeking to an older time) would be emitted without the seek emit time (because the user seeks again immediately and there's a next state which prevents seek backfill from setting the emit time. Since we have a "background" job for preloading data, this job would call `queueEmitState` which is what ultimately resulted in emitting a batch of messages from a seek backfill without their last emit time.

The fix is to move the logic in `stateSeekBackfill` to set messages after the `_nextState` check to ensure outgoing messages are only set if also setting the `lastSeekEmitTime`.

Fixes: #4222


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
