### PR TITLE
remove focus outline from canvas elements

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -43,6 +43,9 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     "b, strong": {
       fontWeight: 700,
     },
+    canvas: {
+      outline: "none",
+    },
 
     // container styling
     height: "100%",

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -839,7 +839,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         <canvas
           ref={setCanvas}
           style={{
-            outline: "none",
             position: "absolute",
             top: 0,
             left: 0,

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -839,6 +839,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         <canvas
           ref={setCanvas}
           style={{
+            outline: "none",
             position: "absolute",
             top: 0,
             left: 0,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This globally removes the focus outline from canvas elements.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
