### PR TITLE
Use system color scheme instead of dark theme by default

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -45,7 +45,7 @@ function isFileToOpen(arg: string) {
 }
 
 function updateNativeColorScheme() {
-  const colorScheme = getAppSetting<string>(AppSetting.COLOR_SCHEME) ?? "dark";
+  const colorScheme = getAppSetting<string>(AppSetting.COLOR_SCHEME) ?? "system";
   nativeTheme.themeSource =
     colorScheme === "dark" ? "dark" : colorScheme === "light" ? "light" : "system";
 }

--- a/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
+++ b/packages/studio-base/src/components/ColorSchemeThemeProvider.tsx
@@ -11,7 +11,7 @@ import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 export function ColorSchemeThemeProvider({
   children,
 }: React.PropsWithChildren<unknown>): JSX.Element {
-  const [colorScheme = "dark"] = useAppConfigurationValue<string>(AppSetting.COLOR_SCHEME);
+  const [colorScheme = "system"] = useAppConfigurationValue<string>(AppSetting.COLOR_SCHEME);
   const systemSetting = useMedia("(prefers-color-scheme: dark)");
   const isDark = colorScheme === "dark" || (colorScheme === "system" && systemSetting);
   return <ThemeProvider isDark={isDark}>{children}</ThemeProvider>;

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -79,7 +79,7 @@ function formatTimezone(name: string) {
 
 function ColorSchemeSettings(): JSX.Element {
   const { classes } = useStyles();
-  const [colorScheme = "dark", setColorScheme] = useAppConfigurationValue<string>(
+  const [colorScheme = "system", setColorScheme] = useAppConfigurationValue<string>(
     AppSetting.COLOR_SCHEME,
   );
 


### PR DESCRIPTION
**User-Facing Changes**
The system's color scheme is now used by default instead of dark mode. The color scheme can be changed in the Preferences sidebar.

**Details**
Related: https://github.com/foxglove/studio/issues/4234