### PR TITLE
Allow cdr (ros2) encoded messages for foxglove websocket

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -161,6 +161,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
           } else if (channel.encoding === "ros1") {
             schemaEncoding = "ros1msg";
             schemaData = new TextEncoder().encode(channel.schema);
+          } else if (channel.encoding === "cdr") {
+            schemaEncoding = "ros2msg";
+            schemaData = new TextEncoder().encode(channel.schema);
           } else {
             throw new Error(`Unsupported encoding ${channel.encoding}`);
           }


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Similar to #4623, this PR allows subscribing to `cdr` encoded messages that are sent using the [foxglove websocket protocol](https://github.com/foxglove/ws-protocol/blob/87cae3504c560c65503e24c43620d75d54999bb8/docs/spec.md).
