### PR TITLE
Remove incorrect yarn install instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note: All contributors must agree to our [Contributor License Agreement](https:/
 
 **Dependencies:**
 
-- [Node.js](https://nodejs.org/en/) v16+
+- [Node.js](https://nodejs.org/en/) v16.10+
 - [Git LFS](https://git-lfs.github.com/)
 - [Visual Studio Code](https://code.visualstudio.com/) – Recommended
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Note: All contributors must agree to our [Contributor License Agreement](https:/
 **Dependencies:**
 
 - [Node.js](https://nodejs.org/en/) v16+
-- [Yarn](https://yarnpkg.com/getting-started/install) – `npm install -g yarn`
 - [Git LFS](https://git-lfs.github.com/)
 - [Visual Studio Code](https://code.visualstudio.com/) – Recommended
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Manually installing `yarn` is no longer necessary since we've moved to `corepack`. The instructions we provided to install yarn via `npm install -g yarn` are no longer the recommended install instructions on the yarn site either.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
