### PR TITLE
[3D] set Grid material transparent=false when only alpha=0 and alpha=1 values are present

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -20,7 +20,7 @@ import { BaseUserData, Renderable } from "../Renderable";
 import { Renderer } from "../Renderer";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
-import { rgbaToCssString, stringToRgba } from "../color";
+import { rgbaToCssString } from "../color";
 import {
   LASERSCAN_DATATYPES as FOXGLOVE_LASERSCAN_DATATYPES,
   POINTCLOUD_DATATYPES as FOXGLOVE_POINTCLOUD_DATATYPES,
@@ -46,6 +46,7 @@ import { makePose, MAX_DURATION, Pose } from "../transforms";
 import { updatePose } from "../updatePose";
 import {
   bestColorByField,
+  colorHasTransparency,
   ColorModeSettings,
   COLOR_FIELDS,
   getColorConverter,
@@ -1358,24 +1359,6 @@ export function createInstancePickingMaterial(
     side: THREE.DoubleSide,
     uniforms: { pointSize: { value: pointSize } },
   });
-}
-
-function colorHasTransparency(settings: LayerSettingsPointCloudAndLaserScan): boolean {
-  switch (settings.colorMode) {
-    case "flat":
-      return stringToRgba(tempColor, settings.flatColor).a < 1.0;
-    case "gradient":
-      return (
-        stringToRgba(tempColor, settings.gradient[0]).a < 1.0 ||
-        stringToRgba(tempColor, settings.gradient[1]).a < 1.0
-      );
-    case "colormap":
-    case "rgb":
-      return settings.explicitAlpha < 1.0;
-    case "rgba":
-      // It's too expensive to check the alpha value of each color. Just assume it's transparent
-      return true;
-  }
 }
 
 function pointCloudColorEncoding(settings: LayerSettingsPointCloudAndLaserScan): "srgb" | "linear" {


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Allows grids with fully transparent and fully opaque values to take advantage of alpha clipping, while still using the depth buffer.

Before | After
--- | ---
<img width="566" src="https://user-images.githubusercontent.com/14237/194450871-d4703d87-8dc7-4cbb-b6ea-7c36cd942468.png"> | <img width="566" alt="image" src="https://user-images.githubusercontent.com/14237/194450853-96c5bb9e-93b1-40cf-9551-e6bb35cfe83b.png">