### PR TITLE
Fix extension panel config reset bug on player change

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -153,7 +153,6 @@ type WorkspaceProps = {
 const DEFAULT_DEEPLINKS = Object.freeze([]);
 
 const selectPlayerPresence = ({ playerState }: MessagePipelineContext) => playerState.presence;
-const selectSetSubscriptions = ({ setSubscriptions }: MessagePipelineContext) => setSubscriptions;
 const selectPlayerProblems = ({ playerState }: MessagePipelineContext) => playerState.problems;
 const selectIsPlaying = (ctx: MessagePipelineContext) =>
   ctx.playerState.activeData?.isPlaying === true;
@@ -161,6 +160,7 @@ const selectPause = (ctx: MessagePipelineContext) => ctx.pausePlayback;
 const selectPlay = (ctx: MessagePipelineContext) => ctx.startPlayback;
 const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
 const selectPlayUntil = (ctx: MessagePipelineContext) => ctx.playUntil;
+const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
 
 const selectSetHelpInfo = (store: HelpInfoStore) => store.setHelpInfo;
 
@@ -184,9 +184,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
 
   const supportsAccountSettings = useContext(ConsoleApiContext) != undefined;
 
-  // we use setSubscriptions to detect when a player changes for RemountOnValueChange below
+  // We use playerId to detect when a player changes for RemountOnValueChange below
   // see comment below above the RemountOnValueChange component
-  const setSubscriptions = useMessagePipeline(selectSetSubscriptions);
+  const playerId = useMessagePipeline(selectPlayerId);
 
   const isPlayerPresent = playerPresence !== PlayerPresence.NOT_PRESENT;
 
@@ -595,7 +595,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           onSelectKey={selectSidebarItem}
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
-          <RemountOnValueChange value={setSubscriptions}>
+          <RemountOnValueChange value={playerId}>
             <Stack>
               <PanelLayout />
               {play && pause && seek && (

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -197,12 +197,9 @@ export function MessagePipelineProvider({
     },
     [updateState],
   );
-  const setPublishers = useCallback(
-    (id: string, publishersForId: AdvertiseOptions[]) => {
-      setAllPublishers((p) => ({ ...p, [id]: publishersForId }));
-    },
-    [setAllPublishers],
-  );
+  const setPublishers = useCallback((id: string, publishersForId: AdvertiseOptions[]) => {
+    setAllPublishers((p) => ({ ...p, [id]: publishersForId }));
+  }, []);
   const setParameter = useCallback(
     (key: string, value: ParameterValue) => (player ? player.setParameter(key, value) : undefined),
     [player],

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -80,8 +80,13 @@ type RenderFn = NonNullable<PanelExtensionContext["onRender"]>;
 function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const { initPanel, config, saveConfig } = props;
 
-  // Buffer initial state so initPanel is not called on every config update.
-  const [initialState, setInitialState] = useState(config);
+  // Unlike the react data flow, the config is only provided to the panel once on setup.
+  // The panel is meant to manage the config and call saveConfig on its own.
+  //
+  // We store the config in a ref to avoid re-initializing the panel when the react config
+  // changes. The initialState is updated in an effect below so that if the panel does re-initialize
+  // it does so with the latest config.
+  const initialState = useRef(config);
 
   const messagePipelineContext = useMessagePipeline(selectContext);
 
@@ -91,7 +96,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
 
   const { openSiblingPanel } = usePanelContext();
 
-  const [panelId] = useState(() => uuid());
+  const [panelId, setPanelId] = useState(() => uuid());
 
   const [error, setError] = useState<Error | undefined>();
   const [watchedFields, setWatchedFields] = useState(new Set<keyof RenderState>());
@@ -138,10 +143,12 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   // Spiritually its like a reducer
   const [buildRenderState, setBuildRenderState] = useState(() => initRenderStateBuilder());
 
-  // Reset panel when config is cleared.
+  // Keep the initialState updated and reset the panel if the config is cleared
+  // This happens when a panel crashes and the user wants to "reset" it
   useUpdateEffect(() => {
+    initialState.current = config;
     if (isEqual(config, {})) {
-      setInitialState(config);
+      setPanelId(() => uuid());
     }
   }, [config]);
 
@@ -274,7 +281,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     };
 
     return {
-      initialState,
+      initialState: initialState.current,
 
       saveState: saveConfig,
 
@@ -396,7 +403,6 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     capabilities,
     clearHoverValue,
     dataSourceProfile,
-    initialState,
     getMessagePipelineContext,
     openSiblingPanel,
     panelId,


### PR DESCRIPTION

**User-Facing Changes**
Extension panel configuration persists through data source changes.

**Description**

There were two layered issues leading to a reset of extension panel config when changing data sources.

The first was a change in Workspace to remount the panels when setSubscriptions from the message pipeline changes. This change was made in https://github.com/foxglove/studio/pull/4292 when requestBackfill was removed. Unfortunately, setSubscriptions is stable and does not change when the player changes. This meant we were not actually getting a new value to remount. The fix is to switch to using playerId which does change when the player changes.

The second bug occurs inside of the panel extension adapter. Due to some react update ordering, the panelExtensionContext was being re-created when the player changed. During this rebuild, the initialState would be provided to the new panelExtensionContext. However this initialState was the original and empty state for the panel because we needed a stable variable for the initialState. The fix is to make initialState a ref so that whenever the panel does initialize it does so with the latest configuration value.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
