### PR TITLE
Incorrect use of "Render Frame" for grid "Frame" selection.

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1255,7 +1255,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
         this.fixedFrameId = undefined;
         return;
       } else {
-        log.debug(`Setting display frame to ${this.renderFrameId}`);
+        log.debug(`Setting render frame to ${this.renderFrameId}`);
         this.settings.errors.remove(FOLLOW_TF_PATH, NO_FRAME_SELECTED);
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1255,7 +1255,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
         this.fixedFrameId = undefined;
         return;
       } else {
-        log.debug(`Setting render frame to ${this.renderFrameId}`);
+        log.debug(`Setting display frame to ${this.renderFrameId}`);
         this.settings.errors.remove(FOLLOW_TF_PATH, NO_FRAME_SELECTED);
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -106,7 +106,7 @@ export class Grids extends SceneExtension<GridRenderable> {
 
       const config = layerConfig as Partial<LayerSettingsGrid>;
       const frameIdOptions = [
-        { label: "<Render Frame>", value: undefined },
+        { label: "Display frame", value: undefined },
         ...this.renderer.coordinateFrameList,
       ];
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Grids.ts
@@ -106,7 +106,7 @@ export class Grids extends SceneExtension<GridRenderable> {
 
       const config = layerConfig as Partial<LayerSettingsGrid>;
       const frameIdOptions = [
-        { label: "Display frame", value: undefined },
+        { label: "<Display frame>", value: undefined },
         ...this.renderer.coordinateFrameList,
       ];
 


### PR DESCRIPTION
**User-Facing Changes**
 n/a


**Description**
 - changed `Render Frame` to `Display frame`
 - also updated a log that was using similar terminology

<!-- link relevant github issues -->
Fixes #4619
<!-- add `docs` label if this PR requires documentation updates -->
