### PR TITLE
Fix topic subscriptions for iterable player

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -358,7 +358,7 @@ describe("IterablePlayer", () => {
     player.close();
   });
 
-  it.only("should make a new message iterator when topic subscriptions change", async () => {
+  it("should make a new message iterator when topic subscriptions change", async () => {
     const source = new TestSource();
     const player = new IterablePlayer({
       source,

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -357,4 +357,35 @@ describe("IterablePlayer", () => {
 
     player.close();
   });
+
+  it.only("should make a new message iterator when topic subscriptions change", async () => {
+    const source = new TestSource();
+    const player = new IterablePlayer({
+      source,
+      enablePreload: false,
+      sourceId: "test",
+    });
+
+    const messageIteratorSpy = jest.spyOn(source, "messageIterator");
+
+    const store = new PlayerStateStore(4);
+    player.setSubscriptions([{ topic: "foo" }]);
+    player.setListener(async (state) => await store.add(state));
+
+    // Wait for initial setup
+    await store.done;
+
+    // Call set subscriptions and add a new topic
+    store.reset(3);
+    player.setSubscriptions([{ topic: "foo" }, { topic: "bar" }]);
+
+    await store.done;
+
+    expect(messageIteratorSpy.mock.calls).toEqual([
+      [{ start: { sec: 0, nsec: 0 }, end: { sec: 1, nsec: 0 }, topics: ["foo"] }],
+      [{ start: { sec: 0, nsec: 99000001 }, end: { sec: 1, nsec: 0 }, topics: ["bar", "foo"] }],
+    ]);
+
+    player.close();
+  });
 });

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -293,11 +293,16 @@ export class IterablePlayer implements Player {
     this._partialTopics = partialTopics;
     this._blockLoader?.setTopics(this._partialTopics);
 
-    // We only seek playback if the player is not playing. If the player is playing, the
-    // playing state will detect any subscription changes and emit new messages.
+    // If the player is playing, the playing state will detect any subscription changes and adjust
+    // iterators accordignly. However if we are idle or already seeking then we need to manually
+    // trigger the backfill.
     if (this._state === "idle" || this._state === "seek-backfill" || this._state === "play") {
       if (!this._isPlaying && this._currentTime) {
-        this.seekPlayback(this._currentTime);
+        this._seekTarget = this._currentTime;
+        this._untilTime = undefined;
+
+        // Trigger a seek backfill to load any missing messages and reset the forward iterator
+        this._setState("seek-backfill");
       }
     }
   }


### PR DESCRIPTION


**User-Facing Changes**
Subscribing to new topics while paused is fixed.

The regression did not appear in a desktop release but did appear in the web release.

**Description**
PR https://github.com/foxglove/studio/pull/4379 broke subscribing to topics when paused. This behavior broke because 4379 added a check to seekPlayback that would avoid seeking if the requested seek time was already the current time. Unfortunately, the IterablePlayer relied on this behavior when subscriptions changed to trigger a backfill and reset the message iterators by calling seekPlayback with the currentTime.

This change fixes the setSubscriptions behavior to instead directly request the seek-backfill state rather than routing through seekPlayback which is a public-facing api.

Fixes: #4395

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
