### PR TITLE
Bugfix 4341 4130 inconsistent time formatting

### DIFF
--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -152,7 +152,7 @@ export function DataSourceInfoView(): JSX.Element {
       endTimeRef={endTimeRef}
       playerName={playerName}
       playerPresence={playerPresence}
-      startTime={endTime}
+      startTime={startTime}
     />
   );
 }

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -75,12 +75,7 @@ function DataSourceInfoContent(props: {
         ) : startTime ? (
           <Timestamp horizontal time={startTime} />
         ) : (
-          <Typography
-            className={classes.numericValue}
-            fontFamily={fonts.MONOSPACE}
-            variant="inherit"
-            color="text.secondary"
-          >
+          <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
             &mdash;
           </Typography>
         )}
@@ -93,12 +88,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : (
-          <Typography
-            className={classes.numericValue}
-            fontFamily={fonts.MONOSPACE}
-            variant="inherit"
-            ref={endTimeRef}
-          >
+          <Typography className={classes.numericValue} variant="inherit" ref={endTimeRef}>
             &mdash;
           </Typography>
         )}
@@ -111,12 +101,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width={100} />
         ) : (
-          <Typography
-            className={classes.numericValue}
-            fontFamily={fonts.MONOSPACE}
-            variant="inherit"
-            ref={durationRef}
-          >
+          <Typography className={classes.numericValue} variant="inherit" ref={durationRef}>
             &mdash;
           </Typography>
         )}
@@ -167,7 +152,7 @@ export function DataSourceInfoView(): JSX.Element {
       endTimeRef={endTimeRef}
       playerName={playerName}
       playerPresence={playerPresence}
-      startTime={startTime}
+      startTime={endTime}
     />
   );
 }

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -75,7 +75,12 @@ function DataSourceInfoContent(props: {
         ) : startTime ? (
           <Timestamp horizontal time={startTime} />
         ) : (
-          <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
+          <Typography
+            className={classes.numericValue}
+            fontFamily={fonts.MONOSPACE}
+            variant="inherit"
+            color="text.secondary"
+          >
             &mdash;
           </Typography>
         )}
@@ -88,7 +93,12 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : (
-          <Typography className={classes.numericValue} variant="inherit" ref={endTimeRef}>
+          <Typography
+            className={classes.numericValue}
+            fontFamily={fonts.MONOSPACE}
+            variant="inherit"
+            ref={endTimeRef}
+          >
             &mdash;
           </Typography>
         )}
@@ -101,7 +111,12 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width={100} />
         ) : (
-          <Typography className={classes.numericValue} variant="inherit" ref={durationRef}>
+          <Typography
+            className={classes.numericValue}
+            fontFamily={fonts.MONOSPACE}
+            variant="inherit"
+            ref={durationRef}
+          >
             &mdash;
           </Typography>
         )}

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -16,7 +16,7 @@ import Timestamp from "@foxglove/studio-base/components/Timestamp";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import { formatDate, formatDuration } from "@foxglove/studio-base/util/formatTime";
+import { formatDuration } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { MultilineMiddleTruncate } from "./MultilineMiddleTruncate";
@@ -34,12 +34,12 @@ const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => player
 
 function DataSourceInfoContent(props: {
   durationRef: MutableRefObject<ReactNull | HTMLDivElement>;
-  endTimeRef: MutableRefObject<ReactNull | HTMLDivElement>;
   playerName?: string;
   playerPresence: PlayerPresence;
+  endTime?: Time;
   startTime?: Time;
 }): JSX.Element {
-  const { durationRef, endTimeRef, playerName, playerPresence, startTime } = props;
+  const { durationRef, endTime, playerName, playerPresence, startTime } = props;
   const { classes } = useStyles();
 
   return (
@@ -86,8 +86,10 @@ function DataSourceInfoContent(props: {
         </Typography>
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
+        ) : endTime ? (
+          <Timestamp horizontal time={endTime} />
         ) : (
-          <Typography className={classes.numericValue} variant="inherit" ref={endTimeRef}>
+          <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
             &mdash;
           </Typography>
         )}
@@ -119,7 +121,6 @@ export function DataSourceInfoView(): JSX.Element {
   const playerName = useMessagePipeline(selectPlayerName);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const durationRef = useRef<HTMLDivElement>(ReactNull);
-  const endTimeRef = useRef<HTMLDivElement>(ReactNull);
   const { formatTime } = useAppTimeFormat();
 
   // We bypass react and update the DOM elements directly for better performance here.
@@ -133,23 +134,15 @@ export function DataSourceInfoView(): JSX.Element {
         durationRef.current.innerText = EmDash;
       }
     }
-    if (endTimeRef.current) {
-      if (endTime) {
-        const date = formatDate(endTime, undefined);
-        endTimeRef.current.innerText = `${date} ${formatTime(endTime)}`;
-      } else {
-        endTimeRef.current.innerHTML = EmDash;
-      }
-    }
   }, [endTime, formatTime, startTime, playerPresence]);
 
   return (
     <MemoDataSourceInfoContent
       durationRef={durationRef}
-      endTimeRef={endTimeRef}
       playerName={playerName}
       playerPresence={playerPresence}
       startTime={startTime}
+      endTime={endTime}
     />
   );
 }

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -35,7 +35,7 @@ const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => player
 
 function DataSourceInfoContent(props: {
   durationRef: MutableRefObject<ReactNull | HTMLDivElement>;
-  endTimeRef?: MutableRefObject<ReactNull | HTMLDivElement>;
+  endTimeRef: MutableRefObject<ReactNull | HTMLDivElement>;
   playerName?: string;
   playerPresence: PlayerPresence;
   startTime?: Time;

--- a/packages/studio-base/src/components/Timestamp.tsx
+++ b/packages/studio-base/src/components/Timestamp.tsx
@@ -29,7 +29,9 @@ export default function Timestamp(props: Props): JSX.Element {
   if (!isAbsoluteTime(time)) {
     return (
       <Stack direction="row" alignItems="center" flexGrow={0}>
-        <Typography fontFamily={fonts.MONOSPACE}>{rawTimeStr}</Typography>
+        <Typography fontFamily={fonts.MONOSPACE} variant="inherit">
+          {rawTimeStr}
+        </Typography>
       </Stack>
     );
   }

--- a/packages/studio-base/src/components/Timestamp.tsx
+++ b/packages/studio-base/src/components/Timestamp.tsx
@@ -10,7 +10,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { formatDate } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
-import { formatTimeRaw } from "@foxglove/studio-base/util/time";
+import { isAbsoluteTime, formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 type Props = {
   disableDate?: boolean;
@@ -18,13 +18,6 @@ type Props = {
   time: Time;
   timezone?: string;
 };
-
-const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
-
-// Values "too small" to be absolute epoch-based times are probably relative durations.
-function isAbsoluteTime(time: Time): boolean {
-  return time.sec > DURATION_20_YEARS_SEC;
-}
 
 export default function Timestamp(props: Props): JSX.Element {
   const { disableDate = false, horizontal = false, time, timezone } = props;

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -27,6 +27,13 @@ export function formatTimeRaw(stamp: Time): string {
   return `${stamp.sec}.${stamp.nsec.toFixed().padStart(9, "0")}`;
 }
 
+const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
+
+// Values "too small" to be absolute epoch-based times are probably relative durations.
+export function isAbsoluteTime(time: Time): boolean {
+  return time.sec > DURATION_20_YEARS_SEC;
+}
+
 export function formatFrame({ sec, nsec }: Time): string {
   return `${sec}.${String.prototype.padStart.call(nsec, 9, "0")}`;
 }


### PR DESCRIPTION
**User-Facing Changes**

<img width="372" alt="Screen Shot 2022-09-02 at 11 57 27 AM" src="https://user-images.githubusercontent.com/44953690/188125436-0a32cd42-40f6-4ca8-8188-68fa379cfac4.png">


**Description**
I took a closer look and discovered that the start time was being passed into the Timestamp component which contains a function for properly formatting nonabsolute time:

```
if (!isAbsoluteTime(time)) {
    return (
      <Stack direction="row" alignItems="center" flexGrow={0}>
        <Typography fontFamily={fonts.MONOSPACE}>{rawTimeStr}</Typography>
      </Stack>
    );
  }
```

The end-time wasn't being passed into the timestamp component hence the error.

Initially, I scrapped the ref completely for endTime and used the `<TimeStamp />` component to keep it uniform with startTime. I noticed that would introduce performance loss in relation to @foxymiles improvements in #4273. So instead I decided to format it manually and append it to the ref's innerHTML as a walk-around.

```
endTimeRef.current.innerText = !isAbsoluteTime(endTime)
          ? `${formatTimeRaw(endTime)}`
          : `${date} ${formatTime(endTime)}`;
          
```

On further digging, I noticed that issue #4130 was also caused by the `<TimeStamp />` component returning different typography for absolute time. Adding variant="inherit" to the absolute time typography fixed that.

```
<Typography
            className={classes.numericValue}
            variant="inherit" // this was also missing
            ref={endTimeRef}
>
``` 

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
