### PR TITLE
Improve plot and state transition panel zoom state handling

### DIFF
--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -29,6 +29,7 @@ const dataPoint = {
 const props: ComponentProps<typeof ChartComponent> = {
   width: 500,
   height: 700,
+  resetBounds: false,
   data: {
     datasets: [
       {

--- a/packages/studio-base/src/components/Chart/index.stories.tsx
+++ b/packages/studio-base/src/components/Chart/index.stories.tsx
@@ -29,7 +29,7 @@ const dataPoint = {
 const props: ComponentProps<typeof ChartComponent> = {
   width: 500,
   height: 700,
-  resetBounds: false,
+  isBoundsReset: false,
   data: {
     datasets: [
       {

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -8,7 +8,7 @@
 /// <reference types="chartjs-plugin-datalabels" />
 /// <reference types="@foxglove/chartjs-plugin-zoom" />
 
-import { ChartOptions, ChartData as ChartJsChartData, ScatterDataPoint } from "chart.js";
+import { ChartData as ChartJsChartData, ChartOptions, ScatterDataPoint } from "chart.js";
 import Hammer from "hammerjs";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
@@ -16,7 +16,9 @@ import { v4 as uuidv4 } from "uuid";
 
 import Logger from "@foxglove/log";
 import { RpcElement, RpcScales } from "@foxglove/studio-base/components/Chart/types";
-import ChartJsMux from "@foxglove/studio-base/components/Chart/worker/ChartJsMux";
+import ChartJsMux, {
+  ChartUpdateMessage,
+} from "@foxglove/studio-base/components/Chart/worker/ChartJsMux";
 import Rpc, { createLinkedChannels } from "@foxglove/studio-base/util/Rpc";
 import WebWorkerManager from "@foxglove/studio-base/util/WebWorkerManager";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
@@ -43,6 +45,7 @@ export type ChartData = ChartJsChartData<"scatter", (ScatterDataPoint | typeof C
 type Props = {
   data: ChartData;
   options: ChartOptions;
+  resetBounds: boolean;
   type: string;
   height: number;
   width: number;
@@ -106,7 +109,7 @@ function Chart(props: Props): JSX.Element {
   const zoomEnabled = props.options.plugins?.zoom?.zoom?.enabled ?? false;
   const panEnabled = props.options.plugins?.zoom?.pan?.enabled ?? false;
 
-  const { type, data, options, width, height, onStartRender, onFinishRender } = props;
+  const { type, data, resetBounds, options, width, height, onStartRender, onFinishRender } = props;
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -183,8 +186,7 @@ function Chart(props: Props): JSX.Element {
   // if they are unchanged from a previous initialization or update.
   const getNewUpdateMessage = useCallback(() => {
     const prev = previousUpdateMessage.current;
-    const out: Partial<{ width: number; height: number; data: ChartData; options: ChartOptions }> =
-      {};
+    const out: Partial<ChartUpdateMessage> = {};
 
     // NOTE(Roman): I don't know why this happens but when I initialize a chart using some data
     // and width/height of 0. Even when I later send an update for correct width/height the chart
@@ -209,13 +211,15 @@ function Chart(props: Props): JSX.Element {
       prev.width = out.width = width;
     }
 
+    out.resetBounds = resetBounds;
+
     // nothing to update
     if (Object.keys(out).length === 0) {
       return;
     }
 
     return out;
-  }, [data, height, options, width]);
+  }, [data, height, options, resetBounds, width]);
 
   const { error: updateError } = useAsync(async () => {
     if (!sendWrapperRef.current) {

--- a/packages/studio-base/src/components/Chart/index.tsx
+++ b/packages/studio-base/src/components/Chart/index.tsx
@@ -45,7 +45,7 @@ export type ChartData = ChartJsChartData<"scatter", (ScatterDataPoint | typeof C
 type Props = {
   data: ChartData;
   options: ChartOptions;
-  resetBounds: boolean;
+  isBoundsReset: boolean;
   type: string;
   height: number;
   width: number;
@@ -109,7 +109,8 @@ function Chart(props: Props): JSX.Element {
   const zoomEnabled = props.options.plugins?.zoom?.zoom?.enabled ?? false;
   const panEnabled = props.options.plugins?.zoom?.pan?.enabled ?? false;
 
-  const { type, data, resetBounds, options, width, height, onStartRender, onFinishRender } = props;
+  const { type, data, isBoundsReset, options, width, height, onStartRender, onFinishRender } =
+    props;
 
   const sendWrapperRef = useRef<RpcSend | undefined>();
   const rpcSendRef = useRef<RpcSend | undefined>();
@@ -211,7 +212,7 @@ function Chart(props: Props): JSX.Element {
       prev.width = out.width = width;
     }
 
-    out.resetBounds = resetBounds;
+    out.isBoundsReset = isBoundsReset;
 
     // nothing to update
     if (Object.keys(out).length === 0) {
@@ -219,7 +220,7 @@ function Chart(props: Props): JSX.Element {
     }
 
     return out;
-  }, [data, height, options, resetBounds, width]);
+  }, [data, height, options, isBoundsReset, width]);
 
   const { error: updateError } = useAsync(async () => {
     if (!sendWrapperRef.current) {

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -184,11 +184,13 @@ export default class ChartJSManager {
     options,
     width,
     height,
+    resetBounds,
     data,
   }: {
     options?: ChartOptions;
     width?: number;
     height?: number;
+    resetBounds: boolean;
     data?: ChartData;
   }): RpcScales {
     const instance = this._chartInstance;
@@ -213,8 +215,17 @@ export default class ChartJSManager {
       }
 
       // If the user manually zoomed or panned this chart we avoid updating the scales since they have updated.
-      if (!this._hasZoomed && !this._hasPanned) {
-        instance.options.scales = options.scales;
+      if (!this._hasZoomed && !this._hasPanned && instance.options.scales) {
+        instance.options.scales.x = scales.x;
+      }
+
+      // Let the chart manage its own y scale unless we've been told to reset or if an explicit
+      // min and max have been specified.
+      if (
+        (resetBounds || (scales.y?.min != undefined && scales.y.max != undefined)) &&
+        instance.options.scales
+      ) {
+        instance.options.scales.y = scales.y;
       }
     }
 
@@ -299,7 +310,7 @@ export default class ChartJSManager {
       });
     }
 
-    // sort elemtents by proximity to the cursor
+    // sort elements by proximity to the cursor
     out.sort((itemA, itemB) => {
       const dxA = event.clientX - itemA.view.x;
       const dyA = event.clientY - itemA.view.y;

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -69,8 +69,6 @@ export default class ChartJSManager {
   private _fakeNodeEvents = new EventEmitter();
   private _fakeDocumentEvents = new EventEmitter();
   private _lastDatalabelClickContext?: DatalabelContext;
-  private _hasZoomed = false;
-  private _hasPanned = false;
 
   public constructor(initOpts: InitOpts) {
     log.info(`new ChartJSManager(id=${initOpts.id})`);
@@ -201,21 +199,9 @@ export default class ChartJSManager {
     if (options != undefined) {
       instance.options.plugins = this.addFunctionsToConfig(options).plugins;
 
-      // If the options specify specific values for min/max then we go back into a state where scales are updated
-      // We need scales to update with undefined values if we haven't zoomed so new data is shown on the chart.
-      // If we do not update the scales to undefined, the initial zoom range stays and new data is not visible.
-      const scales = options.scales ?? {};
-      if (scales.x?.min != undefined && scales.x.max != undefined) {
-        this._hasPanned = false;
-        this._hasZoomed = false;
-      }
-      if (scales.y?.min != undefined && scales.y.max != undefined) {
-        this._hasPanned = false;
-        this._hasZoomed = false;
-      }
-
       // Let the chart manage its own scales unless we've been told to reset or if an explicit
       // min and max have been specified.
+      const scales = options.scales ?? {};
       if (
         (resetBounds || (scales.x?.min != undefined && scales.x.max != undefined)) &&
         instance.options.scales
@@ -384,18 +370,6 @@ export default class ChartJSManager {
         // eslint-disable-next-line no-restricted-syntax
         return value.label ?? null;
       };
-
-      if (config.plugins.zoom?.zoom) {
-        config.plugins.zoom.zoom.onZoom = () => {
-          this._hasZoomed = true;
-        };
-      }
-
-      if (config.plugins.zoom?.pan) {
-        config.plugins.zoom.pan.onPan = () => {
-          this._hasPanned = true;
-        };
-      }
 
       // Override color so that it can be set per-dataset.
       const staticColor = config.plugins.datalabels.color ?? "white";

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -182,13 +182,13 @@ export default class ChartJSManager {
     options,
     width,
     height,
-    resetBounds,
+    isBoundsReset,
     data,
   }: {
     options?: ChartOptions;
     width?: number;
     height?: number;
-    resetBounds: boolean;
+    isBoundsReset: boolean;
     data?: ChartData;
   }): RpcScales {
     const instance = this._chartInstance;
@@ -203,13 +203,13 @@ export default class ChartJSManager {
       // min and max have been specified.
       const scales = options.scales ?? {};
       if (
-        (resetBounds || (scales.x?.min != undefined && scales.x.max != undefined)) &&
+        (isBoundsReset || (scales.x?.min != undefined && scales.x.max != undefined)) &&
         instance.options.scales
       ) {
         instance.options.scales.x = scales.x;
       }
       if (
-        (resetBounds || (scales.y?.min != undefined && scales.y.max != undefined)) &&
+        (isBoundsReset || (scales.y?.min != undefined && scales.y.max != undefined)) &&
         instance.options.scales
       ) {
         instance.options.scales.y = scales.y;

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -214,13 +214,14 @@ export default class ChartJSManager {
         this._hasZoomed = false;
       }
 
-      // If the user manually zoomed or panned this chart we avoid updating the scales since they have updated.
-      if (!this._hasZoomed && !this._hasPanned && instance.options.scales) {
+      // Let the chart manage its own scales unless we've been told to reset or if an explicit
+      // min and max have been specified.
+      if (
+        (resetBounds || (scales.x?.min != undefined && scales.x.max != undefined)) &&
+        instance.options.scales
+      ) {
         instance.options.scales.x = scales.x;
       }
-
-      // Let the chart manage its own y scale unless we've been told to reset or if an explicit
-      // min and max have been specified.
       if (
         (resetBounds || (scales.y?.min != undefined && scales.y.max != undefined)) &&
         instance.options.scales

--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -12,22 +12,22 @@
 //   You may not use this file except in compliance with the License.
 
 import {
-  Chart,
-  Ticks,
-  LineElement,
-  PointElement,
-  LineController,
-  ScatterController,
   CategoryScale,
-  LinearScale,
-  TimeScale,
-  TimeSeriesScale,
+  Chart,
+  ChartData,
+  ChartOptions,
   Filler,
   Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  ScatterController,
+  Ticks,
+  TimeScale,
+  TimeSeriesScale,
   Title,
   Tooltip,
-  ChartOptions,
-  ChartData,
 } from "chart.js";
 import AnnotationPlugin from "chartjs-plugin-annotation";
 
@@ -39,13 +39,17 @@ import ChartJSManager, { InitOpts } from "./ChartJSManager";
 
 type RpcEvent<EventType> = { id: string; event: EventType };
 
+export type ChartUpdateMessage = {
+  data?: ChartData;
+  height?: number;
+  options?: ChartOptions;
+  resetBounds: boolean;
+  width?: number;
+};
+
 type RpcUpdateEvent = {
   id: string;
-  options?: ChartOptions;
-  width?: number;
-  height?: number;
-  data?: ChartData;
-};
+} & ChartUpdateMessage;
 
 // Explicitly load the "Plex Mono" font, since custom fonts from the main renderer are not inherited
 // by web workers. This is required to draw "Plex Mono" on an OffscreenCanvas, and it also appears
@@ -114,8 +118,8 @@ function fixTicks(args: RpcUpdateEvent): RpcUpdateEvent {
 // Since we use a capped number of web-workers, a single web-worker may be running multiple chartjs instances
 // The ChartJsWorkerMux forwards an rpc request for a specific chartjs instance id to the appropriate instance
 export default class ChartJsMux {
-  private _rpc: Rpc;
-  private _managers = new Map<string, ChartJSManager>();
+  private readonly _rpc: Rpc;
+  private readonly _managers = new Map<string, ChartJSManager>();
 
   public constructor(rpc: Rpc) {
     this._rpc = rpc;

--- a/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJsMux.ts
@@ -43,7 +43,7 @@ export type ChartUpdateMessage = {
   data?: ChartData;
   height?: number;
   options?: ChartOptions;
-  resetBounds: boolean;
+  isBoundsReset: boolean;
   width?: number;
 };
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -99,6 +99,7 @@ type ChartComponentProps = ComponentProps<typeof ChartComponent>;
 // eslint-disable-next-line no-restricted-syntax
 const ChartNull = null;
 
+const selectGlobalBounds = (store: TimelineInteractionStateStore) => store.globalBounds;
 const selectSetGlobalBounds = (store: TimelineInteractionStateStore) => store.setGlobalBounds;
 
 // Calculation mode for the "reset view" view.
@@ -206,15 +207,14 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
   const hoverBar = useRef<HTMLDivElement>(ReactNull);
 
-  // Ignore global bounds if we're not synced.
-  const globalBoundsSelector = useCallback(
-    (store: TimelineInteractionStateStore) => {
-      return isSynced ? store.globalBounds : undefined;
-    },
-    [isSynced],
-  );
-  const globalBounds = useTimelineInteractionState(globalBoundsSelector);
+  const globalBounds = useTimelineInteractionState(selectGlobalBounds);
   const setGlobalBounds = useTimelineInteractionState(selectSetGlobalBounds);
+
+  // Ignore global bounds if we're not synced.
+  const syncedGlobalBounds = useMemo(
+    () => (isSynced ? globalBounds : undefined),
+    [globalBounds, isSynced],
+  );
 
   const linesToHide = useMemo(() => props.linesToHide ?? {}, [props.linesToHide]);
 
@@ -460,13 +460,13 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   // we memo the min/max X values so only when the values change is the scales object re-made
   const { min: minX, max: maxX } = useMemo(() => {
     // when unlocking sync keep the last manually panned/zoomed chart state
-    if (!globalBounds && hasUserPannedOrZoomed) {
+    if (!syncedGlobalBounds && hasUserPannedOrZoomed) {
       return { min: undefined, max: undefined };
     }
 
     // If we're the source of global bounds then use our current values
     // to avoid scale feedback jitter.
-    if (globalBounds?.sourceId === componentId && globalBounds.userInteraction) {
+    if (syncedGlobalBounds?.sourceId === componentId && syncedGlobalBounds.userInteraction) {
       return { min: undefined, max: undefined };
     }
 
@@ -486,9 +486,9 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     }
 
     // If the global bounds are from user interaction, we use that unconditionally.
-    if (globalBounds?.userInteraction === true) {
-      min = globalBounds.min;
-      max = globalBounds.max;
+    if (syncedGlobalBounds?.userInteraction === true) {
+      min = syncedGlobalBounds.min;
+      max = syncedGlobalBounds.max;
     }
 
     // if the min/max are the same, use undefined to fall-back to chart component auto-scales
@@ -504,7 +504,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     datasetBounds.x.max,
     datasetBounds.x.min,
     defaultView,
-    globalBounds,
+    syncedGlobalBounds,
     hasUserPannedOrZoomed,
   ]);
 
@@ -804,8 +804,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
   // The reason we check for pan lock is to remove reset display from all sync'd plots once
   // the range has been reset.
   const showReset = useMemo(() => {
-    return isSynced ? globalBounds?.userInteraction === true : hasUserPannedOrZoomed;
-  }, [globalBounds?.userInteraction, hasUserPannedOrZoomed, isSynced]);
+    return isSynced ? syncedGlobalBounds?.userInteraction === true : hasUserPannedOrZoomed;
+  }, [syncedGlobalBounds?.userInteraction, hasUserPannedOrZoomed, isSynced]);
 
   // We don't memo this since each option itself is memo'd and this is just convenience to pass to
   // the component.
@@ -813,6 +813,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     type,
     width,
     height,
+    resetBounds: globalBounds == undefined,
     options,
     data: downsampledData,
     onClick: props.onClick,

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -813,7 +813,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     type,
     width,
     height,
-    resetBounds: globalBounds == undefined,
+    isBoundsReset: globalBounds == undefined,
     options,
     data: downsampledData,
     onClick: props.onClick,

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -450,6 +450,7 @@ function TwoDimensionalPlot(props: Props) {
               width={width}
               height={height}
               options={options}
+              resetBounds={false}
               onScalesUpdate={onScaleBoundsUpdate}
               onHover={onHover}
               data={data}

--- a/packages/studio-base/src/panels/LegacyPlot/index.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.tsx
@@ -450,7 +450,7 @@ function TwoDimensionalPlot(props: Props) {
               width={width}
               height={height}
               options={options}
-              resetBounds={false}
+              isBoundsReset={false}
               onScalesUpdate={onScaleBoundsUpdate}
               onHover={onHover}
               data={data}

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -11,6 +11,8 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
 
@@ -429,7 +431,7 @@ export function LineGraphWithSettings(): JSX.Element {
   return (
     <PlotWrapper
       pauseFrame={pauseFrame}
-      config={{ ...exampleConfig, minYValue: 1, maxYValue: -1, minXValue: 0, maxXValue: 3 }}
+      config={{ ...exampleConfig, minYValue: -1, maxYValue: 1, minXValue: 0, maxXValue: 3 }}
       includeSettings
     />
   );
@@ -437,6 +439,11 @@ export function LineGraphWithSettings(): JSX.Element {
 LineGraphWithSettings.parameters = {
   colorScheme: "light",
   useReadySignal: true,
+};
+LineGraphWithSettings.play = async () => {
+  const user = userEvent.setup();
+  const label = await screen.findByText("Y Axis");
+  await user.click(label);
 };
 
 LineGraphWithLegendsHidden.storyName = "line graph with legends hidden";
@@ -644,6 +651,7 @@ export function WithMinAndMaxYValues(): JSX.Element {
 
   return (
     <PlotWrapper
+      includeSettings
       pauseFrame={pauseFrame}
       config={{
         ...exampleConfig,
@@ -661,7 +669,13 @@ export function WithMinAndMaxYValues(): JSX.Element {
   );
 }
 WithMinAndMaxYValues.parameters = {
+  colorScheme: "light",
   useReadySignal: true,
+};
+WithMinAndMaxYValues.play = async () => {
+  const user = userEvent.setup();
+  const label = await screen.findByText("Y Axis");
+  await user.click(label);
 };
 
 WithJustMinYValueLessThanMinimumValue.storyName = "with just min Y value less than minimum value";

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -384,7 +384,7 @@ function Plot(props: Props) {
             accumulated[path] = [[plotDataItem]];
           } else {
             const plotDataPath = (accumulated[path] ??= [[]]);
-            // PlotDataPaths have 2d arrays of items to accomodate blocks which may have gaps so
+            // PlotDataPaths have 2d arrays of items to accommodate blocks which may have gaps so
             // each continuous set of blocks forms one continuous line. For streaming messages we
             // treat this as one continuous set of items and always add to the first "range"
             const plotDataItems = plotDataPath[0]!;


### PR DESCRIPTION
**User-Facing Changes**
Improves handling of plot and state transition panel zoom state.

**Description**
Change ChartJSManager to respect and not change existing, user manipulated scales except in two cases:
1. When an explicit min/max are specified in settings those take precedence.
2. When we pass an explicit `isBoundsReset` flag in the update message.

The second case is necessary because a min/max of `undefined` is currently interpreted as an intention to let the chart determine its own bounds based on the dataset but this has the side effect of clearing any change in the scale the user has initiated directly, so we want to avoid this unless the user has clicked the "reset view" button, which we currently interpret as a temporary absence of global bounds.

https://user-images.githubusercontent.com/93935560/194870062-2b7d7123-2422-400e-aa35-fc99fd4fb25e.mov

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4351
Fixes #4684