### PR TITLE
[3D] Throw a more helpful error if DynamicBufferGeometry is missing an _attributeConstructors entry

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
@@ -59,7 +59,7 @@ export class DynamicBufferGeometry extends THREE.BufferGeometry {
       const dataConstructor = this._attributeConstructors.get(attributeName);
       if (!dataConstructor) {
         throw new Error(
-          `DynamicBufferGeometry resize(${itemCount}) failed, missing data constructor for attribute "${attributeName}"`,
+          `DynamicBufferGeometry resize(${itemCount}) failed, missing data constructor for attribute "${attributeName}". Attributes must be created using createAttribute().`,
         );
       }
       const data = new dataConstructor(itemCount * attribute.itemSize);

--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicBufferGeometry.ts
@@ -55,9 +55,13 @@ export class DynamicBufferGeometry extends THREE.BufferGeometry {
       return;
     }
 
-    for (const attributeName of Object.keys(this.attributes)) {
-      const attribute = this.attributes[attributeName]!;
-      const dataConstructor = this._attributeConstructors.get(attributeName)!;
+    for (const [attributeName, attribute] of Object.entries(this.attributes)) {
+      const dataConstructor = this._attributeConstructors.get(attributeName);
+      if (!dataConstructor) {
+        throw new Error(
+          `DynamicBufferGeometry resize(${itemCount}) failed, missing data constructor for attribute "${attributeName}"`,
+        );
+      }
       const data = new dataConstructor(itemCount * attribute.itemSize);
       const newAttrib = new THREE.BufferAttribute(data, attribute.itemSize, attribute.normalized);
       newAttrib.setUsage(this._usage);


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
Improved error message for a panel-crashing failure. This will help debugging in the future
