### PR TITLE
Change RosDb3IterableSource to launch worker on demand

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -18,10 +18,6 @@ import type { RosDb3IterableSource as RosDb3Source } from "./RosDb3IterableSourc
 
 Comlink.transferHandlers.set("iterable", iterableTransferHandler);
 
-const ComlinkWrapper = Comlink.wrap<new (files: File[]) => RosDb3Source>(
-  new Worker(new URL("./RosDb3IterableSource.worker", import.meta.url)),
-);
-
 export class RosDb3IterableSource implements IIterableSource {
   private files: File[];
   private wrapper?: Comlink.Remote<IIterableSource>;
@@ -31,6 +27,12 @@ export class RosDb3IterableSource implements IIterableSource {
   }
 
   public async initialize(): Promise<Initalization> {
+    // Generate a wrapper around the launched worker. Note this launches the worker and should
+    // happen on-demand rather than at the file level.
+    const ComlinkWrapper = Comlink.wrap<new (files: File[]) => RosDb3Source>(
+      new Worker(new URL("./RosDb3IterableSource.worker", import.meta.url)),
+    );
+
     const wrapper = (this.wrapper = await new ComlinkWrapper(this.files));
     return await wrapper.initialize();
   }


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than launching the db3 source worker at file level this change launches the worker only when initialized. Prior to this change the worker would launch even when there was no use of the db3 iterable source.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
