### PR TITLE
[New3D] Add option to ignore "up axis" for STL models

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -16,10 +16,13 @@ import Logger from "@foxglove/log";
 
 const log = Logger.getLogger(__filename);
 
+export type StlUpAxis = "y_up" | "z_up";
+export const DEFAULT_STL_UP_AXIS: StlUpAxis = "y_up";
+
 export type ModelCacheOptions = {
   edgeMaterial: THREE.Material;
   ignoreColladaUpAxis: boolean;
-  ignoreStlUpAxis: boolean;
+  stlUpAxis: StlUpAxis;
 };
 
 type LoadModelOptions = {
@@ -100,7 +103,7 @@ export class ModelCache {
 
     // Check if this is a STL file based on content-type or file extension
     if (STL_MIME_TYPES.includes(contentType) || /\.stl$/i.test(url)) {
-      return loadSTL(url, buffer, this.options.ignoreStlUpAxis);
+      return loadSTL(url, buffer, this.options.stlUpAxis);
     }
 
     // Check if this is a COLLADA file based on content-type or file extension
@@ -146,8 +149,7 @@ async function loadGltf(url: string, reportError: ErrorCallback): Promise<Loaded
 function loadSTL(
   url: string,
   buffer: ArrayBuffer,
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  ignoreUpAxis: boolean,
+  stlUpAxis: StlUpAxis,
 ): LoadedModel {
   // STL files do not reference any external assets, no LoadingManager needed
   const stlLoader = new STLLoader();
@@ -166,7 +168,7 @@ function loadSTL(
 
   // THREE.js uses Y-up, while Studio follows the ROS
   // [REP-0103](https://www.ros.org/reps/rep-0103.html) convention of Z-up
-  if (!ignoreUpAxis) {
+  if (stlUpAxis === "y_up") {
     group.rotateX(Math.PI / 2);
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -146,10 +146,7 @@ async function loadGltf(url: string, reportError: ErrorCallback): Promise<Loaded
   return gltf.scene;
 }
 
-function loadSTL(
-  url: string,
-  buffer: ArrayBuffer,
-  stlUpAxis: StlUpAxis,
+function loadSTL(url: string, buffer: ArrayBuffer, stlUpAxis: StlUpAxis
 ): LoadedModel {
   // STL files do not reference any external assets, no LoadingManager needed
   const stlLoader = new STLLoader();

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -146,8 +146,7 @@ async function loadGltf(url: string, reportError: ErrorCallback): Promise<Loaded
   return gltf.scene;
 }
 
-function loadSTL(url: string, buffer: ArrayBuffer, stlUpAxis: StlUpAxis
-): LoadedModel {
+function loadSTL(url: string, buffer: ArrayBuffer, stlUpAxis: StlUpAxis): LoadedModel {
   // STL files do not reference any external assets, no LoadingManager needed
   const stlLoader = new STLLoader();
   const bufferGeometry = stlLoader.parse(buffer);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ModelCache.ts
@@ -143,10 +143,12 @@ async function loadGltf(url: string, reportError: ErrorCallback): Promise<Loaded
   return gltf.scene;
 }
 
-function loadSTL(url: string, buffer: ArrayBuffer,
-    // eslint-disable-next-line @foxglove/no-boolean-parameters
-    ignoreUpAxis: boolean,
-    ): LoadedModel {
+function loadSTL(
+  url: string,
+  buffer: ArrayBuffer,
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  ignoreUpAxis: boolean,
+): LoadedModel {
   // STL files do not reference any external assets, no LoadingManager needed
   const stlLoader = new STLLoader();
   const bufferGeometry = stlLoader.parse(buffer);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -28,7 +28,7 @@ import { LabelMaterial, LabelPool } from "@foxglove/three-text";
 
 import { Input } from "./Input";
 import { LineMaterial } from "./LineMaterial";
-import { ModelCache, StlUpAxis, DEFAULT_STL_UP_AXIS } from "./ModelCache";
+import { ModelCache, MeshUpAxis, DEFAULT_MESH_UP_AXIS } from "./ModelCache";
 import { PickedRenderable, Picker } from "./Picker";
 import type { Renderable } from "./Renderable";
 import { SceneExtension } from "./SceneExtension";
@@ -118,7 +118,7 @@ export type RendererConfig = {
     labelScaleFactor?: number;
     /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
     ignoreColladaUpAxis?: boolean;
-    stlUpAxis?: StlUpAxis;
+    meshUpAxis?: MeshUpAxis;
     transforms?: {
       /** Toggles translation and rotation offset controls for frames */
       editable?: boolean;
@@ -368,7 +368,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.modelCache = new ModelCache({
       ignoreColladaUpAxis: config.scene.ignoreColladaUpAxis ?? false,
-      stlUpAxis: config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS,
+      meshUpAxis: config.scene.meshUpAxis ?? DEFAULT_MESH_UP_AXIS,
       edgeMaterial: this.outlineMaterial,
     });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -28,7 +28,7 @@ import { LabelMaterial, LabelPool } from "@foxglove/three-text";
 
 import { Input } from "./Input";
 import { LineMaterial } from "./LineMaterial";
-import { ModelCache } from "./ModelCache";
+import { ModelCache, StlUpAxis, DEFAULT_STL_UP_AXIS } from "./ModelCache";
 import { PickedRenderable, Picker } from "./Picker";
 import type { Renderable } from "./Renderable";
 import { SceneExtension } from "./SceneExtension";
@@ -118,7 +118,7 @@ export type RendererConfig = {
     labelScaleFactor?: number;
     /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
     ignoreColladaUpAxis?: boolean;
-    ignoreStlUpAxis?: boolean;
+    stlUpAxis?: StlUpAxis;
     transforms?: {
       /** Toggles translation and rotation offset controls for frames */
       editable?: boolean;
@@ -368,7 +368,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.modelCache = new ModelCache({
       ignoreColladaUpAxis: config.scene.ignoreColladaUpAxis ?? false,
-      ignoreStlUpAxis: config.scene.ignoreStlUpAxis ?? false,
+      stlUpAxis: config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS,
       edgeMaterial: this.outlineMaterial,
     });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -118,6 +118,7 @@ export type RendererConfig = {
     labelScaleFactor?: number;
     /** Ignore the <up_axis> tag in COLLADA files (matching rviz behavior) */
     ignoreColladaUpAxis?: boolean;
+    ignoreStlUpAxis?: boolean;
     transforms?: {
       /** Toggles translation and rotation offset controls for frames */
       editable?: boolean;
@@ -367,6 +368,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.modelCache = new ModelCache({
       ignoreColladaUpAxis: config.scene.ignoreColladaUpAxis ?? false,
+      ignoreStlUpAxis: config.scene.ignoreStlUpAxis ?? false,
       edgeMaterial: this.outlineMaterial,
     });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -6,6 +6,7 @@ import { cloneDeep, round, set } from "lodash";
 
 import { SettingsTreeAction } from "@foxglove/studio";
 
+import { DEFAULT_STL_UP_AXIS } from "../ModelCache";
 import { FollowMode, Renderer, RendererConfig } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
@@ -149,14 +150,18 @@ export class CoreSettings extends SceneExtension {
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },
-            ignoreStlUpAxis: {
-              label: "Ignore STL <up_axis>",
+            stlUpAxis: {
+              label: "STL up axis",
               help: "Match the behavior of rviz by ignoring the <up_axis> tag in STL files",
-              input: "boolean",
-              value: config.scene.ignoreStlUpAxis,
+              input: "select",
+              value: config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS,
+              options: [
+                { label: "Y axis", value: "y_up" },
+                { label: "Z axis", value: "z_up" },
+              ],
               error:
-                (config.scene.ignoreStlUpAxis ?? false) !==
-                this.renderer.modelCache.options.ignoreStlUpAxis
+                (config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS) !==
+                this.renderer.modelCache.options.stlUpAxis
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -152,7 +152,7 @@ export class CoreSettings extends SceneExtension {
             },
             meshUpAxis: {
               label: "Mesh up axis",
-              help: "The direction to use as “up” when loading meshes without orientation info(STL, OBJ)",
+              help: "The direction to use as “up” when loading meshes without orientation info (STL and OBJ)",
               input: "select",
               value: config.scene.meshUpAxis ?? DEFAULT_MESH_UP_AXIS,
               options: [

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -152,7 +152,7 @@ export class CoreSettings extends SceneExtension {
             },
             stlUpAxis: {
               label: "STL up axis",
-              help: "Match the behavior of rviz by ignoring the <up_axis> tag in STL files",
+              help: "The direction to use as “up” when loading meshes without orientation info",
               input: "select",
               value: config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS,
               options: [

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -6,7 +6,7 @@ import { cloneDeep, round, set } from "lodash";
 
 import { SettingsTreeAction } from "@foxglove/studio";
 
-import { DEFAULT_STL_UP_AXIS } from "../ModelCache";
+import { DEFAULT_MESH_UP_AXIS } from "../ModelCache";
 import { FollowMode, Renderer, RendererConfig } from "../Renderer";
 import { SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry } from "../SettingsManager";
@@ -150,18 +150,18 @@ export class CoreSettings extends SceneExtension {
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },
-            stlUpAxis: {
-              label: "STL up axis",
-              help: "The direction to use as “up” when loading meshes without orientation info",
+            meshUpAxis: {
+              label: "Mesh up axis",
+              help: "The direction to use as “up” when loading meshes without orientation info(STL, OBJ)",
               input: "select",
-              value: config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS,
+              value: config.scene.meshUpAxis ?? DEFAULT_MESH_UP_AXIS,
               options: [
-                { label: "Y axis", value: "y_up" },
-                { label: "Z axis", value: "z_up" },
+                { label: "Y-up", value: "y_up" },
+                { label: "Z-up", value: "z_up" },
               ],
               error:
-                (config.scene.stlUpAxis ?? DEFAULT_STL_UP_AXIS) !==
-                this.renderer.modelCache.options.stlUpAxis
+                (config.scene.meshUpAxis ?? DEFAULT_MESH_UP_AXIS) !==
+                this.renderer.modelCache.options.meshUpAxis
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -149,6 +149,17 @@ export class CoreSettings extends SceneExtension {
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },
+            ignoreStlUpAxis: {
+              label: "Ignore STL <up_axis>",
+              help: "Match the behavior of rviz by ignoring the <up_axis> tag in STL files",
+              input: "boolean",
+              value: config.scene.ignoreStlUpAxis,
+              error:
+                (config.scene.ignoreStlUpAxis ?? false) !==
+                this.renderer.modelCache.options.ignoreStlUpAxis
+                  ? "This setting requires a restart to take effect"
+                  : undefined,
+            },
           },
           children: {
             cameraState: {


### PR DESCRIPTION
**User-Facing Changes**
Add `Ignore STL <up_axis>` option to New3D panel->Settings->Scene

**Description**
In my case, after this [commit](https://github.com/foxglove/studio/commit/09f46a498e9431f95f090839932ba74ee9a9e509#diff-1e01cf8f145a7673bda300ba7644ba3b3e911d63d2cc880e4afc85b8a3f81f67R163), my robot model was totally broken. So I  added this option, similar to the existing one  - `Ignore COLLADA <up_axis>`. 
P.S. My robot model displayed ok in RVIZ and previous versions of Foxglove(prior to mentioned commit).

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
