### PR TITLE
Restack and style playback bar so Scrubber is above controls

### DIFF
--- a/packages/studio-base/src/components/LoopIcon.tsx
+++ b/packages/studio-base/src/components/LoopIcon.tsx
@@ -2,10 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export default function LoopIcon({ strokeWidth = 1 }: { strokeWidth: number }): JSX.Element {
+import { SvgIcon, SvgIconProps } from "@mui/material";
+
+export default function LoopIcon(props: { strokeWidth: number } & SvgIconProps): JSX.Element {
+  const { strokeWidth = 1, ...rest } = props;
   return (
-    <svg height="100%" viewBox="0 0 24 24">
-      <g>
+    <SvgIcon {...rest}>
+      <g fill="currentColor">
         <path
           fill="none"
           stroke="currentColor"
@@ -37,6 +40,6 @@ export default function LoopIcon({ strokeWidth = 1 }: { strokeWidth: number }): 
           d="M13.308,20.121l-2.121,-2.121l2.121,-2.121"
         />
       </g>
-    </svg>
+    </SvgIcon>
   );
 }

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -1,17 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
-import { Typography } from "@mui/material";
+import { Tooltip, Typography } from "@mui/material";
 import { useMemo } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { makeStyles } from "tss-react/mui";
@@ -31,26 +22,17 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 const useStyles = makeStyles()((theme) => ({
   tick: {
     position: "absolute",
-    left: 0,
-    width: 0,
-    height: 0,
-    borderLeft: "5px solid transparent",
-    borderRight: "5px solid transparent",
-    marginLeft: -5,
+    height: 16,
+    borderRadius: 1,
+    width: 2,
+    top: 2,
+    transform: "translate(-50%, 0)",
+    backgroundColor: theme.palette.warning.main,
   },
-  tickTop: {
-    top: 8,
-    borderTop: `5px solid ${theme.palette.warning.main}`,
-  },
-  tickBottom: {
-    bottom: 8,
-    borderBottom: `5px solid ${theme.palette.warning.main}`,
-  },
-  label: {
-    position: "absolute",
-    left: 0,
-    top: 0,
-    transform: "translate(-50%, -50%)",
+  tooltip: {
+    '&[data-popper-placement*="top"] .MuiTooltip-tooltip': {
+      marginBottom: theme.spacing(1),
+    },
   },
 }));
 
@@ -68,7 +50,7 @@ type Props = {
 
 export default function PlaybackBarHoverTicks(props: Props): JSX.Element {
   const { componentId } = props;
-  const { classes, cx } = useStyles();
+  const { classes } = useStyles();
 
   const startTime = useMessagePipeline(getStartTime);
   const endTime = useMessagePipeline(getEndTime);
@@ -119,20 +101,24 @@ export default function PlaybackBarHoverTicks(props: Props): JSX.Element {
     <Stack ref={ref} flex="auto">
       {scaleBounds && (
         <HoverBar componentId={componentId} scales={scaleBounds} isTimestampScale>
-          {displayHoverTime && (
-            <Typography
-              className={classes.label}
-              align="center"
-              variant="caption"
-              color="warning.main"
-              fontFamily={fonts.MONOSPACE}
-              noWrap
-            >
-              {hoverTimeDisplay}
-            </Typography>
-          )}
-          <div className={cx(classes.tick, classes.tickTop)} />
-          <div className={cx(classes.tick, classes.tickBottom)} />
+          <Tooltip
+            arrow
+            classes={{ popper: classes.tooltip }}
+            placement="top"
+            disableFocusListener
+            disableHoverListener
+            disableTouchListener
+            disableInteractive
+            TransitionProps={{ timeout: 0 }}
+            open={displayHoverTime}
+            title={
+              <Typography align="center" variant="caption" fontFamily={fonts.MONOSPACE} noWrap>
+                {hoverTimeDisplay}
+              </Typography>
+            }
+          >
+            <div className={classes.tick} />
+          </Tooltip>
         </HoverBar>
       )}
     </Stack>

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()((theme) => ({
     height: 16,
     borderRadius: 1,
     width: 2,
-    top: 2,
+    top: 8,
     transform: "translate(-50%, 0)",
     backgroundColor: theme.palette.warning.main,
   },

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -40,7 +40,20 @@ type PlaybackTimeDisplayMethodProps = {
 
 const StyledTextField = muiStyled(TextField)<{ error?: boolean }>(({ error, theme }) => ({
   borderRadius: theme.shape.borderRadius,
+  ":hover": {
+    backgroundColor: theme.palette.action.hover,
 
+    ".MuiIconButton-root": {
+      visibility: "visible",
+    },
+  },
+  ".MuiFilledInput-root": {
+    backgroundColor: "transparent",
+
+    ":hover": {
+      backgroundColor: "transparent",
+    },
+  },
   ".MuiInputBase-input": {
     fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, 'zero' !important`,
     minWidth: "20ch",
@@ -49,6 +62,8 @@ const StyledTextField = muiStyled(TextField)<{ error?: boolean }>(({ error, them
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
     borderLeft: `1px solid ${theme.palette.background.paper}`,
+    visibility: "hidden",
+    marginRight: theme.spacing(-1),
   },
   ...(error === true && {
     outline: `1px solid ${theme.palette.error.main}`,
@@ -80,7 +95,6 @@ function PlaybackTimeMethodMenu({
   return (
     <>
       <IconButton
-        edge="end"
         id="playback-time-display-toggle-button"
         aria-controls={open ? "playback-time-display-toggle-menu" : undefined}
         aria-haspopup="true"
@@ -214,6 +228,7 @@ export default function PlaybackTimeDisplayMethod({
             value={isEditing ? inputText : currentTimeString}
             error={hasError}
             variant="filled"
+            size="small"
             InputProps={{
               startAdornment: hasError ? <WarningIcon color="error" /> : undefined,
               endAdornment: (

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -29,7 +29,6 @@ import Slider from "./Slider";
 
 const useStyles = makeStyles()((theme) => ({
   tooltipWrapper: {
-    label: "Scrubber-tooltipWrapper",
     fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, "zero"`,
     fontFamily: fonts.SANS_SERIF,
     whiteSpace: "nowrap",
@@ -39,7 +38,6 @@ const useStyles = makeStyles()((theme) => ({
     flexDirection: "column",
   },
   marker: {
-    label: "Scrubber-marker",
     backgroundColor: theme.palette.text.primary,
     position: "absolute",
     height: 16,
@@ -48,7 +46,6 @@ const useStyles = makeStyles()((theme) => ({
     transform: "translate(-50%, 0)",
   },
   track: {
-    label: "Scrubber-track",
     position: "absolute",
     left: 0,
     right: 0,
@@ -56,7 +53,6 @@ const useStyles = makeStyles()((theme) => ({
     backgroundColor: theme.palette.action.focus,
   },
   trackDisabled: {
-    label: "Scrubber-trackDisabled",
     opacity: theme.palette.action.disabledOpacity,
   },
 }));

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles()((theme) => ({
     position: "absolute",
     left: 0,
     right: 0,
-    height: 8,
+    height: 4,
     backgroundColor: theme.palette.action.focus,
   },
   trackDisabled: {
@@ -190,11 +190,11 @@ export default function Scrubber(props: Props): JSX.Element {
       flexGrow={1}
       alignItems="center"
       position="relative"
-      style={{ height: 20 }}
+      style={{ height: 32 }}
     >
       {tooltip}
       <div className={cx(classes.track, { [classes.trackDisabled]: !startTime })} />
-      <Stack position="absolute" flex="auto" fullWidth style={{ height: 8 }}>
+      <Stack position="absolute" flex="auto" fullWidth style={{ height: 4 }}>
         <ProgressPlot loading={loading} availableRanges={ranges} />
       </Stack>
       <Stack ref={el} fullHeight fullWidth position="absolute" flex={1}>

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles()((theme) => ({
     label: "Scrubber-marker",
     backgroundColor: theme.palette.text.primary,
     position: "absolute",
-    height: 8,
+    height: 16,
     borderRadius: 1,
     width: 2,
     transform: "translate(-50%, 0)",
@@ -52,7 +52,7 @@ const useStyles = makeStyles()((theme) => ({
     position: "absolute",
     left: 0,
     right: 0,
-    height: 4,
+    height: 8,
     backgroundColor: theme.palette.action.focus,
   },
   trackDisabled: {
@@ -194,14 +194,13 @@ export default function Scrubber(props: Props): JSX.Element {
       flexGrow={1}
       alignItems="center"
       position="relative"
-      style={{ height: 28 }}
+      style={{ height: 20 }}
     >
       {tooltip}
       <div className={cx(classes.track, { [classes.trackDisabled]: !startTime })} />
-      <Stack position="absolute" flex="auto" fullWidth style={{ height: 4 }}>
+      <Stack position="absolute" flex="auto" fullWidth style={{ height: 8 }}>
         <ProgressPlot loading={loading} availableRanges={ranges} />
       </Stack>
-      <PlaybackBarHoverTicks componentId={hoverComponentId} />
       <Stack ref={el} fullHeight fullWidth position="absolute" flex={1}>
         <Slider
           min={min ?? 0}
@@ -215,6 +214,7 @@ export default function Scrubber(props: Props): JSX.Element {
           renderSlider={renderSlider}
         />
       </Stack>
+      <PlaybackBarHoverTicks componentId={hoverComponentId} />
     </Stack>
   );
 }

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -45,7 +45,6 @@ const useStyles = makeStyles()((theme) => ({
     display: "flex",
     flexDirection: "column",
     padding: theme.spacing(0.5, 1, 1, 1),
-    gap: theme.spacing(0.5),
     position: "relative",
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -28,10 +28,6 @@ import { compare, Time } from "@foxglove/rostime";
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
 import LoopIcon from "@foxglove/studio-base/components/LoopIcon";
-import {
-  jumpSeek,
-  DIRECTION,
-} from "@foxglove/studio-base/components/PlaybackControls/sharedHelpers";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { Player } from "@foxglove/studio-base/players/types";
@@ -39,6 +35,7 @@ import { Player } from "@foxglove/studio-base/players/types";
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
 import { RepeatAdapter } from "./RepeatAdapter";
 import Scrubber from "./Scrubber";
+import { jumpSeek, DIRECTION } from "./sharedHelpers";
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -42,9 +42,10 @@ import Scrubber from "./Scrubber";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
-    displauy: "flex",
+    display: "flex",
     flexDirection: "column",
     padding: theme.spacing(0.5, 1, 1, 1),
+    gap: theme.spacing(0.5),
     position: "relative",
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -21,7 +21,6 @@ import {
   Previous20Filled,
   Previous20Regular,
 } from "@fluentui/react-icons";
-import { Divider } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -43,29 +42,14 @@ import Scrubber from "./Scrubber";
 
 const useStyles = makeStyles()((theme) => ({
   root: {
+    displauy: "flex",
+    flexDirection: "column",
+    padding: theme.spacing(1),
+    position: "relative",
     label: "PlaybackControls-root",
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,
-  },
-  buttonGroup: {
-    label: "PlaybackControls-buttonGroup",
-    backgroundColor: theme.palette.action.focus,
-    borderRadius: theme.shape.borderRadius,
-
-    ".MuiIconButton-root": {
-      "&:not(:first-of-type)": {
-        borderTopLeftRadius: 0,
-        borderBottomLeftRadius: 0,
-      },
-      "&:not(:last-of-type)": {
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-      },
-    },
-    ".MuiDivider-root": {
-      borderColor: theme.palette.background.paper,
-      borderRightWidth: 2,
-    },
+    zIndex: 100000,
   },
 }));
 
@@ -154,45 +138,48 @@ export default function PlaybackControls(props: {
     <>
       <RepeatAdapter play={play} seek={seek} repeatEnabled={repeat} />
       <KeyListener global keyDownHandlers={keyDownHandlers} />
-      <Stack className={classes.root} direction="row" alignItems="center" gap={1} padding={1}>
-        <Stack direction="row" alignItems="center" gap={1}>
-          <PlaybackSpeedControls />
-        </Stack>
-        <Stack direction="row" alignItems="center" flex={1} gap={1}>
+      <div className={classes.root}>
+        <Scrubber onSeek={seek} />
+        <Stack direction="row" alignItems="center" justifyContent="space-evenly" flex={1} gap={1}>
+          <Stack direction="row" flex={1}>
+            <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
+          </Stack>
           <Stack direction="row" alignItems="center" gap={1}>
             <HoverableIconButton
+              size="small"
+              title="Seek backward"
+              icon={<Previous20Regular />}
+              activeIcon={<Previous20Filled />}
+              onClick={() => seekBackwardAction()}
+            />
+            <HoverableIconButton
+              size="small"
+              title={isPlaying ? "Pause" : "Play"}
+              onClick={togglePlayPause}
+              icon={isPlaying ? <Pause20Regular /> : <Play20Regular />}
+              activeIcon={isPlaying ? <Pause20Filled /> : <Play20Filled />}
+            />
+            <HoverableIconButton
+              size="small"
+              title="Seek forward"
+              icon={<Next20Regular />}
+              activeIcon={<Next20Filled />}
+              onClick={() => seekForwardAction()}
+            />
+          </Stack>
+          <Stack direction="row" flex={1} alignItems="center" justifyContent="flex-end" gap={0.5}>
+            <HoverableIconButton
+              size="small"
               title="Loop playback"
               color={repeat ? "primary" : "inherit"}
               onClick={toggleRepeat}
               icon={repeat ? <LoopIcon strokeWidth={1.9375} /> : <LoopIcon strokeWidth={1.375} />}
               activeIcon={<LoopIcon strokeWidth={1.875} />}
             />
-            <HoverableIconButton
-              title={isPlaying ? "Pause" : "Play"}
-              onClick={togglePlayPause}
-              icon={isPlaying ? <Pause20Regular /> : <Play20Regular />}
-              activeIcon={isPlaying ? <Pause20Filled /> : <Play20Filled />}
-            />
+            <PlaybackSpeedControls />
           </Stack>
-          <Scrubber onSeek={seek} />
-          <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
         </Stack>
-        <Stack direction="row" className={classes.buttonGroup}>
-          <HoverableIconButton
-            title="Seek backward"
-            icon={<Previous20Regular />}
-            activeIcon={<Previous20Filled />}
-            onClick={() => seekBackwardAction()}
-          />
-          <Divider flexItem orientation="vertical" />
-          <HoverableIconButton
-            title="Seek forward"
-            icon={<Next20Regular />}
-            activeIcon={<Next20Filled />}
-            onClick={() => seekForwardAction()}
-          />
-        </Stack>
-      </Stack>
+      </div>
     </>
   );
 }

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -44,9 +44,8 @@ const useStyles = makeStyles()((theme) => ({
   root: {
     displauy: "flex",
     flexDirection: "column",
-    padding: theme.spacing(1),
+    padding: theme.spacing(0.5, 1, 1, 1),
     position: "relative",
-    label: "PlaybackControls-root",
     backgroundColor: theme.palette.background.paper,
     borderTop: `1px solid ${theme.palette.divider}`,
     zIndex: 100000,

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -29,8 +29,12 @@ const configSpeedSelector = (state: LayoutState) =>
   state.selectedLayout?.data?.playbackConfig.speed;
 
 const StyledButton = muiStyled(Button)(({ theme }) => ({
-  paddingTop: theme.spacing(1),
-  paddingBottom: theme.spacing(1),
+  padding: theme.spacing(0.625, 0.5),
+  backgroundColor: "transparent",
+
+  ":hover": {
+    backgroundColor: theme.palette.action.hover,
+  },
 }));
 
 export default function PlaybackSpeedControls(): JSX.Element {


### PR DESCRIPTION
**User-Facing Changes**
<img width="642" alt="Screen Shot 2022-09-01 at 3 42 31 pm" src="https://user-images.githubusercontent.com/924528/187840107-8fbe4686-753c-4d3d-bbea-c63a56f0dafc.png">

<img width="640" alt="Screen Shot 2022-09-01 at 3 42 45 pm" src="https://user-images.githubusercontent.com/924528/187840123-9272d46d-658f-4884-a0e6-4e3347b60c83.png">

**Description**
Moves scrubber bar above playback controls, removes background color from buttons and styles Hover timestamp like other tooltips.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
