### PR TITLE
Remove zustand/context for panel settings editor context

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -19,8 +19,8 @@ import {
   useSelectedPanels,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
+import { usePanelSettingsEditorStore } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
-import { usePanelSettingsEditorStore } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -18,9 +18,11 @@ import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { PanelSettingsEditorStore } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+import {
+  PanelSettingsEditorStore,
+  usePanelSettingsEditorStore,
+} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
-import { usePanelSettingsEditorStore } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -18,11 +18,9 @@ import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { PanelSettingsEditorStore } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
-import {
-  PanelSettingsEditorStore,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsEditorStore } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 

--- a/packages/studio-base/src/context/PanelSettingsEditorContext.ts
+++ b/packages/studio-base/src/context/PanelSettingsEditorContext.ts
@@ -4,9 +4,10 @@
 
 import { createContext } from "react";
 import { DeepReadonly } from "ts-essentials";
-import { StoreApi } from "zustand";
+import { useStore, StoreApi } from "zustand";
 
 import { SettingsTree } from "@foxglove/studio";
+import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 export type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
 
@@ -18,3 +19,11 @@ export type PanelSettingsEditorStore = {
 export const PanelSettingsEditorContext = createContext<
   undefined | StoreApi<PanelSettingsEditorStore>
 >(undefined);
+
+export function usePanelSettingsEditorStore<T>(
+  selector: (store: PanelSettingsEditorStore) => T,
+  equalityFn?: (a: T, b: T) => boolean,
+): T {
+  const context = useGuaranteedContext(PanelSettingsEditorContext);
+  return useStore(context, selector, equalityFn);
+}

--- a/packages/studio-base/src/context/PanelSettingsEditorContext.ts
+++ b/packages/studio-base/src/context/PanelSettingsEditorContext.ts
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext } from "react";
+import { DeepReadonly } from "ts-essentials";
+import { StoreApi } from "zustand";
+
+import { SettingsTree } from "@foxglove/studio";
+
+export type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
+
+export type PanelSettingsEditorStore = {
+  settingsTrees: Record<string, ImmutableSettingsTree>;
+  updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
+};
+
+export const PanelSettingsEditorContext = createContext<
+  undefined | StoreApi<PanelSettingsEditorStore>
+>(undefined);

--- a/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
@@ -2,25 +2,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { ReactNode, useCallback } from "react";
-import { DeepReadonly } from "ts-essentials";
-import create, { StoreApi } from "zustand";
-import createContext from "zustand/context";
+import { ReactNode, useCallback, useState } from "react";
+import { createStore, useStore, StoreApi } from "zustand";
 
-import { SettingsTree } from "@foxglove/studio";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
+import {
+  ImmutableSettingsTree,
+  PanelSettingsEditorContext,
+  PanelSettingsEditorStore,
+} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
-type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
-
-export type PanelSettingsEditorStore = {
-  settingsTrees: Record<string, ImmutableSettingsTree>;
-  updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
-};
-
-const { Provider, useStore } = createContext<StoreApi<PanelSettingsEditorStore>>();
-
-export function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
-  return create((set) => {
+function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
+  return createStore((set) => {
     return {
       settingsTrees: {},
       updateSettingsTree: (panelId, settingsTree) => {
@@ -35,16 +29,22 @@ export function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> 
   });
 }
 
-export const usePanelSettingsEditorStore = useStore;
-
 const updateSettingsTreeSelector = (store: PanelSettingsEditorStore) => store.updateSettingsTree;
+
+export function usePanelSettingsEditorStore<T>(
+  selector: (store: PanelSettingsEditorStore) => T,
+  equalityFn?: (a: T, b: T) => boolean,
+): T {
+  const context = useGuaranteedContext(PanelSettingsEditorContext);
+  return useStore(context, selector, equalityFn);
+}
 
 /**
  * Returns updater function for the current panels settings tree.
  */
 export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) => void {
   const { id } = usePanelContext();
-  const updateStoreTree = useStore(updateSettingsTreeSelector);
+  const updateStoreTree = usePanelSettingsEditorStore(updateSettingsTreeSelector);
 
   const updateSettingsTree = useCallback(
     (newTree: ImmutableSettingsTree) => {
@@ -61,5 +61,11 @@ export function PanelSettingsEditorContextProvider({
 }: {
   children?: ReactNode;
 }): JSX.Element {
-  return <Provider createStore={createSettingsEditorStore}>{children}</Provider>;
+  const [store] = useState(createSettingsEditorStore());
+
+  return (
+    <PanelSettingsEditorContext.Provider value={store}>
+      {children}
+    </PanelSettingsEditorContext.Provider>
+  );
 }

--- a/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelSettingsEditorContextProvider.tsx
@@ -3,15 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { ReactNode, useCallback, useState } from "react";
-import { createStore, useStore, StoreApi } from "zustand";
+import { createStore, StoreApi } from "zustand";
 
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   ImmutableSettingsTree,
   PanelSettingsEditorContext,
   PanelSettingsEditorStore,
+  usePanelSettingsEditorStore,
 } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
-import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
   return createStore((set) => {
@@ -30,14 +30,6 @@ function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
 }
 
 const updateSettingsTreeSelector = (store: PanelSettingsEditorStore) => store.updateSettingsTree;
-
-export function usePanelSettingsEditorStore<T>(
-  selector: (store: PanelSettingsEditorStore) => T,
-  equalityFn?: (a: T, b: T) => boolean,
-): T {
-  const context = useGuaranteedContext(PanelSettingsEditorContext);
-  return useStore(context, selector, equalityFn);
-}
 
 /**
  * Returns updater function for the current panels settings tree.

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -36,6 +36,7 @@ import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
+import { usePanelSettingsEditorStore } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
 import {
   UserNodeStateProvider,
   useUserNodeState,
@@ -53,10 +54,7 @@ import {
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import HelpInfoProvider from "@foxglove/studio-base/providers/HelpInfoProvider";
-import {
-  PanelSettingsEditorContextProvider,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
As of v4 it's no longer necessary to use the wrapped `zustand/context`. The store can be used directly as a value for a vanilla react context.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
