### PR TITLE
Show preferences sidebar button even if sign in is disabled

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -542,13 +542,13 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         title: currentUser != undefined ? `Signed in as ${currentUser.email}` : "Account",
         component: AccountSettings,
       });
-
-      bottomItems.set("preferences", {
-        iconName: "Settings",
-        title: "Preferences",
-        component: Preferences,
-      });
     }
+
+    bottomItems.set("preferences", {
+      iconName: "Settings",
+      title: "Preferences",
+      component: Preferences,
+    });
 
     return [topItems, bottomItems];
   }, [


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Show the preferences sidebar button even if sign in is disabled.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
