### PR TITLE
[3D] Add a setting for ignoring COLLADA <up_axis> tags

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -42,7 +42,7 @@ export class ModelCache {
   private _models = new Map<string, Promise<LoadedModel | undefined>>();
   private _edgeMaterial: THREE.Material;
 
-  public constructor(private options: ModelCacheOptions) {
+  public constructor(public readonly options: ModelCacheOptions) {
     this._edgeMaterial = options.edgeMaterial;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -114,6 +114,8 @@ export type RendererConfig = {
     backgroundColor?: string;
     /* Scale factor to apply to all labels */
     labelScaleFactor?: number;
+    /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
+    ignoreColladaUpAxis?: boolean;
     transforms?: {
       /** Toggles visibility of frame axis labels */
       showLabel?: boolean;
@@ -357,7 +359,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
 
     this.modelCache = new ModelCache({
-      ignoreColladaUpAxis: true,
+      ignoreColladaUpAxis: config.scene.ignoreColladaUpAxis ?? false,
       edgeMaterial: this.outlineMaterial,
     });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -136,6 +136,17 @@ export class CoreSettings extends SceneExtension {
               value: config.scene.labelScaleFactor,
               placeholder: String(DEFAULT_LABEL_SCALE_FACTOR),
             },
+            ignoreColladaUpAxis: {
+              label: "Ignore COLLADA <up_axis>",
+              help: "Match the behavior of rviz by ignoring the <up_axis> tag in COLLADA files",
+              input: "boolean",
+              value: config.scene.ignoreColladaUpAxis,
+              error:
+                (config.scene.ignoreColladaUpAxis ?? false) !==
+                this.renderer.modelCache.options.ignoreColladaUpAxis
+                  ? "This setting requires a restart to take effect"
+                  : undefined,
+            },
           },
           children: {
             cameraState: {


### PR DESCRIPTION
**User-Facing Changes**
- Correctly handle COLLADA <up_axis> tags for loaded .dae files
- Added a setting to 3D panel for ignoring COLLADA <up_axis> tags to match rviz behavior

**Description**
This matches the behavior and configurability of the legacy 3D panel
