### PR TITLE
[3D] Transform editor

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -115,6 +115,8 @@ export type RendererConfig = {
     /* Scale factor to apply to all labels */
     labelScaleFactor?: number;
     transforms?: {
+      /** Toggles translation and rotation offset controls for frames */
+      editable?: boolean;
       /** Toggles visibility of frame axis labels */
       showLabel?: boolean;
       /** Size of frame axis labels */

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -38,7 +38,6 @@ import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
-import { DEFAULT_PUBLISH_SETTINGS } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/CoreSettings";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import { DebugGui } from "./DebugGui";
@@ -56,6 +55,8 @@ import {
   makePoseEstimateMessage,
   makePoseMessage,
 } from "./publish";
+import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/CoreSettings";
+import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
 
 const log = Logger.getLogger(__filename);
@@ -369,12 +370,17 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     );
     const publish = merge(cloneDeep(DEFAULT_PUBLISH_SETTINGS), partialConfig?.publish);
 
+    const transforms = (partialConfig?.transforms ?? {}) as Record<
+      string,
+      Partial<LayerSettingsTransform>
+    >;
+
     return {
       cameraState,
       followMode: partialConfig?.followMode ?? "follow-pose",
       followTf: partialConfig?.followTf,
       scene: partialConfig?.scene ?? {},
-      transforms: partialConfig?.transforms ?? {},
+      transforms,
       topics: partialConfig?.topics ?? {},
       layers: partialConfig?.layers ?? {},
       publish,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -480,15 +480,8 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     }
 
     const frameKey = `frame:${renderable.userData.frameId}`;
-    const xyzOffset = this.renderer.config.transforms[frameKey]?.xyzOffset;
-    const rpyOffset = this.renderer.config.transforms[frameKey]?.rpyOffset;
-
-    frame.offsetPosition = xyzOffset
-      ? [xyzOffset[0] ?? 0, xyzOffset[1] ?? 0, xyzOffset[2] ?? 0]
-      : undefined;
-    frame.offsetEulerDegrees = rpyOffset
-      ? [rpyOffset[0] ?? 0, rpyOffset[1] ?? 0, rpyOffset[2] ?? 0]
-      : undefined;
+    frame.offsetPosition = getOffset(this.renderer.config.transforms[frameKey]?.xyzOffset);
+    frame.offsetEulerDegrees = getOffset(this.renderer.config.transforms[frameKey]?.rpyOffset);
   }
 
   private static LineGeometry(): LineGeometry {
@@ -630,4 +623,19 @@ function round(x: number, precision: number): number {
 
 function vec3IsZero(v: THREE.Vector3Tuple, eps = 1e-6): boolean {
   return Math.abs(v[0]) < eps && Math.abs(v[1]) < eps && Math.abs(v[2]) < eps;
+}
+
+function getOffset(
+  maybeOffset: Readonly<[number | undefined, number | undefined, number | undefined]> | undefined,
+): THREE.Vector3Tuple | undefined {
+  if (!maybeOffset) {
+    return undefined;
+  }
+  const x = maybeOffset[0] ?? 0;
+  const y = maybeOffset[1] ?? 0;
+  const z = maybeOffset[2] ?? 0;
+  if (x === 0 && y === 0 && z === 0) {
+    return undefined;
+  }
+  return [x, y, z];
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -37,6 +37,8 @@ export type LayerSettingsTransform = BaseSettings & {
 const PICKING_LINE_SIZE = 6;
 const PI_2 = Math.PI / 2;
 
+const DEFAULT_EDITABLE = true;
+
 const DEFAULT_SETTINGS: LayerSettingsTransform = {
   visible: true,
   frameLocked: true,
@@ -129,7 +131,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
           editable: {
             label: "Editable",
             input: "boolean",
-            value: config.scene.transforms?.editable ?? true,
+            value: config.scene.transforms?.editable ?? DEFAULT_EDITABLE,
           },
           showLabel: {
             label: "Labels",
@@ -470,7 +472,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const frame = this.renderer.transformTree.getOrCreateFrame(renderable.userData.frameId);
 
     // Check if TF editing is disabled
-    const editable = this.renderer.config.scene.transforms?.editable ?? true;
+    const editable = this.renderer.config.scene.transforms?.editable ?? DEFAULT_EDITABLE;
     if (!editable) {
       frame.offsetPosition = undefined;
       frame.offsetEulerDegrees = undefined;
@@ -563,7 +565,7 @@ function buildSettingsFields(
     },
   };
 
-  if (config.scene.transforms?.editable ?? true) {
+  if (config.scene.transforms?.editable ?? DEFAULT_EDITABLE) {
     let xyzOffsetValue = config.transforms[frameKey]?.xyzOffset as THREE.Vector3Tuple | undefined;
     let rpyOffsetValue = config.transforms[frameKey]?.rpyOffset as THREE.Vector3Tuple | undefined;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Immutable } from "immer";
 import * as THREE from "three";
 import { Line2 } from "three/examples/jsm/lines/Line2";
 import { LineGeometry } from "three/examples/jsm/lines/LineGeometry";
@@ -12,11 +13,11 @@ import type { RosValue } from "@foxglove/studio-base/players/types";
 import { Label } from "@foxglove/three-text";
 
 import { BaseUserData, Renderable } from "../Renderable";
-import { Renderer } from "../Renderer";
+import { Renderer, RendererConfig } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
 import { getLuminance, stringToRgb } from "../color";
-import { BaseSettings, fieldSize } from "../settings";
+import { BaseSettings, fieldSize, PRECISION_DEGREES, PRECISION_DISTANCE } from "../settings";
 import { Duration, Transform, makePose, CoordinateFrame, MAX_DURATION } from "../transforms";
 import { Axis, AXIS_LENGTH } from "./Axis";
 import {
@@ -28,7 +29,10 @@ import {
 } from "./CoreSettings";
 import { makeLinePickingMaterial } from "./markers/materials";
 
-export type LayerSettingsTransform = BaseSettings;
+export type LayerSettingsTransform = BaseSettings & {
+  xyzOffset: Readonly<[number | undefined, number | undefined, number | undefined]>;
+  rpyOffset: Readonly<[number | undefined, number | undefined, number | undefined]>;
+};
 
 const PICKING_LINE_SIZE = 6;
 const PI_2 = Math.PI / 2;
@@ -36,12 +40,15 @@ const PI_2 = Math.PI / 2;
 const DEFAULT_SETTINGS: LayerSettingsTransform = {
   visible: true,
   frameLocked: true,
+  xyzOffset: [0, 0, 0],
+  rpyOffset: [0, 0, 0],
 };
 
 export type FrameAxisUserData = BaseUserData & {
   axis: Axis;
   label: Label;
   parentLine: Line2;
+  group: THREE.Group;
 };
 
 class FrameAxisRenderable extends Renderable<FrameAxisUserData> {
@@ -120,6 +127,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         defaultExpansionState: "collapsed",
         order: 0,
         fields: {
+          editable: {
+            label: "Editable",
+            input: "boolean",
+            value: config.scene.transforms?.editable ?? true,
+          },
           showLabel: {
             label: "Labels",
             input: "boolean",
@@ -161,12 +173,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
     let order = 1;
     for (const { label, value: frameId } of this.renderer.coordinateFrameList) {
-      const frameIdSanitized = frameId === "settings" ? "$settings" : frameId;
-      const tfConfig = (configTransforms[frameIdSanitized] ??
-        {}) as Partial<LayerSettingsTransform>;
+      const frameKey = `frame:${frameId}`;
+      const tfConfig = (configTransforms[frameKey] ?? {}) as Partial<LayerSettingsTransform>;
       const frame = this.renderer.transformTree.frame(frameId);
-      const fields = buildSettingsFields(frame, this.renderer.currentTime);
-      children[frameIdSanitized] = {
+      const fields = buildSettingsFields(frame, this.renderer.currentTime, config);
+      children[frameKey] = {
         label,
         fields,
         visible: tfConfig.visible ?? true,
@@ -215,13 +226,14 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
     // Update the lines and labels between coordinate frames
     for (const renderable of this.renderables.values()) {
+      const group = renderable.userData.group;
       const label = renderable.userData.label;
       const line = renderable.userData.parentLine;
       const childFrame = this.renderer.transformTree.frame(renderable.userData.frameId);
       const parentFrame = childFrame?.parent();
       // NOTE: tempVecB should not be used until the label uses it below
       const worldPosition = tempVecB;
-      renderable.getWorldPosition(worldPosition);
+      group.getWorldPosition(worldPosition);
       // Lines require a parent renderable because they draw a line from the parent
       // frame origin to the child frame origin
       line.visible = false;
@@ -229,7 +241,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         const parentRenderable = this.renderables.get(parentFrame.id);
         if (parentRenderable?.visible === true) {
           const parentWorldPosition = tempVec;
-          parentRenderable.getWorldPosition(parentWorldPosition);
+          parentRenderable.userData.group.getWorldPosition(parentWorldPosition);
           const dist = parentWorldPosition.distanceTo(worldPosition);
           line.lookAt(parentWorldPosition);
           line.rotateY(-PI_2);
@@ -242,7 +254,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       worldPosition.z += labelOffsetZ;
       // Transform worldPosition back to the local coordinate frame of the
       // renderable, which the label is a child of
-      renderable.worldToLocal(worldPosition);
+      group.worldToLocal(worldPosition);
       label.position.set(worldPosition.x, worldPosition.y, worldPosition.z);
     }
   }
@@ -333,7 +345,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     }
 
     if (path.length !== 3) {
-      return; // Doesn't match the pattern of ["transforms", "settings" | frameId, field]
+      return; // Doesn't match the pattern of ["transforms", "settings" | `frame:${frameId}`, field]
     }
 
     if (path[1] === "settings") {
@@ -342,7 +354,9 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
       this.saveSetting(["scene", "transforms", setting], value);
 
-      if (setting === "showLabel") {
+      if (setting === "editable") {
+        //
+      } else if (setting === "showLabel") {
         const showLabel = value as boolean | undefined;
         this.setLabelVisible(showLabel ?? true);
       } else if (setting === "labelSize") {
@@ -362,13 +376,16 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       this.saveSetting(path, action.payload.value);
 
       // Update the renderable
-      const frameId = path[1]!;
+      const frameKey = path[1]!;
+      const frameId = frameKey.replace(/^frame:/, "");
       const renderable = this.renderables.get(frameId);
       if (renderable) {
-        const settings = this.renderer.config.transforms[frameId] as
+        const settings = this.renderer.config.transforms[frameKey] as
           | Partial<LayerSettingsTransform>
           | undefined;
         renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
+
+        this._updateFrameAxis(renderable);
       }
     }
   };
@@ -421,6 +438,9 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const axisScale = config.scene.transforms?.axisScale ?? DEFAULT_AXIS_SCALE;
     axis.scale.set(axisScale, axisScale, axisScale);
 
+    // Group containing the renderables that can be independently translated/rotated
+    const group = new THREE.Group();
+
     // Create a scene graph object to hold the axis, a text label, and a line to
     // the parent frame
     const renderable = new FrameAxisRenderable(frameId, this.renderer, {
@@ -433,13 +453,39 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       axis,
       label,
       parentLine,
+      group,
     });
-    renderable.add(axis);
-    renderable.add(label);
-    renderable.add(parentLine);
+    group.add(axis);
+    group.add(label);
+    group.add(parentLine);
+    renderable.add(group);
 
     this.add(renderable);
     this.renderables.set(frameId, renderable);
+
+    this._updateFrameAxis(renderable);
+  }
+
+  private _updateFrameAxis(renderable: FrameAxisRenderable): void {
+    const group = renderable.userData.group;
+    const frameKey = `frame:${renderable.userData.frameId}`;
+    const xyzOffset = this.renderer.config.transforms[frameKey]?.xyzOffset;
+    const rpyOffset = this.renderer.config.transforms[frameKey]?.rpyOffset;
+
+    if (xyzOffset) {
+      group.position.set(xyzOffset[0] ?? 0, xyzOffset[1] ?? 0, xyzOffset[2] ?? 0);
+    } else {
+      group.position.set(0, 0, 0);
+    }
+
+    if (rpyOffset) {
+      const r = THREE.MathUtils.degToRad(rpyOffset[0] ?? 0);
+      const p = THREE.MathUtils.degToRad(rpyOffset[1] ?? 0);
+      const y = THREE.MathUtils.degToRad(rpyOffset[2] ?? 0);
+      group.rotation.set(r, p, y);
+    } else {
+      group.rotation.set(0, 0, 0);
+    }
   }
 
   private static LineGeometry(): LineGeometry {
@@ -454,15 +500,18 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 function buildSettingsFields(
   frame: CoordinateFrame | undefined,
   currentTime: bigint | undefined,
+  config: Immutable<RendererConfig>,
 ): SettingsTreeFields {
-  let ageValue: string | undefined;
-  let xyzValue: THREE.Vector3Tuple | undefined;
-  let rpyValue: THREE.Vector3Tuple | undefined;
+  const frameKey = frame ? `frame:${frame.id}` : "";
   const parentFrameId = frame?.parent()?.id;
 
   if (parentFrameId == undefined) {
     return { parent: { label: "Parent", input: "string", readonly: true, value: "<root>" } };
   }
+
+  let ageValue: string | undefined;
+  let xyzValue: THREE.Vector3Tuple | undefined;
+  let rpyValue: THREE.Vector3Tuple | undefined;
 
   if (currentTime != undefined && frame) {
     if (frame.findClosestTransforms(tempLower, tempUpper, currentTime, MAX_DURATION)) {
@@ -482,7 +531,7 @@ function buildSettingsFields(
     }
   }
 
-  return {
+  const fields: SettingsTreeFields = {
     parent: {
       label: "Parent",
       input: "string",
@@ -498,7 +547,7 @@ function buildSettingsFields(
     xyz: {
       label: "Translation",
       input: "vec3",
-      precision: 3,
+      precision: PRECISION_DISTANCE,
       labels: ["X", "Y", "Z"],
       readonly: true,
       value: xyzValue,
@@ -506,12 +555,45 @@ function buildSettingsFields(
     rpy: {
       label: "Rotation",
       input: "vec3",
-      precision: 3,
+      precision: PRECISION_DEGREES,
       labels: ["R", "P", "Y"],
       readonly: true,
       value: rpyValue,
     },
   };
+
+  if (config.scene.transforms?.editable ?? true) {
+    let xyzOffsetValue = config.transforms[frameKey]?.xyzOffset as THREE.Vector3Tuple | undefined;
+    let rpyOffsetValue = config.transforms[frameKey]?.rpyOffset as THREE.Vector3Tuple | undefined;
+
+    if (xyzOffsetValue && vec3IsZero(xyzOffsetValue)) {
+      xyzOffsetValue = undefined;
+    }
+    if (rpyOffsetValue && vec3IsZero(rpyOffsetValue)) {
+      rpyOffsetValue = undefined;
+    }
+
+    fields.xyzOffset = {
+      label: "Translation Offset",
+      input: "vec3",
+      precision: PRECISION_DISTANCE,
+      step: 0.1,
+      labels: ["X", "Y", "Z"],
+      value: xyzOffsetValue,
+    };
+    fields.rpyOffset = {
+      label: "Rotation Offset",
+      input: "vec3",
+      precision: PRECISION_DEGREES,
+      step: 1,
+      min: -180,
+      max: 180,
+      labels: ["R", "P", "Y"],
+      value: rpyOffsetValue,
+    };
+  }
+
+  return fields;
 }
 
 const MS_TENTH_NS = BigInt(1e5);
@@ -541,4 +623,8 @@ function abs(x: bigint): bigint {
 
 function round(x: number, precision: number): number {
   return Number(x.toFixed(precision));
+}
+
+function vec3IsZero(v: THREE.Vector3Tuple, eps = 1e-6): boolean {
+  return Math.abs(v[0]) < eps && Math.abs(v[1]) < eps && Math.abs(v[2]) < eps;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -631,9 +631,7 @@ function getOffset(
   if (!maybeOffset) {
     return undefined;
   }
-  const x = maybeOffset[0] ?? 0;
-  const y = maybeOffset[1] ?? 0;
-  const z = maybeOffset[2] ?? 0;
+  const [x = 0, y = 0, z = 0] = maybeOffset;
   if (x === 0 && y === 0 && z === 0) {
     return undefined;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -48,7 +48,6 @@ export type FrameAxisUserData = BaseUserData & {
   axis: Axis;
   label: Label;
   parentLine: Line2;
-  group: THREE.Group;
 };
 
 class FrameAxisRenderable extends Renderable<FrameAxisUserData> {
@@ -226,14 +225,13 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
     // Update the lines and labels between coordinate frames
     for (const renderable of this.renderables.values()) {
-      const group = renderable.userData.group;
       const label = renderable.userData.label;
       const line = renderable.userData.parentLine;
       const childFrame = this.renderer.transformTree.frame(renderable.userData.frameId);
       const parentFrame = childFrame?.parent();
       // NOTE: tempVecB should not be used until the label uses it below
       const worldPosition = tempVecB;
-      group.getWorldPosition(worldPosition);
+      renderable.getWorldPosition(worldPosition);
       // Lines require a parent renderable because they draw a line from the parent
       // frame origin to the child frame origin
       line.visible = false;
@@ -241,7 +239,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
         const parentRenderable = this.renderables.get(parentFrame.id);
         if (parentRenderable?.visible === true) {
           const parentWorldPosition = tempVec;
-          parentRenderable.userData.group.getWorldPosition(parentWorldPosition);
+          parentRenderable.getWorldPosition(parentWorldPosition);
           const dist = parentWorldPosition.distanceTo(worldPosition);
           line.lookAt(parentWorldPosition);
           line.rotateY(-PI_2);
@@ -254,7 +252,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       worldPosition.z += labelOffsetZ;
       // Transform worldPosition back to the local coordinate frame of the
       // renderable, which the label is a child of
-      group.worldToLocal(worldPosition);
+      renderable.worldToLocal(worldPosition);
       label.position.set(worldPosition.x, worldPosition.y, worldPosition.z);
     }
   }
@@ -439,9 +437,6 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const axisScale = config.scene.transforms?.axisScale ?? DEFAULT_AXIS_SCALE;
     axis.scale.set(axisScale, axisScale, axisScale);
 
-    // Group containing the renderables that can be independently translated/rotated
-    const group = new THREE.Group();
-
     // Create a scene graph object to hold the axis, a text label, and a line to
     // the parent frame
     const renderable = new FrameAxisRenderable(frameId, this.renderer, {
@@ -454,12 +449,10 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       axis,
       label,
       parentLine,
-      group,
     });
-    group.add(axis);
-    group.add(label);
-    group.add(parentLine);
-    renderable.add(group);
+    renderable.add(axis);
+    renderable.add(label);
+    renderable.add(parentLine);
 
     this.add(renderable);
     this.renderables.set(frameId, renderable);
@@ -468,25 +461,17 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
   }
 
   private _updateFrameAxis(renderable: FrameAxisRenderable): void {
-    const group = renderable.userData.group;
+    const frame = this.renderer.transformTree.getOrCreateFrame(renderable.userData.frameId);
     const frameKey = `frame:${renderable.userData.frameId}`;
     const xyzOffset = this.renderer.config.transforms[frameKey]?.xyzOffset;
     const rpyOffset = this.renderer.config.transforms[frameKey]?.rpyOffset;
 
-    if (xyzOffset) {
-      group.position.set(xyzOffset[0] ?? 0, xyzOffset[1] ?? 0, xyzOffset[2] ?? 0);
-    } else {
-      group.position.set(0, 0, 0);
-    }
-
-    if (rpyOffset) {
-      const r = THREE.MathUtils.degToRad(rpyOffset[0] ?? 0);
-      const p = THREE.MathUtils.degToRad(rpyOffset[1] ?? 0);
-      const y = THREE.MathUtils.degToRad(rpyOffset[2] ?? 0);
-      group.rotation.set(r, p, y);
-    } else {
-      group.rotation.set(0, 0, 0);
-    }
+    frame.offsetPosition = xyzOffset
+      ? [xyzOffset[0] ?? 0, xyzOffset[1] ?? 0, xyzOffset[2] ?? 0]
+      : undefined;
+    frame.offsetEulerDegrees = rpyOffset
+      ? [rpyOffset[0] ?? 0, rpyOffset[1] ?? 0, rpyOffset[2] ?? 0]
+      : undefined;
   }
 
   private static LineGeometry(): LineGeometry {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -37,7 +37,7 @@ export type LayerSettingsTransform = BaseSettings & {
 const PICKING_LINE_SIZE = 6;
 const PI_2 = Math.PI / 2;
 
-const DEFAULT_EDITABLE = true;
+const DEFAULT_EDITABLE = false;
 
 const DEFAULT_SETTINGS: LayerSettingsTransform = {
   visible: true,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -423,7 +423,8 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     );
 
     // Set the initial settings from default values merged with any user settings
-    const userSettings = config.transforms[frameId] as Partial<LayerSettingsTransform> | undefined;
+    const frameKey = `frame:${frameId}`;
+    const userSettings = config.transforms[frameKey] as Partial<LayerSettingsTransform> | undefined;
     const settings = { ...DEFAULT_SETTINGS, ...userSettings };
 
     // Parent line
@@ -448,7 +449,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       messageTime: 0n,
       frameId,
       pose: makePose(),
-      settingsPath: ["transforms", frameId],
+      settingsPath: ["transforms", frameKey],
       settings,
       axis,
       label,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -353,7 +353,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       this.saveSetting(["scene", "transforms", setting], value);
 
       if (setting === "editable") {
-        //
+        this._updateFrameAxes();
       } else if (setting === "showLabel") {
         const showLabel = value as boolean | undefined;
         this.setLabelVisible(showLabel ?? true);
@@ -460,8 +460,23 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     this._updateFrameAxis(renderable);
   }
 
+  private _updateFrameAxes(): void {
+    for (const renderable of this.renderables.values()) {
+      this._updateFrameAxis(renderable);
+    }
+  }
+
   private _updateFrameAxis(renderable: FrameAxisRenderable): void {
     const frame = this.renderer.transformTree.getOrCreateFrame(renderable.userData.frameId);
+
+    // Check if TF editing is disabled
+    const editable = this.renderer.config.scene.transforms?.editable ?? true;
+    if (!editable) {
+      frame.offsetPosition = undefined;
+      frame.offsetEulerDegrees = undefined;
+      return;
+    }
+
     const frameKey = `frame:${renderable.userData.frameId}`;
     const xyzOffset = this.renderer.config.transforms[frameKey]?.xyzOffset;
     const rpyOffset = this.renderer.config.transforms[frameKey]?.rpyOffset;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -114,3 +114,120 @@ export function TransformInterpolation(): JSX.Element {
     </PanelSetup>
   );
 }
+
+TransformOffsets.parameters = { colorScheme: "dark" };
+export function TransformOffsets(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/markers", datatype: "visualization_msgs/Marker" },
+    { name: "/tf", datatype: "geometry_msgs/TransformStamped" },
+  ];
+  const tf_ab: MessageEvent<TransformStamped> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "a" },
+      child_frame_id: "b",
+      transform: {
+        translation: { x: -1, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf_bc: MessageEvent<TransformStamped> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "b" },
+      child_frame_id: "c",
+      transform: {
+        translation: { x: -1, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf_cd: MessageEvent<TransformStamped> = {
+    topic: "/tf",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "c" },
+      child_frame_id: "d",
+      transform: {
+        translation: { x: -1, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const pass1 = makePass({
+    id: 1,
+    frame_id: "d",
+    stamp: fromSec(1),
+    frame_locked: true,
+    colorHex: TEST_COLORS.MARKER_GREEN1,
+  });
+
+  const fixture = useDelayedFixture({
+    topics,
+    frame: {
+      "/markers": [pass1],
+      "/tf": [tf_ab, tf_bc, tf_cd],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 2, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDeeRender
+        overrideConfig={{
+          followTf: "b",
+          layers: {
+            grid: {
+              layerId: "foxglove.Grid",
+              position: [0, 0, -0.25],
+              frameId: "a",
+            },
+          },
+          scene: {
+            transforms: {
+              editable: true,
+            },
+          },
+          transforms: {
+            "frame:b": {
+              xyzOffset: [0, 1, 0],
+              rpyOffset: [45, 0, 0],
+            },
+            "frame:c": {
+              xyzOffset: [0, 1, 0],
+              rpyOffset: [-45, 0, 0],
+            },
+            "frame:d": {
+              xyzOffset: [0, 1, 0],
+            },
+          },
+          cameraState: {
+            perspective: true,
+            distance: 5,
+            phi: 36,
+            thetaOffset: 0,
+            targetOffset: [-0.1, 0.5, 0],
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+            fovy: 45,
+            near: 0.01,
+            far: 5000,
+          },
+          topics: {
+            "/markers": { visible: true },
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -17,6 +17,7 @@ type TimeAndTransform = [time: Time, transform: Transform];
 
 export const MAX_DURATION: Duration = 4_294_967_295n * BigInt(1e9);
 
+const DEG2RAD = Math.PI / 180;
 const RAD2DEG = 180 / Math.PI;
 
 const tempLower: TimeAndTransform = [0n, Transform.Identity()];
@@ -412,7 +413,7 @@ export class CoordinateFrame {
         const rotationMatrix = mat4.fromQuat(temp2Matrix, quaternion);
         const euler = eulerFromMatrixUnscaled(tempVec3, rotationMatrix);
         vec3.add(euler, euler, curFrame.offsetEulerDegrees);
-        tempTransform.setRotation(quat.fromEuler(tempVec4, euler[0], euler[1], euler[2]));
+        tempTransform.setRotation(quaternionFromEuler(tempVec4, euler));
       }
 
       if (curFrame.offsetPosition) {
@@ -518,5 +519,27 @@ function eulerFromMatrixUnscaled(out: vec3, m: mat4): vec3 {
   out[0] *= RAD2DEG;
   out[1] *= RAD2DEG;
   out[2] *= RAD2DEG;
+  return out;
+}
+
+// Compute a quaternion from XYZ Euler angles in degrees. This method is adapted
+// from THREE.js Quaternionr#setFromEuler()
+function quaternionFromEuler(out: quat, euler: vec3): quat {
+  const x = euler[0] * DEG2RAD;
+  const y = euler[1] * DEG2RAD;
+  const z = euler[2] * DEG2RAD;
+
+  const c1 = Math.cos(x / 2);
+  const c2 = Math.cos(y / 2);
+  const c3 = Math.cos(z / 2);
+
+  const s1 = Math.sin(x / 2);
+  const s2 = Math.sin(y / 2);
+  const s3 = Math.sin(z / 2);
+
+  out[0] = s1 * c2 * c3 + c1 * s2 * s3;
+  out[1] = c1 * s2 * c3 - s1 * c2 * s3;
+  out[2] = c1 * c2 * s3 + s1 * s2 * c3;
+  out[3] = c1 * c2 * c3 - s1 * s2 * s3;
   return out;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -5,7 +5,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable @foxglove/no-boolean-parameters */
 
-import { mat4 } from "gl-matrix";
+import { mat4, quat, vec3, vec4 } from "gl-matrix";
 
 import { ArrayMap } from "@foxglove/den/collection";
 
@@ -17,10 +17,15 @@ type TimeAndTransform = [time: Time, transform: Transform];
 
 export const MAX_DURATION: Duration = 4_294_967_295n * BigInt(1e9);
 
+const RAD2DEG = 180 / Math.PI;
+
 const tempLower: TimeAndTransform = [0n, Transform.Identity()];
 const tempUpper: TimeAndTransform = [0n, Transform.Identity()];
+const tempVec3: vec3 = [0, 0, 0];
+const tempVec4: vec4 = [0, 0, 0, 0];
 const tempTransform = Transform.Identity();
 const tempMatrix = mat4Identity();
+const temp2Matrix = mat4Identity();
 
 /**
  * CoordinateFrame is a named 3D coordinate frame with an optional parent frame
@@ -33,6 +38,8 @@ export class CoordinateFrame {
   public readonly id: string;
   public maxStorageTime: Duration;
   public maxCapacity: number;
+  public offsetPosition: vec3 | undefined;
+  public offsetEulerDegrees: vec3 | undefined;
 
   private _parent?: CoordinateFrame;
   private _transforms: ArrayMap<Time, Transform>;
@@ -399,6 +406,21 @@ export class CoordinateFrame {
         return false;
       }
       CoordinateFrame.InterpolateTransform(tempTransform, tempLower, tempUpper, time);
+
+      if (curFrame.offsetEulerDegrees) {
+        const quaternion = tempTransform.rotation();
+        const rotationMatrix = mat4.fromQuat(temp2Matrix, quaternion);
+        const euler = eulerFromMatrixUnscaled(tempVec3, rotationMatrix);
+        vec3.add(euler, euler, curFrame.offsetEulerDegrees);
+        tempTransform.setRotation(quat.fromEuler(tempVec4, euler[0], euler[1], euler[2]));
+      }
+
+      if (curFrame.offsetPosition) {
+        const p = tempTransform.position() as vec3;
+        vec3.add(p, p, curFrame.offsetPosition);
+        tempTransform.setPosition(p);
+      }
+
       mat4.multiply(out, tempTransform.matrix(), out);
 
       if (curFrame._parent == undefined) {
@@ -469,4 +491,32 @@ function copyPose(out: Pose, pose: Readonly<Pose>): void {
   out.orientation.y = o.y;
   out.orientation.z = o.z;
   out.orientation.w = o.w;
+}
+
+// Compute XYZ Euler angles in degrees from an unscaled rotation matrix. This
+// method is adapted from THREE.js Euler#setFromRotationMatrix()
+function eulerFromMatrixUnscaled(out: vec3, m: mat4): vec3 {
+  const m11 = m[0];
+  const m12 = m[4];
+  const m13 = m[8];
+  const m22 = m[5];
+  const m23 = m[9];
+  const m32 = m[6];
+  const m33 = m[10];
+
+  out[1] = Math.asin(Math.max(-1, Math.min(1, m13)));
+
+  if (Math.abs(m13) < 0.9999999) {
+    out[0] = Math.atan2(-m23, m33);
+    out[2] = Math.atan2(-m12, m11);
+  } else {
+    out[0] = Math.atan2(m32, m22);
+    out[2] = 0;
+  }
+
+  // Convert to degrees
+  out[0] *= RAD2DEG;
+  out[1] *= RAD2DEG;
+  out[2] *= RAD2DEG;
+  return out;
 }


### PR DESCRIPTION
**User-Facing Changes**
- [3D] Transform poses can be manually edited

**Description**

A new setting toggle, `Transforms`->`Settings`->`Editable` has been added (defaults to false). When this toggle 
is enabled, six additional fields appear in the settings for each coordinate frame, allowing XYZRPY offsets to 
be manually applied on top of the normal data-driven TF interpolation.

https://user-images.githubusercontent.com/195374/191135453-b1c6f494-d484-4390-b4de-2efc74a8beb0.mp4
