### PR TITLE
add url param &openIn=web/desktop to override launch preference

### DIFF
--- a/benchmark/src/Root.tsx
+++ b/benchmark/src/Root.tsx
@@ -4,7 +4,13 @@
 
 import { useMemo, useState } from "react";
 
-import { App, IDataSourceFactory, ConsoleApi, AppSetting } from "@foxglove/studio-base";
+import {
+  App,
+  IDataSourceFactory,
+  ConsoleApi,
+  AppSetting,
+  LaunchPreferenceValue,
+} from "@foxglove/studio-base";
 
 import { McapLocalBenchmarkDataSourceFactory, SyntheticDataSourceFactory } from "./dataSources";
 import { LAYOUTS } from "./layouts";
@@ -15,7 +21,7 @@ export function Root(): JSX.Element {
     () =>
       new MemoryAppConfiguration({
         defaults: {
-          [AppSetting.LAUNCH_PREFERENCE]: "web",
+          [AppSetting.LAUNCH_PREFERENCE]: LaunchPreferenceValue.WEB,
           [AppSetting.MESSAGE_RATE]: 240,
         },
       }),

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -33,6 +33,7 @@ import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent"
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import { formatTime } from "@foxglove/studio-base/util/formatTime";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
@@ -223,9 +224,19 @@ function TimeFormat(): React.ReactElement {
 
 function LaunchDefault(): React.ReactElement {
   const { classes } = useStyles();
-  const [preference = "unknown", setPreference] = useAppConfigurationValue<string | undefined>(
+  const [preference, setPreference] = useAppConfigurationValue<string | undefined>(
     AppSetting.LAUNCH_PREFERENCE,
   );
+  let sanitizedPreference: LaunchPreferenceValue;
+  switch (preference) {
+    case LaunchPreferenceValue.WEB:
+    case LaunchPreferenceValue.DESKTOP:
+    case LaunchPreferenceValue.ASK:
+      sanitizedPreference = preference;
+      break;
+    default:
+      sanitizedPreference = LaunchPreferenceValue.WEB;
+  }
 
   return (
     <Stack>
@@ -235,16 +246,16 @@ function LaunchDefault(): React.ReactElement {
         size="small"
         fullWidth
         exclusive
-        value={preference}
+        value={sanitizedPreference}
         onChange={(_, value?: string) => value != undefined && void setPreference(value)}
       >
-        <ToggleButton value="web" className={classes.toggleButton}>
+        <ToggleButton value={LaunchPreferenceValue.WEB} className={classes.toggleButton}>
           <WebIcon /> Web app
         </ToggleButton>
-        <ToggleButton value="desktop" className={classes.toggleButton}>
+        <ToggleButton value={LaunchPreferenceValue.DESKTOP} className={classes.toggleButton}>
           <ComputerIcon /> Desktop app
         </ToggleButton>
-        <ToggleButton value="unknown" className={classes.toggleButton}>
+        <ToggleButton value={LaunchPreferenceValue.ASK} className={classes.toggleButton}>
           <QuestionAnswerOutlinedIcon /> Ask each time
         </ToggleButton>
       </ToggleButtonGroup>

--- a/packages/studio-base/src/hooks/useDefaultWebLaunchPreference.ts
+++ b/packages/studio-base/src/hooks/useDefaultWebLaunchPreference.ts
@@ -10,6 +10,7 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const selectHasUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState != undefined;
@@ -29,7 +30,7 @@ export function useDefaultWebLaunchPreference(): void {
     }
 
     if (hasUrlState && !launchPreference) {
-      setLaunchPreference("web");
+      setLaunchPreference(LaunchPreferenceValue.WEB);
     }
   }, [launchPreference, setLaunchPreference, hasUrlState]);
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -15,6 +15,7 @@ import PlayerSelectionContext, {
 import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 
 jest.mock("@foxglove/studio-base/hooks/useSessionStorageValue");
 jest.mock("@foxglove/studio-base/context/CurrentLayoutContext");
@@ -69,7 +70,7 @@ describe("Initial deep link state", () => {
   };
 
   beforeEach(() => {
-    (useSessionStorageValue as jest.Mock).mockReturnValue(["web", jest.fn()]);
+    (useSessionStorageValue as jest.Mock).mockReturnValue([LaunchPreferenceValue.WEB, jest.fn()]);
     (useCurrentLayoutActions as jest.Mock).mockReturnValue({ setSelectedLayoutId });
     selectSource.mockClear();
     setSelectedLayoutId.mockClear();

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -46,3 +46,4 @@ export { default as VelodyneDataSourceFactory } from "./dataSources/VelodyneData
 export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";
 export { default as McapRemoteDataSourceFactory } from "./dataSources/McapRemoteDataSourceFactory";
 export { default as SampleNuscenesDataSourceFactory } from "./dataSources/SampleNuscenesDataSourceFactory";
+export { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";

--- a/packages/studio-base/src/screens/LaunchPreference.tsx
+++ b/packages/studio-base/src/screens/LaunchPreference.tsx
@@ -4,6 +4,8 @@
 
 import { PropsWithChildren } from "react";
 
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
+
 import { AppSetting } from "../AppSetting";
 import { useAppConfigurationValue } from "../hooks";
 import { useSessionStorageValue } from "../hooks/useSessionStorageValue";
@@ -11,22 +13,28 @@ import { LaunchPreferenceScreen } from "./LaunchPreferenceScreen";
 import { LaunchingInDesktopScreen } from "./LaunchingInDesktopScreen";
 
 export function LaunchPreference(props: PropsWithChildren<unknown>): JSX.Element {
-  const [globalLaunchPreference = "unknown"] = useAppConfigurationValue<string>(
-    AppSetting.LAUNCH_PREFERENCE,
-  );
+  const [globalLaunchPreference] = useAppConfigurationValue<string>(AppSetting.LAUNCH_PREFERENCE);
   const [sessionLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
 
   const url = new URL(window.location.href);
 
   // Session preferences take priority over global preferences.
-  const activePreference =
+  let activePreference =
     url.searchParams.get("openIn") ?? sessionLaunchPreference ?? globalLaunchPreference;
+  switch (activePreference) {
+    case LaunchPreferenceValue.WEB:
+    case LaunchPreferenceValue.DESKTOP:
+    case LaunchPreferenceValue.ASK:
+      break;
+    default:
+      activePreference = LaunchPreferenceValue.WEB;
+  }
 
   const hasParams = Array.from(url.searchParams.entries()).length > 0;
   // Ask the user in which environment they want to open this session.
-  if (activePreference === "unknown" && hasParams) {
+  if (activePreference === LaunchPreferenceValue.ASK && hasParams) {
     return <LaunchPreferenceScreen />;
-  } else if (activePreference === "desktop" && hasParams) {
+  } else if (activePreference === LaunchPreferenceValue.DESKTOP && hasParams) {
     return <LaunchingInDesktopScreen />;
   } else {
     return <>{props.children}</>;

--- a/packages/studio-base/src/screens/LaunchPreference.tsx
+++ b/packages/studio-base/src/screens/LaunchPreference.tsx
@@ -16,10 +16,12 @@ export function LaunchPreference(props: PropsWithChildren<unknown>): JSX.Element
   );
   const [sessionLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
 
-  // Session preferences take priority over global preferences.
-  const activePreference = sessionLaunchPreference ?? globalLaunchPreference;
-
   const url = new URL(window.location.href);
+
+  // Session preferences take priority over global preferences.
+  const activePreference =
+    url.searchParams.get("openIn") ?? sessionLaunchPreference ?? globalLaunchPreference;
+
   const hasParams = Array.from(url.searchParams.entries()).length > 0;
   // Ask the user in which environment they want to open this session.
   if (activePreference === "unknown" && hasParams) {

--- a/packages/studio-base/src/screens/LaunchPreference.tsx
+++ b/packages/studio-base/src/screens/LaunchPreference.tsx
@@ -18,9 +18,10 @@ export function LaunchPreference(props: PropsWithChildren<unknown>): JSX.Element
 
   const url = new URL(window.location.href);
 
-  // Session preferences take priority over global preferences.
+  // Session preferences take priority over URL and global preferences. This allows the button in
+  // LaunchPreferenceScreen to override the url when clicked.
   let activePreference =
-    url.searchParams.get("openIn") ?? sessionLaunchPreference ?? globalLaunchPreference;
+    sessionLaunchPreference ?? url.searchParams.get("openIn") ?? globalLaunchPreference;
   switch (activePreference) {
     case LaunchPreferenceValue.WEB:
     case LaunchPreferenceValue.DESKTOP:

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -41,9 +41,6 @@ export function LaunchPreferenceScreen(): ReactElement {
   const [_, setSessionPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
   const [rememberPreference, setRememberPreference] = useState(globalPreference != undefined);
 
-  const cleanWebURL = new URL(window.location.href);
-  cleanWebURL.searchParams.delete("launch");
-
   async function launchInWeb() {
     if (rememberPreference) {
       await setGlobalPreference("web");

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -18,6 +18,7 @@ import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 
 const useStyles = makeStyles()((theme) => ({
   button: {
@@ -43,17 +44,17 @@ export function LaunchPreferenceScreen(): ReactElement {
 
   async function launchInWeb() {
     if (rememberPreference) {
-      await setGlobalPreference("web");
+      await setGlobalPreference(LaunchPreferenceValue.WEB);
     } else {
-      setSessionPreference("web");
+      setSessionPreference(LaunchPreferenceValue.WEB);
     }
   }
 
   async function launchInDesktop() {
     if (rememberPreference) {
-      await setGlobalPreference("desktop");
+      await setGlobalPreference(LaunchPreferenceValue.DESKTOP);
     } else {
-      setSessionPreference("desktop");
+      setSessionPreference(LaunchPreferenceValue.DESKTOP);
     }
   }
 
@@ -66,13 +67,13 @@ export function LaunchPreferenceScreen(): ReactElement {
 
   const actions = [
     {
-      key: "web",
+      key: LaunchPreferenceValue.WEB,
       primary: "Web",
       secondary: "Requires Chrome v76+",
       onClick: () => void launchInWeb(),
     },
     {
-      key: "desktop",
+      key: LaunchPreferenceValue.DESKTOP,
       primary: "Desktop App",
       secondary: "For Linux, Windows, and macOS",
       onClick: () => void launchInDesktop(),

--- a/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchPreferenceScreen.tsx
@@ -43,18 +43,16 @@ export function LaunchPreferenceScreen(): ReactElement {
   const [rememberPreference, setRememberPreference] = useState(globalPreference != undefined);
 
   async function launchInWeb() {
+    setSessionPreference(LaunchPreferenceValue.WEB); // always set session preference to allow overriding the URL param
     if (rememberPreference) {
       await setGlobalPreference(LaunchPreferenceValue.WEB);
-    } else {
-      setSessionPreference(LaunchPreferenceValue.WEB);
     }
   }
 
   async function launchInDesktop() {
+    setSessionPreference(LaunchPreferenceValue.DESKTOP); // always set session preference to allow overriding the URL param
     if (rememberPreference) {
       await setGlobalPreference(LaunchPreferenceValue.DESKTOP);
-    } else {
-      setSessionPreference(LaunchPreferenceValue.DESKTOP);
     }
   }
 

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -8,6 +8,7 @@ import { ReactElement, useEffect } from "react";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
+import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 
 export function LaunchingInDesktopScreen(): ReactElement {
   const [, setLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
@@ -16,7 +17,7 @@ export function LaunchingInDesktopScreen(): ReactElement {
   cleanWebURL.searchParams.delete("openIn");
 
   function openWeb() {
-    setLaunchPreference("web");
+    setLaunchPreference(LaunchPreferenceValue.WEB);
     window.location.href = cleanWebURL.href;
   }
 

--- a/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
+++ b/packages/studio-base/src/screens/LaunchingInDesktopScreen.tsx
@@ -13,7 +13,7 @@ export function LaunchingInDesktopScreen(): ReactElement {
   const [, setLaunchPreference] = useSessionStorageValue(AppSetting.LAUNCH_PREFERENCE);
 
   const cleanWebURL = new URL(window.location.href);
-  cleanWebURL.searchParams.delete("launch");
+  cleanWebURL.searchParams.delete("openIn");
 
   function openWeb() {
     setLaunchPreference("web");

--- a/packages/studio-base/src/types/LaunchPreferenceValue.ts
+++ b/packages/studio-base/src/types/LaunchPreferenceValue.ts
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/** Whether links should open in the web app or desktop app */
+export enum LaunchPreferenceValue {
+  ASK = "ask",
+  WEB = "web",
+  DESKTOP = "desktop",
+}


### PR DESCRIPTION
**User-Facing Changes**
Added a URL param `&openIn=[web/desktop]` to override the default behavior of asking the user whether to open urls in the desktop app.

**Description**
Resolves #3129 