### PR TITLE
panels/3d: update light backdrop color to match Studio app palette background

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -192,7 +192,7 @@ const MAX_SELECTIONS = 10;
 
 // NOTE: These do not use .convertSRGBToLinear() since background color is not
 // affected by gamma correction
-const LIGHT_BACKDROP = new THREE.Color(0xececec);
+const LIGHT_BACKDROP = new THREE.Color(0xf4f4f5);
 const DARK_BACKDROP = new THREE.Color(0x121217);
 
 // Define rendering layers for multipass rendering used for the selection effect

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -23,6 +23,7 @@ import {
   VariableValue,
 } from "@foxglove/studio";
 import { FoxgloveGrid } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/FoxgloveGrid";
+import { light, dark } from "@foxglove/studio-base/theme/palette";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { LabelMaterial, LabelPool } from "@foxglove/three-text";
 
@@ -192,8 +193,8 @@ const MAX_SELECTIONS = 10;
 
 // NOTE: These do not use .convertSRGBToLinear() since background color is not
 // affected by gamma correction
-const LIGHT_BACKDROP = new THREE.Color(0xf4f4f5);
-const DARK_BACKDROP = new THREE.Color(0x121217);
+const LIGHT_BACKDROP = new THREE.Color(light.background?.default);
+const DARK_BACKDROP = new THREE.Color(dark.background?.default);
 
 // Define rendering layers for multipass rendering used for the selection effect
 const LAYER_DEFAULT = 0;


### PR DESCRIPTION


**User-Facing Changes**
Default background color for 3d panel matches other panels in light and dark mode.

**Description**
The 3d panel's background color for light mode did not match the palette background. This updates the panel to match the light background palette as it already did for dark background palette.

Fixes: #4365

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
