### PR TITLE
Disable background transition on MuiButton

### DIFF
--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -109,6 +109,9 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
         disableElevation: true,
       },
       styleOverrides: {
+        root: {
+          ...disableBackgroundColorTransition,
+        },
         containedInherit: {
           backgroundColor: theme.palette.action.focus,
         },


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Follow up to #4331, disabling the transition for MuiButton as well for consistency.