### PR TITLE
set meta theme-color to background.paper

### DIFF
--- a/packages/studio-base/src/theme/ThemeProvider.tsx
+++ b/packages/studio-base/src/theme/ThemeProvider.tsx
@@ -51,6 +51,15 @@ export default function ThemeProvider({
   const muiTheme = useMemo(() => createMuiTheme(isDark ? "dark" : "light"), [isDark]);
   const fluentTheme = useMemo(() => createFluentTheme({ isInverted: isDark }), [isDark]);
 
+  useLayoutEffect(() => {
+    // Set the theme color to match the sidebar and playback bar
+    const meta = document.createElement("meta");
+    meta.name = "theme-color";
+    meta.content = muiTheme.palette.background.paper;
+    document.head.appendChild(meta);
+    return () => meta.remove();
+  }, [muiTheme]);
+
   if (!iconsRegistered) {
     return ReactNull;
   }


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Closes https://github.com/foxglove/studio/issues/4152

Before:

<img width="300" alt="Screen Shot 2022-08-31 at 1 49 46 PM" src="https://user-images.githubusercontent.com/14237/187779605-c00e1635-3fe0-40df-8200-e542a88ce48e.png"> <img width="300" alt="Screen Shot 2022-08-31 at 1 48 39 PM" src="https://user-images.githubusercontent.com/14237/187779621-776d3576-b0f1-4e91-8ab6-883863ebed27.png">

After:

<img width="300" alt="Screen Shot 2022-08-31 at 1 49 37 PM" src="https://user-images.githubusercontent.com/14237/187779636-3b2acda5-5c5c-49da-9a72-780a647d1b48.png"> <img width="300" alt="Screen Shot 2022-08-31 at 1 49 33 PM" src="https://user-images.githubusercontent.com/14237/187779640-fdcdd775-c800-49dc-bb6b-565560da0dcc.png">
