### PR TITLE
Editing a marker color hides the color input as it is still being edited

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -644,6 +644,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
             value: this.topicsFilter,
           },
         },
+        children: this.settings.tree()["topics"]?.children,
         handler: this.handleTopicsAction,
       },
     };


### PR DESCRIPTION
Fix Color Editors closing in 3D panel

**User-Facing Changes**
- n/a


**Description**
 - was rebuilding topics nodes each time and it was causing the continous editors from staying open

<!-- link relevant github issues -->
Fixes #4487
<!-- add `docs` label if this PR requires documentation updates -->
