### PR TITLE
Fix shallowequal in MessagePipeline topics/datatypes comparison

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/store.ts
+++ b/packages/studio-base/src/components/MessagePipeline/store.ts
@@ -267,16 +267,13 @@ function updatePlayerStateAction(
   };
 
   const topics = action.playerState.activeData?.topics;
-  if (!shallowequal(topics, prevState.public.playerState.activeData?.topics)) {
+  if (topics !== prevState.public.playerState.activeData?.topics) {
     newPublicState.sortedTopics = topics
       ? [...topics].sort((a, b) => a.name.localeCompare(b.name))
       : [];
   }
   if (
-    !shallowequal(
-      action.playerState.activeData?.datatypes,
-      prevState.public.playerState.activeData?.datatypes,
-    )
+    action.playerState.activeData?.datatypes !== prevState.public.playerState.activeData?.datatypes
   ) {
     newPublicState.datatypes = action.playerState.activeData?.datatypes ?? new Map();
   }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes an issue where datatypes from a bag file would not be vended out to panels. (regression from #4407)
topics is `Topic[]` and datatypes is a `Map`, neither of which are really appropriate for `shallowequal`. Just use object identity.