### PR TITLE
Listen on all interfaces for Ros1Player

### DIFF
--- a/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
+++ b/packages/studio-base/src/dataSources/Ros1SocketDataSourceFactory.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { isString, isUndefined } from "lodash";
+
 import { RosNode } from "@foxglove/ros1";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import {
@@ -49,8 +51,8 @@ class Ros1SocketDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const hostname = args.hostname ?? "localhost";
-    if (typeof hostname !== "string") {
+    const hostname = args.hostname;
+    if (!isUndefined(hostname) && !isString(hostname)) {
       throw new Error(`Unable to initialize Ros1. Invalid hostname ${hostname}`);
     }
 

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -113,7 +113,16 @@ export default class Ros1Player implements Player {
       return await net.createSocket(options.host, options.port);
     };
     const tcpServer = await net.createServer();
-    await tcpServer.listen(undefined, hostname, 10);
+
+    // Mirror the ros_comm c++ library behavior when setting up the tcp server listener.
+    // ros_comm listens on all interfaces unless the hostname is explicity set to 'localhost'
+    // https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport/transport_tcp.cpp#L393-L395
+    // https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/clients/roscpp/src/libros/transport/transport.cpp#L67-L72
+    let listenHostname = undefined;
+    if (hostname && hostname === "localhost") {
+      listenHostname = "localhost";
+    }
+    await tcpServer.listen(undefined, listenHostname, 10);
 
     if (this._rosNode == undefined) {
       const rosNode = new RosNode({

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -119,7 +119,7 @@ export default class Ros1Player implements Player {
     // https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport/transport_tcp.cpp#L393-L395
     // https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/clients/roscpp/src/libros/transport/transport.cpp#L67-L72
     let listenHostname = undefined;
-    if (hostname && hostname === "localhost") {
+    if (hostname === "localhost") {
       listenHostname = "localhost";
     }
     await tcpServer.listen(undefined, listenHostname, 10);


### PR DESCRIPTION


**User-Facing Changes**
When publishing messages from studio using the ROS1 native connection, the internal ROS node within Studio will listen on all network interfaces.

**Description**
This change updates the Ros1Player to listen on all interfaces for the rosnode internal to studio. This mirrors the ros_comm c++ behavior.

Fixes: #3182

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
