### PR TITLE
Don't log topic errors to the console in legacy 3D

### DIFF
--- a/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/SceneBuilder/index.ts
@@ -411,7 +411,6 @@ export default class SceneBuilder implements MarkerProvider {
   }
 
   private _setTopicError = (topic: string, message: string): void => {
-    log.warn(`[TOPIC ERROR][${topic}] ${message}`);
     this.errors.topicsWithError.set(topic, message);
     this._updateErrorsByTopic();
   };


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
Removes a spammy console.warn() in legacy 3D panel