### PR TITLE
Pin caddy version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yarn install --immutable
 RUN yarn run web:build:prod
 
 # Release stage
-FROM caddy:2
+FROM caddy:2.5.2-alpine
 WORKDIR /src
 COPY --from=build /src/web/.webpack ./
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Our Dockerfile referenced caddy simply as `FROM caddy:2` but it seems like the recently upgraded Caddy 2.6 is crashing in our setup. This pins it to `2.5.2-alpine`.

Fixes https://github.com/foxglove/studio/issues/4468