### PR TITLE
Gauge: allow string values that can be converted to numbers

### DIFF
--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -250,7 +250,10 @@ export function Gauge({ context }: Props): JSX.Element {
   }, [renderDone]);
 
   const rawValue =
-    typeof state.latestMatchingQueriedData === "number" ? state.latestMatchingQueriedData : NaN;
+    typeof state.latestMatchingQueriedData === "number" ||
+    typeof state.latestMatchingQueriedData === "string"
+      ? Number(state.latestMatchingQueriedData)
+      : NaN;
 
   const { minValue, maxValue } = config;
   const scaledValue =

--- a/packages/studio-base/src/panels/Gauge/index.stories.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.stories.tsx
@@ -179,3 +179,23 @@ MessagePathWithFilter.parameters = {
     },
   },
 };
+
+export const StringValue = (): JSX.Element => {
+  return <GaugePanel overrideConfig={{ path: `/data.value`, minValue: 0, maxValue: 1 }} />;
+};
+StringValue.parameters = {
+  panelSetup: {
+    fixture: {
+      topics: [{ name: "/data", datatype: "foo_msgs/Bar" }],
+      frame: {
+        "/data": [
+          {
+            topic: "/data",
+            receiveTime: { sec: 123, nsec: 456 },
+            message: { value: "0.2" },
+          },
+        ],
+      },
+    },
+  },
+};

--- a/packages/studio-base/src/panels/Gauge/settings.ts
+++ b/packages/studio-base/src/panels/Gauge/settings.ts
@@ -38,6 +38,7 @@ const supportedDataTypes = [
   "uint32",
   "float32",
   "float64",
+  "string",
 ];
 
 export function useSettingsTree(


### PR DESCRIPTION
**User-Facing Changes**
Updated Gauge panel to support string values that can be converted to numbers.

**Description**
Can be useful for plotting values from diagnostics. The Plot panel also supports plotting strings, so it seems sensible to allow it in the Gauge panel too.