### PR TITLE
Disable sign in sidebar tab for docker instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:16 as build
 WORKDIR /src
 COPY . ./
 
+ENV FOXGLOVE_DISABLE_SIGN_IN=true
 RUN yarn install --immutable
 RUN yarn run web:build:prod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM node:16 as build
 WORKDIR /src
 COPY . ./
 
-ENV FOXGLOVE_DISABLE_SIGN_IN=true
 RUN yarn install --immutable
+
+ENV FOXGLOVE_DISABLE_SIGN_IN=true
 RUN yarn run web:build:prod
 
 # Release stage

--- a/packages/studio-base/environment.ts
+++ b/packages/studio-base/environment.ts
@@ -34,6 +34,7 @@ export function buildEnvironmentDefaults(
     FOXGLOVE_ACCOUNT_DASHBOARD_URL:
       process.env.FOXGLOVE_ACCOUNT_DASHBOARD_URL ?? serverURLs.console + "/dashboard",
     FOXGLOVE_CONSOLE_URL: serverURLs.console,
+    FOXGLOVE_DISABLE_SIGN_IN: process.env.FOXGLOVE_DISABLE_SIGN_IN ?? null, // eslint-disable-line no-restricted-syntax
     OAUTH_CLIENT_ID: process.env.OAUTH_CLIENT_ID ?? "oSJGEAQm16LNF09FSVTMYJO5aArQzq8o",
     SENTRY_DSN: process.env.SENTRY_DSN ?? null, // eslint-disable-line no-restricted-syntax
     SENTRY_PROJECT: process.env.SENTRY_PROJECT ?? null, // eslint-disable-line no-restricted-syntax

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -55,6 +55,7 @@ type AppProps = {
   extensionLoaders: readonly ExtensionLoader[];
   nativeAppMenu?: INativeAppMenu;
   nativeWindow?: INativeWindow;
+  disableSignin?: boolean;
   enableDialogAuth?: boolean;
   enableLaunchPreferenceScreen?: boolean;
 };
@@ -77,6 +78,7 @@ export function App(props: AppProps): JSX.Element {
     dataSources,
     layoutStorage,
     consoleApi,
+    disableSignin,
     extensionLoaders,
     nativeAppMenu,
     nativeWindow,
@@ -142,7 +144,7 @@ export function App(props: AppProps): JSX.Element {
                 <DndProvider backend={HTML5Backend}>
                   <Suspense fallback={<></>}>
                     <PanelCatalogProvider>
-                      <Workspace deepLinks={deepLinks} />
+                      <Workspace deepLinks={deepLinks} disableSignin={disableSignin} />
                     </PanelCatalogProvider>
                   </Suspense>
                 </DndProvider>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -185,7 +185,8 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     return extensions;
   }, [availableSources]);
 
-  const supportsAccountSettings = useContext(ConsoleApiContext) != undefined;
+  const supportsAccountSettings =
+    useContext(ConsoleApiContext) != undefined && props.disableSignin !== true;
 
   // We use playerId to detect when a player changes for RemountOnValueChange below
   // see comment below above the RemountOnValueChange component
@@ -535,7 +536,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ["help", { iconName: "QuestionCircle", title: "Help", component: HelpSidebar }],
     ]);
 
-    if (supportsAccountSettings && props.disableSignin !== true) {
+    if (supportsAccountSettings) {
       bottomItems.set("account", {
         iconName: currentUser != undefined ? "BlockheadFilled" : "Blockhead",
         title: currentUser != undefined ? `Signed in as ${currentUser.email}` : "Account",
@@ -555,7 +556,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     playerProblems,
     enableStudioLogsSidebar,
     supportsAccountSettings,
-    props.disableSignin,
     currentUser,
   ]);
 

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -150,6 +150,7 @@ function AddPanel() {
 
 type WorkspaceProps = {
   deepLinks?: string[];
+  disableSignin?: boolean;
 };
 
 const DEFAULT_DEEPLINKS = Object.freeze([]);
@@ -534,7 +535,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ["help", { iconName: "QuestionCircle", title: "Help", component: HelpSidebar }],
     ]);
 
-    if (supportsAccountSettings) {
+    if (supportsAccountSettings && props.disableSignin !== true) {
       bottomItems.set("account", {
         iconName: currentUser != undefined ? "BlockheadFilled" : "Blockhead",
         title: currentUser != undefined ? `Signed in as ${currentUser.email}` : "Account",
@@ -552,9 +553,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   }, [
     DataSourceSidebarItem,
     playerProblems,
-    supportsAccountSettings,
-    currentUser,
     enableStudioLogsSidebar,
+    supportsAccountSettings,
+    props.disableSignin,
+    currentUser,
   ]);
 
   const keyDownHandlers = useMemo(

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -60,8 +60,11 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
   const enableDialogAuth =
     process.env.NODE_ENV === "development" || process.env.FOXGLOVE_ENABLE_DIALOG_AUTH != undefined;
 
+  const disableSignin = process.env.FOXGLOVE_DISABLE_SIGN_IN != undefined;
+
   return (
     <App
+      disableSignin={disableSignin}
       enableDialogAuth={enableDialogAuth}
       enableLaunchPreferenceScreen
       deepLinks={[window.location.href]}


### PR DESCRIPTION
**User-Facing Changes**
Disable sign in sidebar tab for docker hosted instances.

**Description**
Sign in doesn't currently work for instances hosted from docker so hide the sidebar tab.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4404