### PR TITLE
Make a copy of each rosbag message event data

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -195,7 +195,7 @@ export class BagIterableSource implements IIterableSource {
 
       if (reader) {
         // bagMsgEvent.data is a view on top of the entire chunk. To avoid keeping references for
-        // chunks (which will full up memory space when we cache messages) when make a copy of the
+        // chunks (which will fill up memory space when we cache messages) when make a copy of the
         // data.
         const dataCopy = bagMsgEvent.data.slice();
         const parsedMessage = reader.readMessage(dataCopy);

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -194,7 +194,11 @@ export class BagIterableSource implements IIterableSource {
       }
 
       if (reader) {
-        const parsedMessage = reader.readMessage(bagMsgEvent.data);
+        // bagMsgEvent.data is a view on top of the entire chunk. To avoid keeping references for
+        // chunks (which will full up memory space when we cache messages) when make a copy of the
+        // data.
+        const dataCopy = bagMsgEvent.data.slice();
+        const parsedMessage = reader.readMessage(dataCopy);
 
         yield {
           connectionId,


### PR DESCRIPTION
**User-Facing Changes**
Opening a large bag file and viewing a few topics does not cause Studio to run out of memory.

**Description**
Each rosbag message event contains the raw data for the message. This data is a view on top of the chunk and keeps a reference to the entire chunk data for the lifetime of the message data.

Studio users are often displaying only a subset of the messages within a file. As we load messages we cache them in memory. When every message keeps a reference to the original chunk this results in large memory use even when viewing one or two topics. For large bag files this memory use can grow so large that eventually Studio crashes.

Even tho Studio playback does have a caching layer with a limit of memory use, this caching layer looks at the individual message data size. This does not take into account any underlying shared buffers or references for that data.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
