### PR TITLE
Safely parse color values in the ColorSwatch component

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
@@ -2,7 +2,13 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { styled as muiStyled } from "@mui/material";
+import { styled as muiStyled, Theme } from "@mui/material";
+import tinycolor from "tinycolor2";
+
+function calculateBorderColor(theme: Theme, color: string): string {
+  const parsedColor = tinycolor(color);
+  return parsedColor.isValid() ? theme.palette.getContrastText(parsedColor.toHexString()) : color;
+}
 
 export const ColorSwatch = muiStyled("div", {
   shouldForwardProp: (prop) => prop !== "color",
@@ -12,6 +18,6 @@ export const ColorSwatch = muiStyled("div", {
   width: theme.spacing(2.5),
   margin: theme.spacing(0.625),
   borderRadius: 1,
-  border: `1px solid ${theme.palette.getContrastText(color)}`,
+  border: `1px solid ${calculateBorderColor(theme, color)}`,
   flexShrink: 0,
 }));

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
@@ -7,7 +7,9 @@ import tinycolor from "tinycolor2";
 
 function calculateBorderColor(theme: Theme, color: string): string {
   const parsedColor = tinycolor(color);
-  return parsedColor.isValid() ? theme.palette.getContrastText(parsedColor.toHexString()) : color;
+  return parsedColor.isValid()
+    ? theme.palette.getContrastText(parsedColor.toHexString())
+    : theme.palette.text.primary;
 }
 
 export const ColorSwatch = muiStyled("div", {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Use tinycolor to parse the incoming color value before passing it on to MUI's color utility to avoid throwing an exception on an invalid color.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4497