### PR TITLE
Revert ROS1 player to bind on ROS_HOSTNAME

### DIFF
--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -114,15 +114,7 @@ export default class Ros1Player implements Player {
     };
     const tcpServer = await net.createServer();
 
-    // Mirror the ros_comm c++ library behavior when setting up the tcp server listener.
-    // ros_comm listens on all interfaces unless the hostname is explicity set to 'localhost'
-    // https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport/transport_tcp.cpp#L393-L395
-    // https://github.com/ros/ros_comm/blob/f5fa3a168760d62e9693f10dcb9adfffc6132d22/clients/roscpp/src/libros/transport/transport.cpp#L67-L72
-    let listenHostname = undefined;
-    if (hostname === "localhost") {
-      listenHostname = "localhost";
-    }
-    await tcpServer.listen(undefined, listenHostname, 10);
+    await tcpServer.listen(undefined, hostname, 10);
 
     if (this._rosNode == undefined) {
       const rosNode = new RosNode({


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue in publishing to a ROS1 system from studio.

**Description**
Fixes regression from https://github.com/foxglove/studio/pull/4400.

The issue is that the `hostname` we pass to the TCP server `listen` call is returned in the `requestTopic` call:

https://github.com/foxglove/ros1/blob/73839e31c678749042651ff852fa39a1e4634f29/src/RosFollower.ts#L175-L198

This needs to be an actual IP address that other subscribers can reach so returning something like `localhost` or `0.0.0.0` is nonsensical and breaks subscribers.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4598 