### PR TITLE
Fix Toggling Show/Hide all in Transforms not update visibility

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -457,7 +457,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     renderable.add(parentLine);
 
     this.add(renderable);
-    this.renderables.set(frameId, renderable);
+    this.renderables.set(frameKey, renderable);
 
     this._updateFrameAxis(renderable);
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -324,9 +324,9 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
 
       this.renderer.updateConfig((draft) => {
         for (const frameId of this.renderables.keys()) {
-          const frameIdSanitized = frameId === "settings" ? "$settings" : frameId;
-          draft.transforms[frameIdSanitized] ??= {};
-          draft.transforms[frameIdSanitized]!.visible = value;
+          const frameKeySanitized = frameId === "settings" ? "$settings" : `frame:${frameId}`;
+          draft.transforms[frameKeySanitized] ??= {};
+          draft.transforms[frameKeySanitized]!.visible = value;
         }
       });
 
@@ -457,7 +457,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     renderable.add(parentLine);
 
     this.add(renderable);
-    this.renderables.set(frameKey, renderable);
+    this.renderables.set(frameId, renderable);
 
     this._updateFrameAxis(renderable);
   }


### PR DESCRIPTION
**User-Facing Changes**
 - fixed ability to show/hide all transforms

**Description**
 - `frameId` was being used as renderable key instead of full `frameKey` which was used to initialize settings. The toggle function only iterates through the keys of the renderables, thus it was creating settings keys not linked to the original renderables


<!-- link relevant github issues -->
Fixes #4501
<!-- add `docs` label if this PR requires documentation updates -->
