### PR TITLE
Fix datasource info view end time and duration

### DIFF
--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -21,15 +21,11 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { MultilineMiddleTruncate } from "./MultilineMiddleTruncate";
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()({
   numericValue: {
-    color: theme.palette.secondary.main,
     fontFamily: fonts.MONOSPACE,
   },
-  value: {
-    color: theme.palette.secondary.main,
-  },
-}));
+});
 
 const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
 const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
@@ -57,11 +53,9 @@ function DataSourceInfoContent(props: {
             <Skeleton animation="wave" width="40%" />
           </Typography>
         ) : playerPresence === PlayerPresence.RECONNECTING ? (
-          <Typography className={classes.value} variant="inherit">
-            Waiting for connection…
-          </Typography>
+          <Typography variant="inherit">Waiting for connection…</Typography>
         ) : playerName ? (
-          <Typography className={classes.value} variant="inherit" component="span">
+          <Typography variant="inherit" component="span">
             <MultilineMiddleTruncate text={playerName} />
           </Typography>
         ) : (

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -128,7 +128,7 @@ export function DataSourceInfoView(): JSX.Element {
         endTimeRef.current.innerText = EmDash;
       }
     }
-  }, [endTime, formatTime, startTime]);
+  }, [endTime, formatTime, startTime, playerPresence]);
 
   return (
     <MemoDataSourceInfoContent

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -16,6 +16,7 @@ import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { formatDate, formatDuration } from "@foxglove/studio-base/util/formatTime";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { MultilineMiddleTruncate } from "./MultilineMiddleTruncate";
 
@@ -74,7 +75,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : (
-          <Typography variant="inherit" ref={endTimeRef}>
+          <Typography fontFamily={fonts.MONOSPACE} variant="inherit" ref={endTimeRef}>
             &mdash;
           </Typography>
         )}
@@ -87,7 +88,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width={100} />
         ) : (
-          <Typography variant="inherit" ref={durationRef}>
+          <Typography fontFamily={fonts.MONOSPACE} variant="inherit" ref={durationRef}>
             &mdash;
           </Typography>
         )}

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -4,6 +4,7 @@
 
 import { Skeleton, Typography } from "@mui/material";
 import { MutableRefObject, useEffect, useRef } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { Time } from "@foxglove/rostime";
 import {
@@ -20,6 +21,16 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { MultilineMiddleTruncate } from "./MultilineMiddleTruncate";
 
+const useStyles = makeStyles()((theme) => ({
+  numericValue: {
+    color: theme.palette.secondary.main,
+    fontFamily: fonts.MONOSPACE,
+  },
+  value: {
+    color: theme.palette.secondary.main,
+  },
+}));
+
 const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
 const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
 const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
@@ -33,6 +44,7 @@ function DataSourceInfoContent(props: {
   startTime?: Time;
 }): JSX.Element {
   const { durationRef, endTimeRef, playerName, playerPresence, startTime } = props;
+  const { classes } = useStyles();
 
   return (
     <Stack gap={1.5} paddingX={2} paddingBottom={2}>
@@ -45,13 +57,17 @@ function DataSourceInfoContent(props: {
             <Skeleton animation="wave" width="40%" />
           </Typography>
         ) : playerPresence === PlayerPresence.RECONNECTING ? (
-          <Typography variant="inherit">Waiting for connection…</Typography>
+          <Typography className={classes.value} variant="inherit">
+            Waiting for connection…
+          </Typography>
         ) : playerName ? (
-          <Typography variant="inherit" component="span">
+          <Typography className={classes.value} variant="inherit" component="span">
             <MultilineMiddleTruncate text={playerName} />
           </Typography>
         ) : (
-          <Typography>&mdash;</Typography>
+          <Typography className={classes.numericValue} variant="inherit">
+            &mdash;
+          </Typography>
         )}
       </Stack>
 
@@ -64,7 +80,9 @@ function DataSourceInfoContent(props: {
         ) : startTime ? (
           <Timestamp horizontal time={startTime} />
         ) : (
-          <Typography color="text.secondary">&mdash;</Typography>
+          <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
+            &mdash;
+          </Typography>
         )}
       </Stack>
 
@@ -75,7 +93,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : (
-          <Typography fontFamily={fonts.MONOSPACE} variant="inherit" ref={endTimeRef}>
+          <Typography className={classes.numericValue} variant="inherit" ref={endTimeRef}>
             &mdash;
           </Typography>
         )}
@@ -88,7 +106,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width={100} />
         ) : (
-          <Typography fontFamily={fonts.MONOSPACE} variant="inherit" ref={durationRef}>
+          <Typography className={classes.numericValue} variant="inherit" ref={durationRef}>
             &mdash;
           </Typography>
         )}
@@ -126,7 +144,7 @@ export function DataSourceInfoView(): JSX.Element {
         const date = formatDate(endTime, undefined);
         endTimeRef.current.innerText = `${date} ${formatTime(endTime)}`;
       } else {
-        endTimeRef.current.innerText = EmDash;
+        endTimeRef.current.innerHTML = EmDash;
       }
     }
   }, [endTime, formatTime, startTime, playerPresence]);


### PR DESCRIPTION
**User-Facing Changes**
This fixes an issue with the display of end time and duration for non-live data sources.

**Description**
This fixes a regression from https://github.com/foxglove/studio/pull/4238. The issue is that non-live data sources don't send multiple updates for the session end time so for these data sources we also need to update when the player presence changes in order to display the correct end time and duration.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4269