### PR TITLE
TriangleListPrimitive: track normal attribute with DynamicBufferGeometry.createAttribute

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -62,6 +62,9 @@ export class RenderableTriangles extends RenderablePrimitive {
       if (!geometry.attributes.position) {
         geometry.createAttribute("position", Float32Array, 3);
       }
+      if (!geometry.attributes.normal) {
+        geometry.createAttribute("normal", Float32Array, 3);
+      }
       const vertices = geometry.attributes.position!;
 
       const singleColor = this.userData.settings.color


### PR DESCRIPTION
**User-Facing Changes**
[3D] Fixed an issue where TriangleListPrimitives with changing numbers of points would sometimes crash the 3D panel.

**Description**
Fixes https://github.com/foxglove/studio/issues/4555 by tracking the `normal` attribute with DynamicBufferGeometry