### PR TITLE
Improve horizontal scaling of settings editor fields

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -9,7 +9,6 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Typography,
-  styled as muiStyled,
   List,
   MenuItem,
   Select,
@@ -18,6 +17,7 @@ import {
   ListProps,
 } from "@mui/material";
 import { DeepReadonly } from "ts-essentials";
+import { makeStyles } from "tss-react/mui";
 import { v4 as uuid } from "uuid";
 
 import { SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
@@ -29,82 +29,88 @@ import { ColorPickerInput, ColorGradientInput, NumberInput, Vec3Input, Vec2Input
 // Used to both undefined and empty string in select inputs.
 const UNDEFINED_SENTINEL_VALUE = uuid();
 
-const StyledToggleButtonGroup = muiStyled(ToggleButtonGroup)(({ theme }) => ({
-  backgroundColor: theme.palette.action.hover,
-  gap: theme.spacing(0.25),
-
-  "& .MuiToggleButtonGroup-grouped": {
-    margin: theme.spacing(0.55),
-    borderRadius: theme.shape.borderRadius,
-    paddingTop: 0,
-    paddingBottom: 0,
-    borderColor: "transparent",
-    lineHeight: 1.75,
-
-    "&.Mui-selected": {
-      background: theme.palette.background.paper,
-      borderColor: "transparent",
-
-      "&:hover": {
-        borderColor: theme.palette.action.active,
-      },
-    },
-    "&:not(:first-of-type)": {
-      borderRadius: theme.shape.borderRadius,
-    },
-    "&:first-of-type": {
-      borderRadius: theme.shape.borderRadius,
-    },
-  },
-}));
-
-const PsuedoInputWrapper = muiStyled(Stack)(({ theme }) => {
+const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
   const prefersDarkMode = theme.palette.mode === "dark";
-  const backgroundColor = prefersDarkMode ? "rgba(255, 255, 255, 0.09)" : "rgba(0, 0, 0, 0.06)";
+  const inputBackgroundColor = prefersDarkMode
+    ? "rgba(255, 255, 255, 0.09)"
+    : "rgba(0, 0, 0, 0.06)";
 
   return {
-    padding: theme.spacing(0.75, 1),
-    borderRadius: theme.shape.borderRadius,
-    fontSize: "0.75em",
-    backgroundColor,
-
-    input: {
-      height: "1.4375em",
+    error: {},
+    fieldLabel: {
+      textAlign: "end",
+      color: theme.palette.text.secondary,
+      whiteSpace: "nowrap",
+      flex: "auto",
     },
-    "&:hover": {
-      backgroundColor: prefersDarkMode ? "rgba(255, 255, 255, 0.13)" : "rgba(0, 0, 0, 0.09)",
-      // Reset on touch devices, it doesn't add specificity
-      "@media (hover: none)": {
-        backgroundColor,
+    fieldWrapper: {
+      marginRight: theme.spacing(1.25),
+      [`.${classes.error}`]: {
+        ".MuiInputBase-root": {
+          outline: `1px ${theme.palette.error.main} solid`,
+          outlineOffset: -1,
+        },
       },
     },
-    "&:focus-within": {
-      backgroundColor,
+    multiLabelWrapper: {
+      display: "grid",
+      gridTemplateColumns: "1fr auto",
+      columnGap: theme.spacing(0.5),
+      height: "100%",
+      width: "100%",
+      alignItems: "center",
+      textAlign: "end",
+    },
+    pseudoInputWrapper: {
+      padding: theme.spacing(0.75, 1),
+      borderRadius: theme.shape.borderRadius,
+      fontSize: "0.75em",
+      backgroundColor: inputBackgroundColor,
+
+      input: {
+        height: "1.4375em",
+      },
+      "&:hover": {
+        backgroundColor: prefersDarkMode ? "rgba(255, 255, 255, 0.13)" : "rgba(0, 0, 0, 0.09)",
+        // Reset on touch devices, it doesn't add specificity
+        "@media (hover: none)": {
+          backgroundColor: inputBackgroundColor,
+        },
+      },
+      "&:focus-within": {
+        backgroundColor: inputBackgroundColor,
+      },
+    },
+    styledToggleButtonGroup: {
+      backgroundColor: theme.palette.action.hover,
+      gap: theme.spacing(0.25),
+
+      "& .MuiToggleButtonGroup-grouped": {
+        margin: theme.spacing(0.55),
+        borderRadius: theme.shape.borderRadius,
+        paddingTop: 0,
+        paddingBottom: 0,
+        borderColor: "transparent",
+        lineHeight: 1.75,
+
+        "&.Mui-selected": {
+          background: theme.palette.background.paper,
+          borderColor: "transparent",
+
+          "&:hover": {
+            borderColor: theme.palette.action.active,
+          },
+        },
+        "&:not(:first-of-type)": {
+          borderRadius: theme.shape.borderRadius,
+        },
+        "&:first-of-type": {
+          borderRadius: theme.shape.borderRadius,
+        },
+      },
     },
   };
 });
-
-const MultiLabelWrapper = muiStyled("div")(({ theme }) => ({
-  display: "grid",
-  gridTemplateColumns: "1fr auto",
-  columnGap: theme.spacing(0.5),
-  height: "100%",
-  width: "100%",
-  alignItems: "center",
-}));
-
-const FieldWrapper = muiStyled("div", {
-  shouldForwardProp: (prop) => prop !== "error",
-})<{ error: boolean }>(({ error, theme }) => ({
-  marginRight: theme.spacing(1.25),
-
-  ...(error && {
-    ".MuiInputBase-root": {
-      outline: `1px ${theme.palette.error.main} solid`,
-      outlineOffset: -1,
-    },
-  }),
-}));
 
 function FieldInput({
   actionHandler,
@@ -115,6 +121,8 @@ function FieldInput({
   field: DeepReadonly<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
+  const { classes } = useStyles();
+
   switch (field.input) {
     case "autocomplete":
       return (
@@ -167,7 +175,8 @@ function FieldInput({
       );
     case "toggle":
       return (
-        <StyledToggleButtonGroup
+        <ToggleButtonGroup
+          className={classes.styledToggleButtonGroup}
           fullWidth
           value={field.value ?? UNDEFINED_SENTINEL_VALUE}
           exclusive
@@ -194,7 +203,7 @@ function FieldInput({
               {typeof opt === "string" ? opt : opt.label}
             </ToggleButton>
           ))}
-        </StyledToggleButtonGroup>
+        </ToggleButtonGroup>
       );
     case "string":
       return (
@@ -218,7 +227,8 @@ function FieldInput({
       );
     case "boolean":
       return (
-        <StyledToggleButtonGroup
+        <ToggleButtonGroup
+          className={classes.styledToggleButtonGroup}
           fullWidth
           value={field.value ?? false}
           exclusive
@@ -235,7 +245,7 @@ function FieldInput({
         >
           <ToggleButton value={false}>Off</ToggleButton>
           <ToggleButton value={true}>On</ToggleButton>
-        </StyledToggleButtonGroup>
+        </ToggleButtonGroup>
       );
     case "rgb":
       return (
@@ -271,7 +281,7 @@ function FieldInput({
       );
     case "messagepath":
       return (
-        <PsuedoInputWrapper direction="row">
+        <Stack className={classes.pseudoInputWrapper} direction="row">
           <MessagePathInput
             path={field.value ?? ""}
             disabled={field.disabled}
@@ -284,7 +294,7 @@ function FieldInput({
             }
             validTypes={field.validTypes}
           />
-        </PsuedoInputWrapper>
+        </Stack>
       );
     case "select":
       return (
@@ -373,11 +383,13 @@ function FieldInput({
 }
 
 function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.Element {
+  const { classes } = useStyles();
+
   if (field.input === "vec2") {
     const labels = field.labels ?? ["X", "Y"];
     return (
       <>
-        <MultiLabelWrapper>
+        <div className={classes.multiLabelWrapper}>
           <Typography
             title={field.label}
             variant="subtitle2"
@@ -400,14 +412,14 @@ function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.
               {label}
             </Typography>
           ))}
-        </MultiLabelWrapper>
+        </div>
       </>
     );
   } else if (field.input === "vec3") {
     const labels = field.labels ?? ["X", "Y", "Z"];
     return (
       <>
-        <MultiLabelWrapper>
+        <div className={classes.multiLabelWrapper}>
           <Typography
             title={field.label}
             variant="subtitle2"
@@ -430,18 +442,16 @@ function FieldLabel({ field }: { field: DeepReadonly<SettingsTreeField> }): JSX.
               {label}
             </Typography>
           ))}
-        </MultiLabelWrapper>
+        </div>
       </>
     );
   } else {
     return (
       <>
         <Typography
+          className={classes.fieldLabel}
           title={field.help ?? field.label}
           variant="subtitle2"
-          color="text.secondary"
-          noWrap
-          flex="auto"
         >
           {field.label}
         </Typography>
@@ -461,6 +471,7 @@ function FieldEditorComponent({
 }): JSX.Element {
   const indent = Math.min(path.length, 4);
   const paddingLeft = 0.75 + 2 * (indent - 1);
+  const { classes, cx } = useStyles();
 
   return (
     <>
@@ -476,9 +487,9 @@ function FieldEditorComponent({
           </Tooltip>
         )}
       </Stack>
-      <FieldWrapper error={field.error != undefined}>
+      <div className={cx(classes.fieldWrapper, { [classes.error]: field.error != undefined })}>
         <FieldInput actionHandler={actionHandler} field={field} path={path} />
-      </FieldWrapper>
+      </div>
       <Stack paddingBottom={0.25} style={{ gridColumn: "span 2" }} />
     </>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -40,8 +40,10 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
     fieldLabel: {
       textAlign: "end",
       color: theme.palette.text.secondary,
+      overflow: "hidden",
       whiteSpace: "nowrap",
       flex: "auto",
+      textOverflow: "ellipsis",
     },
     fieldWrapper: {
       marginRight: theme.spacing(1.25),

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -43,6 +43,10 @@ const BasicSettings: SettingsTreeNodes = {
     ],
     fields: {
       emptyField: undefined,
+      longField: {
+        input: "string",
+        label: "A field with a very long label that might wrap or truncate",
+      },
       numberWithPrecision: {
         input: "number",
         label: "Number with precision",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   fieldGrid: {
     display: "grid",
-    gridTemplateColumns: "1fr 2fr",
+    gridTemplateColumns: "minmax(0, 1fr) minmax(0, 2fr)",
     columnGap: theme.spacing(1),
   },
 }));

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -4,10 +4,11 @@
 
 import ClearIcon from "@mui/icons-material/Clear";
 import SearchIcon from "@mui/icons-material/Search";
-import { AppBar, IconButton, TextField, styled as muiStyled } from "@mui/material";
+import { AppBar, IconButton, TextField } from "@mui/material";
 import memoizeWeak from "memoize-weak";
 import { useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
+import { makeStyles } from "tss-react/mui";
 
 import { SettingsTree } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -15,17 +16,18 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { NodeEditor } from "./NodeEditor";
 import { filterTreeNodes, prepareSettingsNodes } from "./utils";
 
-const StyledAppBar = muiStyled(AppBar, { skipSx: true })(({ theme }) => ({
-  top: -1,
-  zIndex: theme.zIndex.appBar - 1,
-  borderBottom: `1px solid ${theme.palette.divider}`,
-  padding: theme.spacing(1),
-}));
-
-const FieldGrid = muiStyled("div", { skipSx: true })(({ theme }) => ({
-  display: "grid",
-  gridTemplateColumns: "minmax(4rem, 1fr) minmax(4rem, 12rem)",
-  columnGap: theme.spacing(1),
+const useStyles = makeStyles()((theme) => ({
+  appBar: {
+    top: -1,
+    zIndex: theme.zIndex.appBar - 1,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(1),
+  },
+  fieldGrid: {
+    display: "grid",
+    gridTemplateColumns: "1fr 2fr",
+    columnGap: theme.spacing(1),
+  },
 }));
 
 const makeStablePath = memoizeWeak((key: string) => [key]);
@@ -35,6 +37,7 @@ export default function SettingsTreeEditor({
 }: {
   settings: DeepReadonly<SettingsTree>;
 }): JSX.Element {
+  const { classes } = useStyles();
   const { actionHandler } = settings;
   const [filterText, setFilterText] = useState<string>("");
 
@@ -51,7 +54,7 @@ export default function SettingsTreeEditor({
   return (
     <Stack fullHeight>
       {settings.enableFilter === true && (
-        <StyledAppBar position="sticky" color="default" elevation={0}>
+        <AppBar className={classes.appBar} position="sticky" color="default" elevation={0}>
           <TextField
             data-testid="settings-filter-field"
             onChange={(event) => setFilterText(event.target.value)}
@@ -73,9 +76,9 @@ export default function SettingsTreeEditor({
               ),
             }}
           />
-        </StyledAppBar>
+        </AppBar>
       )}
-      <FieldGrid>
+      <div className={classes.fieldGrid}>
         {definedNodes.map(([key, root]) => (
           <NodeEditor
             key={key}
@@ -86,7 +89,7 @@ export default function SettingsTreeEditor({
             settings={root}
           />
         ))}
-      </FieldGrid>
+      </div>
     </Stack>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Improves horizontal scaling of settings editor fields.

**Description**
Improves horizontal scaling of settings editor fields and replaces muiStyled with makeStyles for the settings editor fields, improving UX for interactions with wide fields like message paths. Right align field labels for better layout when the sidebar is wide.

<img width="407" alt="Screen Shot 2022-09-12 at 8 31 07 AM" src="https://user-images.githubusercontent.com/93935560/189654644-0eda5a73-b430-427b-83a6-608b6a4c1a36.png">
<img width="409" alt="Screen Shot 2022-09-12 at 8 31 28 AM" src="https://user-images.githubusercontent.com/93935560/189654651-90ad88f7-2940-41b5-ab7b-d83068072cd4.png">
<img width="417" alt="Screen Shot 2022-09-12 at 8 31 38 AM" src="https://user-images.githubusercontent.com/93935560/189654654-b2442c59-c329-4af5-b31d-e6b2ce806e13.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
