### PR TITLE
Allow settings fields to shrink below intrinsic width, truncating text

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
       whiteSpace: "nowrap",
     },
     fieldWrapper: {
-      minWidth: 0,
+      minWidth: theme.spacing(14),
       marginRight: theme.spacing(1.25),
       [`&.${classes.error}`]: {
         ".MuiInputBase-root": {

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
       whiteSpace: "nowrap",
     },
     fieldWrapper: {
+      minWidth: 0,
       marginRight: theme.spacing(1.25),
       [`&.${classes.error}`]: {
         ".MuiInputBase-root": {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes https://github.com/foxglove/studio/issues/4583

Before | After
--- | ---
<img width="434" alt="image" src="https://user-images.githubusercontent.com/14237/194437598-41c59468-2fda-418b-a01c-c2248538be95.png"> | <img width="398" alt="image" src="https://user-images.githubusercontent.com/14237/195688696-97868dc1-b21c-490b-bf2b-f72331628fbf.png">

