### PR TITLE
Change secret for dependabot-fix.yml

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -32,7 +32,7 @@ jobs:
           # Using a Personal Access Token here is required to trigger workflows on our new commit.
           # The default GitHub token doesn't trigger any workflows.
           # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
-          token: ${{ secrets.DEPENDABOT_FIX_GITHUB_TOKEN }}
+          token: ${{ secrets.FOXGLOVEBOT_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - run: git lfs pull --include .yarn/


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The checkout step needs to use a separate access token other than GITHUB_TOKEN to allow a push from the dependabot-fix action to trigger other workflows (lint, test, etc) on the pushed commit.

This change updates the secret to FOXGLOVEBOT_GITHUB_TOKEN from the undefined one used previously.

Fixes: #4739




<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
