### PR TITLE
Remove ThreeDimensionalViz imports from New3D panel except globalvariables

### DIFF
--- a/packages/studio-base/src/components/MultilineMiddleTruncate.tsx
+++ b/packages/studio-base/src/components/MultilineMiddleTruncate.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import TextMiddleTruncate from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/TextMiddleTruncate";
+import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 
 /**
  * Render multiline text using TextMiddleTruncate for each line.

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -14,9 +14,9 @@ import { useMemo } from "react";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
+import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
-import TextMiddleTruncate from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/TextMiddleTruncate";
 
 import ActionList, { ActionListItem } from "./ActionList";
 import { OpenDialogViews } from "./types";

--- a/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.stories.tsx
@@ -16,7 +16,7 @@ import TextMiddleTruncate from "./TextMiddleTruncate";
 
 const LONG_TOPIC_NAME =
   "/some_really_long_topic_name/some/long/text/lorem/ipsum/dolor/sit/amet/consectetur/adipisicing/voluptate/laborum/amet/velit/eius/cum/modi//sapiente/natus/unde/end_topic_name";
-storiesOf("panels/ThreeDimensionalViz/TopicTree/TextMiddleTruncate", module).add("default", () => {
+storiesOf("components/TextMiddleTruncate", module).add("default", () => {
   return (
     <div style={{ width: 240, border: "1px solid gray", margin: 16 }}>
       <div>

--- a/packages/studio-base/src/components/TextMiddleTruncate.tsx
+++ b/packages/studio-base/src/components/TextMiddleTruncate.tsx
@@ -11,36 +11,35 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import styled from "styled-components";
+import { makeStyles } from "tss-react/mui";
 
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 
 export const DEFAULT_END_TEXT_LENGTH = 16;
 
-export const STextMiddleTruncate = styled.div`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-`;
-
-const SStart = styled.div`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex-shrink: 1;
-`;
-
-const SEnd = styled.div`
-  white-space: nowrap;
-  flex-basis: content;
-  flex-grow: 0;
-  flex-shrink: 0;
-  max-width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
+const useStyles = makeStyles()(() => ({
+  STextMiddleTruncate: {
+    display: "flex",
+    flexDirection: "row",
+    flexWrap: "nowrap",
+    justifyContent: "flex-start",
+  },
+  SStart: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    flexShrink: 1,
+  },
+  SEnd: {
+    whiteSpace: "nowrap",
+    flexBasis: "content",
+    flexGrow: 0,
+    flexShrink: 0,
+    maxWidth: "100%",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+}));
 
 type Props = {
   tooltips?: React.ReactNode[];
@@ -59,19 +58,20 @@ export default function TextMiddleTruncate({
   style,
   testShowTooltip,
 }: Props): React.ReactElement {
+  const { classes } = useStyles();
   const startTextLen = Math.max(
     0,
     text.length -
       (endTextLength == undefined || endTextLength === 0 ? DEFAULT_END_TEXT_LENGTH : endTextLength),
   );
-  const startText = text.substr(0, startTextLen);
-  const endText = text.substr(startTextLen);
+  const startText = text.substring(0, startTextLen);
+  const endText = text.substring(startTextLen);
 
   const elem = (
-    <STextMiddleTruncate style={style}>
-      <SStart>{startText}</SStart>
-      <SEnd>{endText}</SEnd>
-    </STextMiddleTruncate>
+    <div className={classes.STextMiddleTruncate} style={style}>
+      <div className={classes.SStart}>{startText}</div>
+      <div className={classes.SEnd}>{endText}</div>
+    </div>
   );
   return (
     <Tooltip contents={tooltips} placement="top" shown={testShowTooltip}>

--- a/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
+++ b/packages/studio-base/src/panels/Image/components/TopicDropdown.tsx
@@ -7,7 +7,7 @@ import { Button, styled as muiStyled, Menu, MenuItem } from "@mui/material";
 import { MouseEvent, useState, useCallback } from "react";
 
 import { Topic } from "@foxglove/studio";
-import TextMiddleTruncate from "@foxglove/studio-base/panels/ThreeDimensionalViz/TopicTree/TextMiddleTruncate";
+import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 
 type TopicDropdownProps = {
   topics: Topic[];

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -15,12 +15,8 @@ import { Stack } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
-import { decodeMarker } from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/decodeMarker";
-import {
-  POINT_CLOUD_MESSAGE,
-  POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
-} from "@foxglove/studio-base/panels/ThreeDimensionalViz/commands/PointClouds/fixture/pointCloudData";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
 
 import Interactions, { OBJECT_TAB_TYPE, LINKED_VARIABLES_TAB_TYPE } from "./Interactions";
 
@@ -55,6 +51,208 @@ const markerObject = {
       w: 1,
     },
   },
+};
+
+// ts-prune-ignore-next
+export const POINT_CLOUD_MESSAGE: PointCloud2 = {
+  fields: [
+    {
+      name: "x",
+      offset: 0,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "y",
+      offset: 4,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "z",
+      offset: 8,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "rgb",
+      offset: 16,
+      datatype: 7,
+      count: 1,
+    },
+  ],
+  type: 102,
+  pose: {
+    position: { x: 0, y: 0, z: 0 },
+    orientation: { x: 0, y: 0, z: 0, w: 0 },
+  },
+  header: {
+    seq: 0,
+    frame_id: "root_frame_id",
+    stamp: {
+      sec: 10,
+      nsec: 10,
+    },
+  },
+  height: 1,
+  is_bigendian: false,
+  is_dense: 1,
+  point_step: 32,
+  row_step: 32,
+  width: 2,
+  data: new Uint8Array([
+    // point 1
+    // x
+    125, 236, 11, 197,
+    // y
+    118, 102, 48, 196,
+    // z
+    50, 194, 23, 192,
+    // ?
+    0, 0, 128, 63,
+    // rgb (abgr ordering)
+    10, 255, 230, 127,
+    // ?
+    254, 127, 0, 0, 16, 142, 140, 0, 161, 254, 127, 0,
+    // point 2
+    // x
+    125, 236, 11, 197,
+    // y
+    118, 102, 48, 196,
+    // z
+    50, 194, 23, 192,
+    // ?
+    0, 0, 128, 63,
+    // rgb (abgr ordering)
+    10, 255, 255, 127,
+    // ?
+    254, 127, 0, 0, 16, 142, 140, 0, 161, 254, 127, 0,
+    // point 3
+    // x
+    118, 102, 48, 196,
+    // y
+    125, 236, 11, 197,
+    // z
+    50, 194, 23, 192,
+    // ?
+    0, 0, 128, 63,
+    // rgb (abgr ordering)
+    10, 127, 255, 127,
+    // ?
+    254, 127, 0, 0, 16, 142, 140, 0, 161, 254, 127, 8,
+  ]),
+};
+
+// ts-prune-ignore-next
+export const POINT_CLOUD_WITH_ADDITIONAL_FIELDS: PointCloud2 = {
+  fields: [
+    {
+      name: "x",
+      offset: 0,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "y",
+      offset: 4,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "z",
+      offset: 8,
+      datatype: 7,
+      count: 1,
+    },
+    {
+      name: "foo",
+      offset: 12,
+      datatype: 2,
+      count: 1,
+    },
+    {
+      name: "bar",
+      offset: 13,
+      datatype: 4,
+      count: 1,
+    },
+    {
+      name: "baz",
+      offset: 15,
+      datatype: 5,
+      count: 1,
+    },
+    {
+      name: "foo16_some_really_really_long_name",
+      offset: 19,
+      datatype: 3,
+      count: 1,
+    },
+  ],
+  type: 102,
+  pose: {
+    position: { x: 0, y: 0, z: 0 },
+    orientation: { x: 0, y: 0, z: 0, w: 0 },
+  },
+  header: {
+    seq: 0,
+    frame_id: "root_frame_id",
+    stamp: {
+      sec: 10,
+      nsec: 10,
+    },
+  },
+  height: 1,
+  is_bigendian: false,
+  is_dense: 1,
+  point_step: 21,
+  row_step: 21,
+  width: 2,
+  data: new Uint8Array([
+    0, //   1, start of point 1
+    0, //   2
+    0, //   3
+    0, //   4, x: float32 = 0
+    0, //   5
+    0, //   6
+    128, // 7
+    63, //  8, y: float32 = 1
+    0, //   9
+    0, //   10
+    0, //   11
+    64, //  12, z: float32 =  2
+    7, //   13, foo: uint8 = 7
+    6, //   14
+    0, //   15, bar: uint16 = 6
+    5, //   16
+    0, //   17
+    0, //   18
+    0, //   19, baz: int32 = 5
+    9, //   20
+    1, //   21, foo16: int16 = 265
+    // ---------- another row
+    0, //   22, start of point 2
+    0, //   23
+    0, //   24
+    0, //   25 x: float32 = 0
+    0, //   26
+    0, //   27
+    128, // 28
+    63, //  29 y: float32 = 1
+    0, //   30
+    0, //   31
+    0, //   32
+    64, //  33, z: float32 =  2
+    9, //   34, foo: uint8 = 9
+    8, //   35
+    0, //   36, bar: uint16 = 8
+    7, //   37
+    0, //   38
+    0, //   39
+    0, //   40, baz: int32 = 7
+    2, //   41
+    0, //   42, foo16: int16 = 2
+  ]),
 };
 
 const interactiveMarkerObject = {
@@ -207,10 +405,10 @@ storiesOf("panels/ThreeDeeRender/Interactions/Interaction", module)
   .add("default", DefaultStory, { colorScheme: "dark" })
   .add("default light", DefaultStory, { colorScheme: "light" })
   .add("PointCloud", () => {
-    const cloud1 = { ...selectedObject.object, ...decodeMarker(POINT_CLOUD_MESSAGE) };
+    const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
     const cloud2 = {
       ...selectedObject.object,
-      ...decodeMarker(POINT_CLOUD_WITH_ADDITIONAL_FIELDS),
+      ...POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
     };
 
     return (

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/InteractionContextMenu.tsx
@@ -5,8 +5,7 @@
 import { Menu, MenuItem, MenuProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { getObject } from "@foxglove/studio-base/panels/ThreeDimensionalViz/threeDimensionalVizUtils";
-import { BaseMarker } from "@foxglove/studio-base/types/Messages";
+import { BaseMarker, InstancedLineListMarker } from "@foxglove/studio-base/types/Messages";
 
 import { MouseEventObject } from "../camera";
 import { Interactive, SelectedObject } from "./types";
@@ -18,6 +17,22 @@ type Props = {
   clickedObjects: MouseEventObject[];
   onClose: MenuProps["onClose"];
   selectObject: (arg0?: MouseEventObject) => void;
+};
+
+const getInstanceObj = (marker: unknown, idx: number): unknown => {
+  if (marker == undefined) {
+    return;
+  }
+  return (marker as InstancedLineListMarker).metadataByIndex?.[idx];
+};
+
+const getObject = (selectedObject?: MouseEventObject): unknown => {
+  const object =
+    (selectedObject?.instanceIndex != undefined &&
+      (selectedObject.object as InstancedLineListMarker).metadataByIndex != undefined &&
+      getInstanceObj(selectedObject.object, selectedObject.instanceIndex)) ||
+    selectedObject?.object;
+  return object;
 };
 
 function InteractionContextMenuItem({

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
@@ -15,7 +15,7 @@ import styled from "styled-components";
 
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 
-import TextMiddleTruncate from "../../../components/TextMiddleTruncate";
+import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import TextHighlight from "./TextHighlight";
 
 // Extra text length to make sure text such as `1000 visible topics` don't get truncated.

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
@@ -13,9 +13,9 @@
 
 import styled from "styled-components";
 
+import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 
-import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
 import TextHighlight from "./TextHighlight";
 
 // Extra text length to make sure text such as `1000 visible topics` don't get truncated.

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/TopicTree/NodeName.tsx
@@ -15,8 +15,8 @@ import styled from "styled-components";
 
 import Tooltip from "@foxglove/studio-base/components/Tooltip";
 
+import TextMiddleTruncate from "../../../components/TextMiddleTruncate";
 import TextHighlight from "./TextHighlight";
-import TextMiddleTruncate from "./TextMiddleTruncate";
 
 // Extra text length to make sure text such as `1000 visible topics` don't get truncated.
 const DEFAULT_END_TEXT_LENGTH = 22;


### PR DESCRIPTION

**User-Facing Changes**
- none

**Description**
 - moved TextMiddleTruncate to components
 - removed decodemarkers from interaction story
 - unsure of how to move forward on `useLinkedGlobalVariables`


<!-- link relevant github issues -->
Fixes #4381 (except link global variables)

<!-- add `docs` label if this PR requires documentation updates -->
