### PR TITLE
Use correct label for automatic update setting

### DIFF
--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -309,7 +309,7 @@ function AutoUpdate(): React.ReactElement {
             onChange={(_event, checked) => void setUpdatedEnabled(checked)}
           />
         }
-        label="Check for updates automatically"
+        label="Automatically install updates"
       />
     </>
   );

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -309,7 +309,7 @@ function AutoUpdate(): React.ReactElement {
             onChange={(_event, checked) => void setUpdatedEnabled(checked)}
           />
         }
-        label="Send anonymized crash reports"
+        label="Check for updates automatically"
       />
     </>
   );


### PR DESCRIPTION
**User-Facing Changes**
App preferences label for automatic updates has the correct language

**Description**

Label says the wrong thing

<img width="264" alt="image" src="https://user-images.githubusercontent.com/108767/193177794-f87c34fe-b2d1-46e2-92ca-a83efd709032.png">


Fixes: https://github.com/foxglove/studio/issues/4511

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
