### PR TITLE
3D: support foxglove Image types

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/foxglove.ts
@@ -8,6 +8,15 @@ addFoxgloveSchema(FRAME_TRANSFORM_DATATYPES, "foxglove.FrameTransform");
 export const POINTCLOUD_DATATYPES = new Set<string>();
 addFoxgloveSchema(POINTCLOUD_DATATYPES, "foxglove.PointCloud");
 
+export const RAW_IMAGE_DATATYPES = new Set<string>();
+addFoxgloveSchema(RAW_IMAGE_DATATYPES, "foxglove.RawImage");
+
+export const COMPRESSED_IMAGE_DATATYPES = new Set<string>();
+addFoxgloveSchema(COMPRESSED_IMAGE_DATATYPES, "foxglove.CompressedImage");
+
+export const CAMERA_CALIBRATION_DATATYPES = new Set<string>();
+addFoxgloveSchema(CAMERA_CALIBRATION_DATATYPES, "foxglove.CameraCalibration");
+
 export const SCENE_UPDATE_DATATYPES = new Set<string>();
 addFoxgloveSchema(SCENE_UPDATE_DATATYPES, "foxglove.SceneUpdate");
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -21,6 +21,7 @@ import {
 } from "@foxglove/den/image";
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
+import { CameraCalibration, CompressedImage, RawImage } from "@foxglove/schemas/schemas/typescript";
 import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 import { MutablePoint } from "@foxglove/studio-base/types/Messages";
@@ -30,13 +31,18 @@ import type { Renderer } from "../Renderer";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { stringToRgba } from "../color";
-import { normalizeByteArray, normalizeHeader } from "../normalizeMessages";
+import {
+  CAMERA_CALIBRATION_DATATYPES,
+  COMPRESSED_IMAGE_DATATYPES,
+  RAW_IMAGE_DATATYPES,
+} from "../foxglove";
+import { normalizeByteArray, normalizeHeader, normalizeTime } from "../normalizeMessages";
 import {
   CameraInfo,
-  Image,
-  CompressedImage,
-  IMAGE_DATATYPES,
-  COMPRESSED_IMAGE_DATATYPES,
+  Image as RosImage,
+  CompressedImage as RosCompressedImage,
+  IMAGE_DATATYPES as ROS_IMAGE_DATATYPES,
+  COMPRESSED_IMAGE_DATATYPES as ROS_COMPRESSED_IMAGE_DATATYPES,
   CAMERA_INFO_DATATYPES,
 } from "../ros";
 import { BaseSettings, PRECISION_DISTANCE, SelectEntry } from "../settings";
@@ -45,6 +51,8 @@ import { CameraInfoUserData } from "./Cameras";
 
 const log = Logger.getLogger(__filename);
 void log;
+
+type AnyImage = RosImage | RosCompressedImage | RawImage | CompressedImage;
 
 export type LayerSettingsImage = BaseSettings & {
   cameraInfoTopic: string | undefined;
@@ -69,7 +77,7 @@ const DEFAULT_SETTINGS: LayerSettingsImage = {
 export type ImageUserData = BaseUserData & {
   topic: string;
   settings: LayerSettingsImage;
-  image: Image | CompressedImage;
+  image: AnyImage;
   texture: THREE.Texture | undefined;
   material: THREE.MeshBasicMaterial | undefined;
   geometry: THREE.PlaneGeometry | undefined;
@@ -102,13 +110,23 @@ export class Images extends SceneExtension<ImageRenderable> {
   public constructor(renderer: Renderer) {
     super("foxglove.Images", renderer);
 
-    renderer.addDatatypeSubscriptions(IMAGE_DATATYPES, this.handleRawImage);
-    renderer.addDatatypeSubscriptions(COMPRESSED_IMAGE_DATATYPES, this.handleCompressedImage);
+    renderer.addDatatypeSubscriptions(ROS_IMAGE_DATATYPES, this.handleRosRawImage);
+    renderer.addDatatypeSubscriptions(
+      ROS_COMPRESSED_IMAGE_DATATYPES,
+      this.handleRosCompressedImage,
+    );
     // Unconditionally subscribe to CameraInfo messages so the `foxglove.Cameras` extension will
     // always receive them and parse into camera models. This extension reuses the parsed camera
     // models from `foxglove.Cameras`
     renderer.addDatatypeSubscriptions(CAMERA_INFO_DATATYPES, {
-      handler: this.handleCameraInfo,
+      handler: this.handleRosCameraInfo,
+      forced: true,
+    });
+
+    renderer.addDatatypeSubscriptions(RAW_IMAGE_DATATYPES, this.handleRawImage);
+    renderer.addDatatypeSubscriptions(COMPRESSED_IMAGE_DATATYPES, this.handleCompressedImage);
+    renderer.addDatatypeSubscriptions(CAMERA_CALIBRATION_DATATYPES, {
+      handler: this.handleCameraCalibration,
       forced: true,
     });
   }
@@ -118,7 +136,12 @@ export class Images extends SceneExtension<ImageRenderable> {
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
     for (const topic of this.renderer.topics ?? []) {
-      if (IMAGE_DATATYPES.has(topic.datatype) || COMPRESSED_IMAGE_DATATYPES.has(topic.datatype)) {
+      if (
+        ROS_IMAGE_DATATYPES.has(topic.datatype) ||
+        ROS_COMPRESSED_IMAGE_DATATYPES.has(topic.datatype) ||
+        RAW_IMAGE_DATATYPES.has(topic.datatype) ||
+        COMPRESSED_IMAGE_DATATYPES.has(topic.datatype)
+      ) {
         const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsImage>;
 
         // Build a list of all matching CameraInfo topics
@@ -175,18 +198,25 @@ export class Images extends SceneExtension<ImageRenderable> {
     }
   };
 
-  private handleRawImage = (messageEvent: PartialMessageEvent<Image>): void => {
-    this.handleImage(messageEvent, normalizeImage(messageEvent.message));
+  private handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
+    this.handleImage(messageEvent, normalizeRosImage(messageEvent.message));
+  };
+
+  private handleRosCompressedImage = (
+    messageEvent: PartialMessageEvent<RosCompressedImage>,
+  ): void => {
+    this.handleImage(messageEvent, normalizeRosCompressedImage(messageEvent.message));
+  };
+
+  private handleRawImage = (messageEvent: PartialMessageEvent<RawImage>): void => {
+    this.handleImage(messageEvent, normalizeRawImage(messageEvent.message));
   };
 
   private handleCompressedImage = (messageEvent: PartialMessageEvent<CompressedImage>): void => {
     this.handleImage(messageEvent, normalizeCompressedImage(messageEvent.message));
   };
 
-  private handleImage = (
-    messageEvent: PartialMessageEvent<Image | CompressedImage>,
-    image: Image | CompressedImage,
-  ): void => {
+  private handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
     const topic = messageEvent.topic;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
@@ -199,8 +229,10 @@ export class Images extends SceneExtension<ImageRenderable> {
     if (!renderable) {
       renderable = new ImageRenderable(topic, this.renderer, {
         receiveTime,
-        messageTime: toNanoSec(image.header.stamp),
-        frameId: this.renderer.normalizeFrameId(image.header.frame_id),
+        messageTime: toNanoSec("header" in image ? image.header.stamp : image.timestamp),
+        frameId: this.renderer.normalizeFrameId(
+          "header" in image ? image.header.frame_id : image.frame_id,
+        ),
         pose: makePose(),
         settingsPath: ["topics", topic],
         topic,
@@ -241,7 +273,25 @@ export class Images extends SceneExtension<ImageRenderable> {
     this._updateImageRenderable(renderable, image, receiveTime, renderable.userData.settings);
   };
 
-  private handleCameraInfo = (messageEvent: PartialMessageEvent<CameraInfo>): void => {
+  private handleRosCameraInfo = (messageEvent: PartialMessageEvent<CameraInfo>): void => {
+    const topic = messageEvent.topic;
+    const updated = !this.cameraInfoTopics.has(topic);
+    this.cameraInfoTopics.add(topic);
+
+    const renderable = this.renderables.get(topic);
+    if (renderable) {
+      const { image, settings } = renderable.userData;
+      this._updateImageRenderable(renderable, image, renderable.userData.receiveTime, settings);
+    }
+
+    if (updated) {
+      this.updateSettingsTree();
+    }
+  };
+
+  private handleCameraCalibration = (
+    messageEvent: PartialMessageEvent<CameraCalibration>,
+  ): void => {
     const topic = messageEvent.topic;
     const updated = !this.cameraInfoTopics.has(topic);
     this.cameraInfoTopics.add(topic);
@@ -259,7 +309,7 @@ export class Images extends SceneExtension<ImageRenderable> {
 
   private _updateImageRenderable(
     renderable: ImageRenderable,
-    image: Image | CompressedImage,
+    image: AnyImage,
     receiveTime: bigint,
     settings: Partial<LayerSettingsImage> | undefined,
   ): void {
@@ -272,9 +322,13 @@ export class Images extends SceneExtension<ImageRenderable> {
     const topic = renderable.userData.topic;
 
     renderable.userData.image = image;
-    renderable.userData.frameId = this.renderer.normalizeFrameId(image.header.frame_id);
+    renderable.userData.frameId = this.renderer.normalizeFrameId(
+      "header" in image ? image.header.frame_id : image.frame_id,
+    );
     renderable.userData.receiveTime = receiveTime;
-    renderable.userData.messageTime = toNanoSec(image.header.stamp);
+    renderable.userData.messageTime = toNanoSec(
+      "header" in image ? image.header.stamp : image.timestamp,
+    );
     renderable.userData.settings = newSettings;
 
     // Dispose of the current geometry if the settings have changed
@@ -313,9 +367,8 @@ export class Images extends SceneExtension<ImageRenderable> {
     }
 
     // Create or update the bitmap texture
-    if ((image as Partial<CompressedImage>).format) {
-      const compressed = image as CompressedImage;
-      const bitmapData = new Blob([image.data], { type: `image/${compressed.format}` });
+    if ("format" in image) {
+      const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
       self
         .createImageBitmap(bitmapData, { resizeWidth: DEFAULT_IMAGE_WIDTH })
         .then((bitmap) => {
@@ -342,7 +395,7 @@ export class Images extends SceneExtension<ImageRenderable> {
           );
         });
     } else {
-      const raw = image as Image;
+      const raw = image as RosImage;
       const { width, height } = raw;
       const prevTexture = renderable.userData.texture as THREE.DataTexture | undefined;
       if (
@@ -551,7 +604,7 @@ function autoSelectCameraInfoTopic(
 }
 
 function rawImageToDataTexture(
-  image: Image,
+  image: RosImage,
   options: RawImageOptions,
   output: THREE.DataTexture,
 ): void {
@@ -602,17 +655,19 @@ function rawImageToDataTexture(
   }
 }
 
-function normalizeImageData(data: unknown): Int8Array | Uint8Array {
+function normalizeImageData(data: unknown): Uint8Array {
   if (data == undefined) {
     return new Uint8Array(0);
-  } else if (data instanceof Int8Array || data instanceof Uint8Array) {
+  } else if (data instanceof Int8Array) {
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  } else if (data instanceof Uint8Array) {
     return data;
   } else {
     return new Uint8Array(0);
   }
 }
 
-function normalizeImage(message: PartialMessage<Image>): Image {
+function normalizeRosImage(message: PartialMessage<RosImage>): RosImage {
   return {
     header: normalizeHeader(message.header),
     height: message.height ?? 0,
@@ -624,9 +679,32 @@ function normalizeImage(message: PartialMessage<Image>): Image {
   };
 }
 
-function normalizeCompressedImage(message: PartialMessage<CompressedImage>): CompressedImage {
+function normalizeRosCompressedImage(
+  message: PartialMessage<RosCompressedImage>,
+): RosCompressedImage {
   return {
     header: normalizeHeader(message.header),
+    format: message.format ?? "",
+    data: normalizeByteArray(message.data),
+  };
+}
+
+function normalizeRawImage(message: PartialMessage<RawImage>): RawImage {
+  return {
+    timestamp: normalizeTime(message.timestamp),
+    frame_id: message.frame_id ?? "",
+    height: message.height ?? 0,
+    width: message.width ?? 0,
+    encoding: message.encoding ?? "",
+    step: message.step ?? 0,
+    data: normalizeImageData(message.data),
+  };
+}
+
+function normalizeCompressedImage(message: PartialMessage<CompressedImage>): CompressedImage {
+  return {
+    timestamp: normalizeTime(message.timestamp),
+    frame_id: message.frame_id ?? "",
     format: message.format ?? "",
     data: normalizeByteArray(message.data),
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -395,8 +395,7 @@ export class Images extends SceneExtension<ImageRenderable> {
           );
         });
     } else {
-      const raw = image as RosImage;
-      const { width, height } = raw;
+      const { width, height } = image;
       const prevTexture = renderable.userData.texture as THREE.DataTexture | undefined;
       if (
         prevTexture == undefined ||
@@ -413,7 +412,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       }
 
       const texture = renderable.userData.texture as THREE.DataTexture;
-      rawImageToDataTexture(raw, {}, texture);
+      rawImageToDataTexture(image, {}, texture);
       texture.needsUpdate = true;
     }
 
@@ -604,11 +603,12 @@ function autoSelectCameraInfoTopic(
 }
 
 function rawImageToDataTexture(
-  image: RosImage,
+  image: RosImage | RawImage,
   options: RawImageOptions,
   output: THREE.DataTexture,
 ): void {
-  const { encoding, width, height, is_bigendian } = image;
+  const { encoding, width, height } = image;
+  const is_bigendian = "is_bigendian" in image ? image.is_bigendian : false;
   const rawData = image.data as Uint8Array;
   switch (encoding) {
     case "yuv422":
@@ -655,12 +655,13 @@ function rawImageToDataTexture(
   }
 }
 
-function normalizeImageData(data: unknown): Uint8Array {
+function normalizeImageData(data: Int8Array): Int8Array;
+function normalizeImageData(data: PartialMessage<Uint8Array> | undefined): Uint8Array;
+function normalizeImageData(data: unknown): Int8Array | Uint8Array;
+function normalizeImageData(data: unknown): Int8Array | Uint8Array {
   if (data == undefined) {
     return new Uint8Array(0);
-  } else if (data instanceof Int8Array) {
-    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-  } else if (data instanceof Uint8Array) {
+  } else if (data instanceof Int8Array || data instanceof Uint8Array) {
     return data;
   } else {
     return new Uint8Array(0);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -2,11 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { CompressedImage, FrameTransform, RawImage } from "@foxglove/schemas/schemas/typescript";
 import { MessageEvent, Topic } from "@foxglove/studio";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
-import { CameraInfo, CompressedImage, Image, TransformStamped } from "../ros";
+import { CameraInfo, CompressedImage as RosCompressedImage, Image, TransformStamped } from "../ros";
 import {
   BASE_LINK_FRAME_ID,
   FIXED_FRAME_ID,
@@ -102,7 +103,7 @@ export function ImageRender(): JSX.Element {
     sizeInBytes: 0,
   };
 
-  const cam1Png: MessageEvent<Partial<CompressedImage>> = {
+  const cam1Png: MessageEvent<Partial<RosCompressedImage>> = {
     topic: "/cam1/png",
     receiveTime: { sec: 10, nsec: 0 },
     message: {
@@ -135,6 +136,188 @@ export function ImageRender(): JSX.Element {
       width: SIZE,
       encoding: "rgba8",
       is_bigendian: false,
+      step: SIZE * 4,
+      data: rgba8,
+    },
+    sizeInBytes: 0,
+  };
+
+  const fixture = useDelayedFixture({
+    topics,
+    frame: {
+      "/tf": [tf1, tf2],
+      "/cam1/info": [cam1],
+      "/cam2/info": [cam2],
+      "/cam1/png": [cam1Png],
+      "/cam2/raw": [cam2Raw],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 0, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDeeRender
+        overrideConfig={{
+          ...ThreeDeeRender.defaultConfig,
+          followTf: SENSOR_FRAME_ID,
+          scene: {
+            labelScaleFactor: 0,
+          },
+          cameraState: {
+            distance: 1.5,
+            perspective: true,
+            phi: rad2deg(0.975),
+            targetOffset: [0, 0.4, 0],
+            thetaOffset: rad2deg(0),
+            fovy: rad2deg(0.75),
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+          topics: {
+            "/cam1/info": {
+              visible: true,
+              color: "rgba(0, 255, 0, 1)",
+              distance: 0.5,
+            },
+            "/cam2/info": {
+              visible: true,
+              color: "rgba(0, 255, 255, 1)",
+              distance: 0.25,
+            },
+            "/cam1/png": {
+              visible: true,
+              color: "rgba(255, 255, 255, 1)",
+              distance: 0.5,
+            },
+            "/cam2/raw": {
+              visible: true,
+              color: "rgba(255, 255, 255, 0.75)",
+              distance: 0.25,
+            },
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}
+
+FoxgloveImageRender.parameters = { colorScheme: "light" };
+export function FoxgloveImageRender(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/tf", datatype: "foxglove.FrameTransform" },
+    { name: "/cam1/info", datatype: "foxglove.CameraCalibration" },
+    { name: "/cam2/info", datatype: "foxglove.CameraCalibration" },
+    { name: "/cam1/png", datatype: "foxglove.CompressedImage" },
+    { name: "/cam2/raw", datatype: "foxglove.RawImage" },
+  ];
+
+  const tf1: MessageEvent<FrameTransform> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      parent_frame_id: FIXED_FRAME_ID,
+      child_frame_id: BASE_LINK_FRAME_ID,
+      translation: { x: 1e7, y: 0, z: 0 },
+      rotation: QUAT_IDENTITY,
+    },
+    sizeInBytes: 0,
+  };
+  const tf2: MessageEvent<FrameTransform> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      parent_frame_id: BASE_LINK_FRAME_ID,
+      child_frame_id: SENSOR_FRAME_ID,
+      translation: { x: 0, y: 0, z: 1 },
+      rotation: { x: 0.383, y: 0, z: 0, w: 0.924 },
+    },
+    sizeInBytes: 0,
+  };
+
+  const cam1: MessageEvent<Partial<CameraInfo>> = {
+    topic: "/cam1/info",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+      height: 480,
+      width: 640,
+      distortion_model: "rational_polynomial",
+      D: [0.452407, 0.273748, -0.00011, 0.000152, 0.027904, 0.817958, 0.358389, 0.108657],
+      K: [
+        381.22076416015625, 0, 318.88323974609375, 0, 381.22076416015625, 233.90321350097656, 0, 0,
+        1,
+      ],
+      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+      P: [
+        381.22076416015625, 0, 318.88323974609375, 0.015031411312520504, 0, 381.22076416015625,
+        233.90321350097656, -0.00011014656047336757, 0, 0, 1, 0.000024338871298823506,
+      ],
+    },
+    sizeInBytes: 0,
+  };
+
+  const cam2: MessageEvent<Partial<CameraInfo>> = {
+    topic: "/cam2/info",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: SENSOR_FRAME_ID },
+      height: 900,
+      width: 1600,
+      distortion_model: "",
+      D: [],
+      K: [
+        1266.417203046554, 0, 816.2670197447984, 0, 1266.417203046554, 491.50706579294757, 0, 0, 1,
+      ],
+      R: [1, 0, 0, 1, 0, 0, 1, 0, 0],
+      P: [
+        1266.417203046554, 0, 816.2670197447984, 0, 0, 1266.417203046554, 491.50706579294757, 0, 0,
+        0, 1, 0,
+      ],
+    },
+    sizeInBytes: 0,
+  };
+
+  const cam1Png: MessageEvent<Partial<CompressedImage>> = {
+    topic: "/cam1/png",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      frame_id: SENSOR_FRAME_ID,
+      format: "png",
+      data: PNG_TEST_IMAGE,
+    },
+    sizeInBytes: 0,
+  };
+
+  // Create a Uint8Array 8x8 RGBA image
+  const SIZE = 8;
+  const rgba8 = new Uint8Array(SIZE * SIZE * 4);
+  for (let y = 0; y < SIZE; y++) {
+    for (let x = 0; x < SIZE; x++) {
+      const i = (y * SIZE + x) * 4;
+      rgba8[i + 0] = Math.trunc((x / (SIZE - 1)) * 255);
+      rgba8[i + 1] = Math.trunc((y / (SIZE - 1)) * 255);
+      rgba8[i + 2] = 0;
+      rgba8[i + 3] = 255;
+    }
+  }
+
+  const cam2Raw: MessageEvent<Partial<RawImage>> = {
+    topic: "/cam2/raw",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      timestamp: { sec: 0, nsec: 0 },
+      frame_id: SENSOR_FRAME_ID,
+      height: SIZE,
+      width: SIZE,
+      encoding: "rgba8",
       step: SIZE * 4,
       data: rgba8,
     },

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -226,12 +226,11 @@ type RosTypedArray =
   | Float32Array
   | Float64Array;
 
-type RosSingularField = number | string | boolean | RosObject; // No time -- consider it a message.
+type RosSingularField = number | string | boolean | RosObject | undefined; // No time -- consider it a message.
 export type RosValue =
   | RosSingularField
   | readonly RosSingularField[]
   | RosTypedArray
-  | undefined
   // eslint-disable-next-line no-restricted-syntax
   | null;
 


### PR DESCRIPTION
**User-Facing Changes**
Added support for Foxglove RawImage, CompressedImage, and CameraCalibration schemas to the new 3D panel.

**Description**
Closes #4323 