### PR TITLE
DP source: report parseChannel errors to Sentry

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { captureException } from "@sentry/core";
 import { isEqual, maxBy, minBy } from "lodash";
 
 import Logger from "@foxglove/log";
@@ -150,6 +151,7 @@ export class DataPlatformIterableSource implements IIterableSource {
           datatypes.set(name, datatype);
         }
       } catch (err) {
+        captureException(err, { extra: { rawTopic } });
         problems.push({
           message: `Failed to parse schema for topic ${topic}`,
           severity: "error",


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
While some of these errors may be from invalid user data, we feel that any errors while streaming from the data platform are unexpected to users, and this may help us debug future issues.