### PR TITLE
Move SEEK_ON_START_NS to IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -36,7 +36,6 @@ import {
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import delay from "@foxglove/studio-base/util/delay";
-import { SEEK_ON_START_NS } from "@foxglove/studio-base/util/time";
 
 import { BlockLoader } from "./BlockLoader";
 import { BufferedIterableSource } from "./BufferedIterableSource";
@@ -61,6 +60,10 @@ const MIN_MEM_CACHE_BLOCK_SIZE_NS = 0.1e9;
 // Adaptive block sizing is simpler than using a tree structure for immutable updates but
 // less flexible, so we may want to move away from a single-level block structure in the future.
 const MAX_BLOCKS = 400;
+
+// Amount to seek into the data source from the start when loading the player. The purpose of this
+// is to provide some initial data to subscribers.
+const SEEK_ON_START_NS = BigInt(99 * 1e6);
 
 type IterablePlayerOptions = {
   metricsCollector?: PlayerMetricsCollectorInterface;

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -38,12 +38,6 @@ export function formatFrame({ sec, nsec }: Time): string {
   return `${sec}.${String.prototype.padStart.call(nsec, 9, "0")}`;
 }
 
-// Amount to seek into the bag from the start when loading the player, to show
-// something useful on the screen. Ideally this is less than BLOCK_SIZE_NS from
-// MemoryCacheDataProvider so we still stay within the first block when fetching
-// initial data.
-export const SEEK_ON_START_NS = BigInt(99 * 1e6); /* ms */
-
 export function getTimestampForMessageEvent(
   messageEvent: MessageEvent<unknown>,
   timestampMethod?: TimestampMethod,


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
IterablePlayer was the only remaining place this constant was used. This constant is specific to the player implementation and better belongs in the player code rather than a time util file.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
