### PR TITLE
RenderableTriangles does not handle colors.length < points.length

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -119,6 +119,11 @@ const useStyles = makeStyles()((theme) => ({
   nodeHeaderToggleVisible: {
     opacity: 1,
   },
+  errorTooltip: {
+    whiteSpace: "pre-line",
+    maxHeight: "15vh",
+    overflowY: "auto",
+  },
 }));
 
 function ExpansionArrow({ expanded }: { expanded: boolean }): JSX.Element {
@@ -351,7 +356,11 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
           {props.settings?.error && (
             <Tooltip
               arrow
-              title={<Typography variant="subtitle2">{props.settings.error}</Typography>}
+              title={
+                <Typography variant="subtitle2" className={classes.errorTooltip}>
+                  {props.settings.error}
+                </Typography>
+              }
             >
               <IconButton size="small" color="error">
                 <ErrorIcon fontSize="small" />

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -148,6 +148,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
         if (!renderable) {
           renderable = this.primitivePool.acquire(primitiveType);
           renderable.name = `${entity.id}:${primitiveType} on ${this.topic}`;
+          renderable.userData.settingsPath = this.userData.settingsPath;
           renderable.setColorScheme(this.renderer.colorScheme);
           // @ts-expect-error TS doesn't know that renderable matches primitiveType
           renderables[primitiveType] = renderable;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
@@ -37,4 +37,16 @@ export class RenderablePrimitive extends Renderable<EntityRenderableUserData> {
     this.userData.entity = undefined;
     this.userData.pose = emptyPose();
   }
+
+  public addError(errorId: string, message: string): void {
+    this.renderer.settings.errors.add(this.userData.settingsPath, errorId, message);
+  }
+
+  public clearErrors(): void {
+    // presumably a renderable has not been assigned a settings path if it is 0
+    // running clearPath([]) will clear all errors from the settings tree
+    if (this.userData.settingsPath.length > 0) {
+      this.renderer.settings.errors.clearPath(this.userData.settingsPath);
+    }
+  }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -91,7 +91,7 @@ export class RenderableTriangles extends RenderablePrimitive {
         vertices.setXYZ(i, point.x, point.y, point.z);
 
         if (!singleColor && colors && primitive.colors.length > 0) {
-          const color = primitive.colors[i] ? primitive.colors[i]! : missingColor;
+          const color = primitive.colors[i] ?? missingColor;
           // only trigger on last point index
           if (i === primitive.points.length - 1 && color === missingColor) {
             // will only show 1st triMeshIdx of issue -- addError prevents the adding of errors with duplicate errorIds

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -16,6 +16,9 @@ import { RenderablePrimitive } from "./RenderablePrimitive";
 
 const tempRgba = makeRgba();
 const tempColor = new THREE.Color();
+const missingColor = { r: 0, g: 1.0, b: 0, a: 1.0 };
+
+const COLOR_LENGTH_ERROR_ID = "INVALID_COLOR_LENGTH";
 
 type TriangleMesh = THREE.Mesh<DynamicBufferGeometry, THREE.MeshStandardMaterial>;
 export class RenderableTriangles extends RenderablePrimitive {
@@ -88,7 +91,15 @@ export class RenderableTriangles extends RenderablePrimitive {
         vertices.setXYZ(i, point.x, point.y, point.z);
 
         if (!singleColor && colors && primitive.colors.length > 0) {
-          const color = primitive.colors[i]!;
+          const color = primitive.colors[i] ? primitive.colors[i]! : missingColor;
+          // only trigger on last point index
+          if (i === primitive.points.length - 1 && color === missingColor) {
+            // will only show 1st triMeshIdx of issue -- addError prevents the adding of errors with duplicate errorIds
+            this.addError(
+              `${this.name}-${COLOR_LENGTH_ERROR_ID}`,
+              `Entity: ${this.userData.entity?.id}.triangles[${triMeshIdx}](1st index) - Colors array should be same size as points array, showing #00ff00 instead`,
+            );
+          }
           const r = (SRGBToLinear(color.r) * 255) | 0;
           const g = (SRGBToLinear(color.g) * 255) | 0;
           const b = (SRGBToLinear(color.b) * 255) | 0;
@@ -194,6 +205,7 @@ export class RenderableTriangles extends RenderablePrimitive {
     }
     this.clear();
     this._triangleMeshes.length = 0;
+    this.clearErrors();
   }
 
   public override update(


### PR DESCRIPTION
**User-Facing Changes**
 - n/a

**Description**
 - renderableTriangles now shows error when the colors array is shorter than the points array and displays a green debug color in its place
 - an error message will also be attached to the related topic
 - topic error tooltips are now scrollable and have a max size

<img width="1352" alt="Screen Shot 2022-10-06 at 4 30 27 PM" src="https://user-images.githubusercontent.com/10187776/194414561-d4b47f34-dff1-4f82-b75e-4f041aa99b0e.png">

<!-- link relevant github issues -->
Fixes #4559

<!-- add `docs` label if this PR requires documentation updates -->
