### PR TITLE
Update default 3d camera position

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
@@ -30,13 +30,13 @@ export type CameraState = {
 };
 
 export const DEFAULT_CAMERA_STATE: CameraState = {
-  distance: 75,
+  distance: 20,
   perspective: true,
-  phi: 45,
+  phi: 60,
   target: [0, 0, 0],
   targetOffset: [0, 0, 0],
   targetOrientation: [0, 0, 0, 1],
-  thetaOffset: 0,
+  thetaOffset: 45,
   fovy: 45,
   near: 0.01,
   far: 5000,


### PR DESCRIPTION
**User-Facing Changes**
Zoom in the 3d camera and angle it more by default. Personal preference based on some tweaks and assuming that many common robots are even smaller than cars.

Bonus: it makes the TF labels possible to read.

**Before**
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/637671/189060079-9ab5d3a8-4fce-4057-ae63-e9ce8059bc6a.png">
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/637671/189059971-fa502e57-54fa-496f-beac-33beaaf688f6.png">

**After**
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/637671/189059694-aa06f2bb-0a2b-4142-95cb-09cd72e973c2.png">
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/637671/189059760-79b68fa6-106c-4a60-8c3a-931cac9dd891.png">
