### PR TITLE
Fix user scripts panel underflow

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -335,7 +335,7 @@ function NodePlayground(props: Props) {
     <Stack fullHeight>
       <PanelToolbar helpContent={helpContent} />
       <Divider />
-      <Stack direction="row" fullHeight>
+      <Stack direction="row" fullHeight overflow="hidden">
         <Sidebar
           explorer={explorer}
           updateExplorer={updateExplorer}


### PR DESCRIPTION
**User-Facing Changes**
Fixes an overflow in the user scripts panel that causes it to underflowing the timeline.

**Description**
Constrains the container stack of the user scripts panel to full height to prevent underflowing the timeline.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4310