### PR TITLE
[3D] Add TF capacity error, delta handling of preloaded messages

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -204,6 +204,7 @@ const DEFAULT_FRAME_IDS = ["base_link", "odom", "map", "earth"];
 const FOLLOW_TF_PATH = ["general", "followTf"];
 const NO_FRAME_SELECTED = "NO_FRAME_SELECTED";
 const FRAME_NOT_FOUND = "FRAME_NOT_FOUND";
+const TF_OVERFLOW = "TF_OVERFLOW";
 
 // An extensionId for creating the top-level settings nodes such as "Topics" and
 // "Custom Layers"
@@ -932,6 +933,17 @@ export class Renderer extends EventEmitter<RendererEvents> {
     if (updated) {
       this.coordinateFrameList = this.transformTree.frameList();
       this.emit("transformTreeUpdated", this);
+    }
+
+    // Check if the transform history for this frame is at capacity and show an error if so. This
+    // error can't be cleared until the scene is reloaded
+    const frame = this.transformTree.getOrCreateFrame(childFrameId);
+    if (frame.transformsSize() === frame.maxCapacity) {
+      this.settings.errors.add(
+        ["transforms", `frame:${childFrameId}`],
+        TF_OVERFLOW,
+        `Transform history is at capacity (${frame.maxCapacity}), TFs will be dropped`,
+      );
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -30,6 +30,8 @@ export const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
   poseEstimateThetaDeviation: round(Math.PI / 12, 8),
 };
 
+const FOLLOW_TF_PATH = ["general", "followTf"];
+
 export class CoreSettings extends SceneExtension {
   public constructor(renderer: Renderer) {
     super("foxglove.CoreSettings", renderer);
@@ -75,7 +77,7 @@ export class CoreSettings extends SceneExtension {
       [this.renderer.followFrameId, config.followTf, this.renderer.renderFrameId],
       followTfOptions,
     );
-    const followTfError = this.renderer.settings.errors.errors.errorAtPath(["general", "followTf"]);
+    const followTfError = this.renderer.settings.errors.errors.errorAtPath(FOLLOW_TF_PATH);
 
     const followModeOptions = [
       { label: "Pose", value: "follow-pose" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -508,6 +508,7 @@ function buildSettingsFields(
     return { parent: { label: "Parent", input: "string", readonly: true, value: "<root>" } };
   }
 
+  const historySizeValue = String(frame?.transformsSize() ?? 0);
   let ageValue: string | undefined;
   let xyzValue: THREE.Vector3Tuple | undefined;
   let rpyValue: THREE.Vector3Tuple | undefined;
@@ -542,6 +543,12 @@ function buildSettingsFields(
       input: "string",
       readonly: true,
       value: ageValue,
+    },
+    historySize: {
+      label: "History size",
+      input: "string",
+      readonly: true,
+      value: historySizeValue,
     },
     xyz: {
       label: "Translation",

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -77,6 +77,7 @@ const tempLower: [Duration, Transform] = [0n, Transform.Identity()];
 const tempUpper: [Duration, Transform] = [0n, Transform.Identity()];
 const tempQuaternion = new THREE.Quaternion();
 const tempEuler = new THREE.Euler();
+const tempTfPath: [string, string] = ["transforms", ""];
 
 export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
   private static lineGeometry: LineGeometry | undefined;
@@ -178,12 +179,14 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
       const tfConfig = (configTransforms[frameKey] ?? {}) as Partial<LayerSettingsTransform>;
       const frame = this.renderer.transformTree.frame(frameId);
       const fields = buildSettingsFields(frame, this.renderer.currentTime, config);
+      tempTfPath[1] = frameKey;
       children[frameKey] = {
         label,
         fields,
         visible: tfConfig.visible ?? true,
         order: order++,
         defaultExpansionState: "collapsed",
+        error: this.renderer.settings.errors.errors.errorAtPath(tempTfPath),
       };
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -83,6 +83,13 @@ export class CoordinateFrame {
   }
 
   /**
+   * Returns the number of transforms stored in the transform history.
+   */
+  public transformsSize(): number {
+    return this._transforms.size;
+  }
+
+  /**
    * Set the parent frame for this frame. If the parent frame is already set to
    * a different frame, the transform history is cleared.
    */
@@ -128,7 +135,7 @@ export class CoordinateFrame {
     }
 
     // Trim down to the maximum history size
-    if (this._transforms.size > this.maxCapacity) {
+    while (this._transforms.size > this.maxCapacity) {
       this._transforms.shift();
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -7,7 +7,7 @@ import { Transform } from "./Transform";
 import { Pose } from "./geometry";
 import { Duration, Time } from "./time";
 
-const DEFAULT_MAX_CAPACITY_PER_FRAME = 10_000;
+const DEFAULT_MAX_CAPACITY_PER_FRAME = 50_000;
 
 /**
  * TransformTree is a collection of coordinate frames with convenience methods


### PR DESCRIPTION
**User-Facing Changes**
- [3D] An error will be shown when a transform history reaches capacity
- [3D] Faster preloading of transform messages
- [3D] Transform history size is shown for each frame under `Transforms` in the sidebar
- [3D] Transform history max capacity has been increased from 10,000 to 50,000 transforms

**Description**
- Add CoordinateFrame#transformsSize(), handle maxCapacity changing after construction
- Increase max per-frame TF capacity from 10k to 50k
- Only process preloaded messages with newer receiveTime (reset on seek), handle allFrames before currentFrame
- Show an error when TF history fills up
- Show TF history size

<img width="486" alt="Screen Shot 2022-10-01 at 11 59 58 AM" src="https://user-images.githubusercontent.com/195374/193424286-de7bf1b7-bd05-4cd0-8725-5b2a42e06b8d.png">