### PR TITLE
Fix playback controls buttons overflowing outside of container bounds

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -164,7 +164,7 @@ export default function PlaybackControls(props: {
       <KeyListener global keyDownHandlers={keyDownHandlers} />
       <div className={classes.root}>
         <Scrubber onSeek={seek} />
-        <Stack direction="row" alignItems="center" justifyContent="space-evenly" flex={1} gap={1}>
+        <Stack direction="row" alignItems="center" flex={1} gap={1} overflowX="auto">
           <Stack direction="row" flex={1} gap={0.5}>
             {currentUser && deviceId && (
               <HoverableIconButton


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes https://github.com/foxglove/studio/issues/4447


https://user-images.githubusercontent.com/14237/191558235-9588a3b3-7b79-4889-80ab-b02873f23375.mov

