### PR TITLE
Upgrade node development requirement to v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
 
       - name: Restore cache
         uses: actions/cache@v3
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
 
       - name: Restore cache
         uses: actions/cache@v3
@@ -119,7 +119,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
 
       - name: Restore cache
         uses: actions/cache@v3

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
           cache: yarn
 
       - run: yarn install --immutable
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
           registry-url: https://registry.npmjs.org
           cache: yarn
 
@@ -196,7 +196,7 @@ jobs:
 
       - uses: actions/setup-node@v3.4.1
         with:
-          node-version: 14.x
+          node-version: 16.17
           cache: yarn
 
       - run: yarn install --immutable

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note: All contributors must agree to our [Contributor License Agreement](https:/
 
 **Dependencies:**
 
-- [Node.js](https://nodejs.org/en/) v14+
+- [Node.js](https://nodejs.org/en/) v16+
 - [Yarn](https://yarnpkg.com/getting-started/install) – `npm install -g yarn`
 - [Git LFS](https://git-lfs.github.com/)
 - [Visual Studio Code](https://code.visualstudio.com/) – Recommended

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": "14" } }],
+    ["@babel/preset-env", { "targets": { "node": "16" } }],
     "@babel/preset-typescript",
     "@babel/preset-react"
   ],


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Use node 16 in CI. Update the README to reference 16+ as the required version for development.

16 is the current stable LTS release and we were already using it in our Dockerfile.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
