### PR TITLE
fixes to old3d->new3d upgrade flow

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -26,7 +26,7 @@ export enum AppSetting {
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",
   LAUNCH_PREFERENCE = "launchPreference",
   SHOW_OPEN_DIALOG_ON_STARTUP = "ui.open-dialog-startup",
-  CLOSED_OLD3D_DEPRECATION_BANNER = "closedOld3dDeprecationBanner",
+  CLOSED_OLD3D_DEPRECATION_BANNER = "closedOld3dDeprecationBannerV2",
 
   // Dev only
   ENABLE_LAYOUT_DEBUGGING = "enableLayoutDebugging",

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -858,7 +858,13 @@ export default function Layout({
                     : latestConfig.current.followMode === "follow"
                     ? "follow-position"
                     : "follow-none",
-                cameraState: latestConfig.current.cameraState,
+                cameraState: {
+                  ...latestConfig.current.cameraState,
+                  phi: ((latestConfig.current.cameraState.phi ?? Math.PI / 3) * 180) / Math.PI,
+                  thetaOffset:
+                    ((latestConfig.current.cameraState.thetaOffset ?? 0) * 180) / Math.PI,
+                  fovy: ((latestConfig.current.cameraState.fovy ?? Math.PI / 4) * 180) / Math.PI,
+                },
                 publish: {
                   poseTopic: latestConfig.current.clickToPublishPoseTopic,
                   pointTopic: latestConfig.current.clickToPublishPointTopic,
@@ -887,7 +893,6 @@ export default function Layout({
                   ),
                 ]),
               });
-              void setClosedBanner(true);
               setShowUpgradeConfirmDialog(false);
             }}
           >

--- a/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
+++ b/packages/studio-base/src/panels/ThreeDimensionalViz/Layout.tsx
@@ -901,7 +901,7 @@ export default function Layout({
         </DialogActions>
       </Dialog>
     ),
-    [latestConfig, latestTransforms, panelContext, setClosedBanner, showUpgradeConfirmDialog],
+    [latestConfig, latestTransforms, panelContext, showUpgradeConfirmDialog],
   );
 
   return (


### PR DESCRIPTION
**User-Facing Changes**
Fixed issues with upgrading to new 3D panel.

**Description**
Fixes #4530 by converting radians to degrees when migrating camera settings.
Resolves #4531.
Also changes the localStorage key used for the setting so that the banner will re-open for anyone who has clicked it in the past. This will help with #4531 to encourage people to click the banner on other old3d panels even if they've already converted one.