### PR TITLE
Catch schema parsing errors in DataPlatformIterableSource

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -136,17 +136,25 @@ export class DataPlatformIterableSource implements IIterableSource {
         }
       }
 
-      const parsedChannel = parseChannel({
-        messageEncoding,
-        schema: { name: schemaName, data: schema, encoding: schemaEncoding },
-      });
+      try {
+        const parsedChannel = parseChannel({
+          messageEncoding,
+          schema: { name: schemaName, data: schema, encoding: schemaEncoding },
+        });
 
-      topics.push({ name: topic, datatype: parsedChannel.fullSchemaName });
-      parsedChannels.push({ messageEncoding, schemaEncoding, schema, parsedChannel });
+        topics.push({ name: topic, datatype: parsedChannel.fullSchemaName });
+        parsedChannels.push({ messageEncoding, schemaEncoding, schema, parsedChannel });
 
-      // Final datatypes is an unholy union of schemas across all channels
-      for (const [name, datatype] of parsedChannel.datatypes) {
-        datatypes.set(name, datatype);
+        // Final datatypes is an unholy union of schemas across all channels
+        for (const [name, datatype] of parsedChannel.datatypes) {
+          datatypes.set(name, datatype);
+        }
+      } catch (err) {
+        problems.push({
+          message: `Failed to parse schema for topic ${topic}`,
+          severity: "error",
+          error: err,
+        });
       }
     }
 


### PR DESCRIPTION


**User-Facing Changes**
Gracefully handle data platform sources with topics having malformed schemas. Show a problem for the specific topic and continue processing other topics.

**Description**
Prior to this change, the data platform iterable source would fail initialization when it encountered a schema it could not parse. This would prevent the user from looking at any data if only one topic had a schema problem.

This change catches schema parsing errors and adds them to initialization problems. This allows the user to continue using other topics which did not have errors.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
