### PR TITLE
Fix block size tracking for BlockLoader

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -73,7 +73,7 @@ describe("BlockLoader", () => {
 
     const loader = new BlockLoader({
       maxBlocks: 5,
-      cacheSizeBytes: 1,
+      cacheSizeBytes: 5,
       minBlockDurationNs: 1,
       source,
       start: { sec: 0, nsec: 0 },
@@ -82,12 +82,12 @@ describe("BlockLoader", () => {
     });
 
     const msgEvents: MessageEvent<unknown>[] = [];
-    for (let i = 0; i < 5; ++i) {
+    for (let i = 0; i < 10; i += 3) {
       msgEvents.push({
         topic: "a",
         receiveTime: { sec: i, nsec: 0 },
         message: undefined,
-        sizeInBytes: 0,
+        sizeInBytes: 1,
       });
     }
 
@@ -108,7 +108,7 @@ describe("BlockLoader", () => {
     let count = 0;
     await loader.startLoading({
       progress: async (progress) => {
-        if (++count < 3) {
+        if (++count < 4) {
           return;
         }
 
@@ -123,24 +123,17 @@ describe("BlockLoader", () => {
             blocks: [
               {
                 messagesByTopic: {
-                  a: [msgEvents[0], msgEvents[1]],
+                  a: [msgEvents[0]],
                 },
                 needTopics: new Set(),
-                sizeInBytes: 0,
+                sizeInBytes: 1,
               },
               {
                 messagesByTopic: {
-                  a: [msgEvents[2], msgEvents[3]],
+                  a: [msgEvents[1]],
                 },
                 needTopics: new Set(),
-                sizeInBytes: 0,
-              },
-              {
-                messagesByTopic: {
-                  a: [msgEvents[4]],
-                },
-                needTopics: new Set(),
-                sizeInBytes: 0,
+                sizeInBytes: 1,
               },
               {
                 messagesByTopic: {
@@ -151,10 +144,17 @@ describe("BlockLoader", () => {
               },
               {
                 messagesByTopic: {
-                  a: [],
+                  a: [msgEvents[2]],
                 },
                 needTopics: new Set(),
-                sizeInBytes: 0,
+                sizeInBytes: 1,
+              },
+              {
+                messagesByTopic: {
+                  a: [msgEvents[3]],
+                },
+                needTopics: new Set(),
+                sizeInBytes: 1,
               },
             ],
             startTime: { sec: 0, nsec: 0 },

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -162,6 +162,8 @@ export class BlockLoader {
       [0, this.activeBlockId],
     ];
 
+    log.debug("loading segments", segments);
+
     for (const segment of segments) {
       const [beginBlockId, lastBlockId] = segment;
 
@@ -183,6 +185,7 @@ export class BlockLoader {
     progress: LoadArgs["progress"],
   ): Promise<void> {
     const topics = this.topics;
+    log.debug("load block range", { topics, beginBlockId, lastBlockId });
 
     let totalBlockSizeBytes = this.cacheSize();
 
@@ -275,6 +278,7 @@ export class BlockLoader {
             };
 
             // setup a new block cache for the next block
+            sizeInBytes = 0;
             messagesByTopic = {};
             // Set all topic arrays to empty to indicate we've read this topic
             for (const topic of topicsToFetch) {
@@ -320,6 +324,11 @@ export class BlockLoader {
           });
           // If we could not evict any blocks to bring our size down, then we stop loading more data
           if (evictedSize === 0) {
+            log.debug("could not evict more blocks", {
+              totalBlockSizeBytes,
+              messageSizeInBytes,
+              maxCache: this.maxCacheSize,
+            });
             return;
           }
 
@@ -367,6 +376,7 @@ export class BlockLoader {
           sizeInBytes: sizeInBytes + (existingBlock?.sizeInBytes ?? 0),
         };
 
+        sizeInBytes = 0;
         messagesByTopic = {};
         // Set all topic arrays to empty to indicate we've read this topic
         for (const topic of topicsToFetch) {
@@ -392,6 +402,7 @@ export class BlockLoader {
           continue;
         }
 
+        log.debug(`evict block ${i}, size: ${blockToEvict.sizeInBytes}`);
         this.blocks[i] = undefined;
         return blockToEvict.sizeInBytes;
       }
@@ -404,6 +415,7 @@ export class BlockLoader {
           continue;
         }
 
+        log.debug(`evict block ${i}, size: ${blockToEvict.sizeInBytes}`);
         this.blocks[i] = undefined;
         return blockToEvict.sizeInBytes;
       }
@@ -414,6 +426,7 @@ export class BlockLoader {
           continue;
         }
 
+        log.debug(`evict block ${i}, size: ${blockToEvict.sizeInBytes}`);
         this.blocks[i] = undefined;
         return blockToEvict.sizeInBytes;
       }

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/streamMessages.ts
@@ -67,10 +67,11 @@ export async function* streamMessages({
   parsedChannelsByTopic: Map<string, ParsedChannelAndEncodings[]>;
 }): AsyncGenerator<MessageEvent<unknown>[]> {
   const controller = new AbortController();
-  signal?.addEventListener("abort", () => {
+  const abortHandler = () => {
     log.debug("Manual abort of streamMessages", params);
     controller.abort();
-  });
+  };
+  signal?.addEventListener("abort", abortHandler);
   const decompressHandlers = await loadDecompressHandlers();
 
   log.debug("streamMessages", params);
@@ -227,6 +228,7 @@ export async function* streamMessages({
       // If the caller called generator.return() in between body chunks, automatically cancel the request.
       log.debug("Automatic abort of streamMessages", params);
     }
+    signal?.removeEventListener("abort", abortHandler);
     controller.abort();
   }
 


### PR DESCRIPTION


**User-Facing Changes**
Improved caching for playback for file and streaming data sources.

**Description**
Fix incorrect sizeInBytes tracking for BlockLoader when closing out the current block or filling block gaps. Prior to this change the sizeInBytes (which tracks the size all messages within a block), would incorrectly grow when finishing a block and moving to the next block. This would result in blocks having a sizeInBytes that was a sum of all previous block sizes. When calling cacheSize this would result in a large cache size for totalSizeInBytes which would attemt to evict all blocks.

This change also updates streamMessages to remove the abort signal event listener when exiting normally to avoid printing a misleading "Manual abort of streamMessages" log.

Fixes: #4466

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
