### PR TITLE
Add "todo" to list of disallowed words in comments

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -59,7 +59,7 @@ rules:
 
   no-warning-comments:
     - error
-    - terms: ["fixme", "xxx"]
+    - terms: ["fixme", "xxx", "todo"]
       location: anywhere
 
   no-restricted-imports:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.preferences.importModuleSpecifier": "non-relative",
   "jest.autoRun": { "watch": false, "onSave": "test-file" },
-  "jest.jestCommandLine": "yarn test"
+  "jest.jestCommandLine": "yarn test",
+  "eslint.lintTask.enable": true
 }

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -341,7 +341,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
         // Provide filter suggestions for primitive values, since they're the only kinds of values
         // that can be filtered on.
-        // TODO: add support for nested paths to primitives, such as "/some_topic{foo.bar==3}".
         for (const name of Object.keys(structureTraversalResult.structureItem.nextByName)) {
           const item = structureTraversalResult.structureItem.nextByName[name];
           if (item?.structureType === "primitive") {

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -37,10 +37,6 @@ import parseRosPath, { quoteTopicNameIfNeeded } from "./parseRosPath";
 
 export type MessagePathDataItem = {
   value: unknown; // The actual value.
-  // TODO(JP): Maybe this should just be a simple path without nice ids, and then have a separate function
-  // to generate "nice ids". Because they might not always be reliable and we might want to use different
-  // kinds of "nice ids" for different purposes, e.g. `[10]{id==5}{other_id=123}` for tooltips (more information)
-  // but `[:]{other_id==123}` for line graphs (more likely to match values).
   path: string; // The path to get to this value. Tries to use "nice ids" like `[:]{some_id==123}` wherever possible.
   constantName?: string; // The name of the constant that the value matches up with, if any.
 };

--- a/packages/studio-base/src/components/TextHighlight.tsx
+++ b/packages/studio-base/src/components/TextHighlight.tsx
@@ -39,7 +39,6 @@ export default function TextHighlight({ targetStr = "", searchText = "" }: Props
     ? fuzzySort.highlight(match, "<span class='TextHighlight-highlight'>", "</span>")
     : undefined;
 
-  // TODO(Audrey): compute highlighted parts separately in order to avoid dangerouslySetInnerHTML
   return (
     <STextHighlight>
       {result != undefined && result.length > 0 ? (

--- a/packages/studio-base/src/hooks/useSessionStorageValue.ts
+++ b/packages/studio-base/src/hooks/useSessionStorageValue.ts
@@ -8,9 +8,6 @@ import { useCallback, useEffect, useState } from "react";
  * This provides a convenience wrapper around sessionStorage and triggers
  * a react state change when values change.
  *
- * TODO: We should probably refactor LocalStorageAppConfigurationProvider to
- * handle localStorage & sessionStorage and replace this.
- *
  * @param key sessionStorage key to manage.
  * @returns [value, setValue] tuple for that key.
  */

--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
@@ -48,9 +48,6 @@ export class DynamicInstancedMesh<
 
       tempColor.setRGB(color.r, color.g, color.b);
       this.setColorAt(i, tempColor);
-
-      // TODO: Need to adapt InstancedMesh to use an opacity instance buffer attribute
-      // this.setOpacityAt(i, color.a);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/LineMaterial.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/LineMaterial.ts
@@ -38,7 +38,7 @@ import {
   dashOffset: { value: 0 },
   dashScale: { value: 1 },
   dashSize: { value: 1 },
-  gapSize: { value: 1 }, // todo FIX - maybe change to totalSize
+  gapSize: { value: 1 },
 };
 
 ShaderLib["foxglove.line"] = {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -30,10 +30,6 @@ export type LayerSettingsOccupancyGrid = BaseSettings & {
   invalidColor: string;
 };
 
-// TODO(jhurliman): Upload the OccupancyGrid data directly as a R8I texture and
-// use a custom ShaderMaterial with an isampler2D uniform to reimplement the
-// updateTexture() logic in a shader
-
 const INVALID_OCCUPANCY_GRID = "INVALID_OCCUPANCY_GRID";
 
 const DEFAULT_MIN_COLOR = { r: 1, g: 1, b: 1, a: 1 }; // white

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
@@ -30,15 +30,6 @@ export class RenderableCubeList extends RenderableMarker {
     this.mesh.receiveShadow = true;
     this.add(this.mesh);
 
-    // TODO(jhurliman): Instanced cube outlines
-    // Cube outlines
-    // this.outline = new THREE.LineSegments(
-    //   RenderableCubeList.edgesGeometry(),
-    //   materialCache.outlineMaterial,
-    // );
-    // this.outline.userData.picking = false;
-    // this.add(this.outline);
-
     this.update(marker, receiveTime);
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/materials.ts
@@ -145,7 +145,7 @@ export function makePointsMaterial(marker: Marker): THREE.PointsMaterial {
   const transparent = markerHasTransparency(marker);
   return new THREE.PointsMaterial({
     vertexColors: true,
-    size: marker.scale.x, // TODO: Support scale.y
+    size: marker.scale.x,
     sizeAttenuation: true,
     transparent,
     depthWrite: !transparent,

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/DebugStats.tsx
@@ -72,7 +72,6 @@ function validate(stats: Stats) {
 }
 
 // Shows debug regl stats in the 3d panel.  Crashes the panel if regl stats drift outside of acceptable ranges.
-// TODO(bmc): move to regl-worldview at some point
 export default function DebugStats(): JSX.Element | ReactNull {
   const { classes } = useStyles();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -226,8 +226,6 @@ export default class SceneBuilder implements MarkerProvider {
   // rendering. Not to be confused with the graphics rendering frame, or a
   // CoordinateFrame
   public frame?: Frame;
-  // TODO(JP): Get rid of these two different variables `errors` and `errorsByTopic` which we
-  // have to keep in sync.
   public errors: SceneErrors = {
     renderFrameId: "",
     topicsMissingTransforms: new Map(),
@@ -261,7 +259,6 @@ export default class SceneBuilder implements MarkerProvider {
   private _velodyneCloudConverter = new VelodyneCloudConverter();
 
   public allNamespaces: Namespace[] = [];
-  // TODO(Audrey): remove enabledNamespaces once we release topic groups
   public enabledNamespaces: Namespace[] = [];
   public selectedNamespacesByTopic?: { [topicName: string]: Set<string> };
   public flatten: boolean = false;

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/renderStyleExpressionNodes.tsx
@@ -36,7 +36,6 @@ import { SLeft, SRightActions, SToggles, STreeNodeRow } from "./TreeNodeRow";
 import VisibilityToggle from "./VisibilityToggle";
 import { TREE_SPACING, ROW_HEIGHT } from "./constants";
 
-// TODO: Dedupe from renderNamespaceNodes
 const OUTER_LEFT_MARGIN = 12;
 
 export const SDisplayName = styled.div`

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/commands/PointClouds/index.tsx
@@ -340,8 +340,6 @@ const makePointCloudCommand = () => {
           // If we're using "flat" color mode, we pass the actual color in a uniform (see uniforms below)
           // But we still need to provide some color buffer, even if it's not going to be used.
           // Instead of creating a dummy buffer, we just send the one we have for position.
-          // TODO (Hernan): I tried using the constant option provided by Regl, but it leads to
-          // visual artifacts. I need to check if this is a bug in Regl.
           const colorBuffer =
             colorMode == undefined || colorMode.mode === "flat"
               ? props.positionBuffer

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -210,7 +210,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           if (channel.id === id) {
             this._resolvedSubscriptionsById.delete(subId);
             this._resolvedSubscriptionsByTopic.delete(channel.topic);
-            client.unsubscribe(subId); // TODO: batch
+            client.unsubscribe(subId);
             this._unresolvedSubscriptions.add(channel.topic);
           }
         }
@@ -395,7 +395,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     for (const [topic, subId] of this._resolvedSubscriptionsByTopic) {
       if (!newTopics.has(topic)) {
-        this._client.unsubscribe(subId); // TODO: batch?
+        this._client.unsubscribe(subId);
         this._resolvedSubscriptionsByTopic.delete(topic);
         this._resolvedSubscriptionsById.delete(subId);
         this._recentlyCanceledSubscriptions.add(subId);
@@ -426,7 +426,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     for (const topic of this._unresolvedSubscriptions) {
       const chanInfo = this._channelsByTopic.get(topic);
       if (chanInfo) {
-        const subId = this._client.subscribe(chanInfo.channel.id); //TODO: batch?
+        const subId = this._client.subscribe(chanInfo.channel.id);
         this._unresolvedSubscriptions.delete(topic);
         this._resolvedSubscriptionsByTopic.set(topic, subId);
         this._resolvedSubscriptionsById.set(subId, chanInfo);

--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -703,7 +703,6 @@ describe("UserNodePlayer", () => {
         };
       `;
 
-      // TODO: test here to make sure the user node does not produce messages if not subscribed to.
       userNodePlayer.setSubscriptions([{ topic: `${DEFAULT_STUDIO_NODE_PREFIX}1` }]);
       await userNodePlayer.setUserNodes({
         [nodeId]: { name: `${DEFAULT_STUDIO_NODE_PREFIX}1`, sourceCode: unionTypeReturn },

--- a/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeRuntimeWorker/index.ts
@@ -32,7 +32,6 @@ if (!inSharedWorker()) {
   // their associated page, ignoring any policy in the headers of their source file. SharedWorkers
   // use the headers from their source files, though, and we use a CSP to prohibit user scripts
   // workers from making web requests (using enforceFetchIsBlocked, below.)
-  // TODO(steel): Change this back to a web worker if/when Chrome changes its behavior:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=1012640
   throw new Error("Not in a SharedWorker.");
 }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateRosLib.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/generateRosLib.ts
@@ -50,7 +50,6 @@ const createTimeInterfaceDeclaration = (name: string) => {
 };
 
 // Since rosbagjs treats json as a primitive, we have to shim it in.
-// TODO: Update json declaration in a smarter way.
 const jsonInterfaceDeclaration = ts.factory.createInterfaceDeclaration(
   undefined,
   /* decorators */
@@ -117,7 +116,6 @@ export const generateTypeDefs = (datatypes: RosDatatypes): InterfaceDeclarations
       const rosPrimitive = rosPrimitivesToTypeScriptMap.get(type);
       const rosSpecial = rosSpecialTypesToTypescriptMap.get(type);
       if (isConstant === true) {
-        // TODO: Support ROS constants at some point.
         return undefined;
       } else if (isArray === true && typedArray != undefined) {
         node = ts.factory.createTypeReferenceNode(typedArray);

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/index.ts
@@ -31,7 +31,6 @@ if (!inSharedWorker()) {
   // their associated page, ignoring any policy in the headers of their source file. SharedWorkers
   // use the headers from their source files, though, and we use a CSP to prohibit user scripts
   // workers from making web requests (using enforceFetchIsBlocked, below.)
-  // TODO(steel): Change this back to a web worker if/when Chrome changes its behavior:
   // https://bugs.chromium.org/p/chromium/issues/detail?id=1012640
   throw new Error("Not in a SharedWorker.");
 }

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/transform.test.ts
@@ -220,7 +220,7 @@ describe("pipeline", () => {
         "log({ 'a': { 'a': undefined } })",
         "log({ 1: { 'a': undefined } })",
         "const x: [number, number] = [ 1, 1, ]; log({ 'a': x })",
-        "const y: any = {}; log({ 'a': y })", // TODO: Add back in after updating Typescript to support enums
+        "const y: any = {}; log({ 'a': y })",
         // "enum Enums { Red, Green, Blue }; log({ 'a': Enums })",
       ])("can compile logs", (sourceCode) => {
         const { diagnostics } = compile({ ...baseNodeData, sourceCode });
@@ -717,7 +717,7 @@ describe("pipeline", () => {
             return {position: { x: 1, y: 2, z: 3 }, orientation: { x: 4, y: 5, z: 6, w: 7}};
           };`,
         datatypes: poseDataType,
-      }, // TODO: add a test for an import interface type in the return type
+      },
       {
         description: "Type reference as return type",
         sourceCode: `

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/ast.ts
@@ -344,9 +344,6 @@ export const constructDatatypes = (
             secField.isArray !== true &&
             nsecField.isArray !== true
           ) {
-            // TODO(JP): Might want to do some extra checks for types here. But then again,
-            // "time" is just pretty awkward of a field in general; maybe we should instead
-            // just get rid of it throughout our application and treat it as a regular nested object?
             return {
               name,
               type: "time",

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/pointClouds.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/pointClouds.ts
@@ -74,8 +74,6 @@ export function setRayDistance(pt: Point, distance: number): Point {
 export function convertToRangeView(points: Point[], range: number, makeColors: boolean): RGBA[] {
   const colors: RGBA[] = makeColors ? new Array(points.length) : [];
   // First pass to get min and max ranges
-  // TODO: Could be more efficient and extract this during
-  // transforms for free
   let maxRange = Number.MIN_VALUE;
   if (makeColors) {
     for (const point of points) {

--- a/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/nodeTransformerWorker/utils.ts
@@ -53,7 +53,6 @@ export const transformDiagnosticToMarkerData = (diagnostic: ts.Diagnostic): Diag
     startColumn,
     endLineNumber,
     endColumn,
-    // TODO: Maybe map these 'codes' to meaningful strings?
     code: diagnostic.code,
   };
 };

--- a/packages/studio-base/src/players/UserNodePlayer/types.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/types.ts
@@ -118,7 +118,7 @@ export type NodeDataTransformer = (nodeData: NodeData, topics: Topic[]) => NodeD
 
 export type UserNodeLog = {
   source: "registerNode" | "processMessage";
-  value: unknown; // TODO: This should ideally share the type def of `log()` in `lib.js`
+  value: unknown;
 };
 
 export type RegistrationOutput = {

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -101,8 +101,6 @@ export type PlayerState = {
   presence: PlayerPresence;
 
   // Show some sort of progress indication in the playback bar; see `type Progress` for more details.
-  // TODO(JP): Maybe we should unify some progress and the other initialization fields above into
-  // one "status" object?
   progress: Progress;
 
   // Capabilities of this particular `Player`, which are not shared across all players.
@@ -171,9 +169,6 @@ export type PlayerStateActiveData = {
 
   // The last time a seek / discontinuity in messages happened. This will clear out data within
   // `PanelAPI` so we're not looking at stale data.
-  // TODO(JP): This currently is a time per `Date.now()`, but we don't need that anywhere, so we
-  // should change this to a `resetMessagesId` where you just have to set it to a unique id (better
-  // to have an id than a boolean, in case the listener skips parsing a state for some reason).
   lastSeekTime: number;
 
   // A list of topics that panels can subscribe to. This list may change across states,

--- a/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/Ros1MemoryCacheDataProvider.test.ts
@@ -344,10 +344,6 @@ describe("MemoryCacheDataProvider", () => {
     sendNotification.expectCalledDuringTest();
   });
 
-  // TODO(JP): We test getBlocksToKeep separately, but never as part of MemoryCacheDataProvider.
-  // This is a bit more work to set up properly, so I haven't done that for now since I feel like
-  // the units themselves are sufficiently tested, but in the future it would be good to add some
-  // more coverage, especially as this code matures.
   describe("getBlocksToKeep", () => {
     it("keeps all blocks if we haven't reached the maximum cache size yet", () => {
       expect(

--- a/packages/studio-base/src/randomAccessDataProviders/types.ts
+++ b/packages/studio-base/src/randomAccessDataProviders/types.ts
@@ -83,8 +83,6 @@ export interface RandomAccessDataProvider {
   // callbacks that only some implementations care about. May only be called once. If there's an
   // error during initialization, it must be reported using `sendNotification` (even in Web Workers).
   // If the error is unrecoverable, just never resolve the promise.
-  // TODO(JP): It would be better to reject the promise explicitly in case of unrecoverable errors,
-  // so we can update the UI appropriately.
   initialize(extensionPoint: ExtensionPoint): Promise<InitializationResult>;
   // Get messages for a time range inclusive of start and end matching any of the provided topics.
   // May only be called after `initialize` has finished. Returned messages must be ordered by
@@ -121,8 +119,6 @@ export type ExtensionPoint = {
   progressCallback: (progress: Progress) => void;
 
   // Report some sort of metadata to the `Player`, see below for different kinds of metadata.
-  // TODO(JP): this is a bit of an odd one out. Maybe we should unify this with the
-  // `progressCallback` and have one type of "status" object?
   reportMetadataCallback: (metadata: RandomAccessDataProviderMetadata) => void;
 };
 

--- a/packages/studio-base/src/test/transformers/neTransformer.js
+++ b/packages/studio-base/src/test/transformers/neTransformer.js
@@ -13,8 +13,7 @@ module.exports = {
     // Parse the grammar source into an AST
     const grammarParser = new nearley.Parser(nearleyGrammar);
     grammarParser.feed(sourceText);
-    const grammarAst = grammarParser.results[0]; // TODO check for errors
-
+    const grammarAst = grammarParser.results[0];
     // Compile the AST into a set of rules
     const grammarInfoObject = compile(grammarAst, {});
     // Generate JavaScript code from the rules

--- a/packages/studio-base/src/types/Messages.ts
+++ b/packages/studio-base/src/types/Messages.ts
@@ -120,7 +120,7 @@ type Colors = readonly Color[];
 export type BaseMarker = Readonly<
   StampedMessage & {
     ns: string;
-    id: string | number; // TODO: Actually just a number
+    id: string | number;
     action: 0 | 1 | 2 | 3;
     pose: MutablePose;
     scale: Scale;
@@ -130,7 +130,7 @@ export type BaseMarker = Readonly<
     frame_locked: boolean;
     points?: Point[];
     text?: string;
-    mesh_resource?: string; // TODO: required
+    mesh_resource?: string;
     mesh_use_embedded_materials?: boolean;
     primitive?: string;
     metadata?: Readonly<Record<string, unknown>>;

--- a/packages/studio-base/src/util/CachedFilelike.ts
+++ b/packages/studio-base/src/util/CachedFilelike.ts
@@ -60,8 +60,6 @@ export interface FileReader {
 const LOGGING_INTERVAL_IN_BYTES = 1024 * 1024 * 100; // Log every 100MiB to avoid cluttering the logs too much.
 const CACHE_BLOCK_SIZE = 1024 * 1024 * 10; // 10MiB blocks.
 // Don't start a new connection if we're 5MiB away from downloading the requested byte.
-// TODO(JP): It would be better (but a bit more involved) to express this in seconds, and take into
-// account actual download speed.
 const CLOSE_ENOUGH_BYTES_TO_NOT_START_NEW_CONNECTION = 1024 * 1024 * 5;
 
 const log = Logger.getLogger(__filename);

--- a/packages/studio-base/src/util/VirtualLRUBuffer.ts
+++ b/packages/studio-base/src/util/VirtualLRUBuffer.ts
@@ -81,7 +81,6 @@ export default class VirtualLRUBuffer {
 
     // Walk through the blocks and copy the data over. If the input buffer is too large we will
     // currently just evict the earliest copied in data.
-    // TODO(JP): We could throw an error in that case if this is causing a lot of trouble.
     let position = range.start;
     while (position < range.end) {
       const { blockIndex, positionInBlock, remainingBytesInBlock } =
@@ -147,9 +146,6 @@ export default class VirtualLRUBuffer {
       // If we have too many blocks, remove the least recently used one.
       // Note that we don't reuse blocks, since other code might still hold a reference to it
       // via the `VirtualLRUBuffer#slice` method.
-      // TODO(JP): It might be worth measuring if under typical use it's faster to reuse blocks and always
-      // copy to a new buffer in `VirtualLRUBuffer#slice` (less garbage collection), or if the current method
-      // is better (faster slicing).
       const deleteIndex = this._lastAccessedBlockIndices.shift();
       if (deleteIndex != undefined) {
         delete this._blocks[deleteIndex];

--- a/packages/studio-base/src/util/getNewConnection.ts
+++ b/packages/studio-base/src/util/getNewConnection.ts
@@ -91,8 +91,6 @@ function getNewConnectionWithExistingReadRequest({
     // If we're downloading to the end of our range, do some reading ahead while we're at it.
     // Note that we might have already downloaded parts of this range, but we don't know when
     // they get evicted, so for now we just the entire range again.
-    // TODO(JP): In the future it might be good to mark the already downloaded bits as "recently
-    // accessed" so they don't get evicted, and then not download them again.
     return {
       ...notDownloadedRanges[0],
       end: Math.min(readRequestRange.start + maxRequestSize, fileSize),

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -122,7 +122,6 @@ function getLayoutWithNewPanelIds(
       newLayout[key] = layout[key];
     }
   }
-  // TODO: Refactor above to allow for better typing here.
   return newLayout as unknown as MosaicNode<string>;
 }
 


### PR DESCRIPTION
Similar to "fixme", this change adds "todo" to the list of disallowed words in comments.

Rather than use TODO comments in the code, we create tickets for any follow-up work that needs to happen. Tickets are how we review outstanding work and ensure it is prioritized and completed.

If there is an implementation tradeoff, a code comment should describe the comment and and references (which could be tickets too) but it should not do this in the form of a TODO.

**User-Facing Changes**


**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
