### PR TITLE
3D: fix square point shape for point clouds

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -1115,15 +1115,13 @@ export function pointCloudMaterial(
     const SEARCH = "#include <output_fragment>";
     if (shape === "circle") {
       // Patch the fragment shader to render points as circles
-      shader.fragmentShader =
-        FS_SRGB_TO_LINEAR + shader.fragmentShader.replace(SEARCH, FS_POINTCLOUD_CIRCLE + SEARCH);
+      shader.fragmentShader = shader.fragmentShader.replace(SEARCH, FS_POINTCLOUD_CIRCLE + SEARCH);
     }
     if (encoding === "srgb") {
       // Patch the fragment shader to add sRGB->linear color conversion
-      shader.fragmentShader = shader.fragmentShader.replace(
-        SEARCH,
-        FS_POINTCLOUD_SRGB_TO_LINEAR + SEARCH,
-      );
+      shader.fragmentShader =
+        FS_SRGB_TO_LINEAR +
+        shader.fragmentShader.replace(SEARCH, FS_POINTCLOUD_SRGB_TO_LINEAR + SEARCH);
     }
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -17,6 +17,9 @@ import useDelayedFixture from "./useDelayedFixture";
 export default {
   title: "panels/ThreeDeeRender",
   component: ThreeDeeRender,
+  parameters: {
+    colorScheme: "dark",
+  },
 };
 
 function rgba(r: number, g: number, b: number, a: number) {
@@ -31,14 +34,22 @@ function rgba(r: number, g: number, b: number, a: number) {
 export const Foxglove_PointCloud_RGBA = (): JSX.Element => (
   <Foxglove_PointCloud rgbaFieldName="rgba" />
 );
-Foxglove_PointCloud_RGBA.parameters = { colorScheme: "dark" };
 
 export const Foxglove_PointCloud_RGB = (): JSX.Element => (
   <Foxglove_PointCloud rgbaFieldName="rgb" />
 );
-Foxglove_PointCloud_RGB.parameters = { colorScheme: "dark" };
 
-function Foxglove_PointCloud({ rgbaFieldName }: { rgbaFieldName: string }): JSX.Element {
+export const Foxglove_PointCloud_RGB_Square = (): JSX.Element => (
+  <Foxglove_PointCloud rgbaFieldName="rgb" pointShape="square" />
+);
+
+function Foxglove_PointCloud({
+  rgbaFieldName,
+  pointShape = "circle",
+}: {
+  rgbaFieldName: string;
+  pointShape?: "circle" | "square";
+}): JSX.Element {
   const topics: Topic[] = [
     { name: "/pointcloud", schemaName: "foxglove.PointCloud" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -139,6 +150,7 @@ function Foxglove_PointCloud({ rgbaFieldName }: { rgbaFieldName: string }): JSX.
             "/pointcloud": {
               visible: true,
               pointSize: 10,
+              pointShape,
               colorMode: rgbaFieldName,
               colorField: rgbaFieldName,
               rgbByteOrder: "rgba",
@@ -165,7 +177,6 @@ function Foxglove_PointCloud({ rgbaFieldName }: { rgbaFieldName: string }): JSX.
   );
 }
 
-Foxglove_PointCloud_Intensity.parameters = { colorScheme: "dark" };
 export function Foxglove_PointCloud_Intensity(): JSX.Element {
   const topics: Topic[] = [
     { name: "/pointcloud", schemaName: "foxglove.PointCloud" },
@@ -337,7 +348,6 @@ export function Foxglove_PointCloud_Intensity(): JSX.Element {
 }
 
 // Render a flat plane if we only have two dimensions
-Foxglove_PointCloud_TwoDimensions.parameters = { colorScheme: "dark" };
 export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {
   const topics: Topic[] = [{ name: "/pointcloud", schemaName: "foxglove.PointCloud" }];
 


### PR DESCRIPTION
**User-Facing Changes**
[3D] Fixed "square" point shape setting for point clouds.

**Description**
Fixes #4679.
This looks like it has been broken since #3420 (5 months)?! 😧  It was working for LaserScans, but not PointClouds.