### PR TITLE
[3D] fix auto-selection of rgbByteOrder

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -866,6 +866,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
+          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -947,6 +948,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
+          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -1035,6 +1037,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
+          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -375,11 +375,12 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
       case "rgb":
         fields.rgbByteOrder = {
           label: "RGB byte order",
+          help: "Specifies how 32-bit packed RGB values are interpreted as three 8-bit values. For example, “BGR_” would mean the 32-bit value is interpreted as 0xBBGGRR__, where the high (most significant) byte is blue and the low (least significant) byte is ignored. (When the 32-bit value is packed in little-endian order, this would mean the bytes on the wire are actually [0x__, 0xRR, 0xGG, 0xBB].)",
           input: "select",
           options: [
-            { label: "RGB", value: "rgba" },
-            { label: "BGR", value: "bgra" },
-            { label: "XBGR", value: "abgr" },
+            { label: "RGB_", value: "rgba" },
+            { label: "BGR_", value: "bgra" },
+            { label: "_BGR", value: "abgr" },
           ],
           value: rgbByteOrder,
         };
@@ -387,6 +388,7 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
       case "rgba":
         fields.rgbByteOrder = {
           label: "RGBA byte order",
+          help: "Specifies how 32-bit packed RGB values are interpreted as four 8-bit values. For example, “BGRA” would mean the 32-bit value is interpreted as 0xBBGGRRAA, where the high (most significant) byte is blue and the low (least significant) byte is alpha. (When the 32-bit value is packed in little-endian order, this would mean the bytes on the wire are actually [0xAA, 0xRR, 0xGG, 0xBB].)",
           input: "select",
           options: [
             { label: "RGBA", value: "rgba" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -375,12 +375,11 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
       case "rgb":
         fields.rgbByteOrder = {
           label: "RGB byte order",
-          help: "Specifies how 32-bit packed RGB values are interpreted as three 8-bit values. For example, “BGR_” would mean the 32-bit value is interpreted as 0xBBGGRR__, where the high (most significant) byte is blue and the low (least significant) byte is ignored. (When the 32-bit value is packed in little-endian order, this would mean the bytes on the wire are actually [0x__, 0xRR, 0xGG, 0xBB].)",
           input: "select",
           options: [
-            { label: "RGB_", value: "rgba" },
-            { label: "BGR_", value: "bgra" },
-            { label: "_BGR", value: "abgr" },
+            { label: "RGB", value: "rgba" },
+            { label: "BGR", value: "bgra" },
+            { label: "XBGR", value: "abgr" },
           ],
           value: rgbByteOrder,
         };
@@ -388,7 +387,6 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
       case "rgba":
         fields.rgbByteOrder = {
           label: "RGBA byte order",
-          help: "Specifies how 32-bit packed RGB values are interpreted as four 8-bit values. For example, “BGRA” would mean the 32-bit value is interpreted as 0xBBGGRRAA, where the high (most significant) byte is blue and the low (least significant) byte is alpha. (When the 32-bit value is packed in little-endian order, this would mean the bytes on the wire are actually [0xAA, 0xRR, 0xGG, 0xBB].)",
           input: "select",
           options: [
             { label: "RGBA", value: "rgba" },


### PR DESCRIPTION
**User-Facing Changes**
[3D] Fixed a bug with RGB point clouds where the automatically-selected settings would sometimes change after the point cloud was initially displayed.

**Description**
Fixes #4680

We were using the `autoSelectColorField` function to choose the colorMode and rgbByteOrder, but the rgbByteOrder wasn't actually being saved in the panel config. So when the renderable got updated, it would re-read the saved config value, which was undefined, and fall back to a different value.