### PR TITLE
Replace PanelList tooltip with MUI tooltip

### DIFF
--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -217,13 +217,13 @@ function DraggablePanelItem({
           placement="right"
           enterDelay={200}
           title={
-            <Stack style={{ width: 200 }}>
+            <Stack paddingTop={0.25} style={{ width: 200 }}>
               {panel.thumbnail != undefined && <img src={panel.thumbnail} alt={panel.title} />}
               <Stack padding={1} gap={0.5}>
-                <Typography variant="body2" style={{ fontWeight: "bold" }}>
+                <Typography variant="body2" fontWeight="bold">
                   {panel.title}
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography variant="body2" style={{ opacity: 0.6 }}>
                   {panel.description}
                 </Typography>
               </Stack>

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -19,14 +19,15 @@ import {
   CardContent,
   CardMedia,
   Container,
+  Fade,
+  IconButton,
   List,
   ListItem,
   ListItemButton,
   ListItemText,
+  TextField,
   Tooltip,
   Typography,
-  TextField,
-  IconButton,
 } from "@mui/material";
 import fuzzySort from "fuzzysort";
 import { countBy, isEmpty } from "lodash";
@@ -216,6 +217,7 @@ function DraggablePanelItem({
         <Tooltip
           placement="right"
           enterDelay={200}
+          TransitionComponent={Fade}
           title={
             <Stack paddingTop={0.25} style={{ width: 200 }}>
               {panel.thumbnail != undefined && <img src={panel.thumbnail} alt={panel.title} />}

--- a/packages/studio-base/src/components/PanelList/index.tsx
+++ b/packages/studio-base/src/components/PanelList/index.tsx
@@ -23,6 +23,7 @@ import {
   ListItem,
   ListItemButton,
   ListItemText,
+  Tooltip,
   Typography,
   TextField,
   IconButton,
@@ -36,7 +37,6 @@ import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextHighlight from "@foxglove/studio-base/components/TextHighlight";
-import { useTooltip } from "@foxglove/studio-base/components/Tooltip";
 import {
   useCurrentLayoutActions,
   usePanelMosaicId,
@@ -173,33 +173,12 @@ function DraggablePanelItem({
     }
   }, [highlighted]);
 
-  const { ref: tooltipRef, tooltip } = useTooltip({
-    contents:
-      mode === "grid" ? (
-        panel.description
-      ) : (
-        <Stack style={{ width: 200 }}>
-          {panel.thumbnail != undefined && <img src={panel.thumbnail} alt={panel.title} />}
-          <Stack padding={1} gap={0.5}>
-            <Typography variant="body2" style={{ fontWeight: "bold" }}>
-              {panel.title}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {panel.description}
-            </Typography>
-          </Stack>
-        </Stack>
-      ),
-    placement: mode === "grid" ? undefined : "right",
-    delay: 200,
-  });
   const mergedRef = useCallback(
     (el: HTMLElement | ReactNull) => {
       connectDragSource(el);
-      tooltipRef(el);
       scrollRef.current = el;
     },
-    [connectDragSource, tooltipRef, scrollRef],
+    [connectDragSource, scrollRef],
   );
 
   const targetString = panel.extensionNamespace
@@ -234,24 +213,41 @@ function DraggablePanelItem({
 
     case "list":
       return (
-        <ListItem disableGutters disablePadding selected={highlighted}>
-          {tooltip}
-          <ListItemButton
-            className={classes.grab}
-            disabled={checked}
-            ref={mergedRef}
-            onClick={onClick}
-          >
-            <ListItemText
-              primary={
-                <span data-testid={`panel-menu-item ${panel.title}`}>
-                  <TextHighlight targetStr={targetString} searchText={searchQuery} />
-                </span>
-              }
-              primaryTypographyProps={{ fontWeight: checked ? "bold" : undefined }}
-            />
-          </ListItemButton>
-        </ListItem>
+        <Tooltip
+          placement="right"
+          enterDelay={200}
+          title={
+            <Stack style={{ width: 200 }}>
+              {panel.thumbnail != undefined && <img src={panel.thumbnail} alt={panel.title} />}
+              <Stack padding={1} gap={0.5}>
+                <Typography variant="body2" style={{ fontWeight: "bold" }}>
+                  {panel.title}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {panel.description}
+                </Typography>
+              </Stack>
+            </Stack>
+          }
+        >
+          <ListItem disableGutters disablePadding selected={highlighted}>
+            <ListItemButton
+              className={classes.grab}
+              disabled={checked}
+              ref={mergedRef}
+              onClick={onClick}
+            >
+              <ListItemText
+                primary={
+                  <span data-testid={`panel-menu-item ${panel.title}`}>
+                    <TextHighlight targetStr={targetString} searchText={searchQuery} />
+                  </span>
+                }
+                primaryTypographyProps={{ fontWeight: checked ? "bold" : undefined }}
+              />
+            </ListItemButton>
+          </ListItem>
+        </Tooltip>
       );
   }
 }


### PR DESCRIPTION
**User-Facing Changes**
<img width="651" alt="Screen Shot 2022-09-28 at 7 26 48 pm" src="https://user-images.githubusercontent.com/924528/192743094-7cdabd73-0a77-4512-b147-31c363897cd7.png">

**Description**
Refactor PanelList tooltip to use MUI Tooltip

Related to #4207


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
