### PR TITLE
Fix image panel settings

### DIFF
--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -36,6 +36,17 @@ export function NoTopic(): React.ReactElement {
   );
 }
 
+export function WithSettings(): JSX.Element {
+  return (
+    <PanelSetup includeSettings>
+      <ImageView />
+    </PanelSetup>
+  );
+}
+WithSettings.parameters = {
+  colorScheme: "light",
+};
+
 export function TopicButNoDataSource(): React.ReactElement {
   return (
     <PanelSetup>

--- a/packages/studio-base/src/panels/Image/settings.ts
+++ b/packages/studio-base/src/panels/Image/settings.ts
@@ -56,11 +56,16 @@ export function buildSettingsTree({
         },
         transformMarkers: {
           input: "boolean",
-          label: "Synchronize Markers",
+          label: "Transform Markers",
           value: config.transformMarkers,
           help: config.transformMarkers
             ? "Markers are being transformed by Foxglove Studio based on the camera model. Click to turn it off."
             : `Markers can be transformed by Foxglove Studio based on the camera model. Click to turn it on.`,
+        },
+        synchronize: {
+          input: "boolean",
+          label: "Synchronize Timestamps",
+          value: config.synchronize,
         },
         smooth: {
           input: "boolean",


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the image panel settings.

**Description**
This fixes the transform setting and adds back the missing synchronize setting.

<img width="382" alt="Screen Shot 2022-08-25 at 7 27 32 AM" src="https://user-images.githubusercontent.com/93935560/186652584-f4dac87f-1071-49fe-8d8c-f23ce2d11e9d.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4258