### PR TITLE
Fix variable sidebar value updates

### DIFF
--- a/packages/studio-base/src/components/JsonInput.tsx
+++ b/packages/studio-base/src/components/JsonInput.tsx
@@ -177,6 +177,7 @@ function ValidatedInputBase({
         value={inputStr}
         onChange={handleChange}
         language="json"
+        onBlur={() => setIsEditing(false)}
         padding={12}
         style={{ maxHeight: maxHeight ?? 300 }}
       />


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the variable sidebar failing to update values changed outside the sidebar.

**Description**
Fixes logic around updating externally changed values in the variable sidebar.

There is an `isEditing` flag we use to determine if we should apply new values from changes not made directly in the sidebar but once this is set to true there is no way for it to become false again. This uses the editor's `onBlur` event to set it back to false so we can accept external values again.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4722