### PR TITLE
Add geojson message to correct feature group

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -398,14 +398,14 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   );
 
   const addGeoJsonMessage = useCallback(
-    (message: GeoJsonMessage, topicLayer: TopicGroups) => {
+    (message: GeoJsonMessage, group: FeatureGroup) => {
       const parsed = JSON.parse(message.message.geojson) as Parameters<typeof geoJSON>[0];
       geoJSON(parsed, {
         onEachFeature: (_feature, layer) => addGeoFeatureEventHandlers(message, layer),
         style: config.topicColors[message.topic]
           ? { color: config.topicColors[message.topic] }
           : {},
-      }).addTo(topicLayer.allFrames);
+      }).addTo(group);
     },
     [addGeoFeatureEventHandlers, config.topicColors],
   );
@@ -462,7 +462,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
       allGeoMessages
         .filter((message) => message.topic === topic)
-        .forEach((message) => addGeoJsonMessage(message, topicLayer));
+        .forEach((message) => addGeoJsonMessage(message, topicLayer.allFrames));
     }
   }, [
     addGeoJsonMessage,
@@ -511,7 +511,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
       currentGeoMessages
         .filter((message) => message.topic === topic)
-        .forEach((message) => addGeoJsonMessage(message, topicLayer));
+        .forEach((message) => addGeoJsonMessage(message, topicLayer.currentFrame));
     }
   }, [
     addGeoJsonMessage,


### PR DESCRIPTION


**User-Facing Changes**
In live connections old GeoJSON messages are cleared before rendering the new GeoJSON message.

**Description**
The previous behavior of adding a geojson message would always add the message to the allFrames feature group. When connected to a live data source this would result in the geojson messages accumulating since allFrames would not be cleared when receiving new messages.

This change updates the logic for adding geojson messages to ensure they are added to the correct feature group (allFrames or currentFrame). Each feature group is cleared when processing messages for that specific feature group thus avoiding stale messages in the feature group.

Fixes: #4360

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
