### PR TITLE
Remove background color fade transition on mui buttons

### DIFF
--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -39,6 +39,10 @@ const iconHack = {
   },
 };
 
+const disableBackgroundColorTransition = {
+  transition: "none",
+};
+
 export default function muiComponents(theme: Theme): ThemeOptions["components"] & MuiLabComponents {
   const prefersDarkMode = theme.palette.mode === "dark";
 
@@ -196,6 +200,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
           ".MuiAutocomplete-root &": {
             paddingTop: 0,
           },
+          ...disableBackgroundColorTransition,
         },
       },
     },
@@ -262,6 +267,7 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
           "&:hover": {
             backgroundColor: theme.palette.action.hover,
           },
+          ...disableBackgroundColorTransition,
         },
       },
     },
@@ -353,6 +359,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
     },
     MuiListItemButton: {
       defaultProps: { disableRipple: true },
+      styleOverrides: {
+        root: {
+          ...disableBackgroundColorTransition,
+        },
+      },
     },
     MuiMenu: {
       styleOverrides: {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The background color fade transitions were brought back as part of a global change to transitions in https://github.com/foxglove/studio/pull/4245#pullrequestreview-1083079870. IMO the fade makes the app feel slightly less responsive. It is nice to get immediate feedback when I mouse over a button.