### PR TITLE
Move the center of the Map panel GeoJSON story

### DIFF
--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -290,7 +290,7 @@ SinglePointFullCovariance.parameters = {
   },
 };
 
-const GeoCenter = { lat: 34.9949, lon: 135.785 };
+const GeoCenter = { lat: 0.25, lon: 0.25 };
 
 export const GeoJSON = (): JSX.Element => {
   const topics: Topic[] = [


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Move the center of the Map panel GeoJSON story away from an urban area which is subject to frequent map changes so the story isn't incorrectly flagged as changed by chromatic.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
