### PR TITLE
Fix variable sidebar

### DIFF
--- a/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
@@ -292,7 +292,7 @@ export default function Variable(props: {
                       error={isDuplicate}
                       value={editedName ?? name}
                       placeholder="variable_name"
-                      data-testid={`global-variable-key-input-${editedName ?? name}`}
+                      data-testid={`global-variable-key-input-${name}`}
                       onClick={(e) => e.stopPropagation()}
                       onFocus={() => editedName === "" && setExpanded(true)}
                       onChange={(event) => setEditedName(event.target.value)}

--- a/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
@@ -97,20 +97,23 @@ const changeGlobalKey = (
   });
 };
 
-export default function Variable({
-  name,
-  selected = false,
-  linked = false,
-  linkedIndex,
-}: {
+export default function Variable(props: {
   name: string;
   selected?: ListItemButtonProps["selected"];
   linked?: boolean;
   linkedIndex: number;
 }): JSX.Element {
+  const { name, selected = false, linked = false, linkedIndex } = props;
+
   const { classes } = useStyles();
-  const [editedName, setEditedName] = useState(name);
-  const [open, setOpen] = useState<boolean>(true);
+
+  // When editing the variable name, the new name might collide with an existing variable name
+  // If the name matches an existing name, we set the edited name and show an error to the user
+  // indicating there is a name conflict. The user must resolve the name conflict or their edited
+  // name will be reset on blur.
+  const [editedName, setEditedName] = useState<string | undefined>();
+
+  const [expanded, setExpanded] = useState<boolean>(true);
   const [anchorEl, setAnchorEl] = React.useState<undefined | HTMLElement>(undefined);
   const [copied, setCopied] = useState(false);
   const menuOpen = Boolean(anchorEl);
@@ -152,6 +155,7 @@ export default function Variable({
     );
     setLinkedGlobalVariables(newLinkedGlobalVariables);
     setGlobalVariables({ [name]: undefined });
+    handleClose();
   }, [linkedGlobalVariables, name, setGlobalVariables, setLinkedGlobalVariables]);
 
   const value = useMemo(() => globalVariables[name], [globalVariables, name]);
@@ -174,23 +178,24 @@ export default function Variable({
     [name, setGlobalVariables],
   );
 
-  const onChangeName = useCallback(
-    (newName: string) => {
-      setEditedName(newName);
-      if (globalVariables[newName] == undefined) {
-        changeGlobalKey(newName, name, globalVariables, linkedIndex, overwriteGlobalVariables);
-      }
-    },
-    [globalVariables, linkedIndex, name, overwriteGlobalVariables],
-  );
-
-  const nameIsInError = name !== editedName && globalVariables[editedName] != undefined;
+  const onBlur = () => {
+    if (
+      editedName != undefined &&
+      globalVariables[editedName] == undefined &&
+      name !== editedName
+    ) {
+      changeGlobalKey(editedName, name, globalVariables, linkedIndex, overwriteGlobalVariables);
+    }
+    setEditedName(undefined);
+  };
 
   const rootRef = useRef<HTMLDivElement>(ReactNull);
 
   const activeElementIsChild = rootRef.current?.contains(document.activeElement) === true;
 
   const isSelected = selected && !activeElementIsChild;
+  const isDuplicate =
+    editedName != undefined && editedName !== name && globalVariables[editedName] != undefined;
 
   return (
     <Stack className={classes.root} ref={rootRef}>
@@ -226,9 +231,9 @@ export default function Variable({
               size="small"
               id="variable-action-button"
               data-testid="variable-action-button"
-              aria-controls={open ? "variable-action-menu" : undefined}
+              aria-controls={expanded ? "variable-action-menu" : undefined}
               aria-haspopup="true"
-              aria-expanded={open ? "true" : undefined}
+              aria-expanded={expanded ? "true" : undefined}
               onClick={handleClick}
             >
               <MoreVertIcon fontSize="small" />
@@ -269,29 +274,35 @@ export default function Variable({
         <ListItemButton
           className={classes.listItemButton}
           selected={isSelected}
-          onClick={() => setOpen(!open)}
+          onClick={() => setExpanded(!expanded)}
         >
           <ListItemText
             primary={
               <Stack direction="row" alignItems="center" style={{ marginLeft: -12 }}>
-                <ArrowDropDownIcon style={{ transform: !open ? "rotate(-90deg)" : undefined }} />
+                <ArrowDropDownIcon
+                  style={{ transform: !expanded ? "rotate(-90deg)" : undefined }}
+                />
                 {linked ? (
                   name
                 ) : (
                   <>
                     <InputBase
                       className={classes.input}
-                      autoFocus={editedName === ""}
-                      error={nameIsInError}
-                      value={editedName}
+                      autoFocus={name === ""}
+                      error={isDuplicate}
+                      value={editedName ?? name}
                       placeholder="variable_name"
-                      data-testid={`global-variable-key-input-${editedName}`}
+                      data-testid={`global-variable-key-input-${editedName ?? name}`}
                       onClick={(e) => e.stopPropagation()}
-                      onFocus={() => editedName === "" && setOpen(true)}
-                      onChange={(event) => onChangeName(event.target.value)}
+                      onFocus={() => editedName === "" && setExpanded(true)}
+                      onChange={(event) => setEditedName(event.target.value)}
+                      onBlur={onBlur}
                       endAdornment={
-                        nameIsInError && (
-                          <Tooltip arrow title="A variable with this name already exists">
+                        isDuplicate && (
+                          <Tooltip
+                            arrow
+                            title="A variable with this name already exists. Please select a unique variable name to save changes."
+                          >
                             <ErrorIcon className={classes.edgeEnd} fontSize="small" color="error" />
                           </Tooltip>
                         )
@@ -309,7 +320,7 @@ export default function Variable({
           />
         </ListItemButton>
       </ListItem>
-      {open && (
+      {expanded && (
         <div className={classes.editorWrapper}>
           <Divider />
           <Button

--- a/packages/studio-base/src/components/VariablesSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/index.stories.tsx
@@ -68,6 +68,8 @@ Interactive.play = async () => {
   fireEvent.click(deleteButton);
 };
 
+Interactive.parameters = { colorScheme: "light" };
+
 export function WithVariablesLight(): JSX.Element {
   return (
     <DndProvider backend={HTML5Backend}>

--- a/packages/studio-base/src/components/VariablesSidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/index.stories.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { fireEvent, screen } from "@testing-library/dom";
-import { last } from "lodash";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -50,7 +49,7 @@ export function Interactive(): JSX.Element {
   );
 }
 Interactive.play = async () => {
-  const addButton = (await screen.findAllByTestId("add-variable-button"))[0]!;
+  const addButton = await screen.findByTestId("add-variable-button");
   fireEvent.click(addButton);
 
   const input = await screen.findByPlaceholderText("variable_name");
@@ -59,10 +58,13 @@ Interactive.play = async () => {
   const valueInput = await screen.findByDisplayValue('""');
   fireEvent.change(valueInput, { target: { value: '"edited value"' } });
 
-  fireEvent.click(addButton);
-
-  const menuButton = last(await screen.findAllByTestId("variable-action-button"))!;
+  const menuButton = await screen.findByTestId("variable-action-button");
   fireEvent.click(menuButton);
+
+  await screen.findByTestId("global-variable-key-input-new_variable_name");
+
+  const menuButton2 = await screen.findByTestId("variable-action-button");
+  fireEvent.click(menuButton2);
 
   const deleteButton = await screen.findByText("Delete variable");
   fireEvent.click(deleteButton);

--- a/packages/studio-base/src/components/VariablesSidebar/index.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/index.tsx
@@ -79,7 +79,7 @@ export default function VariablesSidebar(): ReactElement {
         <Divider />
         {linked.map((name, idx) => (
           <Variable
-            key={`linked.${idx}`}
+            key={`linked.${name}`}
             name={name}
             selected={!skipAnimation.current && changedVariables.includes(name)}
             linked
@@ -88,7 +88,7 @@ export default function VariablesSidebar(): ReactElement {
         ))}
         {unlinked.map((name, idx) => (
           <Variable
-            key={`unlinked.${idx}`}
+            key={`unlinked.${name}`}
             name={name}
             selected={!skipAnimation.current && changedVariables.includes(name)}
             linkedIndex={linked.length + idx}


### PR DESCRIPTION
**User-Facing Changes**
* Close the context menu when a variable is deleted
* Fix issue with adding a new variable but being told it already exists (when it isn't in the list)
* Fix issue with removing the correct deleted variable from the list

**Description**

The core of these issues is the `key` field within each <Variable> element in the Variable sidebar react component. This key is the list index which meant that when a variable in the middle of the list was removed and the render was re-creating the components from the `map` over the variables, the index made react think the particular item is the same key.

It would pass in the new name and props but because the editableName state was only set to the `name` prop once, the element displayed the wrong (stale) name.

This change updates the keys to key off the variable names and only updates the variable name once the user has blurred from the input. This allows the user to freely iterate on the variable name even through duplicate names and only updates the name at the end if it isn't in conflict.

Fixes: #4216

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
