### PR TITLE
Revert Log panel to react-virtualized implementation

### DIFF
--- a/packages/studio-base/src/panels/Log/LogList.tsx
+++ b/packages/studio-base/src/panels/Log/LogList.tsx
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import DoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
+import { Fab } from "@mui/material";
+import { AutoSizer, CellMeasurer, CellMeasurerCache, List, ListRowProps } from "react-virtualized";
+import { makeStyles } from "tss-react/mui";
+import { v4 as uuidv4 } from "uuid";
+
+const useStyles = makeStyles()((theme) => ({
+  floatingButton: {
+    position: "absolute",
+    bottom: 0,
+    right: 0,
+    margin: theme.spacing(1.5),
+  },
+}));
+
+type RenderRowInput<Item> = ListRowProps & {
+  item: Item;
+  ref?: React.RefCallback<Element>;
+};
+
+export type RenderRow<Item> = (row: RenderRowInput<Item>) => React.ReactNode;
+
+type Props<T> = {
+  items: readonly T[];
+  renderRow: RenderRow<T>;
+};
+
+// List for showing large number of items, which are expected to be appended to the end regularly.
+// Automatically scrolls to the bottom unless you explicitly scroll up.
+function LogList<Item>({ items, renderRow }: Props<Item>): JSX.Element {
+  const { classes } = useStyles();
+
+  // Automatically scrolling to the bottom by default.
+  const [autoScroll, setAutoScroll] = React.useState(true);
+
+  // For keeping a reference to the container <div>. Unfortunately there don't seem to be other
+  // convenient ways to do this; e.g. `ref` doesn't work.
+  const listId = React.useRef<string>(uuidv4());
+
+  // Cache for item heights.
+  const cache = React.useRef<CellMeasurerCache>(new CellMeasurerCache({ fixedWidth: true }));
+
+  // Keep track of the last width to see if we need to clear the cache.
+  const lastWidth = React.useRef<number>(-1);
+
+  // Keep track of the last items that we rendered to see if we need to clear the cache.
+  const lastItems = React.useRef<readonly Item[]>([]);
+
+  // Last time we rendered; used in `onScroll`.
+  const lastRenderTime = React.useRef<number>(0);
+  lastRenderTime.current = Date.now();
+
+  // If we have fewer items now, or if any of the old items don't match any more, we have to clear
+  // the cache of heights.
+  if (
+    items.length < lastItems.current.length ||
+    !lastItems.current.every((item, index) => item === items[index])
+  ) {
+    cache.current.clearAll();
+  }
+  lastItems.current = items;
+
+  // `onWheel` is only called when the user explicitly scrolls using the scroll wheel or track pad.
+  // This is reliable, so we don't need any buffers or checks. However, this doesn't cover all cases
+  // of users scrolling (e.g. keyboard or dragging the scroll bar) so we also need `onScroll` below.
+  const onWheel = React.useCallback(() => {
+    const containerEl = document.getElementById(listId.current);
+    if (!containerEl) {
+      return;
+    }
+    const newAutoScroll =
+      containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight;
+    if (newAutoScroll !== autoScroll) {
+      setAutoScroll(newAutoScroll);
+    }
+  }, [autoScroll]);
+
+  // As said above, we need `onScroll` to catch some of the user scroll events. However, it's also
+  // triggered when a scroll happens for a different reason, e.g. by the browser or initiated from
+  // our own code. There's unfortunately no easy way to differentiate between them, and often during
+  // rendering the `onScroll` events can't quite keep up with the actual rendering, so we require
+  // rendering to not have happened for a second, and we have a bit of a buffer for how much
+  // scrolling we require to have been done. In practice this seems to be working reasonably well.
+  const onScroll = React.useCallback(() => {
+    if (Date.now() - lastRenderTime.current < 1000) {
+      return;
+    }
+    const containerEl = document.getElementById(listId.current);
+    if (!containerEl) {
+      return;
+    }
+    const newAutoScroll =
+      containerEl.scrollHeight - containerEl.scrollTop <= containerEl.clientHeight + 5;
+    if (newAutoScroll !== autoScroll) {
+      setAutoScroll(newAutoScroll);
+    }
+  }, [autoScroll]);
+
+  const onResetView = React.useCallback(() => {
+    setAutoScroll(true);
+  }, []);
+
+  return (
+    <AutoSizer>
+      {({ width, height }) => {
+        // If the width changed, row heights might have changed, so we need to clear the cache.
+        if (lastWidth.current !== width) {
+          cache.current.clearAll();
+        }
+        lastWidth.current = width;
+
+        return (
+          <div style={{ position: "relative", width, height }}>
+            <List
+              width={width}
+              height={height}
+              style={{ outline: "none" }}
+              deferredMeasurementCache={cache.current}
+              rowHeight={cache.current.rowHeight}
+              rowRenderer={(rowProps) => (
+                <CellMeasurer
+                  key={rowProps.key}
+                  cache={cache.current}
+                  parent={rowProps.parent}
+                  columnIndex={0}
+                  rowIndex={rowProps.index}
+                >
+                  {({ registerChild }) =>
+                    renderRow({
+                      ...rowProps,
+                      item: items[rowProps.index] as Item,
+                      ref: registerChild as (element: Element | ReactNull) => void,
+                    })
+                  }
+                </CellMeasurer>
+              )}
+              rowCount={items.length}
+              overscanRowCount={10}
+              onScroll={onScroll}
+              id={listId.current}
+              containerProps={{ onWheel }}
+              {...(autoScroll ? { scrollToIndex: items.length - 1 } : undefined)}
+            />
+            {!autoScroll && (
+              <Fab
+                size="small"
+                title="Scroll to bottom"
+                onClick={onResetView}
+                className={classes.floatingButton}
+              >
+                <DoubleArrowDownIcon />
+              </Fab>
+            )}
+          </div>
+        );
+      }}
+    </AutoSizer>
+  );
+}
+
+export default LogList;

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -11,13 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { List, IList } from "@fluentui/react/lib/List";
-import DoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
-import { Fab } from "@mui/material";
 import produce from "immer";
 import { set } from "lodash";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { makeStyles } from "tss-react/mui";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { SettingsTreeAction } from "@foxglove/studio";
 import { useDataSourceInfo, useMessagesByTopic } from "@foxglove/studio-base/PanelAPI";
@@ -25,18 +21,17 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { normalizedLogMessage } from "@foxglove/studio-base/panels/Log/conversion";
 import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import FilterBar, { FilterBarProps } from "./FilterBar";
+import LogList from "./LogList";
 import LogMessage from "./LogMessage";
-import { normalizedLogMessage } from "./conversion";
 import filterMessages from "./filterMessages";
 import helpContent from "./index.help.md";
 import { buildSettingsTree } from "./settings";
 import { Config, LogMessageEvent } from "./types";
-
-type ArrayElementType<T extends readonly unknown[]> = T extends readonly (infer E)[] ? E : never;
 
 type Props = {
   config: Config;
@@ -44,26 +39,16 @@ type Props = {
 };
 
 const SUPPORTED_DATATYPES = [
-  "rosgraph_msgs/Log",
-  "rcl_interfaces/msg/Log",
-  "ros.rosgraph_msgs.Log",
-  "ros.rcl_interfaces.Log",
   "foxglove_msgs/Log",
   "foxglove_msgs/msg/Log",
   "foxglove.Log",
+  "rcl_interfaces/msg/Log",
+  "ros.rcl_interfaces.Log",
+  "ros.rosgraph_msgs.Log",
+  "rosgraph_msgs/Log",
 ];
 
-const useStyles = makeStyles()((theme) => ({
-  floatingButton: {
-    position: "absolute",
-    bottom: 0,
-    right: 0,
-    margin: theme.spacing(1.5),
-  },
-}));
-
 const LogPanel = React.memo(({ config, saveConfig }: Props) => {
-  const { classes } = useStyles();
   const { topics } = useDataSourceInfo();
   const { minLogLevel, searchTerms } = config;
   const { timeFormat, timeZone } = useAppTimeFormat();
@@ -71,24 +56,22 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
 
   const onFilterChange = useCallback<FilterBarProps["onFilterChange"]>(
-    (filter) => saveConfig({ minLogLevel: filter.minLogLevel, searchTerms: filter.searchTerms }),
+    (filter) => {
+      saveConfig({ minLogLevel: filter.minLogLevel, searchTerms: filter.searchTerms });
+    },
     [saveConfig],
   );
 
-  // Get the topics that have our supported datatypes
-  // Users can select any of these topics for display in the panel
   const availableTopics = useMemo(
     () => topics.filter((topic) => SUPPORTED_DATATYPES.includes(topic.schemaName)),
     [topics],
   );
 
-  // Pick the first available topic, if there are not available topics, then we inform the user
-  // nothing is publishing log messages
   const defaultTopicToRender = useMemo(() => availableTopics[0]?.name, [availableTopics]);
 
   const topicToRender = config.topicToRender ?? defaultTopicToRender ?? "/rosout";
 
-  const { [topicToRender]: msgEvents = [] } = useMessagesByTopic({
+  const { [topicToRender]: messages = [] } = useMessagesByTopic({
     topics: [topicToRender],
     historySize: 100000,
   }) as { [key: string]: LogMessageEvent[] };
@@ -113,11 +96,12 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
   }, [actionHandler, availableTopics, topicToRender, updatePanelSettingsTree]);
 
   // avoid making new sets for node names
+  // the filter bar uess the node names during on-demand filtering
   // the filter bar uses the node names during on-demand filtering
   const seenNodeNamesCache = useRef(new Set<string>());
 
   const seenNodeNames = useMemo(() => {
-    for (const msgEvent of msgEvents) {
+    for (const msgEvent of messages) {
       const name = msgEvent.message.name;
       if (name != undefined) {
         seenNodeNamesCache.current.add(name);
@@ -125,46 +109,14 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
     }
 
     return seenNodeNamesCache.current;
-  }, [msgEvents]);
+  }, [messages]);
 
   const searchTermsSet = useMemo(() => new Set(searchTerms), [searchTerms]);
 
   const filteredMessages = useMemo(
-    () => filterMessages(msgEvents, { minLogLevel, searchTerms }),
-    [msgEvents, minLogLevel, searchTerms],
+    () => filterMessages(messages, { minLogLevel, searchTerms }),
+    [messages, minLogLevel, searchTerms],
   );
-
-  const listRef = useRef<IList>(ReactNull);
-
-  const [hasUserScrolled, setHasUserScrolled] = useState(false);
-  const divRef = useRef<HTMLDivElement>(ReactNull);
-
-  const scrollToBottomAction = useCallback(() => {
-    const div = divRef.current;
-    if (!div) {
-      return;
-    }
-
-    setHasUserScrolled(false);
-    // With column-reverse flex direction, 0 scroll top is the bottom (latest) message
-    div.scrollTop = 0;
-  }, []);
-
-  useLayoutEffect(() => {
-    const div = divRef.current;
-    if (!div) {
-      return;
-    }
-
-    const listener = () => {
-      setHasUserScrolled(div.scrollTop !== 0);
-    };
-
-    div.addEventListener("scroll", listener);
-    return () => {
-      div.removeEventListener("scroll", listener);
-    };
-  }, []);
 
   return (
     <Stack fullHeight>
@@ -177,45 +129,23 @@ const LogPanel = React.memo(({ config, saveConfig }: Props) => {
           onFilterChange={onFilterChange}
         />
       </PanelToolbar>
-      <Stack flexGrow={1} overflow="hidden">
-        <Stack
-          ref={divRef}
-          fullHeight
-          overflowY="auto"
-          direction="column-reverse"
-          data-testid="log-messages-list"
-        >
-          {/* items property wants a mutable array but filteredMessages is readonly */}
-          <List
-            componentRef={listRef}
-            items={filteredMessages as ArrayElementType<typeof filteredMessages>[]}
-            onRenderCell={(item) => {
-              if (!item) {
-                return;
-              }
-
-              const normalizedLog = normalizedLogMessage(item.schemaName, item["message"]);
-              return (
+      <Stack flexGrow={1}>
+        <LogList
+          items={filteredMessages}
+          renderRow={({ item, style, key, ref }) => {
+            const normalizedLog = normalizedLogMessage(item.schemaName, item["message"]);
+            return (
+              <div ref={ref} key={key} style={style}>
                 <LogMessage
                   value={normalizedLog}
                   timestampFormat={timeFormat}
                   timeZone={timeZone}
                 />
-              );
-            }}
-          />
-        </Stack>
+              </div>
+            );
+          }}
+        />
       </Stack>
-      {hasUserScrolled && (
-        <Fab
-          size="small"
-          title="Scroll to bottom"
-          onClick={scrollToBottomAction}
-          className={classes.floatingButton}
-        >
-          <DoubleArrowDownIcon />
-        </Fab>
-      )}
     </Stack>
   );
 });


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Reverts the Log panel to the previous react-virtualized implementation, preserving styling work done since the switch to fluent.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes #4079 