### PR TITLE
fix rosbridge test and remove remaining done()-style tests

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -107,7 +107,6 @@ rules:
         `// eslint-disable-next-line no-restricted-syntax`. For rationale, see:
         https://github.com/sindresorhus/meta/discussions/7"
 
-  jest/no-done-callback: off # Can be a useful alternative to promises
   jest/expect-expect:
     [error, { assertFunctionNames: [expect*, sendNotification.expectCalledDuringTest] }]
 

--- a/packages/studio-base/src/components/Icon.test.tsx
+++ b/packages/studio-base/src/components/Icon.test.tsx
@@ -15,6 +15,8 @@
 import CircleIcon from "@mdi/svg/svg/circle.svg";
 import { render } from "@testing-library/react";
 
+import { signal } from "@foxglove/den/async";
+
 import Icon from "./Icon";
 
 describe("<Icon />", () => {
@@ -27,11 +29,12 @@ describe("<Icon />", () => {
     expect(result.container.querySelector("svg")).not.toBeNullOrUndefined();
   });
 
-  it("stops click event with custom handler", (done) => {
+  it("stops click event with custom handler", async () => {
     expect.assertions(0);
+    const sig = signal();
     const Container = () => (
-      <div onClick={() => done("should not bubble")}>
-        <Icon onClick={() => done()}>
+      <div onClick={() => sig.reject(new Error("should not bubble"))}>
+        <Icon onClick={() => setTimeout(() => sig.resolve(), 0)}>
           <CircleIcon />
         </Icon>
       </div>
@@ -40,12 +43,14 @@ describe("<Icon />", () => {
     result.container
       .querySelector(".icon")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await sig;
   });
 
-  it("does not prevent click by default", (done) => {
+  it("does not prevent click by default", async () => {
     expect.assertions(0);
+    const sig = signal();
     const Container = () => (
-      <div onClick={() => done()}>
+      <div onClick={() => sig.resolve()}>
         <Icon>
           <CircleIcon />
         </Icon>
@@ -55,5 +60,6 @@ describe("<Icon />", () => {
     result.container
       .querySelector(".icon")
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await sig;
   });
 });

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.test.tsx
@@ -4,6 +4,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+/* eslint-disable jest/no-done-callback */
+
 import { render } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 

--- a/packages/studio-base/src/players/RosbridgePlayer.test.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.test.ts
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { signal } from "@foxglove/den/async";
 import { Time } from "@foxglove/rostime";
 import NoopMetricsCollector from "@foxglove/studio-base/players/NoopMetricsCollector";
 import RosbridgePlayer from "@foxglove/studio-base/players/RosbridgePlayer";
@@ -144,7 +145,7 @@ describe("RosbridgePlayer", () => {
     player.close();
   });
 
-  it("subscribes to topics without errors", (done) => {
+  it("subscribes to topics without errors", async () => {
     workerInstance.setup({
       topics: ["/topic/A"],
       types: ["/std_msgs/Header", "rosgraph_msgs/Log"],
@@ -159,6 +160,7 @@ describe("RosbridgePlayer", () => {
       ],
     });
 
+    const sig = signal();
     player.setSubscriptions([{ topic: "/topic/A" }]);
     player.setListener(async ({ activeData }) => {
       const { topics } = activeData ?? {};
@@ -167,8 +169,10 @@ describe("RosbridgePlayer", () => {
       }
 
       expect(topics).toStrictEqual([{ name: "/topic/A", datatype: "/std_msgs/Header" }]);
-      done();
+      sig.resolve();
     });
+
+    await sig;
   });
 
   describe("parsedMessages", () => {
@@ -205,9 +209,10 @@ describe("RosbridgePlayer", () => {
       });
     });
 
-    it("returns parsedMessages with complex type", (done) => {
+    it("returns parsedMessages with complex type", async () => {
       player.setSubscriptions([{ topic: "/topic/A" }]);
 
+      const sig = signal();
       player.setListener(async ({ activeData }) => {
         const { messages } = activeData ?? {};
         if (!messages) {
@@ -223,13 +228,15 @@ describe("RosbridgePlayer", () => {
           },
         });
 
-        done();
+        sig.resolve();
       });
+      await sig;
     });
 
-    it("returns parsedMessages with basic types", (done) => {
+    it("returns parsedMessages with basic types", async () => {
       player.setSubscriptions([{ topic: "/topic/B" }]);
 
+      const sig = signal();
       player.setListener(async ({ activeData }) => {
         const { messages } = activeData ?? {};
         if (!messages) {
@@ -241,8 +248,9 @@ describe("RosbridgePlayer", () => {
           text: "some text",
         });
 
-        done();
+        sig.resolve();
       });
+      await sig;
     });
   });
 });


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Remove remaining `done()`-style tests (fixing a RosbridgePlayer test failure that happened only locally for some reason).
Re-enable the Jest lint rule that disallows this style of test. We have utilities such as `signal()`, `Condvar`, and `new Promise()` that make it relatively painless to avoid using `done`.