### PR TITLE
Emit state during velodyne player setup

### DIFF
--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -102,7 +102,8 @@ export default class VelodynePlayer implements Player {
     if (this._closed) {
       return;
     }
-    this._presence = PlayerPresence.INITIALIZING;
+    this._presence = PlayerPresence.PRESENT;
+    this._emitState();
 
     if (this._socket == undefined) {
       const net = await Sockets.Create();


### PR DESCRIPTION

**User-Facing Changes**
When connecting to Velodyne data sources, the open dialog is immediately dismissed upon clicking "open".

**Description**
When selecting a data source, the open dialog remains open until a player presence other than NOT_PRESENT is set of the player state. Since the velodyne player would only produce a player state when receiving its first message the open dialog would remain open after setting the port and clicking "open". This behavior makes it look like the dialog is broken and the user's click action was not registered.

This change updates the Velodyne player to emit a state update during initialization which clears the open dialog and shows the user the data source information. I've opted to change the state from INITIALIZING to PRESENT since we know all the datatype information for the player and are waiting for new messages. These messages will start to arrive when the user turns on the sensor or configured their network to match the sensor requirements.

Fixes: #4689



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
