### PR TITLE
3D Beta: Adding Grid or URDF layers makes all other topics disappear

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -549,6 +549,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
           { id: "show-all", type: "action", label: "Show All" },
           { id: "hide-all", type: "action", label: "Hide All" },
         ],
+        children: this.settings.tree()["topics"]?.children,
         handler: this.handleTopicsAction,
       },
     };


### PR DESCRIPTION
**User-Facing Changes**
 - fixes Adding Grid or URDF layers makes all other topics disappear

**Description**
 - add topics children to its settings tree action in `addCustomLayerAction` so that it's not erased when the function is called again on `handleCustomLayerAction`

<!-- link relevant github issues -->
Fixes #4267
