### PR TITLE
Fix crash in state transition panel on large datasets

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -235,8 +235,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
   const { datasets, tooltips, minY } = useMemo(() => {
     let outMinY: number | undefined;
 
-    const outTooltips: TimeBasedChartTooltipData[] = [];
-    const outDatasets: ChartData["datasets"] = [];
+    let outTooltips: TimeBasedChartTooltipData[] = [];
+    let outDatasets: ChartData["datasets"] = [];
 
     // ignore all data when we don't have a start time
     if (!startTime) {
@@ -264,8 +264,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
           blocks: blocksForPath,
         });
 
-        outDatasets.push(...newDataSets);
-        outTooltips.push(...newTooltips);
+        outDatasets = outDatasets.concat(newDataSets);
+        outTooltips = outTooltips.concat(newTooltips);
       }
 
       // If we have have messages in blocks for this path, we ignore streamed messages and only
@@ -284,8 +284,8 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
           pathIndex,
           blocks: [items],
         });
-        outDatasets.push(...newDataSets);
-        outTooltips.push(...newTooltips);
+        outDatasets = outDatasets.concat(newDataSets);
+        outTooltips = outTooltips.concat(newTooltips);
       }
     });
 


### PR DESCRIPTION
**User-Facing Changes**
Fix crash in the state transition panel on large datasets.

**Description**
Fix a crash in large datasets in the state transition panel. The panel uses `array.push(...data)` to append new items to the accumulated message array but when data is large this overflows the stack since the elements in data have to be pushed onto the stack to make the function call. In my testing this occurs somewhere above 300k elements.

Further work will be necessary to make the state transition panel performant for datesets with this many messages but this will at least address the crash.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
