### PR TITLE
[3D] Avoid synchronously calling SceneExtension methods that may be overridden from the base class constructor

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
@@ -69,7 +69,10 @@ export class SceneExtension<
     super();
     this.extensionId = this.name = extensionId;
     this.renderer = renderer;
-    this.updateSettingsTree();
+    // updateSettingsTree() will call settingsNodes() which may be overridden in a child class.
+    // The child class may not assign its members until after this constructor returns. This breaks
+    // type assumptions, so we need to defer the call to updateSettingsTree()
+    queueMicrotask(() => this.updateSettingsTree());
   }
 
   /**


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
This fixes a potential bug that could cause undefined behavior in SceneExtension subclasses, by calling the subclass 
`settingsNodes()` method before the constructor ran.
