### PR TITLE
Hide PointCloud2 fields having `count` ≠ 1

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -4,6 +4,7 @@
 
 import * as THREE from "three";
 
+import { filterMap } from "@foxglove/den/collection";
 import { Time, toNanoSec } from "@foxglove/rostime";
 import {
   LaserScan as FoxgloveLaserScan,
@@ -220,7 +221,9 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
       for (const field of pointCloud.fields) {
         const pointOffset = instanceId * pointStep;
         const reader = getReader(field, stride);
-        details[field.name] = reader?.(view, pointOffset);
+        if (reader) {
+          details[field.name] = reader(view, pointOffset);
+        }
       }
 
       return details;
@@ -431,9 +434,8 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
           : (field as PointField).datatype;
 
       if (count != undefined && count !== 1) {
-        const message = `PointCloud field "${field.name}" has invalid count ${count}. Only 1 is supported`;
-        invalidPointCloudOrLaserScanError(this.renderer, renderable, message);
-        return false;
+        // Skip this field, we don't support counts other than 1
+        continue;
       } else if (field.offset < 0) {
         const message = `PointCloud field "${field.name}" has invalid offset ${field.offset}. Must be >= 0`;
         invalidPointCloudOrLaserScanError(this.renderer, renderable, message);
@@ -996,7 +998,10 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
     // Update the mapping of topic to point cloud field names if necessary
     let fields = this.pointCloudFieldsByTopic.get(topic);
     if (!fields || fields.length !== pointCloud.fields.length) {
-      fields = pointCloud.fields.map((field) => field.name);
+      // Omit fields with count != 1
+      fields = filterMap(pointCloud.fields, (field) =>
+        field.count === 1 ? field.name : undefined,
+      );
       this.pointCloudFieldsByTopic.set(topic, fields);
       this.updateSettingsTree();
     }
@@ -1380,6 +1385,9 @@ export function autoSelectColorField(
 ): void {
   // Prefer color fields first
   for (const field of pointCloud.fields) {
+    if ("count" in field && field.count !== 1) {
+      continue;
+    }
     const fieldNameLower = field.name.toLowerCase();
     if (COLOR_FIELDS.has(fieldNameLower)) {
       output.colorField = field.name;
@@ -1412,6 +1420,9 @@ export function autoSelectColorField(
 
   // Intensity fields are second priority
   for (const field of pointCloud.fields) {
+    if ("count" in field && field.count !== 1) {
+      continue;
+    }
     if (INTENSITY_FIELDS.has(field.name)) {
       output.colorField = field.name;
       output.colorMode = "colormap";
@@ -1421,8 +1432,10 @@ export function autoSelectColorField(
   }
 
   // Fall back to using the first point cloud field
-  if (pointCloud.fields.length > 0) {
-    const firstField = pointCloud.fields[0]!;
+  const firstField = (pointCloud.fields as readonly (PackedElementField | PointField)[]).find(
+    (field) => !("count" in field) || field.count === 1,
+  );
+  if (firstField != undefined) {
     output.colorField = firstField.name;
     output.colorMode = "colormap";
     output.colorMap = "turbo";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -53,7 +53,7 @@ import {
   getColorConverter,
   INTENSITY_FIELDS,
 } from "./pointClouds/colors";
-import { FieldReader, getReader } from "./pointClouds/fieldReaders";
+import { FieldReader, getReader, isSupportedField } from "./pointClouds/fieldReaders";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
 
 export type LayerSettingsPointCloudAndLaserScan = BaseSettings &
@@ -426,17 +426,17 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
 
     for (let i = 0; i < pointCloud.fields.length; i++) {
       const field = pointCloud.fields[i]!;
-      const count = (field as Partial<PointField>).count;
+      // Skip this field, we don't support counts other than 1
+      if (!isSupportedField(field)) {
+        continue;
+      }
       const numericType = (field as Partial<PackedElementField>).type;
       const type =
         numericType != undefined
           ? numericTypeToPointFieldType(numericType)
           : (field as PointField).datatype;
 
-      if (count != undefined && count !== 1) {
-        // Skip this field, we don't support counts other than 1
-        continue;
-      } else if (field.offset < 0) {
+      if (field.offset < 0) {
         const message = `PointCloud field "${field.name}" has invalid offset ${field.offset}. Must be >= 0`;
         invalidPointCloudOrLaserScanError(this.renderer, renderable, message);
         return false;
@@ -997,7 +997,11 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
 
     // Update the mapping of topic to point cloud field names if necessary
     let fields = this.pointCloudFieldsByTopic.get(topic);
-    if (!fields || fields.length !== pointCloud.fields.length) {
+    // filter count to compare only supported fields
+    const numSupportedFields = pointCloud.fields.reduce((numSupported, field) => {
+      return numSupported + (isSupportedField(field) ? 1 : 0);
+    }, 0);
+    if (!fields || fields.length !== numSupportedFields) {
       // Omit fields with count != 1
       fields = filterMap(pointCloud.fields, (field) =>
         field.count === 1 ? field.name : undefined,
@@ -1385,7 +1389,7 @@ export function autoSelectColorField(
 ): void {
   // Prefer color fields first
   for (const field of pointCloud.fields) {
-    if ("count" in field && field.count !== 1) {
+    if (!isSupportedField(field)) {
       continue;
     }
     const fieldNameLower = field.name.toLowerCase();
@@ -1420,7 +1424,7 @@ export function autoSelectColorField(
 
   // Intensity fields are second priority
   for (const field of pointCloud.fields) {
-    if ("count" in field && field.count !== 1) {
+    if (!isSupportedField(field)) {
       continue;
     }
     if (INTENSITY_FIELDS.has(field.name)) {
@@ -1433,7 +1437,7 @@ export function autoSelectColorField(
 
   // Fall back to using the first point cloud field
   const firstField = (pointCloud.fields as readonly (PackedElementField | PointField)[]).find(
-    (field) => !("count" in field) || field.count === 1,
+    (field) => isSupportedField(field),
   );
   if (firstField != undefined) {
     output.colorField = firstField.name;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -1004,7 +1004,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
     if (!fields || fields.length !== numSupportedFields) {
       // Omit fields with count != 1
       fields = filterMap(pointCloud.fields, (field) =>
-        field.count === 1 ? field.name : undefined,
+        isSupportedField(field) ? field.name : undefined,
       );
       this.pointCloudFieldsByTopic.set(topic, fields);
       this.updateSettingsTree();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
@@ -40,14 +40,23 @@ export function float64Reader(fieldOffset: number): FieldReader {
   return (view: DataView, pointOffset: number) => view.getFloat64(pointOffset + fieldOffset, true);
 }
 
+export function isSupportedField(field: PackedElementField | PointField): boolean {
+  // Only PointFields with count === 1 are supported (doesn't apply to PackedElementFields)
+  if ("count" in field && field.count !== 1) {
+    return false;
+  }
+  return true;
+}
+
 export function getReader(
   field: PackedElementField | PointField,
   stride: number,
   forceType?: PointFieldType | NumericType,
 ): FieldReader | undefined {
-  if ("count" in field && field.count !== 1) {
+  if (!isSupportedField(field)) {
     return undefined;
   }
+
   const numericType = (field as Partial<PackedElementField>).type;
   if (numericType == undefined) {
     const type = forceType ?? (field as PointField).datatype;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
@@ -45,6 +45,9 @@ export function getReader(
   stride: number,
   forceType?: PointFieldType | NumericType,
 ): FieldReader | undefined {
+  if ("count" in field && field.count !== 1) {
+    return undefined;
+  }
   const numericType = (field as Partial<PackedElementField>).type;
   if (numericType == undefined) {
     const type = forceType ?? (field as PointField).datatype;


### PR DESCRIPTION
**User-Facing Changes**
3D panel can now load PointCloud2 messages with fields whose `count` is unsupported (i.e. ≠ 1), and these fields are hidden. Previously, the whole point cloud topic was unusable.

**Description**
Resolves https://github.com/foxglove/studio/issues/4746

Hides these multi-valued fields from the "Color by" settings and the "selected object details" popup. A future feature could be to actually support multiple values in the selected object popup (displaying them as an array). For now we will leave it as-is until we receive user feedback that supporting multi-valued fields is desired.