### PR TITLE
Move unavailable data source error messages into alerts

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -130,7 +130,9 @@ export default function Connection(props: ConnectionProps): JSX.Element {
           </Tabs>
         </Stack>
         <Stack key={selectedSource?.id} flex="1 0" gap={2}>
-          {selectedSource?.warning && <Alert severity="warning">{selectedSource.warning}</Alert>}
+          {selectedSource?.disabledReason == undefined && selectedSource?.warning && (
+            <Alert severity="warning">{selectedSource.warning}</Alert>
+          )}
           {selectedSource?.disabledReason != undefined && (
             <Alert severity="warning">{selectedSource.disabledReason}</Alert>
           )}

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -131,6 +131,10 @@ export default function Connection(props: ConnectionProps): JSX.Element {
         </Stack>
         <Stack key={selectedSource?.id} flex="1 0" gap={2}>
           {selectedSource?.warning && <Alert severity="warning">{selectedSource.warning}</Alert>}
+          {selectedSource?.disabledReason != undefined && (
+            <Alert severity="warning">{selectedSource.disabledReason}</Alert>
+          )}
+
           {selectedSource?.description && <Typography>{selectedSource.description}</Typography>}
           {selectedSource?.formConfig != undefined && (
             <Stack flexGrow={1} justifyContent="space-between">
@@ -162,11 +166,6 @@ export default function Connection(props: ConnectionProps): JSX.Element {
                 ))}
               </Stack>
             </Stack>
-          )}
-          {selectedSource?.disabledReason != undefined && (
-            <Typography color="text.secondary" variant="body2">
-              {selectedSource.disabledReason}
-            </Typography>
           )}
           {selectedSource?.docsLink && (
             <Link color="primary" href={selectedSource.docsLink}>

--- a/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros1UnavailableDataSourceFactory.tsx
@@ -2,19 +2,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Link, Typography } from "@mui/material";
+import { Link } from "@mui/material";
 
 import { IDataSourceFactory, Ros1SocketDataSourceFactory } from "@foxglove/studio-base";
 
 class Ros1UnavailableDataSourceFactory extends Ros1SocketDataSourceFactory {
   public disabledReason = (
-    <Typography>
+    <>
       ROS 1 connections require TCP sockets, which are not available in a web browser.{" "}
       <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
         Download our desktop app
       </Link>{" "}
       to connect to a ROS 1 system.
-    </Typography>
+    </>
   );
 
   public override initialize(): ReturnType<IDataSourceFactory["initialize"]> {

--- a/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/Ros2UnavailableDataSourceFactory.tsx
@@ -2,19 +2,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Link, Typography } from "@mui/material";
+import { Link } from "@mui/material";
 
 import { IDataSourceFactory, Ros2SocketDataSourceFactory } from "@foxglove/studio-base";
 
 export default class Ros2UnavailableDataSourceFactory extends Ros2SocketDataSourceFactory {
   public disabledReason = (
-    <Typography>
+    <>
       ROS 2 connections require UDP sockets, which are not available in a web browser.{" "}
       <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
         Download our desktop app
       </Link>{" "}
       to connect to a ROS 2 system.
-    </Typography>
+    </>
   );
 
   public override initialize(): ReturnType<IDataSourceFactory["initialize"]> {

--- a/web/src/dataSources/VelodyneUnavailableDataSourceFactory.tsx
+++ b/web/src/dataSources/VelodyneUnavailableDataSourceFactory.tsx
@@ -2,19 +2,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Link, Typography } from "@mui/material";
+import { Link } from "@mui/material";
 
 import { IDataSourceFactory, VelodyneDataSourceFactory } from "@foxglove/studio-base";
 
 export default class VelodyneUnavailableDataSourceFactory extends VelodyneDataSourceFactory {
   public disabledReason = (
-    <Typography>
+    <>
       Velodyne connections require UDP sockets, which are not available in a web browser.{" "}
       <Link href="https://foxglove.dev/download" target="_blank" rel="noreferrer">
         Download our desktop app
       </Link>{" "}
       to connect to a Velodyne sensor.
-    </Typography>
+    </>
   );
 
   public override initialize(): ReturnType<IDataSourceFactory["initialize"]> {


### PR DESCRIPTION
**User-Facing Changes**
- Move unavailable data source error messages into alerts

<img width="892" alt="Screen Shot 2022-11-01 at 4 13 04 PM" src="https://user-images.githubusercontent.com/6993359/199359795-be460b1e-04a1-4462-b037-13d83a9642b8.png">
<img width="904" alt="Screen Shot 2022-11-01 at 4 13 01 PM" src="https://user-images.githubusercontent.com/6993359/199359792-6e16aca7-7e3b-41ea-bcc0-86a16baafd7d.png">
<img width="894" alt="Screen Shot 2022-11-01 at 4 13 08 PM" src="https://user-images.githubusercontent.com/6993359/199359798-b54d96ea-350f-49ef-9f1b-c08a9ee0e9e3.png">


Resolves #4727