### PR TITLE
Add FOXGLOVE_ENABLE_DIALOG_AUTH env var to control dialog auth

### DIFF
--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -39,5 +39,6 @@ export function buildEnvironmentDefaults(
     SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax
     SIGNUP_API_URL: "https://foxglove.dev/api/signup",
     SLACK_INVITE_URL: "https://foxglove.dev/join-slack",
+    FOXGLOVE_ENABLE_DIALOG_AUTH: process.env.FOXGLOVE_ENABLE_DIALOG_AUTH ?? null, // eslint-disable-line no-restricted-syntax
   };
 }

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -59,7 +59,8 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
 
   // Enable dialog auth in development since using cookie auth does not work between
   // localhost and the hosted dev deployment due to browser cookie/host security.
-  const enableDialogAuth = process.env.NODE_ENV === "development";
+  const enableDialogAuth =
+    process.env.NODE_ENV === "development" || process.env.FOXGLOVE_ENABLE_DIALOG_AUTH != undefined;
 
   return (
     <App


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
We want to allow the studio preview deployment to sign into the dev deployment of our api (for testing signed-in features). To support this we will use the device code auth flow for studio preview deployments to handle sign-in and session. This change adds a new environment variable which we control in the preview build to enable the dialog auth flow.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
