### PR TITLE
Fix velodyne open dialog

### DIFF
--- a/packages/studio-base/src/dataSources/VelodyneDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/VelodyneDataSourceFactory.ts
@@ -23,7 +23,7 @@ class VelodyneDataSourceFactory implements IDataSourceFactory {
   };
 
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
-    const portStr = args.params?.portStr;
+    const portStr = args.params?.port;
     if (portStr == undefined) {
       return;
     }


### PR DESCRIPTION

**User-Facing Changes**
Fix opening a connection to a velodyne in the desktop app.

**Description**
The VelodyneDataSourceFactory incorrectly queried for the _portStr_ parameter from the form config. The actual id of the parameter is _port_. This fixes the parameter lookup and allows the player to be built.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
