### PR TITLE
Add typography catalog story

### DIFF
--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useTheme as useFluentTheme } from "@fluentui/react";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
 export default {
   title: "Theme",
@@ -35,5 +35,55 @@ export function SemanticColors(): JSX.Element {
         name1.localeCompare(name2),
       )}
     />
+  );
+}
+
+export function TypographyCatalog(): JSX.Element {
+  return (
+    <Box>
+      <Typography variant="h1" gutterBottom>
+        h1. Heading
+      </Typography>
+      <Typography variant="h2" gutterBottom>
+        h2. Heading
+      </Typography>
+      <Typography variant="h3" gutterBottom>
+        h3. Heading
+      </Typography>
+      <Typography variant="h4" gutterBottom>
+        h4. Heading
+      </Typography>
+      <Typography variant="h5" gutterBottom>
+        h5. Heading
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        h6. Heading
+      </Typography>
+      <Typography variant="subtitle1" gutterBottom>
+        subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+      </Typography>
+      <Typography variant="subtitle2" gutterBottom>
+        subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+        unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam
+        dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+      </Typography>
+      <Typography variant="body2" gutterBottom>
+        body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+        unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam
+        dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+      </Typography>
+      <Typography variant="button" display="block" gutterBottom>
+        button text
+      </Typography>
+      <Typography variant="caption" display="block" gutterBottom>
+        caption text
+      </Typography>
+      <Typography variant="overline" display="block" gutterBottom>
+        overline text
+      </Typography>
+    </Box>
   );
 }

--- a/packages/studio-base/src/theme/index.stories.tsx
+++ b/packages/studio-base/src/theme/index.stories.tsx
@@ -4,6 +4,7 @@
 
 import { useTheme as useFluentTheme } from "@fluentui/react";
 import { Box, Stack, Typography } from "@mui/material";
+import { ReactNode } from "react";
 
 export default {
   title: "Theme",
@@ -38,52 +39,87 @@ export function SemanticColors(): JSX.Element {
   );
 }
 
+function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+  return <Box style={{ border: "1px dotted blue" }}>{children}</Box>;
+}
+
 export function TypographyCatalog(): JSX.Element {
   return (
-    <Box>
-      <Typography variant="h1" gutterBottom>
-        h1. Heading
-      </Typography>
-      <Typography variant="h2" gutterBottom>
-        h2. Heading
-      </Typography>
-      <Typography variant="h3" gutterBottom>
-        h3. Heading
-      </Typography>
-      <Typography variant="h4" gutterBottom>
-        h4. Heading
-      </Typography>
-      <Typography variant="h5" gutterBottom>
-        h5. Heading
-      </Typography>
-      <Typography variant="h6" gutterBottom>
-        h6. Heading
-      </Typography>
-      <Typography variant="subtitle1" gutterBottom>
-        subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-      </Typography>
-      <Typography variant="subtitle2" gutterBottom>
-        subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-        unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam
-        dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
-      </Typography>
-      <Typography variant="body2" gutterBottom>
-        body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
-        unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate numquam
-        dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
-      </Typography>
-      <Typography variant="button" display="block" gutterBottom>
-        button text
-      </Typography>
-      <Typography variant="caption" display="block" gutterBottom>
-        caption text
-      </Typography>
-      <Typography variant="overline" display="block" gutterBottom>
-        overline text
-      </Typography>
-    </Box>
+    <Stack gap={1} padding={1}>
+      <Wrapper>
+        <Typography variant="h1" gutterBottom>
+          h1. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="h2" gutterBottom>
+          h2. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="h3" gutterBottom>
+          h3. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="h4" gutterBottom>
+          h4. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="h5" gutterBottom>
+          h5. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="h6" gutterBottom>
+          h6. Heading
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="subtitle1" gutterBottom>
+          subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
+          tenetur
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="subtitle2" gutterBottom>
+          subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis
+          tenetur
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="body1" gutterBottom>
+          body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+          unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
+          numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="body2" gutterBottom>
+          body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos blanditiis tenetur
+          unde suscipit, quam beatae rerum inventore consectetur, neque doloribus, cupiditate
+          numquam dignissimos laborum fugiat deleniti? Eum quasi quidem quibusdam.
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="button" display="block" gutterBottom>
+          button text
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="caption" display="block" gutterBottom>
+          caption text
+        </Typography>
+      </Wrapper>
+      <Wrapper>
+        <Typography variant="overline" display="block" gutterBottom>
+          overline text
+        </Typography>
+      </Wrapper>
+    </Stack>
   );
 }
+TypographyCatalog.parameters = {
+  colorScheme: "light",
+};


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add a new story demonstrating all variants of the `Typography` component. This is useful as a reference for styling work and also to catch any unintended theme changes.

<img width="956" alt="Screen Shot 2022-09-19 at 6 38 41 AM" src="https://user-images.githubusercontent.com/93935560/191000129-839cf5ca-2b4b-432d-9d85-ae8b8e2f893f.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
