### PR TITLE
Fix Flaky screenshot test: Plot:in a line graph with multiple plots, x-axes are synced

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -463,7 +463,7 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
       <Plot
         overrideConfig={{
           ...exampleConfig,

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -464,6 +464,7 @@ const useStyles = makeStyles()(() => ({
   PanelSetup: {
     flexDirection: "column",
     "& > *": {
+      // minHeight necessary to get around otherwise flaky test because of layout
       minHeight: "50%",
     },
   },
@@ -475,7 +476,6 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
-      {/*minHeight necessary to get around otherwise flaky test because of layout */}
       <Plot
         overrideConfig={{
           ...exampleConfig,

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -470,12 +470,11 @@ const useStyles = makeStyles()(() => ({
   },
 }));
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
-  const readySignal = useReadySignal({ count: 6 });
+  const readySignal = useReadySignal({ count: 7 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
-  const { classes } = useStyles();
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "row" }}>
       <Plot
         overrideConfig={{
           ...exampleConfig,

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -15,6 +15,7 @@ import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { fromSec } from "@foxglove/rostime";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
@@ -459,12 +460,22 @@ LineGraphWithLegendsHidden.parameters = {
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
   "in a line graph with multiple plots, x-axes are synced";
 
+const useStyles = makeStyles()(() => ({
+  PanelSetup: {
+    flexDirection: "column",
+    "& > *": {
+      // minHeight necessary to get around otherwise flaky test because of layout
+      minHeight: "50%",
+    },
+  },
+}));
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
-  const readySignal = useReadySignal({ count: 8 });
+  const readySignal = useReadySignal({ count: 6 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  const { classes } = useStyles();
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
       <Plot
         overrideConfig={{
           ...exampleConfig,
@@ -494,7 +505,6 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
 }
 InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
   useReadySignal: true,
-  colorScheme: "light",
 };
 
 LineGraphAfterZoom.storyName = "line graph after zoom";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -15,6 +15,7 @@ import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
+import { makeStyles } from "tss-react/mui";
 
 import { fromSec } from "@foxglove/rostime";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
@@ -458,41 +459,47 @@ LineGraphWithLegendsHidden.parameters = {
 
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
   "in a line graph with multiple plots, x-axes are synced";
+
+const useStyles = makeStyles()(() => ({
+  PanelSetup: {
+    flexDirection: "column",
+    "& > *": {
+      minHeight: "50%",
+    },
+  },
+}));
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
   const readySignal = useReadySignal({ count: 6 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
+  const { classes } = useStyles();
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} className={classes.PanelSetup}>
       {/*minHeight necessary to get around otherwise flaky test because of layout */}
-      <div style={{ minHeight: "50%" }}>
-        <Plot
-          overrideConfig={{
-            ...exampleConfig,
-            paths: [
-              {
-                value: "/some_topic/location.pose.acceleration",
-                enabled: true,
-                timestampMethod: "receiveTime",
-              },
-            ],
-          }}
-        />
-      </div>
-      <div style={{ minHeight: "50%" }}>
-        <Plot
-          overrideConfig={{
-            ...exampleConfig,
-            paths: [
-              {
-                value: "/some_topic/location_subset.pose.velocity",
-                enabled: true,
-                timestampMethod: "receiveTime",
-              },
-            ],
-          }}
-        />
-      </div>
+      <Plot
+        overrideConfig={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location.pose.acceleration",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+        }}
+      />
+      <Plot
+        overrideConfig={{
+          ...exampleConfig,
+          paths: [
+            {
+              value: "/some_topic/location_subset.pose.velocity",
+              enabled: true,
+              timestampMethod: "receiveTime",
+            },
+          ],
+        }}
+      />
     </PanelSetup>
   );
 }

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -15,7 +15,6 @@ import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { shuffle } from "lodash";
 import { useCallback, useRef } from "react";
-import { makeStyles } from "tss-react/mui";
 
 import { fromSec } from "@foxglove/rostime";
 import Plot, { PlotConfig } from "@foxglove/studio-base/panels/Plot";
@@ -460,17 +459,8 @@ LineGraphWithLegendsHidden.parameters = {
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
   "in a line graph with multiple plots, x-axes are synced";
 
-const useStyles = makeStyles()(() => ({
-  PanelSetup: {
-    flexDirection: "column",
-    "& > *": {
-      // minHeight necessary to get around otherwise flaky test because of layout
-      minHeight: "50%",
-    },
-  },
-}));
 export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
-  const readySignal = useReadySignal({ count: 7 });
+  const readySignal = useReadySignal({ count: 8 });
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -454,7 +454,6 @@ export function LineGraphWithLegendsHidden(): JSX.Element {
 }
 LineGraphWithLegendsHidden.parameters = {
   useReadySignal: true,
-  colorScheme: "light",
 };
 
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =
@@ -495,6 +494,7 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
 }
 InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
   useReadySignal: true,
+  colorScheme: "light",
 };
 
 LineGraphAfterZoom.storyName = "line graph after zoom";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -454,6 +454,7 @@ export function LineGraphWithLegendsHidden(): JSX.Element {
 }
 LineGraphWithLegendsHidden.parameters = {
   useReadySignal: true,
+  colorScheme: "light",
 };
 
 InALineGraphWithMultiplePlotsXAxesAreSynced.storyName =

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -493,6 +493,8 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
 }
 InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
   useReadySignal: true,
+  // Test has been flaky on layout and needs additional time to settle
+  chromatic: { delay: 300 },
 };
 
 LineGraphAfterZoom.storyName = "line graph after zoom";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -463,38 +463,41 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame}>
-      <Plot
-        overrideConfig={{
-          ...exampleConfig,
-          paths: [
-            {
-              value: "/some_topic/location.pose.acceleration",
-              enabled: true,
-              timestampMethod: "receiveTime",
-            },
-          ],
-        }}
-      />
-      <Plot
-        overrideConfig={{
-          ...exampleConfig,
-          paths: [
-            {
-              value: "/some_topic/location_subset.pose.velocity",
-              enabled: true,
-              timestampMethod: "receiveTime",
-            },
-          ],
-        }}
-      />
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
+      {/*minHeight necessary to get around otherwise flaky test because of layout */}
+      <div style={{ minHeight: "50%" }}>
+        <Plot
+          overrideConfig={{
+            ...exampleConfig,
+            paths: [
+              {
+                value: "/some_topic/location.pose.acceleration",
+                enabled: true,
+                timestampMethod: "receiveTime",
+              },
+            ],
+          }}
+        />
+      </div>
+      <div style={{ minHeight: "50%" }}>
+        <Plot
+          overrideConfig={{
+            ...exampleConfig,
+            paths: [
+              {
+                value: "/some_topic/location_subset.pose.velocity",
+                enabled: true,
+                timestampMethod: "receiveTime",
+              },
+            ],
+          }}
+        />
+      </div>
     </PanelSetup>
   );
 }
 InALineGraphWithMultiplePlotsXAxesAreSynced.parameters = {
   useReadySignal: true,
-  // Test has been flaky on layout and needs additional time to settle
-  chromatic: { delay: 300 },
 };
 
 LineGraphAfterZoom.storyName = "line graph after zoom";

--- a/packages/studio-base/src/panels/Plot/index.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/index.stories.tsx
@@ -474,7 +474,7 @@ export function InALineGraphWithMultiplePlotsXAxesAreSynced(): JSX.Element {
   const pauseFrame = useCallback(() => readySignal, [readySignal]);
 
   return (
-    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "row" }}>
+    <PanelSetup fixture={fixture} pauseFrame={pauseFrame} style={{ flexDirection: "column" }}>
       <Plot
         overrideConfig={{
           ...exampleConfig,

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -111,6 +111,8 @@ type UnconnectedProps = {
   ) => void;
   onFirstMount?: (arg0: HTMLDivElement) => void;
   style?: React.CSSProperties;
+  // Needed for functionality not in React.CSSProperties, like child selectors: "& > *"
+  className?: string;
 };
 
 function setNativeValue(element: unknown, value: unknown) {
@@ -287,6 +289,7 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
   const inner = (
     <div
       style={{ width: "100%", height: "100%", display: "flex", ...props.style }}
+      className={props.className}
       ref={(el) => {
         const { onFirstMount, onMount } = props;
         if (el && onFirstMount && !hasMounted.current) {

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -111,8 +111,6 @@ type UnconnectedProps = {
   ) => void;
   onFirstMount?: (arg0: HTMLDivElement) => void;
   style?: React.CSSProperties;
-  // Needed for functionality not in React.CSSProperties, like child selectors: "& > *"
-  className?: string;
 };
 
 function setNativeValue(element: unknown, value: unknown) {
@@ -289,7 +287,6 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
   const inner = (
     <div
       style={{ width: "100%", height: "100%", display: "flex", ...props.style }}
-      className={props.className}
       ref={(el) => {
         const { onFirstMount, onMount } = props;
         if (el && onFirstMount && !hasMounted.current) {


### PR DESCRIPTION
**User-Facing Changes**
 - n/a

**Description**
 - I don't really know a better way to test this other than running it a few times in CI
 - since this is really hard to test locally I'm just going to add a minHeight css via child selector to the PanelSetup component to assign the minHeight for each panel to be 50%. this at least prevents the test from being flaky (so far)


<!-- link relevant github issues -->
Fixes #4733
<!-- add `docs` label if this PR requires documentation updates -->
