### PR TITLE
3D Panel will error on cyclical transforms within the TransformTree

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -27,7 +27,6 @@ const tempVec4: vec4 = [0, 0, 0, 0];
 const tempTransform = Transform.Identity();
 const tempMatrix = mat4Identity();
 const temp2Matrix = mat4Identity();
-const visitedNodes = new Set<string>();
 
 /**
  * CoordinateFrame is a named 3D coordinate frame with an optional parent frame
@@ -70,16 +69,7 @@ export class CoordinateFrame {
   public root(): CoordinateFrame {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let root: CoordinateFrame = this;
-
-    visitedNodes.clear();
     while (root._parent) {
-      if (visitedNodes.has(root._parent.id)) {
-        throw new Error(
-          `Frame "${this.id}" has no root frame. Frame "${root.id}" creates a cycle to frame "${root._parent.id}" in the transform tree.`,
-        );
-        break;
-      }
-      visitedNodes.add(root.id);
       root = root._parent;
     }
     return root;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -27,6 +27,7 @@ const tempVec4: vec4 = [0, 0, 0, 0];
 const tempTransform = Transform.Identity();
 const tempMatrix = mat4Identity();
 const temp2Matrix = mat4Identity();
+const visitedNodes = new Set<string>();
 
 /**
  * CoordinateFrame is a named 3D coordinate frame with an optional parent frame
@@ -69,7 +70,16 @@ export class CoordinateFrame {
   public root(): CoordinateFrame {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let root: CoordinateFrame = this;
+
+    visitedNodes.clear();
     while (root._parent) {
+      if (visitedNodes.has(root._parent.id)) {
+        throw new Error(
+          `Frame "${this.id}" has no root frame. Frame "${root.id}" creates a cycle to frame "${root._parent.id}" in the transform tree.`,
+        );
+        break;
+      }
+      visitedNodes.add(root.id);
       root = root._parent;
     }
     return root;

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Transform } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms/Transform";
+
+import { TransformTree } from "./TransformTree";
+
+const tf = Transform.Identity();
+const bigint = BigInt("0");
+describe("TransformTree", () => {
+  it("does not error when adding a transform that would not create a cycle", () => {
+    const tfTree = new TransformTree();
+    expect(() => {
+      tfTree.addTransform("b", "a", bigint, tf);
+      tfTree.addTransform("c", "b", bigint, tf);
+      tfTree.addTransform("d", "c", bigint, tf);
+    }).not.toThrow(/cycle/i);
+  });
+  it("errors when adding a transform that would create a cycle with 2 frames", () => {
+    const tfTree = new TransformTree();
+    // a <- b
+    tfTree.addTransform("b", "a", bigint, tf);
+    // b <- a <- b ERROR - cycle created
+    expect(() => tfTree.addTransform("a", "b", bigint, tf)).toThrow(/cycle/i);
+  });
+  it("errors when adding a transform that would create a cycle with 3 frames", () => {
+    const tfTree = new TransformTree();
+    // a <- b
+    tfTree.addTransform("b", "a", bigint, tf);
+    // a <- b <- c
+    tfTree.addTransform("c", "b", bigint, tf);
+    // c <- a <- b <- c  ERROR - cycle created
+    expect(() => tfTree.addTransform("a", "c", bigint, tf)).toThrow(/cycle/i);
+  });
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -36,6 +36,8 @@ export class TransformTree {
     const frame = this.getOrCreateFrame(frameId);
     const curParentFrame = frame.parent();
     if (curParentFrame == undefined || curParentFrame.id !== parentFrameId) {
+      // will throw error if cycle is created
+      this._checkParentForCycle(frameId, parentFrameId);
       // This frame was previously unparented but now we know its parent, or we
       // are reparenting this frame
       frame.setParent(this.getOrCreateFrame(parentFrameId));
@@ -136,6 +138,18 @@ export class TransformTree {
     }
 
     return output;
+  }
+  private _checkParentForCycle(frameId: string, parentFrameId: string) {
+    // walk up tree from parent Frame to check if it eventually crosses the frame
+    let frame = this.frame(parentFrameId);
+    while (frame?.parent()) {
+      if (frame.parent()?.id === frameId) {
+        throw Error(
+          `Transform tree cycle detected: Cannot add parent frame "${parentFrameId}" to frame"${frameId}. Aborted adding of transform.`,
+        );
+      }
+      frame = frame.parent();
+    }
   }
 
   public static Clone(tree: TransformTree): TransformTree {

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -145,7 +145,7 @@ export class TransformTree {
     while (frame?.parent()) {
       if (frame.parent()?.id === frameId) {
         throw Error(
-          `Transform tree cycle detected: Cannot add parent frame "${parentFrameId}" to frame"${frameId}. Aborted adding of transform.`,
+          `Transform tree cycle detected: Cannot set parent frame "${parentFrameId}" to frame "${frameId}. Aborted adding of transform.`,
         );
       }
       frame = frame.parent();


### PR DESCRIPTION
**User-Facing Changes**
 - 3D panel will throw an error when a file attempts to add a cyclical transform to the tree. The error tells them what parent/child frame pair first caused the cycle.
 - user must fix file in order to load transforms

**Description**
 - cycles in the transform tree will throw an error instead of freezing the chrome tab.
<img width="959" alt="image" src="https://user-images.githubusercontent.com/10187776/195429903-49b7b92f-5777-47c9-94cd-d8bc2690e1ef.png">


<!-- link relevant github issues -->
Fixes #4618
<!-- add `docs` label if this PR requires documentation updates -->
