### PR TITLE
Fix Gauge/Indicator skipping messages on high-frequency topics

### DIFF
--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { last } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useReducer, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
@@ -38,7 +39,7 @@ type State = {
 };
 
 type Action =
-  | { type: "message"; message: MessageEvent<unknown> }
+  | { type: "frame"; messages: readonly MessageEvent<unknown>[] }
   | { type: "path"; path: string }
   | { type: "seek" };
 
@@ -52,19 +53,27 @@ function getSingleDataItem(results: unknown[]) {
 function reducer(state: State, action: Action): State {
   try {
     switch (action.type) {
-      case "message": {
+      case "frame": {
         if (state.pathParseError != undefined) {
-          return { ...state, latestMessage: action.message, error: undefined };
+          return { ...state, latestMessage: last(action.messages), error: undefined };
         }
-        const data = state.parsedPath
-          ? getSingleDataItem(simpleGetMessagePathDataItems(action.message, state.parsedPath))
-          : undefined;
-        return {
-          ...state,
-          latestMessage: action.message,
-          latestMatchingQueriedData: data ?? state.latestMatchingQueriedData,
-          error: undefined,
-        };
+        let latestMatchingQueriedData = state.latestMatchingQueriedData;
+        let latestMessage = state.latestMessage;
+        if (state.parsedPath) {
+          for (const message of action.messages) {
+            if (message.topic !== state.parsedPath.topicName) {
+              continue;
+            }
+            const data = getSingleDataItem(
+              simpleGetMessagePathDataItems(message, state.parsedPath),
+            );
+            if (data != undefined) {
+              latestMatchingQueriedData = data;
+              latestMessage = message;
+            }
+          }
+        }
+        return { ...state, latestMessage, latestMatchingQueriedData, error: undefined };
       }
       case "path": {
         const newPath = parseRosPath(action.path);
@@ -203,11 +212,7 @@ export function Gauge({ context }: Props): JSX.Element {
       }
 
       if (renderState.currentFrame) {
-        for (const message of renderState.currentFrame) {
-          if (message.topic === state.parsedPath?.topicName) {
-            dispatch({ type: "message", message });
-          }
-        }
+        dispatch({ type: "frame", messages: renderState.currentFrame });
       }
     };
     context.watch("currentFrame");
@@ -216,7 +221,7 @@ export function Gauge({ context }: Props): JSX.Element {
     return () => {
       context.onRender = undefined;
     };
-  }, [context, state.parsedPath?.topicName]);
+  }, [context]);
 
   const settingsActionHandler = useCallback(
     (action: SettingsTreeAction) =>

--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -2,7 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { last } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useReducer, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 
@@ -203,9 +202,12 @@ export function Gauge({ context }: Props): JSX.Element {
         dispatch({ type: "seek" });
       }
 
-      const message = last(renderState.currentFrame);
-      if (message != undefined && message.topic === state.parsedPath?.topicName) {
-        dispatch({ type: "message", message });
+      if (renderState.currentFrame) {
+        for (const message of renderState.currentFrame) {
+          if (message.topic === state.parsedPath?.topicName) {
+            dispatch({ type: "message", message });
+          }
+        }
       }
     };
     context.watch("currentFrame");

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -149,3 +149,33 @@ export const CustomRange = (): JSX.Element => {
   return <GaugePanel overrideConfig={{ path: "/data.value", minValue: 5, maxValue: 7 }} />;
 };
 CustomRange.parameters = { panelSetup: { fixture: makeFixture(6.5) } };
+
+export const MessagePathWithFilter = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: `/data{id=="b"}.value`, minValue: 0, maxValue: 4 }} />;
+};
+MessagePathWithFilter.parameters = {
+  panelSetup: {
+    fixture: {
+      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+      frame: {
+        "/data": [
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "a", value: 1 },
+          },
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "b", value: 2 },
+          },
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "c", value: 3 },
+          },
+        ],
+      },
+    },
+  },
+};

--- a/packages/studio-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/studio-base/src/panels/Indicator/Indicator.tsx
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Typography, useTheme } from "@mui/material";
-import { last } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useState } from "react";
 import { withStyles } from "tss-react/mui";
 
@@ -169,9 +168,12 @@ export function Indicator({ context }: Props): JSX.Element {
         dispatch({ type: "seek" });
       }
 
-      const message = last(renderState.currentFrame);
-      if (message != undefined && message.topic === state.parsedPath?.topicName) {
-        dispatch({ type: "message", message });
+      if (renderState.currentFrame) {
+        for (const message of renderState.currentFrame) {
+          if (message.topic === state.parsedPath?.topicName) {
+            dispatch({ type: "message", message });
+          }
+        }
       }
     };
     context.watch("currentFrame");

--- a/packages/studio-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/studio-base/src/panels/Indicator/Indicator.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Typography, useTheme } from "@mui/material";
+import { last } from "lodash";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useState } from "react";
 import { withStyles } from "tss-react/mui";
 
@@ -53,7 +54,7 @@ type State = {
 };
 
 type Action =
-  | { type: "message"; message: MessageEvent<unknown> }
+  | { type: "frame"; messages: readonly MessageEvent<unknown>[] }
   | { type: "path"; path: string }
   | { type: "seek" };
 
@@ -67,19 +68,27 @@ function getSingleDataItem(results: unknown[]) {
 function reducer(state: State, action: Action): State {
   try {
     switch (action.type) {
-      case "message": {
+      case "frame": {
         if (state.pathParseError != undefined) {
-          return { ...state, latestMessage: action.message, error: undefined };
+          return { ...state, latestMessage: last(action.messages), error: undefined };
         }
-        const data = state.parsedPath
-          ? getSingleDataItem(simpleGetMessagePathDataItems(action.message, state.parsedPath))
-          : undefined;
-        return {
-          ...state,
-          latestMessage: action.message,
-          latestMatchingQueriedData: data ?? state.latestMatchingQueriedData,
-          error: undefined,
-        };
+        let latestMatchingQueriedData = state.latestMatchingQueriedData;
+        let latestMessage = state.latestMessage;
+        if (state.parsedPath) {
+          for (const message of action.messages) {
+            if (message.topic !== state.parsedPath.topicName) {
+              continue;
+            }
+            const data = getSingleDataItem(
+              simpleGetMessagePathDataItems(message, state.parsedPath),
+            );
+            if (data != undefined) {
+              latestMatchingQueriedData = data;
+              latestMessage = message;
+            }
+          }
+        }
+        return { ...state, latestMessage, latestMatchingQueriedData, error: undefined };
       }
       case "path": {
         const newPath = parseRosPath(action.path);
@@ -169,11 +178,7 @@ export function Indicator({ context }: Props): JSX.Element {
       }
 
       if (renderState.currentFrame) {
-        for (const message of renderState.currentFrame) {
-          if (message.topic === state.parsedPath?.topicName) {
-            dispatch({ type: "message", message });
-          }
-        }
+        dispatch({ type: "frame", messages: renderState.currentFrame });
       }
     };
     context.watch("currentFrame");
@@ -182,7 +187,7 @@ export function Indicator({ context }: Props): JSX.Element {
     return () => {
       context.onRender = undefined;
     };
-  }, [context, state.parsedPath?.topicName]);
+  }, [context]);
 
   const settingsActionHandler = useCallback(
     (action: SettingsTreeAction) =>

--- a/packages/studio-base/src/panels/Indicator/index.stories.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.stories.tsx
@@ -134,3 +134,46 @@ export const NumberZero = (): JSX.Element => <NumberStory />;
 NumberZero.parameters = { panelSetup: { fixture: makeFixture(0) } };
 export const NumberPositive = (): JSX.Element => <NumberStory />;
 NumberPositive.parameters = { panelSetup: { fixture: makeFixture(1) } };
+
+export const MessagePathWithFilter = (): JSX.Element => {
+  return (
+    <Indicator
+      overrideConfig={{
+        path: `/data{id=="b"}.value`,
+        style: "bulb",
+        rules: [
+          { operator: "=", rawValue: "true", color: "#00dd00", label: "True" },
+          { operator: "=", rawValue: "false", color: "#dd00dd", label: "False" },
+        ],
+        fallbackColor: "#dddd00",
+        fallbackLabel: "Fallback",
+      }}
+    />
+  );
+};
+MessagePathWithFilter.parameters = {
+  panelSetup: {
+    fixture: {
+      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+      frame: {
+        "/data": [
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "a", value: false },
+          },
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "b", value: true },
+          },
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { id: "c", value: false },
+          },
+        ],
+      },
+    },
+  },
+};


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug in the Gauge and Indicator panels where messages on high-frequency topics would sometimes be skipped when using a message path filter.

**Description**
These panels only processed the _last_ message on each `currentFrame`. That's incorrect, because if the message path contains a filter, one of the intermediate messages in the frame might match the filter even if the last one does not. To fix the issue, we process all messages in the currentFrame on the requested topic. Also added stories with fixture data containing multiple messages per frame to prevent regressions.

Thanks to @2metres for noticing the bug.