### PR TITLE
Allow specifying label & value for toggle settings

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -188,10 +188,10 @@ function FieldInput({
         >
           {field.options.map((opt) => (
             <ToggleButton
-              key={opt.value ?? UNDEFINED_SENTINEL_VALUE}
-              value={opt.value ?? UNDEFINED_SENTINEL_VALUE}
+              key={(typeof opt === "string" ? opt : opt.value) ?? UNDEFINED_SENTINEL_VALUE}
+              value={(typeof opt === "string" ? opt : opt.value) ?? UNDEFINED_SENTINEL_VALUE}
             >
-              {opt.label}
+              {typeof opt === "string" ? opt : opt.label}
             </ToggleButton>
           ))}
         </StyledToggleButtonGroup>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -175,13 +175,23 @@ function FieldInput({
           size="small"
           onChange={(_event, value) => {
             if (field.readonly !== true) {
-              actionHandler({ action: "update", payload: { path, input: "toggle", value } });
+              actionHandler({
+                action: "update",
+                payload: {
+                  path,
+                  input: "toggle",
+                  value: value === UNDEFINED_SENTINEL_VALUE ? undefined : value,
+                },
+              });
             }
           }}
         >
           {field.options.map((opt) => (
-            <ToggleButton key={opt} value={opt}>
-              {opt}
+            <ToggleButton
+              key={opt.value ?? UNDEFINED_SENTINEL_VALUE}
+              value={opt.value ?? UNDEFINED_SENTINEL_VALUE}
+            >
+              {opt.label}
             </ToggleButton>
           ))}
         </StyledToggleButtonGroup>

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -169,7 +169,7 @@ function FieldInput({
       return (
         <StyledToggleButtonGroup
           fullWidth
-          value={field.value}
+          value={field.value ?? UNDEFINED_SENTINEL_VALUE}
           exclusive
           disabled={field.disabled}
           size="small"

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -211,7 +211,10 @@ const DisabledSettings: SettingsTreeNodes = {
         input: "toggle",
         label: "Toggle",
         value: "One",
-        options: ["One", "Two"],
+        options: [
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+        ],
         disabled: true,
       },
       vec2: {
@@ -297,7 +300,10 @@ const ReadonlySettings: SettingsTreeNodes = {
         input: "toggle",
         label: "Toggle",
         value: "One",
-        options: ["One", "Two"],
+        options: [
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+        ],
         readonly: true,
       },
       vec2: {
@@ -354,7 +360,10 @@ const PanelExamplesSettings: SettingsTreeNodes = {
         label: "Color by",
         value: "Flat",
         input: "toggle",
-        options: ["Flat", "Point data"],
+        options: [
+          { label: "Flat", value: "flat" },
+          { label: "Point data", value: "data" },
+        ],
       },
       marker_color: {
         label: "Marker color",
@@ -540,7 +549,10 @@ const TopicSettings: SettingsTreeNodes = {
             label: "Point Shape",
             input: "toggle",
             value: "Circle",
-            options: ["Circle", "Square"],
+            options: [
+              { label: "Circle", value: "circle" },
+              { label: "Square", value: "square" },
+            ],
           },
           decay_time: {
             label: "Decay Time (seconds)",
@@ -562,7 +574,10 @@ const TopicSettings: SettingsTreeNodes = {
             label: "Point Shape",
             input: "toggle",
             value: "Circle",
-            options: ["Circle", "Square"],
+            options: [
+              { label: "Circle", value: "circle" },
+              { label: "Square", value: "square" },
+            ],
           },
           decay_time: {
             label: "Decay Time (seconds)",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -574,10 +574,7 @@ const TopicSettings: SettingsTreeNodes = {
             label: "Point Shape",
             input: "toggle",
             value: "Circle",
-            options: [
-              { label: "Circle", value: "circle" },
-              { label: "Square", value: "square" },
-            ],
+            options: ["Circle", "Square"],
           },
           decay_time: {
             label: "Decay Time (seconds)",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -210,7 +210,7 @@ const DisabledSettings: SettingsTreeNodes = {
       toggle: {
         input: "toggle",
         label: "Toggle",
-        value: "One",
+        value: "one",
         options: [
           { label: "One", value: "one" },
           { label: "Two", value: "two" },
@@ -299,7 +299,7 @@ const ReadonlySettings: SettingsTreeNodes = {
       toggle: {
         input: "toggle",
         label: "Toggle",
-        value: "One",
+        value: "one",
         options: [
           { label: "One", value: "one" },
           { label: "Two", value: "two" },
@@ -358,7 +358,7 @@ const PanelExamplesSettings: SettingsTreeNodes = {
       },
       color_by: {
         label: "Color by",
-        value: "Flat",
+        value: "flat",
         input: "toggle",
         options: [
           { label: "Flat", value: "flat" },
@@ -548,7 +548,7 @@ const TopicSettings: SettingsTreeNodes = {
           point_shape: {
             label: "Point Shape",
             input: "toggle",
-            value: "Circle",
+            value: "circle",
             options: [
               { label: "Circle", value: "circle" },
               { label: "Square", value: "square" },

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -449,7 +449,7 @@ declare module "@foxglove/studio" {
     | {
         input: "toggle";
         value?: string;
-        options: Array<{ label: string; value: undefined | string }>;
+        options: string[] | Array<{ label: string; value: undefined | string }>;
       }
     | {
         input: "vec3";

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -446,7 +446,11 @@ declare module "@foxglove/studio" {
          */
         placeholder?: string;
       }
-    | { input: "toggle"; value?: string; options: string[] }
+    | {
+        input: "toggle";
+        value?: string;
+        options: Array<{ label: string; value: undefined | string }>;
+      }
     | {
         input: "vec3";
         value?: [undefined | number, undefined | number, undefined | number];


### PR DESCRIPTION
**User-Facing Changes**
Extensions using the `updatePanelSettingsEditor` API with `"toggle"` inputs can now specify `options` with a distinct `value` and `label`.

**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
