### PR TITLE
[New3D] Fix URDF transforms disappearing on seek or loop

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -458,8 +458,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
    * This is useful when seeking to a new playback position or when a new data source is loaded.
    */
   public clear(): void {
+    // These must be cleared before calling `SceneExtension#removeAllRenderables()` to allow
+    // extensions to add errors or transforms back afterward
     this.settings.errors.clear();
     this.transformTree.clear();
+
     for (const extension of this.sceneExtensions.values()) {
       extension.removeAllRenderables();
     }


### PR DESCRIPTION
**User-Facing Changes**

- Fixes URDF transforms disappearing in `3D (Beta)` when seeking or looping playback

**Description**

Renderer#clear() is called on any playback discontinuity (seeking, looping) which clears the transform trees and most renderables. The URDF SceneExtension was already overriding removeAllRenderables() to prevent the URDF model from disappearing, but Renderer.transformTree gets cleared as well which made the URDF-loaded transforms disappear. This change adds them back to the scene when removeAllRenderables() is called
