### PR TITLE
[3D] Disable TF preloading

### DIFF
--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -57,7 +57,7 @@ export class ArrayMap<K, V> {
   public removeAfter(key: K): void {
     const index = this.binarySearch(key);
     const greaterThanIndex = index >= 0 ? index + 1 : ~index;
-    this._list.splice(greaterThanIndex);
+    this._list.length = greaterThanIndex;
   }
 
   /** Access the first key/value tuple in the list, without modifying the list. */

--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -53,6 +53,13 @@ export class ArrayMap<K, V> {
     return this._list.pop();
   }
 
+  /** Removes all elements with keys greater than the given key. */
+  public removeAfter(key: K): void {
+    const index = this.binarySearch(key);
+    const greaterThanIndex = index >= 0 ? index + 1 : ~index;
+    this._list.splice(greaterThanIndex);
+  }
+
   /** Access the first key/value tuple in the list, without modifying the list. */
   public minEntry(): [K, V] | undefined {
     return this._list[0];

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -521,8 +521,9 @@ export class Renderer extends EventEmitter<RendererEvents> {
    * This is useful when seeking to a new playback position or when a new data source is loaded.
    */
   public clear(): void {
-    // This must be cleared before calling `SceneExtension#removeAllRenderables()` to allow
-    // extensions to add errors back afterward
+    // These must be cleared before calling `SceneExtension#removeAllRenderables()` to allow
+    // extensions to add transforms and errors back afterward
+    this.transformTree.clearAfter(this.currentTime);
     this.settings.errors.clear();
 
     for (const extension of this.sceneExtensions.values()) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -442,17 +442,20 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addDatatypeSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.handleFrameTransform,
       forced: true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      // Disabled until we can efficiently preload transforms
+      // preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addDatatypeSubscriptions(TF_DATATYPES, {
       handler: this.handleTFMessage,
       forced: true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      // Disabled until we can efficiently preload transforms
+      // preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addDatatypeSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
       handler: this.handleTransformStamped,
       forced: true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      // Disabled until we can efficiently preload transforms
+      // preload: config.scene.transforms?.enablePreloading ?? true,
     });
 
     this.addSceneExtension(this.coreSettings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -442,7 +442,8 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addDatatypeSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.handleFrameTransform,
       forced: true,
-      // Disabled until we can efficiently preload transforms
+      // Disabled until we can efficiently preload transforms. See
+      // <https://github.com/foxglove/studio/issues/4657> for more details.
       // preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addDatatypeSubscriptions(TF_DATATYPES, {

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -852,7 +852,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     return this.config.cameraState.perspective ? this.perspectiveCamera : this.orthographicCamera;
   }
 
-  public addMessageEvent(messageEvent: Readonly<MessageEvent<unknown>>, datatype: string): void {
+  public addMessageEvent(messageEvent: Readonly<MessageEvent<unknown>>): void {
     const { message } = messageEvent;
 
     const maybeHasHeader = message as DeepPartial<{ header: Header }>;
@@ -883,7 +883,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
 
     handleMessage(messageEvent, this.topicHandlers.get(messageEvent.topic));
-    handleMessage(messageEvent, this.datatypeHandlers.get(datatype));
+    handleMessage(messageEvent, this.datatypeHandlers.get(messageEvent.schemaName));
   }
 
   /** Match the behavior of `tf::Transformer` by stripping leading slashes from

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -397,7 +397,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     const newRenderer = canvas ? new Renderer(canvas, configRef.current) : undefined;
     setRenderer(newRenderer);
     rendererRef.current = newRenderer;
-    return () => rendererRef.current?.dispose();
+    return () => {
+      rendererRef.current?.dispose();
+      rendererRef.current = undefined;
+    };
   }, [canvas, configRef, config.scene.transforms?.enablePreloading]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -403,11 +403,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [parameters, setParameters] = useState<ReadonlyMap<string, ParameterValue> | undefined>();
   const [variables, setVariables] = useState<ReadonlyMap<string, VariableValue> | undefined>();
   const [messages, setMessages] = useState<ReadonlyArray<MessageEvent<unknown>> | undefined>();
-  const [preloadedMessages, setPreloadedMessages] = useState<
-    ReadonlyArray<MessageEvent<unknown>> | undefined
-  >();
-  const lastPreloadedMessageTimeRef = useRef<Time>(TIME_ZERO);
-  const [currentTime, setCurrentTime] = useState<bigint | undefined>();
+  const [currentTime, setCurrentTime] = useState<Time | undefined>();
   const [didSeek, setDidSeek] = useState<boolean>(false);
 
   const renderRef = useRef({ needsRender: false });
@@ -535,13 +531,12 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     context.onRender = (renderState: RenderState, done) => {
       ReactDOM.unstable_batchedUpdates(() => {
         if (renderState.currentTime) {
-          setCurrentTime(toNanoSec(renderState.currentTime));
+          setCurrentTime(renderState.currentTime);
         }
 
         // Check if didSeek is set to true to reset the preloadedMessageTime and
         // trigger a state flush in Renderer
         if (renderState.didSeek === true) {
-          lastPreloadedMessageTimeRef.current = TIME_ZERO;
           setDidSeek(true);
         }
 
@@ -564,10 +559,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         // currentFrame has messages on subscribed topics since the last render call
         deepParseMessageEvents(renderState.currentFrame);
         setMessages(renderState.currentFrame);
-
-        // allFrames has messages on preloaded topics across all frames (as they are loaded)
-        deepParseMessageEvents(renderState.allFrames);
-        setPreloadedMessages(renderState.allFrames);
       });
     };
 
@@ -649,7 +640,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   // Keep the renderer currentTime up to date
   useEffect(() => {
     if (renderer && currentTime != undefined) {
-      renderer.currentTime = currentTime;
+      renderer.currentTime = toNanoSec(currentTime);
       renderRef.current.needsRender = true;
     }
   }, [currentTime, renderer]);
@@ -669,34 +660,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       renderRef.current.needsRender = true;
     }
   }, [backgroundColor, colorScheme, renderer]);
-
-  // Handle preloaded messages and render a frame if new messages are available
-  useEffect(() => {
-    if (!renderer || !preloadedMessages) {
-      return;
-    }
-
-    for (const message of preloadedMessages) {
-      // Skip preloaded messages before the last receiveTime we've previously processed
-      if (isLessThan(message.receiveTime, lastPreloadedMessageTimeRef.current)) {
-        continue;
-      }
-
-      const datatype = topicsToDatatypes.get(message.topic);
-      if (!datatype) {
-        continue;
-      }
-
-      renderer.addMessageEvent(message, datatype);
-    }
-
-    const lastMessage = preloadedMessages[preloadedMessages.length - 1];
-    if (lastMessage) {
-      lastPreloadedMessageTimeRef.current = lastMessage.receiveTime;
-    }
-
-    renderRef.current.needsRender = true;
-  }, [preloadedMessages, renderer, topicsToDatatypes]);
 
   // Handle messages and render a frame if new messages are available
   useEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -392,10 +392,13 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
   const [canvas, setCanvas] = useState<HTMLCanvasElement | ReactNull>(ReactNull);
   const [renderer, setRenderer] = useState<Renderer | undefined>(undefined);
-  useEffect(
-    () => setRenderer(canvas ? new Renderer(canvas, configRef.current) : undefined),
-    [canvas, configRef, config.scene.transforms?.enablePreloading],
-  );
+  const rendererRef = useRef<Renderer | undefined>(undefined);
+  useEffect(() => {
+    const newRenderer = canvas ? new Renderer(canvas, configRef.current) : undefined;
+    setRenderer(newRenderer);
+    rendererRef.current = newRenderer;
+    return () => rendererRef.current?.dispose();
+  }, [canvas, configRef, config.scene.transforms?.enablePreloading]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -21,7 +21,7 @@ import { DeepPartial } from "ts-essentials";
 import { useDebouncedCallback } from "use-debounce";
 
 import Logger from "@foxglove/log";
-import { isLessThan, Time, toNanoSec } from "@foxglove/rostime";
+import { Time, toNanoSec } from "@foxglove/rostime";
 import {
   LayoutActions,
   MessageEvent,
@@ -69,7 +69,6 @@ const PANEL_STYLE: React.CSSProperties = {
   display: "flex",
   position: "relative",
 };
-const TIME_ZERO = { sec: 0, nsec: 0 };
 
 type SubscriptionWithOptions = Subscription & {
   preload: boolean;
@@ -437,18 +436,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     return () => void renderer?.removeListener("cameraMove", listener);
   }, [renderer]);
 
-  // Build a map from topic name to datatype
-  const topicsToDatatypes = useMemo(() => {
-    const map = new Map<string, string>();
-    if (!topics) {
-      return map;
-    }
-    for (const topic of topics) {
-      map.set(topic.name, topic.schemaName);
-    }
-    return map;
-  }, [topics]);
-
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
     (action: SettingsTreeAction) =>
@@ -668,16 +655,11 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     }
 
     for (const message of messages) {
-      const datatype = topicsToDatatypes.get(message.topic);
-      if (!datatype) {
-        continue;
-      }
-
-      renderer.addMessageEvent(message, datatype);
+      renderer.addMessageEvent(message);
     }
 
     renderRef.current.needsRender = true;
-  }, [messages, renderer, topicsToDatatypes]);
+  }, [messages, renderer]);
 
   // Update the renderer when the camera moves
   useEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -169,11 +169,12 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
             input: "rgb",
             value: config.scene.transforms?.lineColor ?? DEFAULT_LINE_COLOR_STR,
           },
-          enablePreloading: {
-            label: "Enable preloading",
-            input: "boolean",
-            value: config.scene.transforms?.enablePreloading ?? true,
-          },
+          // Disabled until we can efficiently preload transforms
+          // enablePreloading: {
+          //   label: "Enable preloading",
+          //   input: "boolean",
+          //   value: config.scene.transforms?.enablePreloading ?? true,
+          // },
         },
       },
     };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -116,7 +116,7 @@ export function ImageRender(): JSX.Element {
       format: "png",
       data: PNG_TEST_IMAGE,
     },
-    schemaName: "sensor_msgs/CameraInfo",
+    schemaName: "sensor_msgs/CompressedImage",
     sizeInBytes: 0,
   };
 
@@ -333,7 +333,7 @@ export function FoxgloveImageRender(): JSX.Element {
       step: SIZE * 4,
       data: rgba8,
     },
-    schemaName: "sensor_msgs/Image",
+    schemaName: "foxglove.RawImage",
     sizeInBytes: 0,
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -140,6 +140,11 @@ export class CoordinateFrame {
     }
   }
 
+  /** Remove all transforms with timestamps greater than the given timestamp. */
+  public removeTransformsAfter(time: Time): void {
+    this._transforms.removeAfter(time);
+  }
+
   /**
    * Find the closest transform(s) in the transform history to the given time.
    * Note that if an exact match is found, both `outLower` and `outUpper` will

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -52,6 +52,12 @@ export class TransformTree {
     this._frames.clear();
   }
 
+  public clearAfter(time: Time): void {
+    for (const frame of this._frames.values()) {
+      frame.removeTransformsAfter(time);
+    }
+  }
+
   public hasFrame(id: string): boolean {
     return this._frames.has(id);
   }


### PR DESCRIPTION
**User-Facing Changes**
- [3D] Preloading of transform topics is disabled until performance and correctness issues are resolved

**Description**
With the current implementation of preloaded topics in the extension API, whenever a new `allFrames` is received we must 
iterate over the entire list looking for new messages. Further complicating things, message events in Studio do not have 
unique keys so we must re-ingest every TF each time `allFrames` changes.

One solution to this would be to provide a delta API that incrementally provides preloaded message events similar to how 
`currentFrame` works.
