### PR TITLE
Add `playbackSpeed` to `PanelExtensionAdapter.RenderState`

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -193,6 +193,14 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       }
     }
 
+    if (watchedFields.has("playbackSpeed")) {
+      const playbackSpeed = activeData?.speed;
+      if (playbackSpeed !== renderState.playbackSpeed) {
+        renderState.playbackSpeed = playbackSpeed;
+        shouldRender = true;
+      }
+    }
+
     if (!shouldRender) {
       return undefined;
     }

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -193,6 +193,9 @@ declare module "@foxglove/studio" {
 
     /** Application settings. This will only contain subscribed application setting key/values */
     appSettings?: ReadonlyMap<string, AppSettingValue>;
+
+    /** The speed of playback currently set on the player. */
+    playbackSpeed?: number;
   }
 
   export type PanelExtensionContext = {


### PR DESCRIPTION
**User-Facing Changes**

Adding `playbackSpeed` to `@foxglove/studio/RenderState` so that extensions can react to changes to the playback speed.

**Description**

For certain extensions, it might be required to know the current playback speed. For example my [experimental H64 extension](https://github.com/codewithpassion/foxglove-studio-h264-extension). 

This PR is adding a `playbackSpeed` to the extension context render state.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
