### PR TITLE
Improve Cyclical Transform Error state

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -950,13 +950,13 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.settings.errors.add(
         ["transforms", `frame:${childFrameId}`],
         CYCLE_DETECTED,
-        `Transform tree cycle detected: Received transform with parent "${parentFrameId}" and child "${childFrameId}", but "${childFrameId}" is already an ancestor of "${parentFrameId}".`,
+        `Transform tree cycle detected: Received transform with parent "${parentFrameId}" and child "${childFrameId}", but "${childFrameId}" is already an ancestor of "${parentFrameId}". Transform message dropped.`,
       );
       if (errorSettingsPath) {
         this.settings.errors.add(
           errorSettingsPath,
           CYCLE_DETECTED,
-          `Attempted to add cyclical transform: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}". Frame was not re-parented`,
+          `Attempted to add cyclical transform: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}". Transform message dropped.`,
         );
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -71,7 +71,7 @@ import {
   Vector3,
 } from "./ros";
 import { BaseSettings, CustomLayerSettings, SelectEntry } from "./settings";
-import { makePose, Pose, Transform, TransformTree } from "./transforms";
+import { AddTransformResult, makePose, Pose, Transform, TransformTree } from "./transforms";
 
 const log = Logger.getLogger(__filename);
 
@@ -939,19 +939,14 @@ export class Renderer extends EventEmitter<RendererEvents> {
     const q = rotation;
 
     const transform = new Transform([t.x, t.y, t.z], [q.x, q.y, q.z, q.w]);
-    const { updated, cycleDetected } = this.transformTree.addTransform(
-      childFrameId,
-      parentFrameId,
-      stamp,
-      transform,
-    );
+    const status = this.transformTree.addTransform(childFrameId, parentFrameId, stamp, transform);
 
-    if (updated) {
+    if (status === AddTransformResult.UPDATED) {
       this.coordinateFrameList = this.transformTree.frameList();
       this.emit("transformTreeUpdated", this);
     }
 
-    if (cycleDetected) {
+    if (status === AddTransformResult.CYCLE_DETECTED) {
       this.settings.errors.add(
         ["transforms", `frame:${childFrameId}`],
         CYCLE_DETECTED,

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -955,13 +955,13 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.settings.errors.add(
         ["transforms", `frame:${childFrameId}`],
         CYCLE_DETECTED,
-        `Transform tree cycle detected: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}. Frame was not re-parented`,
+        `Transform tree cycle detected: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}". Frame was not re-parented`,
       );
       if (errorSettingsPath) {
         this.settings.errors.add(
           errorSettingsPath,
           CYCLE_DETECTED,
-          `Attempted to add cyclical transform: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}. Frame was not re-parented`,
+          `Attempted to add cyclical transform: Frame "${parentFrameId}" cannot be the parent of frame "${childFrameId}". Frame was not re-parented`,
         );
       }
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -585,8 +585,10 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     this.transformsByInstanceId.set(instanceId, transforms);
 
     // Import all transforms from the URDF into the scene
+    const isTopic = instanceId === TOPIC_NAME;
+    const settingsPath = isTopic ? ["topics", TOPIC_NAME] : ["layers", instanceId];
     for (const { parent, child, translation, rotation } of transforms) {
-      this.renderer.addTransform(parent, child, 0n, translation, rotation);
+      this.renderer.addTransform(parent, child, 0n, translation, rotation, settingsPath);
     }
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -11,18 +11,22 @@ const bigint = BigInt("0");
 describe("TransformTree", () => {
   it("does not error when adding a transform that would not create a cycle", () => {
     const tfTree = new TransformTree();
-    expect(() => {
-      tfTree.addTransform("b", "a", bigint, tf);
-      tfTree.addTransform("c", "b", bigint, tf);
-      tfTree.addTransform("d", "c", bigint, tf);
-    }).not.toThrow(/cycle/i);
+    tfTree.addTransform("b", "a", bigint, tf);
+    tfTree.addTransform("c", "b", bigint, tf);
+    expect(tfTree.addTransform("d", "c", bigint, tf)).toEqual({
+      cycleDetected: false,
+      updated: true,
+    });
   });
   it("errors when adding a transform that would create a cycle with 2 frames", () => {
     const tfTree = new TransformTree();
     // a <- b
     tfTree.addTransform("b", "a", bigint, tf);
     // b <- a <- b ERROR - cycle created
-    expect(() => tfTree.addTransform("a", "b", bigint, tf)).toThrow(/cycle/i);
+    expect(tfTree.addTransform("a", "b", bigint, tf)).toEqual({
+      cycleDetected: true,
+      updated: false,
+    });
   });
   it("errors when adding a transform that would create a cycle with 3 frames", () => {
     const tfTree = new TransformTree();
@@ -31,6 +35,9 @@ describe("TransformTree", () => {
     // a <- b <- c
     tfTree.addTransform("c", "b", bigint, tf);
     // c <- a <- b <- c  ERROR - cycle created
-    expect(() => tfTree.addTransform("a", "c", bigint, tf)).toThrow(/cycle/i);
+    expect(tfTree.addTransform("a", "c", bigint, tf)).toEqual({
+      cycleDetected: true,
+      updated: false,
+    });
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -4,40 +4,31 @@
 
 import { Transform } from "@foxglove/studio-base/panels/ThreeDeeRender/transforms/Transform";
 
-import { TransformTree } from "./TransformTree";
+import { AddTransformResult, TransformTree } from "./TransformTree";
 
 const tf = Transform.Identity();
 const bigint = BigInt("0");
 describe("TransformTree", () => {
-  it("does not error when adding a transform that would not create a cycle", () => {
+  it("updates tree when adding a transform that would not create a cycle", () => {
     const tfTree = new TransformTree();
     tfTree.addTransform("b", "a", bigint, tf);
     tfTree.addTransform("c", "b", bigint, tf);
-    expect(tfTree.addTransform("d", "c", bigint, tf)).toEqual({
-      cycleDetected: false,
-      updated: true,
-    });
+    expect(tfTree.addTransform("d", "c", bigint, tf)).toEqual(AddTransformResult.UPDATED);
   });
-  it("errors when adding a transform that would create a cycle with 2 frames", () => {
+  it("detects a cycle adding a transform that would create a cycle with 2 frames", () => {
     const tfTree = new TransformTree();
     // a <- b
     tfTree.addTransform("b", "a", bigint, tf);
     // b <- a <- b ERROR - cycle created
-    expect(tfTree.addTransform("a", "b", bigint, tf)).toEqual({
-      cycleDetected: true,
-      updated: false,
-    });
+    expect(tfTree.addTransform("a", "b", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
   });
-  it("errors when adding a transform that would create a cycle with 3 frames", () => {
+  it("detects a cycle when adding a transform that would create a cycle with 3 frames", () => {
     const tfTree = new TransformTree();
     // a <- b
     tfTree.addTransform("b", "a", bigint, tf);
     // a <- b <- c
     tfTree.addTransform("c", "b", bigint, tf);
     // c <- a <- b <- c  ERROR - cycle created
-    expect(tfTree.addTransform("a", "c", bigint, tf)).toEqual({
-      cycleDetected: true,
-      updated: false,
-    });
+    expect(tfTree.addTransform("a", "c", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -52,7 +52,9 @@ export class TransformTree {
       }
     }
 
-    frame.addTransform(time, transform);
+    if (!cycleDetected) {
+      frame.addTransform(time, transform);
+    }
     return cycleDetected
       ? AddTransformResult.CYCLE_DETECTED
       : updated

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -9,6 +9,7 @@ import { Duration, Time } from "./time";
 
 const DEFAULT_MAX_CAPACITY_PER_FRAME = 50_000;
 
+const transformStatus = { updated: false, cycleDetected: false };
 /**
  * TransformTree is a collection of coordinate frames with convenience methods
  * for getting and creating frames and adding transforms between frames.
@@ -32,22 +33,22 @@ export class TransformTree {
     time: Time,
     transform: Transform,
   ): { updated: boolean; cycleDetected: boolean } {
-    let updated = !this.hasFrame(frameId);
-    let cycleDetected = false;
+    transformStatus.updated = !this.hasFrame(frameId);
+    transformStatus.cycleDetected = false;
     const frame = this.getOrCreateFrame(frameId);
     const curParentFrame = frame.parent();
     if (curParentFrame == undefined || curParentFrame.id !== parentFrameId) {
-      cycleDetected = this._checkParentForCycle(frameId, parentFrameId);
+      transformStatus.cycleDetected = this._checkParentForCycle(frameId, parentFrameId);
       // This frame was previously unparented but now we know its parent, or we
       // are reparenting this frame
-      if (!cycleDetected) {
+      if (!transformStatus.cycleDetected) {
         frame.setParent(this.getOrCreateFrame(parentFrameId));
-        updated = true;
+        transformStatus.updated = true;
       }
     }
 
     frame.addTransform(time, transform);
-    return { updated, cycleDetected };
+    return transformStatus;
   }
 
   public clear(): void {


### PR DESCRIPTION
**User-Facing Changes**
 - cyclical transforms will no longer error 3D Panel
 - settings panel errors will appear next to relevant childFrame nodes, and, if relevant, responsible URDF nodes.

**Description**
 - add transform returns whether a cycle was detected or not
 - child frames are still added and can be viewed in UI but are not re-parented to avoid creating cycle
 - responsible URDFs will also get a settings node error

My one issue with this is that it is a little hidden to the user unless they open the Transforms dropdown, since it's on the settings node itself rather than a top-level issue. If it's a subtle mistake in the 3D scene it will not be evident to them.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/10187776/195841751-41ec0e1e-3b4d-4573-b7f0-666af71329bd.png">
<img width="530" alt="image" src="https://user-images.githubusercontent.com/10187776/195842958-c5c6f9ac-45da-4cad-962e-ebbfd3e791f5.png">


<!-- link relevant github issues -->
Fixes #4636
<!-- add `docs` label if this PR requires documentation updates -->
