### PR TITLE
improve duplicate topic error message

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -175,7 +175,7 @@ describe("IterablePlayer", () => {
     player.close();
   });
 
-  it("provides error message for duplicate topics", async () => {
+  it("provides error message for inconsistent topic datatypes", async () => {
     class DuplicateTopicsSource implements IIterableSource {
       public async initialize(): Promise<Initalization> {
         return {
@@ -214,9 +214,9 @@ describe("IterablePlayer", () => {
     const playerStates = await store.done;
     expect(last(playerStates)!.problems).toEqual([
       {
-        message: "Duplicate topic: A",
+        message: "Inconsistent datatype for topic: A",
         severity: "warn",
-        tip: "Source produced two topics named A, with datatypes B and C. This may result in errors during visualization.",
+        tip: "Topic A has messages with multiple datatypes: B, C. This may result in errors during visualization.",
       },
     ]);
     (console.warn as jest.Mock).mockClear();

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -3,6 +3,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { last } from "lodash";
+
 import {
   MessageEvent,
   PlayerCapabilities,
@@ -171,6 +173,53 @@ describe("IterablePlayer", () => {
     ]);
 
     player.close();
+  });
+
+  it("provides error message for duplicate topics", async () => {
+    class DuplicateTopicsSource implements IIterableSource {
+      public async initialize(): Promise<Initalization> {
+        return {
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 1, nsec: 0 },
+          topics: [
+            { name: "A", datatype: "B" },
+            { name: "A", datatype: "C" },
+          ],
+          topicStats: new Map(),
+          profile: undefined,
+          problems: [],
+          datatypes: new Map([
+            ["B", { name: "B", definitions: [] }],
+            ["C", { name: "C", definitions: [] }],
+          ]),
+          publishersByTopic: new Map(),
+        };
+      }
+
+      public async *messageIterator() {}
+
+      public async getBackfillMessages() {
+        return [];
+      }
+    }
+
+    const source = new DuplicateTopicsSource();
+    const player = new IterablePlayer({
+      source,
+      enablePreload: false,
+      sourceId: "test",
+    });
+    const store = new PlayerStateStore(4);
+    player.setListener(async (state) => await store.add(state));
+    const playerStates = await store.done;
+    expect(last(playerStates)!.problems).toEqual([
+      {
+        message: "Duplicate topic: A",
+        severity: "warn",
+        tip: "Source produced two topics named A, with datatypes B and C. This may result in errors during visualization.",
+      },
+    ]);
+    (console.warn as jest.Mock).mockClear();
   });
 
   it("when seeking during a seek backfill, start another seek after the current one exits", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -455,6 +455,11 @@ export class IterablePlayer implements Player {
           problems.push({
             severity: "warn",
             message: `Duplicate topic: ${topic.name}`,
+            tip: `Source${name ? ` “${name}”` : ``} produced two topics named ${
+              topic.name
+            }, with datatypes ${existingTopic.datatype} and ${
+              topic.datatype
+            }. This may result in errors during visualization.`,
           });
           continue;
         }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -454,12 +454,8 @@ export class IterablePlayer implements Player {
         if (existingTopic) {
           problems.push({
             severity: "warn",
-            message: `Duplicate topic: ${topic.name}`,
-            tip: `Source${name ? ` “${name}”` : ``} produced two topics named ${
-              topic.name
-            }, with datatypes ${existingTopic.datatype} and ${
-              topic.datatype
-            }. This may result in errors during visualization.`,
+            message: `Inconsistent datatype for topic: ${topic.name}`,
+            tip: `Topic ${topic.name} has messages with multiple datatypes: ${existingTopic.datatype}, ${topic.datatype}. This may result in errors during visualization.`,
           });
           continue;
         }


### PR DESCRIPTION
**User-Facing Changes**
Improved error message when duplicate topics are found when streaming data from the Data Platform.

**Description**
Fixes https://github.com/foxglove/studio/issues/4574
