### PR TITLE
[3D] Preload transform topics

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -157,8 +157,15 @@ export type RendererConfig = {
 export type MessageHandler<T = unknown> = (messageEvent: MessageEvent<T>) => void;
 
 export type RendererSubscription<T = unknown> = {
+  /** Preload the full history of topic messages as a best effort */
   preload?: boolean;
+  /**
+   * By default, topic subscriptions are only created when the topic visibility
+   * has been toggled on by the user in the settings sidebar. Enabling forced
+   * will unconditionally create the topic subscription(s)
+   */
   forced?: boolean;
+  /** Callback that will be fired for each matching incoming message */
   handler: MessageHandler<T>;
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -68,7 +68,7 @@ import {
   TRANSFORM_STAMPED_DATATYPES,
   Vector3,
 } from "./ros";
-import { BaseSettings, CustomLayerSettings, SelectEntry, SubscriptionType } from "./settings";
+import { BaseSettings, CustomLayerSettings, SelectEntry } from "./settings";
 import { makePose, Pose, Transform, TransformTree } from "./transforms";
 
 const log = Logger.getLogger(__filename);
@@ -154,7 +154,13 @@ export type RendererConfig = {
 };
 
 /** Callback for handling a message received on a topic */
-export type MessageHandler = (messageEvent: MessageEvent<unknown>) => void;
+export type MessageHandler<T = unknown> = (messageEvent: MessageEvent<T>) => void;
+
+export type RendererSubscription<T = unknown> = {
+  preload?: boolean;
+  forced?: boolean;
+  handler: MessageHandler<T>;
+};
 
 /** Menu item entry and callback for the "Custom Layers" menu */
 export type CustomLayerAction = {
@@ -248,14 +254,10 @@ export class Renderer extends EventEmitter<RendererEvents> {
   public variables: ReadonlyMap<string, VariableValue> = new Map();
   // extensionId -> SceneExtension
   public sceneExtensions = new Map<string, SceneExtension>();
-  // datatype -> handler[], only active when visibility is toggled on
-  public datatypeHandlers = new Map<string, MessageHandler[]>();
-  // datatype -> handler[], always active
-  public forcedDatatypeHandlers = new Map<string, MessageHandler[]>();
-  // topicName -> handler[], only active when visibility is toggled on
-  public topicHandlers = new Map<string, MessageHandler[]>();
-  // topicName -> handler[], always active
-  public forcedTopicHandlers = new Map<string, MessageHandler[]>();
+  // datatype -> RendererSubscription[]
+  public datatypeHandlers = new Map<string, RendererSubscription[]>();
+  // topicName -> RendererSubscription[]
+  public topicHandlers = new Map<string, RendererSubscription[]>();
   // layerId -> { action, handler }
   private customLayerActions = new Map<string, CustomLayerAction>();
   private scene: THREE.Scene;
@@ -419,10 +421,21 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.coreSettings = new CoreSettings(this);
 
     // Internal handlers for TF messages to update the transform tree
-    const always = SubscriptionType.Always;
-    this.addDatatypeSubscriptions(FRAME_TRANSFORM_DATATYPES, this.handleFrameTransform, always);
-    this.addDatatypeSubscriptions(TF_DATATYPES, this.handleTFMessage, always);
-    this.addDatatypeSubscriptions(TRANSFORM_STAMPED_DATATYPES, this.handleTransformStamped, always);
+    this.addDatatypeSubscriptions(FRAME_TRANSFORM_DATATYPES, {
+      handler: this.handleFrameTransform,
+      forced: true,
+      preload: true,
+    });
+    this.addDatatypeSubscriptions(TF_DATATYPES, {
+      handler: this.handleTFMessage,
+      forced: true,
+      preload: true,
+    });
+    this.addDatatypeSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
+      handler: this.handleTransformStamped,
+      forced: true,
+      preload: true,
+    });
 
     this.addSceneExtension(this.coreSettings);
     this.addSceneExtension(new Cameras(this));
@@ -488,10 +501,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
    * This is useful when seeking to a new playback position or when a new data source is loaded.
    */
   public clear(): void {
-    // These must be cleared before calling `SceneExtension#removeAllRenderables()` to allow
-    // extensions to add errors or transforms back afterward
+    // This must be cleared before calling `SceneExtension#removeAllRenderables()` to allow
+    // extensions to add errors back afterward
     this.settings.errors.clear();
-    this.transformTree.clear();
 
     for (const extension of this.sceneExtensions.values()) {
       extension.removeAllRenderables();
@@ -518,20 +530,20 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   public addDatatypeSubscriptions<T>(
     datatypes: Iterable<string>,
-    handler: (messageEvent: MessageEvent<T>) => void,
-    type = SubscriptionType.WhenVisible,
+    subscription: RendererSubscription<T> | MessageHandler<T>,
   ): void {
-    const genericHandler = handler as (messageEvent: MessageEvent<unknown>) => void;
-    const handlersMap =
-      type === SubscriptionType.Always ? this.forcedDatatypeHandlers : this.datatypeHandlers;
+    const genericSubscription =
+      subscription instanceof Function
+        ? { handler: subscription as MessageHandler<unknown> }
+        : (subscription as RendererSubscription);
     for (const datatype of datatypes) {
-      let handlers = handlersMap.get(datatype);
+      let handlers = this.datatypeHandlers.get(datatype);
       if (!handlers) {
         handlers = [];
-        handlersMap.set(datatype, handlers);
+        this.datatypeHandlers.set(datatype, handlers);
       }
-      if (!handlers.includes(genericHandler)) {
-        handlers.push(genericHandler);
+      if (!handlers.includes(genericSubscription)) {
+        handlers.push(genericSubscription);
       }
     }
     this.emit("datatypeHandlersChanged", this);
@@ -539,19 +551,19 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   public addTopicSubscription<T>(
     topic: string,
-    handler: (messageEvent: MessageEvent<T>) => void,
-    type = SubscriptionType.WhenVisible,
+    subscription: RendererSubscription<T> | MessageHandler<T>,
   ): void {
-    const genericHandler = handler as (messageEvent: MessageEvent<unknown>) => void;
-    const handlersMap =
-      type === SubscriptionType.Always ? this.forcedTopicHandlers : this.topicHandlers;
-    let handlers = handlersMap.get(topic);
+    const genericSubscription =
+      subscription instanceof Function
+        ? { handler: subscription as MessageHandler<unknown> }
+        : (subscription as RendererSubscription);
+    let handlers = this.topicHandlers.get(topic);
     if (!handlers) {
       handlers = [];
-      handlersMap.set(topic, handlers);
+      this.topicHandlers.set(topic, handlers);
     }
-    if (!handlers.includes(genericHandler)) {
-      handlers.push(genericHandler);
+    if (!handlers.includes(genericSubscription)) {
+      handlers.push(genericSubscription);
     }
     this.emit("topicHandlersChanged", this);
   }
@@ -845,9 +857,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.addCoordinateFrame(maybeHasFrameId.frame_id);
     }
 
-    handleMessage(messageEvent, this.forcedTopicHandlers.get(messageEvent.topic));
     handleMessage(messageEvent, this.topicHandlers.get(messageEvent.topic));
-    handleMessage(messageEvent, this.forcedDatatypeHandlers.get(datatype));
     handleMessage(messageEvent, this.datatypeHandlers.get(datatype));
   }
 
@@ -1320,11 +1330,11 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
 function handleMessage(
   messageEvent: Readonly<MessageEvent<unknown>>,
-  handlers: MessageHandler[] | undefined,
+  subscriptions: RendererSubscription[] | undefined,
 ): void {
-  if (handlers) {
-    for (const handler of handlers) {
-      handler(messageEvent);
+  if (subscriptions) {
+    for (const subscription of subscriptions) {
+      subscription.handler(messageEvent);
     }
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -103,6 +103,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     super.dispose();
   }
 
+  public override removeAllRenderables(): void {
+    // Don't destroy frame axis renderables on clear() since `renderer.transformTree`
+    // is left untouched
+  }
+
   public override settingsNodes(): SettingsTreeEntry[] {
     const config = this.renderer.config;
     const configTransforms = config.transforms;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -39,7 +39,7 @@ import {
   COMPRESSED_IMAGE_DATATYPES,
   CAMERA_INFO_DATATYPES,
 } from "../ros";
-import { BaseSettings, PRECISION_DISTANCE, SelectEntry, SubscriptionType } from "../settings";
+import { BaseSettings, PRECISION_DISTANCE, SelectEntry } from "../settings";
 import { makePose } from "../transforms";
 import { CameraInfoUserData } from "./Cameras";
 
@@ -107,11 +107,10 @@ export class Images extends SceneExtension<ImageRenderable> {
     // Unconditionally subscribe to CameraInfo messages so the `foxglove.Cameras` extension will
     // always receive them and parse into camera models. This extension reuses the parsed camera
     // models from `foxglove.Cameras`
-    renderer.addDatatypeSubscriptions(
-      CAMERA_INFO_DATATYPES,
-      this.handleCameraInfo,
-      SubscriptionType.Always,
-    );
+    renderer.addDatatypeSubscriptions(CAMERA_INFO_DATATYPES, {
+      handler: this.handleCameraInfo,
+      forced: true,
+    });
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {

--- a/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/settings.ts
@@ -34,16 +34,6 @@ export type CustomLayerSettings = BaseSettings & {
   order?: number;
 };
 
-/**
- * Defines the condition for creating a topic subscription.
- */
-export enum SubscriptionType {
-  /** Only create a topic subscription when the user has toggled topic visibility on */
-  WhenVisible,
-  /** Unconditionally subscribe to matching topics */
-  Always,
-}
-
 export const PRECISION_DISTANCE = 3; // [1mm]
 export const PRECISION_DEGREES = 1;
 


### PR DESCRIPTION
**User-Facing Changes**

- [3D] All transforms are preloaded from local and remote file sources

**Description**

Renderer#addDatatypeSubscriptions() and Renderer#addTopicSubscriptions() has been changed to optionally accept a configuration object specifying forced and/or preload. This simplifies the subscription handling code and allows the preload boolean to be passed through to the extension API. Transform (i.e. "/tf") topics are now preloaded, and Renderer#transformTree is not flushed on seek/scrub. This should improve the usability of preload-enabled data sources by always loading the full set of coordinate frames and transforms into the UI.

Note that for most files, this will have the side effect of loading and decompressing every chunk from disk or network since `/tf` messages tend to be small and frequent, interspersed through every chunk in the recording.
