### PR TITLE
Introduce a "stamp" IteratorResult

### DIFF
--- a/benchmark/src/players/BenchmarkPlayer.ts
+++ b/benchmark/src/players/BenchmarkPlayer.ts
@@ -126,10 +126,12 @@ class BenchmarkPlayer implements Player {
     // Load all messages into memory
     for await (const item of iterator) {
       // any problem bails
-      if (item.problem) {
+      if (item.type === "problem") {
         throw new Error(item.problem.message);
       }
-      msgEvents.push(item.msgEvent);
+      if (item.type === "message-event") {
+        msgEvents.push(item.msgEvent);
+      }
       frameMs.push(0);
     }
 

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -200,8 +200,8 @@ export class BagIterableSource implements IIterableSource {
       const schemaName = this._datatypesByConnectionId.get(connectionId);
       if (!schemaName) {
         yield {
+          type: "problem",
           connectionId,
-          msgEvent: undefined,
           problem: {
             severity: "error",
             message: `Cannot missing datatype for connection id ${connectionId}`,
@@ -219,8 +219,8 @@ export class BagIterableSource implements IIterableSource {
         const parsedMessage = reader.readMessage(dataCopy);
 
         yield {
+          type: "message-event",
           connectionId,
-          problem: undefined,
           msgEvent: {
             topic: bagMsgEvent.topic,
             receiveTime: bagMsgEvent.timestamp,
@@ -231,8 +231,8 @@ export class BagIterableSource implements IIterableSource {
         };
       } else {
         yield {
+          type: "problem",
           connectionId,
-          msgEvent: undefined,
           problem: {
             severity: "error",
             message: `Cannot deserialize message for missing connection id ${connectionId}`,
@@ -257,7 +257,7 @@ export class BagIterableSource implements IIterableSource {
         start: time,
         reverse: true,
       })) {
-        if (result.msgEvent) {
+        if (result.type === "message-event") {
           messages.push(result.msgEvent);
         }
         break;

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -98,9 +98,8 @@ describe("BlockLoader", () => {
       for (let i = 0; i < msgEvents.length; ++i) {
         const msgEvent = msgEvents[i]!;
         yield {
+          type: "message-event",
           msgEvent,
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -205,9 +204,8 @@ describe("BlockLoader", () => {
         }
 
         yield {
+          type: "message-event",
           msgEvent,
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -316,9 +314,8 @@ describe("BlockLoader", () => {
         }
 
         yield {
+          type: "message-event",
           msgEvent,
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -577,9 +574,8 @@ describe("BlockLoader", () => {
       for (let i = 0; i < msgEvents.length; ++i) {
         const msgEvent = msgEvents[i]!;
         yield {
+          type: "message-event",
           msgEvent,
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -275,8 +275,12 @@ export class BlockLoader {
 
         let sizeInBytes = 0;
         for (const iterResult of results) {
-          if (iterResult.problem) {
+          if (iterResult.type === "problem") {
             this.problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
+            continue;
+          }
+
+          if (iterResult.type !== "message-event") {
             continue;
           }
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -558,13 +558,13 @@ describe("BufferedIterableSource", () => {
     // Wait for the buffered iterable source to stop reading messages
     await signal.wait();
 
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.0999999999 }]);
 
     // Reading the second message buffers more data
     signal = waiter(1);
     await messageIterator.next();
     await signal.wait();
-    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.1999999999 }]);
 
     // We should have called the messageIterator method only once
     expect(messageIteratorCount).toEqual(1);

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -82,6 +82,7 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -89,8 +90,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -105,8 +104,7 @@ describe("BufferedIterableSource", () => {
       await expect(iterResult).resolves.toEqual({
         done: false,
         value: {
-          problem: undefined,
-          connectionId: undefined,
+          type: "message-event",
           msgEvent: {
             receiveTime: { sec: i, nsec: 0 },
             message: undefined,
@@ -143,6 +141,7 @@ describe("BufferedIterableSource", () => {
 
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -150,8 +149,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
       signal.notify();
@@ -168,8 +165,7 @@ describe("BufferedIterableSource", () => {
         await expect(iterResult).resolves.toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: i, nsec: 0 },
               message: undefined,
@@ -204,6 +200,7 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -211,8 +208,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
       signal.notify();
@@ -232,8 +227,7 @@ describe("BufferedIterableSource", () => {
       await expect(iterResult).resolves.toEqual({
         done: false,
         value: {
-          problem: undefined,
-          connectionId: undefined,
+          type: "message-event",
           msgEvent: {
             receiveTime: { sec: i, nsec: 0 },
             message: undefined,
@@ -266,6 +260,7 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -273,8 +268,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
         partialBuffer.notify();
       }
@@ -307,6 +300,7 @@ describe("BufferedIterableSource", () => {
         _args: MessageIteratorArgs,
       ): AsyncIterableIterator<Readonly<IteratorResult>> {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 5, nsec: 0 },
@@ -314,8 +308,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
         doneYield.notify();
       };
@@ -339,6 +331,7 @@ describe("BufferedIterableSource", () => {
         _args: MessageIteratorArgs,
       ): AsyncIterableIterator<Readonly<IteratorResult>> {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 1, nsec: 0 },
@@ -346,8 +339,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
         doneYield.notify();
       };
@@ -367,8 +358,7 @@ describe("BufferedIterableSource", () => {
           await expect(iterResult).resolves.toEqual({
             done: false,
             value: {
-              problem: undefined,
-              connectionId: undefined,
+              type: "message-event",
               msgEvent: {
                 receiveTime: { sec: 1, nsec: 0 },
                 message: undefined,
@@ -385,8 +375,7 @@ describe("BufferedIterableSource", () => {
           await expect(iterResult).resolves.toEqual({
             done: false,
             value: {
-              problem: undefined,
-              connectionId: undefined,
+              type: "message-event",
               msgEvent: {
                 receiveTime: { sec: 5, nsec: 0 },
                 message: undefined,
@@ -437,6 +426,7 @@ describe("BufferedIterableSource", () => {
       for (let i = 0; i < 8; ++i) {
         debounceNotify();
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -444,8 +434,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -493,6 +481,7 @@ describe("BufferedIterableSource", () => {
         }
 
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -500,8 +489,6 @@ describe("BufferedIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -524,5 +511,62 @@ describe("BufferedIterableSource", () => {
 
     await signal.wait();
     expect(count).toEqual(4);
+  });
+
+  it("should support stamp iterator results and wait to buffer more messages until reading moves forward", async () => {
+    const source = new TestSource();
+    const bufferedSource = new BufferedIterableSource(source, {
+      readAheadDuration: { sec: 1, nsec: 0 },
+    });
+
+    await bufferedSource.initialize();
+
+    let signal = waiter(1);
+
+    const debounceNotify = debounce(() => {
+      signal.notify();
+    }, 500);
+
+    let messageIteratorCount = 0;
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      expect(args).toEqual({
+        topics: ["a"],
+        start: { sec: 0, nsec: 0 },
+        end: { sec: 10, nsec: 0 },
+        consumptionType: "partial",
+      });
+      messageIteratorCount += 1;
+
+      for (let i = 0; i < 8; ++i) {
+        debounceNotify();
+        yield {
+          type: "stamp",
+          stamp: { sec: i, nsec: 0 },
+        };
+      }
+    };
+
+    const messageIterator = bufferedSource.messageIterator({
+      topics: ["a"],
+    });
+
+    // Reading the first message buffers some data
+    await messageIterator.next();
+
+    // Wait for the buffered iterable source to stop reading messages
+    await signal.wait();
+
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
+
+    // Reading the second message buffers more data
+    signal = waiter(1);
+    await messageIterator.next();
+    await signal.wait();
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0 }]);
+
+    // We should have called the messageIterator method only once
+    expect(messageIteratorCount).toEqual(1);
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -103,9 +103,45 @@ class BufferedIterableSource implements IIterableSource {
         this.initResult.end,
       );
 
+      // fixme - We keep reading until we get a message _after_ the readUntil time
+      // that's when we know to stop
+      // however this creates a problem for us because if there are no messages in our window
+      // then we are doomed to make lots fo tiny requests for data platform
+      //
+      // fixme
+      // what if I create a result that is a _stamp_ to indicate ok we are here, but doesn't actually
+      // have a message
+      //
+      // this allows a data source that has some internal process to avoid constantly fetching until we get a
+      // message _after_ the time we want...
       for await (const result of sourceIterator) {
         if (this.aborted) {
           return;
+        }
+
+        if (result.stamp && compare(result.stamp, readUntil) >= 0) {
+          // we enqueue a stamp
+          // now what? we wait until what happens?
+          // nothing is going to read
+
+          // fixme - if cache is 0, the reader is going to wait for us to put something into the cache
+          // so we keep going until we have something in the cache, but we cannot because
+          // wait until the stamp is no longer beyond read until
+          while (compare(result.stamp, readUntil) >= 0) {
+            // enqueue the stamp and wakeup the reader
+            // but the reader might not be reading - cause it is not being read from
+            this.cache.enqueue(result);
+            this.readSignal.notifyAll();
+
+            // fixme - so we won't get notified that it got read from because...?
+            console.log("waiting", result.stamp, readUntil);
+            await this.writeSignal.wait();
+
+            readUntil = addTime(this.readHead, this.readAheadDuration);
+            console.log("next readUntil", readUntil);
+          }
+          console.log("pst wait");
+          continue;
         }
 
         this.cache.enqueue(result);
@@ -113,10 +149,14 @@ class BufferedIterableSource implements IIterableSource {
         // Indicate to the consumer that it can try reading again
         this.readSignal.notifyAll();
 
+        // fixme - the consumer will wake up the next tick, so we should be waiting so we can update the readHead correctly?
+
         // Update the target readUntil to be ahead of the latest readHead
         // Do this before checking whether whether we continue loading more data to keep the
         // readUntil constantly updated relative to the readHead
         readUntil = addTime(this.readHead, this.readAheadDuration);
+
+        console.log("more msg");
 
         // Keep reading while the messages we receive are <= the readUntil time
         if (result.msgEvent && compare(result.msgEvent.receiveTime, readUntil) <= 0) {
@@ -196,8 +236,15 @@ class BufferedIterableSource implements IIterableSource {
             }
 
             // Wait for more stuff to load
+            // fixme - but we won't load more stuff because our stamp is past the read head
+            // so there's no more to load until the read head moves forward more...
+            // but it isn't going to move forward more?
             await self.readSignal.wait();
             continue;
+          }
+
+          if (item.stamp) {
+            self.readHead = item.stamp;
           }
 
           // When there is a new message update the readHead for the producer to know where we are
@@ -209,6 +256,9 @@ class BufferedIterableSource implements IIterableSource {
           self.writeSignal.notifyAll();
 
           yield item;
+
+          // fixme - why? the readHead has not changed...
+          self.writeSignal.notifyAll();
         }
       } finally {
         log.debug("ending buffered message iterator");

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -103,44 +103,28 @@ class BufferedIterableSource implements IIterableSource {
         this.initResult.end,
       );
 
-      // fixme - We keep reading until we get a message _after_ the readUntil time
-      // that's when we know to stop
-      // however this creates a problem for us because if there are no messages in our window
-      // then we are doomed to make lots fo tiny requests for data platform
-      //
-      // fixme
-      // what if I create a result that is a _stamp_ to indicate ok we are here, but doesn't actually
-      // have a message
-      //
-      // this allows a data source that has some internal process to avoid constantly fetching until we get a
-      // message _after_ the time we want...
       for await (const result of sourceIterator) {
         if (this.aborted) {
           return;
         }
 
-        if (result.stamp && compare(result.stamp, readUntil) >= 0) {
-          // we enqueue a stamp
-          // now what? we wait until what happens?
-          // nothing is going to read
+        // Update the target readUntil to be ahead of the latest readHead
+        //
+        // Since reading a result from the iterator is async, we update the readUntil after we have
+        // the result so we can have the latest readHead
+        readUntil = addTime(this.readHead, this.readAheadDuration);
 
-          // fixme - if cache is 0, the reader is going to wait for us to put something into the cache
-          // so we keep going until we have something in the cache, but we cannot because
-          // wait until the stamp is no longer beyond read until
+        // When receiving a stamp result we enqueue the result into the cache and notify a reader.
+        if (result.type === "stamp" && compare(result.stamp, readUntil) >= 0) {
           while (compare(result.stamp, readUntil) >= 0) {
             // enqueue the stamp and wakeup the reader
             // but the reader might not be reading - cause it is not being read from
             this.cache.enqueue(result);
             this.readSignal.notifyAll();
 
-            // fixme - so we won't get notified that it got read from because...?
-            console.log("waiting", result.stamp, readUntil);
             await this.writeSignal.wait();
-
             readUntil = addTime(this.readHead, this.readAheadDuration);
-            console.log("next readUntil", readUntil);
           }
-          console.log("pst wait");
           continue;
         }
 
@@ -149,17 +133,11 @@ class BufferedIterableSource implements IIterableSource {
         // Indicate to the consumer that it can try reading again
         this.readSignal.notifyAll();
 
-        // fixme - the consumer will wake up the next tick, so we should be waiting so we can update the readHead correctly?
-
-        // Update the target readUntil to be ahead of the latest readHead
-        // Do this before checking whether whether we continue loading more data to keep the
-        // readUntil constantly updated relative to the readHead
-        readUntil = addTime(this.readHead, this.readAheadDuration);
-
-        console.log("more msg");
-
-        // Keep reading while the messages we receive are <= the readUntil time
-        if (result.msgEvent && compare(result.msgEvent.receiveTime, readUntil) <= 0) {
+        // Keep reading while the messages we receive are <= the readUntil time.
+        if (
+          result.type === "message-event" &&
+          compare(result.msgEvent.receiveTime, readUntil) <= 0
+        ) {
           continue;
         }
 
@@ -236,29 +214,25 @@ class BufferedIterableSource implements IIterableSource {
             }
 
             // Wait for more stuff to load
-            // fixme - but we won't load more stuff because our stamp is past the read head
-            // so there's no more to load until the read head moves forward more...
-            // but it isn't going to move forward more?
             await self.readSignal.wait();
             continue;
           }
 
-          if (item.stamp) {
+          if (item.type === "stamp") {
             self.readHead = item.stamp;
           }
 
           // When there is a new message update the readHead for the producer to know where we are
           // currently reading
-          if (item.msgEvent) {
+          if (item.type === "message-event") {
             self.readHead = item.msgEvent.receiveTime;
           }
 
+          // Notify the producer thread that it can load more data. Since our producer and consumer are on the same _thread_
+          // this notification is picked up on the next tick.
           self.writeSignal.notifyAll();
 
           yield item;
-
-          // fixme - why? the readHead has not changed...
-          self.writeSignal.notifyAll();
         }
       } finally {
         log.debug("ending buffered message iterator");

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -58,6 +58,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 0, nsec: i * 1e8 },
@@ -65,8 +66,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -82,8 +81,7 @@ describe("CachingIterableSource", () => {
         await expect(iterResult).resolves.toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: 0, nsec: i * 1e8 },
               message: undefined,
@@ -122,8 +120,7 @@ describe("CachingIterableSource", () => {
         await expect(iterResult).resolves.toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: 0, nsec: i * 1e8 },
               message: undefined,
@@ -155,6 +152,7 @@ describe("CachingIterableSource", () => {
       _args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 0, nsec: 1 },
@@ -162,8 +160,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
     };
 
@@ -200,6 +196,7 @@ describe("CachingIterableSource", () => {
         _args: MessageIteratorArgs,
       ): AsyncIterableIterator<Readonly<IteratorResult>> {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 5, nsec: 0 },
@@ -207,8 +204,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       };
 
@@ -223,8 +218,7 @@ describe("CachingIterableSource", () => {
         expect(iterResult).toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: 5, nsec: 0 },
               message: undefined,
@@ -252,6 +246,7 @@ describe("CachingIterableSource", () => {
         _args: MessageIteratorArgs,
       ): AsyncIterableIterator<Readonly<IteratorResult>> {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 0, nsec: 0 },
@@ -259,8 +254,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       };
 
@@ -275,8 +268,7 @@ describe("CachingIterableSource", () => {
         expect(iterResult).toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: 0, nsec: 0 },
               message: undefined,
@@ -293,8 +285,7 @@ describe("CachingIterableSource", () => {
         expect(iterResult).toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: 5, nsec: 0 },
               message: undefined,
@@ -330,6 +321,7 @@ describe("CachingIterableSource", () => {
       _args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 0, nsec: 0 },
@@ -337,11 +329,10 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 101,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 5, nsec: 1 },
@@ -349,11 +340,10 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 101,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 10, nsec: 0 },
@@ -361,8 +351,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 101,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
     };
 
@@ -419,6 +407,7 @@ describe("CachingIterableSource", () => {
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 3, nsec: 0 },
@@ -426,8 +415,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
 
       if ((args.end?.sec ?? 100) < 6) {
@@ -435,6 +422,7 @@ describe("CachingIterableSource", () => {
       }
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 6, nsec: 0 },
@@ -442,8 +430,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
     };
 
@@ -455,6 +441,7 @@ describe("CachingIterableSource", () => {
     {
       const res = await messageIterator.next();
       expect(res.value).toEqual({
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 3, nsec: 0 },
@@ -462,8 +449,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       });
     }
 
@@ -483,6 +468,7 @@ describe("CachingIterableSource", () => {
       _args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 3, nsec: 0 },
@@ -490,11 +476,10 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 6, nsec: 0 },
@@ -502,8 +487,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
     };
 
@@ -525,6 +508,7 @@ describe("CachingIterableSource", () => {
     {
       const res = await messageIterator.next();
       expect(res.value).toEqual({
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 3, nsec: 0 },
@@ -532,8 +516,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       });
     }
 
@@ -554,6 +536,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: 0, nsec: i * 1e8 },
@@ -561,8 +544,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -612,6 +593,7 @@ describe("CachingIterableSource", () => {
       _args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "a",
           receiveTime: { sec: 1, nsec: 0 },
@@ -619,10 +601,9 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 101,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "b",
           receiveTime: { sec: 2, nsec: 0 },
@@ -630,8 +611,6 @@ describe("CachingIterableSource", () => {
           sizeInBytes: 101,
           schemaName: "foo",
         },
-        problem: undefined,
-        connectionId: undefined,
       };
     };
 
@@ -691,6 +670,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 8; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -698,8 +678,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 101,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -732,6 +710,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 10; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: i, nsec: 0 },
@@ -739,8 +718,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 100,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -782,6 +759,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 10; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
@@ -789,8 +767,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 50,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };
@@ -806,8 +782,7 @@ describe("CachingIterableSource", () => {
         await expect(iterResult).resolves.toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
               message: { value: i },
@@ -846,8 +821,7 @@ describe("CachingIterableSource", () => {
         await expect(iterResult).resolves.toEqual({
           done: false,
           value: {
-            problem: undefined,
-            connectionId: undefined,
+            type: "message-event",
             msgEvent: {
               receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
               message: { value: i },
@@ -880,6 +854,7 @@ describe("CachingIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       for (let i = 0; i < 10; ++i) {
         yield {
+          type: "message-event",
           msgEvent: {
             topic: "a",
             receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
@@ -887,10 +862,10 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
         yield {
+          type: "message-event",
+
           msgEvent: {
             topic: "b",
             receiveTime: { sec: Math.floor(i / 3), nsec: 0 },
@@ -898,8 +873,6 @@ describe("CachingIterableSource", () => {
             sizeInBytes: 0,
             schemaName: "foo",
           },
-          problem: undefined,
-          connectionId: undefined,
         };
       }
     };

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -238,7 +238,7 @@ class CachingIterableSource implements IIterableSource {
         }
 
         // If we have a message event, then we update our known time to this message event
-        if (iterResult.msgEvent) {
+        if (iterResult.type === "message-event") {
           const receiveTime = iterResult.msgEvent.receiveTime;
           const receiveTimeNs = toNanoSec(receiveTime);
 
@@ -247,7 +247,9 @@ class CachingIterableSource implements IIterableSource {
           if (receiveTimeNs > lastTime) {
             // write any pending messages to the block
             for (const pendingIterResult of pendingIterResults) {
-              const pendingSizeInBytes = pendingIterResult[1].msgEvent?.sizeInBytes ?? 0;
+              const item = pendingIterResult[1];
+              const pendingSizeInBytes =
+                item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
               block.items.push(pendingIterResult);
               block.size += pendingSizeInBytes;
             }
@@ -275,7 +277,8 @@ class CachingIterableSource implements IIterableSource {
           block = undefined;
         }
 
-        const sizeInBytes = iterResult.msgEvent?.sizeInBytes ?? 0;
+        const sizeInBytes =
+          iterResult.type === "message-event" ? iterResult.msgEvent.sizeInBytes : 0;
         if (this.maybePurgeCache({ activeBlock: block, sizeInBytes })) {
           this.recomputeLoadedRangeCache();
         }
@@ -298,7 +301,8 @@ class CachingIterableSource implements IIterableSource {
 
         // write any pending messages to the block
         for (const pendingIterResult of pendingIterResults) {
-          const pendingSizeInBytes = pendingIterResult[1].msgEvent?.sizeInBytes ?? 0;
+          const item = pendingIterResult[1];
+          const pendingSizeInBytes = item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
           block.items.push(pendingIterResult);
           block.size += pendingSizeInBytes;
         }
@@ -320,7 +324,8 @@ class CachingIterableSource implements IIterableSource {
         };
 
         for (const pendingIterResult of pendingIterResults) {
-          const pendingSizeInBytes = pendingIterResult[1].msgEvent?.sizeInBytes ?? 0;
+          const item = pendingIterResult[1];
+          const pendingSizeInBytes = item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
           newBlock.size += pendingSizeInBytes;
         }
 
@@ -393,7 +398,7 @@ class CachingIterableSource implements IIterableSource {
 
       for (let i = readIdx; i >= 0; --i) {
         const record = cacheBlock.items[i];
-        if (!record || !record[1].msgEvent) {
+        if (!record || record[1].type !== "message-event") {
           continue;
         }
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -237,9 +237,11 @@ class CachingIterableSource implements IIterableSource {
           this.recomputeLoadedRangeCache();
         }
 
-        // If we have a message event, then we update our known time to this message event
-        if (iterResult.type === "message-event") {
-          const receiveTime = iterResult.msgEvent.receiveTime;
+        // When receiving a message event or stamp, we update our known time on the block to the
+        // stamp or receiveTime because we know we've received all the results up to this time
+        if (iterResult.type === "message-event" || iterResult.type === "stamp") {
+          const receiveTime =
+            iterResult.type === "stamp" ? iterResult.stamp : iterResult.msgEvent.receiveTime;
           const receiveTimeNs = toNanoSec(receiveTime);
 
           // There might be multiple messages at the same time, and since block end time

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -54,6 +54,18 @@ export type MessageIteratorArgs = {
   consumptionType?: "full" | "partial";
 };
 
+/**
+ * IteratorResult represents a single result from a message iterator or cursor. There are three
+ * types of results.
+ *
+ * - message-event: the result contains a MessageEvent
+ * - problem: the result contains a problem
+ * - stamp: the result is a timestamp
+ *
+ * Note: A stamp result acts as a marker indicating that the source has reached the specified stamp.
+ * The source may return stamp results to indicate to callers that it has read through some time
+ * when there are no message events available to indicate the time is reached.
+ */
 export type IteratorResult =
   | {
       type: "message-event";

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -59,11 +59,19 @@ export type IteratorResult =
       connectionId: number | undefined;
       msgEvent: MessageEvent<unknown>;
       problem: undefined;
+      stamp: undefined;
     }
   | {
       connectionId: number | undefined;
       msgEvent: undefined;
       problem: PlayerProblem;
+      stamp: undefined;
+    }
+  | {
+      stamp: Time;
+      connectionId: undefined;
+      msgEvent: undefined;
+      problem: undefined;
     };
 
 export type GetBackfillMessagesArgs = {

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -56,22 +56,18 @@ export type MessageIteratorArgs = {
 
 export type IteratorResult =
   | {
-      connectionId: number | undefined;
+      type: "message-event";
+      connectionId?: number;
       msgEvent: MessageEvent<unknown>;
-      problem: undefined;
-      stamp: undefined;
     }
   | {
-      connectionId: number | undefined;
-      msgEvent: undefined;
+      type: "problem";
+      connectionId?: number;
       problem: PlayerProblem;
-      stamp: undefined;
     }
   | {
+      type: "stamp";
       stamp: Time;
-      connectionId: undefined;
-      msgEvent: undefined;
-      problem: undefined;
     };
 
 export type GetBackfillMessagesArgs = {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -154,11 +154,14 @@ describe("IterablePlayer", () => {
         ...baseState,
         presence: PlayerPresence.PRESENT,
       },
-      // startPlay
+      // initial play
       {
         ...baseState,
         presence: PlayerPresence.PRESENT,
-        activeData: { ...baseState.activeData, currentTime: { sec: 0, nsec: 99000000 } },
+        activeData: {
+          ...baseState.activeData,
+          currentTime: { sec: 0, nsec: 99000000 },
+        },
       },
       // idle
       {
@@ -345,6 +348,7 @@ describe("IterablePlayer", () => {
       source.messageIterator = origMsgIterator;
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "foo",
           receiveTime: { sec: 0, nsec: 99000001 },
@@ -352,7 +356,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
         connectionId: undefined,
       };
     };
@@ -391,6 +394,7 @@ describe("IterablePlayer", () => {
       source.messageIterator = origMsgIterator;
 
       yield {
+        type: "message-event",
         msgEvent: {
           topic: "foo",
           receiveTime: { sec: 0, nsec: 99000001 },
@@ -398,7 +402,6 @@ describe("IterablePlayer", () => {
           sizeInBytes: 0,
           schemaName: "foo",
         },
-        problem: undefined,
         connectionId: undefined,
       };
     };

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -785,8 +785,14 @@ export class IterablePlayer implements Player {
     const targetTime = add(this._currentTime, fromMillis(rangeMillis));
     const end: Time = clampTime(targetTime, this._start, this._untilTime ?? this._end);
 
+    // If a lastStamp is available from the previous tick we check the stamp against our current
+    // tick's end time. If this stamp is after our current tick's end time then we don't need to
+    // read any messages and can shortcut the rest of the logic to set the current time to the tick
+    // end time and queue an emit.
+    //
+    // If we have a lastStamp but it isn't after the tick end, then we clear it and proceed with the
+    // tick logic.
     if (this._lastStamp) {
-      // If the last message we saw is still ahead of the tick end time, we don't emit anything
       if (compare(this._lastStamp, end) >= 0) {
         // Wait for the previous render frame to finish
         await this._queueEmitState.currentPromise;

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -142,7 +142,8 @@ export class IterablePlayer implements Player {
   private _receivedBytes: number = 0;
   private _hasError = false;
   private _lastRangeMillis?: number;
-  private _lastMessage?: MessageEvent<unknown>;
+  private _lastMessageEvent?: MessageEvent<unknown>;
+  private _lastStamp?: Time;
   private _publishedTopics = new Map<string, Set<string>>();
   private _seekTarget?: Time;
   private _presence = PlayerPresence.INITIALIZING;
@@ -571,7 +572,7 @@ export class IterablePlayer implements Player {
       consumptionType: "partial",
     });
 
-    this._lastMessage = undefined;
+    this._lastMessageEvent = undefined;
     this._messages = [];
 
     const messageEvents: MessageEvent<unknown>[] = [];
@@ -601,8 +602,12 @@ export class IterablePlayer implements Player {
           continue;
         }
 
+        if (iterResult.stamp && compare(iterResult.stamp, stopTime) >= 0) {
+          break;
+        }
+
         if (compare(iterResult.msgEvent.receiveTime, stopTime) > 0) {
-          this._lastMessage = iterResult.msgEvent;
+          this._lastMessageEvent = iterResult.msgEvent;
           break;
         }
 
@@ -627,7 +632,7 @@ export class IterablePlayer implements Player {
       return;
     }
 
-    this._lastMessage = undefined;
+    this._lastMessageEvent = undefined;
 
     // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
     // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
@@ -776,13 +781,32 @@ export class IterablePlayer implements Player {
     const targetTime = add(this._currentTime, fromMillis(rangeMillis));
     const end: Time = clampTime(targetTime, this._start, this._untilTime ?? this._end);
 
+    if (this._lastStamp) {
+      // If the last message we saw is still ahead of the tick end time, we don't emit anything
+      if (compare(this._lastStamp, end) >= 0) {
+        // Wait for the previous render frame to finish
+        await this._queueEmitState.currentPromise;
+
+        this._currentTime = end;
+        this._messages = [];
+        this._queueEmitState();
+
+        if (this._untilTime && compare(this._currentTime, this._untilTime) >= 0) {
+          this.pausePlayback();
+        }
+        return;
+      }
+
+      this._lastStamp = undefined;
+    }
+
     const msgEvents: MessageEvent<unknown>[] = [];
 
     // When ending the previous tick, we might have already read a message from the iterator which
     // belongs to our tick. This logic brings that message into our current batch of message events.
-    if (this._lastMessage) {
+    if (this._lastMessageEvent) {
       // If the last message we saw is still ahead of the tick end time, we don't emit anything
-      if (compare(this._lastMessage.receiveTime, end) > 0) {
+      if (compare(this._lastMessageEvent.receiveTime, end) > 0) {
         // Wait for the previous render frame to finish
         await this._queueEmitState.currentPromise;
 
@@ -796,8 +820,8 @@ export class IterablePlayer implements Player {
         return;
       }
 
-      msgEvents.push(this._lastMessage);
-      this._lastMessage = undefined;
+      msgEvents.push(this._lastMessageEvent);
+      this._lastMessageEvent = undefined;
     }
 
     // If we take too long to read the tick data, we set the player into a BUFFERING presence. This
@@ -828,9 +852,14 @@ export class IterablePlayer implements Player {
           continue;
         }
 
+        if (iterResult.stamp && compare(iterResult.stamp, end) >= 0) {
+          this._lastStamp = iterResult.stamp;
+          break;
+        }
+
         // The message is past the tick end time, we need to save it for next tick
         if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
-          this._lastMessage = iterResult.msgEvent;
+          this._lastMessageEvent = iterResult.msgEvent;
           break;
         }
 
@@ -924,7 +953,7 @@ export class IterablePlayer implements Player {
         // If subscriptions changed, update to the new subscriptions
         if (this._allTopics !== allTopics) {
           // Discard any last message event since the new iterator will repeat it
-          this._lastMessage = undefined;
+          this._lastMessageEvent = undefined;
 
           // Bail playback and reset the playback iterator when topics have changed so we can load
           // the new topics

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -597,21 +597,25 @@ export class IterablePlayer implements Player {
           return;
         }
 
-        if (iterResult.problem) {
+        if (iterResult.type === "problem") {
           this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
           continue;
         }
 
-        if (iterResult.stamp && compare(iterResult.stamp, stopTime) >= 0) {
+        if (iterResult.type === "stamp" && compare(iterResult.stamp, stopTime) >= 0) {
+          this._lastStamp = iterResult.stamp;
           break;
         }
 
-        if (compare(iterResult.msgEvent.receiveTime, stopTime) > 0) {
-          this._lastMessageEvent = iterResult.msgEvent;
-          break;
-        }
+        if (iterResult.type === "message-event") {
+          // The message is past the tick end time, we need to save it for next tick
+          if (compare(iterResult.msgEvent.receiveTime, stopTime) > 0) {
+            this._lastMessageEvent = iterResult.msgEvent;
+            break;
+          }
 
-        messageEvents.push(iterResult.msgEvent);
+          messageEvents.push(iterResult.msgEvent);
+        }
       }
     } finally {
       clearTimeout(tickTimeout);
@@ -844,26 +848,26 @@ export class IterablePlayer implements Player {
           break;
         }
         const iterResult = result.value;
-        if (iterResult.problem) {
-          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
-        }
 
-        if (iterResult.problem) {
+        if (iterResult.type === "problem") {
+          this._problemManager.addProblem(`connid-${iterResult.connectionId}`, iterResult.problem);
           continue;
         }
 
-        if (iterResult.stamp && compare(iterResult.stamp, end) >= 0) {
+        if (iterResult.type === "stamp" && compare(iterResult.stamp, end) >= 0) {
           this._lastStamp = iterResult.stamp;
           break;
         }
 
-        // The message is past the tick end time, we need to save it for next tick
-        if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
-          this._lastMessageEvent = iterResult.msgEvent;
-          break;
-        }
+        if (iterResult.type === "message-event") {
+          // The message is past the tick end time, we need to save it for next tick
+          if (compare(iterResult.msgEvent.receiveTime, end) > 0) {
+            this._lastMessageEvent = iterResult.msgEvent;
+            break;
+          }
 
-        msgEvents.push(iterResult.msgEvent);
+          msgEvents.push(iterResult.msgEvent);
+        }
       }
     } finally {
       clearTimeout(tickTimeout);

--- a/packages/studio-base/src/players/IterablePlayer/IteratorCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IteratorCursor.ts
@@ -46,7 +46,14 @@ class IteratorCursor implements IMessageCursor {
 
     // if the last result is still past end time, return empty results
     if (
-      this._lastIteratorResult?.msgEvent?.receiveTime &&
+      this._lastIteratorResult?.type === "stamp" &&
+      compare(this._lastIteratorResult.stamp, end) >= 0
+    ) {
+      return results;
+    }
+
+    if (
+      this._lastIteratorResult?.type === "message-event" &&
       compare(this._lastIteratorResult.msgEvent.receiveTime, end) > 0
     ) {
       return results;
@@ -68,7 +75,11 @@ class IteratorCursor implements IMessageCursor {
       }
 
       const value = result.value;
-      if (value.msgEvent?.receiveTime && compare(value.msgEvent.receiveTime, end) > 0) {
+      if (value.type === "stamp" && compare(value.stamp, end) >= 0) {
+        this._lastIteratorResult = value;
+        break;
+      }
+      if (value.type === "message-event" && compare(value.msgEvent.receiveTime, end) > 0) {
         this._lastIteratorResult = value;
         break;
       }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -130,19 +130,17 @@ export class McapIndexedIterableSource implements IIterableSource {
       const channelInfo = this.channelInfoById.get(message.channelId);
       if (!channelInfo) {
         yield {
-          connectionId: undefined,
+          type: "problem",
           problem: {
             message: `Received message on channel ${message.channelId} without prior channel info`,
             severity: "error",
           },
-          msgEvent: undefined,
         };
         continue;
       }
       try {
         yield {
-          connectionId: undefined,
-          problem: undefined,
+          type: "message-event",
           msgEvent: {
             topic: channelInfo.channel.topic,
             receiveTime: fromNanoSec(message.logTime),
@@ -154,13 +152,12 @@ export class McapIndexedIterableSource implements IIterableSource {
         };
       } catch (error) {
         yield {
-          connectionId: undefined,
+          type: "problem",
           problem: {
             message: `Error decoding message on ${channelInfo.channel.topic}`,
             error,
             severity: "error",
           },
-          msgEvent: undefined,
         };
       }
     }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -242,8 +242,8 @@ export class McapStreamingIterableSource implements IIterableSource {
           topicsSet.has(msgEvent.topic)
         ) {
           yield {
+            type: "message-event",
             connectionId: channelId,
-            problem: undefined,
             msgEvent,
           };
         }

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -267,7 +267,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       for await (const messages of stream) {
         for (const message of messages) {
-          yield { connectionId: undefined, msgEvent: message, problem: undefined };
+          yield { type: "message-event", msgEvent: message };
         }
       }
 
@@ -301,7 +301,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       for await (const messages of stream) {
         for (const message of messages) {
-          yield { connectionId: undefined, msgEvent: message, problem: undefined };
+          yield { type: "message-event", msgEvent: message };
         }
       }
 
@@ -309,7 +309,7 @@ export class DataPlatformIterableSource implements IIterableSource {
         return;
       }
 
-      yield { stamp: localEnd, connectionId: undefined, msgEvent: undefined, problem: undefined };
+      yield { type: "stamp", stamp: localEnd };
 
       localStart = addTime(localEnd, { sec: 0, nsec: 1 });
 

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -309,6 +309,8 @@ export class DataPlatformIterableSource implements IIterableSource {
         return;
       }
 
+      yield { stamp: localEnd, connectionId: undefined, msgEvent: undefined, problem: undefined };
+
       localStart = addTime(localEnd, { sec: 0, nsec: 1 });
 
       // Assumes coverage regions are sorted by start time

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -132,6 +132,7 @@ export class RosDb3IterableSource implements IIterableSource {
     });
     for await (const msg of msgIterator) {
       yield {
+        type: "message-event",
         msgEvent: {
           topic: msg.topic.name,
           receiveTime: msg.timestamp,
@@ -139,8 +140,6 @@ export class RosDb3IterableSource implements IIterableSource {
           sizeInBytes: msg.data.byteLength,
           schemaName: msg.topic.type,
         },
-        connectionId: undefined,
-        problem: undefined,
       };
     }
   }

--- a/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
@@ -148,6 +148,7 @@ export class UlogIterableSource implements IIterableSource {
         const topic = sub?.name;
         if (topic && topics.includes(topic) && isTimeInRangeInclusive(receiveTime, start, end)) {
           yield {
+            type: "message-event",
             msgEvent: {
               topic,
               receiveTime,
@@ -155,14 +156,13 @@ export class UlogIterableSource implements IIterableSource {
               sizeInBytes: msg.data.byteLength,
               schemaName: sub.name,
             },
-            connectionId: undefined,
-            problem: undefined,
           };
         }
       } else if (msg.type === MessageType.Log || msg.type === MessageType.LogTagged) {
         const receiveTime = fromMicros(Number(msg.timestamp));
         if (topics.includes(LOG_TOPIC) && isTimeInRangeInclusive(receiveTime, start, end)) {
           yield {
+            type: "message-event",
             msgEvent: {
               topic: LOG_TOPIC,
               receiveTime,
@@ -178,8 +178,6 @@ export class UlogIterableSource implements IIterableSource {
               schemaName: "rosgraph_msgs/Log",
               sizeInBytes: msg.size,
             },
-            connectionId: undefined,
-            problem: undefined,
           };
         }
       }


### PR DESCRIPTION
**User-Facing Changes**
Reduce the number of network requests when subscribed to sparsely populated topics and paused.

**Description**
The BufferedIterableSource is responsible for keeping a time-based read-ahead buffer of messages for playback. It does this using a producer and consumer pattern where the consumer reads from the buffer and updates the `readHead` location while the producer keeps messages buffered based on the read head. To keep the buffer filled, the producer reads messages from the underlying data source message iterator until some `readUntil` time which is a fixed offset ahead of the `readHead`. The producer stops when it encounters a message occurring after the `readUntil` time and waits for the consumer to move the `readHead` forward before attempting to read more messages.

The DataPlatformIterableSource implements two modes for message iteration. `partial` and `full`. In `partial` mode (the mode used for playback buffering), the implementation reads messages from the API using fixed-time request windows (currently 5 seconds). This is because we cannot control back-pressure on the request and want to avoid downloading large quantities of data prior to the user needing to play this data.

When opening a data platform stream and subscribing to a sparsely populated topic, the above behaviors result in many (hundreds to thousands) of requests to fetch each next 5 seconds of data from the api. This happens because the buffered source continues to read from the underlying source (data platform) until it can encounter a message _after_ the `readUntil` time. For a sparsely populated dataset it could be minutes or hours before the next such message exists and we get there in 5 second request increments.

This change provides a workaround to this behavior by introducing a new type of IteratorResult. Unlike the `messageEvent` or `problem` IteratorResult, the _stamp_ iterator result contains only a timestamp (no message or problem). The underlying source uses the stamp result to indicate it has loaded data through the stamp time as a signal to upstream message iterator consumers. The BufferedIterableSource is updated with logic to check the `stamp` time against the `readUntil` time to identify if the underlying source has been sufficiently buffered for playback. The DataPlatformIteraboeSource is updated to emit `stamp` results after each 5 second stream ends. Even if there are no messages in the stream, the stamp result indicates to callers that the specific timestamp has been reached.

Fixes: #4744


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
