### PR TITLE
Set minimum log level to _warn_ for production builds

### DIFF
--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -7,18 +7,19 @@ const channels = new Map<string, Logger>();
 
 const noop = () => {};
 
+type LogLevel = "error" | "warn" | "info" | "debug";
+
 class Logger {
   // default logger has an empty name
   public static default = new Logger("");
 
   private _name: string;
-  private _enabled = true;
+  //private _enabled = true;
 
   // all new loggers are created from the default logger
   private constructor(name: string) {
     this._name = name;
-    this._updateHandlers();
-
+    this.setLevel("debug");
     channels.set(name, this);
   }
 
@@ -27,18 +28,54 @@ class Logger {
     return this._name;
   }
 
-  public isEnabled(): boolean {
-    return this._enabled;
+  /**
+   * Return true if the level would display when logged by the logger
+   */
+  public isLevelOn(level: LogLevel): boolean {
+    switch (level) {
+      case "debug":
+        return this.debug !== noop;
+      case "info":
+        return this.info !== noop;
+      case "warn":
+        return this.warn !== noop;
+      case "error":
+        return this.error !== noop;
+    }
+    return false;
   }
 
-  public enable(): void {
-    this._enabled = true;
-    this._updateHandlers();
-  }
+  /**
+   * Set the allowed log level. Any log calls with severity "below" this one will be ignored.
+   *
+   * i.e. setting a level of "warn" will ignore any "info" or "debug" logs
+   */
+  public setLevel(level: LogLevel): void {
+    this.debug = noop;
+    this.info = noop;
+    this.warn = noop;
+    this.error = noop;
 
-  public disable(): void {
-    this._enabled = false;
-    this._updateHandlers();
+    switch (level) {
+      case "debug":
+        this.debug = console.debug.bind(global.console);
+        this.info = console.info.bind(global.console);
+        this.warn = console.warn.bind(global.console);
+        this.error = console.error.bind(global.console);
+        break;
+      case "info":
+        this.info = console.info.bind(global.console);
+        this.warn = console.warn.bind(global.console);
+        this.error = console.error.bind(global.console);
+        break;
+      case "warn":
+        this.warn = console.warn.bind(global.console);
+        this.error = console.error.bind(global.console);
+        break;
+      case "error":
+        this.error = console.error.bind(global.console);
+        break;
+    }
   }
 
   public debug(..._args: unknown[]): void {}
@@ -64,21 +101,23 @@ class Logger {
   public channels(): Logger[] {
     return Array.from(channels.values());
   }
+}
 
-  private _updateHandlers() {
-    if (this._enabled) {
-      this.debug = console.debug.bind(global.console);
-      this.info = console.info.bind(global.console);
-      this.warn = console.warn.bind(global.console);
-      this.error = console.error.bind(global.console);
-    } else {
-      this.debug = noop;
-      this.info = noop;
-      this.warn = noop;
-      this.error = noop;
-    }
+function toLogLevel(maybeLevel: string): LogLevel {
+  switch (maybeLevel) {
+    case "debug":
+      return "debug";
+    case "info":
+      return "info";
+    case "warn":
+      return "warn";
+    case "error":
+      return "error";
+    default:
+      return "warn";
   }
 }
 
 export default Logger.default;
-export { Logger };
+export { Logger, toLogLevel };
+export type { LogLevel };

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -14,7 +14,6 @@ class Logger {
   public static default = new Logger("");
 
   private _name: string;
-  //private _enabled = true;
 
   // all new loggers are created from the default logger
   private constructor(name: string) {

--- a/packages/studio-base/src/context/StudioLogsSettingsContext.ts
+++ b/packages/studio-base/src/context/StudioLogsSettingsContext.ts
@@ -5,11 +5,14 @@
 import { createContext } from "react";
 import { StoreApi, useStore } from "zustand";
 
+import { LogLevel } from "@foxglove/log";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 type StudioLogConfigChannel = { name: string; enabled: boolean };
 
 interface IStudioLogsSettings {
+  readonly globalLevel: LogLevel;
+
   readonly channels: ReadonlyArray<{ name: string; enabled: boolean }>;
 
   // Enable/disable a channel. Name is the full name of the channel.
@@ -19,6 +22,10 @@ interface IStudioLogsSettings {
   // Enable/disable an entire prefix. Any channels with a name starting with the prefix will be toggled
   enablePrefix(prefix: string): void;
   disablePrefix(prefix: string): void;
+
+  // Set the global log level for all channels
+  // This does not affect whether a channel is enabled or disabled
+  setGlobalLevel(level: LogLevel): void;
 }
 
 const StudioLogsSettingsContext = createContext<undefined | StoreApi<IStudioLogsSettings>>(

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
@@ -2,24 +2,46 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
 import { useLocalStorage } from "react-use";
 
+import Log from "@foxglove/log";
 import { StudioLogsSettingsContext } from "@foxglove/studio-base/context/StudioLogsSettingsContext";
 
 import { createStudioLogsSettingsStore } from "./store";
 import { LocalStorageSaveState } from "./types";
 
 function StudioLogsSettingsProvider(props: PropsWithChildren<unknown>): JSX.Element {
-  const [StudioLogsSettingsSavedState, setStudioLogsSettingsSavedState] =
-    useLocalStorage<LocalStorageSaveState>("fox.studio-logs-settings", { disabledChannels: [] });
+  const [studioLogsSettingsSavedState, setStudioLogsSettingsSavedState] =
+    useLocalStorage<LocalStorageSaveState>("fox.studio-logs-settings", {});
 
-  const [StudioLogsSettingsStore] = useState(() =>
-    createStudioLogsSettingsStore(StudioLogsSettingsSavedState),
+  const [studioLogsSettingsStore, setStudioLogsSettingsStore] = useState(() =>
+    createStudioLogsSettingsStore(studioLogsSettingsSavedState),
   );
 
+  // To avoid resetting effect below when the localstorage state changes we use a ref for the localstorage state
+  const savedStateRef = useRef<LocalStorageSaveState | undefined>(studioLogsSettingsSavedState);
   useEffect(() => {
-    return StudioLogsSettingsStore.subscribe((value) => {
+    savedStateRef.current = studioLogsSettingsSavedState;
+  });
+
+  // Setup an interval to check for changes to the total number of logging channels
+  //
+  // When the total number of channels changes we re-initialize the settings store so we display any
+  // newly added log chnanels.
+  useEffect(() => {
+    const storeChannelsCount = studioLogsSettingsStore.getState().channels.length;
+    const intervalHandle = setInterval(() => {
+      if (storeChannelsCount !== Log.channels().length) {
+        setStudioLogsSettingsStore(createStudioLogsSettingsStore(savedStateRef.current));
+      }
+    });
+
+    return () => clearInterval(intervalHandle);
+  }, [studioLogsSettingsStore, studioLogsSettingsSavedState]);
+
+  useEffect(() => {
+    return studioLogsSettingsStore.subscribe((value) => {
       const disabledChannels: string[] = [];
 
       for (const channel of value.channels) {
@@ -27,12 +49,12 @@ function StudioLogsSettingsProvider(props: PropsWithChildren<unknown>): JSX.Elem
           disabledChannels.push(channel.name);
         }
       }
-      setStudioLogsSettingsSavedState({ disabledChannels });
+      setStudioLogsSettingsSavedState({ globalLevel: value.globalLevel, disabledChannels });
     });
-  }, [StudioLogsSettingsStore, setStudioLogsSettingsSavedState]);
+  }, [studioLogsSettingsStore, setStudioLogsSettingsSavedState]);
 
   return (
-    <StudioLogsSettingsContext.Provider value={StudioLogsSettingsStore}>
+    <StudioLogsSettingsContext.Provider value={studioLogsSettingsStore}>
       {props.children}
     </StudioLogsSettingsContext.Provider>
   );

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
@@ -4,7 +4,7 @@
 
 import { createStore, StoreApi } from "zustand";
 
-import Log, { Logger } from "@foxglove/log";
+import Log, { Logger, LogLevel, toLogLevel } from "@foxglove/log";
 import {
   IStudioLogsSettings,
   StudioLogConfigChannel,
@@ -14,12 +14,16 @@ import { LocalStorageSaveState } from "./types";
 
 const log = Log.getLogger(__filename);
 
+// fixme - override anything in saved settings? reason would be to prevent user from keeping debug logs on...
+const defaultGlobalLevel: LogLevel = process.env.NODE_ENV === "development" ? "debug" : "warn";
+
 function createStudioLogsSettingsStore(
   initialState?: LocalStorageSaveState,
 ): StoreApi<IStudioLogsSettings> {
-  log.debug(
-    `Initializing log Config. ${initialState?.disabledChannels.length ?? 0} disabled channels.`,
-  );
+  const globalLevel = toLogLevel(initialState?.globalLevel ?? defaultGlobalLevel);
+  const disabledChannels = initialState?.disabledChannels ?? [];
+
+  log.debug(`Initializing log Config. ${disabledChannels.length} disabled channels.`);
   const channels: StudioLogConfigChannel[] = [];
 
   // Lookup channel by name, there might be multiple channels that use the same name
@@ -30,11 +34,14 @@ function createStudioLogsSettingsStore(
   for (const channel of sortedChannels) {
     const name = channel.name() ? channel.name() : "<root>";
 
-    if (initialState?.disabledChannels.includes(name) === true) {
-      channel.disable();
+    if (disabledChannels.includes(name)) {
+      channel.setLevel("warn");
     } else {
-      channel.enable();
+      channel.setLevel(globalLevel);
     }
+
+    // enabled means the channel meets at least the global logging level?
+    // if the channel is greater than the global logging level it is not enabled?
 
     // Only add to the channels list (for the provider) if we haven't seen this name.
     // If another channel has the same name we only add to the channels list once because they
@@ -42,7 +49,7 @@ function createStudioLogsSettingsStore(
     if (!channelByName.has(name)) {
       channels.push({
         name,
-        enabled: channel.isEnabled(),
+        enabled: channel.isLevelOn(globalLevel),
       });
     }
 
@@ -51,7 +58,11 @@ function createStudioLogsSettingsStore(
     channelByName.set(name, existing);
   }
 
-  function regenerateChannels(set: (partial: Partial<IStudioLogsSettings>) => void) {
+  function regenerateChannels(
+    get: () => IStudioLogsSettings,
+    set: (partial: Partial<IStudioLogsSettings>) => void,
+  ) {
+    const currentGlobalLevel = get().globalLevel;
     let didChange = false;
     for (const channel of channels) {
       const logChannels = channelByName.get(channel.name);
@@ -60,8 +71,8 @@ function createStudioLogsSettingsStore(
       }
 
       const anyChannel = logChannels[0];
-      if (anyChannel && anyChannel.isEnabled() !== channel.enabled) {
-        channel.enabled = anyChannel.isEnabled();
+      if (anyChannel && anyChannel.isLevelOn(currentGlobalLevel) !== channel.enabled) {
+        channel.enabled = !channel.enabled;
         didChange = true;
       }
     }
@@ -73,8 +84,24 @@ function createStudioLogsSettingsStore(
     set({ channels: [...channels] });
   }
 
-  return createStore<IStudioLogsSettings>((set) => ({
+  return createStore<IStudioLogsSettings>((set, get) => ({
+    globalLevel,
+
     channels,
+
+    setGlobalLevel(level: LogLevel) {
+      log.debug(`Set global level: ${level}`);
+
+      // Enable the underlying log channels
+      for (const [_, logChannels] of channelByName) {
+        for (const channel of logChannels) {
+          channel.setLevel(level);
+        }
+      }
+
+      set({ globalLevel: level });
+      regenerateChannels(get, set);
+    },
 
     enableChannel(name: string) {
       log.debug(`Enable channel: ${name}`);
@@ -82,21 +109,22 @@ function createStudioLogsSettingsStore(
       // Enable the underlying log channels
       const logChannels = channelByName.get(name) ?? [];
       for (const channel of logChannels) {
-        channel.enable();
+        channel.setLevel("debug");
       }
 
-      regenerateChannels(set);
+      regenerateChannels(get, set);
     },
+
     disableChannel(name: string) {
       log.debug(`Disable channel: ${name}`);
 
       // Enable the underlying log channels
       const logChannels = channelByName.get(name) ?? [];
       for (const channel of logChannels) {
-        channel.disable();
+        channel.setLevel("warn");
       }
 
-      regenerateChannels(set);
+      regenerateChannels(get, set);
     },
 
     enablePrefix(prefix: string) {
@@ -105,25 +133,26 @@ function createStudioLogsSettingsStore(
       for (const [key, logChannels] of channelByName) {
         if (key.startsWith(prefix)) {
           for (const channel of logChannels) {
-            channel.enable();
+            channel.setLevel("debug");
           }
         }
       }
 
-      regenerateChannels(set);
+      regenerateChannels(get, set);
     },
+
     disablePrefix(prefix: string) {
       log.debug(`Disable prefix ${prefix}`);
 
       for (const [key, logChannels] of channelByName) {
         if (key.startsWith(prefix)) {
           for (const channel of logChannels) {
-            channel.disable();
+            channel.setLevel("warn");
           }
         }
       }
 
-      regenerateChannels(set);
+      regenerateChannels(get, set);
     },
   }));
 }

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/store.ts
@@ -14,7 +14,6 @@ import { LocalStorageSaveState } from "./types";
 
 const log = Log.getLogger(__filename);
 
-// fixme - override anything in saved settings? reason would be to prevent user from keeping debug logs on...
 const defaultGlobalLevel: LogLevel = process.env.NODE_ENV === "development" ? "debug" : "warn";
 
 function createStudioLogsSettingsStore(

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/types.ts
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/types.ts
@@ -3,7 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 type LocalStorageSaveState = {
-  disabledChannels: string[];
+  globalLevel?: string;
+  disabledChannels?: string[];
 };
 
 export type { LocalStorageSaveState };


### PR DESCRIPTION

**User-Facing Changes**
None.

**Description**
Add a new dropdown to the Studio Logs Settings sidebar (sidebar is under a feature flag), which allows setting the global log level.

The level sets the minimum severity for writing logs to console.

<img width="347" alt="image" src="https://user-images.githubusercontent.com/84792/190560701-3146796c-0873-4acc-b823-ccae88b333e2.png">

This change updates the default minimum severity to "warn" for production builds.

Fixes: #4431


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
