### PR TITLE
[3D] Rename "RGB byte order" setting to "RGB wire format", clarify dropdown options

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -14,6 +14,8 @@ import {
   getColorConverter,
   autoSelectColorField,
   NEEDS_MIN_MAX,
+  DEFAULT_RGB_WIRE_FORMAT,
+  getRgbWireFormat,
 } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointClouds/colors";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
@@ -40,7 +42,6 @@ const DEFAULT_COLOR_MAP = "turbo";
 const DEFAULT_FLAT_COLOR = { r: 1, g: 1, b: 1, a: 1 };
 const DEFAULT_MIN_COLOR = { r: 100 / 255, g: 47 / 255, b: 105 / 255, a: 1 };
 const DEFAULT_MAX_COLOR = { r: 227 / 255, g: 177 / 255, b: 135 / 255, a: 1 };
-const DEFAULT_RGB_BYTE_ORDER = "rgba";
 
 const DEFAULT_SETTINGS: LayerSettingsFoxgloveGrid = {
   visible: false,
@@ -53,8 +54,19 @@ const DEFAULT_SETTINGS: LayerSettingsFoxgloveGrid = {
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
   explicitAlpha: 1,
-  rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
+  rgbWireFormat: DEFAULT_RGB_WIRE_FORMAT,
 };
+
+function mergeSettingsWithDefaults(
+  settings: Partial<LayerSettingsFoxgloveGrid> | undefined,
+): LayerSettingsFoxgloveGrid {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...settings,
+    rgbByteOrder: undefined,
+    rgbWireFormat: settings ? getRgbWireFormat(settings) : DEFAULT_SETTINGS.rgbWireFormat,
+  };
+}
 
 export type FoxgloveGridUserData = BaseUserData & {
   settings: LayerSettingsFoxgloveGrid;
@@ -138,7 +150,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
-      renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
+      renderable.userData.settings = mergeSettingsWithDefaults(settings);
 
       this._updateFoxgloveGridRenderable(
         renderable,
@@ -160,7 +172,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+      const settings = mergeSettingsWithDefaults(userSettings);
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, foxgloveGrid.fields);
         // Update user settings with the newly selected color field
@@ -169,6 +181,8 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
+          updatedUserSettings.rgbWireFormat = settings.rgbWireFormat;
+          delete updatedUserSettings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -49,8 +49,11 @@ import {
   colorHasTransparency,
   ColorModeSettings,
   COLOR_FIELDS,
+  DEFAULT_RGB_WIRE_FORMAT,
   getColorConverter,
+  getRgbWireFormat,
   INTENSITY_FIELDS,
+  NEEDS_MIN_MAX,
 } from "./pointClouds/colors";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
@@ -103,10 +106,8 @@ const DEFAULT_COLOR_MAP = "turbo";
 const DEFAULT_FLAT_COLOR = { r: 1, g: 1, b: 1, a: 1 };
 const DEFAULT_MIN_COLOR = { r: 100 / 255, g: 47 / 255, b: 105 / 255, a: 1 };
 const DEFAULT_MAX_COLOR = { r: 227 / 255, g: 177 / 255, b: 135 / 255, a: 1 };
-const DEFAULT_RGB_BYTE_ORDER = "rgba";
-const NEEDS_MIN_MAX = ["gradient", "colormap"];
 
-export const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
+const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
   visible: false,
   frameLocked: false,
   pointSize: DEFAULT_POINT_SIZE,
@@ -118,10 +119,22 @@ export const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
   explicitAlpha: 1,
-  rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
+  rgbWireFormat: DEFAULT_RGB_WIRE_FORMAT,
   minValue: undefined,
   maxValue: undefined,
 };
+
+/** Add defaults and migrate outdated settings to new keys. */
+export function mergeSettingsWithDefaults(
+  settings: Partial<LayerSettingsPointCloudAndLaserScan> | undefined,
+): LayerSettingsPointCloudAndLaserScan {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...settings,
+    rgbByteOrder: undefined,
+    rgbWireFormat: settings ? getRgbWireFormat(settings) : DEFAULT_SETTINGS.rgbWireFormat,
+  };
+}
 
 const ALL_POINTCLOUD_DATATYPES = new Set<string>([
   ...FOXGLOVE_POINTCLOUD_DATATYPES,
@@ -826,7 +839,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       const prevSettings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
+      const settings = mergeSettingsWithDefaults(prevSettings);
       if (renderable.userData.pointCloud) {
         renderable.updatePointCloud(
           renderable.userData.pointCloud,
@@ -856,7 +869,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+      const settings = mergeSettingsWithDefaults(userSettings);
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, pointCloud);
 
@@ -866,7 +879,8 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
+          updatedUserSettings.rgbWireFormat = settings.rgbWireFormat;
+          delete updatedUserSettings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -938,7 +952,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+      const settings = mergeSettingsWithDefaults(userSettings);
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, pointCloud);
 
@@ -948,7 +962,8 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
+          updatedUserSettings.rgbWireFormat = settings.rgbWireFormat;
+          delete updatedUserSettings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -1025,7 +1040,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+      const settings = mergeSettingsWithDefaults(userSettings);
       if (settings.colorField == undefined) {
         settings.colorField = "intensity";
         settings.colorMode = "colormap";
@@ -1037,7 +1052,8 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
+          updatedUserSettings.rgbWireFormat = settings.rgbWireFormat;
+          delete updatedUserSettings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -29,8 +29,8 @@ import {
   createInstancePickingMaterial,
   createPickingMaterial,
   createPoints,
-  DEFAULT_SETTINGS,
   LayerSettingsPointCloudAndLaserScan,
+  mergeSettingsWithDefaults,
   PointCloudAndLaserScanRenderable,
   pointCloudMaterial,
   pointCloudSettingsNode,
@@ -163,7 +163,7 @@ export class VelodyneScans extends SceneExtension<PointCloudAndLaserScanRenderab
       const prevSettings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...prevSettings };
+      const settings = mergeSettingsWithDefaults(prevSettings);
       if (renderable.userData.pointCloud) {
         renderable.updatePointCloud(
           renderable.userData.pointCloud,
@@ -204,7 +204,7 @@ export class VelodyneScans extends SceneExtension<PointCloudAndLaserScanRenderab
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsPointCloudAndLaserScan>
         | undefined;
-      const settings = { ...DEFAULT_SETTINGS, ...userSettings };
+      const settings = mergeSettingsWithDefaults(userSettings);
       if (settings.colorField == undefined) {
         autoSelectColorField(settings, pointCloud);
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -16,7 +16,9 @@ export type ColorConverter = (output: ColorRGBA, colorValue: number) => void;
 
 const tempColor1 = { r: 0, g: 0, b: 0, a: 0 };
 const tempColor2 = { r: 0, g: 0, b: 0, a: 0 };
+
 export const NEEDS_MIN_MAX = ["gradient", "colormap"];
+export const DEFAULT_RGB_WIRE_FORMAT = "abgr";
 
 export interface ColorModeSettings {
   colorMode: "flat" | "gradient" | "colormap" | "rgb" | "rgba";
@@ -25,7 +27,9 @@ export interface ColorModeSettings {
   gradient: [string, string];
   colorMap: "turbo" | "rainbow";
   explicitAlpha: number;
-  rgbByteOrder: "rgba" | "bgra" | "abgr";
+  /** @deprecated Old setting values that were in reverse order from the new rgbWireFormat */
+  rgbByteOrder?: "rgba" | "bgra" | "abgr";
+  rgbWireFormat: "abgr" | "argb" | "rgba";
   minValue?: number;
   maxValue?: number;
 }
@@ -76,39 +80,39 @@ export function getColorConverter<Settings extends ColorModeSettings>(
       throw new Error(`Unrecognized color map: ${settings.colorMap}`);
     }
     case "rgb":
-      switch (settings.rgbByteOrder) {
+      switch (settings.rgbWireFormat) {
         default:
-        case "rgba":
-          return (output: ColorRGBA, colorValue: number) => {
-            getColorRgb(output, colorValue);
-            output.a = settings.explicitAlpha;
-          };
-        case "bgra":
-          return (output: ColorRGBA, colorValue: number) => {
-            getColorBgr(output, colorValue);
-            output.a = settings.explicitAlpha;
-          };
         case "abgr":
           return (output: ColorRGBA, colorValue: number) => {
-            getColor0bgr(output, colorValue);
+            getColorXBGR(output, colorValue);
+            output.a = settings.explicitAlpha;
+          };
+        case "argb":
+          return (output: ColorRGBA, colorValue: number) => {
+            getColorXRGB(output, colorValue);
+            output.a = settings.explicitAlpha;
+          };
+        case "rgba":
+          return (output: ColorRGBA, colorValue: number) => {
+            getColorRGBX(output, colorValue);
             output.a = settings.explicitAlpha;
           };
       }
     case "rgba":
-      switch (settings.rgbByteOrder) {
+      switch (settings.rgbWireFormat) {
         default:
-        case "rgba":
-          return getColorRgba;
-        case "bgra":
-          return getColorBgra;
         case "abgr":
-          return getColorAbgr;
+          return getColorABGR;
+        case "argb":
+          return getColorARGB;
+        case "rgba":
+          return getColorRGBA;
       }
   }
 }
 
-// 0xrrggbb00
-function getColorRgb(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0x__, 0xBB, 0xGG, 0xRR], or uint32 value 0xRRGGBB__ */
+function getColorXBGR(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0xff000000) >>> 24) / 255;
   output.g = ((num & 0x00ff0000) >>> 16) / 255;
@@ -116,8 +120,8 @@ function getColorRgb(output: ColorRGBA, colorValue: number): void {
   output.a = 1;
 }
 
-// 0xrrggbbaa
-function getColorRgba(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0xAA, 0xBB, 0xGG, 0xRR], or uint32 value 0xRRGGBBAA */
+function getColorABGR(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0xff000000) >>> 24) / 255;
   output.g = ((num & 0x00ff0000) >>> 16) / 255;
@@ -125,8 +129,8 @@ function getColorRgba(output: ColorRGBA, colorValue: number): void {
   output.a = ((num & 0x000000ff) >>> 0) / 255;
 }
 
-// 0xbbggrr00
-function getColorBgr(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0x__, 0xRR, 0xGG, 0xBB], or uint32 value 0xBBGGRR__ */
+function getColorXRGB(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0x0000ff00) >>> 8) / 255;
   output.g = ((num & 0x00ff0000) >>> 16) / 255;
@@ -134,8 +138,8 @@ function getColorBgr(output: ColorRGBA, colorValue: number): void {
   output.a = 1;
 }
 
-// 0xbbggrraa
-function getColorBgra(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0xAA, 0xRR, 0xGG, 0xBB], or uint32 value 0xBBGGRRAA */
+function getColorARGB(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0x0000ff00) >>> 8) / 255;
   output.g = ((num & 0x00ff0000) >>> 16) / 255;
@@ -143,8 +147,8 @@ function getColorBgra(output: ColorRGBA, colorValue: number): void {
   output.a = ((num & 0x000000ff) >>> 0) / 255;
 }
 
-// 0x00bbggrr
-function getColor0bgr(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0xRR, 0xGG, 0xBB, 0x__], or uint32 value 0x__BBGGRR */
+function getColorRGBX(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0x000000ff) >>> 0) / 255;
   output.g = ((num & 0x0000ff00) >>> 8) / 255;
@@ -152,8 +156,8 @@ function getColor0bgr(output: ColorRGBA, colorValue: number): void {
   output.a = 1;
 }
 
-// 0xaabbggrr
-function getColorAbgr(output: ColorRGBA, colorValue: number): void {
+/** Little-endian wire order [0xRR, 0xGG, 0xBB, 0xAA], or uint32 value 0xAABBGGRR */
+function getColorRGBA(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
   output.r = ((num & 0x000000ff) >>> 0) / 255;
   output.g = ((num & 0x0000ff00) >>> 8) / 255;
@@ -258,24 +262,29 @@ export function autoSelectColorField<Settings extends ColorModeSettings>(
       switch (fieldNameLower) {
         case "rgb":
           output.colorMode = "rgb";
-          output.rgbByteOrder = "abgr";
+          output.rgbWireFormat = "rgba";
+          delete output.rgbByteOrder;
           break;
         default:
         case "rgba":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
+          output.rgbWireFormat = "rgba";
+          delete output.rgbByteOrder;
           break;
         case "bgr":
           output.colorMode = "rgb";
-          output.rgbByteOrder = "bgra";
+          output.rgbWireFormat = "argb";
+          delete output.rgbByteOrder;
           break;
         case "bgra":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "bgra";
+          output.rgbWireFormat = "argb";
+          delete output.rgbByteOrder;
           break;
         case "abgr":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
+          output.rgbWireFormat = "rgba";
+          delete output.rgbByteOrder;
           break;
       }
       return;
@@ -306,6 +315,26 @@ export function bestColorByField(fields: string[]): string {
   return fields.find((field) => field === "x") || fields[0] ? fields[0]! : "";
 }
 
+/** Convert the deprecated rgbByteOrder value to rgbWireFormat */
+export function getRgbWireFormat(
+  config: Partial<ColorModeSettings>,
+): ColorModeSettings["rgbWireFormat"] {
+  if (config.rgbWireFormat != undefined) {
+    return config.rgbWireFormat;
+  }
+  if (config.rgbByteOrder != undefined) {
+    switch (config.rgbByteOrder) {
+      case "rgba":
+        return "abgr";
+      case "bgra":
+        return "argb";
+      case "abgr":
+        return "rgba";
+    }
+  }
+  return DEFAULT_RGB_WIRE_FORMAT;
+}
+
 export function baseColorModeSettingsNode<Settings extends ColorModeSettings & BaseSettings>(
   msgFields: string[],
   config: Partial<Settings>,
@@ -320,7 +349,7 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
   const gradient = config.gradient;
   const colorMap = config.colorMap ?? "turbo";
   const explicitAlpha = config.explicitAlpha ?? 1;
-  const rgbByteOrder = config.rgbByteOrder ?? "rgba";
+  const rgbWireFormat = getRgbWireFormat(config);
   const minValue = config.minValue;
   const maxValue = config.maxValue;
 
@@ -373,27 +402,29 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
         };
         break;
       case "rgb":
-        fields.rgbByteOrder = {
-          label: "RGB byte order",
+        fields.rgbWireFormat = {
+          label: "RGB wire format",
+          help: "Order of bytes in a 4-byte packed RGB field",
           input: "select",
           options: [
-            { label: "RGB", value: "rgba" },
-            { label: "BGR", value: "bgra" },
-            { label: "XBGR", value: "abgr" },
+            { label: "_BGR", value: "abgr" },
+            { label: "_RGB", value: "argb" },
+            { label: "RGB_", value: "rgba" },
           ],
-          value: rgbByteOrder,
+          value: rgbWireFormat,
         };
         break;
       case "rgba":
-        fields.rgbByteOrder = {
-          label: "RGBA byte order",
+        fields.rgbWireFormat = {
+          label: "RGBA wire format",
+          help: "Order of bytes in a 4-byte packed RGBA field",
           input: "select",
           options: [
-            { label: "RGBA", value: "rgba" },
-            { label: "BGRA", value: "bgra" },
             { label: "ABGR", value: "abgr" },
+            { label: "ARGB", value: "argb" },
+            { label: "RGBA", value: "rgba" },
           ],
-          value: rgbByteOrder,
+          value: rgbWireFormat,
         };
         break;
       default:


### PR DESCRIPTION
**User-Facing Changes**
Improved the clarity of RGB byte order settings for point clouds and grids in the 3D panel.

**Description**
Related: #4483

This replaces `rgbByteOrder` with `rgbWireFormat`. The dropdown labels and raw config values have been byte-swapped, so what used to be called "RGBA" and stored in the config as `{ rgbByteOrder: "rgba" }` is now called "ABGR" and stored in the config as `{ rgbWireFormat: "abgr" }`.

This corrects a misleading inconsistency where the setting was called "byte order", but the order of bytes in the pointcloud/grid `data` was actually the opposite from what was shown in the settings UI and stored in the config.

Previously, the "RGB byte order" setting was interpreted by Studio as though it actually referred to the order of color components in the human-readable **positional notation** (where the most significant digits are on the left). That is, a setting of "RGBA" meant that the 32-bit numeric value of 0x11223344 (287454020 in base 10) would be interpreted as red=0x11, green=0x22, blue=0x33, alpha=0x44. Where this becomes confusing is that Studio also requires 32-bit numeric values to be encoded with **little-endian byte order**. This means that the actual order of bytes in the `data` would be equivalent to `new Uint8Array([0x44, 0x33, 0x22, 0x11])`.

To address this confusion, we replace "byte order" with "wire format" to be more clear that we are talking about the encoded bytes in the buffer. We also swap the labels of the options, so that the option labeled "RGBA" option now actually refers to a wire format of `new Uint8Array([0xRR, 0xGG, 0xBB, 0xAA])` (which is equivalent to `new Uint32Array([0xAABBGGRR])` on a little-endian system).

### Proposed docs update
This is a proposal for some additions to the 3D panel documentation to explain packed RGB support and help users work through these inconsistencies:

----
Foxglove Studio allows PointClouds and Grids to contain embedded color information. Rather than using a numeric field (for example, the `intensity` of a lidar return), and choosing point or cell colors based on the range of those `intensity` values, the RGB or RGBA values can be **packed** into a single 4-byte field, where each byte represents one channel (red, green, blue, or alpha).

The values may be packed into any 4-byte field supported by [PackedElementField](https://foxglove.dev/docs/studio/messages/packed-element-field), but `uint32` is recommended. To color a point cloud or grid using packed RGB data, choose the **RGB** or **RGBA** options in the "**Color mode**" dropdown. (RGBA reads all four channels from the packed data, while RGB ignores the packed alpha channel and allows you to configure an explicit alpha value in the topic settings.)

Different robotics frameworks or custom software stacks may choose to pack the red, green, blue, and alpha values into byte buffers in different ways. To accommodate the most common encodings, the 3D panel also provides a topic setting called "**RGB wire format**". This setting tells Studio what to expect when it reads the packed 4-byte field. The setting values refer to the **order of bytes "on the wire"** (meaning in the `data` buffer, or in your computer's memory). So, if the wire format is set to **ABGR**, then the first byte in the buffer would represent the alpha value, and the fourth would represent the red value.

> Note: when writing code to pack your own RGBA values, be aware that your computer likely represents 32-bit numbers in **little-endian byte order** (least significant bytes come first in memory). This means that a 32-bit numeric value of `0x12345678` (305419896 in base 10) in your source code would actually be encoded in memory as the 4-byte sequence `[0x78, 0x56, 0x34, 0x12]`.

The following table demonstrates Foxglove Studio's different wire format settings and how they map to common code patterns.

"RGB wire format" setting | Bytes in memory | 32-bit unsigned integer value (little-endian)
--- | --- | ---
RGBA | <pre>buffer[offset+0] = 0xRR<br>buffer[offset+1] = 0xGG<br>buffer[offset+2] = 0xBB<br>buffer[offset+3] = 0xAA</pre> | `0xAABBGGRR` or <code>(0xAA << 24) \| (0xBB << 16) \| (0xGG << 8) \| 0xRR</code>
ARGB | <pre>buffer[offset+0] = 0xAA<br>buffer[offset+1] = 0xRR<br>buffer[offset+2] = 0xGG<br>buffer[offset+3] = 0xBB</pre> | `0xBBGGRRAA` or <code>(0xBB << 24) \| (0xGG << 16) \| (0xRR << 8) \| 0xAA</code>
ABGR | <pre>buffer[offset+0] = 0xAA<br>buffer[offset+1] = 0xBB<br>buffer[offset+2] = 0xGG<br>buffer[offset+3] = 0xRR</pre> | `0xRRGGBBAA` or <code>(0xRR << 24) \| (0xGG << 16) \| (0xBB << 8) \| 0xAA</code>