### PR TITLE
3D settings: filter topics by visibility

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -134,9 +134,34 @@ function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
 
 const makeStablePath = memoizeWeak((path: readonly string[], key: string) => [...path, key]);
 
+type SelectVisibilityFilterValue = "all" | "visible" | "invisible";
+const SelectVisibilityFilterOptions: { label: string; value: SelectVisibilityFilterValue }[] = [
+  { label: "List all", value: "all" },
+  { label: "List visible", value: "visible" },
+  { label: "List invisible", value: "invisible" },
+];
+function showVisibleFilter(child: DeepReadonly<SettingsTreeNode>): boolean {
+  // want to show children with undefined visibility
+  return child.visible !== false;
+}
+function showInvisibleFilter(child: DeepReadonly<SettingsTreeNode>): boolean {
+  // want to show children with undefined visibility
+  return child.visible !== true;
+}
+const SelectVisibilityFilterField = {
+  input: "select",
+  label: "Filter list",
+  help: "Filter list by visibility",
+  options: SelectVisibilityFilterOptions,
+} as const;
+
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const { actionHandler, defaultOpen = true, filter, settings = {} } = props;
-  const [state, setState] = useImmer({ open: defaultOpen, editing: false });
+  const [state, setState] = useImmer({
+    open: defaultOpen,
+    editing: false,
+    visibilityFilter: "all",
+  });
 
   const { classes, cx } = useStyles();
 
@@ -144,6 +169,15 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
   const indent = props.path.length;
   const allowVisibilityToggle = props.settings?.visible != undefined;
   const visible = props.settings?.visible !== false;
+  const selectVisibilityFilterEnabled = props.settings?.selectVisibilityFilterEnabled === true;
+
+  const selectVisibilityFilter = (action: SettingsTreeAction) => {
+    if (action.action === "update" && action.payload.input === "select") {
+      setState((draft) => {
+        draft.visibilityFilter = action.payload.value as SelectVisibilityFilterValue;
+      });
+    }
+  };
 
   const toggleVisibility = () => {
     actionHandler({
@@ -170,18 +204,27 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     ) : undefined;
   });
 
-  const childNodes = prepareSettingsNodes(children ?? {}).map(([key, child]) => {
-    return (
-      <NodeEditor
-        actionHandler={actionHandler}
-        defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
-        filter={filter}
-        key={key}
-        settings={child}
-        path={makeStablePath(props.path, key)}
-      />
-    );
-  });
+  const filterFn =
+    state.visibilityFilter === "visible"
+      ? showVisibleFilter
+      : state.visibilityFilter === "invisible"
+      ? showInvisibleFilter
+      : undefined;
+  const childNodes = prepareSettingsNodes(children ?? {}).reduce((agg, [key, child]) => {
+    if (!filterFn || filterFn(child)) {
+      agg.push(
+        <NodeEditor
+          actionHandler={actionHandler}
+          defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
+          filter={filter}
+          key={key}
+          settings={child}
+          path={makeStablePath(props.path, key)}
+        />,
+      );
+    }
+    return agg;
+  }, [] as JSX.Element[]);
 
   const IconComponent = settings.icon ? icons[settings.icon] : undefined;
 
@@ -328,6 +371,14 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           {fieldEditors}
           <div className={classes.fieldPadding} />
         </>
+      )}
+      {state.open && selectVisibilityFilterEnabled && (
+        <FieldEditor
+          key="visibilityFilter"
+          field={{ ...SelectVisibilityFilterField, value: state.visibilityFilter }}
+          path={makeStablePath(props.path, "visibilityFilter")}
+          actionHandler={selectVisibilityFilter}
+        />
       )}
       {state.open && childNodes}
       {indent === 1 && <Divider style={{ gridColumn: "span 2" }} />}

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -601,6 +601,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     const topics: SettingsTreeEntry = {
       path: ["topics"],
       node: {
+        selectVisibilityFilterEnabled: true,
         label: "Topics",
         defaultExpansionState: "expanded",
         actions: [

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -597,6 +597,11 @@ declare module "@foxglove/studio" {
      * to the action handler.
      **/
     visible?: boolean;
+
+    /**
+     * Filter Children by visibility status
+     */
+    selectVisibilityFilterEnabled?: boolean;
   };
 
   /**


### PR DESCRIPTION
**User-Facing Changes**
 - enable filtering of topics list by visibility in the 3D panel

**Description**
 - made this generic in the NodeEditor, so anything in the settings tree can enable this to filter it's children by visibility
 - should be much faster than previous implementation because it doesn't rebuild the settings nodes whenever the settings change, just filters child nodes at the tree level


<!-- link relevant github issues -->
Fixes #4433
<!-- add `docs` label if this PR requires documentation updates -->
