### PR TITLE
Use case insensitive name comparisons for org extension sync operations

### DIFF
--- a/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.test.tsx
@@ -58,6 +58,7 @@ describe("Private registry sync adapter", () => {
     getExtensions.mockReturnValue([
       { name: "id1" },
       { name: "id2" },
+      { name: "mixedCaseName", activeVersion: "1" },
       { name: "private-installed-1", activeVersion: "2" },
       { name: "private-installed-2", activeVersion: "1" },
     ]);
@@ -70,6 +71,7 @@ describe("Private registry sync adapter", () => {
       getExtensions: jest
         .fn()
         .mockResolvedValue([
+          fakeExtension({ namespace: "org", name: "mixedcasename", version: "1" }),
           fakeExtension({ namespace: "org", name: "private-installed-1", version: "1" }),
           fakeExtension({ namespace: "org", name: "private-installed-2", version: "1" }),
           fakeExtension({ namespace: "org", name: "private-to-delete", version: "1" }),

--- a/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.tsx
+++ b/packages/studio-base/src/components/OrgExtensionRegistrySyncAdapter.tsx
@@ -68,13 +68,13 @@ export function OrgExtensionRegistrySyncAdapter(): ReactNull {
       const toInstall = differenceWith(
         remoteExtensions,
         installedPrivateExtensions,
-        (a, b) => a.name === b.name && a.activeVersion === b.version,
+        (a, b) => a.name.toLowerCase() === b.name.toLowerCase() && a.activeVersion === b.version,
       );
 
       const toRemove = differenceWith(
         installedPrivateExtensions,
         remoteExtensions,
-        (a, b) => a.name === b.name,
+        (a, b) => a.name.toLowerCase() === b.name.toLowerCase(),
       );
 
       for (const extension of toInstall) {


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with org extension syncing.

**Description**
Use case insensitive name comparisons when syncing org extensions.

We lowercase the extension name when we use it as an identifier in layouts to make it easy to do a fast case insensitive lookup for loading panels. But for syncing purposes we need to do a case insensitive comparison of the extension name in case the original name had any uppercase characters.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4509