### PR TITLE
Allow ros1 encoded messages for foxglove websocket

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -158,6 +158,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
             if (base64.decode(channel.schema, schemaData, 0) !== schemaData.byteLength) {
               throw new Error(`Failed to decode base64 schema on channel ${channel.id}`);
             }
+          } else if (channel.encoding === "ros1") {
+            schemaEncoding = "ros1msg";
+            schemaData = new TextEncoder().encode(channel.schema);
           } else {
             throw new Error(`Unsupported encoding ${channel.encoding}`);
           }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Allows subscribing to ros1 encoded messages that are send using the [foxglove websocket protocol](https://github.com/foxglove/ws-protocol/blob/87cae3504c560c65503e24c43620d75d54999bb8/docs/spec.md).
