### PR TITLE
Fix bug #4088 set Playhead to start on .bag load

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -576,7 +576,6 @@ export class IterablePlayer implements Player {
       clearTimeout(tickTimeout);
     }
 
-    this._currentTime = stopTime;
     this._messages = messageEvents;
     this._presence = PlayerPresence.PRESENT;
     this._queueEmitState();


### PR DESCRIPTION
**User-Facing Changes**

https://user-images.githubusercontent.com/44953690/188307222-da2f6183-f6e8-4baa-99a0-181539311c35.mov

**Description**
It seems this was a `bug` not a `UX` issue. 

When Studio loads a bag file for the first time it reads a small amount of data from the data source with the hope of producing a message or two.
Without an initial read, the user would be looking at a blank layout since no messages have yet been delivered.
 

Studio was setting the currentTime to the stopTime from the preload, which was causing the slider to jump ahead a little.

You can read more about it at IterablePlayer.ts on line 519


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
