### PR TITLE
Add spheres scene entity support to new 3D panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -19,6 +19,7 @@ import { RenderableCubes } from "./primitives/RenderableCubes";
 import { RenderableCylinders } from "./primitives/RenderableCylinders";
 import { RenderableLines } from "./primitives/RenderableLines";
 import { RenderableModels } from "./primitives/RenderableModels";
+import { RenderableSpheres } from "./primitives/RenderableSpheres";
 import { ALL_PRIMITIVE_TYPES, PrimitiveType } from "./primitives/types";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
 
@@ -35,6 +36,7 @@ type EntityRenderables = {
   [PrimitiveType.LINES]?: RenderableLines;
   [PrimitiveType.CYLINDERS]?: RenderableCylinders;
   [PrimitiveType.ARROWS]?: RenderableArrows;
+  [PrimitiveType.SPHERES]?: RenderableSpheres;
 };
 
 const PRIMITIVE_KEYS = {
@@ -43,6 +45,7 @@ const PRIMITIVE_KEYS = {
   [PrimitiveType.LINES]: "lines",
   [PrimitiveType.CYLINDERS]: "cylinders",
   [PrimitiveType.ARROWS]: "arrows",
+  [PrimitiveType.SPHERES]: "spheres",
 } as const;
 
 export class TopicEntities extends Renderable<EntityTopicUserData> {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/PrimitivePool.ts
@@ -9,6 +9,7 @@ import { RenderableCylinders } from "./RenderableCylinders";
 import { RenderableLines } from "./RenderableLines";
 import { RenderableModels } from "./RenderableModels";
 import { RenderablePrimitive } from "./RenderablePrimitive";
+import { RenderableSpheres } from "./RenderableSpheres";
 import { PrimitiveType } from "./types";
 
 const CONSTRUCTORS = {
@@ -17,6 +18,7 @@ const CONSTRUCTORS = {
   [PrimitiveType.LINES]: RenderableLines,
   [PrimitiveType.CYLINDERS]: RenderableCylinders,
   [PrimitiveType.ARROWS]: RenderableArrows,
+  [PrimitiveType.SPHERES]: RenderableSpheres,
 };
 
 /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -1,0 +1,168 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+import { toNanoSec } from "@foxglove/rostime";
+import { SpherePrimitive, SceneEntity } from "@foxglove/schemas/schemas/typescript";
+import { emptyPose } from "@foxglove/studio-base/util/Pose";
+
+import type { Renderer } from "../../Renderer";
+import { makeRgba, rgbToThreeColor, stringToRgba } from "../../color";
+import { LayerSettingsEntity } from "../SceneEntities";
+import { MeshStandardMaterialWithInstanceOpacity } from "../materials/MeshStandardMaterialWithInstanceOpacity";
+import { RenderablePrimitive } from "./RenderablePrimitive";
+
+const tempColor = new THREE.Color();
+const tempVec3 = new THREE.Vector3();
+const tempVec3_2 = new THREE.Vector3();
+const tempMat4 = new THREE.Matrix4();
+const tempQuat = new THREE.Quaternion();
+const tempRgba = makeRgba();
+
+export class RenderableSpheres extends RenderablePrimitive {
+  private static sphereGeometry: THREE.SphereGeometry | undefined;
+
+  private geometry = new THREE.SphereGeometry(0.5, 16, 16);
+  private mesh: THREE.InstancedMesh<THREE.SphereGeometry, MeshStandardMaterialWithInstanceOpacity>;
+  private instanceOpacity: THREE.InstancedBufferAttribute;
+  private material = new MeshStandardMaterialWithInstanceOpacity({
+    metalness: 0,
+    roughness: 1,
+    dithering: true,
+  });
+
+  /**
+   * The initial count passed to `mesh`'s constructor, i.e. the maximum number of instances it can
+   * render before we need to create a new mesh object
+   */
+  private maxInstances: number;
+
+  public constructor(renderer: Renderer) {
+    super("", renderer, {
+      receiveTime: -1n,
+      messageTime: -1n,
+      frameId: "",
+      pose: emptyPose(),
+      settings: { visible: true, color: undefined },
+      settingsPath: [],
+      entity: undefined,
+    });
+
+    // Sphere mesh
+    this.maxInstances = 16;
+    this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
+    this.instanceOpacity = new THREE.InstancedBufferAttribute(
+      new Float32Array(this.maxInstances),
+      1,
+    );
+    this.geometry.copy(RenderableSpheres.Geometry());
+    this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
+    this.mesh.count = 0;
+    this.add(this.mesh);
+  }
+
+  private _ensureCapacity(numInstances: number) {
+    if (numInstances > this.maxInstances) {
+      const newCapacity = Math.trunc(numInstances * 1.5) + 16;
+      this.maxInstances = newCapacity;
+
+      this.mesh.removeFromParent();
+      this.mesh.dispose();
+      this.mesh = new THREE.InstancedMesh(this.mesh.geometry, this.material, this.maxInstances);
+      this.instanceOpacity = new THREE.InstancedBufferAttribute(
+        new Float32Array(this.maxInstances),
+        1,
+      );
+      this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
+      this.add(this.mesh);
+    }
+  }
+
+  private _updateMesh(spheres: SpherePrimitive[]) {
+    let isTransparent = false;
+
+    this._ensureCapacity(spheres.length);
+
+    const overrideColor = this.userData.settings.color
+      ? stringToRgba(tempRgba, this.userData.settings.color)
+      : undefined;
+
+    let i = 0;
+    for (const sphere of spheres) {
+      const color = overrideColor ?? sphere.color;
+      if (color.a < 1) {
+        isTransparent = true;
+      }
+      this.mesh.setColorAt(i, rgbToThreeColor(tempColor, color));
+      this.instanceOpacity.setX(i, color.a);
+      this.mesh.setMatrixAt(
+        i,
+        tempMat4.compose(
+          tempVec3.set(sphere.pose.position.x, sphere.pose.position.y, sphere.pose.position.z),
+          tempQuat.set(
+            sphere.pose.orientation.x,
+            sphere.pose.orientation.y,
+            sphere.pose.orientation.z,
+            sphere.pose.orientation.w,
+          ),
+          tempVec3_2.set(sphere.size.x, sphere.size.y, sphere.size.z),
+        ),
+      );
+      i++;
+    }
+
+    if (this.material.transparent !== isTransparent) {
+      this.material.transparent = isTransparent;
+      this.material.depthWrite = !isTransparent;
+      this.material.needsUpdate = true;
+    }
+
+    if (this.mesh.count === 0 && spheres.length > 0) {
+      // needed to make colors work: https://discourse.threejs.org/t/instancedmesh-color-doesnt-work-when-initial-count-is-0/41355
+      this.material.needsUpdate = true;
+    }
+    this.mesh.count = spheres.length;
+    this.mesh.instanceMatrix.needsUpdate = true;
+    this.instanceOpacity.needsUpdate = true;
+
+    // may be null if we were initialized with count 0 and still have 0 spheres
+    if (this.mesh.instanceColor) {
+      this.mesh.instanceColor.needsUpdate = true;
+    }
+  }
+
+  public override dispose(): void {
+    this.mesh.dispose();
+    this.geometry.dispose();
+    this.material.dispose();
+  }
+
+  public override update(
+    entity: SceneEntity | undefined,
+    settings: LayerSettingsEntity,
+    receiveTime: bigint,
+  ): void {
+    this.userData.entity = entity;
+    this.userData.settings = settings;
+    this.userData.receiveTime = receiveTime;
+    if (entity) {
+      const lifetimeNs = toNanoSec(entity.lifetime);
+      this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
+      this._updateMesh(entity.spheres);
+    }
+  }
+
+  public updateSettings(settings: LayerSettingsEntity): void {
+    this.update(this.userData.entity, settings, this.userData.receiveTime);
+  }
+
+  private static Geometry(): THREE.SphereGeometry {
+    if (!RenderableSpheres.sphereGeometry) {
+      RenderableSpheres.sphereGeometry = new THREE.SphereGeometry(0.5, 16, 16);
+      RenderableSpheres.sphereGeometry.computeBoundingSphere();
+    }
+    return RenderableSpheres.sphereGeometry;
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/types.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/types.ts
@@ -8,6 +8,7 @@ export enum PrimitiveType {
   LINES = "LINES",
   CYLINDERS = "CYLINDERS",
   ARROWS = "ARROWS",
+  SPHERES = "SPHERES",
 }
 
 export const ALL_PRIMITIVE_TYPES = [
@@ -16,4 +17,5 @@ export const ALL_PRIMITIVE_TYPES = [
   PrimitiveType.LINES,
   PrimitiveType.CYLINDERS,
   PrimitiveType.ARROWS,
+  PrimitiveType.SPHERES,
 ];

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -85,7 +85,18 @@ function makeStoryScene({
             },
           ],
 
-          spheres: [],
+          spheres: [
+            {
+              pose: xyzrpyToPose([0, 6, 0], [0, 0, 0]),
+              size: { x: 0.8, y: 0.5, z: 1 },
+              color: makeColor("#ff6136", 0.5),
+            },
+            {
+              pose: xyzrpyToPose([1, 6, 0], [0, 0, 30]),
+              size: { x: 0.4, y: 0.2, z: 1 },
+              color: makeColor("#afe6c3", 0.9),
+            },
+          ],
 
           cylinders: [
             {


### PR DESCRIPTION
**User-Facing Changes**
 - can now render Sphere entities using the foxglove schema in the new 3D panel

**Description**
 - add spheres renderable
 - add spheres as primitive type
- update scene entities story with spheres


<!-- link relevant github issues -->
Fixes #4316
<!-- add `docs` label if this PR requires documentation updates -->
