### PR TITLE
Remove requestBackfill method from player API

### DIFF
--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -54,9 +54,6 @@ class BenchmarkPlayer implements Player {
   public async callService(_service: string, _request: unknown): Promise<unknown> {
     throw new Error("Method not implemented.");
   }
-  public requestBackfill(): void {
-    // no-op
-  }
   public setGlobalVariables(_globalVariables: GlobalVariables): void {
     throw new Error("Method not implemented.");
   }

--- a/benchmark/src/players/SinewavePlayer.ts
+++ b/benchmark/src/players/SinewavePlayer.ts
@@ -61,9 +61,6 @@ class SinewavePlayer implements Player {
   public async callService(_service: string, _request: unknown): Promise<unknown> {
     throw new Error("Method not implemented.");
   }
-  public requestBackfill(): void {
-    // no-op
-  }
   public setGlobalVariables(_globalVariables: GlobalVariables): void {
     throw new Error("Method not implemented.");
   }

--- a/packages/studio-base/src/PanelAPI/useMessageReducer.test.tsx
+++ b/packages/studio-base/src/PanelAPI/useMessageReducer.test.tsx
@@ -535,51 +535,6 @@ describe("useMessageReducer", () => {
     expect(result.current).toEqual(1);
   });
 
-  it("calls requestBackfill when topics change", async () => {
-    const requestBackfill = jest.fn();
-    const initialRestore = jest.fn().mockReturnValue(1);
-    const initialAddMessage = jest.fn().mockImplementation((_, msg) => msg.message.value);
-
-    const { rerender } = renderHook(
-      ({ topics, addMessage, restore }) =>
-        PanelAPI.useMessageReducer({ topics, restore, addMessage }),
-      {
-        initialProps: { topics: ["/foo"], addMessage: initialAddMessage, restore: initialRestore },
-        wrapper: ({ children }) => (
-          <MockMessagePipelineProvider requestBackfill={requestBackfill}>
-            {children}
-          </MockMessagePipelineProvider>
-        ),
-      },
-    );
-
-    // Calls `requestBackfill` initially.
-    expect(requestBackfill.mock.calls.length).toEqual(1);
-    requestBackfill.mockClear();
-
-    // Rendering again with the same topics should NOT result in any calls.
-    rerender({ topics: ["/foo"], restore: initialRestore, addMessage: initialAddMessage });
-    expect(requestBackfill.mock.calls.length).toEqual(0);
-    requestBackfill.mockClear();
-
-    // However, changing the topics results in another `requestBackfill` call.
-    rerender({ topics: ["/foo", "/bar"], restore: initialRestore, addMessage: initialAddMessage });
-    expect(requestBackfill.mock.calls.length).toEqual(1);
-    requestBackfill.mockClear();
-
-    // Passing in a different `addMessage` function should NOT result in any calls.
-    const newAddMessage = jest.fn();
-    rerender({ topics: ["/foo", "/bar"], restore: initialRestore, addMessage: newAddMessage });
-    expect(requestBackfill.mock.calls.length).toEqual(0);
-    requestBackfill.mockClear();
-
-    // Passing in a different `restore` function should NOT result in any calls.
-    const newRestore = jest.fn();
-    rerender({ topics: ["/foo", "/bar"], restore: newRestore, addMessage: newAddMessage });
-    expect(requestBackfill.mock.calls.length).toEqual(0);
-    requestBackfill.mockClear();
-  });
-
   it("restore called when addMessages changes", async () => {
     const message1 = {
       topic: "/foo",

--- a/packages/studio-base/src/PanelAPI/useMessageReducer.ts
+++ b/packages/studio-base/src/PanelAPI/useMessageReducer.ts
@@ -46,10 +46,6 @@ type Params<T> = {
   addMessages?: MessagesReducer<T>;
 };
 
-function selectRequestBackfill(ctx: MessagePipelineContext) {
-  return ctx.requestBackfill;
-}
-
 function selectSetSubscriptions(ctx: MessagePipelineContext) {
   return ctx.setSubscriptions;
 }
@@ -96,11 +92,6 @@ export function useMessageReducer<T>(props: Params<T>): T {
   const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
   useEffect(() => setSubscriptions(id, subscriptions), [id, setSubscriptions, subscriptions]);
   useCleanup(() => setSubscriptions(id, []));
-
-  const requestBackfill = useMessagePipeline(selectRequestBackfill);
-
-  // Whenever `subscriptions` change, request a backfill, since we'd like to show fresh data.
-  useEffect(() => requestBackfill(), [requestBackfill, subscriptions]);
 
   const state = useRef<
     | Readonly<{

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -158,7 +158,7 @@ type WorkspaceProps = {
 const DEFAULT_DEEPLINKS = Object.freeze([]);
 
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
-const selectRequestBackfill = ({ requestBackfill }: MessagePipelineContext) => requestBackfill;
+const selectSetSubscriptions = ({ setSubscriptions }: MessagePipelineContext) => setSubscriptions;
 const selectPlayerProblems = ({ playerState }: MessagePipelineContext) => playerState.problems;
 const selectIsPlaying = (ctx: MessagePipelineContext) =>
   ctx.playerState.activeData?.isPlaying === true;
@@ -189,9 +189,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const supportsAccountSettings = useContext(ConsoleApiContext) != undefined;
 
-  // we use requestBackfill to signal when a player changes for RemountOnValueChange below
+  // we use setSubscriptions to detect when a player changes for RemountOnValueChange below
   // see comment below above the RemountOnValueChange component
-  const requestBackfill = useMessagePipeline(selectRequestBackfill);
+  const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
 
   const isPlayerPresent = playerPresence !== PlayerPresence.NOT_PRESENT;
 
@@ -604,7 +604,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           onSelectKey={selectSidebarItem}
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
-          <RemountOnValueChange value={requestBackfill}>
+          <RemountOnValueChange value={setSubscriptions}>
             <Stack>
               <PanelLayout />
               {play && pause && seek && (

--- a/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
+++ b/packages/studio-base/src/components/MessagePipeline/FakePlayer.ts
@@ -96,9 +96,6 @@ export default class FakePlayer implements Player {
   public seekPlayback = (): void => {
     // no-op
   };
-  public requestBackfill = (): void => {
-    // no-op
-  };
   public setGlobalVariables = (): void => {
     // no-op
   };

--- a/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/MockMessagePipelineProvider.tsx
@@ -67,7 +67,6 @@ export default function MockMessagePipelineProvider(props: {
   isPlaying?: boolean;
   pauseFrame?: (arg0: string) => () => void;
   playerId?: string;
-  requestBackfill?: () => void;
   progress?: Progress;
   urlState?: PlayerURLState;
 }): React.ReactElement {
@@ -104,11 +103,6 @@ export default function MockMessagePipelineProvider(props: {
       }
     },
     [setAllSubscriptions, props.setSubscriptions],
-  );
-
-  const requestBackfill = useMemo(
-    () => props.requestBackfill ?? (() => {}),
-    [props.requestBackfill],
   );
 
   const capabilities = useShallowMemo(props.capabilities ?? []);
@@ -199,7 +193,6 @@ export default function MockMessagePipelineProvider(props: {
         setPlaybackSpeed: noop,
         seekPlayback: props.seekPlayback ?? noop,
         pauseFrame: props.pauseFrame ?? (() => noop),
-        requestBackfill,
       }}
     >
       {props.children}

--- a/packages/studio-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.test.tsx
@@ -106,7 +106,6 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         seekPlayback: undefined,
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
-        requestBackfill: expect.any(Function),
       },
     ]);
   });

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -62,7 +62,6 @@ export type MessagePipelineContext = {
   seekPlayback?: (time: Time) => void;
   // Don't render the next frame until the returned function has been called.
   pauseFrame: (name: string) => ResumeFrame;
-  requestBackfill: () => void;
 };
 
 // exported only for MockMessagePipelineProvider
@@ -235,10 +234,6 @@ export function MessagePipelineProvider({
       condvar.notifyAll();
     };
   }, []);
-  const requestBackfill = useMemo(
-    () => debounce(() => (player ? player.requestBackfill() : undefined)),
-    [player],
-  );
 
   useEffect(() => {
     player?.setGlobalVariables(globalVariables);
@@ -264,7 +259,6 @@ export function MessagePipelineProvider({
         setPlaybackSpeed,
         seekPlayback,
         pauseFrame,
-        requestBackfill,
       })}
     >
       {children}

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { debounce, flatten } from "lodash";
+import { flatten } from "lodash";
 
 import { Condvar } from "@foxglove/den/async";
 import { useShallowMemo } from "@foxglove/hooks";

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -85,8 +85,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
   const messagePipelineContext = useMessagePipeline(selectContext);
 
-  const { playerState, pauseFrame, setSubscriptions, requestBackfill, seekPlayback } =
-    messagePipelineContext;
+  const { playerState, pauseFrame, setSubscriptions, seekPlayback } = messagePipelineContext;
 
   const { capabilities, profile: dataSourceProfile } = playerState;
 
@@ -339,9 +338,6 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
         setSubscribedTopics(newSubscribedTopics);
         setSubscriptions(panelId, subscribePayloads);
-        if (topics.length > 0) {
-          requestBackfill();
-        }
       },
 
       advertise: capabilities.includes(PlayerCapabilities.advertise)
@@ -404,7 +400,6 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     getMessagePipelineContext,
     openSiblingPanel,
     panelId,
-    requestBackfill,
     saveConfig,
     seekPlayback,
     setGlobalVariables,

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -452,6 +452,5 @@ export default class FoxgloveWebSocketPlayer implements Player {
     throw new Error("Service calls are not supported by the Foxglove WebSocket connection");
   }
 
-  public requestBackfill(): void {}
   public setGlobalVariables(): void {}
 }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -274,6 +274,7 @@ export class IterablePlayer implements Player {
       ),
     );
 
+    // If there are no changes to topics there's no reason to perform a "seek" to trigger loading
     if (isEqual(allTopics, this._allTopics) && isEqual(partialTopics, this._partialTopics)) {
       return;
     }
@@ -281,17 +282,7 @@ export class IterablePlayer implements Player {
     this._allTopics = allTopics;
     this._partialTopics = partialTopics;
     this._blockLoader?.setTopics(this._partialTopics);
-  }
 
-  public requestBackfill(): void {
-    // The message pipeline invokes requestBackfill after setting subscriptions. It does this so any
-    // new panels that subscribe receive their messages even if the topic was already subscribed.
-    //
-    // Note(Roman): This behavior was designed around RandomAccessPlayer (I think) which does not do
-    // anything in setSubscriptions other than update internal members. While we still have
-    // RandomAccessPlayer we mimick that behavior in this player. Eventually we can update
-    // MessagePipeline to remove requestBackfill.
-    //
     // We only seek playback if the player is not playing. If the player is playing, the
     // playing state will detect any subscription changes and emit new messages.
     if (this._state === "idle" || this._state === "seek-backfill" || this._state === "play") {

--- a/packages/studio-base/src/players/RandomAccessPlayer.ts
+++ b/packages/studio-base/src/players/RandomAccessPlayer.ts
@@ -650,9 +650,7 @@ export default class RandomAccessPlayer implements Player {
   public setSubscriptions(newSubscriptions: SubscribePayload[]): void {
     this._parsedSubscribedTopics = new Set(newSubscriptions.map(({ topic }) => topic));
     this._metricsCollector.setSubscriptions(newSubscriptions);
-  }
 
-  public requestBackfill(): void {
     if (this._isPlaying || this._initializing || !this._currentTime) {
       return;
     }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -567,9 +567,6 @@ export default class Ros1Player implements Player {
   }
 
   // Bunch of unsupported stuff. Just don't do anything for these.
-  public requestBackfill(): void {
-    // no-op
-  }
   public setGlobalVariables(): void {
     // no-op
   }

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -635,9 +635,6 @@ export default class Ros2Player implements Player {
   }
 
   // Bunch of unsupported stuff. Just don't do anything for these.
-  public requestBackfill(): void {
-    // no-op
-  }
   public setGlobalVariables(): void {
     // no-op
   }

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -657,9 +657,6 @@ export default class RosbridgePlayer implements Player {
   public setPlaybackSpeed(_speedFraction: number): void {
     // no-op
   }
-  public requestBackfill(): void {
-    // no-op
-  }
   public setGlobalVariables(): void {
     // no-op
   }

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -774,7 +774,6 @@ export default class UserNodePlayer implements Player {
         this._lastPlayerStateActiveData = activeData;
         await this._resetWorkers();
         this.setSubscriptions(this._subscriptions);
-        this.requestBackfill();
       } else {
         // Reset node state after seeking
         let shouldReset = activeData.lastSeekTime !== this._lastPlayerStateActiveData.lastSeekTime;
@@ -961,9 +960,5 @@ export default class UserNodePlayer implements Player {
 
   public seekPlayback(time: Time, backfillDuration?: Time): void {
     this._player.seekPlayback?.(time, backfillDuration);
-  }
-
-  public requestBackfill(): void {
-    this._player.requestBackfill();
   }
 }

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -300,10 +300,6 @@ export default class VelodynePlayer implements Player {
     throw new Error("Service calls are not supported for VelodynePlayer");
   }
 
-  public requestBackfill(): void {
-    // no-op
-  }
-
   public setGlobalVariables(_globalVariables: GlobalVariables): void {
     // no-op
   }

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -70,14 +70,6 @@ export interface Player {
   // If the Player supports non-real-time speeds (i.e. PlayerState#capabilities contains
   // PlayerCapabilities.setSpeed), set that speed. E.g. 1.0 is real time, 0.2 is 20% of real time.
   setPlaybackSpeed?(speedFraction: number): void;
-  // Request a backfill for Players that support it. Allowed to be a no-op if the player does not
-  // support backfilling, or if it's already playing (in which case we'd get new messages soon anyway).
-  // This is currently called after subscriptions changed. We do our best in the MessagePipeline to
-  // not call this method too often (e.g. it's debounced).
-  // TODO(JP): We can't call this too often right now, since it clears out all existing data in
-  // panels, so e.g. the Plot panel which might have a lot of data loaded would get cleared to just
-  // a small backfilled amount of data. We should somehow make this more granular.
-  requestBackfill(): void;
   // Set the globalVariables for Players that support it.
   // This is generally used to pass new globalVariables to the UserNodePlayer
   setGlobalVariables(globalVariables: GlobalVariables): void;


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
The request backfill method was called by the message pipeline after updating subscriptions. It would tell the player to backfill data for new subscriptions. Instead, this functionality is moved to the player setSubscriptions method for RandomAccessPlayer and IterablePlayer. The player can better determine what actions it should take when setting subscriptions or when seeking.

Fixes: #4290

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
