### PR TITLE
ColorGradientInput: display alpha color with checkerboard

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.stories.tsx
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useState } from "react";
+
+import { ColorGradientInput } from "./ColorGradientInput";
+
+export default {
+  title: "components/ColorGradientInput",
+  component: ColorGradientInput,
+};
+
+export function Default(): JSX.Element {
+  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+
+  return <ColorGradientInput colors={colors} onChange={setColors} />;
+}
+
+export function Disabled(): JSX.Element {
+  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+
+  return <ColorGradientInput disabled colors={colors} onChange={setColors} />;
+}
+
+export function ReadOnly(): JSX.Element {
+  const [colors, setColors] = useState<[string, string]>(["#ffaa00", "#0026ff"]);
+
+  return <ColorGradientInput readOnly colors={colors} onChange={setColors} />;
+}
+
+export function WithAlpha(): JSX.Element {
+  const [colors, setColors] = useState<[string, string]>(["#ffaa0088", "#0026ffcc"]);
+
+  return <ColorGradientInput colors={colors} onChange={setColors} />;
+}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -66,7 +66,7 @@ export function ColorGradientInput({
         opacity: disabled ? 0.5 : 1,
         pointerEvents: disabled ? "none" : "auto",
         position: "relative",
-        backgroundImage: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor})`,
+        background: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor}), repeating-conic-gradient(white 0 90deg, gray 90deg 180deg) top left/10px 10px repeat`,
       }}
     >
       <ColorSwatch color={safeLeftColor} onClick={handleLeftClick} />

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Popover, TextField } from "@mui/material";
+import { Popover, TextField, useTheme } from "@mui/material";
 import { useCallback, useState } from "react";
 import tinycolor from "tinycolor2";
 
@@ -59,6 +59,8 @@ export function ColorGradientInput({
   const safeLeftColor = tinycolor(leftColor).isValid() ? leftColor : "#000000";
   const safeRightColor = tinycolor(rightColor).isValid() ? rightColor : "#FFFFFF";
 
+  const theme = useTheme();
+
   return (
     <Stack
       direction="row"
@@ -66,7 +68,7 @@ export function ColorGradientInput({
         opacity: disabled ? 0.5 : 1,
         pointerEvents: disabled ? "none" : "auto",
         position: "relative",
-        background: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor}), repeating-conic-gradient(white 0 90deg, gray 90deg 180deg) top left/10px 10px repeat`,
+        background: `linear-gradient(to right, ${safeLeftColor}, ${safeRightColor}), repeating-conic-gradient(transparent 0 90deg, ${theme.palette.action.disabled} 90deg 180deg) top left/10px 10px repeat`,
       }}
     >
       <ColorSwatch color={safeLeftColor} onClick={handleLeftClick} />

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorSwatch.tsx
@@ -15,7 +15,9 @@ function calculateBorderColor(theme: Theme, color: string): string {
 export const ColorSwatch = muiStyled("div", {
   shouldForwardProp: (prop) => prop !== "color",
 })<{ color: string }>(({ theme, color }) => ({
-  backgroundColor: color,
+  // Color on top of white/black diagonal gradient. Color must be specified as a gradient because a
+  // background color can't be stacked on top of a background image.
+  background: `linear-gradient(${color}, ${color}), linear-gradient(to bottom right, white 50%, black 50%)`,
   aspectRatio: "1/1",
   width: theme.spacing(2.5),
   margin: theme.spacing(0.625),


### PR DESCRIPTION
**User-Facing Changes**
Colors and gradients with alpha values are now visually distinguishable in the settings editor.

<img width="443" alt="image" src="https://user-images.githubusercontent.com/14237/194445176-e391c9e5-c364-46d4-81d0-47c74eceee41.png">


**Description**
Relates to #4560 
Took the idea for the black/white diagonal thing from macOS color picker: 
<img width="270" alt="image" src="https://user-images.githubusercontent.com/14237/194445224-b6d6e11f-3921-4b0d-87e1-5af1383c9869.png">
