### PR TITLE
Convert playback controls tooltip to MUI

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Divider, Typography } from "@mui/material";
+import { isEmpty } from "lodash";
+import { Fragment } from "react";
+import { makeStyles } from "tss-react/mui";
+
+import { subtract as subtractTimes, toSec, fromSec } from "@foxglove/rostime";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import {
+  TimelineInteractionStateStore,
+  useTimelineInteractionState,
+} from "@foxglove/studio-base/context/TimelineInteractionStateContext";
+import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
+
+export type PlaybackControlsTooltipItem =
+  | { type: "divider" }
+  | { type: "item"; title: string; value: string };
+
+const useStyles = makeStyles()((theme) => ({
+  tooltipDivider: {
+    gridColumn: "span 2",
+    marginBlock: theme.spacing(0.5),
+    opacity: 0.5,
+  },
+  tooltipWrapper: {
+    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, "zero"`,
+    fontFamily: fonts.SANS_SERIF,
+    whiteSpace: "nowrap",
+    columnGap: theme.spacing(0.5),
+    display: "grid",
+    alignItems: "center",
+    gridTemplateColumns: "auto 1fr",
+    flexDirection: "column",
+  },
+  itemKey: {
+    fontSize: "0.7rem",
+    opacity: 0.7,
+    textAlign: "end",
+    textTransform: "lowercase",
+  },
+}));
+
+const selectHoveredEvents = (store: TimelineInteractionStateStore) => store.eventsAtHoverValue;
+const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
+
+export function PlaybackControlsTooltipContent(params: {
+  hoverXPosition: number;
+}): ReactNull | JSX.Element {
+  const { hoverXPosition } = params;
+  const { formatTime, timeFormat } = useAppTimeFormat();
+  const hoveredEvents = useTimelineInteractionState(selectHoveredEvents);
+  const startTime = useMessagePipeline(selectStartTime);
+  const { classes } = useStyles();
+
+  if (!startTime) {
+    return ReactNull;
+  }
+
+  const stamp = fromSec(hoverXPosition);
+  const timeFromStart = subtractTimes(stamp, startTime);
+
+  const tooltipItems: PlaybackControlsTooltipItem[] = [];
+
+  if (!isEmpty(hoveredEvents)) {
+    Object.values(hoveredEvents).forEach(({ event }) => {
+      tooltipItems.push({
+        type: "item",
+        title: "Start",
+        value: formatTime(event.startTime),
+      });
+      tooltipItems.push({
+        type: "item",
+        title: "End",
+        value: formatTime(event.endTime),
+      });
+      if (!isEmpty(event.metadata)) {
+        Object.entries(event.metadata).forEach(([metaKey, metaValue]) => {
+          tooltipItems.push({ type: "item", title: metaKey, value: metaValue });
+        });
+      }
+      tooltipItems.push({ type: "divider" });
+    });
+  }
+
+  switch (timeFormat) {
+    case "TOD":
+      tooltipItems.push({ type: "item", title: "Time", value: formatTime(stamp) });
+      break;
+    case "SEC":
+      tooltipItems.push({ type: "item", title: "SEC", value: formatTime(stamp) });
+      break;
+  }
+
+  tooltipItems.push({
+    type: "item",
+    title: "Elapsed",
+    value: `${toSec(timeFromStart).toFixed(9)} sec`,
+  });
+
+  return (
+    <div className={classes.tooltipWrapper}>
+      {tooltipItems.map((item, idx) => {
+        if (item.type === "divider") {
+          return <Divider key={`divider_${idx}`} className={classes.tooltipDivider} />;
+        }
+        return (
+          <Fragment key={`${item.title}_${idx}`}>
+            <Typography className={classes.itemKey}>{item.title}</Typography>
+            <Typography variant="subtitle2">{item.value}</Typography>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Tooltip } from "@mui/material";
+import { Fade, Tooltip } from "@mui/material";
 import { Instance } from "@popperjs/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLatest } from "react-use";
@@ -138,6 +138,8 @@ export default function Scrubber(props: Props): JSX.Element {
     <Tooltip
       title={hoverX != undefined ? <PlaybackControlsTooltipContent hoverXPosition={hoverX} /> : ""}
       placement="top"
+      TransitionComponent={Fade}
+      TransitionProps={{ timeout: 0 }}
       PopperProps={{
         popperRef,
         anchorEl: {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -142,11 +142,20 @@ export default function Scrubber(props: Props): JSX.Element {
       TransitionProps={{ timeout: 0 }}
       PopperProps={{
         popperRef,
+        modifiers: [
+          {
+            name: "offset",
+            options: {
+              // Offset popper to hug the track better.
+              offset: [0, -12],
+            },
+          },
+        ],
         anchorEl: {
           getBoundingClientRect: () => {
             return new DOMRect(
               positionRef.current.x,
-              8 + (hoverElRef.current?.getBoundingClientRect().y ?? 0),
+              hoverElRef.current?.getBoundingClientRect().y ?? 0,
               0,
               0,
             );

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -138,6 +138,7 @@ export default function Scrubber(props: Props): JSX.Element {
     <Tooltip
       title={hoverX != undefined ? <PlaybackControlsTooltipContent hoverXPosition={hoverX} /> : ""}
       placement="top"
+      disableInteractive
       TransitionComponent={Fade}
       TransitionProps={{ timeout: 0 }}
       PopperProps={{

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -2,10 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider, Tooltip, Typography } from "@mui/material";
+import { Tooltip } from "@mui/material";
 import { Instance } from "@popperjs/core";
-import { isEmpty } from "lodash";
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLatest } from "react-use";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
@@ -17,42 +16,18 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
-  TimelineInteractionStateStore,
   useClearHoverValue,
   useSetHoverValue,
-  useTimelineInteractionState,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
-import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { EventsOverlay } from "./EventsOverlay";
 import PlaybackBarHoverTicks from "./PlaybackBarHoverTicks";
+import { PlaybackControlsTooltipContent } from "./PlaybackControlsTooltipContent";
 import { ProgressPlot } from "./ProgressPlot";
 import Slider from "./Slider";
 
 const useStyles = makeStyles()((theme) => ({
-  tooltipDivider: {
-    gridColumn: "span 2",
-    marginBlock: theme.spacing(0.5),
-    opacity: 0.5,
-  },
-  tooltipWrapper: {
-    fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, "zero"`,
-    fontFamily: fonts.SANS_SERIF,
-    whiteSpace: "nowrap",
-    columnGap: theme.spacing(0.5),
-    display: "grid",
-    alignItems: "center",
-    gridTemplateColumns: "auto 1fr",
-    flexDirection: "column",
-  },
-  itemKey: {
-    fontSize: "0.7rem",
-    opacity: 0.7,
-    textAlign: "end",
-    textTransform: "lowercase",
-  },
   marker: {
     backgroundColor: theme.palette.text.primary,
     position: "absolute",
@@ -73,7 +48,6 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-const selectHoveredEvents = (store: TimelineInteractionStateStore) => store.eventsAtHoverValue;
 const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
 const selectEndTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.endTime;
@@ -85,23 +59,18 @@ type Props = {
   onSeek: (seekTo: Time) => void;
 };
 
-type TooltipItem = { type: "divider" } | { type: "item"; title: string; value: string };
-
 export default function Scrubber(props: Props): JSX.Element {
   const { onSeek } = props;
   const { classes, cx } = useStyles();
 
   const [hoverComponentId] = useState<string>(() => uuidv4());
-  const el = useRef<HTMLDivElement>(ReactNull);
-
-  const { formatTime, timeFormat } = useAppTimeFormat();
+  const hoverElRef = useRef<HTMLDivElement>(ReactNull);
 
   const startTime = useMessagePipeline(selectStartTime);
   const currentTime = useMessagePipeline(selectCurrentTime);
   const endTime = useMessagePipeline(selectEndTime);
   const presence = useMessagePipeline(selectPresence);
   const ranges = useMessagePipeline(selectRanges);
-  const hoveredEvents = useTimelineInteractionState(selectHoveredEvents);
 
   const setHoverValue = useSetHoverValue();
 
@@ -111,8 +80,8 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const latestStartTime = useLatest(startTime);
   const onHoverOver = useCallback(
-    (x: number, value: number) => {
-      if (!latestStartTime.current || el.current == undefined) {
+    (_x: number, value: number) => {
+      if (!latestStartTime.current || hoverElRef.current == undefined) {
         return;
       }
       const stamp = fromSec(value);
@@ -132,68 +101,6 @@ export default function Scrubber(props: Props): JSX.Element {
   const onHoverOut = useCallback(() => {
     clearHoverValue(hoverComponentId);
   }, [clearHoverValue, hoverComponentId]);
-
-  const tooltip = useMemo(() => {
-    if (!latestStartTime.current || el.current == undefined || hoverX == undefined) {
-      return;
-    }
-    const stamp = fromSec(hoverX);
-    const timeFromStart = subtractTimes(stamp, latestStartTime.current);
-
-    const tooltipItems: TooltipItem[] = [];
-
-    if (!isEmpty(hoveredEvents)) {
-      Object.values(hoveredEvents).forEach(({ event }) => {
-        tooltipItems.push({
-          type: "item",
-          title: "Start",
-          value: formatTime(event.startTime),
-        });
-        tooltipItems.push({
-          type: "item",
-          title: "End",
-          value: formatTime(event.endTime),
-        });
-        if (!isEmpty(event.metadata)) {
-          Object.entries(event.metadata).forEach(([metaKey, metaValue]) => {
-            tooltipItems.push({ type: "item", title: metaKey, value: metaValue });
-          });
-        }
-        tooltipItems.push({ type: "divider" });
-      });
-    }
-
-    switch (timeFormat) {
-      case "TOD":
-        tooltipItems.push({ type: "item", title: "Time", value: formatTime(stamp) });
-        break;
-      case "SEC":
-        tooltipItems.push({ type: "item", title: "SEC", value: formatTime(stamp) });
-        break;
-    }
-
-    tooltipItems.push({
-      type: "item",
-      title: "Elapsed",
-      value: `${toSec(timeFromStart).toFixed(9)} sec`,
-    });
-
-    return (
-      <div className={classes.tooltipWrapper}>
-        {tooltipItems.map((item, idx) => {
-          if (item.type === "divider") {
-            return <Divider key={`divider_${idx}`} className={classes.tooltipDivider} />;
-          }
-          return (
-            <Fragment key={`${item.title}_${idx}`}>
-              <Typography className={classes.itemKey}>{item.title}</Typography>
-              <Typography variant="subtitle2">{item.value}</Typography>
-            </Fragment>
-          );
-        })}
-      </div>
-    );
-  }, [classes, formatTime, hoveredEvents, latestStartTime, timeFormat, hoverX]);
 
   // Clean up the hover value when we are unmounted -- important for storybook.
   useEffect(() => onHoverOut, [onHoverOut]);
@@ -217,13 +124,9 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const popperRef = React.useRef<Instance>(ReactNull);
 
-  const areaRef = useRef<HTMLDivElement>(ReactNull);
-  const positionRef = React.useRef<{ x: number; y: number }>({
-    x: 0,
-    y: 0,
-  });
+  const positionRef = React.useRef({ x: 0, y: 0 });
 
-  const handleMouseMove = (event: React.MouseEvent) => {
+  const handlePointerMove = (event: React.PointerEvent) => {
     positionRef.current = { x: event.clientX, y: event.clientY };
 
     if (popperRef.current != undefined) {
@@ -233,7 +136,7 @@ export default function Scrubber(props: Props): JSX.Element {
 
   return (
     <Tooltip
-      title={<>{tooltip}</>}
+      title={hoverX != undefined ? <PlaybackControlsTooltipContent hoverXPosition={hoverX} /> : ""}
       placement="top"
       PopperProps={{
         popperRef,
@@ -241,7 +144,7 @@ export default function Scrubber(props: Props): JSX.Element {
           getBoundingClientRect: () => {
             return new DOMRect(
               positionRef.current.x,
-              areaRef.current!.getBoundingClientRect().y,
+              8 + (hoverElRef.current?.getBoundingClientRect().y ?? 0),
               0,
               0,
             );
@@ -250,18 +153,19 @@ export default function Scrubber(props: Props): JSX.Element {
       }}
     >
       <Stack
+        ref={hoverElRef}
         direction="row"
         flexGrow={1}
-        onMouseMove={handleMouseMove}
+        onPointerMove={handlePointerMove}
         alignItems="center"
         position="relative"
         style={{ height: 32 }}
       >
         <div className={cx(classes.track, { [classes.trackDisabled]: !startTime })} />
-        <Stack ref={areaRef} position="absolute" flex="auto" fullWidth style={{ height: 6 }}>
+        <Stack position="absolute" flex="auto" fullWidth style={{ height: 6 }}>
           <ProgressPlot loading={loading} availableRanges={ranges} />
         </Stack>
-        <Stack ref={el} fullHeight fullWidth position="absolute" flex={1}>
+        <Stack fullHeight fullWidth position="absolute" flex={1}>
           <Slider
             min={min ?? 0}
             max={max ?? 100}

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -145,6 +145,12 @@ export default function Scrubber(props: Props): JSX.Element {
         popperRef,
         modifiers: [
           {
+            name: "computeStyles",
+            options: {
+              gpuAcceleration: false, // Fixes hairline seam on arrow in chrome.
+            },
+          },
+          {
             name: "offset",
             options: {
               // Offset popper to hug the track better.

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -2,9 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider, Typography } from "@mui/material";
+import { Divider, Tooltip, Typography } from "@mui/material";
+import { Instance } from "@popperjs/core";
 import { isEmpty } from "lodash";
-import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLatest } from "react-use";
 import { makeStyles } from "tss-react/mui";
 import { v4 as uuidv4 } from "uuid";
@@ -15,7 +16,6 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import {
   TimelineInteractionStateStore,
   useClearHoverValue,
@@ -35,15 +35,23 @@ const useStyles = makeStyles()((theme) => ({
   tooltipDivider: {
     gridColumn: "span 2",
     marginBlock: theme.spacing(0.5),
+    opacity: 0.5,
   },
   tooltipWrapper: {
     fontFeatureSettings: `${fonts.SANS_SERIF_FEATURE_SETTINGS}, "zero"`,
     fontFamily: fonts.SANS_SERIF,
     whiteSpace: "nowrap",
-    gap: theme.spacing(0.5),
+    columnGap: theme.spacing(0.5),
     display: "grid",
+    alignItems: "center",
     gridTemplateColumns: "auto 1fr",
     flexDirection: "column",
+  },
+  itemKey: {
+    fontSize: "0.7rem",
+    opacity: 0.7,
+    textAlign: "end",
+    textTransform: "lowercase",
   },
   marker: {
     backgroundColor: theme.palette.text.primary,
@@ -97,6 +105,8 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const setHoverValue = useSetHoverValue();
 
+  const [hoverX, setHoverX] = useState<undefined | number>();
+
   const onChange = useCallback((value: number) => onSeek(fromSec(value)), [onSeek]);
 
   const latestStartTime = useLatest(startTime);
@@ -105,95 +115,85 @@ export default function Scrubber(props: Props): JSX.Element {
       if (!latestStartTime.current || el.current == undefined) {
         return;
       }
-      const currentEl = el.current;
-      // fix the y position of the tooltip to float on top of the playback bar
-      const y = currentEl.getBoundingClientRect().top;
-
       const stamp = fromSec(value);
       const timeFromStart = subtractTimes(stamp, latestStartTime.current);
-
-      const tooltipItems: TooltipItem[] = [];
-
-      if (!isEmpty(hoveredEvents)) {
-        Object.values(hoveredEvents).forEach(({ event }) => {
-          tooltipItems.push({
-            type: "item",
-            title: "Start",
-            value: formatTime(event.startTime),
-          });
-          tooltipItems.push({
-            type: "item",
-            title: "End",
-            value: formatTime(event.endTime),
-          });
-          if (!isEmpty(event.metadata)) {
-            Object.entries(event.metadata).forEach(([metaKey, metaValue]) => {
-              tooltipItems.push({ type: "item", title: metaKey, value: metaValue });
-            });
-          }
-          tooltipItems.push({ type: "divider" });
-        });
-      }
-
-      switch (timeFormat) {
-        case "TOD":
-          tooltipItems.push({ type: "item", title: "Time", value: formatTime(stamp) });
-          break;
-        case "SEC":
-          tooltipItems.push({ type: "item", title: "SEC", value: formatTime(stamp) });
-          break;
-      }
-
-      tooltipItems.push({
-        type: "item",
-        title: "Elapsed",
-        value: `${toSec(timeFromStart).toFixed(9)} sec`,
-      });
-
-      const tip = (
-        <div className={classes.tooltipWrapper}>
-          {tooltipItems.map((item, idx) => {
-            if (item.type === "divider") {
-              return <Divider key={`divider_${idx}`} className={classes.tooltipDivider} />;
-            }
-            return (
-              <Fragment key={`${item.title}_${idx}`}>
-                <Typography align="right" variant="body2">
-                  {item.title}:
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {item.value}
-                </Typography>
-              </Fragment>
-            );
-          })}
-        </div>
-      );
-      setTooltipState({ x, y, tip });
+      setHoverX(value);
       setHoverValue({
         componentId: hoverComponentId,
         type: "PLAYBACK_SECONDS",
         value: toSec(timeFromStart),
       });
     },
-    [
-      classes.tooltipDivider,
-      classes.tooltipWrapper,
-      formatTime,
-      hoverComponentId,
-      hoveredEvents,
-      latestStartTime,
-      setHoverValue,
-      timeFormat,
-    ],
+    [hoverComponentId, latestStartTime, setHoverValue],
   );
 
   const clearHoverValue = useClearHoverValue();
 
   const onHoverOut = useCallback(() => {
-    setTooltipState(undefined);
     clearHoverValue(hoverComponentId);
   }, [clearHoverValue, hoverComponentId]);
+
+  const tooltip = useMemo(() => {
+    if (!latestStartTime.current || el.current == undefined || hoverX == undefined) {
+      return;
+    }
+    const stamp = fromSec(hoverX);
+    const timeFromStart = subtractTimes(stamp, latestStartTime.current);
+
+    const tooltipItems: TooltipItem[] = [];
+
+    if (!isEmpty(hoveredEvents)) {
+      Object.values(hoveredEvents).forEach(({ event }) => {
+        tooltipItems.push({
+          type: "item",
+          title: "Start",
+          value: formatTime(event.startTime),
+        });
+        tooltipItems.push({
+          type: "item",
+          title: "End",
+          value: formatTime(event.endTime),
+        });
+        if (!isEmpty(event.metadata)) {
+          Object.entries(event.metadata).forEach(([metaKey, metaValue]) => {
+            tooltipItems.push({ type: "item", title: metaKey, value: metaValue });
+          });
+        }
+        tooltipItems.push({ type: "divider" });
+      });
+    }
+
+    switch (timeFormat) {
+      case "TOD":
+        tooltipItems.push({ type: "item", title: "Time", value: formatTime(stamp) });
+        break;
+      case "SEC":
+        tooltipItems.push({ type: "item", title: "SEC", value: formatTime(stamp) });
+        break;
+    }
+
+    tooltipItems.push({
+      type: "item",
+      title: "Elapsed",
+      value: `${toSec(timeFromStart).toFixed(9)} sec`,
+    });
+
+    return (
+      <div className={classes.tooltipWrapper}>
+        {tooltipItems.map((item, idx) => {
+          if (item.type === "divider") {
+            return <Divider key={`divider_${idx}`} className={classes.tooltipDivider} />;
+          }
+          return (
+            <Fragment key={`${item.title}_${idx}`}>
+              <Typography className={classes.itemKey}>{item.title}</Typography>
+              <Typography variant="subtitle2">{item.value}</Typography>
+            </Fragment>
+          );
+        })}
+      </div>
+    );
+  }, [classes, formatTime, hoveredEvents, latestStartTime, timeFormat, hoverX]);
 
   // Clean up the hover value when we are unmounted -- important for storybook.
   useEffect(() => onHoverOut, [onHoverOut]);
@@ -208,19 +208,6 @@ export default function Scrubber(props: Props): JSX.Element {
     [classes.marker],
   );
 
-  const [tooltipState, setTooltipState] = useState<
-    { x: number; y: number; tip: JSX.Element } | undefined
-  >();
-  const { tooltip } = useTooltip({
-    contents: tooltipState?.tip,
-    noPointerEvents: true,
-    shown: tooltipState != undefined,
-    targetPosition: {
-      x: tooltipState?.x ?? 0,
-      y: tooltipState?.y ?? 0,
-    },
-  });
-
   const min = startTime && toSec(startTime);
   const max = endTime && toSec(endTime);
   const value = currentTime == undefined ? undefined : toSec(currentTime);
@@ -228,34 +215,68 @@ export default function Scrubber(props: Props): JSX.Element {
 
   const loading = presence === PlayerPresence.INITIALIZING || presence === PlayerPresence.BUFFERING;
 
+  const popperRef = React.useRef<Instance>(ReactNull);
+
+  const areaRef = useRef<HTMLDivElement>(ReactNull);
+  const positionRef = React.useRef<{ x: number; y: number }>({
+    x: 0,
+    y: 0,
+  });
+
+  const handleMouseMove = (event: React.MouseEvent) => {
+    positionRef.current = { x: event.clientX, y: event.clientY };
+
+    if (popperRef.current != undefined) {
+      void popperRef.current.update();
+    }
+  };
+
   return (
-    <Stack
-      direction="row"
-      flexGrow={1}
-      alignItems="center"
-      position="relative"
-      style={{ height: 32 }}
+    <Tooltip
+      title={<>{tooltip}</>}
+      placement="top"
+      PopperProps={{
+        popperRef,
+        anchorEl: {
+          getBoundingClientRect: () => {
+            return new DOMRect(
+              positionRef.current.x,
+              areaRef.current!.getBoundingClientRect().y,
+              0,
+              0,
+            );
+          },
+        },
+      }}
     >
-      {tooltip}
-      <div className={cx(classes.track, { [classes.trackDisabled]: !startTime })} />
-      <Stack position="absolute" flex="auto" fullWidth style={{ height: 6 }}>
-        <ProgressPlot loading={loading} availableRanges={ranges} />
+      <Stack
+        direction="row"
+        flexGrow={1}
+        onMouseMove={handleMouseMove}
+        alignItems="center"
+        position="relative"
+        style={{ height: 32 }}
+      >
+        <div className={cx(classes.track, { [classes.trackDisabled]: !startTime })} />
+        <Stack ref={areaRef} position="absolute" flex="auto" fullWidth style={{ height: 6 }}>
+          <ProgressPlot loading={loading} availableRanges={ranges} />
+        </Stack>
+        <Stack ref={el} fullHeight fullWidth position="absolute" flex={1}>
+          <Slider
+            min={min ?? 0}
+            max={max ?? 100}
+            disabled={min == undefined || max == undefined}
+            step={step}
+            value={value}
+            onHoverOver={onHoverOver}
+            onHoverOut={onHoverOut}
+            onChange={onChange}
+            renderSlider={renderSlider}
+          />
+        </Stack>
+        <EventsOverlay />
+        <PlaybackBarHoverTicks componentId={hoverComponentId} />
       </Stack>
-      <Stack ref={el} fullHeight fullWidth position="absolute" flex={1}>
-        <Slider
-          min={min ?? 0}
-          max={max ?? 100}
-          disabled={min == undefined || max == undefined}
-          step={step}
-          value={value}
-          onHoverOver={onHoverOver}
-          onHoverOut={onHoverOut}
-          onChange={onChange}
-          renderSlider={renderSlider}
-        />
-      </Stack>
-      <EventsOverlay />
-      <PlaybackBarHoverTicks componentId={hoverComponentId} />
-    </Stack>
+    </Tooltip>
   );
 }

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -241,4 +241,6 @@ export type StackProps = {
 
   /** CSS styles to apply to the component. */
   style?: CSSProperties;
+
+  onMouseMove?: React.DOMAttributes<HTMLDivElement>["onMouseMove"];
 };

--- a/packages/studio-base/src/components/Stack.tsx
+++ b/packages/studio-base/src/components/Stack.tsx
@@ -242,5 +242,11 @@ export type StackProps = {
   /** CSS styles to apply to the component. */
   style?: CSSProperties;
 
-  onMouseMove?: React.DOMAttributes<HTMLDivElement>["onMouseMove"];
+  /** Standard pointer events. */
+  onPointerDown?: React.DOMAttributes<HTMLDivElement>["onPointerDown"];
+  onPointerEnter?: React.DOMAttributes<HTMLDivElement>["onPointerEnter"];
+  onPointerLeave?: React.DOMAttributes<HTMLDivElement>["onPointerLeave"];
+  onPointerMove?: React.DOMAttributes<HTMLDivElement>["onPointerMove"];
+  onPointerOver?: React.DOMAttributes<HTMLDivElement>["onPointerOver"];
+  onPointerUp?: React.DOMAttributes<HTMLDivElement>["onPointerUp"];
 };

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -499,7 +499,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
         arrow: true,
       },
       styleOverrides: {
+        arrow: {
+          color: theme.palette.grey[700],
+        },
         tooltip: {
+          backgroundColor: theme.palette.grey[700],
           fontWeight: "normal",
           fontSize: "0.75rem",
         },


### PR DESCRIPTION
**User-Facing Changes**
Minor visual changes.

**Description**
Convert the playback controls tooltip to the MUI tooltip.

<img width="385" alt="Screen Shot 2022-09-09 at 7 58 53 AM" src="https://user-images.githubusercontent.com/93935560/189351108-9cf6a7a2-df9d-420b-8ab1-715fdb6808f8.png">

Note: This looks a bit different. We can of course style it more like the existing tooltip but maybe it's better to stick to the standard MUI tooltip styling?

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Partially addresses https://github.com/foxglove/studio/issues/4207