### PR TITLE
Improve performance of state transition panel

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { ScatterDataPoint } from "chart.js";
 import stringHash from "string-hash";
 
 import { Time, toSec, subtract as subtractTimes } from "@foxglove/rostime";
@@ -20,6 +21,9 @@ type DatasetInfo = {
   tooltips: TimeBasedChartTooltipData[];
 };
 
+type Dataset = ChartData["datasets"][number];
+type DatasetData = ChartData["datasets"][number]["data"];
+
 const baseColors = [grey, ...expandedLineColors];
 
 type Args = {
@@ -31,21 +35,22 @@ type Args = {
 };
 
 export default function messagesToDatasets(args: Args): DatasetInfo {
-  const { path, startTime, y, pathIndex, blocks } = args;
+  const { path, startTime, y, blocks } = args;
 
   const info: DatasetInfo = {
     datasets: [],
     tooltips: [],
   };
 
-  let prevQueryValue: string | number | bigint | boolean | undefined;
   let previousTimestamp: Time | undefined;
-  let currentData: ChartData["datasets"][0]["data"] = [];
+  let currentData: DatasetData = [];
+
+  const datasetIndexMap = new Map<unknown, number>();
+  let lastDatasetIndex: undefined | number = undefined;
 
   for (const messages of blocks) {
     if (!messages) {
-      currentData = [];
-      prevQueryValue = undefined;
+      lastDatasetIndex = undefined;
       previousTimestamp = undefined;
       continue;
     }
@@ -63,11 +68,13 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
 
       const { constantName, value } = queriedData;
 
+      const datasetIndex = datasetIndexMap.get(value);
+
       // Skip duplicates.
       if (
         previousTimestamp &&
         toSec(subtractTimes(previousTimestamp, timestamp)) === 0 &&
-        prevQueryValue === value
+        datasetIndex === lastDatasetIndex
       ) {
         continue;
       }
@@ -94,8 +101,6 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
 
       const x = toSec(subtractTimes(timestamp, startTime));
 
-      const element = { x, y };
-
       const tooltip: TimeBasedChartTooltipData = {
         x,
         y,
@@ -105,28 +110,31 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
       };
       info.tooltips.unshift(tooltip);
 
-      // the current point is added even if different from previous value to avoid _gaps_ in the data
-      // this is a byproduct of using separate datasets to render each color
-      currentData.push({ x, y });
-
-      // if the value is different from previous value, make a new dataset
-      if (value !== prevQueryValue) {
-        const label =
-          constantName != undefined ? `${constantName} (${String(value)})` : String(value);
-
+      // If the value maps to a different dataset than the last value, close the previous segment
+      // and insert a gap.
+      const newSegment = datasetIndex !== lastDatasetIndex;
+      if (newSegment) {
+        currentData.push({ x, y });
+        currentData.push({ x: NaN, y: NaN });
+      }
+      const label =
+        constantName != undefined ? `${constantName} (${String(value)})` : String(value);
+      if (datasetIndex == undefined) {
+        datasetIndexMap.set(value, info.datasets.length);
         const elementWithLabel = {
-          ...element,
+          x,
+          y,
           label,
           labelColor: color,
         };
 
         // new data starts with our current point, the current point
         currentData = [elementWithLabel];
-        const dataset: ChartData["datasets"][0] = {
+        const dataset: Dataset = {
           borderWidth: 10,
           borderColor: color,
           data: currentData,
-          label: pathIndex.toString(),
+          label: info.datasets.length.toString(),
           pointBackgroundColor: darkColor(color),
           pointBorderColor: "transparent",
           pointHoverRadius: 3,
@@ -138,10 +146,17 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
           },
         };
 
+        lastDatasetIndex = info.datasets.length;
         info.datasets.push(dataset);
+      } else {
+        currentData = info.datasets[datasetIndex]?.data ?? [];
+        if (newSegment) {
+          currentData.push({ x, y, label, labelColor: color } as ScatterDataPoint);
+        } else {
+          currentData.push({ x, y });
+        }
+        lastDatasetIndex = datasetIndex;
       }
-
-      prevQueryValue = value;
     }
   }
 

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -50,6 +50,7 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
 
   for (const messages of blocks) {
     if (!messages) {
+      currentData.push({ x: NaN, y: NaN });
       lastDatasetIndex = undefined;
       previousTimestamp = undefined;
       continue;

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -35,7 +35,7 @@ type Args = {
 };
 
 export default function messagesToDatasets(args: Args): DatasetInfo {
-  const { path, startTime, y, blocks } = args;
+  const { path, pathIndex, startTime, y, blocks } = args;
 
   const info: DatasetInfo = {
     datasets: [],
@@ -135,7 +135,7 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
           borderWidth: 10,
           borderColor: color,
           data: currentData,
-          label: info.datasets.length.toString(),
+          label: pathIndex.toString(),
           pointBackgroundColor: darkColor(color),
           pointBorderColor: "transparent",
           pointHoverRadius: 3,


### PR DESCRIPTION
**User-Facing Changes**
Improves performance of the state transition panel.

**Description**
Currently we map each state transition to a new dataset. For data with a large number of transitions this results in very bad interactive performance in ChartJS. The fix here is to use a different dataset for each distinct value in the data instead of for each transition and to create gaps at each state transition point.

Longer term we will probably want to rework this to put all points in a single dataset and use the ChartJS per-segment coloring features to delineate changes but this is difficult in the current architecture because the chart config needs to be serializable to pass to the worker and this precludes passing a function for the `segments` parameter:

https://www.chartjs.org/docs/latest/samples/line/segments.html

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
