### PR TITLE
 Prevent LinePrimitive scene entities from crashing with empty `points`

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -39,6 +39,9 @@ export class RenderableLines extends RenderablePrimitive {
     this._lines.length = 0;
 
     for (const primitive of lines) {
+      if (primitive.points.length === 0) {
+        continue;
+      }
       const line = this._makeLine(primitive);
       const group = new THREE.Group().add(line);
       group.position.set(
@@ -111,6 +114,8 @@ export class RenderableLines extends RenderablePrimitive {
     }
 
     const positions = getPositions(primitive);
+    // setPosition requires the position array to be >= 6 length or else it will error
+    // we skip primitives with empty points before calling this function
     geometry.setPositions(positions);
 
     const singleColor = this.userData.settings.color

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -151,7 +151,7 @@ export class RenderableLines extends RenderablePrimitive {
       ? primitive.points.length >>> 1
       : isLoop
       ? primitive.points.length
-      : primitive.points.length - 1;
+      : Math.max(primitive.points.length - 1, 0);
 
     line.userData.pickingMaterial = pickingMaterial;
     return line;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -214,6 +214,17 @@ function makeStoryScene({
                 ),
                 indices: rearrange(new Array(10).fill(0).map((_, i) => i)),
               },
+              {
+                // empty points
+                type,
+                pose: xyzrpyToPose([1, 1.8 + typeIndex * 0.2, 0], [0, 0, 0]),
+                thickness: 5,
+                scale_invariant: true,
+                points: [],
+                color: makeColor("#7995fb", 0.8),
+                colors: [],
+                indices: [],
+              },
             ],
           ),
 


### PR DESCRIPTION
**User-Facing Changes**
 - prevent LinePrimitive scene entities from crashing when `points` is empty and not a loop

**Description**
 - prevent LinePrimitive scene entities from crashing when `points` is empty and not a loop
- add test case to SceneEntities story

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
