### PR TITLE
Move settings actions after error icon

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -272,9 +272,6 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               disabled={!allowVisibilityToggle}
             />
           )}
-          {settings.actions && (
-            <NodeActionsMenu actions={settings.actions} onSelectAction={handleNodeAction} />
-          )}
           {props.settings?.error && (
             <Tooltip
               arrow
@@ -284,6 +281,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
                 <ErrorIcon fontSize="small" />
               </IconButton>
             </Tooltip>
+          )}
+          {settings.actions && (
+            <NodeActionsMenu actions={settings.actions} onSelectAction={handleNodeAction} />
           )}
         </Stack>
       </NodeHeader>


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out.

Before

<img width="657" alt="image" src="https://user-images.githubusercontent.com/84792/189184010-e4c7be8d-5094-4e0f-ace3-a94e0f11b8ee.png">


After

<img width="642" alt="image" src="https://user-images.githubusercontent.com/84792/189183904-4d2c9f0d-9132-4df6-ab13-1f003c85851e.png">


**Description**
The settings actions are represented as a context menu icon. The typical pattern for context menu icons is to appear at the start or end of the component (or line) as the vertical dot icons are representative of a "more" action.

This change moves the actions icon after the error icon in the NodeEditor.

The error indicator was placed after the actions in https://github.com/foxglove/studio/pull/3384/ which correctly moved the actions after the visibility icon but also placed them before the error icon rather than at the end.

Fixes: #4268


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
