### PR TITLE
Update IterablePlayer to indicate PRESENT after initialize

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -148,7 +148,10 @@ describe("IterablePlayer", () => {
       // before initialize
       { ...baseState, activeData: { ...baseState.activeData, endTime: { sec: 0, nsec: 0 } } },
       // start delay
-      baseState,
+      {
+        ...baseState,
+        presence: PlayerPresence.PRESENT,
+      },
       // startPlay
       {
         ...baseState,

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -498,7 +498,7 @@ export class IterablePlayer implements Player {
         }
       }
 
-      // set the initial topics for the loader
+      this._presence = PlayerPresence.PRESENT;
     } catch (error) {
       this._setError(`Error initializing: ${error.message}`, error);
     }


### PR DESCRIPTION


**User-Facing Changes**
Faster indication a player is present.

**Description**
IterablePlayer should indicate player is present at the end of initialization so the next emit contains a new presence value.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
