### PR TITLE
Add opengraph/twitter meta tags to studio web build

### DIFF
--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -113,6 +113,13 @@ const mainConfig = (env: unknown, argv: WebpackArgv): Configuration => {
     <head>
       <meta charset="utf-8">
       <meta name="apple-mobile-web-app-capable" content="yes">
+      <meta property="og:title" content="Foxglove Studio"/>
+      <meta property="og:description" content="Open source visualization and debugging tool for robotics"/>
+      <meta property="og:type" content="website"/>
+      <meta property="og:image" content="https://foxglove.dev/images/og-image.jpeg"/>
+      <meta property="og:url" content="https://studio.foxglove.dev/"/>
+      <meta name="twitter:card" content="summary_large_image"/>
+      <meta name="twitter:site" content="@foxglovedev"/>
       <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Studio will show a nicer preview when shared in apps that support opengraph tags.

<img width="536" alt="image" src="https://user-images.githubusercontent.com/14237/187778316-d1f60f95-1f04-476c-ba68-400fa02e6d16.png">

<img width="604" alt="image" src="https://user-images.githubusercontent.com/14237/187779018-23219bbb-8a46-4803-b066-82ab1a90731c.png">
