### PR TITLE
dependabot: disable default labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels: [] # disable default labels


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
We do not need dependabot PRs to be labeled with `dependencies` `github_actions` / `javascript`.
