### PR TITLE
Fix race condition in Marker mesh_resource loading

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+export function disposeMaterial(material: THREE.Material): void {
+  if (material instanceof THREE.MeshStandardMaterial) {
+    material.map?.dispose();
+    material.lightMap?.dispose();
+    material.aoMap?.dispose();
+    material.emissiveMap?.dispose();
+    material.bumpMap?.dispose();
+    material.normalMap?.dispose();
+    material.displacementMap?.dispose();
+    material.roughnessMap?.dispose();
+    material.metalnessMap?.dispose();
+    material.alphaMap?.dispose();
+    material.envMap?.dispose();
+  }
+  material.dispose();
+}
+
+export function disposeMeshesRecursive(object: THREE.Object3D): void {
+  object.traverse((child) => {
+    if (child instanceof THREE.Mesh) {
+      child.geometry.dispose();
+      if (Array.isArray(child.material)) {
+        for (const material of child.material) {
+          if (material instanceof THREE.Material) {
+            disposeMaterial(material);
+          }
+        }
+      } else if (child.material instanceof THREE.Material) {
+        disposeMaterial(child.material);
+      }
+    }
+  });
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -6,6 +6,7 @@ import * as THREE from "three";
 
 import type { Renderer } from "../../Renderer";
 import { rgbToThreeColor } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
 import { removeLights, replaceMaterials } from "../models";
 import { RenderableMarker } from "./RenderableMarker";
@@ -22,6 +23,9 @@ export class RenderableMeshResource extends RenderableMarker {
   private mesh: THREE.Group | THREE.Scene | undefined;
   private material: THREE.MeshStandardMaterial;
 
+  /** Track updates to avoid race conditions when asynchronously loading models */
+  private updateId = 0;
+
   public constructor(
     topic: string,
     marker: Marker,
@@ -35,6 +39,9 @@ export class RenderableMeshResource extends RenderableMarker {
   }
 
   public override dispose(): void {
+    if (this.mesh) {
+      disposeMeshesRecursive(this.mesh);
+    }
     this.material.dispose();
   }
 
@@ -59,26 +66,49 @@ export class RenderableMeshResource extends RenderableMarker {
     this.material.opacity = marker.color.a;
 
     if (forceLoad === true || marker.mesh_resource !== prevMarker.mesh_resource) {
+      const curUpdateId = ++this.updateId;
+
       const opts = { useEmbeddedMaterials: marker.mesh_use_embedded_materials };
       const errors = this.renderer.settings.errors;
-      this._loadModel(marker.mesh_resource, opts).catch((err) => {
-        errors.add(
-          this.userData.settingsPath,
-          MESH_FETCH_FAILED,
-          `Unhandled error loading mesh from "${marker.mesh_resource}": ${err.message}`,
-        );
-      });
+      if (this.mesh) {
+        this.remove(this.mesh);
+        disposeMeshesRecursive(this.mesh);
+        this.mesh = undefined;
+      }
+      this._loadModel(marker.mesh_resource, opts)
+        .then((mesh) => {
+          if (!mesh) {
+            return;
+          }
+          if (this.updateId !== curUpdateId) {
+            // another update has started
+            disposeMeshesRecursive(mesh);
+            return;
+          }
+          this.mesh = mesh;
+          this.add(mesh);
+
+          // Remove any mesh fetch error message since loading was successful
+          this.renderer.settings.errors.remove(this.userData.settingsPath, MESH_FETCH_FAILED);
+          // Render a new frame now that the model is loaded
+          this.renderer.queueAnimationFrame();
+        })
+        .catch((err) => {
+          errors.add(
+            this.userData.settingsPath,
+            MESH_FETCH_FAILED,
+            `Unhandled error loading mesh from "${marker.mesh_resource}": ${err.message}`,
+          );
+        });
     }
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }
 
-  private async _loadModel(url: string, opts: { useEmbeddedMaterials: boolean }): Promise<void> {
-    if (this.mesh) {
-      this.remove(this.mesh);
-      this.mesh = undefined;
-    }
-
+  private async _loadModel(
+    url: string,
+    opts: { useEmbeddedMaterials: boolean },
+  ): Promise<THREE.Group | THREE.Scene | undefined> {
     const cachedModel = await this.renderer.modelCache.load(url, {}, (err) => {
       this.renderer.settings.errors.add(
         this.userData.settingsPath,
@@ -95,7 +125,7 @@ export class RenderableMeshResource extends RenderableMarker {
           `Failed to load mesh from "${url}"`,
         );
       }
-      return;
+      return undefined;
     }
 
     const mesh = cachedModel.clone(true);
@@ -104,12 +134,6 @@ export class RenderableMeshResource extends RenderableMarker {
       replaceMaterials(mesh, this.material);
     }
 
-    this.mesh = mesh;
-    this.add(mesh);
-
-    // Remove any mesh fetch error message since loading was successful
-    this.renderer.settings.errors.remove(this.userData.settingsPath, MESH_FETCH_FAILED);
-    // Render a new frame now that the model is loaded
-    this.renderer.queueAnimationFrame();
+    return mesh;
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -11,6 +11,7 @@ import { emptyPose } from "@foxglove/studio-base/util/Pose";
 import { LoadedModel } from "../../ModelCache";
 import type { Renderer } from "../../Renderer";
 import { makeRgba, rgbToThreeColor, stringToRgba } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { LayerSettingsEntity } from "../SceneEntities";
 import { removeLights, replaceMaterials } from "../models";
 import { RenderablePrimitive } from "./RenderablePrimitive";
@@ -229,8 +230,8 @@ export class RenderableModels extends RenderablePrimitive {
 
   private _disposeModel(renderable: RenderableModel) {
     renderable.material?.dispose();
-    disposeModel(renderable.model);
-    disposeModel(renderable.cachedModel);
+    disposeMeshesRecursive(renderable.model);
+    disposeMeshesRecursive(renderable.cachedModel);
   }
 }
 
@@ -238,26 +239,4 @@ function cloneAndPrepareModel(cachedModel: LoadedModel) {
   const model = cachedModel.clone(true);
   removeLights(model);
   return new THREE.Group().add(model);
-}
-
-function disposeModel(object: THREE.Object3D) {
-  object.traverse((child) => {
-    if (child instanceof THREE.Mesh) {
-      child.geometry.dispose();
-      if (child.material instanceof THREE.MeshStandardMaterial) {
-        child.material.map?.dispose();
-        child.material.lightMap?.dispose();
-        child.material.aoMap?.dispose();
-        child.material.emissiveMap?.dispose();
-        child.material.bumpMap?.dispose();
-        child.material.normalMap?.dispose();
-        child.material.displacementMap?.dispose();
-        child.material.roughnessMap?.dispose();
-        child.material.metalnessMap?.dispose();
-        child.material.alphaMap?.dispose();
-        child.material.envMap?.dispose();
-      }
-      child.material.dispose();
-    }
-  });
 }


### PR DESCRIPTION
**User-Facing Changes**
[3D] Fixed an issue where ROS mesh_resource markers would sometimes overwrite each other due to a race condition.

**Description**
Also added dispose() calls to RenderableMeshResource

Test data:
[models.mcap.zip](https://github.com/foxglove/studio/files/9736873/models.mcap.zip)
[layout.json.zip](https://github.com/foxglove/studio/files/9736875/layout.json.zip)
