### PR TITLE
Add WorkerIterablePlayer

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -169,7 +169,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
             `Buffer not large enough: expected ${size} bytes, got ${data.byteLength}`,
           );
         }
-        return reader.readMessage(data);
+        return reader.readMessage(data).toObject();
       },
     };
   }

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -6,7 +6,7 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { IterablePlayer } from "@foxglove/studio-base/players/IterablePlayer";
+import { IterablePlayer, WorkerIterablePlayer } from "@foxglove/studio-base/players/IterablePlayer";
 import { McapIterableSource } from "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSource";
 import { Player } from "@foxglove/studio-base/players/types";
 
@@ -17,7 +17,18 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
   public iconName: IDataSourceFactory["iconName"] = "OpenFile";
   public supportedFileTypes = [".mcap"];
 
+  // fixme - feature flag
+  private _enableExperimentalWorker = true;
+
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
+    if (this._enableExperimentalWorker) {
+      return new WorkerIterablePlayer({
+        sourceType: "mcap",
+        sourceId: this.id,
+        factoryArgs: args,
+      });
+    }
+
     const file = args.file;
     if (!file) {
       return;

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
@@ -6,7 +6,7 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { IterablePlayer } from "@foxglove/studio-base/players/IterablePlayer";
+import { IterablePlayer, WorkerIterablePlayer } from "@foxglove/studio-base/players/IterablePlayer";
 import { BagIterableSource } from "@foxglove/studio-base/players/IterablePlayer/BagIterableSource";
 import { Player } from "@foxglove/studio-base/players/types";
 
@@ -17,7 +17,18 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
   public iconName: IDataSourceFactory["iconName"] = "OpenFile";
   public supportedFileTypes = [".bag"];
 
+  // fixme - feature flag
+  private _enableExperimentalWorker = true;
+
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
+    if (this._enableExperimentalWorker) {
+      return new WorkerIterablePlayer({
+        sourceType: "rosbag",
+        sourceId: this.id,
+        factoryArgs: args,
+      });
+    }
+
     const file = args.file;
     if (!file) {
       return;

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -9,6 +9,7 @@ import { BlobReader } from "@foxglove/rosbag/web";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { LazyMessageReader } from "@foxglove/rosmsg-serialization";
 import { compare } from "@foxglove/rostime";
+import type { DataSourceFactoryInitializeArgs } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import {
   PlayerProblem,
   MessageEvent,
@@ -247,4 +248,13 @@ export class BagIterableSource implements IIterableSource {
     messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
     return messages;
   }
+}
+
+export function initialize(args: DataSourceFactoryInitializeArgs): BagIterableSource {
+  const file = args.file;
+  if (!file) {
+    throw new Error("file arg required");
+  }
+
+  return new BagIterableSource({ type: "file", file });
 }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -36,7 +36,6 @@ import {
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import delay from "@foxglove/studio-base/util/delay";
-import { SEEK_ON_START_NS } from "@foxglove/studio-base/util/time";
 
 import { BlockLoader } from "./BlockLoader";
 import { BufferedIterableSource } from "./BufferedIterableSource";
@@ -61,6 +60,10 @@ const MIN_MEM_CACHE_BLOCK_SIZE_NS = 0.1e9;
 // Adaptive block sizing is simpler than using a tree structure for immutable updates but
 // less flexible, so we may want to move away from a single-level block structure in the future.
 const MAX_BLOCKS = 400;
+
+// Amount to seek into the bag from the start when loading the player, to show
+// something useful on the screen.
+const SEEK_ON_START_NS = BigInt(99 * 1e6);
 
 type IterablePlayerOptions = {
   metricsCollector?: PlayerMetricsCollectorInterface;
@@ -495,7 +498,7 @@ export class IterablePlayer implements Player {
         }
       }
 
-      // set the initial topics for the loader
+      this._presence = PlayerPresence.PRESENT;
     } catch (error) {
       this._setError(`Error initializing: ${error.message}`, error);
     }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -6,9 +6,10 @@ import { Mcap0IndexedReader, Mcap0Types } from "@mcap/core";
 
 import Log from "@foxglove/log";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
+import { DataSourceFactoryInitializeArgs } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { MessageEvent } from "@foxglove/studio-base/players/types";
 
-import {
+import type {
   IIterableSource,
   IteratorResult,
   Initalization,
@@ -111,4 +112,13 @@ export class McapIterableSource implements IIterableSource {
 
     return await this._sourceImpl.getBackfillMessages(args);
   }
+}
+
+export function initialize(args: DataSourceFactoryInitializeArgs): McapIterableSource {
+  const file = args.file;
+  if (!file) {
+    throw new Error("file arg required");
+  }
+
+  return new McapIterableSource({ type: "file", file });
 }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayer.ts
@@ -98,6 +98,7 @@ export class WorkerIterablePlayer implements Player {
 
   public setPlaybackSpeed(speed: number): void {
     // fixme
+    void this._worker?.setPlaybackSpeed(speed);
   }
 
   public seekPlayback(time: Time): void {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayer.ts
@@ -1,0 +1,213 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import Log from "@foxglove/log";
+import { Time } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
+import type { DataSourceFactoryInitializeArgs } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import {
+  AdvertiseOptions,
+  Player,
+  PlayerMetricsCollectorInterface,
+  PlayerPresence,
+  PlayerState,
+  PublishPayload,
+  SubscribePayload,
+} from "@foxglove/studio-base/players/types";
+
+import type {
+  PlaybackState,
+  WorkerIterablePlayerWorker,
+  WorkerIterablePlayerWorkerArgs,
+} from "./WorkerIterablePlayerWorker.worker";
+
+const log = Log.getLogger(__filename);
+
+type WorkerIterablePlayerOptions = {
+  metricsCollector?: PlayerMetricsCollectorInterface;
+
+  sourceType: string;
+
+  // Source identifier used in constructing state urls.
+  sourceId: string;
+
+  factoryArgs: DataSourceFactoryInitializeArgs;
+};
+
+/**
+ * IterablePlayer implements the Player interface for IIterableSource instances.
+ *
+ * The iterable player reads messages from an IIterableSource. The player is implemented as a state
+ * machine. Each state runs until it finishes. A request to change state is handled by each state
+ * detecting that there is another state waiting and cooperatively ending itself.
+ */
+export class WorkerIterablePlayer implements Player {
+  private _listener?: (playerState: PlayerState) => Promise<void>;
+
+  private _thread: Worker;
+  private _worker?: Comlink.Remote<WorkerIterablePlayerWorker>;
+  private _playerState: PlayerState;
+
+  private readonly _sourceId: string;
+  private readonly _sourceType: string;
+  private readonly _factoryArgs: DataSourceFactoryInitializeArgs;
+
+  public constructor(options: WorkerIterablePlayerOptions) {
+    const { sourceType, sourceId } = options;
+
+    this._sourceType = sourceType;
+    this._sourceId = sourceId;
+    this._factoryArgs = options.factoryArgs;
+    this._playerState = {
+      presence: PlayerPresence.NOT_PRESENT,
+      progress: {},
+      capabilities: [],
+      profile: undefined,
+      playerId: "",
+    };
+
+    // Note: this launches the worker.
+    this._thread = new Worker(new URL("./WorkerIterablePlayerWorker.worker", import.meta.url));
+  }
+
+  public setListener(listener: (playerState: PlayerState) => Promise<void>): void {
+    if (this._listener) {
+      throw new Error("Cannot setListener again");
+    }
+    this._listener = listener;
+    void this._stateInitialize();
+  }
+
+  public startPlayback(): void {
+    // fixme - catch/log
+    void this._worker?.startPlay();
+  }
+
+  public playUntil(time: Time): void {
+    // fixme - catch/log
+    void this._worker?.startPlay({ untilTime: time });
+  }
+
+  public pausePlayback(): void {
+    // fixme - catch/log
+    void this._worker?.pausePlayback();
+  }
+
+  public setPlaybackSpeed(speed: number): void {
+    // fixme
+  }
+
+  public seekPlayback(time: Time): void {
+    // fixme - catch/log
+    void this._worker?.seekPlayback(time);
+  }
+
+  public setSubscriptions(newSubscriptions: SubscribePayload[]): void {
+    // fixme - catch/log
+    void this._worker?.setSubscriptions(newSubscriptions);
+  }
+
+  public setPublishers(_publishers: AdvertiseOptions[]): void {
+    // no-op
+  }
+
+  public setParameter(_key: string, _value: ParameterValue): void {
+    throw new Error("Parameter editing is not supported by this data source");
+  }
+
+  public publish(_payload: PublishPayload): void {
+    throw new Error("Publishing is not supported by this data source");
+  }
+
+  public async callService(): Promise<unknown> {
+    throw new Error("Service calls are not supported by this data source");
+  }
+
+  public close(): void {
+    this._thread.terminate();
+  }
+
+  public setGlobalVariables(): void {
+    // no-op
+  }
+
+  // Initialize the source and player members
+  private async _stateInitialize(): Promise<void> {
+    try {
+      const Wrapped = Comlink.wrap<
+        new (args: WorkerIterablePlayerWorkerArgs) => WorkerIterablePlayerWorker
+      >(this._thread);
+
+      // fixme
+      // emit player state indicating we are loading
+
+      this._worker = await new Wrapped({
+        sourceId: this._sourceId,
+        sourceType: this._sourceType,
+        factoryArgs: this._factoryArgs,
+      });
+
+      const boundEmitState = this._emitStateImpl.bind(this);
+      await this._worker.registerListener(Comlink.proxy(boundEmitState));
+
+      await this._worker.initialize();
+    } catch (err) {
+      log.error(err);
+    }
+  }
+
+  private async _emitStateImpl(partialPlayerState: Partial<PlaybackState>): Promise<void> {
+    if (!this._listener) {
+      return;
+    }
+
+    this._playerState.name = partialPlayerState.name ?? this._playerState.name;
+    this._playerState.presence = partialPlayerState.presence ?? this._playerState.presence;
+    this._playerState.progress = partialPlayerState.progress ?? this._playerState.progress;
+    this._playerState.capabilities =
+      partialPlayerState.capabilities ?? this._playerState.capabilities;
+    this._playerState.profile = partialPlayerState.profile ?? this._playerState.profile;
+    this._playerState.playerId = partialPlayerState.playerId ?? this._playerState.playerId;
+    this._playerState.problems = partialPlayerState.problems ?? this._playerState.problems;
+    this._playerState.urlState = partialPlayerState.urlState ?? this._playerState.urlState;
+
+    const activeData: NonNullable<PlayerState["activeData"]> = this._playerState.activeData ?? {
+      messages: [],
+      totalBytesReceived: 0,
+      currentTime: { sec: 0, nsec: 0 },
+      startTime: { sec: 0, nsec: 0 },
+      endTime: { sec: 0, nsec: 0 },
+      isPlaying: false,
+      speed: 1,
+      lastSeekTime: 0,
+      topics: [],
+      topicStats: new Map(),
+      datatypes: new Map(),
+    };
+
+    // active data
+    activeData.messages = partialPlayerState.messages ?? activeData.messages;
+    activeData.totalBytesReceived =
+      partialPlayerState.totalBytesReceived ?? activeData.totalBytesReceived;
+    activeData.currentTime = partialPlayerState.currentTime ?? activeData.currentTime;
+    activeData.startTime = partialPlayerState.startTime ?? activeData.startTime;
+    activeData.endTime = partialPlayerState.endTime ?? activeData.endTime;
+    activeData.isPlaying = partialPlayerState.isPlaying ?? activeData.isPlaying;
+    activeData.speed = partialPlayerState.speed ?? activeData.speed;
+    activeData.lastSeekTime = partialPlayerState.lastSeekTime ?? activeData.lastSeekTime;
+    activeData.topics = partialPlayerState.topics ?? activeData.topics;
+    activeData.topicStats = partialPlayerState.topicStats ?? activeData.topicStats;
+    activeData.datatypes = partialPlayerState.datatypes ?? activeData.datatypes;
+    activeData.publishedTopics = partialPlayerState.publishedTopics ?? activeData.publishedTopics;
+    activeData.subscribedTopics =
+      partialPlayerState.subscribedTopics ?? activeData.subscribedTopics;
+    activeData.services = partialPlayerState.services ?? activeData.services;
+    activeData.parameters = partialPlayerState.parameters ?? activeData.parameters;
+
+    this._playerState.activeData = activeData;
+    return await this._listener(this._playerState);
+  }
+}

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayerWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayerWorker.worker.ts
@@ -1,0 +1,902 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+import { isEqual } from "lodash";
+import { v4 as uuidv4 } from "uuid";
+
+import { debouncePromise } from "@foxglove/den/async";
+import { filterMap } from "@foxglove/den/collection";
+import Log from "@foxglove/log";
+import {
+  Time,
+  add,
+  compare,
+  clampTime,
+  fromMillis,
+  fromNanoSec,
+  toString,
+} from "@foxglove/rostime";
+import { MessageEvent, ParameterValue } from "@foxglove/studio";
+import type { DataSourceFactoryInitializeArgs } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { BufferedIterableSource } from "@foxglove/studio-base/players/IterablePlayer/BufferedIterableSource";
+import type {
+  IIterableSource,
+  IteratorResult,
+} from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
+import {
+  Progress,
+  Topic,
+  PlayerPresence,
+  PlayerCapabilities,
+  TopicStats,
+  SubscribePayload,
+  PlayerProblem,
+  PlayerURLState,
+} from "@foxglove/studio-base/players/types";
+import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import delay from "@foxglove/studio-base/util/delay";
+
+const log = Log.getLogger(__filename);
+
+log.debug("WorkerIterablePlayerWorker thread started");
+
+// Amount to wait until panels have had the chance to subscribe to topics before
+// we start playback
+const START_DELAY_MS = 100;
+
+// Amount to seek into the bag from the start when loading the player, to show
+// something useful on the screen.
+const SEEK_ON_START_NS = BigInt(99 * 1e6);
+
+type SourceFn = () => Promise<{
+  initialize: (args: DataSourceFactoryInitializeArgs) => IIterableSource;
+}>;
+
+const RegisteredSources: Record<string, SourceFn> = {
+  mcap: async () => await import("./Mcap/McapIterableSource"),
+  rosbag: async () => await import("./BagIterableSource"),
+};
+
+export type WorkerIterablePlayerWorkerArgs = {
+  sourceId: string;
+  sourceType: string;
+  factoryArgs: DataSourceFactoryInitializeArgs;
+};
+
+// fixme - flat list from PlayerState
+// comments
+export type PlaybackState = {
+  presence: PlayerPresence;
+  progress: Progress;
+  capabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][];
+  profile: string | undefined;
+  playerId: string;
+  name?: string;
+  problems?: PlayerProblem[];
+  urlState?: PlayerURLState;
+
+  // active data
+
+  messages: readonly MessageEvent<unknown>[];
+  totalBytesReceived: number; // always-increasing
+  currentTime: Time;
+  startTime: Time;
+  endTime: Time;
+  isPlaying: boolean;
+  speed: number;
+  lastSeekTime: number;
+  topics: Topic[];
+  topicStats: Map<string, TopicStats>;
+  datatypes: RosDatatypes;
+  publishedTopics?: Map<string, Set<string>>;
+  subscribedTopics?: Map<string, Set<string>>;
+  services?: Map<string, Set<string>>;
+  parameters?: Map<string, ParameterValue>;
+};
+
+type State =
+  | "preinit"
+  | "start-play"
+  | "idle"
+  | "seek-backfill"
+  | "play"
+  | "reset-playback-iterator";
+
+export class WorkerIterablePlayerWorker {
+  private _nextState?: State;
+  private _state: State = "preinit";
+  private _runningState: boolean = false;
+  // Some states register an abort controller to signal they should abort
+  private _abort?: AbortController;
+  private _subscriptions: SubscribePayload[] = [];
+
+  private _args: WorkerIterablePlayerWorkerArgs;
+  private _registeredSource?: SourceFn;
+  private _listener?: (partialPlayerState: Partial<PlaybackState>) => Promise<void>;
+  private _sourceId: string;
+  private _urlParams?: Record<string, string> = {};
+  private _name?: string;
+  private _progress: Progress = {};
+  private _id: string = uuidv4();
+  private _messages: MessageEvent<unknown>[] = [];
+  private _receivedBytes: number = 0;
+  private _hasError = false;
+  private _publishedTopics = new Map<string, Set<string>>();
+  private _presence = PlayerPresence.INITIALIZING;
+  private _isPlaying: boolean = false;
+  private _speed: number = 1.0;
+  private _start: Time = { sec: 0, nsec: 0 };
+  private _end: Time = { sec: 0, nsec: 0 };
+  private _profile: string | undefined;
+  private _allTopics: Set<string> = new Set();
+  private _partialTopics: Set<string> = new Set();
+
+  private _lastRangeMillis?: number;
+  // next read start time indicates where to start reading for the next tick
+  // after a tick read, it is set to 1nsec past the end of the read operation (preparing for the next tick)
+  private _lastTickMillis?: number;
+
+  // To keep reference equality for downstream user memoization cache the currentTime provided in the last activeData update
+  // See additional comments below where _currentTime is set
+  private _currentTime?: Time;
+  // This is the "lastSeekTime" emitted in the playerState. This indicates the emit is due to a seek.
+  private _lastSeekEmitTime: number = Date.now();
+  private _untilTime?: Time;
+  private _lastMessage?: MessageEvent<unknown>;
+  private _seekTarget?: Time;
+
+  private _problemManager = new PlayerProblemManager();
+
+  private _iterableSource?: IIterableSource;
+  private _bufferedSource?: BufferedIterableSource;
+  // The iterator for reading messages during playback
+  private _playbackIterator?: AsyncIterator<Readonly<IteratorResult>>;
+
+  private _capabilities: string[] = [
+    PlayerCapabilities.setSpeed,
+    PlayerCapabilities.playbackControl,
+  ];
+
+  private _providerTopics: Topic[] = [];
+  private _providerTopicStats = new Map<string, TopicStats>();
+  private _providerDatatypes: RosDatatypes = new Map();
+
+  private _queueEmitState: ReturnType<typeof debouncePromise>;
+
+  public constructor(args: WorkerIterablePlayerWorkerArgs) {
+    log.debug("Init new worker:", args.sourceType);
+
+    this._args = args;
+    this._sourceId = args.sourceId;
+    this._registeredSource = RegisteredSources[args.sourceType];
+
+    // Wrap emitStateImpl in a debouncePromise for our states to call. Since we can emit from states
+    // or from block loading updates we use debouncePromise to guard against concurrent emits.
+    this._queueEmitState = debouncePromise(this._emitStateImpl.bind(this));
+  }
+
+  public registerListener(
+    listener: (partialPlayerState: Partial<PlaybackState>) => Promise<void>,
+  ): void {
+    this._listener = listener;
+  }
+
+  public async initialize(): Promise<void> {
+    if (!this._registeredSource) {
+      throw new Error(`No such source type: ${this._args.sourceType}`);
+    }
+
+    this._queueEmitState();
+
+    log.debug("Initializing worker registered source");
+    const module = await this._registeredSource();
+    this._iterableSource = module.initialize(this._args.factoryArgs);
+    this._bufferedSource = new BufferedIterableSource(this._iterableSource);
+
+    const initResult = await this._bufferedSource.initialize();
+
+    try {
+      const {
+        start,
+        end,
+        topics,
+        profile,
+        topicStats,
+        problems,
+        publishersByTopic,
+        datatypes,
+        name,
+      } = initResult;
+
+      this._profile = profile;
+      this._start = this._currentTime = start;
+      this._end = end;
+      this._publishedTopics = publishersByTopic;
+      this._providerDatatypes = datatypes;
+      this._name = name;
+
+      // Studio does not like duplicate topics or topics with different datatypes
+      // Check for duplicates or for mismatched datatypes
+      const uniqueTopics = new Map<string, Topic>();
+      for (const topic of topics) {
+        const existingTopic = uniqueTopics.get(topic.name);
+        if (existingTopic) {
+          problems.push({
+            severity: "warn",
+            message: `Duplicate topic: ${topic.name}`,
+          });
+          continue;
+        }
+
+        uniqueTopics.set(topic.name, topic);
+      }
+
+      this._providerTopics = Array.from(uniqueTopics.values());
+      this._providerTopicStats = topicStats;
+
+      let idx = 0;
+      for (const problem of problems) {
+        this._problemManager.addProblem(`init-problem-${idx}`, problem);
+        idx += 1;
+      }
+
+      this._presence = PlayerPresence.PRESENT;
+    } catch (error) {
+      this._setError(`Error initializing: ${error.message}`, error);
+    }
+
+    this._queueEmitState();
+
+    if (!this._hasError) {
+      // Wait a bit until panels have had the chance to subscribe to topics before we start
+      // playback.
+      await delay(START_DELAY_MS);
+
+      this._setState("start-play");
+    }
+  }
+
+  public pausePlayback(): void {
+    if (!this._isPlaying) {
+      return;
+    }
+    // clear out last tick millis so we don't read a huge chunk when we unpause
+    this._lastTickMillis = undefined;
+    this._isPlaying = false;
+    this._untilTime = undefined;
+    if (this._state === "play") {
+      this._setState("idle");
+    }
+  }
+
+  public startPlay(opt?: { untilTime: Time }): void {
+    if (this._isPlaying || this._untilTime) {
+      return;
+    }
+
+    if (opt?.untilTime) {
+      if (this._currentTime && compare(opt.untilTime, this._currentTime) <= 0) {
+        throw new Error("Invariant: playUntil time must be after the current time");
+      }
+      this._untilTime = clampTime(opt.untilTime, this._start, this._end);
+    }
+    this._isPlaying = true;
+
+    // If we are idling we can start playing, if we have a next state queued we let that state
+    // finish and it will see that we should be playing
+    if (this._state === "idle" && (!this._nextState || this._nextState === "idle")) {
+      this._setState("play");
+    }
+  }
+
+  public setSubscriptions(newSubscriptions: SubscribePayload[]): void {
+    log.debug("set subscriptions", newSubscriptions);
+    this._subscriptions = newSubscriptions;
+
+    const allTopics = new Set(this._subscriptions.map((subscription) => subscription.topic));
+    const partialTopics = new Set(
+      filterMap(this._subscriptions, (sub) =>
+        sub.preloadType !== "partial" ? sub.topic : undefined,
+      ),
+    );
+
+    // If there are no changes to topics there's no reason to perform a "seek" to trigger loading
+    if (isEqual(allTopics, this._allTopics) && isEqual(partialTopics, this._partialTopics)) {
+      return;
+    }
+
+    this._allTopics = allTopics;
+    this._partialTopics = partialTopics;
+
+    // If the player is playing, the playing state will detect any subscription changes and adjust
+    // iterators accordignly. However if we are idle or already seeking then we need to manually
+    // trigger the backfill.
+    if (this._state === "idle" || this._state === "seek-backfill" || this._state === "play") {
+      if (!this._isPlaying && this._currentTime) {
+        this._seekTarget = this._currentTime;
+        this._untilTime = undefined;
+
+        // Trigger a seek backfill to load any missing messages and reset the forward iterator
+        this._setState("seek-backfill");
+      }
+    }
+  }
+
+  /** Request the state to switch to newState */
+  private _setState(newState: State) {
+    log.debug(`Set next state: ${newState}`);
+    this._nextState = newState;
+    this._abort?.abort();
+    this._abort = undefined;
+
+    // Support moving between idle (pause) and play and preserving the playback iterator
+    if (newState !== "idle" && newState !== "play" && this._playbackIterator) {
+      log.debug("Ending playback iterator because next state is not IDLE or PLAY");
+      const oldIterator = this._playbackIterator;
+      this._playbackIterator = undefined;
+      void oldIterator.return?.().catch((err) => {
+        log.error(err);
+      });
+    }
+
+    void this._runState();
+  }
+
+  /**
+   * Run the requested state while there is a state to run.
+   *
+   * Ensures that only one state is running at a time.
+   * */
+  private async _runState() {
+    if (this._runningState) {
+      return;
+    }
+
+    this._runningState = true;
+    try {
+      while (this._nextState) {
+        const state = (this._state = this._nextState);
+        this._nextState = undefined;
+
+        log.debug(`Start state: ${state}`);
+
+        switch (state) {
+          case "preinit":
+            // no-op
+            break;
+          case "start-play":
+            await this._stateStartPlay();
+            break;
+          case "idle":
+            await this._stateIdle();
+            break;
+          case "seek-backfill":
+            // We allow aborting requests when moving on to the next state
+            await this._stateSeekBackfill();
+            break;
+          case "play":
+            await this._statePlay();
+            break;
+          case "reset-playback-iterator":
+            await this._stateResetPlaybackIterator();
+        }
+
+        log.debug(`Done state ${state}`);
+      }
+    } catch (err) {
+      log.error(err);
+      this._setError((err as Error).message, err);
+      this._queueEmitState();
+    } finally {
+      this._runningState = false;
+    }
+  }
+
+  private _setError(message: string, error?: Error): void {
+    this._hasError = true;
+    this._problemManager.addProblem("global-error", {
+      severity: "error",
+      message,
+      error,
+    });
+    this._isPlaying = false;
+  }
+
+  // fixme - cleanup
+  private _hasEmittedError = false;
+
+  private _prevState?: PlaybackState;
+
+  /** Emit the player state to the registered listener */
+  private async _emitStateImpl() {
+    if (!this._listener) {
+      return;
+    }
+
+    if (this._hasEmittedError) {
+      return;
+    }
+
+    const name = this._name;
+
+    if (this._hasError) {
+      // once we emit this error state we don't need to emit these fields again
+      this._hasEmittedError = true;
+      return await this._listener({
+        name,
+        presence: PlayerPresence.ERROR,
+        progress: {},
+        capabilities: this._capabilities,
+        profile: this._profile,
+        playerId: this._id,
+        problems: this._problemManager.problems(),
+        urlState: {
+          sourceId: this._sourceId,
+          parameters: this._urlParams,
+        },
+      });
+    }
+
+    const messages = this._messages;
+    this._messages = [];
+
+    const currentTime = this._currentTime ?? this._start;
+
+    const playerState: PlaybackState = {
+      name,
+      presence: this._presence,
+      progress: this._progress,
+      capabilities: this._capabilities,
+      profile: this._profile,
+      playerId: this._id,
+      problems: this._problemManager.problems(),
+      urlState: {
+        sourceId: this._sourceId,
+        parameters: this._urlParams,
+      },
+      // active data
+      messages,
+      totalBytesReceived: this._receivedBytes,
+      currentTime,
+      startTime: this._start,
+      endTime: this._end,
+      isPlaying: this._isPlaying,
+      speed: this._speed,
+      lastSeekTime: this._lastSeekEmitTime,
+      topics: this._providerTopics,
+      topicStats: this._providerTopicStats,
+      datatypes: this._providerDatatypes,
+      publishedTopics: this._publishedTopics,
+    };
+
+    const partialPlayerState: Partial<PlaybackState> = {};
+
+    type Keys = keyof PlaybackState;
+    const keys = Object.keys(playerState) as Keys[];
+
+    // fixme - hack to get changed fields from prevState
+    for (const key of keys) {
+      if (this._prevState?.[key] !== playerState[key]) {
+        // @ts-ignore-error
+        partialPlayerState[key] = playerState[key];
+      }
+    }
+
+    // fixme urlState should use subfields
+
+    this._prevState = playerState;
+    return await this._listener(partialPlayerState);
+  }
+
+  public seekPlayback(time: Time): void {
+    // Limit seek to within the valid range
+    const targetTime = clampTime(time, this._start, this._end);
+
+    // We are already seeking to this time, no need to reset seeking
+    if (this._seekTarget && compare(this._seekTarget, targetTime) === 0) {
+      return;
+    }
+
+    // We are already at this time, no need to reset seeking
+    if (this._currentTime && compare(this._currentTime, targetTime) === 0) {
+      return;
+    }
+
+    this._seekTarget = targetTime;
+    this._untilTime = undefined;
+
+    this._setState("seek-backfill");
+  }
+
+  private async resetPlaybackIterator() {
+    if (!this._bufferedSource) {
+      throw new Error("uninitialized");
+    }
+    if (!this._currentTime) {
+      throw new Error("Invariant: Tried to reset playback iterator with no current time.");
+    }
+
+    const next = add(this._currentTime, { sec: 0, nsec: 1 });
+
+    await this._playbackIterator?.return?.();
+
+    // set the playIterator to the seek time
+    log.debug("Initializing forward iterator from", next);
+    await this._bufferedSource.stopProducer();
+    this._playbackIterator = this._bufferedSource.messageIterator({
+      topics: Array.from(this._allTopics),
+      start: next,
+      consumptionType: "partial",
+    });
+  }
+
+  /**
+   * Run one tick loop by reading from the message iterator a "tick" worth of messages.
+   * */
+  private async _tick(): Promise<void> {
+    if (!this._isPlaying) {
+      return;
+    }
+
+    // compute how long of a time range we want to read by taking into account
+    // the time since our last read and how fast we're currently playing back
+    const tickTime = performance.now();
+    const durationMillis =
+      this._lastTickMillis != undefined && this._lastTickMillis !== 0
+        ? tickTime - this._lastTickMillis
+        : 20;
+    this._lastTickMillis = tickTime;
+
+    // Read at most 300ms worth of messages, otherwise things can get out of control if rendering
+    // is very slow. Also, smooth over the range that we request, so that a single slow frame won't
+    // cause the next frame to also be unnecessarily slow by increasing the frame size.
+    let rangeMillis = Math.min(durationMillis * this._speed, 300);
+    if (this._lastRangeMillis != undefined) {
+      rangeMillis = this._lastRangeMillis * 0.9 + rangeMillis * 0.1;
+    }
+    this._lastRangeMillis = rangeMillis;
+
+    if (!this._currentTime) {
+      throw new Error("Invariant: Tried to play with no current time.");
+    }
+
+    // The end time when we want to stop reading messages and emit state for the tick
+    // The end time is inclusive.
+    const targetTime = add(this._currentTime, fromMillis(rangeMillis));
+    const end: Time = clampTime(targetTime, this._start, this._untilTime ?? this._end);
+
+    const msgEvents: MessageEvent<unknown>[] = [];
+
+    // When ending the previous tick, we might have already read a message from the iterator which
+    // belongs to our tick. This logic brings that message into our current batch of message events.
+    if (this._lastMessage) {
+      // If the last message we saw is still ahead of the tick end time, we don't emit anything
+      if (compare(this._lastMessage.receiveTime, end) > 0) {
+        // Wait for the previous render frame to finish
+        await this._queueEmitState.currentPromise;
+
+        this._currentTime = end;
+        this._messages = msgEvents;
+        this._queueEmitState();
+
+        if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+          this.pausePlayback();
+        }
+        return;
+      }
+
+      msgEvents.push(this._lastMessage);
+      this._lastMessage = undefined;
+    }
+
+    // If we take too long to read the tick data, we set the player into a BUFFERING presence. This
+    // indicates that the player is waiting to load more data. When the tick finally finishes, we
+    // clear this timeout.
+    const tickTimeout = setTimeout(() => {
+      this._presence = PlayerPresence.BUFFERING;
+      this._queueEmitState();
+    }, 500);
+
+    try {
+      // Read from the iterator through the end of the tick time
+      for (;;) {
+        if (!this._playbackIterator) {
+          throw new Error("Invariant. this._playbackIterator is undefined.");
+        }
+
+        const result = await this._playbackIterator.next();
+        if (result.done === true || this._nextState) {
+          break;
+        }
+        const iterResult = result.value;
+        if (iterResult.problem) {
+          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+        }
+
+        if (iterResult.problem) {
+          continue;
+        }
+
+        // The message is past the tick end time, we need to save it for next tick
+        if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
+          this._lastMessage = iterResult.msgEvent;
+          break;
+        }
+
+        msgEvents.push(iterResult.msgEvent);
+      }
+    } finally {
+      clearTimeout(tickTimeout);
+    }
+
+    // Set the presence back to PRESENT since we are no longer buffering
+    this._presence = PlayerPresence.PRESENT;
+
+    if (this._nextState) {
+      return;
+    }
+
+    // Wait on any active emit state to finish as part of this tick
+    // Without waiting on the emit state to finish we might drop messages since our emitState
+    // might get debounced
+    await this._queueEmitState.currentPromise;
+
+    this._currentTime = end;
+    this._messages = msgEvents;
+    this._queueEmitState();
+
+    // This tick has reached the end of the untilTime so we go back to pause
+    if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+      this.pausePlayback();
+    }
+  }
+
+  // Read a small amount of data from the datasource with the hope of producing a message or two.
+  // Without an initial read, the user would be looking at a blank layout since no messages have yet
+  // been delivered.
+  private async _stateStartPlay() {
+    if (!this._bufferedSource) {
+      throw new Error("uninitialized");
+    }
+
+    const stopTime = clampTime(
+      add(this._start, fromNanoSec(SEEK_ON_START_NS)),
+      this._start,
+      this._end,
+    );
+
+    log.debug(`Playing from ${toString(this._start)} to ${toString(stopTime)}`);
+
+    if (this._playbackIterator) {
+      throw new Error("Invariant. playbackIterator was already set");
+    }
+
+    log.debug("Initializing forward iterator from", this._start);
+    this._playbackIterator = this._bufferedSource.messageIterator({
+      topics: Array.from(this._allTopics),
+      start: this._start,
+      consumptionType: "partial",
+    });
+
+    this._lastMessage = undefined;
+    this._messages = [];
+
+    const messageEvents: MessageEvent<unknown>[] = [];
+
+    // If we take too long to read the data, we set the player into a BUFFERING presence. This
+    // indicates that the player is waiting to load more data.
+    const tickTimeout = setTimeout(() => {
+      this._presence = PlayerPresence.BUFFERING;
+      this._queueEmitState();
+    }, 100);
+
+    try {
+      for (;;) {
+        const result = await this._playbackIterator.next();
+        if (result.done === true) {
+          break;
+        }
+        const iterResult = result.value;
+        // Bail if a new state is requested while we are loading messages
+        // This usually happens when seeking before the initial load is complete
+        if (this._nextState) {
+          return;
+        }
+
+        if (iterResult.problem) {
+          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+          continue;
+        }
+
+        if (compare(iterResult.msgEvent.receiveTime, stopTime) > 0) {
+          this._lastMessage = iterResult.msgEvent;
+          break;
+        }
+
+        messageEvents.push(iterResult.msgEvent);
+      }
+    } finally {
+      clearTimeout(tickTimeout);
+    }
+
+    this._currentTime = stopTime;
+    this._messages = messageEvents;
+    this._presence = PlayerPresence.PRESENT;
+    this._queueEmitState();
+    this._setState("idle");
+  }
+
+  // Process a seek request. The seek is performed by requesting a getBackfillMessages from the source.
+  // This provides the last message on all subscribed topics.
+  private async _stateSeekBackfill() {
+    if (!this._bufferedSource) {
+      throw new Error("uninitialized");
+    }
+
+    const targetTime = this._seekTarget;
+    if (!targetTime) {
+      return;
+    }
+
+    this._lastMessage = undefined;
+
+    // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
+    // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
+    const seekAckTimeout = setTimeout(() => {
+      this._presence = PlayerPresence.BUFFERING;
+      this._messages = [];
+      this._currentTime = targetTime;
+      this._lastSeekEmitTime = Date.now();
+      this._queueEmitState();
+    }, 100);
+
+    const topics = Array.from(this._allTopics);
+
+    try {
+      this._abort = new AbortController();
+      const messages = await this._bufferedSource.getBackfillMessages({
+        topics,
+        time: targetTime,
+        abortSignal: this._abort.signal,
+      });
+
+      // We've successfully loaded the messages and will emit those, no longer need the ackTimeout
+      clearTimeout(seekAckTimeout);
+
+      if (this._nextState) {
+        return;
+      }
+
+      this._messages = messages;
+      this._currentTime = targetTime;
+      this._lastSeekEmitTime = Date.now();
+      this._presence = PlayerPresence.PRESENT;
+      this._queueEmitState();
+      await this.resetPlaybackIterator();
+      this._setState(this._isPlaying ? "play" : "idle");
+    } catch (err) {
+      if (this._nextState && err instanceof DOMException && err.name === "AbortError") {
+        log.debug("Aborted backfill");
+      } else {
+        throw err;
+      }
+    } finally {
+      // Unless the next state is a seek backfill, we clear the seek target since we have finished seeking
+      if (this._nextState !== "seek-backfill") {
+        this._seekTarget = undefined;
+      }
+      clearTimeout(seekAckTimeout);
+      this._abort = undefined;
+    }
+  }
+
+  private async _stateIdle() {
+    if (!this._bufferedSource) {
+      throw new Error("uninitialized");
+    }
+
+    this._isPlaying = false;
+    this._presence = PlayerPresence.PRESENT;
+    this._queueEmitState();
+
+    if (this._abort) {
+      throw new Error("Invariant: some other abort controller exists");
+    }
+    const abort = (this._abort = new AbortController());
+
+    const aborted = new Promise<void>((resolve) => {
+      abort.signal.addEventListener("abort", () => {
+        resolve();
+      });
+    });
+
+    for (;;) {
+      this._progress = {
+        fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
+        messageCache: this._progress.messageCache,
+      };
+      this._queueEmitState();
+
+      // When idling nothing is querying the source, but our buffered source might be
+      // buffering behind the scenes. Every second we emit state with an update to show that
+      // buffering is happening.
+      await Promise.race([delay(1000), aborted]);
+      if (this._nextState) {
+        break;
+      }
+    }
+  }
+
+  private async _stateResetPlaybackIterator() {
+    if (!this._currentTime) {
+      throw new Error("Invariant: Tried to reset playback iterator with no current time.");
+    }
+
+    await this.resetPlaybackIterator();
+    this._setState(this._isPlaying ? "play" : "idle");
+  }
+
+  private async _statePlay() {
+    if (!this._bufferedSource) {
+      throw new Error("uninitialized");
+    }
+
+    this._presence = PlayerPresence.PRESENT;
+
+    if (!this._currentTime) {
+      throw new Error("Invariant: currentTime not set before statePlay");
+    }
+
+    // Track the identity of allTopics, if this changes we need to reset our iterator to
+    // get new messages for new topics
+    const allTopics = this._allTopics;
+
+    try {
+      while (this._isPlaying && !this._hasError && !this._nextState) {
+        if (compare(this._currentTime, this._end) >= 0) {
+          this._setState("idle");
+          return;
+        }
+
+        const start = Date.now();
+
+        await this._tick();
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
+        if (this._nextState) {
+          return;
+        }
+
+        // If subscriptions changed, update to the new subscriptions
+        if (this._allTopics !== allTopics) {
+          // Discard any last message event since the new iterator will repeat it
+          this._lastMessage = undefined;
+
+          // Bail playback and reset the playback iterator when topics have changed so we can load
+          // the new topics
+          this._setState("reset-playback-iterator");
+          return;
+        }
+
+        this._progress = {
+          fullyLoadedFractionRanges: this._bufferedSource.loadedRanges(),
+          messageCache: this._progress.messageCache,
+        };
+
+        const time = Date.now() - start;
+        // make sure we've slept at least 16 millis or so (aprox 1 frame)
+        // to give the UI some time to breathe and not burn in a tight loop
+        if (time < 16) {
+          await delay(16 - time);
+        }
+      }
+    } catch (err) {
+      this._setError((err as Error).message, err);
+      this._queueEmitState();
+    }
+  }
+}
+
+Comlink.expose(WorkerIterablePlayerWorker);

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayerWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterablePlayerWorker.worker.ts
@@ -272,6 +272,14 @@ export class WorkerIterablePlayerWorker {
     }
   }
 
+  public setPlaybackSpeed(speed: number): void {
+    delete this._lastRangeMillis;
+    this._speed = speed;
+
+    // Queue event state update to update speed in player state to UI
+    this._queueEmitState();
+  }
+
   public startPlay(opt?: { untilTime: Time }): void {
     if (this._isPlaying || this._untilTime) {
       return;

--- a/packages/studio-base/src/players/IterablePlayer/index.ts
+++ b/packages/studio-base/src/players/IterablePlayer/index.ts
@@ -3,3 +3,4 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export * from "./IterablePlayer";
+export * from "./WorkerIterablePlayer";

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -38,12 +38,6 @@ export function formatFrame({ sec, nsec }: Time): string {
   return `${sec}.${String.prototype.padStart.call(nsec, 9, "0")}`;
 }
 
-// Amount to seek into the bag from the start when loading the player, to show
-// something useful on the screen. Ideally this is less than BLOCK_SIZE_NS from
-// MemoryCacheDataProvider so we still stay within the first block when fetching
-// initial data.
-export const SEEK_ON_START_NS = BigInt(99 * 1e6); /* ms */
-
 export function getTimestampForMessageEvent(
   messageEvent: MessageEvent<unknown>,
   timestampMethod?: TimestampMethod,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add a new WorkerIterablePlayer which runs the player loop in a web worker. This moves all data source handling (decompression, reading, deserialization) into a worker. The player state messages cross the worker boundary.

Only .bag and .mcap files are run in workers in this PR.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
