### PR TITLE
Fix Cube List markers not updating

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/DynamicInstancedMesh.ts
@@ -49,6 +49,10 @@ export class DynamicInstancedMesh<
       tempColor.setRGB(color.r, color.g, color.b);
       this.setColorAt(i, tempColor);
     }
+    this.instanceMatrix.needsUpdate = true;
+    if (this.instanceColor) {
+      this.instanceColor.needsUpdate = true;
+    }
   }
 
   private _setCount(count: number) {


### PR DESCRIPTION
**User-Facing Changes**
 - fix cube list (type = 6) marker primitives not updating


**Description**
 - attributebuffers need `needsUpdate = true` after they're changed to be sent to the GPU again. should also fix similar issue with spheres and other `DynamicInstanceMesh` renderables


<!-- link relevant github issues -->
Fixes #4699
<!-- add `docs` label if this PR requires documentation updates -->
