### PR TITLE
Add MCAP mdimporter to macOS app bundle

### DIFF
--- a/desktop/afterPack.ts
+++ b/desktop/afterPack.ts
@@ -60,7 +60,7 @@ async function copySpotlightImporter(context: AfterPackContext) {
   const zipPath = path.join(outDir, "MCAPSpotlightImporter.mdimporter.zip");
   await fs.unlink(zipPath).catch(() => {});
   await downloadTool(
-    "https://github.com/foxglove/MCAPSpotlightImporter/releases/download/v1.0.1/MCAPSpotlightImporter.mdimporter.zip",
+    "https://github.com/foxglove/MCAPSpotlightImporter/releases/download/v1.0.2/MCAPSpotlightImporter.mdimporter.zip",
     zipPath,
   );
   try {
@@ -114,7 +114,7 @@ async function configureQuickLookExtension(context: AfterPackContext) {
     NSExtension: {
       ...(originalInfo.NSExtension as PlistObject),
       NSExtensionAttributes: {
-        QLSupportedContentTypes: ["org.ros.bag", "dev.foxglove.mcap"],
+        QLSupportedContentTypes: ["org.ros.bag", "dev.mcap.mcap"],
         QLSupportsSearchableItems: false,
       },
     },

--- a/desktop/afterPack.ts
+++ b/desktop/afterPack.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { exec } from "@actions/exec";
+import { downloadTool, extractZip } from "@actions/tool-cache";
 import type MacPackager from "app-builder-lib/out/macPackager";
 import { log, Arch } from "builder-util";
 import { AfterPackContext } from "electron-builder";
@@ -21,6 +22,61 @@ async function getKeychainFile(context: AfterPackContext): Promise<string | unde
 
 export default async function afterPack(context: AfterPackContext): Promise<void> {
   await configureQuickLookExtension(context);
+  await copySpotlightImporter(context);
+}
+
+/**
+ * When building a universal app, electron-builder uses lipo to merge binaries at the same path.
+ * Since our bundled Quick Look and Spotlight extensions already provide universal binaries, we need
+ * to strip out other architectures so that lipo doesn't fail when it gets two copies of each slice.
+ */
+async function extractTargetArchitecture(executablePath: string, context: AfterPackContext) {
+  const arch = new Map([
+    [Arch.arm64, "arm64"],
+    [Arch.x64, "x86_64"],
+    [Arch.universal, "universal"],
+  ]).get(context.arch);
+  if (arch == undefined) {
+    throw new Error(`Unsupported arch ${context.arch}`);
+  }
+  if (arch !== "universal") {
+    await exec("lipo", ["-extract", arch, executablePath, "-output", executablePath]);
+    log.info({ executablePath }, `Extracted ${arch} from universal executable`);
+  }
+}
+
+/**
+ * Download the Spotlight importer for MCAP files and include it in the app bundle.
+ */
+async function copySpotlightImporter(context: AfterPackContext) {
+  const { electronPlatformName, outDir, appOutDir } = context;
+  if (electronPlatformName !== "darwin") {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(appOutDir, `${appName}.app`);
+  const spotlightDirPath = path.join(appPath, "Contents", "Library", "Spotlight");
+  const zipPath = path.join(outDir, "MCAPSpotlightImporter.mdimporter.zip");
+  await fs.unlink(zipPath).catch(() => {});
+  await downloadTool(
+    "https://github.com/foxglove/MCAPSpotlightImporter/releases/download/v1.0.1/MCAPSpotlightImporter.mdimporter.zip",
+    zipPath,
+  );
+  try {
+    await extractZip(zipPath, spotlightDirPath);
+    const executablePath = path.join(
+      spotlightDirPath,
+      "MCAPSpotlightImporter.mdimporter",
+      "Contents",
+      "MacOS",
+      "MCAPSpotlightImporter",
+    );
+    await extractTargetArchitecture(executablePath, context);
+  } finally {
+    await fs.unlink(zipPath).catch((err: Error) => log.error(err.toString()));
+  }
+  log.info({ path: spotlightDirPath }, "Copied mdimporter");
 }
 
 /**
@@ -79,21 +135,7 @@ async function configureQuickLookExtension(context: AfterPackContext) {
   }
   log.info("Copied .webpack/quicklook into appex resources");
 
-  // When building a universal app, electron-builder uses lipo to merge binaries at the same path.
-  // Since quicklookjs already provides a universal binary, we need to strip out other architectures
-  // so that lipo doesn't fail when it gets two copies of each slice.
-  const arch = new Map([
-    [Arch.arm64, "arm64"],
-    [Arch.x64, "x86_64"],
-    [Arch.universal, "universal"],
-  ]).get(context.arch);
-  if (arch == undefined) {
-    throw new Error(`Unsupported arch ${context.arch}`);
-  }
-  if (arch !== "universal") {
-    await exec("lipo", ["-extract", arch, appexExecutablePath, "-output", appexExecutablePath]);
-    log.info(`Extracted ${arch} from appex executable`);
-  }
+  await extractTargetArchitecture(appexExecutablePath, context);
 
   // The notarization step requires a valid signature from our "Developer ID Application"
   // certificate. However this certificate is only available in CI, so for packaging to succeed in a

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -172,14 +172,16 @@
           "UTTypeDescription": "MCAP File",
           "UTTypeIcons": { "UTTypeIconText": "mcap" },
           "UTTypeIdentifier": "dev.mcap.mcap",
-          "UTTypeTagSpecification": { "public.filename-extension": "mcap" }
+          "UTTypeTagSpecification": { "public.filename-extension": "mcap" },
+          "UTTypeReferenceURL": "https://mcap.dev/"
         },
         {
           "UTTypeConformsTo": ["public.data", "public.archive", "public.zip-archive"],
           "UTTypeDescription": "Foxglove Studio Extension File",
           "UTTypeIcons": { "UTTypeIconText": "foxe" },
           "UTTypeIdentifier": "dev.foxglove.extension",
-          "UTTypeTagSpecification": { "public.filename-extension": "foxe" }
+          "UTTypeTagSpecification": { "public.filename-extension": "foxe" },
+          "UTTypeReferenceURL": "https://foxglove.dev/docs/studio/extensions/getting-started"
         }
       ],
       "UTImportedTypeDeclarations": [
@@ -188,21 +190,24 @@
           "UTTypeDescription": "ROS 1 Bag File",
           "UTTypeIcons": { "UTTypeIconText": "bag" },
           "UTTypeIdentifier": "org.ros.bag",
-          "UTTypeTagSpecification": { "public.filename-extension": "bag" }
+          "UTTypeTagSpecification": { "public.filename-extension": "bag" },
+          "UTTypeReferenceURL": "http://wiki.ros.org/Bags"
         },
         {
           "UTTypeConformsTo": ["public.xml"],
           "UTTypeDescription": "Unified Robot Description Format File",
           "UTTypeIcons": { "UTTypeIconText": "urdf" },
           "UTTypeIdentifier": "org.ros.urdf",
-          "UTTypeTagSpecification": { "public.filename-extension": "urdf" }
+          "UTTypeTagSpecification": { "public.filename-extension": "urdf" },
+          "UTTypeReferenceURL": "http://wiki.ros.org/urdf"
         },
         {
           "UTTypeConformsTo": ["public.xml"],
           "UTTypeDescription": "Xacro File",
           "UTTypeIcons": { "UTTypeIconText": "xacro" },
           "UTTypeIdentifier": "org.ros.xacro",
-          "UTTypeTagSpecification": { "public.filename-extension": "xacro" }
+          "UTTypeTagSpecification": { "public.filename-extension": "xacro" },
+          "UTTypeReferenceURL": "https://github.com/ros/xacro/wiki"
         }
       ]
     }

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -107,6 +107,7 @@
     ],
     "extraResources": [
       { "from": "resources/icon/BagIcon.png", "to": "BagIcon.png" },
+      { "from": "resources/icon/McapIcon.png", "to": "McapIcon.png" },
       { "from": "resources/icon/FoxeIcon.png", "to": "FoxeIcon.png" },
       { "from": "resources/icon/URDFIcon.png", "to": "URDFIcon.png" },
       { "from": "resources/icon/XacroIcon.png", "to": "XacroIcon.png" }
@@ -129,14 +130,14 @@
           "CFBundleTypeRole": "Viewer",
           "LSHandlerRank": "Owner",
           "CFBundleTypeIconSystemGenerated": 1,
-          "LSItemContentTypes": ["dev.foxglove.mcap"]
+          "LSItemContentTypes": ["dev.mcap.mcap"]
         },
         {
           "CFBundleTypeExtensions": ["foxe"],
           "CFBundleTypeIconFile": "FoxeIcon",
           "CFBundleTypeName": "Foxglove Studio Extension File",
           "CFBundleTypeRole": "Viewer",
-          "LSHandlerRank": "Default",
+          "LSHandlerRank": "Owner",
           "CFBundleTypeIconSystemGenerated": 1,
           "LSItemContentTypes": ["dev.foxglove.extension"]
         },
@@ -165,19 +166,12 @@
           "CFBundleTypeRole": "Viewer"
         }
       ],
-      "UTImportedTypeDeclarations": [
+      "UTExportedTypeDeclarations": [
         {
-          "UTTypeConformsTo": ["public.data"],
-          "UTTypeDescription": "ROS Bag File",
-          "UTTypeIcons": { "UTTypeIconText": "bag" },
-          "UTTypeIdentifier": "org.ros.bag",
-          "UTTypeTagSpecification": { "public.filename-extension": "bag" }
-        },
-        {
-          "UTTypeConformsTo": ["public.data"],
+          "UTTypeConformsTo": ["public.data", "public.log", "public.composite-content"],
           "UTTypeDescription": "MCAP File",
           "UTTypeIcons": { "UTTypeIconText": "mcap" },
-          "UTTypeIdentifier": "dev.foxglove.mcap",
+          "UTTypeIdentifier": "dev.mcap.mcap",
           "UTTypeTagSpecification": { "public.filename-extension": "mcap" }
         },
         {
@@ -186,6 +180,15 @@
           "UTTypeIcons": { "UTTypeIconText": "foxe" },
           "UTTypeIdentifier": "dev.foxglove.extension",
           "UTTypeTagSpecification": { "public.filename-extension": "foxe" }
+        }
+      ],
+      "UTImportedTypeDeclarations": [
+        {
+          "UTTypeConformsTo": ["public.data", "public.log", "public.composite-content"],
+          "UTTypeDescription": "ROS 1 Bag File",
+          "UTTypeIcons": { "UTTypeIconText": "bag" },
+          "UTTypeIdentifier": "org.ros.bag",
+          "UTTypeTagSpecification": { "public.filename-extension": "bag" }
         },
         {
           "UTTypeConformsTo": ["public.xml"],

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@actions/core": "1.6.0",
     "@actions/exec": "1.1.0",
+    "@actions/tool-cache": "2.0.1",
     "@babel/core": "7.17.2",
     "@babel/preset-env": "7.16.11",
     "@babel/preset-typescript": "7.16.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,12 +21,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@actions/core@npm:^1.2.6":
+  version: 1.10.0
+  resolution: "@actions/core@npm:1.10.0"
+  dependencies:
+    "@actions/http-client": ^2.0.1
+    uuid: ^8.3.2
+  checksum: 0a75621e007ab20d887434cdd165f0b9036f14c22252a2faed33543d8b9d04ec95d823e69ca636a25245574e4585d73e1e9e47a845339553c664f9f2c9614669
+  languageName: node
+  linkType: hard
+
 "@actions/exec@npm:1.1.0":
   version: 1.1.0
   resolution: "@actions/exec@npm:1.1.0"
   dependencies:
     "@actions/io": ^1.0.1
   checksum: 1fad630ec2ca02438e0c05a9596f375edb3b04de50bf8cd712d6b79aec9f3cc3a175836d3ea610667e32431e7749cb93d8f4dec4947a48e29a720cfc3220216c
+  languageName: node
+  linkType: hard
+
+"@actions/exec@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "@actions/exec@npm:1.1.1"
+  dependencies:
+    "@actions/io": ^1.0.1
+  checksum: d976e66dd51ab03d76a143da8e1406daa1bcdee06046168e6e0bec681c87a12999eefaad7a81cb81f28e4190610f55a58b8458ae4b82cbaaba13200490f4e8c2
   languageName: node
   linkType: hard
 
@@ -39,10 +58,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/io@npm:^1.0.1":
-  version: 1.1.1
-  resolution: "@actions/io@npm:1.1.1"
-  checksum: d291869b19ac5eea87697100fe51849ea5bacedd556f12789629a5e4ba722fc0daadb37374892301b1c446d1d3b9798ec0fea6ad39e08bccb4ec39bbffb3263e
+"@actions/http-client@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@actions/http-client@npm:2.0.1"
+  dependencies:
+    tunnel: ^0.0.6
+  checksum: 799ec3df91e28a9da91ce6592e94f8b8923ccf6cc21a2f72c7429be5af5273f1625335411adc2a1bb222d56c852d5767214dfa6fa32a6da7e81dba8290e08f17
+  languageName: node
+  linkType: hard
+
+"@actions/io@npm:^1.0.1, @actions/io@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@actions/io@npm:1.1.2"
+  checksum: 3c6583c4557abf6c95e9cfc9b6377045e65ba2c5dd4863f4feedd6be9daf4f6b60e588ab0151d5626b5f8320a37f05b8d44ab5c329b8c19f65be31b0616e1464
+  languageName: node
+  linkType: hard
+
+"@actions/tool-cache@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@actions/tool-cache@npm:2.0.1"
+  dependencies:
+    "@actions/core": ^1.2.6
+    "@actions/exec": ^1.0.0
+    "@actions/http-client": ^2.0.1
+    "@actions/io": ^1.1.1
+    semver: ^6.1.0
+    uuid: ^3.3.2
+  checksum: 33f6393b9b163e4af2b9759e8d37cda4f018f10ddda3643355bb8a9f92d732e5bdff089cf8036b46d181e1ef2b3210b895b2f746fdf54487afe88f1d340aa9e1
   languageName: node
   linkType: hard
 
@@ -12725,6 +12767,7 @@ __metadata:
   dependencies:
     "@actions/core": 1.6.0
     "@actions/exec": 1.1.0
+    "@actions/tool-cache": 2.0.1
     "@babel/core": 7.17.2
     "@babel/preset-env": 7.16.11
     "@babel/preset-typescript": 7.16.7
@@ -21481,7 +21524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.2.0, semver@npm:^6.3.0":
+"semver@npm:^6.0.0, semver@npm:^6.1.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.2.0, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
   bin:


### PR DESCRIPTION
**User-Facing Changes**
Added a Spotlight importer for MCAP files to the macOS desktop app. The names of topics, schemas, attachments, and metadata in MCAP files can now be used as search terms in Finder and Spotlight.

**Description**
Added https://github.com/foxglove/MCAPSpotlightImporter to app bundle via afterPack script.

Also made some updates to Studio's Info.plist:
- Make Studio the "owner/exporter" of .mcap and .foxe types
- Rename MCAP UTI from `dev.foxglove.mcap` to `dev.mcap.mcap` now that mcap.dev is a registered domain
- Added McapIcon.png which was missing from the app bundle
- Add more conformances to "functional" type hierarchy for mcap and bag files: `public.log` and `public.composite-content`
- Change .bag description from "ROS Bag File" to "ROS 1 Bag File"
- Added reference URLs for all the file types

<img width="300" alt="Finder Get Info window" src="https://user-images.githubusercontent.com/14237/199407465-9886f55d-dc75-48bc-8c0d-5b5392a33d34.png">
<img width="430" alt="Finder search" src="https://user-images.githubusercontent.com/14237/199407550-fc36c034-5541-41db-86a7-eade699fd09f.png">
<img width="500" alt="Finder search by topics and schemas" src="https://user-images.githubusercontent.com/14237/199407593-b32836c5-f6b2-4b78-bfb0-25c4168c5f85.png">
<img width="500" alt="Spotlight search" src="https://user-images.githubusercontent.com/14237/199407603-3adbedb6-adfa-4322-a7e8-ea7487eb055d.png">
