### PR TITLE
Support loading files which contain messages spanning decades

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -516,21 +516,25 @@ describe("BlockLoader", () => {
 
     expect(messageIteratorCallArgs).toEqual([
       {
+        consumptionType: "full",
         topics: ["a"],
         start: { sec: 0, nsec: 0 },
         end: { sec: 9, nsec: 0 },
       },
       {
+        consumptionType: "full",
         topics: ["a"],
         start: { sec: 4, nsec: 500000003 },
         end: { sec: 9, nsec: 0 },
       },
       {
+        consumptionType: "full",
         topics: ["a"],
         start: { sec: 1, nsec: 500000001 },
         end: { sec: 4, nsec: 500000002 },
       },
       {
+        consumptionType: "full",
         topics: ["a"],
         start: { sec: 7, nsec: 500000005 },
         end: { sec: 9, nsec: 0 },

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -229,6 +229,7 @@ export class BlockLoader {
         topics: Array.from(topicsToFetch),
         start: iteratorStartTime,
         end: iteratorEndTime,
+        consumptionType: "full",
       });
 
       let messagesByTopic: Record<string, MessageEvent<unknown>[]> = {};

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -419,6 +419,7 @@ describe("BufferedIterableSource", () => {
         topics: ["a"],
         start: { sec: 0, nsec: 0 },
         end: { sec: 10, nsec: 0 },
+        consumptionType: "partial",
       });
       messageIteratorCount += 1;
 
@@ -447,20 +448,13 @@ describe("BufferedIterableSource", () => {
     // Wait for the buffered iterable source to stop reading messages
     await signal.wait();
 
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2999999999 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.1999999999 }]);
 
-    // Reading the second message does not need to buffer any data because we still have enough data
-    // to read
-    await messageIterator.next();
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2999999999 }]);
-
-    // Reading the third message pushes us to buffer more data, so we setup another signal and wait
-    // for the buffered iterable source to settle
+    // Reading the second message buffers more data
     signal = waiter(1);
     await messageIterator.next();
-
     await signal.wait();
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.4999999999 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2999999999 }]);
 
     // We should have called the messageIterator method only once
     expect(messageIteratorCount).toEqual(1);

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { debounce } from "lodash";
+
 import { MessageEvent } from "@foxglove/studio";
 
 import { BufferedIterableSource } from "./BufferedIterableSource";
@@ -405,18 +407,23 @@ describe("BufferedIterableSource", () => {
 
     let signal = waiter(1);
 
-    let count = 0;
+    const debounceNotify = debounce(() => {
+      signal.notify();
+    }, 500);
+
+    let messageIteratorCount = 0;
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      count += 1;
+      expect(args).toEqual({
+        topics: ["a"],
+        start: { sec: 0, nsec: 0 },
+        end: { sec: 10, nsec: 0 },
+      });
+      messageIteratorCount += 1;
 
-      const start = args.start?.sec ?? 0;
-      const end = args.end?.sec ?? 1000;
       for (let i = 0; i < 8; ++i) {
-        if (i < start || i > end) {
-          continue;
-        }
+        debounceNotify();
         yield {
           msgEvent: {
             topic: "a",
@@ -428,7 +435,6 @@ describe("BufferedIterableSource", () => {
           connectionId: undefined,
         };
       }
-      signal.notify();
     };
 
     const messageIterator = bufferedSource.messageIterator({
@@ -438,23 +444,25 @@ describe("BufferedIterableSource", () => {
     // Reading the first message buffers some data
     await messageIterator.next();
 
-    // Wait for the producer to finish
+    // Wait for the buffered iterable source to stop reading messages
     await signal.wait();
 
-    expect(count).toEqual(1);
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2999999999 }]);
 
     // Reading the second message does not need to buffer any data because we still have enough data
     // to read
     await messageIterator.next();
-    expect(count).toEqual(1);
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.2999999999 }]);
 
-    // Reading the third message pushes us to buffer more data
+    // Reading the third message pushes us to buffer more data, so we setup another signal and wait
+    // for the buffered iterable source to settle
     signal = waiter(1);
     await messageIterator.next();
+
     await signal.wait();
-    expect(count).toEqual(2);
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.4000000001 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.4999999999 }]);
+
+    // We should have called the messageIterator method only once
+    expect(messageIteratorCount).toEqual(1);
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -20,7 +20,7 @@ import {
 
 const log = Log.getLogger(__filename);
 
-const DEFAULT_READ_AHEAD_DURATION = { sec: 5, nsec: 0 };
+const DEFAULT_READ_AHEAD_DURATION = { sec: 10, nsec: 0 };
 
 type Options = {
   // How far ahead to buffer
@@ -88,8 +88,6 @@ class BufferedIterableSource implements IIterableSource {
     // the start of the array.
     this.cache.clear();
 
-    const twoTimesReadAhead = addTime(this.readAheadDuration, this.readAheadDuration);
-
     try {
       const sourceIterator = this.source.messageIterator({
         topics: args.topics,
@@ -97,10 +95,12 @@ class BufferedIterableSource implements IIterableSource {
         consumptionType: "partial",
       });
 
-      // Messages are read from the source until they read the readUntil time. readUntil is set to
-      // two readAheadDuration values from the start time
+      // Messages are read from the source until reaching the readUntil time. Then we wait for the read head
+      // to move forward until it is within 1 headAheadDuration of the readUntil time until trying to read more.
+      // We set the readUntil time to 2x readAheadDuration so that every move of the read head does not require
+      // also reading the underlying source. This creates the effect of buffering some
       let readUntil = clampTime(
-        addTime(this.readHead, twoTimesReadAhead),
+        addTime(this.readHead, this.readAheadDuration),
         this.initResult.start,
         this.initResult.end,
       );
@@ -120,28 +120,14 @@ class BufferedIterableSource implements IIterableSource {
           continue;
         }
 
-        // We've buffered through the current readUntil. Wait until the reader is within 1 readAheadDuration
-        // of readUntil and then buffer more
-        for (;;) {
-          if (this.cache.size() === 0) {
-            break;
-          }
-          const targetUntil = addTime(this.readHead, this.readAheadDuration);
-          if (result.msgEvent && compare(targetUntil, readUntil) > 0) {
-            // reset the readUntil to two readAheadDurations from the read head
-            readUntil = clampTime(
-              addTime(this.readHead, twoTimesReadAhead),
-              this.initResult.start,
-              this.initResult.end,
-            );
-            break;
-          }
-          await this.writeSignal.wait();
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (this.aborted) {
-            return;
-          }
+        // If we didn't load anything into the cache keep reading
+        if (this.cache.size() === 0) {
+          continue;
         }
+
+        // Wait for messages to be read and then update the new readUntil
+        await this.writeSignal.wait();
+        readUntil = addTime(this.readHead, this.readAheadDuration);
       }
     } finally {
       // Indicate to the consumer that it can try reading again

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -88,64 +88,59 @@ class BufferedIterableSource implements IIterableSource {
     // the start of the array.
     this.cache.clear();
 
-    // Streaming starts where the read head is and adjust as data is buffered and read
-    let streamStart = this.readHead;
+    const twoTimesReadAhead = addTime(this.readAheadDuration, this.readAheadDuration);
 
     try {
-      for (;;) {
+      const sourceIterator = this.source.messageIterator({
+        topics: args.topics,
+        start: this.readHead,
+        consumptionType: "partial",
+      });
+
+      // Messages are read from the source until they read the readUntil time. readUntil is set to
+      // two readAheadDuration values from the start time
+      let readUntil = clampTime(
+        addTime(this.readHead, twoTimesReadAhead),
+        this.initResult.start,
+        this.initResult.end,
+      );
+
+      for await (const result of sourceIterator) {
         if (this.aborted) {
-          break;
-        }
-
-        const readUntil = addTime(
-          streamStart,
-          addTime(this.readAheadDuration, this.readAheadDuration),
-        );
-        const streamEnd = clampTime(readUntil, this.initResult.start, this.initResult.end);
-
-        const sourceIterator = this.source.messageIterator({
-          topics: args.topics,
-          start: streamStart,
-          end: streamEnd,
-        });
-
-        for await (const result of sourceIterator) {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (this.aborted) {
-            break;
-          }
-
-          if (result.msgEvent && compare(result.msgEvent.receiveTime, streamEnd) > 0) {
-            throw new Error("Invariant: out of bounds result");
-          }
-
-          this.cache.enqueue(result);
-
-          // Indicate to the consumer that it can try reading again
-          this.readSignal.notifyAll();
-        }
-
-        // We've streamed through the end of our data source
-        if (compare(streamEnd, this.initResult.end) >= 0) {
           return;
         }
 
-        // Wait until we've consumed enough data that we should read more
+        this.cache.enqueue(result);
+
+        // Indicate to the consumer that it can try reading again
+        this.readSignal.notifyAll();
+
+        // Keep reading while the messages we receive are <= the readUntil time
+        if (result.msgEvent && compare(result.msgEvent.receiveTime, readUntil) <= 0) {
+          continue;
+        }
+
+        // We've buffered through the current readUntil. Wait until the reader is within 1 readAheadDuration
+        // of readUntil and then buffer more
         for (;;) {
+          if (this.cache.size() === 0) {
+            break;
+          }
+          const targetUntil = addTime(this.readHead, this.readAheadDuration);
+          if (result.msgEvent && compare(targetUntil, readUntil) > 0) {
+            // reset the readUntil to two readAheadDurations from the read head
+            readUntil = clampTime(
+              addTime(this.readHead, twoTimesReadAhead),
+              this.initResult.start,
+              this.initResult.end,
+            );
+            break;
+          }
+          await this.writeSignal.wait();
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           if (this.aborted) {
-            break;
+            return;
           }
-
-          // If this.readHead + readAheadTime > streamEnd, we start another stream for buffering
-          // otherwise we wait
-          const targetUntil = addTime(this.readHead, this.readAheadDuration);
-          if (compare(targetUntil, streamEnd) > 0 || this.cache.size() === 0) {
-            streamStart = addTime(streamEnd, { sec: 0, nsec: 1 });
-            break;
-          }
-
-          await this.writeSignal.wait();
         }
       }
     } finally {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -207,6 +207,7 @@ class CachingIterableSource implements IIterableSource {
         topics: this.cachedTopics,
         start: sourceReadStart,
         end: sourceReadEnd,
+        consumptionType: args.consumptionType,
       });
 
       // The cache is indexed on time, but iterator results that are problems might not have a time.

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -41,6 +41,17 @@ export type MessageIteratorArgs = {
    * The last message receiveTime will be <= end.
    * */
   end?: Time;
+
+  /**
+   * Indicate the expected way the iterator is consumed.
+   *
+   * Data sources may choose to change internal mechanics depending on whether the messages are
+   * consumed immediate in full from the iterator or if it might be read partially.
+   *
+   * `full` indicates that the caller plans to read the entire iterator
+   * `partial` indicates that the caller plans to read the iterator but may not read all the messages
+   */
+  consumptionType?: "full" | "partial";
 };
 
 export type IteratorResult =

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -382,8 +382,22 @@ describe("IterablePlayer", () => {
     await store.done;
 
     expect(messageIteratorSpy.mock.calls).toEqual([
-      [{ start: { sec: 0, nsec: 0 }, end: { sec: 1, nsec: 0 }, topics: ["foo"] }],
-      [{ start: { sec: 0, nsec: 99000001 }, end: { sec: 1, nsec: 0 }, topics: ["bar", "foo"] }],
+      [
+        {
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 1, nsec: 0 },
+          topics: ["foo"],
+          consumptionType: "partial",
+        },
+      ],
+      [
+        {
+          start: { sec: 0, nsec: 99000001 },
+          end: { sec: 1, nsec: 0 },
+          topics: ["bar", "foo"],
+          consumptionType: "partial",
+        },
+      ],
     ]);
 
     player.close();

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -468,16 +468,26 @@ export class IterablePlayer implements Player {
       }
 
       if (this._enablePreload) {
-        // --- setup blocks
-        this._blockLoader = new BlockLoader({
-          cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
-          source: this._iterableSource,
-          start: this._start,
-          end: this._end,
-          maxBlocks: MAX_BLOCKS,
-          minBlockDurationNs: MIN_MEM_CACHE_BLOCK_SIZE_NS,
-          problemManager: this._problemManager,
-        });
+        // --- setup block loader which loads messages for _full_ subscriptions in the "background"
+        try {
+          this._blockLoader = new BlockLoader({
+            cacheSizeBytes: DEFAULT_CACHE_SIZE_BYTES,
+            source: this._iterableSource,
+            start: this._start,
+            end: this._end,
+            maxBlocks: MAX_BLOCKS,
+            minBlockDurationNs: MIN_MEM_CACHE_BLOCK_SIZE_NS,
+            problemManager: this._problemManager,
+          });
+        } catch (err) {
+          log.error(err);
+          this._problemManager.addProblem("block-loader", {
+            severity: "warn",
+            message: "Failed to initialize message preloading",
+            tip: "Check that the start and end time of your data are the same year.",
+            error: err,
+          });
+        }
       }
 
       // set the initial topics for the loader
@@ -516,6 +526,7 @@ export class IterablePlayer implements Player {
     this._playbackIterator = this._bufferedSource.messageIterator({
       topics: Array.from(this._allTopics),
       start: next,
+      consumptionType: "partial",
     });
   }
 
@@ -548,6 +559,7 @@ export class IterablePlayer implements Player {
     this._playbackIterator = this._bufferedSource.messageIterator({
       topics: Array.from(this._allTopics),
       start: this._start,
+      consumptionType: "partial",
     });
 
     this._lastMessage = undefined;

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -16,6 +16,7 @@ import {
   fromMillis,
   fromNanoSec,
   toString,
+  toRFC3339String,
 } from "@foxglove/rostime";
 import { MessageEvent, ParameterValue } from "@foxglove/studio";
 import NoopMetricsCollector from "@foxglove/studio-base/players/NoopMetricsCollector";
@@ -481,10 +482,14 @@ export class IterablePlayer implements Player {
           });
         } catch (err) {
           log.error(err);
+
+          const startStr = toRFC3339String(this._start);
+          const endStr = toRFC3339String(this._end);
+
           this._problemManager.addProblem("block-loader", {
             severity: "warn",
             message: "Failed to initialize message preloading",
-            tip: "Check that the start and end time of your data are the same year.",
+            tip: `The start (${startStr}) and end (${endStr}) of your data is too far apart.`,
             error: err,
           });
         }

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -373,5 +373,5 @@ class ConsoleApi {
   }
 }
 
-export type { Org, DeviceCodeResponse, Session };
+export type { Org, DeviceCodeResponse, Session, CoverageResponse };
 export default ConsoleApi;


### PR DESCRIPTION
**User-Facing Changes**
Opening a file which has a message at epoch time second: 0 and other messages at "now" no longer causes studio to hang. The user can play and seek the file as they can with other files.

**Description**
The BufferedIterableSource is responsible for wrapping an IIterableSource and performing "look ahead" fetching in the "background" with the purpose of fetching upcoming data before the player actually needs to read the message. The background loading logic would request a message iterator for a fixed amount of time (the readahead window of 5 seconds) from the underlying source. As the player consumed messages from the message iterator of the BufferedIterableSource instance the background process would move forward and start new message iterators as needed to fill the readahead buffer. It knows it can stop buffering new data when it reads a message that is beyond the required time of the readahead window.

When loading a file that contains a massive gap in time (decades), this logic of reading a fixed amount of time fall apart. The BufferedIterableSource effectively goes into a tight loop. It wants to read 5 seconds into the buffer. To do this it keeps trying to read 5 second increments from the underlying data source but since the next message is decades away this creates a tight loop.

I originally wrote the BufferedIterableSource to work in fixed increments on the underlying source because the DataPlatformIterable source would otherwise try to fetch too much data over the network too soon. I now believe this is a problem specific to the DataPlatformIterableSource and behavior that should be internalized within that source rather than impacting how buffering is done for all sources.

This change updates the BufferedIterableSource to create a single messageIterator on the underlying source and read from that as necessary to keep the readahead buffer filled to the appropriate time. This avoids the tight loop because the messageIterator is responsible for producing the next message from the source regardless of how far from the previous message it might be.

This means the sliding window reading logic needs to move into the DataPlatformIterableSource (because we want to avoid making an open-ended _fetch_ request since that will download the entire range even if we don't play the range). Unfortunately, moving the sliding window logic means the same "looping" behavior now happens in DataPlatformIterableSource. When you open a stream that has gaps, the source will make many 5 second requests only to learn there are no messages and move on to the next 5 second section. The fix for this is to use the _coverage_ information and skip querying sections of time which have no data.

And finally, when preloading data in the BlockLoader the app wants to load certain topics for the entire range to display in plot panel or for 3d panel tf preloading. When reading these messages from DataPlatformIterableSource, we want the app to avoid making many separate 5 second requests for the data since this is much slower than 1 request for the entire range. To support this (while also avoiding making 1 request for playback use), we introduce a `consumptionType` field to the `messageIterator` args. This field can be set to `full` to indicate the caller plans to read all the data from the iterator in one continuous pass or `partial` to indicate the iterator will be read incrementally during playback. The source can use this argument to change how it wants to load data.

Fixes: #4396

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
