### PR TITLE
Make copybutton text only created on click to avoid perf implications 

### DIFF
--- a/packages/studio-base/src/components/CopyButton.tsx
+++ b/packages/studio-base/src/components/CopyButton.tsx
@@ -19,7 +19,7 @@ import clipboard from "@foxglove/studio-base/util/clipboard";
 
 export default function CopyButton(
   props: PropsWithChildren<{
-    copyText: () => string;
+    getText: () => string;
     size?: "small" | "medium" | "large";
     iconSize?: SvgIconProps["fontSize"];
     color?: ButtonProps["color"] | IconButtonProps["color"];
@@ -34,19 +34,19 @@ export default function CopyButton(
     edge,
     size = "medium",
     iconSize = "medium",
-    copyText,
+    getText,
   } = props;
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
     clipboard
-      .copy(copyText())
+      .copy(getText())
       .then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
       })
       .catch((err) => console.warn(err));
-  }, [copyText]);
+  }, [getText]);
 
   if (children == undefined) {
     return (

--- a/packages/studio-base/src/components/CopyButton.tsx
+++ b/packages/studio-base/src/components/CopyButton.tsx
@@ -19,7 +19,7 @@ import clipboard from "@foxglove/studio-base/util/clipboard";
 
 export default function CopyButton(
   props: PropsWithChildren<{
-    value: string;
+    copyText: () => string;
     size?: "small" | "medium" | "large";
     iconSize?: SvgIconProps["fontSize"];
     color?: ButtonProps["color"] | IconButtonProps["color"];
@@ -34,19 +34,19 @@ export default function CopyButton(
     edge,
     size = "medium",
     iconSize = "medium",
-    value,
+    copyText,
   } = props;
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
     clipboard
-      .copy(value)
+      .copy(copyText())
       .then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
       })
       .catch((err) => console.warn(err));
-  }, [value]);
+  }, [copyText]);
 
   if (children == undefined) {
     return (

--- a/packages/studio-base/src/components/ShareJsonModal.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.tsx
@@ -96,7 +96,7 @@ export default function ShareJsonModal({
           fullWidth
           multiline
           rows={10}
-          value={() => value}
+          value={value}
           onChange={(event) => setValue(event.target.value)}
           autoFocus
           error={error != undefined}

--- a/packages/studio-base/src/components/ShareJsonModal.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.tsx
@@ -67,6 +67,8 @@ export default function ShareJsonModal({
     downloadTextFile(value, "layout.json");
   }, [value]);
 
+  const copyText = useCallback(() => value, [value]);
+
   return (
     <Dialog open onClose={onRequestClose} maxWidth="sm" fullWidth>
       <Stack
@@ -94,7 +96,7 @@ export default function ShareJsonModal({
           fullWidth
           multiline
           rows={10}
-          value={value}
+          value={() => value}
           onChange={(event) => setValue(event.target.value)}
           autoFocus
           error={error != undefined}
@@ -110,7 +112,7 @@ export default function ShareJsonModal({
           <IconButton onClick={handleDownload} title="Download" aria-label="Download">
             <FileDownloadIcon />
           </IconButton>
-          <CopyButton color="default" value={value} />
+          <CopyButton color="default" copyText={copyText} />
           <HoverableIconButton
             activeColor="error"
             onClick={() => setValue("{}")}

--- a/packages/studio-base/src/components/ShareJsonModal.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.tsx
@@ -67,7 +67,7 @@ export default function ShareJsonModal({
     downloadTextFile(value, "layout.json");
   }, [value]);
 
-  const copyText = useCallback(() => value, [value]);
+  const getText = useCallback(() => value, [value]);
 
   return (
     <Dialog open onClose={onRequestClose} maxWidth="sm" fullWidth>
@@ -112,7 +112,7 @@ export default function ShareJsonModal({
           <IconButton onClick={handleDownload} title="Download" aria-label="Download">
             <FileDownloadIcon />
           </IconButton>
-          <CopyButton color="default" copyText={copyText} />
+          <CopyButton color="default" getText={getText} />
           <HoverableIconButton
             activeColor="error"
             onClick={() => setValue("{}")}

--- a/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
@@ -186,6 +186,8 @@ export default function Variable(props: {
   const isDuplicate =
     editedName != undefined && editedName !== name && globalVariables[editedName] != undefined;
 
+  const copyText = useCallback(() => JSON.stringify(value, undefined, 2) ?? "", [value]);
+
   return (
     <Stack className={classes.root} ref={rootRef}>
       <ListItem
@@ -316,7 +318,7 @@ export default function Variable(props: {
             className={classes.copyButton}
             size="small"
             color={copied ? "primary" : "inherit"}
-            value={JSON.stringify(value, undefined, 2) ?? ""}
+            copyText={copyText}
           >
             {copied ? "Copied" : "Copy"}
           </CopyButton>

--- a/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
+++ b/packages/studio-base/src/components/VariablesSidebar/Variable.tsx
@@ -186,7 +186,7 @@ export default function Variable(props: {
   const isDuplicate =
     editedName != undefined && editedName !== name && globalVariables[editedName] != undefined;
 
-  const copyText = useCallback(() => JSON.stringify(value, undefined, 2) ?? "", [value]);
+  const getText = useCallback(() => JSON.stringify(value, undefined, 2) ?? "", [value]);
 
   return (
     <Stack className={classes.root} ref={rootRef}>
@@ -318,7 +318,7 @@ export default function Variable(props: {
             className={classes.copyButton}
             size="small"
             color={copied ? "primary" : "inherit"}
-            copyText={copyText}
+            getText={getText}
           >
             {copied ? "Copied" : "Copy"}
           </CopyButton>

--- a/packages/studio-base/src/panels/DataSourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.tsx
@@ -77,7 +77,7 @@ function TopicRow({ topic }: { topic: Topic }): JSX.Element {
           edge="end"
           size="small"
           iconSize="small"
-          copyText={() => topic.name}
+          getText={() => topic.name}
         />
       </td>
       <td>
@@ -87,7 +87,7 @@ function TopicRow({ topic }: { topic: Topic }): JSX.Element {
           edge="end"
           size="small"
           iconSize="small"
-          copyText={() => topic.datatype}
+          getText={() => topic.datatype}
         />
       </td>
       <td data-topic={topic.name} data-topic-stat="count">

--- a/packages/studio-base/src/panels/DataSourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.tsx
@@ -77,7 +77,7 @@ function TopicRow({ topic }: { topic: Topic }): JSX.Element {
           edge="end"
           size="small"
           iconSize="small"
-          value={topic.name}
+          copyText={() => topic.name}
         />
       </td>
       <td>
@@ -87,7 +87,7 @@ function TopicRow({ topic }: { topic: Topic }): JSX.Element {
           edge="end"
           size="small"
           iconSize="small"
-          value={topic.datatype}
+          copyText={() => topic.datatype}
         />
       </td>
       <td data-topic={topic.name} data-topic-stat="count">

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -191,7 +191,7 @@ function Parameters(): ReactElement {
                       edge="end"
                       size="small"
                       iconSize="small"
-                      value={`${name}: ${value}`}
+                      copyText={() => `${name}: ${value}`}
                     />
                   </TableCell>
                 </TableRow>

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -191,7 +191,7 @@ function Parameters(): ReactElement {
                       edge="end"
                       size="small"
                       iconSize="small"
-                      copyText={() => `${name}: ${value}`}
+                      getText={() => `${name}: ${value}`}
                     />
                   </TableCell>
                 </TableRow>

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Link, Typography } from "@mui/material";
+import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
@@ -57,6 +58,12 @@ export default function Metadata({
 }: Props): JSX.Element {
   const { classes } = useStyles();
   const docsLink = datatype ? getMessageDocumentationLink(datatype) : undefined;
+  const copyData = useCallback(() => JSON.stringify(data, copyMessageReplacer, 2) ?? "", [data]);
+  const copyDiffData = useCallback(
+    () => JSON.stringify(diffData, copyMessageReplacer, 2) ?? "",
+    [diffData],
+  );
+  const copyDiff = useCallback(() => JSON.stringify(diff, copyMessageReplacer, 2) ?? "", [diff]);
   return (
     <Stack alignItems="flex-start" padding={0.25}>
       <Stack direction="row" alignItems="center" gap={0.5}>
@@ -83,7 +90,7 @@ export default function Metadata({
           size="small"
           iconSize="inherit"
           className={classes.button}
-          value={JSON.stringify(data, copyMessageReplacer, 2) ?? ""}
+          copyText={copyData}
         />
       </Stack>
 
@@ -99,14 +106,14 @@ export default function Metadata({
               size="small"
               iconSize="inherit"
               className={classes.button}
-              value={JSON.stringify(diffData, copyMessageReplacer, 2) ?? ""}
+              copyText={copyDiffData}
             />
           </Stack>
           <CopyButton
             size="small"
             iconSize="inherit"
             className={classes.button}
-            value={JSON.stringify(diff, copyMessageReplacer, 2) ?? ""}
+            copyText={copyDiff}
           >
             Copy diff of msgs
           </CopyButton>

--- a/packages/studio-base/src/panels/RawMessages/Metadata.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Metadata.tsx
@@ -86,12 +86,7 @@ export default function Metadata({
           )}
           {` @ ${formatTimeRaw(message.receiveTime)} sec`}
         </Typography>
-        <CopyButton
-          size="small"
-          iconSize="inherit"
-          className={classes.button}
-          copyText={copyData}
-        />
+        <CopyButton size="small" iconSize="inherit" className={classes.button} getText={copyData} />
       </Stack>
 
       {diffMessage?.receiveTime && (
@@ -106,15 +101,10 @@ export default function Metadata({
               size="small"
               iconSize="inherit"
               className={classes.button}
-              copyText={copyDiffData}
+              getText={copyDiffData}
             />
           </Stack>
-          <CopyButton
-            size="small"
-            iconSize="inherit"
-            className={classes.button}
-            copyText={copyDiff}
-          >
+          <CopyButton size="small" iconSize="inherit" className={classes.button} getText={copyDiff}>
             Copy diff of msgs
           </CopyButton>
         </>


### PR DESCRIPTION
**User-Facing Changes**
 - raw message panel being open will no longer hang when loading new large messages

**Description**
 - changed `value: string` to `copyText: () => string` so that JSON.stringify isn't called if the value isn't copied.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
