### PR TITLE
3D beta: fix some settings bugs

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -435,6 +435,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
     (action: SettingsTreeAction) =>
+      // Wrapping in unstable_batchedUpdates causes React to run effects _after_ the handleAction
+      // function has finished executing. This allows scene extensions that call
+      // renderer.updateConfig to read out the new config value and configure their renderables
+      // before the render occurs.
       ReactDOM.unstable_batchedUpdates(() => renderer?.settings.handleAction(action)),
     [renderer],
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -434,7 +434,8 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
-    (action: SettingsTreeAction) => renderer?.settings.handleAction(action),
+    (action: SettingsTreeAction) =>
+      ReactDOM.unstable_batchedUpdates(() => renderer?.settings.handleAction(action)),
     [renderer],
   );
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -113,7 +113,7 @@ export class Markers extends SceneExtension<TopicMarkers> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsMarker>
         | undefined;
-      topicMarkers.userData.settings = { ...topicMarkers.userData.settings, ...settings };
+      topicMarkers.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
       topicMarkers.update();
     }
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -131,7 +131,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsOccupancyGrid>
         | undefined;
-      renderable.userData.settings = { ...renderable.userData.settings, ...settings };
+      renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
 
       // Check if the transparency changed and we need to create a new material
       const newTransparent = occupancyGridHasTransparency(renderable.userData.settings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -235,7 +235,8 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       // Remove expired entries from the history of points when decayTime is enabled
       const pointsHistory = renderable.userData.pointsHistory;
       const decayTime = renderable.userData.settings.decayTime;
-      const expireTime = decayTime > 0 ? currentTime - BigInt(decayTime * 1e9) : MAX_DURATION;
+      const expireTime =
+        decayTime > 0 ? currentTime - BigInt(Math.round(decayTime * 1e9)) : MAX_DURATION;
       while (pointsHistory.length > 1 && pointsHistory[0]!.receiveTime < expireTime) {
         const entry = renderable.userData.pointsHistory.shift()!;
         renderable.remove(entry.points);
@@ -1261,6 +1262,7 @@ function settingsNode(
     input: "number",
     step: 0.5,
     placeholder: "0 seconds",
+    min: 0,
     precision: 3,
     value: decayTime,
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -292,7 +292,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       const prevSettings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...renderable.userData.settings, ...prevSettings };
+      const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
       if (renderable.userData.pointCloud) {
         this._updatePointCloudRenderable(
           renderable,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Polygons.ts
@@ -110,7 +110,7 @@ export class Polygons extends SceneExtension<PolygonRenderable> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsPolygon>
         | undefined;
-      renderable.userData.settings = { ...renderable.userData.settings, ...settings };
+      renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
       this._updatePolygonRenderable(
         renderable,
         renderable.userData.polygonStamped,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PoseArrays.ts
@@ -209,7 +209,7 @@ export class PoseArrays extends SceneExtension<PoseArrayRenderable> {
         renderable,
         renderable.userData.poseArrayMessage,
         renderable.userData.receiveTime,
-        { ...renderable.userData.settings, ...settings },
+        { ...DEFAULT_SETTINGS, ...settings },
       );
     }
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Poses.ts
@@ -196,7 +196,7 @@ export class Poses extends SceneExtension<PoseRenderable> {
         renderable,
         renderable.userData.poseMessage,
         renderable.userData.receiveTime,
-        { ...renderable.userData.settings, ...settings },
+        { ...DEFAULT_SETTINGS, ...settings },
       );
     }
   };


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
- Fixes #4284, which occurred because the old settings were being spread in with the new settings, rather than falling back to the defaults.
- Fixes a crash when scrubbing on the decay time field. Adds missing `min` to decay time setting.
- Fixes issues with some settings not updating the UI immediately (because the scene was re-rendering before the update was fully applied).