### PR TITLE
Fix playback bar overlapping fullscreen panel

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, screen } from "@testing-library/dom";
+
+import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
+import Panel from "@foxglove/studio-base/components/Panel";
+import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
+import PanelCatalogContext, {
+  PanelCatalog,
+  PanelInfo,
+} from "@foxglove/studio-base/context/PanelCatalogContext";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import Workspace from "./Workspace";
+
+export default {
+  title: "Workspace",
+  component: Workspace,
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
+class MockPanelCatalog implements PanelCatalog {
+  static #fakePanel: PanelInfo = {
+    title: "Fake Panel",
+    type: "Fake",
+    module: async () => {
+      return {
+        default: Panel(
+          Object.assign(
+            () => (
+              <>
+                <PanelToolbar />
+                <div>I’m a fake panel</div>
+              </>
+            ),
+            { panelType: "Fake", defaultConfig: {} },
+          ),
+        ),
+      };
+    },
+  };
+  public getPanels(): readonly PanelInfo[] {
+    return [MockPanelCatalog.#fakePanel];
+  }
+  public getPanelByType(_type: string): PanelInfo | undefined {
+    return MockPanelCatalog.#fakePanel;
+  }
+}
+
+export function Basic(): JSX.Element {
+  const providers = [
+    /* eslint-disable react/jsx-key */
+    <PanelSetup>{undefined}</PanelSetup>,
+    <ConsoleApiContext.Provider value={{} as any} />,
+    <EventsProvider />,
+    <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
+    <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
+    /* eslint-enable react/jsx-key */
+  ];
+  return (
+    <MultiProvider providers={providers}>
+      <Workspace />
+    </MultiProvider>
+  );
+}
+
+export const FullscreenPanel = Basic.bind({});
+Object.assign(FullscreenPanel, {
+  play: async () => {
+    fireEvent.click(await screen.findByTestId("panel-menu"));
+    fireEvent.click(await screen.findByTestId("panel-menu-fullscreen"));
+  },
+});

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -26,7 +26,6 @@ import React, {
   Profiler,
   MouseEventHandler,
   useLayoutEffect,
-  useEffect,
   CSSProperties,
   useContext,
 } from "react";
@@ -478,16 +477,6 @@ export default function Panel<
       }),
       [exitFullscreen],
     );
-
-    /* Ensure user exits full-screen mode when leaving window, even if key is still pressed down */
-    useEffect(() => {
-      const listener = () => {
-        exitFullscreen();
-        setQuickActionsKeyPressed(false);
-      };
-      window.addEventListener("blur", listener);
-      return () => window.removeEventListener("blur", listener);
-    }, [exitFullscreen]);
 
     const otherPanelProps = useShallowMemo(otherProps);
     const childProps = useMemo(

--- a/packages/studio-base/src/components/PanelRoot.tsx
+++ b/packages/studio-base/src/components/PanelRoot.tsx
@@ -70,7 +70,7 @@ export const usePanelRootStyles = makeStyles<
       top: 0,
       left: 0,
       right: 0,
-      bottom: 50, // match PlaybackBar height
+      bottom: 77, // match PlaybackBar height
       zIndex: 10000,
       transition: transitions.create(["border-width", "top", "right", "bottom", "left"], {
         duration, // match to timeout duration inside Panel component

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -62,6 +62,8 @@ import { SavedProps, UserNodes } from "@foxglove/studio-base/types/panels";
 
 const log = Logger.getLogger(__filename);
 
+function noop() {}
+
 type Frame = {
   [topic: string]: MessageEvent<unknown>[];
 };
@@ -306,9 +308,9 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
         activeData={activeData}
         progress={progress}
         publish={publish}
-        startPlayback={() => {}}
-        pausePlayback={() => {}}
-        seekPlayback={() => {}}
+        startPlayback={noop}
+        pausePlayback={noop}
+        seekPlayback={noop}
         setPublishers={setPublishers}
         setSubscriptions={setSubscriptions}
       >

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -306,6 +306,9 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
         activeData={activeData}
         progress={progress}
         publish={publish}
+        startPlayback={() => {}}
+        pausePlayback={() => {}}
+        seekPlayback={() => {}}
         setPublishers={setPublishers}
         setSubscriptions={setSubscriptions}
       >


### PR DESCRIPTION
**User-Facing Changes**
Fixed a visual artifact with fullscreen panels.

**Description**
Fixes https://github.com/foxglove/studio/issues/4478
Removed the behavior where we automatically exit fullscreen when the window loses focus, because we no longer have the "lock fullscreen" feature or the ability to fullscreen from the quick actions overlay.