### PR TITLE
Clear tab index on number input step buttons

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -168,7 +168,7 @@ export function NumberInput(
             className={classes.iconButton}
             size="small"
             edge="start"
-            tabIndex={-1}
+            tabIndex={-1} // Disable tabbing to the step buttons.
             onClick={(event: React.MouseEvent) =>
               updateValue((value ?? placeHolderValue ?? 0) - (event.shiftKey ? step * 10 : step))
             }
@@ -181,7 +181,7 @@ export function NumberInput(
             className={classes.iconButton}
             size="small"
             edge="end"
-            tabIndex={-1}
+            tabIndex={-1} // Disable tabbing to the step buttons.
             onClick={(event: React.MouseEvent) =>
               updateValue((value ?? placeHolderValue ?? 0) + (event.shiftKey ? step * 10 : step))
             }

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -168,6 +168,7 @@ export function NumberInput(
             className={classes.iconButton}
             size="small"
             edge="start"
+            tabIndex={-1}
             onClick={(event: React.MouseEvent) =>
               updateValue((value ?? placeHolderValue ?? 0) - (event.shiftKey ? step * 10 : step))
             }
@@ -180,6 +181,7 @@ export function NumberInput(
             className={classes.iconButton}
             size="small"
             edge="end"
+            tabIndex={-1}
             onClick={(event: React.MouseEvent) =>
               updateValue((value ?? placeHolderValue ?? 0) + (event.shiftKey ? step * 10 : step))
             }


### PR DESCRIPTION
**User-Facing Changes**
Improve tab behavior on settings editor input fields.

**Description**
Set tab index for the stepper buttons on the number input to -1 so that hitting tab on the keyboard moves directly to the next input field.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4451