### PR TITLE
Automatically select another existing layout after deleting multiple layouts at once

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -243,8 +243,7 @@ export default function CurrentLayoutProvider({
 
       if (event.layoutId === layoutStateRef.current.selectedLayout.id) {
         const layouts = await layoutManager.getLayouts();
-        const currLayout = layouts[0];
-        await setSelectedLayoutId(currLayout?.id ?? undefined);
+        await setSelectedLayoutId(layouts[0]?.id);
       }
     };
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -243,7 +243,7 @@ export default function CurrentLayoutProvider({
 
       if (event.layoutId === layoutStateRef.current.selectedLayout.id) {
         const layouts = await layoutManager.getLayouts();
-        const currLayout = layouts[layouts.length - 1];
+        const currLayout = layouts[0];
         await setSelectedLayoutId(currLayout?.id ?? undefined);
       }
     };

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -242,8 +242,9 @@ export default function CurrentLayoutProvider({
       }
 
       if (event.layoutId === layoutStateRef.current.selectedLayout.id) {
-        await setSelectedLayoutId(undefined);
-        enqueueSnackbar("Your active layout was deleted.", { variant: "warning" });
+        const layouts = await layoutManager.getLayouts();
+        const currLayout = layouts[layouts.length - 1];
+        await setSelectedLayoutId(currLayout?.id ?? undefined);
       }
     };
 


### PR DESCRIPTION
**User-facing changes**
Not worth calling out in release notes

**Description**
This makes multi-layout delete consistent with single layout delete.

Resolves #4454 