### PR TITLE
Fix value escaping in parameter panel

### DIFF
--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -35,8 +35,10 @@ const getFixture = ({
             ["number", -42],
             ["string", "Hello, world!"],
             ["date", new Date(1618876820517)],
-            ["Uint8Array", new Uint8Array([0, 1, 2, 3, 4, 5])],
-            ["struct", { a: 1, b: [2, 3, 4], c: "String value" }],
+            ["Uint8Array", new Uint8Array([0, 1])],
+            ["array", [1, 2]],
+            ["string array", ["one", "two", "three"]],
+            ["struct", { a: 1, b: [2, 3], c: "String value" }],
           ])
         : undefined,
     },
@@ -59,6 +61,14 @@ export function Default(): JSX.Element {
 export function WithParameters(): JSX.Element {
   return (
     <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
+      <Parameters />
+    </PanelSetup>
+  );
+}
+
+export function WithEditableParameters(): JSX.Element {
+  return (
+    <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
       <Parameters />
     </PanelSetup>
   );

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -185,7 +185,7 @@ function Parameters(): ReactElement {
                   {canSetParams ? (
                     <TableCell padding="none">
                       <JsonInput
-                        dataTestId={`parameter-value-input-${editValue}`}
+                        dataTestId={`parameter-value-input-${displayValue}`}
                         value={editValue}
                         onChange={(newVal) => {
                           setParameter(name, newVal as ParameterValue);

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles<void, "copyIcon">()((_theme, _params, classes) => (
   },
 }));
 
-function displayValue(value: unknown): string | number | boolean | unknown[] | object {
+function editableValue(value: unknown): string | number | boolean | unknown[] | object {
   if (
     typeof value === "string" ||
     typeof value === "number" ||
@@ -166,7 +166,8 @@ function Parameters(): ReactElement {
           </TableHead>
           <TableBody>
             {parameterNames.map((name) => {
-              const value = displayValue(parameters.get(name));
+              const displayValue = JSON.stringify(parameters.get(name)) ?? "";
+              const editValue = editableValue(parameters.get(name));
 
               return (
                 <TableRow
@@ -184,8 +185,8 @@ function Parameters(): ReactElement {
                   {canSetParams ? (
                     <TableCell padding="none">
                       <JsonInput
-                        dataTestId={`parameter-value-input-${value}`}
-                        value={value}
+                        dataTestId={`parameter-value-input-${editValue}`}
+                        value={editValue}
                         onChange={(newVal) => {
                           setParameter(name, newVal as ParameterValue);
                         }}
@@ -195,11 +196,11 @@ function Parameters(): ReactElement {
                     <TableCell>
                       <Typography
                         noWrap
-                        title={String(value)}
+                        title={String(editValue)}
                         variant="inherit"
                         color="text.secondary"
                       >
-                        {value}
+                        {displayValue}
                       </Typography>
                     </TableCell>
                   )}
@@ -210,7 +211,7 @@ function Parameters(): ReactElement {
                       edge="end"
                       size="small"
                       iconSize="small"
-                      getText={() => `${name}: ${value}`}
+                      getText={() => `${name}: ${editValue}`}
                     />
                   </TableCell>
                 </TableRow>

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -211,7 +211,7 @@ function Parameters(): ReactElement {
                       edge="end"
                       size="small"
                       iconSize="small"
-                      getText={() => `${name}: ${editValue}`}
+                      getText={() => `${name}: ${displayValue}`}
                     />
                   </TableCell>
                 </TableRow>

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -196,7 +196,7 @@ function Parameters(): ReactElement {
                     <TableCell>
                       <Typography
                         noWrap
-                        title={String(editValue)}
+                        title={displayValue}
                         variant="inherit"
                         color="text.secondary"
                       >

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { union } from "lodash";
+import { isObject, union } from "lodash";
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
@@ -78,6 +78,20 @@ const useStyles = makeStyles<void, "copyIcon">()((_theme, _params, classes) => (
     },
   },
 }));
+
+function displayValue(value: unknown): string | number | boolean | unknown[] | object {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    Array.isArray(value) ||
+    isObject(value)
+  ) {
+    return value;
+  } else {
+    return JSON.stringify(value) ?? "";
+  }
+}
 
 function Parameters(): ReactElement {
   const { classes } = useStyles();
@@ -152,7 +166,7 @@ function Parameters(): ReactElement {
           </TableHead>
           <TableBody>
             {parameterNames.map((name) => {
-              const value = JSON.stringify(parameters.get(name)) ?? "";
+              const value = displayValue(parameters.get(name));
 
               return (
                 <TableRow
@@ -179,7 +193,12 @@ function Parameters(): ReactElement {
                     </TableCell>
                   ) : (
                     <TableCell>
-                      <Typography noWrap title={value} variant="inherit" color="text.secondary">
+                      <Typography
+                        noWrap
+                        title={String(value)}
+                        variant="inherit"
+                        color="text.secondary"
+                      >
                         {value}
                       </Typography>
                     </TableCell>


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the display of values in the parameter panel.

**Description**
The parameter panel was applying `JSON.stringify` to all parameter values. We should only do this in cases where the value isn't a type we can edit directly.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4681