### PR TITLE
Upgrade protobufjs to fix syntax error

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -30,6 +30,7 @@
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "2.0.6",
     "flatbuffers_reflection": "0.0.1",
+    "protobufjs": "7.1.2",
     "wasm-lz4": "2.0.0",
     "zstd-codec": "patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch"
   }

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -50,6 +50,37 @@ describe("parseChannel", () => {
     expect(deserialized.file[0]!.name).toEqual("google_protobuf.proto");
   });
 
+  it("handles protobuf repeated enum having multiple default value aliases", () => {
+    /*
+    syntax = "proto3";
+
+    enum ExampleEnum {
+        option allow_alias = true;
+        UNKNOWN = 0;
+        WHATEVER = 0;
+        FOO = 1;
+        BAR = 2;
+    }
+
+    message ExampleMessage {
+        repeated ExampleEnum data = 1;
+    }
+    */
+    const channel = parseChannel({
+      messageEncoding: "protobuf",
+      schema: {
+        name: "ExampleMessage",
+        encoding: "protobuf",
+        data: Buffer.from(
+          "0A8D010A156578616D706C655F6D6573736167652E70726F746F222C0A0E4578616D706C654D657373616765121A0A046461746118012003280E320C2E4578616D706C65456E756D2A3E0A0B4578616D706C65456E756D120B0A07554E4B4E4F574E1000120C0A085748415445564552100012070A03464F4F100112070A0342415210021A021001620670726F746F33",
+          "hex",
+        ),
+      },
+    });
+    expect(channel.fullSchemaName).toEqual("ExampleMessage");
+    expect(channel.deserializer(Buffer.from("0A0101", "hex"))).toEqual({ data: [1] });
+  });
+
   it("works with ros1", () => {
     const channel = parseChannel({
       messageEncoding: "ros1",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -163,7 +163,6 @@
     "path-browserify": "1.0.1",
     "prettier": "2.5.1",
     "promise-queue": "2.2.5",
-    "protobufjs": "6.11.3",
     "quickhull3d": "2.0.5",
     "rc-tree": "5.4.3",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2230,6 +2230,7 @@ __metadata:
     "@types/zstd-codec": "workspace:*"
     flatbuffers: 2.0.6
     flatbuffers_reflection: 0.0.1
+    protobufjs: 7.1.2
     typescript: 4.8.2
     wasm-lz4: 2.0.0
     zstd-codec: "patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch"
@@ -2562,7 +2563,6 @@ __metadata:
     path-browserify: 1.0.1
     prettier: 2.5.1
     promise-queue: 2.2.5
-    protobufjs: 6.11.3
     quickhull3d: 2.0.5
     rc-tree: 5.4.3
     react: 17.0.2
@@ -5787,13 +5787,6 @@ __metadata:
   version: 4.14.182
   resolution: "@types/lodash@npm:4.14.182"
   checksum: 7dd137aa9dbabd632408bd37009d984655164fa1ecc3f2b6eb94afe35bf0a5852cbab6183148d883e9c73a958b7fec9a9bcf7c8e45d41195add6a18c34958209
-  languageName: node
-  linkType: hard
-
-"@types/long@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@types/long@npm:4.0.1"
-  checksum: ff9653c33f5000d0f131fd98a950a0343e2e33107dd067a97ac4a3b9678e1a2e39ea44772ad920f54ef6e8f107f76bc92c2584ba905a0dc4253282a4101166d0
   languageName: node
   linkType: hard
 
@@ -16567,10 +16560,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "long@npm:4.0.0"
-  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
+"long@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "long@npm:5.2.0"
+  checksum: 37aa4e67b9c3eebc6d9d675adcc9d06f06059ca268922a71273de389746bf07f0ff282f9e604d17fdf84c4149099b44e936ea2b621a6c4759a216621afa97efd
   languageName: node
   linkType: hard
 
@@ -19484,9 +19477,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:6.11.3":
-  version: 6.11.3
-  resolution: "protobufjs@npm:6.11.3"
+"protobufjs@npm:7.1.2":
+  version: 7.1.2
+  resolution: "protobufjs@npm:7.1.2"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -19498,13 +19491,9 @@ __metadata:
     "@protobufjs/path": ^1.1.2
     "@protobufjs/pool": ^1.1.0
     "@protobufjs/utf8": ^1.1.0
-    "@types/long": ^4.0.1
     "@types/node": ">=13.7.0"
-    long: ^4.0.0
-  bin:
-    pbjs: bin/pbjs
-    pbts: bin/pbts
-  checksum: 4a6ce1964167e4c45c53fd8a312d7646415c777dd31b4ba346719947b88e61654912326101f927da387d6b6473ab52a7ea4f54d6f15d63b31130ce28e2e15070
+    long: ^5.0.0
+  checksum: ae41669b1b0372fb1d49f506f2d1f2b0fb3dc3cece85987b17bcb544e4cef7c8d27f480486cdec324146ad0a5d22a327166a7ea864a9b3e49cc3c92a5d3f6500
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where certain Protobuf enum values would fail to load with a SyntaxError.

**Description**
Fix was in https://github.com/protobufjs/protobuf.js/pull/1801. Added a unit test to ensure parsing succeeds.

Example file containing dummy enum that reproduces the issue before this fix:  [dupe_enum.mcap.zip](https://github.com/foxglove/studio/files/9814444/dupe_enum.mcap.zip)
