### PR TITLE
Introduce memory check and cap in plot panel preload

### DIFF
--- a/packages/studio-base/src/hooks/useMemoryInfo.ts
+++ b/packages/studio-base/src/hooks/useMemoryInfo.ts
@@ -8,26 +8,11 @@ import Logger from "@foxglove/log";
 
 const log = Logger.getLogger(__filename);
 
-type MemoryInfo = {
-  /// Maximum heap size in bytes
-  jsHeapSizeLimit: number;
-  /// current size in bytes of the JS heap including free space not occupied by any JS objects
-  totalJSHeapSize: number;
-  /// total amount of memory in bytes being used by JS objects including V8 internal objects
-  usedJSHeapSize: number;
-};
-
-// Our DOM types don't have types for performance.memory since this is a chrome feature
-// We make our own version of Performance which optionally has MemoryInfo
-interface Performance {
-  memory?: MemoryInfo;
-}
-
 type UseMemoryInfoOptions = {
   refreshIntervalMs: number;
 };
 
-const performance = window.performance as Performance;
+const performance = window.performance;
 
 export function useMemoryInfo(opt: UseMemoryInfoOptions): MemoryInfo | undefined {
   const { refreshIntervalMs } = opt;

--- a/packages/studio-base/src/typings/web.d.ts
+++ b/packages/studio-base/src/typings/web.d.ts
@@ -7,3 +7,18 @@ interface WindowOrWorkerGlobalScope {
 }
 
 declare function structuredClone<T>(value: T, options?: StructuredSerializeOptions): T;
+
+type MemoryInfo = {
+  /// Maximum heap size in bytes
+  jsHeapSizeLimit: number;
+  /// current size in bytes of the JS heap including free space not occupied by any JS objects
+  totalJSHeapSize: number;
+  /// total amount of memory in bytes being used by JS objects including V8 internal objects
+  usedJSHeapSize: number;
+};
+
+// Our DOM types don't have types for performance.memory since this is a chrome feature
+// We make our own version of Performance which optionally has MemoryInfo
+interface Performance {
+  memory?: MemoryInfo;
+}


### PR DESCRIPTION

**User-Facing Changes**
The app crashes less when trying to plot series like `/map.data[:]` which results in many millions of points.

**Description**
To avoid crashing the app when trying to prepare large datasets, check the memory use after 1 million points. If the memory use is above a threshold (60%) when abort adding any more data points. If the memory use remains below the threshold we continue to add points.

Fixes: #4270


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
