### PR TITLE
Add debounce to setSubscriptions in message pipeline

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.test.tsx
@@ -427,6 +427,7 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
     const player2 = new FakePlayer();
     setPlayer(player2);
     rerender();
+    await act(async () => await delay(1));
     expect(player2.subscriptions).toEqual([{ topic: "/studio/test" }, { topic: "/studio/test2" }]);
     expect(player2.publishers).toEqual([{ topic: "/studio/test", datatype: "test" }]);
   });


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Previously the requestBackfill method debounced telling a player to update itself with new subscriptions. This method was removed from the pipeline in https://github.com/foxglove/studio/pull/4292. This change brings back the debounce logic on setSubscriptions to batch subscriber updates before they get to the player. This helps avoid the player starting to fetch topics only to immediately have to fetch other topics.

Fixes: #4293


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
