### PR TITLE
Show error when point definition is not finite and skip the adding of the point

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
@@ -6,13 +6,14 @@ import * as THREE from "three";
 
 import type { Renderer } from "../../Renderer";
 import { rgbaToLinear } from "../../color";
-import { Marker } from "../../ros";
+import { Marker, Vector3 } from "../../ros";
 import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardVertexColorMaterial } from "./materials";
 
 const NOT_DIVISIBLE_ERR = "NOT_DIVISIBLE";
 const EMPTY_ERR = "EMPTY";
 const COLORS_MISMATCH_ERR = "COLORS_MISMATCH";
+const INVALID_POINT_ERR = "INVALID_POINT";
 const EMPTY_FLOAT32 = new Float32Array();
 
 const tempColor = { r: 0, g: 0, b: 0, a: 0 };
@@ -105,6 +106,14 @@ export class RenderableTriangleList extends RenderableMarker {
     // Update position/color buffers with the new marker data
     for (let i = 0; i < vertexCount; i++) {
       const point = marker.points[i]!;
+      if (!isPointValid(point)) {
+        this.renderer.settings.errors.addToTopic(
+          this.userData.topic,
+          INVALID_POINT_ERR,
+          `TRIANGLE_LIST: point at index ${i} is not finite`,
+        );
+        continue;
+      }
       dataChanged =
         dataChanged ||
         vertices[i * 3] !== point.x ||
@@ -139,4 +148,8 @@ export class RenderableTriangleList extends RenderableMarker {
       geometry.computeBoundingSphere();
     }
   }
+}
+
+function isPointValid(pt: Vector3): boolean {
+  return Number.isFinite(pt.x) && Number.isFinite(pt.y) && Number.isFinite(pt.z);
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -5,7 +5,7 @@
 import * as THREE from "three";
 
 import { toNanoSec } from "@foxglove/rostime";
-import { SceneEntity, TriangleListPrimitive } from "@foxglove/schemas";
+import { Point3, SceneEntity, TriangleListPrimitive } from "@foxglove/schemas";
 import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRender/DynamicBufferGeometry";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
@@ -19,6 +19,7 @@ const tempColor = new THREE.Color();
 const missingColor = { r: 0, g: 1.0, b: 0, a: 1.0 };
 
 const COLOR_LENGTH_ERROR_ID = "INVALID_COLOR_LENGTH";
+const INVALID_POINT_ERROR_ID = "INVALID_POINT";
 
 type TriangleMesh = THREE.Mesh<DynamicBufferGeometry, THREE.MeshStandardMaterial>;
 export class RenderableTriangles extends RenderablePrimitive {
@@ -83,6 +84,13 @@ export class RenderableTriangles extends RenderablePrimitive {
 
       for (let i = 0; i < primitive.points.length; i++) {
         const point = primitive.points[i]!;
+        if (!isPointValid(point)) {
+          this.addError(
+            `${this.name}-${INVALID_POINT_ERROR_ID}`,
+            `Entity: ${this.userData.entity?.id}.triangles[${triMeshIdx}](1st index) - Point definition at index ${i} is not finite`,
+          );
+          continue;
+        }
         vertChanged =
           vertChanged ||
           vertices.getX(i) !== point.x ||
@@ -238,4 +246,8 @@ function makeTriangleMesh(): TriangleMesh {
       side: THREE.DoubleSide,
     }),
   );
+}
+
+function isPointValid(pt: Point3): boolean {
+  return Number.isFinite(pt.x) && Number.isFinite(pt.y) && Number.isFinite(pt.z);
 }


### PR DESCRIPTION
**User-Facing Changes**
- n/a


**Description**
 - show error when point is not finite in triangle list marker and scene entities
- will continue reading in other points


<!-- link relevant github issues -->
Fixes #4558
<!-- add `docs` label if this PR requires documentation updates -->
