### PR TITLE
update Raw Message to link to foxglove docs for foxglove datatypes

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -56,24 +56,27 @@ export default function Metadata({
   diffMessage,
 }: Props): JSX.Element {
   const { classes } = useStyles();
+  const docsLink = datatype ? getMessageDocumentationLink(datatype) : undefined;
   return (
     <Stack alignItems="flex-start" padding={0.25}>
       <Stack direction="row" alignItems="center" gap={0.5}>
         <Typography variant="caption" lineHeight={1.2} color="text.secondary">
-          {diffMessage
-            ? "base"
-            : datatype && (
-                <Link
-                  target="_blank"
-                  color="inherit"
-                  variant="caption"
-                  underline="hover"
-                  rel="noopener noreferrer"
-                  href={getMessageDocumentationLink(datatype)}
-                >
-                  {datatype}
-                </Link>
-              )}
+          {diffMessage ? (
+            "base"
+          ) : docsLink ? (
+            <Link
+              target="_blank"
+              color="inherit"
+              variant="caption"
+              underline="hover"
+              rel="noopener noreferrer"
+              href={docsLink}
+            >
+              {datatype}
+            </Link>
+          ) : (
+            datatype
+          )}
           {` @ ${formatTimeRaw(message.receiveTime)} sec`}
         </Typography>
         <CopyButton

--- a/packages/studio-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.test.ts
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getMessageDocumentationLink } from "@foxglove/studio-base/panels/RawMessages/utils";
+
+describe("getMessageDocumentationLink", () => {
+  it("links to ROS and Foxglove docs", () => {
+    expect(getMessageDocumentationLink("std_msgs/String")).toEqual(
+      "https://docs.ros.org/api/std_msgs/html/msg/String.html",
+    );
+    expect(getMessageDocumentationLink("foxglove_msgs/CircleAnnotation")).toEqual(
+      "https://foxglove.dev/docs/studio/messages/circle-annotation",
+    );
+    expect(getMessageDocumentationLink("foxglove_msgs/msg/CircleAnnotation")).toEqual(
+      "https://foxglove.dev/docs/studio/messages/circle-annotation",
+    );
+    expect(getMessageDocumentationLink("foxglove.CircleAnnotation")).toEqual(
+      "https://foxglove.dev/docs/studio/messages/circle-annotation",
+    );
+    expect(getMessageDocumentationLink("foxglove.DoesNotExist")).toEqual(
+      "https://www.google.com/search?q=foxglove.DoesNotExist",
+    );
+  });
+});

--- a/packages/studio-base/src/panels/RawMessages/utils.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.test.ts
@@ -18,8 +18,6 @@ describe("getMessageDocumentationLink", () => {
     expect(getMessageDocumentationLink("foxglove.CircleAnnotation")).toEqual(
       "https://foxglove.dev/docs/studio/messages/circle-annotation",
     );
-    expect(getMessageDocumentationLink("foxglove.DoesNotExist")).toEqual(
-      "https://www.google.com/search?q=foxglove.DoesNotExist",
-    );
+    expect(getMessageDocumentationLink("foxglove.DoesNotExist")).toBeUndefined();
   });
 });

--- a/packages/studio-base/src/panels/RawMessages/utils.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.ts
@@ -11,12 +11,13 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { first, last } from "lodash";
+import { first, kebabCase, last } from "lodash";
 
+import { foxgloveMessageSchemas } from "@foxglove/schemas";
 import { diffLabels, DiffObject } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 
 export const DATA_ARRAY_PREVIEW_LIMIT = 20;
-export const ROS_COMMON_MSGS: Set<string> = new Set([
+const ROS_COMMON_MSG_PACKAGES: Set<string> = new Set([
   "actionlib_msgs",
   "diagnostic_msgs",
   "geometry_msgs",
@@ -98,11 +99,27 @@ export function getChangeCounts(
   return startingCounts;
 }
 
+const foxgloveDocsLinksByDatatype = new Map<string, string>();
+for (const schema of Object.values(foxgloveMessageSchemas)) {
+  const url = `https://foxglove.dev/docs/studio/messages/${kebabCase(schema.name)}`;
+  foxgloveDocsLinksByDatatype.set(`foxglove_msgs/${schema.name}`, url);
+  foxgloveDocsLinksByDatatype.set(`foxglove_msgs/msg/${schema.name}`, url);
+  foxgloveDocsLinksByDatatype.set(`foxglove.${schema.name}`, url);
+}
+
 export function getMessageDocumentationLink(datatype: string): string {
-  const parts = datatype.split("/");
+  const parts = datatype.split(/[/.]/);
   const pkg = first(parts);
   const filename = last(parts);
-  return pkg != undefined && ROS_COMMON_MSGS.has(pkg)
-    ? `http://docs.ros.org/api/${pkg}/html/msg/${filename}.html`
-    : `https://www.google.com/search?q=${pkg}/${filename}`;
+
+  if (pkg != undefined && ROS_COMMON_MSG_PACKAGES.has(pkg)) {
+    return `https://docs.ros.org/api/${pkg}/html/msg/${filename}.html`;
+  }
+
+  const foxgloveDocsLink = foxgloveDocsLinksByDatatype.get(datatype);
+  if (foxgloveDocsLink != undefined) {
+    return foxgloveDocsLink;
+  }
+
+  return `https://www.google.com/search?q=${datatype}`;
 }

--- a/packages/studio-base/src/panels/RawMessages/utils.ts
+++ b/packages/studio-base/src/panels/RawMessages/utils.ts
@@ -13,23 +13,13 @@
 
 import { first, kebabCase, last } from "lodash";
 
+import { definitions as commonDefs } from "@foxglove/rosmsg-msgs-common";
 import { foxgloveMessageSchemas } from "@foxglove/schemas";
 import { diffLabels, DiffObject } from "@foxglove/studio-base/panels/RawMessages/getDiff";
 
 export const DATA_ARRAY_PREVIEW_LIMIT = 20;
-const ROS_COMMON_MSG_PACKAGES: Set<string> = new Set([
-  "actionlib_msgs",
-  "diagnostic_msgs",
-  "geometry_msgs",
-  "nav_msgs",
-  "sensor_msgs",
-  "shape_msgs",
-  "std_msgs",
-  "stereo_msgs",
-  "trajectory_msgs",
-  "visualization_msgs",
-  "turtlesim",
-]);
+const ROS_COMMON_MSG_PACKAGES = new Set(Object.keys(commonDefs).map((key) => key.split("/")[0]!));
+ROS_COMMON_MSG_PACKAGES.add("turtlesim");
 
 function isTypedArray(obj: unknown) {
   return Boolean(
@@ -107,7 +97,7 @@ for (const schema of Object.values(foxgloveMessageSchemas)) {
   foxgloveDocsLinksByDatatype.set(`foxglove.${schema.name}`, url);
 }
 
-export function getMessageDocumentationLink(datatype: string): string {
+export function getMessageDocumentationLink(datatype: string): string | undefined {
   const parts = datatype.split(/[/.]/);
   const pkg = first(parts);
   const filename = last(parts);
@@ -121,5 +111,5 @@ export function getMessageDocumentationLink(datatype: string): string {
     return foxgloveDocsLink;
   }
 
-  return `https://www.google.com/search?q=${datatype}`;
+  return undefined;
 }


### PR DESCRIPTION
**User-Facing Changes**
When using Foxglove schemas, Raw Messages panel now includes a link to the schema documentation.

**Description**
I thought we had a ticket for this but I can't find it...