### PR TITLE
Feat #4241 Improve empty layout state

### DIFF
--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -40,8 +40,8 @@ import {
   LayoutState,
   useCurrentLayoutSelector,
   usePanelMosaicId,
+  useCurrentLayoutActions,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import "react-mosaic-component/react-mosaic-component.css";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -276,7 +276,7 @@ export default function PanelLayout(): JSX.Element {
   return (
     <EmptyState>
       <Typography display="block" variant="body1" color="text.primary">
-        You currently don&apos;t have a selected layout.
+        You don&apos;t currently have a layout selected.
       </Typography>
       <Link onClick={selectExistingLayout} underline="hover" color="primary" variant="body1">
         Select an existing layout

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -12,7 +12,6 @@
 //   You may not use this file except in compliance with the License.
 
 import { Button, CircularProgress, styled as muiStyled } from "@mui/material";
-import moment from "moment";
 import React, {
   useCallback,
   useMemo,
@@ -42,13 +41,13 @@ import {
   usePanelMosaicId,
   useCurrentLayoutActions,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import "react-mosaic-component/react-mosaic-component.css";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
+import { useUserProfileStorage } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
-import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
+import { defaultLayout } from "@foxglove/studio-base/providers/CurrentLayoutProvider/defaultLayout";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
@@ -221,14 +220,11 @@ export default function PanelLayout(): JSX.Element {
   const { changePanelLayout, setSelectedLayoutId } = useCurrentLayoutActions();
   const { openLayoutBrowser } = useWorkspace();
   const layoutManager = useLayoutManager();
+  const { getUserProfile } = useUserProfileStorage();
   const layoutExists = useCurrentLayoutSelector(selectedLayoutExistsSelector);
   const layoutLoading = useCurrentLayoutSelector(selectedLayoutLoadingSelector);
   const mosaicLayout = useCurrentLayoutSelector(selectedLayoutMosaicSelector);
   const registeredExtensions = useExtensionCatalog((state) => state.installedExtensions);
-
-  const currentDateForStorybook = useMemo(() => new Date("2021-06-16T04:28:33.549Z"), []);
-  const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
-  const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
 
   const [, dispatch] = useLayoutBrowserReducer({
     busy: layoutManager.isBusy,
@@ -238,25 +234,21 @@ export default function PanelLayout(): JSX.Element {
 
   const createNewLayout = async () => {
     openLayoutBrowser();
-    const panelState: Omit<PanelsState, "name" | "id"> = {
-      configById: {},
-      globalVariables: {},
-      userNodes: {},
-      linkedGlobalVariables: [],
-      playbackConfig: defaultPlaybackConfig,
-    };
-    const name = `Unnamed layout ${moment(currentDateForStorybook).format("l")} at ${moment(
-      currentDateForStorybook,
-    ).format("LT")}`;
-    const newLayout = await layoutManager.saveNewLayout({
-      name,
-      data: panelState as PanelsState,
-      permission: "CREATOR_WRITE",
-    });
+    const { currentLayoutId } = await getUserProfile();
+    const layouts = await layoutManager.getLayouts();
+    let layout = layouts[layouts.length - 1] ?? undefined;
 
-    if (newLayout.id !== currentLayoutId) {
-      setSelectedLayoutId(newLayout.id);
-      dispatch({ type: "select-id", id: newLayout.id });
+    if (layout == undefined) {
+      layout = await layoutManager.saveNewLayout({
+        name: "Default",
+        data: defaultLayout,
+        permission: "CREATOR_WRITE",
+      });
+    }
+
+    if (layout.id !== currentLayoutId) {
+      setSelectedLayoutId(layout.id);
+      dispatch({ type: "select-id", id: layout.id });
     }
   };
 

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -45,7 +45,6 @@ import "react-mosaic-component/react-mosaic-component.css";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { useUserProfileStorage } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { defaultLayout } from "@foxglove/studio-base/providers/CurrentLayoutProvider/defaultLayout";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
@@ -220,7 +219,6 @@ export default function PanelLayout(): JSX.Element {
   const { changePanelLayout, setSelectedLayoutId } = useCurrentLayoutActions();
   const { openLayoutBrowser } = useWorkspace();
   const layoutManager = useLayoutManager();
-  const { getUserProfile } = useUserProfileStorage();
   const layoutExists = useCurrentLayoutSelector(selectedLayoutExistsSelector);
   const layoutLoading = useCurrentLayoutSelector(selectedLayoutLoadingSelector);
   const mosaicLayout = useCurrentLayoutSelector(selectedLayoutMosaicSelector);
@@ -233,7 +231,6 @@ export default function PanelLayout(): JSX.Element {
   });
 
   const createNewLayout = async () => {
-    openLayoutBrowser();
     const layout = await layoutManager.saveNewLayout({
       name: "Default",
       data: defaultLayout,
@@ -241,15 +238,16 @@ export default function PanelLayout(): JSX.Element {
     });
     setSelectedLayoutId(layout.id);
     dispatch({ type: "select-id", id: layout.id });
+    openLayoutBrowser();
   };
 
   const selectExistingLayout = async () => {
-    const { currentLayoutId } = await getUserProfile();
     const layouts = await layoutManager.getLayouts();
-    if (layouts[0] && layouts[0].id !== currentLayoutId) {
+    if (layouts[0]) {
       setSelectedLayoutId(layouts[0].id);
       dispatch({ type: "select-id", id: layouts[0].id });
     }
+    openLayoutBrowser();
   };
 
   const onChange = useCallback(

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -11,7 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { CircularProgress, Link, styled as muiStyled } from "@mui/material";
+import { Button, CircularProgress, styled as muiStyled } from "@mui/material";
+import moment from "moment";
 import React, {
   useCallback,
   useMemo,
@@ -29,21 +30,25 @@ import {
   MosaicNode,
   MosaicPath,
 } from "react-mosaic-component";
-import "react-mosaic-component/react-mosaic-component.css";
 
 import { EmptyPanelLayout } from "@foxglove/studio-base/components/EmptyPanelLayout";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
+import { useLayoutBrowserReducer } from "@foxglove/studio-base/components/LayoutBrowser/reducer";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import {
   LayoutState,
-  useCurrentLayoutActions,
   useCurrentLayoutSelector,
   usePanelMosaicId,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import "react-mosaic-component/react-mosaic-component.css";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
 import { getPanelIdForType, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
@@ -213,12 +218,47 @@ const selectedLayoutExistsSelector = (state: LayoutState) =>
 const selectedLayoutMosaicSelector = (state: LayoutState) => state.selectedLayout?.data?.layout;
 
 export default function PanelLayout(): JSX.Element {
-  const { changePanelLayout } = useCurrentLayoutActions();
+  const { changePanelLayout, setSelectedLayoutId } = useCurrentLayoutActions();
   const { openLayoutBrowser } = useWorkspace();
+  const layoutManager = useLayoutManager();
   const layoutExists = useCurrentLayoutSelector(selectedLayoutExistsSelector);
   const layoutLoading = useCurrentLayoutSelector(selectedLayoutLoadingSelector);
   const mosaicLayout = useCurrentLayoutSelector(selectedLayoutMosaicSelector);
   const registeredExtensions = useExtensionCatalog((state) => state.installedExtensions);
+
+  const currentDateForStorybook = useMemo(() => new Date("2021-06-16T04:28:33.549Z"), []);
+  const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+  const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
+
+  const [, dispatch] = useLayoutBrowserReducer({
+    busy: layoutManager.isBusy,
+    error: layoutManager.error,
+    online: layoutManager.isOnline,
+  });
+
+  const createNewLayout = async () => {
+    openLayoutBrowser();
+    const panelState: Omit<PanelsState, "name" | "id"> = {
+      configById: {},
+      globalVariables: {},
+      userNodes: {},
+      linkedGlobalVariables: [],
+      playbackConfig: defaultPlaybackConfig,
+    };
+    const name = `Unnamed layout ${moment(currentDateForStorybook).format("l")} at ${moment(
+      currentDateForStorybook,
+    ).format("LT")}`;
+    const newLayout = await layoutManager.saveNewLayout({
+      name,
+      data: panelState as PanelsState,
+      permission: "CREATOR_WRITE",
+    });
+
+    if (newLayout.id !== currentLayoutId) {
+      setSelectedLayoutId(newLayout.id);
+      dispatch({ type: "select-id", id: newLayout.id });
+    }
+  };
 
   const onChange = useCallback(
     (newLayout: MosaicNode<string> | undefined) => {
@@ -243,10 +283,9 @@ export default function PanelLayout(): JSX.Element {
 
   return (
     <EmptyState>
-      <Link onClick={openLayoutBrowser} underline="hover">
-        Select a layout
-      </Link>{" "}
-      in the sidebar to get started!
+      <Button variant="contained" size="large" onClick={createNewLayout}>
+        Create new layout
+      </Button>
     </EmptyState>
   );
 }

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Button, CircularProgress, styled as muiStyled } from "@mui/material";
+import { Link, CircularProgress, Typography, styled as muiStyled } from "@mui/material";
 import React, {
   useCallback,
   useMemo,
@@ -234,21 +234,21 @@ export default function PanelLayout(): JSX.Element {
 
   const createNewLayout = async () => {
     openLayoutBrowser();
+    const layout = await layoutManager.saveNewLayout({
+      name: "Default",
+      data: defaultLayout,
+      permission: "CREATOR_WRITE",
+    });
+    setSelectedLayoutId(layout.id);
+    dispatch({ type: "select-id", id: layout.id });
+  };
+
+  const selectExistingLayout = async () => {
     const { currentLayoutId } = await getUserProfile();
     const layouts = await layoutManager.getLayouts();
-    let layout = layouts[layouts.length - 1] ?? undefined;
-
-    if (layout == undefined) {
-      layout = await layoutManager.saveNewLayout({
-        name: "Default",
-        data: defaultLayout,
-        permission: "CREATOR_WRITE",
-      });
-    }
-
-    if (layout.id !== currentLayoutId) {
-      setSelectedLayoutId(layout.id);
-      dispatch({ type: "select-id", id: layout.id });
+    if (layouts[0] && layouts[0].id !== currentLayoutId) {
+      setSelectedLayoutId(layouts[0].id);
+      dispatch({ type: "select-id", id: layouts[0].id });
     }
   };
 
@@ -275,9 +275,18 @@ export default function PanelLayout(): JSX.Element {
 
   return (
     <EmptyState>
-      <Button variant="contained" size="large" onClick={createNewLayout}>
+      <Typography display="block" variant="body1" color="text.primary">
+        You currently don&apos;t have a selected layout.
+      </Typography>
+      <Link onClick={selectExistingLayout} underline="hover" color="primary" variant="body1">
+        Select an existing layout
+      </Link>{" "}
+      <Typography display="inline-flex" variant="body1" color="text.primary">
+        or
+      </Typography>{" "}
+      <Link onClick={createNewLayout} underline="hover" color="primary" variant="body1">
         Create new layout
-      </Button>
+      </Link>{" "}
     </EmptyState>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**


**Description**
Add's `Create new layout` button as referenced in issue foxglove/community#489 

<img width="1440" alt="Screen Shot 2022-10-06 at 2 42 46 PM" src="https://user-images.githubusercontent.com/44953690/194328811-df8a15b3-9f61-4f81-8a90-99ee331e1389.png">


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
