### PR TITLE
Add Toggle for Auto-Calculating Min/Max to Datatypes with Fields

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -471,12 +471,12 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       renderable.handleSettingsChange(fullSettings);
 
       if (settings?.calcMinMax === true) {
-        this.updateSettingsMinMaxFromRenderable(renderable);
+        this._updateMinMaxValueSettings(renderable);
       }
     }
   };
 
-  private updateSettingsMinMaxFromRenderable(renderable: FoxgloveGridRenderable) {
+  private _updateMinMaxValueSettings(renderable: FoxgloveGridRenderable): void {
     const settingsPath = [...renderable.userData.settingsPath, "minValue"];
     renderable.getMinMaxColorValues(tempMinMaxColor);
     this.saveSetting(settingsPath, tempMinMaxColor[0]);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -30,9 +30,6 @@ export type LayerSettingsFoxgloveGrid = BaseSettings &
   ColorModeSettings & {
     frameLocked: boolean;
   };
-function zeroReader(): number {
-  return 0;
-}
 
 const floatTextureColorModes: ColorModeSettings["colorMode"][] = ["gradient", "colormap"];
 
@@ -108,6 +105,8 @@ export type FoxgloveGridUserData = BaseUserData & {
 const tempColor = { r: 0, g: 0, b: 0, a: 1 };
 const tempMinMaxColor: THREE.Vector2Tuple = [0, 0];
 export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
+  private fieldReader: FieldReader | undefined = undefined;
+
   public override dispose(): void {
     this.userData.texture.dispose();
     this.userData.material.dispose();
@@ -124,10 +123,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     pickingMaterial.needsUpdate = true;
   }
 
-  private _getFieldReader(
-    foxgloveGrid: Grid,
-    settings: LayerSettingsFoxgloveGrid,
-  ): FieldReader | undefined {
+  public updateFieldReader(foxgloveGrid: Grid, settings: LayerSettingsFoxgloveGrid): void {
     let colorReader: FieldReader | undefined;
 
     const stride = foxgloveGrid.cell_stride;
@@ -167,10 +163,41 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
       invalidFoxgloveGridError(this.renderer, this, message);
       return undefined;
     }
-
-    return colorReader ?? zeroReader;
+    this.fieldReader = colorReader;
   }
 
+  /**
+   * Will return min/max color values for the passed foxglovegrid message
+   * @param output  - will contain [min, max]
+   * @param foxgloveGrid  -  necessary to get the data and rows/cols
+   */
+  public getMinMaxValue(output: THREE.Vector2Tuple, foxgloveGrid: Grid): void {
+    let minColorValue = Number.POSITIVE_INFINITY;
+    let maxColorValue = Number.NEGATIVE_INFINITY;
+
+    if (this.fieldReader) {
+      const view = new DataView(
+        foxgloveGrid.data.buffer,
+        foxgloveGrid.data.byteOffset,
+        foxgloveGrid.data.length,
+      );
+      const cols = foxgloveGrid.column_count;
+      const rows = foxgloveGrid.data.length / foxgloveGrid.row_stride;
+      for (let y = 0; y < rows; y++) {
+        for (let x = 0; x < cols; x++) {
+          const offset = y * foxgloveGrid.row_stride + x * foxgloveGrid.cell_stride;
+          const colorValue = this.fieldReader(view, offset);
+          minColorValue = Math.min(minColorValue, colorValue);
+          maxColorValue = Math.max(maxColorValue, colorValue);
+        }
+      }
+    }
+
+    output[0] = minColorValue;
+    output[1] = maxColorValue;
+  }
+
+  /** Updates the Transparency of the material and any other necessary properties dependent on settings */
   public updateMaterial(settings: LayerSettingsFoxgloveGrid): void {
     const { colorMode } = settings;
     const { material } = this.userData;
@@ -198,6 +225,20 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     }
   }
 
+  /**
+   *
+   * @param output  - holds the output min and max values contained in the uniform
+   */
+  public getMinMaxColorValues(output: THREE.Vector2Tuple): void {
+    output[0] = this.userData.material.uniforms.minValue.value;
+    output[1] = this.userData.material.uniforms.maxValue.value;
+  }
+
+  /**
+   *  Updates the uniforms on the material according to the message and settings
+   * @param foxgloveGrid - Grid Message
+   * @param settings - settings
+   */
   public updateUniforms(foxgloveGrid: Grid, settings: LayerSettingsFoxgloveGrid): void {
     const { material } = this.userData;
     const {
@@ -218,12 +259,16 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
 
     colorMapOpacity.value = settings.explicitAlpha;
 
-    minMaxColorValues(
-      tempMinMaxColor,
-      settings,
-      foxgloveGrid.fields.find((field) => settings.colorField === field.name)?.type ??
-        NumericType.UNKNOWN,
-    );
+    if (settings.calcMinMax === true) {
+      this.getMinMaxValue(tempMinMaxColor, foxgloveGrid);
+    } else {
+      minMaxNumericValues(
+        tempMinMaxColor,
+        settings,
+        foxgloveGrid.fields.find((field) => settings.colorField === field.name)?.type ??
+          NumericType.UNKNOWN,
+      );
+    }
 
     const [minColorValue, maxColorValue] = tempMinMaxColor;
     minValue.value = minColorValue;
@@ -239,9 +284,16 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     // unnecessary to update material because all uniforms are sent to GPU every frame
   }
 
+  /**
+   * Updates the source array of the texture being passed to the shader based off of the current message
+   *
+   * @param foxgloveGrid - Grid message
+   * @param settings - settings config
+   * @returns
+   */
   public updateTexture(foxgloveGrid: Grid, settings: LayerSettingsFoxgloveGrid): void {
     let texture = this.userData.texture;
-    const fieldReader = this._getFieldReader(foxgloveGrid, settings);
+    const fieldReader = this.fieldReader;
     if (!fieldReader) {
       return;
     }
@@ -313,6 +365,50 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     }
     this.userData.material.uniforms.map.value.needsUpdate = true;
   }
+
+  /**
+   * Updates the renderable in the proper order in response to a settings change
+   * @param settings - new settings to be applied to the renderable
+   */
+  public handleSettingsChange(settings: LayerSettingsFoxgloveGrid): void {
+    const colorModeChanged = this.userData.settings.colorMode !== settings.colorMode;
+    const colorFieldChanged = this.userData.settings.colorField !== settings.colorField;
+    this.userData.settings = settings;
+
+    this.updateMaterial(this.userData.settings);
+    if (colorModeChanged || colorFieldChanged) {
+      this.updateFieldReader(this.userData.foxgloveGrid, this.userData.settings);
+      // needs to recalculate texture when colorMode or colorField changes
+      // technically it doesn't if it's going between gradient and colorMap, but since it's an infrequent user-action it's not a big hit
+      this.updateTexture(this.userData.foxgloveGrid, this.userData.settings);
+    }
+    this.updateUniforms(this.userData.foxgloveGrid, this.userData.settings);
+    this.syncPickingMaterial();
+  }
+
+  /**
+   * Update the renderable to reflect a new Grid Message
+   * @param foxgloveGrid - new Foxglove grid message to update the renderable to
+   */
+  public handleMessage(foxgloveGrid: Grid): void {
+    this.userData.foxgloveGrid = foxgloveGrid;
+    this.userData.messageTime = toNanoSec(foxgloveGrid.timestamp);
+    this.userData.frameId = this.renderer.normalizeFrameId(foxgloveGrid.frame_id);
+    this.userData.foxgloveGrid = foxgloveGrid;
+    this.userData.pose = foxgloveGrid.pose;
+
+    this.updateMaterial(this.userData.settings);
+    this.updateFieldReader(this.userData.foxgloveGrid, this.userData.settings);
+    this.updateTexture(this.userData.foxgloveGrid, this.userData.settings);
+    this.updateUniforms(this.userData.foxgloveGrid, this.userData.settings);
+    const rows = foxgloveGrid.data.byteLength / foxgloveGrid.row_stride;
+    this.scale.set(
+      foxgloveGrid.cell_size.x * foxgloveGrid.column_count,
+      foxgloveGrid.cell_size.y * rows,
+      1,
+    );
+    this.syncPickingMaterial();
+  }
 }
 
 export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
@@ -371,18 +467,22 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       const settings = this.renderer.config.topics[topicName] as
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
-      renderable.userData.settings = { ...DEFAULT_SETTINGS, ...settings };
+      const fullSettings = { ...DEFAULT_SETTINGS, ...settings };
+      renderable.handleSettingsChange(fullSettings);
 
-      renderable.updateMaterial(renderable.userData.settings);
-      renderable.updateUniforms(renderable.userData.foxgloveGrid, renderable.userData.settings);
-      if (action.payload.path[2] === "colorMode" || action.payload.path[2] === "colorField") {
-        // needs to recalculate texture when colorMode or colorField changes
-        // technically it doesn't if it's going between gradient and colorMap, but since it's an infrequent user-action it's not a big hit
-        renderable.updateTexture(renderable.userData.foxgloveGrid, renderable.userData.settings);
+      if (settings?.calcMinMax === true) {
+        this.updateSettingsMinMaxFromRenderable(renderable);
       }
-      renderable.syncPickingMaterial();
     }
   };
+
+  private updateSettingsMinMaxFromRenderable(renderable: FoxgloveGridRenderable) {
+    const settingsPath = [...renderable.userData.settingsPath, "minValue"];
+    renderable.getMinMaxColorValues(tempMinMaxColor);
+    this.saveSetting(settingsPath, tempMinMaxColor[0]);
+    settingsPath[2] = "maxValue";
+    this.saveSetting(settingsPath, tempMinMaxColor[1]);
+  }
 
   private handleFoxgloveGrid = (messageEvent: PartialMessageEvent<Grid>): void => {
     const topic = messageEvent.topic;
@@ -442,28 +542,15 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       this.updateSettingsTree();
     }
 
-    this._updateFoxgloveGridRenderable(
-      renderable,
-      foxgloveGrid,
-      receiveTime,
-      renderable.userData.settings,
-    );
+    if (this._validateMessage(renderable, foxgloveGrid)) {
+      this._updateFoxgloveGridRenderable(renderable, foxgloveGrid, receiveTime);
+    }
   };
 
-  private _updateFoxgloveGridRenderable(
-    renderable: FoxgloveGridRenderable,
-    foxgloveGrid: Grid,
-    receiveTime: bigint,
-    settings: LayerSettingsFoxgloveGrid,
-  ): void {
-    renderable.userData.foxgloveGrid = foxgloveGrid;
-    renderable.userData.pose = foxgloveGrid.pose;
-    renderable.userData.receiveTime = receiveTime;
-    renderable.userData.messageTime = toNanoSec(foxgloveGrid.timestamp);
-    renderable.userData.frameId = this.renderer.normalizeFrameId(foxgloveGrid.frame_id);
+  private _validateMessage(renderable: FoxgloveGridRenderable, foxgloveGrid: Grid): boolean {
     if (foxgloveGrid.fields.length === 0) {
       invalidFoxgloveGridError(this.renderer, renderable, `Grid has no fields to color by`);
-      return;
+      return false;
     }
     const { cell_stride, row_stride, column_count: cols } = foxgloveGrid;
     const rows = foxgloveGrid.data.byteLength / row_stride;
@@ -471,7 +558,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     if (Math.floor(cols) !== cols || Math.floor(rows) !== rows) {
       const message = `Grid column count (${foxgloveGrid.column_count}) or row count (${rows} = data.byteLength ${foxgloveGrid.data.byteLength} / row_stride ${row_stride}) is not an integer.`;
       invalidFoxgloveGridError(this.renderer, renderable, message);
-      return;
+      return false;
     }
 
     if (cell_stride * cols > row_stride) {
@@ -479,16 +566,19 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         cols * cell_stride
       }) `;
       invalidFoxgloveGridError(this.renderer, renderable, message);
-      return;
+      return false;
     }
+    return true;
+  }
 
-    renderable.updateMaterial(settings);
-    renderable.updateUniforms(foxgloveGrid, settings);
-    renderable.updateTexture(foxgloveGrid, settings);
+  private _updateFoxgloveGridRenderable(
+    renderable: FoxgloveGridRenderable,
+    foxgloveGrid: Grid,
+    receiveTime: bigint,
+  ): void {
+    renderable.userData.receiveTime = receiveTime;
 
-    renderable.scale.set(foxgloveGrid.cell_size.x * cols, foxgloveGrid.cell_size.y * rows, 1);
-
-    renderable.syncPickingMaterial();
+    renderable.handleMessage(foxgloveGrid);
   }
 
   public static Geometry(): THREE.PlaneGeometry {
@@ -752,7 +842,7 @@ function normalizeFoxgloveGrid(message: PartialMessage<Grid>): Grid {
   };
 }
 
-function minMaxColorValues(
+function minMaxNumericValues(
   output: THREE.Vector2Tuple,
   settings: LayerSettingsFoxgloveGrid,
   numericType: NumericType,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -824,7 +824,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
     }
   }
 
-  private _updateMinMaxColorValues(renderable: PointCloudAndLaserScanRenderable): void {
+  private _updateMinMaxValueSettings(renderable: PointCloudAndLaserScanRenderable): void {
     const path = [...renderable.userData.settingsPath, "minValue"];
     const [minValue, maxValue] = renderable.minMaxColor;
     this.saveSetting(path, minValue);
@@ -864,7 +864,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
         );
       }
       if (settings.calcMinMax === true) {
-        this._updateMinMaxColorValues(renderable);
+        this._updateMinMaxValueSettings(renderable);
       }
     }
   };
@@ -950,7 +950,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       receiveTime,
     );
     if (renderable.userData.settings.calcMinMax === true) {
-      this._updateMinMaxColorValues(renderable);
+      this._updateMinMaxValueSettings(renderable);
     }
   };
 
@@ -1035,7 +1035,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       receiveTime,
     );
     if (renderable.userData.settings.calcMinMax === true) {
-      this._updateMinMaxColorValues(renderable);
+      this._updateMinMaxValueSettings(renderable);
     }
   };
 
@@ -1122,7 +1122,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       receiveTime,
     );
     if (renderable.userData.settings.calcMinMax === true) {
-      this._updateMinMaxColorValues(renderable);
+      this._updateMinMaxValueSettings(renderable);
     }
   };
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -171,7 +171,6 @@ if (dot(cxy, cxy) > 1.0) { discard; }
 `;
 
 const tempColor = { r: 0, g: 0, b: 0, a: 0 };
-const tempMinMaxColor: THREE.Vector2Tuple = [0, 0];
 const tempFieldReaders: PointCloudFieldReaders = {
   xReader: zeroReader,
   yReader: zeroReader,
@@ -189,6 +188,7 @@ export function createGeometry(topic: string, usage: THREE.Usage): DynamicBuffer
 
 export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLaserScanUserData> {
   public override pickableInstances = true;
+  public minMaxColor: THREE.Vector2Tuple = [0, 0];
 
   public override dispose(): void {
     this.userData.pointCloud = undefined;
@@ -518,11 +518,12 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     pointStep: number,
     settings: LayerSettingsPointCloudAndLaserScan,
   ): void {
-    let minColorValue = settings.minValue ?? Number.POSITIVE_INFINITY;
-    let maxColorValue = settings.maxValue ?? Number.NEGATIVE_INFINITY;
+    let minColorValue = Number.POSITIVE_INFINITY;
+    let maxColorValue = Number.NEGATIVE_INFINITY;
+    const calcMinMax = settings.calcMinMax === true;
     if (
       NEEDS_MIN_MAX.includes(settings.colorMode) &&
-      (settings.minValue == undefined || settings.maxValue == undefined)
+      (settings.minValue == undefined || settings.maxValue == undefined || calcMinMax)
     ) {
       for (let i = 0; i < pointCount; i++) {
         const pointOffset = i * pointStep;
@@ -530,8 +531,10 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
         minColorValue = Math.min(minColorValue, colorValue);
         maxColorValue = Math.max(maxColorValue, colorValue);
       }
-      minColorValue = settings.minValue ?? minColorValue;
-      maxColorValue = settings.maxValue ?? maxColorValue;
+      // if only calculated b/c one of the settings was undefined (calMinMax disabled)
+      // use the found min/max value for the undefined
+      minColorValue = calcMinMax ? minColorValue : settings.minValue ?? minColorValue;
+      maxColorValue = calcMinMax ? maxColorValue : settings.maxValue ?? maxColorValue;
     }
 
     output[0] = minColorValue;
@@ -552,8 +555,8 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     const { xReader, yReader, zReader, colorReader } = readers;
 
     // Iterate the point cloud data to determine min/max color values (if needed)
-    this._minMaxColorValues(tempMinMaxColor, colorReader, view, pointCount, pointStep, settings);
-    const [minColorValue, maxColorValue] = tempMinMaxColor;
+    this._minMaxColorValues(this.minMaxColor, colorReader, view, pointCount, pointStep, settings);
+    const [minColorValue, maxColorValue] = this.minMaxColor;
 
     // Build a method to convert raw color field values to RGBA
     const colorConverter = getColorConverter(settings, minColorValue, maxColorValue);
@@ -653,9 +656,15 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     pickingMaterial.update(settings, laserScan);
 
     // Determine min/max color values (if needed) and max range
-    let minColorValue = settings.minValue ?? Number.POSITIVE_INFINITY;
-    let maxColorValue = settings.maxValue ?? Number.NEGATIVE_INFINITY;
-    if (settings.minValue == undefined || settings.maxValue == undefined) {
+    let minColorValue = Number.POSITIVE_INFINITY;
+    let maxColorValue = Number.NEGATIVE_INFINITY;
+    const calcMinMax = settings.calcMinMax === true;
+    // calculate min/max when setting is enabled or when min/max values are unknown
+    if (
+      settings.minValue == undefined ||
+      settings.maxValue == undefined ||
+      settings.calcMinMax === true
+    ) {
       let maxRange = 0;
 
       for (let i = 0; i < ranges.length; i++) {
@@ -670,20 +679,24 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
           maxColorValue = Math.max(maxColorValue, colorValue!);
         }
       }
-      minColorValue = settings.minValue ?? minColorValue;
-      maxColorValue = settings.maxValue ?? maxColorValue;
+
+      // if calcMinMax is disabled, we still want to calculate if min/max value in settings is undefined
+      this.minMaxColor[0] = calcMinMax ? minColorValue : settings.minValue ?? minColorValue;
+      this.minMaxColor[1] = calcMinMax ? maxColorValue : settings.maxValue ?? maxColorValue;
 
       // Update the LaserScan bounding sphere
       latestEntry.points.geometry.boundingSphere ??= new THREE.Sphere();
       latestEntry.points.geometry.boundingSphere.set(VEC3_ZERO, maxRange);
       latestEntry.points.frustumCulled = true;
     } else {
+      this.minMaxColor[0] = settings.minValue;
+      this.minMaxColor[1] = settings.maxValue;
       latestEntry.points.geometry.boundingSphere = ReactNull;
       latestEntry.points.frustumCulled = false;
     }
 
     // Build a method to convert raw color field values to RGBA
-    const colorConverter = getColorConverter(settings, minColorValue, maxColorValue);
+    const colorConverter = getColorConverter(settings, this.minMaxColor[0], this.minMaxColor[1]);
 
     // Iterate the point cloud data to update color attribute
     for (let i = 0; i < ranges.length; i++) {
@@ -811,6 +824,14 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
     }
   }
 
+  private _updateMinMaxColorValues(renderable: PointCloudAndLaserScanRenderable): void {
+    const path = [...renderable.userData.settingsPath, "minValue"];
+    const [minValue, maxValue] = renderable.minMaxColor;
+    this.saveSetting(path, minValue);
+    path[2] = "maxValue";
+    this.saveSetting(path, maxValue);
+  }
+
   public override handleSettingsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
     if (action.action !== "update" || path.length !== 3) {
@@ -841,6 +862,9 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           settings,
           renderable.userData.receiveTime,
         );
+      }
+      if (settings.calcMinMax === true) {
+        this._updateMinMaxColorValues(renderable);
       }
     }
   };
@@ -925,6 +949,9 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       renderable.userData.settings,
       receiveTime,
     );
+    if (renderable.userData.settings.calcMinMax === true) {
+      this._updateMinMaxColorValues(renderable);
+    }
   };
 
   private handleRosPointCloud = (messageEvent: PartialMessageEvent<PointCloud2>): void => {
@@ -1007,6 +1034,9 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       renderable.userData.settings,
       receiveTime,
     );
+    if (renderable.userData.settings.calcMinMax === true) {
+      this._updateMinMaxColorValues(renderable);
+    }
   };
 
   private handleLaserScan = (
@@ -1091,6 +1121,9 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
       renderable.userData.settings,
       receiveTime,
     );
+    if (renderable.userData.settings.calcMinMax === true) {
+      this._updateMinMaxColorValues(renderable);
+    }
   };
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -148,6 +148,14 @@ export class VelodyneScans extends SceneExtension<PointCloudAndLaserScanRenderab
     return entries;
   }
 
+  private _updateMinMaxColorValues(renderable: PointCloudAndLaserScanRenderable): void {
+    const path = [...renderable.userData.settingsPath, "minValue"];
+    const [minValue, maxValue] = renderable.minMaxColor;
+    this.saveSetting(path, minValue);
+    path[2] = "maxValue";
+    this.saveSetting(path, maxValue);
+  }
+
   public override handleSettingsAction = (action: SettingsTreeAction): void => {
     const path = action.payload.path;
     if (action.action !== "update" || path.length !== 3) {
@@ -171,6 +179,9 @@ export class VelodyneScans extends SceneExtension<PointCloudAndLaserScanRenderab
           settings,
           renderable.userData.receiveTime,
         );
+        if (settings.calcMinMax === true) {
+          this._updateMinMaxColorValues(renderable);
+        }
       }
     }
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -28,6 +28,7 @@ export interface ColorModeSettings {
   rgbByteOrder: "rgba" | "bgra" | "abgr";
   minValue?: number;
   maxValue?: number;
+  calcMinMax?: boolean;
 }
 
 export function getColorConverter<Settings extends ColorModeSettings>(
@@ -323,6 +324,7 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
   const rgbByteOrder = config.rgbByteOrder ?? "rgba";
   const minValue = config.minValue;
   const maxValue = config.maxValue;
+  const calcMinMax = config.calcMinMax;
 
   const fields: SettingsTreeFields = {};
 
@@ -414,12 +416,19 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
     }
 
     if (NEEDS_MIN_MAX.includes(colorMode)) {
+      fields.calcMinMax = {
+        label: "Calculate Min/Max Every Message",
+        input: "boolean",
+        value: calcMinMax,
+        help: "Will impact performance and will overwrite your existing min/max values. When enabled, the min/max values will be calculated and set for the current message and each new message.",
+      };
       fields.minValue = {
         label: "Value min",
         input: "number",
         placeholder: "auto",
         precision: 4,
         value: minValue,
+        disabled: calcMinMax,
       };
       fields.maxValue = {
         label: "Value max",
@@ -427,6 +436,7 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
         placeholder: "auto",
         precision: 4,
         value: maxValue,
+        disabled: calcMinMax,
       };
     }
   }


### PR DESCRIPTION
**User-Facing Changes**
 - can now toggle the finding of min/max field values for topics with datatypes that have fields and colorMap modes
 - will find the new min/max values every message and set them in the UI when active. the min/max value fields are disabled while this is active
 - leaving the min/max value field as auto/undefined will remain the same as before while the Calculate Min/Max toggle is disabled

**Description**
 - Move more logic into renderable for foxglove grids
 - Tried to separate things out more in foxglove grid to optimize updates.
 - with point clouds I tried to change as little as possible while maintaining the same overall pattern as the grids
 - Point clouds now hold the min/max color values on the instance. This is read after reading/handling the message to set the UI by calling `updateSettingsMinMax`/`_updateMinMaxColorValues`. Hopefully it's fine to call the `saveSetting` twice like that because of the debounce

https://user-images.githubusercontent.com/10187776/199346755-fe2d40ea-5bf6-47c8-9455-b8187ea109a9.mov


<!-- link relevant github issues -->
Fixes #4720 
<!-- add `docs` label if this PR requires documentation updates -->
