### PR TITLE
Add settings toggle to allow disabling TF preloading

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -129,6 +129,8 @@ export type RendererConfig = {
       lineWidth?: number;
       /** Color of the connecting line between child and parent frames */
       lineColor?: string;
+      /** Enable transform preloading */
+      enablePreloading?: boolean;
     };
     /** Toggles visibility of all topics */
     topicsVisible?: boolean;
@@ -435,17 +437,17 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addDatatypeSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.handleFrameTransform,
       forced: true,
-      preload: true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addDatatypeSubscriptions(TF_DATATYPES, {
       handler: this.handleTFMessage,
       forced: true,
-      preload: true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addDatatypeSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
       handler: this.handleTransformStamped,
       forced: true,
-      preload: true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
 
     this.addSceneExtension(this.coreSettings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -386,7 +386,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       publish,
     };
   });
-  const configRef = useRef(config);
+  const configRef = useLatest(config);
   const { cameraState } = config;
   const backgroundColor = config.scene.backgroundColor;
 
@@ -394,7 +394,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [renderer, setRenderer] = useState<Renderer | undefined>(undefined);
   useEffect(
     () => setRenderer(canvas ? new Renderer(canvas, configRef.current) : undefined),
-    [canvas],
+    [canvas, configRef, config.scene.transforms?.enablePreloading],
   );
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -168,6 +168,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
             input: "rgb",
             value: config.scene.transforms?.lineColor ?? DEFAULT_LINE_COLOR_STR,
           },
+          enablePreloading: {
+            label: "Enable preloading",
+            input: "boolean",
+            value: config.scene.transforms?.enablePreloading ?? true,
+          },
         },
       },
     };


### PR DESCRIPTION
**User-Facing Changes**
Added a setting to 3D panel to allow disabling transform preloading.

**Description**
We don't currently handle it well when a dataset reaches the CoordinateFrame capacity limit (currently 10k TF messages). This change allows the user to opt out of preloading with a setting.