### PR TITLE
Hides Clear button when color is cleared or when flag is set to true

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -261,7 +261,7 @@ function FieldInput({
               payload: { path, input: "rgb", value },
             })
           }
-          hideClearButton={field.shouldHideClearButton}
+          hideClearButton={field.hideClearButton}
         />
       );
     case "rgba":

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -261,6 +261,7 @@ function FieldInput({
               payload: { path, input: "rgb", value },
             })
           }
+          hideClearButton={field.shouldHideClearButton}
         />
       );
     case "rgba":

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -632,7 +632,14 @@ const ColorSettings: SettingsTreeNodes = {
     fields: {
       undefined: { label: "Undefined", input: "rgb", value: undefined, placeholder: "placeholder" },
       invalid: { label: "Invalid", input: "rgb", value: "invalid" },
+      hiddenClearButton: {
+        label: "Hidden Clear Button",
+        input: "rgb",
+        value: "#00ffbf",
+        shouldHideClearButton: true,
+      },
       hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
+      hex7: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
       hex8: { label: "Hex 8", input: "rgb", value: "#00aaff88" },
       rgb: { label: "RGB", input: "rgb", value: "rgb(255, 128, 0)" },
       rgba: { label: "RGBA", input: "rgba", value: "rgba(255, 0, 0, 0.5)" },
@@ -642,22 +649,6 @@ const ColorSettings: SettingsTreeNodes = {
     },
   },
 };
-
-// const EmptyValueSettings: SettingsTreeNodes = {
-//   EmptyValue: {
-//     fields: {
-//       undefined: { label: "Undefined", input: "rgb", value: undefined, placeholder: "placeholder" },
-//       invalid: { label: "Invalid", input: "rgb", value: "invalid" },
-//       hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
-//       hex8: { label: "Hex 8", input: "rgb", value: "#00aaff88" },
-//       rgb: { label: "RGB", input: "rgb", value: "rgb(255, 128, 0)" },
-//       rgba: { label: "RGBA", input: "rgba", value: "rgba(255, 0, 0, 0.5)" },
-//       rgbaBlack: { label: "RGBA Black", input: "rgba", value: "rgba(0, 0, 0, 1)" },
-//       rgbaWhite: { label: "RGBA White", input: "rgba", value: "rgba(255, 255, 255, 1)" },
-//       gradient: { label: "Gradient", input: "gradient", value: ["#000000", "#ffffff"] },
-//     },
-//   },
-// };
 
 function updateSettingsTreeNodes(
   previous: SettingsTreeNodes,

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -636,7 +636,7 @@ const ColorSettings: SettingsTreeNodes = {
         label: "Hidden Clear Button",
         input: "rgb",
         value: "#00ffbf",
-        shouldHideClearButton: true,
+        hideClearButton: true,
       },
       hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
       hex7: { label: "Hex 6", input: "rgb", value: "#ffaa00" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -643,6 +643,22 @@ const ColorSettings: SettingsTreeNodes = {
   },
 };
 
+// const EmptyValueSettings: SettingsTreeNodes = {
+//   EmptyValue: {
+//     fields: {
+//       undefined: { label: "Undefined", input: "rgb", value: undefined, placeholder: "placeholder" },
+//       invalid: { label: "Invalid", input: "rgb", value: "invalid" },
+//       hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
+//       hex8: { label: "Hex 8", input: "rgb", value: "#00aaff88" },
+//       rgb: { label: "RGB", input: "rgb", value: "rgb(255, 128, 0)" },
+//       rgba: { label: "RGBA", input: "rgba", value: "rgba(255, 0, 0, 0.5)" },
+//       rgbaBlack: { label: "RGBA Black", input: "rgba", value: "rgba(0, 0, 0, 1)" },
+//       rgbaWhite: { label: "RGBA White", input: "rgba", value: "rgba(255, 255, 255, 1)" },
+//       gradient: { label: "Gradient", input: "gradient", value: ["#000000", "#ffffff"] },
+//     },
+//   },
+// };
+
 function updateSettingsTreeNodes(
   previous: SettingsTreeNodes,
   path: readonly string[],
@@ -826,6 +842,14 @@ Filter.play = () => {
 };
 
 export function Colors(): JSX.Element {
+  return <Wrapper nodes={ColorSettings} />;
+}
+
+export function EmptyValue(): JSX.Element {
+  return <Wrapper nodes={ColorSettings} />;
+}
+
+export function SetHiddenValueToTrue(): JSX.Element {
   return <Wrapper nodes={ColorSettings} />;
 }
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -639,7 +639,6 @@ const ColorSettings: SettingsTreeNodes = {
         hideClearButton: true,
       },
       hex6: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
-      hex7: { label: "Hex 6", input: "rgb", value: "#ffaa00" },
       hex8: { label: "Hex 8", input: "rgb", value: "#00aaff88" },
       rgb: { label: "RGB", input: "rgb", value: "rgb(255, 128, 0)" },
       rgba: { label: "RGBA", input: "rgba", value: "rgba(255, 0, 0, 0.5)" },

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -89,13 +89,8 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
         InputProps={{
           readOnly: true,
           startAdornment: <ColorSwatch color={swatchColor} onClick={handleClick} />,
-          endAdornment: (
-            <IconButton
-              onClick={clearValue}
-              size="small"
-              disabled={disabled}
-              style={{ visibility: shouldHideClearButton ? "hidden" : "visible" }}
-            >
+          endAdornment: !shouldHideClearButton && (
+            <IconButton onClick={clearValue} size="small" disabled={disabled}>
               <ClearIcon />
             </IconButton>
           ),

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -71,8 +71,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
 
   const open = Boolean(anchorElement);
 
-  const shouldHideClearButton = (displayValue ?? "") !== "" || (hideClearButton ?? false);
-
+  const shouldHideClearButton = (displayValue ?? "") === "" || (hideClearButton ?? false);
   return (
     <Stack
       className={cx(classes.root, {
@@ -94,7 +93,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
             <IconButton
               onClick={clearValue}
               size="small"
-              style={{ display: shouldHideClearButton ? "block" : "none" }}
+              style={{ visibility: shouldHideClearButton ? "hidden" : "visible" }}
             >
               <ClearIcon />
             </IconButton>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -42,10 +42,11 @@ type ColorPickerInputProps = {
   onChange: (value: undefined | string) => void;
   placeholder?: string;
   readOnly?: boolean;
+  hideClearButton?: boolean;
 };
 
 export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
-  const { alphaType, disabled, onChange, readOnly, value } = props;
+  const { alphaType, disabled, onChange, readOnly, hideClearButton, value } = props;
 
   const { classes, cx } = useStyles();
 
@@ -70,6 +71,8 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
 
   const open = Boolean(anchorElement);
 
+  const shouldHideClearButton = (displayValue ?? "") !== "" || (hideClearButton ?? false);
+
   return (
     <Stack
       className={cx(classes.root, {
@@ -88,7 +91,11 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
           readOnly: true,
           startAdornment: <ColorSwatch color={swatchColor} onClick={handleClick} />,
           endAdornment: (
-            <IconButton onClick={clearValue} size="small" disabled={disabled}>
+            <IconButton
+              onClick={clearValue}
+              size="small"
+              style={{ display: shouldHideClearButton ? "block" : "none" }}
+            >
               <ClearIcon />
             </IconButton>
           ),

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -93,6 +93,7 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
             <IconButton
               onClick={clearValue}
               size="small"
+              disabled={disabled}
               style={{ visibility: shouldHideClearButton ? "hidden" : "visible" }}
             >
               <ClearIcon />

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -402,6 +402,11 @@ declare module "@foxglove/studio" {
          * Optional placeholder text displayed in the field input when value is undefined
          */
         placeholder?: string;
+
+        /**
+         * Optional field that's true if the clear button should be hidden.
+         */
+        hideClearButton?: boolean;
       }
     | {
         input: "rgba";
@@ -411,6 +416,11 @@ declare module "@foxglove/studio" {
          * Optional placeholder text displayed in the field input when value is undefined
          */
         placeholder?: string;
+
+        /**
+         * Optional field that's true if the clear button should be hidden.
+         */
+        hideClearButton?: boolean;
       }
     | { input: "gradient"; value?: [string, string] }
     | { input: "messagepath"; value?: string; validTypes?: string[] }
@@ -497,11 +507,6 @@ declare module "@foxglove/studio" {
      * Optional message indicating any error state for the field.
      */
     error?: string;
-
-    /**
-     * True if the clear button should be hidden.
-     */
-    hideClearButton?: boolean;
   };
 
   export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -501,7 +501,7 @@ declare module "@foxglove/studio" {
     /**
      * True if the clear button should be hidden.
      */
-    shouldHideClearButton?: boolean;
+    hideClearButton?: boolean;
   };
 
   export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -497,6 +497,11 @@ declare module "@foxglove/studio" {
      * Optional message indicating any error state for the field.
      */
     error?: string;
+
+    /**
+     * True if the clear button should be hidden.
+     */
+    shouldHideClearButton?: boolean;
   };
 
   export type SettingsTreeFields = Record<string, undefined | SettingsTreeField>;


### PR DESCRIPTION
**User-Facing Changes**
The Clear button is now hidden whenever there is no color defined in the color picker or when the panel author chooses to hide it.

**Description**
This adds a new flag for color pickers, `hideClearButton`, which hides the clear button when set to true by the panel author. 

On top of covering the case where the color value is cleared, this allows flexibility for different use-cases, such as if different color values are being generated dynamically or if the author conditionally wants or doesn't want users to change the color picker (such as hiding when a user-defined default value is chosen).

Fixes #4122
