### PR TITLE
Tweak NuScenes demo layout near plane

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -52,7 +52,7 @@
         "targetOrientation": [0, 0, 0, 1],
         "thetaOffset": 45,
         "fovy": 45,
-        "near": 0.01,
+        "near": 1.0,
         "far": 5000
       },
       "scene": {},

--- a/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/camera.ts
@@ -38,6 +38,6 @@ export const DEFAULT_CAMERA_STATE: CameraState = {
   targetOrientation: [0, 0, 0, 1],
   thetaOffset: 45,
   fovy: 45,
-  near: 0.01,
+  near: 0.5,
   far: 5000,
 };


### PR DESCRIPTION
This pushes the near plane out to 1 meter, resulting in significantly better Z-fighting behavior for close planes.

Having a near plane at 1m means one only sees clipping at pretty tight distances, as shown here:
<img width="1006" alt="Screen Shot 2022-10-19 at 8 05 27 am" src="https://user-images.githubusercontent.com/18162835/196544799-5565d090-e166-452f-aee2-72b8897d3c88.png">

This may be inappropriate for applications like robot manipulation, but the setting is still configurable for those situations.
**User-Facing Changes**


**Description**


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
