### PR TITLE
3D settings: filter topics by visibility

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -17,6 +17,7 @@ import {
   ParameterValue,
   SettingsIcon,
   SettingsTreeAction,
+  SettingsTreeField,
   SettingsTreeNodeActionItem,
   SettingsTreeNodes,
   Topic,
@@ -43,7 +44,7 @@ import {
   normalizeTransformStamped,
 } from "./normalizeMessages";
 import { Cameras } from "./renderables/Cameras";
-import { CoreSettings } from "./renderables/CoreSettings";
+import { CoreSettings, TopicsFilterSelect } from "./renderables/CoreSettings";
 import { FrameAxes, LayerSettingsTransform } from "./renderables/FrameAxes";
 import { Grids } from "./renderables/Grids";
 import { Images } from "./renderables/Images";
@@ -99,6 +100,7 @@ export type RendererEvents = {
 };
 
 export type FollowMode = "follow-pose" | "follow-position" | "follow-none";
+export type TopicsFilter = "list-all" | "list-visible" | "list-not-visible";
 
 export type RendererConfig = {
   /** Camera settings for the currently rendering scene */
@@ -107,6 +109,8 @@ export type RendererConfig = {
   followTf: string | undefined;
   /** Camera follow mode */
   followMode: FollowMode;
+  /** Filter Mode for Showing Topics in Settings Panel */
+  topicsFilter: TopicsFilter;
   scene: {
     /** Show rendering metrics in a DOM overlay */
     enableStats?: boolean;
@@ -287,6 +291,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   private aspect: number;
   private controls: OrbitControls;
   public followMode: FollowMode;
+  private topicSettingsFilter: TopicsFilter;
   // The pose of the render frame in the fixed frame when following was disabled
   private unfollowPoseSnapshot: Pose | undefined;
 
@@ -417,6 +422,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.followFrameId = config.followTf;
     this.followMode = config.followMode;
+
+    this.topicSettingsFilter = config.topicsFilter;
 
     const samples = msaaSamples(this.gl.capabilities);
     const renderSize = this.gl.getDrawingBufferSize(tempVec2);
@@ -593,24 +600,21 @@ export class Renderer extends EventEmitter<RendererEvents> {
     };
     this.customLayerActions.set(options.layerId, { action, handler });
 
-    // "Topics" settings tree node
-    const topics: SettingsTreeEntry = {
-      path: ["topics"],
-      node: {
-        label: "Topics",
-        defaultExpansionState: "expanded",
-        actions: [
-          { id: "show-all", type: "action", label: "Show All" },
-          { id: "hide-all", type: "action", label: "Hide All" },
-        ],
-        children: this.settings.tree()["topics"]?.children,
-        handler: this.handleTopicsAction,
-      },
-    };
+    this.syncSettingsTree();
+  }
 
+  public syncSettingsTree(): void {
+    // "Topics" settings tree node
+    const topics = this._getTopicsSettings();
     // "Custom Layers" settings tree node
+    const customLayers = this._getCustomlayerSettings();
+    this.settings.setNodesForKey(RENDERER_ID, [topics, customLayers]);
+    this._rebuildSceneExtensionNodes();
+  }
+
+  private _getCustomlayerSettings() {
     const layerCount = Object.keys(this.config.layers).length;
-    const customLayers: SettingsTreeEntry = {
+    return {
       path: ["layers"],
       node: {
         label: `Custom Layers${layerCount > 0 ? ` (${layerCount})` : ""}`,
@@ -619,8 +623,27 @@ export class Renderer extends EventEmitter<RendererEvents> {
         handler: this.handleCustomLayersAction,
       },
     };
+  }
 
-    this.settings.setNodesForKey(RENDERER_ID, [topics, customLayers]);
+  private _getTopicsSettings(): SettingsTreeEntry {
+    return {
+      path: ["topics"],
+      node: {
+        label: "Topics",
+        defaultExpansionState: "expanded",
+        actions: [
+          { id: "show-all", type: "action", label: "Show All" },
+          { id: "hide-all", type: "action", label: "Hide All" },
+        ],
+        fields: {
+          topicsFilter: {
+            ...TopicsFilterSelect,
+            value: this.topicSettingsFilter,
+          } as SettingsTreeField,
+        },
+        handler: this.handleTopicsAction,
+      },
+    };
   }
 
   private defaultFrameId(): string | undefined {
@@ -698,10 +721,30 @@ export class Renderer extends EventEmitter<RendererEvents> {
       // Rebuild topicsByName
       this.topicsByName = topics ? new Map(topics.map((topic) => [topic.name, topic])) : undefined;
 
-      // Rebuild the settings nodes for all scene extensions
-      for (const extension of this.sceneExtensions.values()) {
-        this.settings.setNodesForKey(extension.extensionId, extension.settingsNodes());
-      }
+      this._rebuildSceneExtensionNodes();
+    }
+  }
+
+  private _rebuildSceneExtensionNodes(): void {
+    const listAllFilter = (_: SettingsTreeEntry) => true;
+    const listVisibleFilter = (entry: SettingsTreeEntry) =>
+      entry.node.visible == undefined || entry.node.visible;
+    const listInvisibleFilter = (entry: SettingsTreeEntry) =>
+      entry.node.visible == undefined || !entry.node.visible;
+
+    const filterFn =
+      this.topicSettingsFilter === "list-all"
+        ? listAllFilter
+        : this.topicSettingsFilter === "list-visible"
+        ? listVisibleFilter
+        : listInvisibleFilter;
+
+    // Rebuild the settings nodes for all scene extensions
+    for (const extension of this.sceneExtensions.values()) {
+      this.settings.setNodesForKey(
+        extension.extensionId,
+        extension.settingsNodes().filter(filterFn),
+      );
     }
   }
 
@@ -1099,6 +1142,18 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   private handleTopicsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
+    if (
+      action.action === "update" &&
+      path.length === 2 &&
+      path[0] === "topics" &&
+      path[1] === "topicsFilter"
+    ) {
+      const value = action.payload.value as TopicsFilter;
+      this.topicSettingsFilter = value;
+      this.syncSettingsTree();
+      return;
+    }
+
     if (action.action !== "perform-node-action" || path.length !== 1 || path[0] !== "topics") {
       return;
     }
@@ -1125,6 +1180,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
       // Hide all topics
       toggleTopicVisibility(false);
     }
+    this.syncSettingsTree();
   };
 
   private handleCustomLayersAction = (action: SettingsTreeAction): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -729,25 +729,24 @@ export class Renderer extends EventEmitter<RendererEvents> {
   }
 
   private _rebuildSceneExtensionNodes(): void {
-    const listAllFilter = (_: SettingsTreeEntry) => true;
     const listVisibleFilter = (entry: SettingsTreeEntry) =>
       entry.node.visible == undefined || entry.node.visible;
     const listInvisibleFilter = (entry: SettingsTreeEntry) =>
       entry.node.visible == undefined || !entry.node.visible;
 
     const filterFn =
-      this.topicsFilter === "all"
-        ? listAllFilter
-        : this.topicsFilter === "visible"
+      this.topicsFilter === "visible"
         ? listVisibleFilter
-        : listInvisibleFilter;
+        : this.topicsFilter === "not-visible"
+        ? listInvisibleFilter
+        : undefined;
 
     // Rebuild the settings nodes for all scene extensions
     for (const extension of this.sceneExtensions.values()) {
-      this.settings.setNodesForKey(
-        extension.extensionId,
-        extension.settingsNodes().filter(filterFn),
-      );
+      const settingsNodes = filterFn
+        ? extension.settingsNodes().filter(filterFn)
+        : extension.settingsNodes();
+      this.settings.setNodesForKey(extension.extensionId, settingsNodes);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -17,7 +17,6 @@ import {
   ParameterValue,
   SettingsIcon,
   SettingsTreeAction,
-  SettingsTreeField,
   SettingsTreeNodeActionItem,
   SettingsTreeNodes,
   Topic,
@@ -100,7 +99,7 @@ export type RendererEvents = {
 };
 
 export type FollowMode = "follow-pose" | "follow-position" | "follow-none";
-export type TopicsFilter = "list-all" | "list-visible" | "list-not-visible";
+export type TopicsFilter = "all" | "visible" | "not-visible";
 
 export type RendererConfig = {
   /** Camera settings for the currently rendering scene */
@@ -295,7 +294,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   private aspect: number;
   private controls: OrbitControls;
   public followMode: FollowMode;
-  private topicSettingsFilter: TopicsFilter;
+  private topicsFilter: TopicsFilter;
   // The pose of the render frame in the fixed frame when following was disabled
   private unfollowPoseSnapshot: Pose | undefined;
 
@@ -427,7 +426,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.followFrameId = config.followTf;
     this.followMode = config.followMode;
 
-    this.topicSettingsFilter = config.topicsFilter;
+    this.topicsFilter = config.topicsFilter;
 
     const samples = msaaSamples(this.gl.capabilities);
     const renderSize = this.gl.getDrawingBufferSize(tempVec2);
@@ -642,8 +641,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
         fields: {
           topicsFilter: {
             ...TopicsFilterSelect,
-            value: this.topicSettingsFilter,
-          } as SettingsTreeField,
+            value: this.topicsFilter,
+          },
         },
         handler: this.handleTopicsAction,
       },
@@ -737,9 +736,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
       entry.node.visible == undefined || !entry.node.visible;
 
     const filterFn =
-      this.topicSettingsFilter === "list-all"
+      this.topicsFilter === "all"
         ? listAllFilter
-        : this.topicSettingsFilter === "list-visible"
+        : this.topicsFilter === "visible"
         ? listVisibleFilter
         : listInvisibleFilter;
 
@@ -1153,7 +1152,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
       path[1] === "topicsFilter"
     ) {
       const value = action.payload.value as TopicsFilter;
-      this.topicSettingsFilter = value;
+      this.topicsFilter = value;
       this.syncSettingsTree();
       return;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
@@ -56,7 +56,10 @@ export class SceneExtension<
   public readonly renderables = new Map<string, TRenderable>();
 
   private _settingsUpdateDebounced = debounce(
-    () => this.renderer.settings.setNodesForKey(this.extensionId, this.settingsNodes()),
+    () => {
+      this.renderer.settings.setNodesForKey(this.extensionId, this.settingsNodes());
+      this.renderer.syncSettingsTree();
+    },
     SETTINGS_DEBOUNCE_MS,
     { leading: true, trailing: true, maxWait: SETTINGS_DEBOUNCE_MS },
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -378,7 +378,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     return {
       cameraState,
       followMode: partialConfig?.followMode ?? "follow-pose",
-      topicsFilter: partialConfig?.topicsFilter ?? "list-all",
+      topicsFilter: partialConfig?.topicsFilter ?? "all",
       followTf: partialConfig?.followTf,
       scene: partialConfig?.scene ?? {},
       transforms,

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -372,6 +372,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     return {
       cameraState,
       followMode: partialConfig?.followMode ?? "follow-pose",
+      topicsFilter: partialConfig?.topicsFilter ?? "list-all",
       followTf: partialConfig?.followTf,
       scene: partialConfig?.scene ?? {},
       transforms: partialConfig?.transforms ?? {},

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -31,14 +31,14 @@ export const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
 };
 
 const TopicsFilterOptions = [
-  { label: "All", value: "list-all" },
-  { label: "Visible", value: "list-visible" },
-  { label: "Not Visible", value: "list-not-visible" },
+  { label: "All", value: "all" },
+  { label: "Visible", value: "visible" },
+  { label: "Not Visible", value: "not-visible" },
 ];
 export const TopicsFilterSelect = {
   label: "Filter Topics",
   help: "Filter Topics By Visibility",
-  input: "select",
+  input: "select" as const,
   options: TopicsFilterOptions,
 };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -30,6 +30,18 @@ export const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
   poseEstimateThetaDeviation: round(Math.PI / 12, 8),
 };
 
+const TopicsFilterOptions = [
+  { label: "All", value: "list-all" },
+  { label: "Visible", value: "list-visible" },
+  { label: "Not Visible", value: "list-not-visible" },
+];
+export const TopicsFilterSelect = {
+  label: "Filter Topics",
+  help: "Filter Topics By Visibility",
+  input: "select",
+  options: TopicsFilterOptions,
+};
+
 export class CoreSettings extends SceneExtension {
   public constructor(renderer: Renderer) {
     super("foxglove.CoreSettings", renderer);

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -132,6 +132,11 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
       defaultProps: {
         disableRipple: true,
       },
+      styleOverrides: {
+        focusHighlight: {
+          ...disableBackgroundColorTransition,
+        },
+      },
     },
     MuiCardContent: {
       styleOverrides: {


### PR DESCRIPTION

**User-Facing Changes**
 - add filter field to topics settings node with the ability to filter the topics list by visibility

**Description**
 - broke out some functions to enable updating of settings without adding customLayerActions
 - topics and custom layer settings nodes now synced in debounce update

<!-- link relevant github issues -->
Fixes #4433

<!-- add `docs` label if this PR requires documentation updates -->
