### PR TITLE
Add media-src to desktop app CSP

### DIFF
--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -254,6 +254,7 @@ function main() {
       "font-src": "'self' data:",
       // Include http in the CSP to allow loading images (i.e. map tiles) from http endpoints like localhost
       "img-src": "'self' data: https: package: x-foxglove-converted-tiff: http:",
+      "media-src": "'self' data: https: http: blob: file:",
     };
     const cspHeader = Object.entries(contentSecurityPolicy)
       .map(([key, val]) => `${key} ${val}`)


### PR DESCRIPTION
**User-Facing Changes**
Users can load extensions into the desktop app which make use of media elements.

**Description**
Allows for media elements within Studio extensions. Brings parity with what the web app app allowed.

Fixes: #4614 


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
