### PR TITLE
Add --allow-empty to dependabot-fix commit

### DIFF
--- a/.github/workflows/dependabot-fix.yml
+++ b/.github/workflows/dependabot-fix.yml
@@ -66,5 +66,5 @@ jobs:
           git config user.name "dependabot[bot]"
           git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
           git add yarn.lock
-          git commit -m '[dependabot skip] Fix yarn.lock'
+          git commit -m '[dependabot skip] Fix yarn.lock' --allow-empty
           git push


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Sometimes there is nothing to dedupe and no update to yarn.lock. This change will still make the empty commit so the dependabot-fix action does not fail at the commit command.



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
