### PR TITLE
Support plot panel data series configuration in settings sidebar

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -20,6 +20,7 @@ export enum AppSetting {
   // Experimental features
   SHOW_DEBUG_PANELS = "showDebugPanels",
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
+  ENABLE_PLOT_PANEL_SERIES_SETTINGS = "enablePlotPathSeriesSettings",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -53,6 +53,11 @@ const features: Feature[] = [
     name: "Memory use indicator",
     description: <>Show the app memory use in the sidebar.</>,
   },
+  {
+    key: AppSetting.ENABLE_PLOT_PANEL_SERIES_SETTINGS,
+    name: "Plot panel series in settings",
+    description: <>Allow editing plot panel data series in the sidebar.</>,
+  },
 ];
 if (process.env.NODE_ENV === "development") {
   features.push({

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -233,8 +233,8 @@ function FieldInput({
             }
           }}
         >
-          <ToggleButton value={true}>On</ToggleButton>
           <ToggleButton value={false}>Off</ToggleButton>
+          <ToggleButton value={true}>On</ToggleButton>
         </StyledToggleButtonGroup>
       );
     case "rgb":

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -27,6 +27,7 @@ import {
   toSec,
 } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
 import parseRosPath, {
@@ -52,6 +53,7 @@ import {
   ChartDefaultView,
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
@@ -472,6 +474,10 @@ function Plot(props: Props) {
 
   usePlotPanelSettings(config, saveConfig);
 
+  const [seriesSettings = false] = useAppConfigurationValue(
+    AppSetting.ENABLE_PLOT_PANEL_SERIES_SETTINGS,
+  );
+
   const stackDirection = useMemo(
     () => (legendDisplay === "top" ? "column" : "row"),
     [legendDisplay],
@@ -506,19 +512,21 @@ function Plot(props: Props) {
         fullWidth
         style={{ height: `calc(100% - ${PANEL_TOOLBAR_MIN_HEIGHT}px)` }}
       >
-        <PlotLegend
-          paths={yAxisPaths}
-          datasets={datasets}
-          currentTime={currentTimeSinceStart}
-          saveConfig={saveConfig}
-          showLegend={showLegend}
-          xAxisVal={xAxisVal}
-          xAxisPath={xAxisPath}
-          pathsWithMismatchedDataLengths={pathsWithMismatchedDataLengths}
-          legendDisplay={legendDisplay}
-          showPlotValuesInLegend={showPlotValuesInLegend}
-          sidebarDimension={sidebarDimension}
-        />
+        {seriesSettings === false && (
+          <PlotLegend
+            paths={yAxisPaths}
+            datasets={datasets}
+            currentTime={currentTimeSinceStart}
+            saveConfig={saveConfig}
+            showLegend={showLegend}
+            xAxisVal={xAxisVal}
+            xAxisPath={xAxisPath}
+            pathsWithMismatchedDataLengths={pathsWithMismatchedDataLengths}
+            legendDisplay={legendDisplay}
+            showPlotValuesInLegend={showPlotValuesInLegend}
+            sidebarDimension={sidebarDimension}
+          />
+        )}
         <Stack flex="auto" alignItems="center" justifyContent="center" overflow="hidden">
           <PlotChart
             isSynced={xAxisVal === "timestamp" && isSynced}

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -23,8 +23,9 @@ export type BasePlotPath = {
 };
 
 export type PlotPath = BasePlotPath & {
-  timestampMethod: TimestampMethod;
   color?: string;
+  label?: string;
+  timestampMethod: TimestampMethod;
 };
 
 export type Datum = {

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -8,6 +8,8 @@ import memoizeWeak from "memoize-weak";
 import { useCallback, useEffect } from "react";
 
 import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -15,9 +17,9 @@ import { lineColors } from "@foxglove/studio-base/util/plotColors";
 
 import { plotableRosTypes, PlotConfig } from "./types";
 
-const makePathNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNode => {
+const makeSeriesNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNode => {
   return {
-    actions: [{ type: "action", id: "delete-path", label: "Delete" }],
+    actions: [{ type: "action", id: "delete-series", label: "Delete" }],
     label: path.label ?? `Series ${index + 1}`,
     renamable: true,
     visible: path.enabled,
@@ -46,18 +48,19 @@ const makePathNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNo
   };
 });
 
-const makeRootPathNode = memoizeWeak((paths: PlotPath[]): SettingsTreeNode => {
+const makeRootSeriesNode = memoizeWeak((paths: PlotPath[]): SettingsTreeNode => {
   const children = Object.fromEntries(
-    paths.map((path, index) => [`${index}`, makePathNode(path, index)]),
+    paths.map((path, index) => [`${index}`, makeSeriesNode(path, index)]),
   );
   return {
-    label: "Paths",
+    label: "Series",
     children,
-    actions: [{ type: "action", id: "add-path", label: "Add Path" }],
+    actions: [{ type: "action", id: "add-series", label: "Add series" }],
   };
 });
 
-function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsTreeNodes {
   const maxYError =
     isNumber(config.minYValue) && isNumber(config.maxYValue) && config.minYValue >= config.maxYValue
       ? "Y max must be greater than Y min."
@@ -92,7 +95,7 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
         },
       },
     },
-    paths: makeRootPathNode(config.paths),
+    paths: enableSeries ? makeRootSeriesNode(config.paths) : undefined,
     yAxis: {
       label: "Y Axis",
       fields: {
@@ -150,6 +153,9 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
 
 export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<PlotConfig>): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
+  const [enableSeries = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_PLOT_PANEL_SERIES_SETTINGS,
+  );
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
@@ -173,7 +179,7 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
           }),
         );
       } else {
-        if (action.payload.id === "add-path") {
+        if (action.payload.id === "add-series") {
           saveConfig(
             produce<PlotConfig>((draft) => {
               draft.paths.push({
@@ -183,7 +189,7 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
               });
             }),
           );
-        } else if (action.payload.id === "delete-path") {
+        } else if (action.payload.id === "delete-series") {
           const index = action.payload.path[1];
           saveConfig(
             produce<PlotConfig>((draft) => {
@@ -199,7 +205,7 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
   useEffect(() => {
     updatePanelSettingsTree({
       actionHandler,
-      nodes: buildSettingsTree(config),
+      nodes: buildSettingsTree(config, enableSeries),
     });
-  }, [actionHandler, config, updatePanelSettingsTree]);
+  }, [actionHandler, config, enableSeries, updatePanelSettingsTree]);
 }

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -78,21 +78,25 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
       fields: {
         title: { label: "Title", input: "string", value: config.title, placeholder: "Plot" },
         isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },
-        legendDisplay: {
-          label: "Legend position",
-          input: "select",
-          value: config.legendDisplay,
-          options: [
-            { value: "floating", label: "Floating" },
-            { value: "left", label: "Left" },
-            { value: "top", label: "Top" },
-          ],
-        },
-        showPlotValuesInLegend: {
-          label: "Show plot values in legend",
-          input: "boolean",
-          value: config.showPlotValuesInLegend,
-        },
+        legendDisplay: enableSeries
+          ? undefined
+          : {
+              label: "Legend position",
+              input: "select",
+              value: config.legendDisplay,
+              options: [
+                { value: "floating", label: "Floating" },
+                { value: "left", label: "Left" },
+                { value: "top", label: "Top" },
+              ],
+            },
+        showPlotValuesInLegend: enableSeries
+          ? undefined
+          : {
+              label: "Show plot values in legend",
+              input: "boolean",
+              value: config.showPlotValuesInLegend,
+            },
       },
     },
     yAxis: {

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -10,7 +10,7 @@ import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
-import { PlotConfig } from "./types";
+import { plotableRosTypes, PlotConfig } from "./types";
 
 function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
   const maxYError =
@@ -22,6 +22,35 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
     isNumber(config.minXValue) && isNumber(config.maxXValue) && config.minXValue >= config.maxXValue
       ? "X max must be greater than X min."
       : undefined;
+
+  const paths: SettingsTreeNodes = Object.fromEntries(
+    config.paths.map((path, index) => [
+      `${index}`,
+      {
+        actions: [{ type: "action", id: "delete-path", label: "Delete" }],
+        label: `Series ${index + 1}`,
+        visible: path.enabled,
+        fields: {
+          value: {
+            input: "messagepath",
+            label: "Path",
+            value: path.value,
+            validTypes: plotableRosTypes,
+          },
+          color: { input: "rgb", label: "Color", value: path.color },
+          timestampMethod: {
+            input: "select",
+            label: "Timestamp",
+            value: path.timestampMethod,
+            options: [
+              { label: "Receive Time", value: "receiveTime" },
+              { label: "Header Stamp", value: "headerStamp" },
+            ],
+          },
+        },
+      },
+    ]),
+  );
 
   return {
     general: {
@@ -46,6 +75,11 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
           value: config.showPlotValuesInLegend,
         },
       },
+    },
+    paths: {
+      label: "Paths",
+      children: paths,
+      actions: [{ type: "action", id: "add-path", label: "Add Path" }],
     },
     yAxis: {
       label: "Y Axis",
@@ -107,24 +141,41 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
 
   const actionHandler = useCallback(
     (action: SettingsTreeAction) => {
-      if (action.action !== "update") {
-        return;
+      if (action.action === "update") {
+        const { path, value } = action.payload;
+        saveConfig(
+          produce((draft) => {
+            if (path[0] === "paths") {
+              set(draft, path, value);
+            } else {
+              set(draft, path.slice(1), value);
+
+              // X min/max and following width are mutually exclusive.
+              if (path[1] === "followingViewWidth") {
+                draft.minXValue = undefined;
+                draft.maxXValue = undefined;
+              } else if (path[1] === "minXValue" || path[1] === "maxXValue") {
+                draft.followingViewWidth = undefined;
+              }
+            }
+          }),
+        );
+      } else {
+        if (action.payload.id === "add-path") {
+          saveConfig(
+            produce<PlotConfig>((draft) => {
+              draft.paths.push({ timestampMethod: "receiveTime", value: "", enabled: true });
+            }),
+          );
+        } else if (action.payload.id === "delete-path") {
+          const index = action.payload.path[1];
+          saveConfig(
+            produce<PlotConfig>((draft) => {
+              draft.paths.splice(Number(index), 1);
+            }),
+          );
+        }
       }
-
-      const { path, value } = action.payload;
-      saveConfig(
-        produce((draft) => {
-          set(draft, path.slice(1), value);
-
-          // X min/max and following width are mutually exclusive.
-          if (path[1] === "followingViewWidth") {
-            draft.minXValue = undefined;
-            draft.maxXValue = undefined;
-          } else if (path[1] === "minXValue" || path[1] === "maxXValue") {
-            draft.followingViewWidth = undefined;
-          }
-        }),
-      );
     },
     [saveConfig],
   );

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -95,9 +95,9 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
         },
       },
     },
-    paths: enableSeries ? makeRootSeriesNode(config.paths) : undefined,
     yAxis: {
       label: "Y Axis",
+      defaultExpansionState: "collapsed",
       fields: {
         showYAxisLabels: {
           label: "Show labels",
@@ -121,6 +121,7 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
     },
     xAxis: {
       label: "X Axis",
+      defaultExpansionState: "collapsed",
       fields: {
         showXAxisLabels: {
           label: "Show labels",
@@ -148,6 +149,7 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
         },
       },
     },
+    paths: enableSeries ? makeRootSeriesNode(config.paths) : undefined,
   };
 }
 

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -4,13 +4,58 @@
 
 import produce from "immer";
 import { isNumber, set } from "lodash";
+import memoizeWeak from "memoize-weak";
 import { useCallback, useEffect } from "react";
 
-import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
+import { lineColors } from "@foxglove/studio-base/util/plotColors";
 
 import { plotableRosTypes, PlotConfig } from "./types";
+
+const makePathNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNode => {
+  return {
+    actions: [{ type: "action", id: "delete-path", label: "Delete" }],
+    label: path.label ?? `Series ${index + 1}`,
+    renamable: true,
+    visible: path.enabled,
+    fields: {
+      value: {
+        input: "messagepath",
+        label: "Path",
+        value: path.value,
+        validTypes: plotableRosTypes,
+      },
+      color: {
+        input: "rgb",
+        label: "Color",
+        value: path.color ?? lineColors[index % lineColors.length],
+      },
+      timestampMethod: {
+        input: "select",
+        label: "Timestamp",
+        value: path.timestampMethod,
+        options: [
+          { label: "Receive Time", value: "receiveTime" },
+          { label: "Header Stamp", value: "headerStamp" },
+        ],
+      },
+    },
+  };
+});
+
+const makeRootPathNode = memoizeWeak((paths: PlotPath[]): SettingsTreeNode => {
+  const children = Object.fromEntries(
+    paths.map((path, index) => [`${index}`, makePathNode(path, index)]),
+  );
+  return {
+    label: "Paths",
+    children,
+    actions: [{ type: "action", id: "add-path", label: "Add Path" }],
+  };
+});
 
 function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
   const maxYError =
@@ -22,35 +67,6 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
     isNumber(config.minXValue) && isNumber(config.maxXValue) && config.minXValue >= config.maxXValue
       ? "X max must be greater than X min."
       : undefined;
-
-  const paths: SettingsTreeNodes = Object.fromEntries(
-    config.paths.map((path, index) => [
-      `${index}`,
-      {
-        actions: [{ type: "action", id: "delete-path", label: "Delete" }],
-        label: `Series ${index + 1}`,
-        visible: path.enabled,
-        fields: {
-          value: {
-            input: "messagepath",
-            label: "Path",
-            value: path.value,
-            validTypes: plotableRosTypes,
-          },
-          color: { input: "rgb", label: "Color", value: path.color },
-          timestampMethod: {
-            input: "select",
-            label: "Timestamp",
-            value: path.timestampMethod,
-            options: [
-              { label: "Receive Time", value: "receiveTime" },
-              { label: "Header Stamp", value: "headerStamp" },
-            ],
-          },
-        },
-      },
-    ]),
-  );
 
   return {
     general: {
@@ -76,11 +92,7 @@ function buildSettingsTree(config: PlotConfig): SettingsTreeNodes {
         },
       },
     },
-    paths: {
-      label: "Paths",
-      children: paths,
-      actions: [{ type: "action", id: "add-path", label: "Add Path" }],
-    },
+    paths: makeRootPathNode(config.paths),
     yAxis: {
       label: "Y Axis",
       fields: {
@@ -164,7 +176,11 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
         if (action.payload.id === "add-path") {
           saveConfig(
             produce<PlotConfig>((draft) => {
-              draft.paths.push({ timestampMethod: "receiveTime", value: "", enabled: true });
+              draft.paths.push({
+                timestampMethod: "receiveTime",
+                value: "",
+                enabled: true,
+              });
             }),
           );
         } else if (action.payload.id === "delete-path") {


### PR DESCRIPTION
**User-Facing Changes**
None. This is under a feature flag for now.

**Description**
This is a proof of concept. I think in order to make this viable we need to find a way of making editing long message paths more ergonomic.

_Note_: Due to some optimizations in the plot panel legend, changes you make in the settings sidebar will not show up in the plot legend. This is fixable but I thought it wasn't worth spending the time until we decided if we like this approach or not.

<img width="361" alt="Screen Shot 2022-08-31 at 1 53 16 PM" src="https://user-images.githubusercontent.com/93935560/187746379-d8983f28-6c74-4a7d-8002-60041c6238e5.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/3432