### PR TITLE
[3D] Updates to RGBA color options for PointCloud2, foxglove.PointCloud & foxglove.Grid

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -8,13 +8,6 @@ import { toNanoSec } from "@foxglove/rostime";
 import { Grid, NumericType, PackedElementField } from "@foxglove/schemas";
 import { SettingsTreeAction } from "@foxglove/studio";
 import { GRID_DATATYPES } from "@foxglove/studio-base/panels/ThreeDeeRender/foxglove";
-import {
-  baseColorModeSettingsNode,
-  ColorModeSettings,
-  getColorConverter,
-  autoSelectColorField,
-  NEEDS_MIN_MAX,
-} from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/pointClouds/colors";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { BaseUserData, Renderable } from "../Renderable";
@@ -24,17 +17,30 @@ import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../Setting
 import { rgbaToCssString, rgbaToLinear, stringToRgba } from "../color";
 import { normalizePose, normalizeTime, normalizeByteArray } from "../normalizeMessages";
 import { BaseSettings } from "../settings";
+import {
+  baseColorModeSettingsNode,
+  ColorModeSettings,
+  getColorConverter,
+  autoSelectColorField,
+  NEEDS_MIN_MAX,
+  FS_SRGB_TO_LINEAR,
+} from "./pointClouds/colors";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
 
+type GridColorModeSettings = ColorModeSettings & {
+  // rgba packed modes are only supported for sensor_msgs/PointCloud2
+  colorMode: Exclude<ColorModeSettings["colorMode"], "rgb" | "rgba">;
+};
+
 export type LayerSettingsFoxgloveGrid = BaseSettings &
-  ColorModeSettings & {
+  GridColorModeSettings & {
     frameLocked: boolean;
   };
 function zeroReader(): number {
   return 0;
 }
 
-const floatTextureColorModes: ColorModeSettings["colorMode"][] = ["gradient", "colormap"];
+const floatTextureColorModes: GridColorModeSettings["colorMode"][] = ["gradient", "colormap"];
 
 const INVALID_FOXGLOVE_GRID = "INVALID_FOXGLOVE_GRID";
 
@@ -42,16 +48,16 @@ const DEFAULT_COLOR_MAP = "turbo";
 const DEFAULT_FLAT_COLOR = { r: 1, g: 1, b: 1, a: 1 };
 const DEFAULT_MIN_COLOR = { r: 100 / 255, g: 47 / 255, b: 105 / 255, a: 1 };
 const DEFAULT_MAX_COLOR = { r: 227 / 255, g: 177 / 255, b: 135 / 255, a: 1 };
-const DEFAULT_RGB_BYTE_ORDER = "rgba";
 
 const COLOR_MODE_TO_GLSL: {
-  [K in ColorModeSettings["colorMode"] as `COLOR_MODE_${Uppercase<K>}`]: number;
+  [K in GridColorModeSettings["colorMode"] as `COLOR_MODE_${K extends "rgba-fields"
+    ? "RGBA"
+    : Uppercase<K>}`]: number;
 } = {
   COLOR_MODE_FLAT: 0,
-  COLOR_MODE_RGB: 1,
-  COLOR_MODE_RGBA: 2,
-  COLOR_MODE_GRADIENT: 3,
-  COLOR_MODE_COLORMAP: 4,
+  COLOR_MODE_RGBA: 1,
+  COLOR_MODE_GRADIENT: 2,
+  COLOR_MODE_COLORMAP: 3,
 };
 
 const COLOR_MAP_TO_GLSL: {
@@ -72,7 +78,6 @@ const DEFAULT_SETTINGS: LayerSettingsFoxgloveGrid = {
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
   explicitAlpha: 1,
-  rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
 };
 
 interface GridShaderMaterial extends THREE.ShaderMaterial {
@@ -105,6 +110,37 @@ export type FoxgloveGridUserData = BaseUserData & {
   pickingMaterial: THREE.ShaderMaterial;
 };
 
+type RgbaFieldReaders = {
+  redReader: FieldReader;
+  greenReader: FieldReader;
+  blueReader: FieldReader;
+  alphaReader: FieldReader;
+};
+const tempRgbaFieldReaders: RgbaFieldReaders = {
+  redReader: zeroReader,
+  greenReader: zeroReader,
+  blueReader: zeroReader,
+  alphaReader: zeroReader,
+};
+
+function numericTypeName(type: NumericType): string {
+  return NumericType[type] ?? `${type}`;
+}
+
+function getTextureEncoding(settings: GridColorModeSettings) {
+  switch (settings.colorMode) {
+    case "flat":
+      // color is converted to linear by getColorConverter before being written to the texture
+      return THREE.LinearEncoding;
+    case "gradient":
+    case "colormap":
+      // color value is raw numeric value
+      return THREE.LinearEncoding;
+    case "rgba-fields":
+      return THREE.sRGBEncoding;
+  }
+}
+
 const tempColor = { r: 0, g: 0, b: 0, a: 1 };
 const tempMinMaxColor: THREE.Vector2Tuple = [0, 0];
 export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
@@ -124,51 +160,46 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     pickingMaterial.needsUpdate = true;
   }
 
-  private _getFieldReader(
+  private _getRgbaFieldReaders(out: RgbaFieldReaders, foxgloveGrid: Grid) {
+    const { cell_stride } = foxgloveGrid;
+    for (const field of foxgloveGrid.fields) {
+      const { name } = field;
+      if (name === "red") {
+        out.redReader = getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+      } else if (name === "green") {
+        out.greenReader =
+          getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+      } else if (name === "blue") {
+        out.blueReader = getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+      } else if (name === "alpha") {
+        out.alphaReader =
+          getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+      }
+    }
+  }
+
+  private _getColorByFieldReader(
     foxgloveGrid: Grid,
     settings: LayerSettingsFoxgloveGrid,
   ): FieldReader | undefined {
-    let colorReader: FieldReader | undefined;
+    const { cell_stride } = foxgloveGrid;
 
-    const stride = foxgloveGrid.cell_stride;
-
-    // Determine the minimum bytes needed per cell based on offset/size of each
-    // field, so we can ensure cell_stride is >= this value
-    let minBytesPerCell = 0;
-
-    for (let i = 0; i < foxgloveGrid.fields.length; i++) {
-      const field = foxgloveGrid.fields[i]!;
+    for (const field of foxgloveGrid.fields) {
       const { type, offset, name } = field;
 
-      const byteWidth = numericTypeWidth(type);
-      minBytesPerCell = Math.max(minBytesPerCell, offset + byteWidth);
-
       if (name === settings.colorField) {
-        // If the selected color mode is rgb/rgba and the field only has one channel with at least a
-        // four byte width, force the color data to be interpreted as four individual bytes. This
-        // overcomes a common problem where the color field data type is set to float32 or something
-        // other than uint32
-        const forceType =
-          (settings.colorMode === "rgb" || settings.colorMode === "rgba") && byteWidth >= 4
-            ? NumericType.UINT32
-            : undefined;
-        colorReader = getReader(field, stride, forceType);
-        if (!colorReader) {
+        const fieldReader = getReader(field, cell_stride);
+        if (!fieldReader) {
           const typeName = NumericType[type];
-          const message = `Grid field "${field.name}" is invalid. type=${typeName}, offset=${field.offset}, stride=${stride}`;
-          invalidFoxgloveGridError(this.renderer, this, message);
+          const message = `Grid field "${name}" is invalid. type=${typeName}, offset=${offset}, stride=${cell_stride}`;
+          invalidFoxgloveGridError(this.renderer, this.userData.topic, message);
           return undefined;
         }
+        return fieldReader;
       }
     }
 
-    if (minBytesPerCell > stride) {
-      const message = `Grid stride ${stride} is less than minimum bytes per cell ${minBytesPerCell}`;
-      invalidFoxgloveGridError(this.renderer, this, message);
-      return undefined;
-    }
-
-    return colorReader ?? zeroReader;
+    return zeroReader;
   }
 
   public updateMaterial(settings: LayerSettingsFoxgloveGrid): void {
@@ -212,9 +243,13 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
       },
     } = material;
 
-    colorMode.value = COLOR_MODE_TO_GLSL[`COLOR_MODE_${settings.colorMode.toUpperCase()}`]!;
+    if (settings.colorMode === "rgba-fields") {
+      colorMode.value = COLOR_MODE_TO_GLSL.COLOR_MODE_RGBA;
+    } else {
+      colorMode.value = COLOR_MODE_TO_GLSL[`COLOR_MODE_${settings.colorMode.toUpperCase()}`];
+    }
 
-    colorMap.value = COLOR_MAP_TO_GLSL[`COLOR_MAP_${settings.colorMap.toUpperCase()}`]!;
+    colorMap.value = COLOR_MAP_TO_GLSL[`COLOR_MAP_${settings.colorMap.toUpperCase()}`];
 
     colorMapOpacity.value = settings.explicitAlpha;
 
@@ -241,7 +276,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
 
   public updateTexture(foxgloveGrid: Grid, settings: LayerSettingsFoxgloveGrid): void {
     let texture = this.userData.texture;
-    const fieldReader = this._getFieldReader(foxgloveGrid, settings);
+    const fieldReader = this._getColorByFieldReader(foxgloveGrid, settings);
     if (!fieldReader) {
       return;
     }
@@ -252,8 +287,8 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
       foxgloveGrid.data.byteLength,
     );
 
-    const cols = foxgloveGrid.column_count;
-    const rows = foxgloveGrid.data.length / foxgloveGrid.row_stride;
+    const { column_count: cols, row_stride, cell_stride } = foxgloveGrid;
+    const rows = foxgloveGrid.data.length / row_stride;
     const sizeChanged = cols !== texture.image.width || rows !== texture.image.height;
     const floatMode = floatTextureColorModes.includes(settings.colorMode);
     const formatChanged = floatMode
@@ -262,46 +297,80 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     if (formatChanged || sizeChanged) {
       // The image dimensions or format changed, regenerate the texture
       texture.dispose();
-      texture = createTexture(foxgloveGrid, settings.colorMode);
+      texture = createTexture(foxgloveGrid, settings);
       texture.generateMipmaps = false;
       this.userData.texture = texture;
       this.userData.material.uniforms.map.value = texture;
     }
 
+    const encoding = getTextureEncoding(settings);
+    if (encoding !== texture.encoding) {
+      texture.encoding = encoding;
+      texture.needsUpdate = true;
+    }
+
     if (floatMode) {
-      // FLOAT texture handling
+      // FLOAT texture handling (gradient & colorMap)
       // type of image.data is Uint8ClampedArray, but it is in fact the raw texture data even thought it's
       // meant to be used as an RGBA image data array
       const valueData = texture.image.data as unknown as Float32Array;
       for (let y = 0; y < rows; y++) {
         for (let x = 0; x < cols; x++) {
-          const offset = y * foxgloveGrid.row_stride + x * foxgloveGrid.cell_stride;
+          const offset = y * row_stride + x * cell_stride;
           const colorValue = fieldReader(view, offset);
           const i = y * cols + x;
           valueData[i] = colorValue;
         }
       }
     } else {
-      // RGBA textures
-      let hasTransparency = false;
-      const colorConverter = getColorConverter(settings, 0, 1);
+      // RGBA textures (flat & rgba modes)
       const rgba = texture.image.data;
-      for (let y = 0; y < rows; y++) {
-        for (let x = 0; x < cols; x++) {
-          const offset = y * foxgloveGrid.row_stride + x * foxgloveGrid.cell_stride;
-          const colorValue = fieldReader(view, offset);
-          colorConverter(tempColor, colorValue);
-          const i = y * cols + x;
-          const rgbaOffset = i * 4;
-          rgba[rgbaOffset + 0] = Math.floor(tempColor.r * 255);
-          rgba[rgbaOffset + 1] = Math.floor(tempColor.g * 255);
-          rgba[rgbaOffset + 2] = Math.floor(tempColor.b * 255);
-          rgba[rgbaOffset + 3] = Math.floor(tempColor.a * 255);
+      let hasTransparency = false;
+      if (settings.colorMode === "rgba-fields") {
+        this._getRgbaFieldReaders(tempRgbaFieldReaders, foxgloveGrid);
+        const { redReader, greenReader, blueReader, alphaReader } = tempRgbaFieldReaders;
+        for (let y = 0; y < rows; y++) {
+          for (let x = 0; x < cols; x++) {
+            const offset = y * row_stride + x * cell_stride;
+            const i = y * cols + x;
+            const rgbaOffset = i * 4;
+            const alpha = alphaReader(view, offset);
+            rgba[rgbaOffset + 0] = (redReader(view, offset) * 255) | 0;
+            rgba[rgbaOffset + 1] = (greenReader(view, offset) * 255) | 0;
+            rgba[rgbaOffset + 2] = (blueReader(view, offset) * 255) | 0;
+            rgba[rgbaOffset + 3] = (alpha * 255) | 0;
 
-          // We cheat a little with transparency: alpha 0 will be handled by the alphaTest setting, so
-          // we don't need to set material.transparent = true.
-          if (tempColor.a !== 0 && tempColor.a !== 1) {
-            hasTransparency = true;
+            // We cheat a little with transparency: alpha 0 will be handled by the alphaTest setting, so
+            // we don't need to set material.transparent = true.
+            if (alpha !== 0 && alpha !== 1) {
+              hasTransparency = true;
+            }
+          }
+        }
+      } else {
+        // flat
+        const colorConverter = getColorConverter(
+          settings as typeof settings & { colorMode: typeof settings.colorMode },
+          0,
+          1,
+        );
+        for (let y = 0; y < rows; y++) {
+          for (let x = 0; x < cols; x++) {
+            const offset = y * row_stride + x * cell_stride;
+            const colorValue = fieldReader(view, offset);
+            colorConverter(tempColor, colorValue);
+            const i = y * cols + x;
+            const rgbaOffset = i * 4;
+            rgba[rgbaOffset + 0] = Math.floor(tempColor.r * 255);
+            rgba[rgbaOffset + 1] = Math.floor(tempColor.g * 255);
+            rgba[rgbaOffset + 2] = Math.floor(tempColor.b * 255);
+            rgba[rgbaOffset + 3] = Math.floor(tempColor.a * 255);
+
+            // We cheat a little with transparency: alpha 0 will be handled by the alphaTest setting, so
+            // we don't need to set material.transparent = true.
+            if (tempColor.a !== 0 && tempColor.a !== 1) {
+              hasTransparency = true;
+            }
           }
         }
       }
@@ -338,7 +407,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
           config,
           topic,
           DEFAULT_SETTINGS,
-          { supportsRgbModes: true },
+          { supportsPackedRgbModes: false, supportsRgbaFieldsMode: true },
         );
         node.icon = "Cells";
         node.fields.frameLocked = {
@@ -375,7 +444,11 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
 
       renderable.updateMaterial(renderable.userData.settings);
       renderable.updateUniforms(renderable.userData.foxgloveGrid, renderable.userData.settings);
-      if (action.payload.path[2] === "colorMode" || action.payload.path[2] === "colorField") {
+      if (
+        action.payload.path[2] === "colorMode" ||
+        action.payload.path[2] === "colorField" ||
+        action.payload.path[2] === "flatColor"
+      ) {
         // needs to recalculate texture when colorMode or colorField changes
         // technically it doesn't if it's going between gradient and colorMap, but since it's an infrequent user-action it's not a big hit
         renderable.updateTexture(renderable.userData.foxgloveGrid, renderable.userData.settings);
@@ -390,7 +463,17 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     const receiveTime = toNanoSec(messageEvent.receiveTime);
 
     let renderable = this.renderables.get(topic);
-    if (!renderable) {
+
+    if (!this._validateFoxgloveGrid(foxgloveGrid, messageEvent.topic)) {
+      if (renderable) {
+        renderable.visible = false;
+      }
+      return;
+    }
+
+    if (renderable) {
+      renderable.visible = true;
+    } else {
       // Set the initial settings from default values merged with any user settings
       const userSettings = this.renderer.config.topics[topic] as
         | Partial<LayerSettingsFoxgloveGrid>
@@ -409,7 +492,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
       }
 
       // Check color
-      const texture = createTexture(foxgloveGrid, settings.colorMode);
+      const texture = createTexture(foxgloveGrid, settings);
       const mesh = createMesh(topic, texture);
       const material = mesh.material as GridShaderMaterial;
       const pickingMaterial = mesh.userData.pickingMaterial as THREE.ShaderMaterial;
@@ -450,6 +533,59 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     );
   };
 
+  private _validateFoxgloveGrid(foxgloveGrid: Grid, topic: string): boolean {
+    const { cell_stride, row_stride, column_count: cols } = foxgloveGrid;
+    const rows = foxgloveGrid.data.byteLength / row_stride;
+
+    if (foxgloveGrid.fields.length === 0) {
+      invalidFoxgloveGridError(
+        this.renderer,
+        topic,
+        `Grid has no fields. At least one field is required for the Grid to be displayed.`,
+      );
+      return false;
+    }
+
+    if (Math.floor(cols) !== cols || Math.floor(rows) !== rows) {
+      const message = `Grid column count (${foxgloveGrid.column_count}) or row count (${rows} = data.byteLength ${foxgloveGrid.data.byteLength} / row_stride ${row_stride}) is not an integer.`;
+      invalidFoxgloveGridError(this.renderer, topic, message);
+      return false;
+    }
+
+    if (cell_stride * cols > row_stride) {
+      const message = `Grid row_stride (${row_stride}) does not allow for requisite column_count (${cols}) with cell stride (${cell_stride}). Minimum requisite bytes in row_stride needed: (${
+        cols * cell_stride
+      }) `;
+      invalidFoxgloveGridError(this.renderer, topic, message);
+      return false;
+    }
+
+    // Determine the minimum bytes needed per cell based on offset/size of each
+    // field, so we can ensure cell_stride is >= this value
+    let minBytesPerCell = 0;
+    let maxField: PackedElementField | undefined;
+    for (const field of foxgloveGrid.fields) {
+      const byteWidth = numericTypeWidth(field.type);
+      if (field.offset + byteWidth > minBytesPerCell) {
+        minBytesPerCell = field.offset + byteWidth;
+        maxField = field;
+      }
+    }
+    if (minBytesPerCell > cell_stride) {
+      let message = `Grid cell_stride (${cell_stride}) is less than minimum bytes per cell (${minBytesPerCell})`;
+      if (maxField) {
+        message += ` required by “${maxField.name}” field, type=${numericTypeName(
+          maxField.type,
+        )}, offset=${maxField.offset}`;
+      }
+      invalidFoxgloveGridError(this.renderer, topic, message);
+      return false;
+    }
+
+    return true;
+  }
+
+  /** @param foxgloveGrid must be validated already */
   private _updateFoxgloveGridRenderable(
     renderable: FoxgloveGridRenderable,
     foxgloveGrid: Grid,
@@ -461,26 +597,8 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     renderable.userData.receiveTime = receiveTime;
     renderable.userData.messageTime = toNanoSec(foxgloveGrid.timestamp);
     renderable.userData.frameId = this.renderer.normalizeFrameId(foxgloveGrid.frame_id);
-    if (foxgloveGrid.fields.length === 0) {
-      invalidFoxgloveGridError(this.renderer, renderable, `Grid has no fields to color by`);
-      return;
-    }
-    const { cell_stride, row_stride, column_count: cols } = foxgloveGrid;
+    const { row_stride, column_count: cols } = foxgloveGrid;
     const rows = foxgloveGrid.data.byteLength / row_stride;
-
-    if (Math.floor(cols) !== cols || Math.floor(rows) !== rows) {
-      const message = `Grid column count (${foxgloveGrid.column_count}) or row count (${rows} = data.byteLength ${foxgloveGrid.data.byteLength} / row_stride ${row_stride}) is not an integer.`;
-      invalidFoxgloveGridError(this.renderer, renderable, message);
-      return;
-    }
-
-    if (cell_stride * cols > row_stride) {
-      const message = `Grid row_stride (${row_stride}) does not allow for requisite column_count (${cols}) with cell stride (${cell_stride}). Minimum requisite bytes in row_stride needed: (${
-        cols * cell_stride
-      }) `;
-      invalidFoxgloveGridError(this.renderer, renderable, message);
-      return;
-    }
 
     renderable.updateMaterial(settings);
     renderable.updateUniforms(foxgloveGrid, settings);
@@ -501,22 +619,15 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
   }
 }
 
-function invalidFoxgloveGridError(
-  renderer: Renderer,
-  renderable: FoxgloveGridRenderable,
-  message: string,
-): void {
-  renderer.settings.errors.addToTopic(renderable.userData.topic, INVALID_FOXGLOVE_GRID, message);
+function invalidFoxgloveGridError(renderer: Renderer, topic: string, message: string): void {
+  renderer.settings.errors.addToTopic(topic, INVALID_FOXGLOVE_GRID, message);
 }
 
-function createTexture(
-  foxgloveGrid: Grid,
-  colorMode: ColorModeSettings["colorMode"],
-): THREE.DataTexture {
+function createTexture(foxgloveGrid: Grid, settings: GridColorModeSettings): THREE.DataTexture {
   const { column_count: cols, row_stride } = foxgloveGrid;
   const rows = foxgloveGrid.data.byteLength / row_stride;
-  const size = cols * rows;
-  const isFloatType = floatTextureColorModes.includes(colorMode);
+  const size = isFinite(cols * rows) ? cols * rows : 0;
+  const isFloatType = floatTextureColorModes.includes(settings.colorMode);
   const data = isFloatType ? new Float32Array(size) : new Uint8ClampedArray(size * 4);
   const format = isFloatType ? THREE.RedFormat : THREE.RGBAFormat;
   const type = isFloatType ? THREE.FloatType : THREE.UnsignedByteType;
@@ -532,7 +643,7 @@ function createTexture(
     THREE.NearestFilter,
     THREE.LinearFilter,
     1,
-    THREE.LinearEncoding, // FoxgloveGrid carries linear grayscale values, not sRGB
+    getTextureEncoding(settings),
   );
   texture.generateMipmaps = false;
   return texture;
@@ -616,8 +727,10 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
 
       varying vec2 vUv;
 
+      ${FS_SRGB_TO_LINEAR}
+
       // adapted from https://gist.github.com/mikhailov-work/0d177465a8151eb6ede1768d51d476c7
-      vec3 turbo(float x) {
+      vec3 turboLinear(float x) {
         const vec4 kRedVec4 = vec4(0.13572138, 4.61539260, -42.66032258, 132.13108234);
         const vec4 kGreenVec4 = vec4(0.09140261, 2.19418839, 4.84296658, -14.18503333);
         const vec4 kBlueVec4 = vec4(0.10667330, 12.64194608, -60.58204836, 110.36276771);
@@ -627,17 +740,17 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
 
         vec4 v4 = vec4(1.0, x, x * x, x * x * x);
         vec2 v2 = v4.zw * v4.z;
-        return vec3(
+        return sRGBToLinear(vec3(
           (dot(v4, kRedVec4)   + dot(v2, kRedVec2)),
           (dot(v4, kGreenVec4) + dot(v2, kGreenVec2)),
           (dot(v4, kBlueVec4)  + dot(v2, kBlueVec2))
-        );
+        ));
       }
 
 
       // taken from http://docs.ros.org/jade/api/rviz/html/c++/point__cloud__transformers_8cpp_source.html
       // line 47
-      vec3 rainbow(float pct) {
+      vec3 rainbowLinear(float pct) {
         vec3 colorOut = vec3(0.0);
         float h = (1.0 - clamp(pct, 0.0, 1.0)) * 5.0 + 1.0;
         float i = floor(h);
@@ -669,21 +782,23 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
           colorOut.g = n;
           colorOut.b = 0.0;
         }
-        return colorOut;
+        return sRGBToLinear(colorOut);
       }
 
       void main() {
         vec4 color = texture2D(map, vUv);
-        if(colorMode == COLOR_MODE_RGBA || colorMode == COLOR_MODE_RGB || colorMode == COLOR_MODE_FLAT) {
-          // colors that are coming from CPU need to be converted
-          gl_FragColor = LinearTosRGB(color);
+        if(colorMode == COLOR_MODE_RGBA) {
+          // input color is in sRGB, texture.encoding is sRGB, so no conversion is needed
+          gl_FragColor = color;
+        } else if (colorMode == COLOR_MODE_FLAT) {
+          // input color was already converted to linear by getColorConverter
+          gl_FragColor = color;
         } else {
+          // input color was already converted to linear by getColorConverter
           float delta = max(maxValue - minValue, 0.00001);
           float colorValue = color.r;
           float normalizedColorValue = (colorValue - minValue) / delta;
           if(colorMode == COLOR_MODE_GRADIENT) {
-
-
             /**
             * Computes a gradient step from colors a to b using pre-multiplied alpha to
             * match CSS linear gradients. The inputs are assumed to not have pre-multiplied
@@ -692,15 +807,14 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
             vec4 weightedMinColor = vec4(minGradientColorLinear.rgb * minGradientColorLinear.a, minGradientColorLinear.a);
             vec4 weightedMaxColor = vec4(maxGradientColorLinear.rgb * maxGradientColorLinear.a, maxGradientColorLinear.a);
             vec4 finalColor = mix(weightedMinColor, weightedMaxColor, normalizedColorValue);
-            // gradient computation takes place in linear colorspace and must be translated to sRGB
-            gl_FragColor = LinearTosRGB(finalColor);
+            // gradient computation takes place in linear colorspace
+            gl_FragColor = finalColor;
           } else if(colorMode == COLOR_MODE_COLORMAP) {
             // colormap
-            // don't need to go through LinearTosRGB because they are created in the shader
             if(colorMap == COLOR_MAP_TURBO) {
-              gl_FragColor = vec4(turbo(normalizedColorValue), colorMapOpacity);
+              gl_FragColor = vec4(turboLinear(normalizedColorValue), colorMapOpacity);
             } else if(colorMap == COLOR_MAP_RAINBOW) {
-              gl_FragColor = vec4(rainbow(normalizedColorValue), colorMapOpacity);
+              gl_FragColor = vec4(rainbowLinear(normalizedColorValue), colorMapOpacity);
             }
           }
         }
@@ -709,6 +823,8 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
             discard;
           }
           gl_FragColor = objectId;
+        } else {
+          #include <encodings_fragment>
         }
       }
     `,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -165,15 +165,13 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
     for (const field of foxgloveGrid.fields) {
       const { name } = field;
       if (name === "red") {
-        out.redReader = getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+        out.redReader = getReader(field, cell_stride, /*normalize*/ true) ?? zeroReader;
       } else if (name === "green") {
-        out.greenReader =
-          getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+        out.greenReader = getReader(field, cell_stride, /*normalize*/ true) ?? zeroReader;
       } else if (name === "blue") {
-        out.blueReader = getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+        out.blueReader = getReader(field, cell_stride, /*normalize*/ true) ?? zeroReader;
       } else if (name === "alpha") {
-        out.alphaReader =
-          getReader(field, cell_stride, undefined, /*normalize*/ true) ?? zeroReader;
+        out.alphaReader = getReader(field, cell_stride, /*normalize*/ true) ?? zeroReader;
       }
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -480,7 +480,7 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
-        autoSelectColorField(settings, foxgloveGrid.fields);
+        autoSelectColorField(settings, foxgloveGrid.fields, { supportsPackedRgbModes: false });
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {
           const updatedUserSettings = { ...userSettings };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -48,9 +48,10 @@ import {
   baseColorModeSettingsNode,
   colorHasTransparency,
   ColorModeSettings,
-  COLOR_FIELDS,
+  RGBA_PACKED_FIELDS,
   getColorConverter,
   INTENSITY_FIELDS,
+  FS_SRGB_TO_LINEAR,
 } from "./pointClouds/colors";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
 import { missingTransformMessage, MISSING_TRANSFORM } from "./transforms";
@@ -70,7 +71,11 @@ type PointCloudFieldReaders = {
   xReader: FieldReader;
   yReader: FieldReader;
   zReader: FieldReader;
-  colorReader: FieldReader;
+  packedColorReader: FieldReader;
+  redReader: FieldReader;
+  greenReader: FieldReader;
+  blueReader: FieldReader;
+  alphaReader: FieldReader;
 };
 
 type NormalizedLaserScan = {
@@ -103,7 +108,6 @@ const DEFAULT_COLOR_MAP = "turbo";
 const DEFAULT_FLAT_COLOR = { r: 1, g: 1, b: 1, a: 1 };
 const DEFAULT_MIN_COLOR = { r: 100 / 255, g: 47 / 255, b: 105 / 255, a: 1 };
 const DEFAULT_MAX_COLOR = { r: 227 / 255, g: 177 / 255, b: 135 / 255, a: 1 };
-const DEFAULT_RGB_BYTE_ORDER = "rgba";
 const NEEDS_MIN_MAX = ["gradient", "colormap"];
 
 export const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
@@ -118,7 +122,6 @@ export const DEFAULT_SETTINGS: LayerSettingsPointCloudAndLaserScan = {
   gradient: [rgbaToCssString(DEFAULT_MIN_COLOR), rgbaToCssString(DEFAULT_MAX_COLOR)],
   colorMap: DEFAULT_COLOR_MAP,
   explicitAlpha: 1,
-  rgbByteOrder: DEFAULT_RGB_BYTE_ORDER,
   minValue: undefined,
   maxValue: undefined,
 };
@@ -142,23 +145,6 @@ const INVALID_POINTCLOUD_OR_LASERSCAN = "INVALID_POINTCLOUD_OR_LASERSCAN";
 
 const VEC3_ZERO = new THREE.Vector3();
 
-// Fragment shader chunk to convert sRGB to linear RGB. This is used by some
-// PointCloud materials to avoid expensive per-point colorspace conversion on
-// the CPU. Source: <https://github.com/mrdoob/three.js/blob/13b67d96/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js#L16-L18>
-const FS_SRGB_TO_LINEAR = /* glsl */ `
-vec3 sRGBToLinear(in vec3 value) {
-	return vec3(mix(
-    pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
-    value.rgb * 0.0773993808,
-    vec3(lessThanEqual(value.rgb, vec3(0.04045)))
-  ));
-}
-
-vec4 sRGBToLinear(in vec4 value) {
-  return vec4(sRGBToLinear(value.rgb), value.a);
-}
-`;
-
 // Fragment shader chunk to convert sRGB to linear RGB
 const FS_POINTCLOUD_SRGB_TO_LINEAR = /* glsl */ `
 outgoingLight = sRGBToLinear(outgoingLight);
@@ -176,7 +162,11 @@ const tempFieldReaders: PointCloudFieldReaders = {
   xReader: zeroReader,
   yReader: zeroReader,
   zReader: zeroReader,
-  colorReader: zeroReader,
+  packedColorReader: zeroReader,
+  redReader: zeroReader,
+  greenReader: zeroReader,
+  blueReader: zeroReader,
+  alphaReader: zeroReader,
 };
 
 export function createGeometry(topic: string, usage: THREE.Usage): DynamicBufferGeometry {
@@ -413,7 +403,11 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     let xReader: FieldReader | undefined;
     let yReader: FieldReader | undefined;
     let zReader: FieldReader | undefined;
-    let colorReader: FieldReader | undefined;
+    let packedColorReader: FieldReader | undefined;
+    let redReader: FieldReader | undefined;
+    let greenReader: FieldReader | undefined;
+    let blueReader: FieldReader | undefined;
+    let alphaReader: FieldReader | undefined;
 
     const stride = getStride(pointCloud);
 
@@ -464,6 +458,14 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
           invalidPointCloudOrLaserScanError(this.renderer, renderable, message);
           return false;
         }
+      } else if (field.name === "red") {
+        redReader = getReader(field, stride, undefined, /*normalize*/ true);
+      } else if (field.name === "green") {
+        greenReader = getReader(field, stride, undefined, /*normalize*/ true);
+      } else if (field.name === "blue") {
+        blueReader = getReader(field, stride, undefined, /*normalize*/ true);
+      } else if (field.name === "alpha") {
+        alphaReader = getReader(field, stride, undefined, /*normalize*/ true);
       }
 
       const byteWidth = pointFieldWidth(type);
@@ -480,8 +482,8 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
               ? NumericType.UINT32
               : PointFieldType.UINT32
             : undefined;
-        colorReader = getReader(field, stride, forceType);
-        if (!colorReader) {
+        packedColorReader = getReader(field, stride, forceType);
+        if (!packedColorReader) {
           const typeName = pointFieldTypeName(type);
           const message = `PointCloud field "${field.name}" is invalid. type=${typeName}, offset=${field.offset}, stride=${stride}`;
           invalidPointCloudOrLaserScanError(this.renderer, renderable, message);
@@ -506,7 +508,11 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     output.xReader = xReader ?? zeroReader;
     output.yReader = yReader ?? zeroReader;
     output.zReader = zReader ?? zeroReader;
-    output.colorReader = colorReader ?? xReader ?? yReader ?? zReader ?? zeroReader;
+    output.packedColorReader = packedColorReader ?? xReader ?? yReader ?? zReader ?? zeroReader;
+    output.redReader = redReader ?? zeroReader;
+    output.greenReader = greenReader ?? zeroReader;
+    output.blueReader = blueReader ?? zeroReader;
+    output.alphaReader = alphaReader ?? zeroReader;
     return true;
   }
 
@@ -549,34 +555,69 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     const data = pointCloud.data;
     const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
     const pointStep = getStride(pointCloud);
-    const { xReader, yReader, zReader, colorReader } = readers;
+    const {
+      xReader,
+      yReader,
+      zReader,
+      packedColorReader,
+      redReader,
+      greenReader,
+      blueReader,
+      alphaReader,
+    } = readers;
 
-    // Iterate the point cloud data to determine min/max color values (if needed)
-    this._minMaxColorValues(tempMinMaxColor, colorReader, view, pointCount, pointStep, settings);
-    const [minColorValue, maxColorValue] = tempMinMaxColor;
-
-    // Build a method to convert raw color field values to RGBA
-    const colorConverter = getColorConverter(settings, minColorValue, maxColorValue);
-
+    // Update position attribute
     for (let i = 0; i < pointCount; i++) {
       const pointOffset = i * pointStep;
-
-      // Update position attribute
       const x = xReader(view, pointOffset);
       const y = yReader(view, pointOffset);
       const z = zReader(view, pointOffset);
       positionAttribute.setXYZ(i, x, y, z);
+    }
 
-      // Update color attribute
-      const colorValue = colorReader(view, pointOffset);
-      colorConverter(tempColor, colorValue);
-      colorAttribute.setXYZW(
-        i,
-        (tempColor.r * 255) | 0,
-        (tempColor.g * 255) | 0,
-        (tempColor.b * 255) | 0,
-        (tempColor.a * 255) | 0,
+    // Update color attribute
+    if (settings.colorMode === "rgba-fields") {
+      for (let i = 0; i < pointCount; i++) {
+        const pointOffset = i * pointStep;
+        colorAttribute.setXYZW(
+          i,
+          (redReader(view, pointOffset) * 255) | 0,
+          (greenReader(view, pointOffset) * 255) | 0,
+          (blueReader(view, pointOffset) * 255) | 0,
+          (alphaReader(view, pointOffset) * 255) | 0,
+        );
+      }
+    } else {
+      // Iterate the point cloud data to determine min/max color values (if needed)
+      this._minMaxColorValues(
+        tempMinMaxColor,
+        packedColorReader,
+        view,
+        pointCount,
+        pointStep,
+        settings,
       );
+      const [minColorValue, maxColorValue] = tempMinMaxColor;
+
+      // Build a method to convert raw color field values to RGBA
+      const colorConverter = getColorConverter(
+        settings as typeof settings & { colorMode: typeof settings.colorMode },
+        minColorValue,
+        maxColorValue,
+      );
+
+      for (let i = 0; i < pointCount; i++) {
+        const pointOffset = i * pointStep;
+        const colorValue = packedColorReader(view, pointOffset);
+        colorConverter(tempColor, colorValue);
+        colorAttribute.setXYZW(
+          i,
+          (tempColor.r * 255) | 0,
+          (tempColor.g * 255) | 0,
+          (tempColor.b * 255) | 0,
+          (tempColor.a * 255) | 0,
+        );
+      }
     }
 
     positionAttribute.needsUpdate = true;
@@ -683,7 +724,14 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
     }
 
     // Build a method to convert raw color field values to RGBA
-    const colorConverter = getColorConverter(settings, minColorValue, maxColorValue);
+    const colorConverter =
+      settings.colorMode === "rgba-fields"
+        ? () => NaN // should never happen: rgba-fields is not supported for LaserScans
+        : getColorConverter(
+            settings as typeof settings & { colorMode: typeof settings.colorMode },
+            minColorValue,
+            maxColorValue,
+          );
 
     // Iterate the point cloud data to update color attribute
     for (let i = 0; i < ranges.length; i++) {
@@ -866,7 +914,6 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -948,7 +995,6 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -1037,7 +1083,6 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
           updatedUserSettings.colorField = settings.colorField;
           updatedUserSettings.colorMode = settings.colorMode;
           updatedUserSettings.colorMap = settings.colorMap;
-          updatedUserSettings.rgbByteOrder = settings.rgbByteOrder;
           draft.topics[topic] = updatedUserSettings;
         });
       }
@@ -1367,9 +1412,11 @@ function pointCloudColorEncoding(settings: LayerSettingsPointCloudAndLaserScan):
     case "flat":
     case "colormap":
     case "gradient":
+      // converted to linear by getColorConverter
       return "linear";
     case "rgb":
     case "rgba":
+    case "rgba-fields":
       return "srgb";
   }
 }
@@ -1381,29 +1428,15 @@ export function autoSelectColorField(
   // Prefer color fields first
   for (const field of pointCloud.fields) {
     const fieldNameLower = field.name.toLowerCase();
-    if (COLOR_FIELDS.has(fieldNameLower)) {
+    if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
       output.colorField = field.name;
       switch (fieldNameLower) {
         case "rgb":
           output.colorMode = "rgb";
-          output.rgbByteOrder = "abgr";
           break;
         default:
         case "rgba":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
-          break;
-        case "bgr":
-          output.colorMode = "rgb";
-          output.rgbByteOrder = "bgra";
-          break;
-        case "bgra":
-          output.colorMode = "rgba";
-          output.rgbByteOrder = "bgra";
-          break;
-        case "abgr":
-          output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
           break;
       }
       return;
@@ -1445,7 +1478,8 @@ export function pointCloudSettingsNode(
   const decayTime = config.decayTime;
 
   const node = baseColorModeSettingsNode(msgFields, config, topic, DEFAULT_SETTINGS, {
-    supportsRgbModes: kind === "pointcloud",
+    supportsPackedRgbModes: ROS_POINTCLOUD_DATATYPES.has(topic.schemaName),
+    supportsRgbaFieldsMode: FOXGLOVE_POINTCLOUD_DATATYPES.has(topic.schemaName),
   });
   node.fields = {
     pointSize: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -461,13 +461,13 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
           return false;
         }
       } else if (field.name === "red") {
-        redReader = getReader(field, stride, undefined, /*normalize*/ true);
+        redReader = getReader(field, stride, /*normalize*/ true);
       } else if (field.name === "green") {
-        greenReader = getReader(field, stride, undefined, /*normalize*/ true);
+        greenReader = getReader(field, stride, /*normalize*/ true);
       } else if (field.name === "blue") {
-        blueReader = getReader(field, stride, undefined, /*normalize*/ true);
+        blueReader = getReader(field, stride, /*normalize*/ true);
       } else if (field.name === "alpha") {
-        alphaReader = getReader(field, stride, undefined, /*normalize*/ true);
+        alphaReader = getReader(field, stride, /*normalize*/ true);
       }
 
       const byteWidth = pointFieldWidth(type);
@@ -484,7 +484,7 @@ export class PointCloudAndLaserScanRenderable extends Renderable<PointCloudAndLa
               ? NumericType.UINT32
               : PointFieldType.UINT32
             : undefined;
-        packedColorReader = getReader(field, stride, forceType);
+        packedColorReader = getReader(field, stride, /*normalize*/ false, forceType);
         if (!packedColorReader) {
           const typeName = pointFieldTypeName(type);
           const message = `PointCloud field "${field.name}" is invalid. type=${typeName}, offset=${field.offset}, stride=${stride}`;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointCloudsAndLaserScans.ts
@@ -908,7 +908,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
-        autoSelectColorField(settings, pointCloud);
+        autoSelectColorField(settings, pointCloud, { supportsPackedRgbModes: false });
 
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {
@@ -989,7 +989,7 @@ export class PointCloudsAndLaserScans extends SceneExtension<PointCloudAndLaserS
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
-        autoSelectColorField(settings, pointCloud);
+        autoSelectColorField(settings, pointCloud, { supportsPackedRgbModes: true });
 
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {
@@ -1433,25 +1433,28 @@ function pointCloudColorEncoding(settings: LayerSettingsPointCloudAndLaserScan):
 export function autoSelectColorField(
   output: LayerSettingsPointCloudAndLaserScan,
   pointCloud: PointCloud | PointCloud2,
+  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
 ): void {
   // Prefer color fields first
-  for (const field of pointCloud.fields) {
-    if (!isSupportedField(field)) {
-      continue;
-    }
-    const fieldNameLower = field.name.toLowerCase();
-    if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
-      output.colorField = field.name;
-      switch (fieldNameLower) {
-        case "rgb":
-          output.colorMode = "rgb";
-          break;
-        default:
-        case "rgba":
-          output.colorMode = "rgba";
-          break;
+  if (supportsPackedRgbModes) {
+    for (const field of pointCloud.fields) {
+      if (!isSupportedField(field)) {
+        continue;
       }
-      return;
+      const fieldNameLower = field.name.toLowerCase();
+      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
+        output.colorField = field.name;
+        switch (fieldNameLower) {
+          case "rgb":
+            output.colorMode = "rgb";
+            break;
+          default:
+          case "rgba":
+            output.colorMode = "rgba";
+            break;
+        }
+        return;
+      }
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -206,7 +206,7 @@ export class VelodyneScans extends SceneExtension<PointCloudAndLaserScanRenderab
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
-        autoSelectColorField(settings, pointCloud);
+        autoSelectColorField(settings, pointCloud, { supportsPackedRgbModes: false });
 
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -19,22 +19,21 @@ const tempColor2 = { r: 0, g: 0, b: 0, a: 0 };
 export const NEEDS_MIN_MAX = ["gradient", "colormap"];
 
 export interface ColorModeSettings {
-  colorMode: "flat" | "gradient" | "colormap" | "rgb" | "rgba";
+  colorMode: "flat" | "gradient" | "colormap" | "rgb" | "rgba" | "rgba-fields";
   flatColor: string;
   colorField?: string;
   gradient: [string, string];
   colorMap: "turbo" | "rainbow";
   explicitAlpha: number;
-  rgbByteOrder: "rgba" | "bgra" | "abgr";
   minValue?: number;
   maxValue?: number;
 }
 
-export function getColorConverter<Settings extends ColorModeSettings>(
-  settings: Settings,
-  minValue: number,
-  maxValue: number,
-): ColorConverter {
+export function getColorConverter<
+  Settings extends ColorModeSettings & {
+    readonly colorMode: Exclude<ColorModeSettings["colorMode"], "rgba-fields">;
+  },
+>(settings: Settings, minValue: number, maxValue: number): ColorConverter {
   switch (settings.colorMode) {
     case "flat": {
       const flatColor = stringToRgba(tempColor1, settings.flatColor);
@@ -63,107 +62,42 @@ export function getColorConverter<Settings extends ColorModeSettings>(
         case "turbo":
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
-            turboCached(output, t);
+            turboLinearCached(output, t);
             output.a = settings.explicitAlpha;
           };
         case "rainbow":
           return (output: ColorRGBA, colorValue: number) => {
             const t = (colorValue - minValue) / valueDelta;
-            rainbow(output, t);
+            rainbowLinear(output, t);
             output.a = settings.explicitAlpha;
           };
       }
       throw new Error(`Unrecognized color map: ${settings.colorMap}`);
     }
     case "rgb":
-      switch (settings.rgbByteOrder) {
-        default:
-        case "rgba":
-          return (output: ColorRGBA, colorValue: number) => {
-            getColorRgb(output, colorValue);
-            output.a = settings.explicitAlpha;
-          };
-        case "bgra":
-          return (output: ColorRGBA, colorValue: number) => {
-            getColorBgr(output, colorValue);
-            output.a = settings.explicitAlpha;
-          };
-        case "abgr":
-          return (output: ColorRGBA, colorValue: number) => {
-            getColor0bgr(output, colorValue);
-            output.a = settings.explicitAlpha;
-          };
-      }
+      return (output: ColorRGBA, colorValue: number) => {
+        getColorBgra(output, colorValue);
+        output.a = settings.explicitAlpha;
+      };
     case "rgba":
-      switch (settings.rgbByteOrder) {
-        default:
-        case "rgba":
-          return getColorRgba;
-        case "bgra":
-          return getColorBgra;
-        case "abgr":
-          return getColorAbgr;
-      }
+      return getColorBgra;
   }
 }
 
-// 0xrrggbb00
-function getColorRgb(output: ColorRGBA, colorValue: number): void {
-  const num = colorValue >>> 0;
-  output.r = ((num & 0xff000000) >>> 24) / 255;
-  output.g = ((num & 0x00ff0000) >>> 16) / 255;
-  output.b = ((num & 0x0000ff00) >>> 8) / 255;
-  output.a = 1;
-}
-
-// 0xrrggbbaa
-function getColorRgba(output: ColorRGBA, colorValue: number): void {
-  const num = colorValue >>> 0;
-  output.r = ((num & 0xff000000) >>> 24) / 255;
-  output.g = ((num & 0x00ff0000) >>> 16) / 255;
-  output.b = ((num & 0x0000ff00) >>> 8) / 255;
-  output.a = ((num & 0x000000ff) >>> 0) / 255;
-}
-
-// 0xbbggrr00
-function getColorBgr(output: ColorRGBA, colorValue: number): void {
-  const num = colorValue >>> 0;
-  output.r = ((num & 0x0000ff00) >>> 8) / 255;
-  output.g = ((num & 0x00ff0000) >>> 16) / 255;
-  output.b = ((num & 0xff000000) >>> 24) / 255;
-  output.a = 1;
-}
-
-// 0xbbggrraa
+// 0xaarrggbb
+// Matches rviz behavior:
+// https://github.com/ros-visualization/rviz/blob/a60b334fd10785a6b74893189fcebbd419d468e4/src/rviz/default_plugin/point_cloud_transformers.cpp#L383-L406
 function getColorBgra(output: ColorRGBA, colorValue: number): void {
   const num = colorValue >>> 0;
-  output.r = ((num & 0x0000ff00) >>> 8) / 255;
-  output.g = ((num & 0x00ff0000) >>> 16) / 255;
-  output.b = ((num & 0xff000000) >>> 24) / 255;
-  output.a = ((num & 0x000000ff) >>> 0) / 255;
-}
-
-// 0x00bbggrr
-function getColor0bgr(output: ColorRGBA, colorValue: number): void {
-  const num = colorValue >>> 0;
-  output.r = ((num & 0x000000ff) >>> 0) / 255;
-  output.g = ((num & 0x0000ff00) >>> 8) / 255;
-  output.b = ((num & 0x00ff0000) >>> 16) / 255;
-  output.a = 1;
-}
-
-// 0xaabbggrr
-function getColorAbgr(output: ColorRGBA, colorValue: number): void {
-  const num = colorValue >>> 0;
-  output.r = ((num & 0x000000ff) >>> 0) / 255;
-  output.g = ((num & 0x0000ff00) >>> 8) / 255;
-  output.b = ((num & 0x00ff0000) >>> 16) / 255;
   output.a = ((num & 0xff000000) >>> 24) / 255;
+  output.r = ((num & 0x00ff0000) >>> 16) / 255;
+  output.g = ((num & 0x0000ff00) >>> 8) / 255;
+  output.b = ((num & 0x000000ff) >>> 0) / 255;
 }
 
 // taken from http://docs.ros.org/jade/api/rviz/html/c++/point__cloud__transformers_8cpp_source.html
 // line 47
-function rainbow(output: ColorRGBA, pct: number): void {
+function rainbowLinear(output: ColorRGBA, pct: number): void {
   const h = (1.0 - clamp(pct, 0, 1)) * 5.0 + 1.0;
   const i = Math.floor(h);
   let f = h % 1;
@@ -206,7 +140,7 @@ const v4 = new THREE.Vector4();
 const v2 = new THREE.Vector2();
 
 // adapted from https://gist.github.com/mikhailov-work/0d177465a8151eb6ede1768d51d476c7
-function turbo(output: ColorRGBA, pct: number): void {
+function turboLinear(output: ColorRGBA, pct: number): void {
   // Clamp the input between [0.0, 1.0], then scale to the range [0.01, 1.0]
   const x = clamp(pct, 0.0, 1.0) * 0.99 + 0.01;
   v4.set(1, x, x * x, x * x * x);
@@ -224,12 +158,12 @@ const TURBO_LOOKUP_SIZE = 65535;
 
 // Builds a one-time lookup table for the turbo() function then uses it to
 // convert `pct` to a color
-function turboCached(output: ColorRGBA, pct: number): void {
+function turboLinearCached(output: ColorRGBA, pct: number): void {
   if (!TurboLookup) {
     TurboLookup = new Float32Array(TURBO_LOOKUP_SIZE * 3);
     const tempColor = { r: 0, g: 0, b: 0, a: 0 };
     for (let i = 0; i < TURBO_LOOKUP_SIZE; i++) {
-      turbo(tempColor, i / (TURBO_LOOKUP_SIZE - 1));
+      turboLinear(tempColor, i / (TURBO_LOOKUP_SIZE - 1));
       const offset = i * 3;
       TurboLookup[offset + 0] = tempColor.r;
       TurboLookup[offset + 1] = tempColor.g;
@@ -243,7 +177,7 @@ function turboCached(output: ColorRGBA, pct: number): void {
   output.b = TurboLookup[offset + 2]!;
   output.a = 1;
 }
-export const COLOR_FIELDS = new Set<string>(["rgb", "rgba", "bgr", "bgra", "abgr", "color"]);
+export const RGBA_PACKED_FIELDS = new Set<string>(["rgb", "rgba"]);
 export const INTENSITY_FIELDS = new Set<string>(["intensity", "i"]);
 
 export function autoSelectColorField<Settings extends ColorModeSettings>(
@@ -253,29 +187,15 @@ export function autoSelectColorField<Settings extends ColorModeSettings>(
   // Prefer color fields first
   for (const field of fields) {
     const fieldNameLower = field.name.toLowerCase();
-    if (COLOR_FIELDS.has(fieldNameLower)) {
+    if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
       output.colorField = field.name;
       switch (fieldNameLower) {
         case "rgb":
           output.colorMode = "rgb";
-          output.rgbByteOrder = "abgr";
           break;
         default:
         case "rgba":
           output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
-          break;
-        case "bgr":
-          output.colorMode = "rgb";
-          output.rgbByteOrder = "bgra";
-          break;
-        case "bgra":
-          output.colorMode = "rgba";
-          output.rgbByteOrder = "bgra";
-          break;
-        case "abgr":
-          output.colorMode = "rgba";
-          output.rgbByteOrder = "abgr";
           break;
       }
       return;
@@ -294,7 +214,7 @@ export function autoSelectColorField<Settings extends ColorModeSettings>(
 
 export function bestColorByField(fields: string[]): string {
   for (const field of fields) {
-    if (COLOR_FIELDS.has(field)) {
+    if (RGBA_PACKED_FIELDS.has(field)) {
       return field;
     }
   }
@@ -306,12 +226,39 @@ export function bestColorByField(fields: string[]): string {
   return fields.find((field) => field === "x") || fields[0] ? fields[0]! : "";
 }
 
+function hasSeparateRgbaFields(fields: string[]) {
+  let r = false;
+  let g = false;
+  let b = false;
+  let a = false;
+  for (const field of fields) {
+    switch (field) {
+      case "red":
+        r = true;
+        break;
+      case "green":
+        g = true;
+        break;
+      case "blue":
+        b = true;
+        break;
+      case "alpha":
+        a = true;
+        break;
+    }
+  }
+  return r && g && b && a;
+}
+
 export function baseColorModeSettingsNode<Settings extends ColorModeSettings & BaseSettings>(
   msgFields: string[],
   config: Partial<Settings>,
   topic: Topic,
   defaults: Settings,
-  { supportsRgbModes }: { supportsRgbModes: boolean },
+  {
+    supportsPackedRgbModes,
+    supportsRgbaFieldsMode,
+  }: { supportsPackedRgbModes: boolean; supportsRgbaFieldsMode: boolean },
 ): SettingsTreeNode & { fields: NonNullable<SettingsTreeNode["fields"]> } {
   const colorMode = config.colorMode ?? "flat";
   const flatColor = config.flatColor ?? "#ffffff";
@@ -320,7 +267,6 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
   const gradient = config.gradient;
   const colorMap = config.colorMap ?? "turbo";
   const explicitAlpha = config.explicitAlpha ?? 1;
-  const rgbByteOrder = config.rgbByteOrder ?? "rgba";
   const minValue = config.minValue;
   const maxValue = config.maxValue;
 
@@ -333,19 +279,25 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
       { label: "Flat", value: "flat" },
       { label: "Color map", value: "colormap" },
       { label: "Gradient", value: "gradient" },
-    ].concat(
-      supportsRgbModes
-        ? [
-            { label: "RGB", value: "rgb" },
-            { label: "RGBA", value: "rgba" },
-          ]
-        : [],
-    ),
+    ]
+      .concat(
+        supportsPackedRgbModes
+          ? [
+              { label: "BGR (packed)", value: "rgb" },
+              { label: "BGRA (packed)", value: "rgba" },
+            ]
+          : [],
+      )
+      .concat(
+        supportsRgbaFieldsMode && hasSeparateRgbaFields(msgFields)
+          ? [{ label: "RGBA (separate fields)", value: "rgba-fields" }]
+          : [],
+      ),
     value: colorMode,
   };
   if (colorMode === "flat") {
     fields.flatColor = { label: "Flat color", input: "rgba", value: flatColor };
-  } else {
+  } else if (colorMode !== "rgba-fields") {
     fields.colorField = {
       label: "Color by",
       input: "select",
@@ -370,30 +322,6 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
             { label: "Rainbow", value: "rainbow" },
           ],
           value: colorMap,
-        };
-        break;
-      case "rgb":
-        fields.rgbByteOrder = {
-          label: "RGB byte order",
-          input: "select",
-          options: [
-            { label: "RGB", value: "rgba" },
-            { label: "BGR", value: "bgra" },
-            { label: "XBGR", value: "abgr" },
-          ],
-          value: rgbByteOrder,
-        };
-        break;
-      case "rgba":
-        fields.rgbByteOrder = {
-          label: "RGBA byte order",
-          input: "select",
-          options: [
-            { label: "RGBA", value: "rgba" },
-            { label: "BGRA", value: "bgra" },
-            { label: "ABGR", value: "abgr" },
-          ],
-          value: rgbByteOrder,
         };
         break;
       default:
@@ -454,7 +382,25 @@ export function colorHasTransparency<Settings extends ColorModeSettings>(
     case "rgb":
       return settings.explicitAlpha < 1.0;
     case "rgba":
+    case "rgba-fields":
       // It's too expensive to check the alpha value of each color. Just assume it's transparent
       return true;
   }
 }
+
+// Fragment shader chunk to convert sRGB to linear RGB. This is used by some
+// PointCloud materials to avoid expensive per-point colorspace conversion on
+// the CPU. Source: <https://github.com/mrdoob/three.js/blob/13b67d96/src/renderers/shaders/ShaderChunk/encodings_pars_fragment.glsl.js#L16-L18>
+export const FS_SRGB_TO_LINEAR = /* glsl */ `
+vec3 sRGBToLinear(in vec3 value) {
+	return vec3(mix(
+    pow(value.rgb * 0.9478672986 + vec3(0.0521327014), vec3(2.4)),
+    value.rgb * 0.0773993808,
+    vec3(lessThanEqual(value.rgb, vec3(0.04045)))
+  ));
+}
+
+vec4 sRGBToLinear(in vec4 value) {
+  return vec4(sRGBToLinear(value.rgb), value.a);
+}
+`;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -183,22 +183,25 @@ export const INTENSITY_FIELDS = new Set<string>(["intensity", "i"]);
 export function autoSelectColorField<Settings extends ColorModeSettings>(
   output: Settings,
   fields: PackedElementField[],
+  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
 ): void {
   // Prefer color fields first
-  for (const field of fields) {
-    const fieldNameLower = field.name.toLowerCase();
-    if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
-      output.colorField = field.name;
-      switch (fieldNameLower) {
-        case "rgb":
-          output.colorMode = "rgb";
-          break;
-        default:
-        case "rgba":
-          output.colorMode = "rgba";
-          break;
+  if (supportsPackedRgbModes) {
+    for (const field of fields) {
+      const fieldNameLower = field.name.toLowerCase();
+      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
+        output.colorField = field.name;
+        switch (fieldNameLower) {
+          case "rgb":
+            output.colorMode = "rgb";
+            break;
+          default:
+          case "rgba":
+            output.colorMode = "rgba";
+            break;
+        }
+        return;
       }
-      return;
     }
   }
 
@@ -212,10 +215,15 @@ export function autoSelectColorField<Settings extends ColorModeSettings>(
   }
 }
 
-export function bestColorByField(fields: string[]): string {
-  for (const field of fields) {
-    if (RGBA_PACKED_FIELDS.has(field)) {
-      return field;
+function bestColorByField(
+  fields: string[],
+  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
+): string {
+  if (supportsPackedRgbModes) {
+    for (const field of fields) {
+      if (RGBA_PACKED_FIELDS.has(field)) {
+        return field;
+      }
     }
   }
   for (const field of fields) {
@@ -262,7 +270,7 @@ export function baseColorModeSettingsNode<Settings extends ColorModeSettings & B
 ): SettingsTreeNode & { fields: NonNullable<SettingsTreeNode["fields"]> } {
   const colorMode = config.colorMode ?? "flat";
   const flatColor = config.flatColor ?? "#ffffff";
-  const colorField = config.colorField ?? bestColorByField(msgFields);
+  const colorField = config.colorField ?? bestColorByField(msgFields, { supportsPackedRgbModes });
   const colorFieldOptions = msgFields.map((field) => ({ label: field, value: field }));
   const gradient = config.gradient;
   const colorMap = config.colorMap ?? "turbo";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
@@ -8,35 +8,77 @@ import { PointField, PointFieldType } from "../../ros";
 
 export type FieldReader = (view: DataView, pointOffset: number) => number;
 
-export function int8Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getInt8(pointOffset + fieldOffset);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function int8Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getInt8(pointOffset + fieldOffset);
+    if (normalize) {
+      return Math.max(value / 0x7f, -1);
+    }
+    return value;
+  };
 }
 
-export function uint8Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getUint8(pointOffset + fieldOffset);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function uint8Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getUint8(pointOffset + fieldOffset);
+    if (normalize) {
+      return value / 0xff;
+    }
+    return value;
+  };
 }
 
-export function int16Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getInt16(pointOffset + fieldOffset, true);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function int16Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getInt16(pointOffset + fieldOffset, true);
+    if (normalize) {
+      return Math.max(value / 0x7fff, -1);
+    }
+    return value;
+  };
 }
 
-export function uint16Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getUint16(pointOffset + fieldOffset, true);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function uint16Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getUint16(pointOffset + fieldOffset, true);
+    if (normalize) {
+      return value / 0xffff;
+    }
+    return value;
+  };
 }
 
-export function int32Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getInt32(pointOffset + fieldOffset, true);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function int32Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getInt32(pointOffset + fieldOffset, true);
+    if (normalize) {
+      return Math.max(value / 0x7fffffff, -1);
+    }
+    return value;
+  };
 }
 
-export function uint32Reader(fieldOffset: number): FieldReader {
-  return (view: DataView, pointOffset: number) => view.getUint32(pointOffset + fieldOffset, true);
+// eslint-disable-next-line @foxglove/no-boolean-parameters
+function uint32Reader(fieldOffset: number, normalize: boolean): FieldReader {
+  return (view: DataView, pointOffset: number) => {
+    const value = view.getUint32(pointOffset + fieldOffset, true);
+    if (normalize) {
+      return value / 0xffffffff;
+    }
+    return value;
+  };
 }
 
-export function float32Reader(fieldOffset: number): FieldReader {
+function float32Reader(fieldOffset: number): FieldReader {
   return (view: DataView, pointOffset: number) => view.getFloat32(pointOffset + fieldOffset, true);
 }
 
-export function float64Reader(fieldOffset: number): FieldReader {
+function float64Reader(fieldOffset: number): FieldReader {
   return (view: DataView, pointOffset: number) => view.getFloat64(pointOffset + fieldOffset, true);
 }
 
@@ -44,23 +86,27 @@ export function getReader(
   field: PackedElementField | PointField,
   stride: number,
   forceType?: PointFieldType | NumericType,
+  /** @see https://www.khronos.org/opengl/wiki/Normalized_Integer */
+  // Performance-sensitive: this code is called for every point cloud message
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  normalize = false,
 ): FieldReader | undefined {
   const numericType = (field as Partial<PackedElementField>).type;
   if (numericType == undefined) {
     const type = forceType ?? (field as PointField).datatype;
     switch (type) {
       case PointFieldType.INT8:
-        return field.offset + 1 <= stride ? int8Reader(field.offset) : undefined;
+        return field.offset + 1 <= stride ? int8Reader(field.offset, normalize) : undefined;
       case PointFieldType.UINT8:
-        return field.offset + 1 <= stride ? uint8Reader(field.offset) : undefined;
+        return field.offset + 1 <= stride ? uint8Reader(field.offset, normalize) : undefined;
       case PointFieldType.INT16:
-        return field.offset + 2 <= stride ? int16Reader(field.offset) : undefined;
+        return field.offset + 2 <= stride ? int16Reader(field.offset, normalize) : undefined;
       case PointFieldType.UINT16:
-        return field.offset + 2 <= stride ? uint16Reader(field.offset) : undefined;
+        return field.offset + 2 <= stride ? uint16Reader(field.offset, normalize) : undefined;
       case PointFieldType.INT32:
-        return field.offset + 4 <= stride ? int32Reader(field.offset) : undefined;
+        return field.offset + 4 <= stride ? int32Reader(field.offset, normalize) : undefined;
       case PointFieldType.UINT32:
-        return field.offset + 4 <= stride ? uint32Reader(field.offset) : undefined;
+        return field.offset + 4 <= stride ? uint32Reader(field.offset, normalize) : undefined;
       case PointFieldType.FLOAT32:
         return field.offset + 4 <= stride ? float32Reader(field.offset) : undefined;
       case PointFieldType.FLOAT64:
@@ -72,17 +118,17 @@ export function getReader(
     const type = (forceType ?? numericType) as NumericType;
     switch (type) {
       case NumericType.INT8:
-        return field.offset + 1 <= stride ? int8Reader(field.offset) : undefined;
+        return field.offset + 1 <= stride ? int8Reader(field.offset, normalize) : undefined;
       case NumericType.UINT8:
-        return field.offset + 1 <= stride ? uint8Reader(field.offset) : undefined;
+        return field.offset + 1 <= stride ? uint8Reader(field.offset, normalize) : undefined;
       case NumericType.INT16:
-        return field.offset + 2 <= stride ? int16Reader(field.offset) : undefined;
+        return field.offset + 2 <= stride ? int16Reader(field.offset, normalize) : undefined;
       case NumericType.UINT16:
-        return field.offset + 2 <= stride ? uint16Reader(field.offset) : undefined;
+        return field.offset + 2 <= stride ? uint16Reader(field.offset, normalize) : undefined;
       case NumericType.INT32:
-        return field.offset + 4 <= stride ? int32Reader(field.offset) : undefined;
+        return field.offset + 4 <= stride ? int32Reader(field.offset, normalize) : undefined;
       case NumericType.UINT32:
-        return field.offset + 4 <= stride ? uint32Reader(field.offset) : undefined;
+        return field.offset + 4 <= stride ? uint32Reader(field.offset, normalize) : undefined;
       case NumericType.FLOAT32:
         return field.offset + 4 <= stride ? float32Reader(field.offset) : undefined;
       case NumericType.FLOAT64:

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/fieldReaders.ts
@@ -93,11 +93,11 @@ export function isSupportedField(field: PackedElementField | PointField): boolea
 export function getReader(
   field: PackedElementField | PointField,
   stride: number,
-  forceType?: PointFieldType | NumericType,
   /** @see https://www.khronos.org/opengl/wiki/Normalized_Integer */
   // Performance-sensitive: this code is called for every point cloud message
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   normalize = false,
+  forceType?: PointFieldType | NumericType,
 ): FieldReader | undefined {
   if (!isSupportedField(field)) {
     return undefined;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -154,7 +154,6 @@ export function Marker_PointCloud2_Alignment(): JSX.Element {
               pointSize: 30,
               colorMode: "rgba",
               colorField: "rgba",
-              rgbByteOrder: "rgba",
             },
           },
           followTf: "base_link",

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -8,7 +8,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { Marker, MarkerType, PointCloud2, TransformStamped } from "../ros";
-import { makeColor, QUAT_IDENTITY, rad2deg, rgba, VEC3_ZERO } from "./common";
+import { makeColor, QUAT_IDENTITY, rad2deg, packRvizRgba, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
@@ -97,7 +97,7 @@ export function Marker_PointCloud2_Alignment(): JSX.Element {
     view.setFloat32(offset + 0, x, true);
     view.setFloat32(offset + 4, y, true);
     view.setFloat32(offset + 8, z, true);
-    view.setUint32(offset + 12, rgba(c.r, c.g, c.b, c.a), true);
+    view.setUint32(offset + 12, packRvizRgba(c.r, c.g, c.b, c.a), true);
   }
 
   const data = new Uint8Array(3 * 16);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -143,7 +143,6 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
               pointSize: 10,
               colorMode: rgbaFieldName,
               colorField: rgbaFieldName,
-              rgbByteOrder: "rgba",
             },
           },
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -10,22 +10,13 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import ThreeDeeRender from "../index";
 import { PointCloud2, TransformStamped } from "../ros";
-import { QUAT_IDENTITY, rad2deg } from "./common";
+import { packRvizRgba, QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 
 export default {
   title: "panels/ThreeDeeRender",
   component: ThreeDeeRender,
 };
-
-function rgba(r: number, g: number, b: number, a: number) {
-  return (
-    (Math.trunc(r * 255) << 24) |
-    (Math.trunc(g * 255) << 16) |
-    (Math.trunc(b * 255) << 8) |
-    Math.trunc(a * 255)
-  );
-}
 
 export const SensorMsgs_PointCloud2_RGBA = (): JSX.Element => (
   <SensorMsgs_PointCloud2 rgbaFieldName="rgba" />
@@ -82,7 +73,7 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
     const r = Math.max(0, Math.min(255, 4 * (i - 96), 255 - 4 * (i - 224)));
     const g = Math.max(0, Math.min(255, 4 * (i - 32), 255 - 4 * (i - 160)));
     const b = Math.max(0, Math.min(255, 4 * i + 127, 255 - 4 * (i - 96)));
-    return rgba(r / 255, g / 255, b / 255, a);
+    return packRvizRgba(r / 255, g / 255, b / 255, a);
   }
 
   const data = new Uint8Array(128 * 128 * 16);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
@@ -153,12 +153,16 @@ export function makeColor(hex: string, alpha?: number): ColorRGBA {
 }
 
 // ts-prune-ignore-next
-export function rgba(r: number, g: number, b: number, a: number): number {
+/**
+ * Pack RGBA values into a uint32 in the order expected by RViz:
+ * https://github.com/ros-visualization/rviz/blob/a60b334fd10785a6b74893189fcebbd419d468e4/src/rviz/default_plugin/point_cloud_transformers.cpp#L400-L404
+ */
+export function packRvizRgba(r: number, g: number, b: number, a: number): number {
   return (
-    (Math.trunc(r * 255) << 24) |
-    (Math.trunc(g * 255) << 16) |
-    (Math.trunc(b * 255) << 8) |
-    Math.trunc(a * 255)
+    (Math.trunc(a * 255) << 24) |
+    (Math.trunc(r * 255) << 16) |
+    (Math.trunc(g * 255) << 8) |
+    Math.trunc(b * 255)
   );
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/common.ts
@@ -152,11 +152,11 @@ export function makeColor(hex: string, alpha?: number): ColorRGBA {
   return color;
 }
 
-// ts-prune-ignore-next
 /**
  * Pack RGBA values into a uint32 in the order expected by RViz:
  * https://github.com/ros-visualization/rviz/blob/a60b334fd10785a6b74893189fcebbd419d468e4/src/rviz/default_plugin/point_cloud_transformers.cpp#L400-L404
  */
+// ts-prune-ignore-next
 export function packRvizRgba(r: number, g: number, b: number, a: number): number {
   return (
     (Math.trunc(a * 255) << 24) |

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -265,7 +265,7 @@ function jet(x: number, a: number) {
   const r = Math.max(0, Math.min(255, 4 * (i - 96), 255 - 4 * (i - 224)));
   const g = Math.max(0, Math.min(255, 4 * (i - 32), 255 - 4 * (i - 160)));
   const b = Math.max(0, Math.min(255, 4 * i + 127, 255 - 4 * (i - 96)));
-  return { r, g, b, a };
+  return { r, g, b, a: (a * 255) | 0 };
 }
 function Foxglove_Grid_RGBA(): JSX.Element {
   const topics: Topic[] = [
@@ -372,6 +372,7 @@ function Foxglove_Grid_RGBA(): JSX.Element {
           topics: {
             "/grid": {
               visible: true,
+              colorField: "red",
               colorMode: "rgba-fields",
             } as LayerSettingsFoxgloveGrid,
           },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -256,24 +256,16 @@ function Foxglove_Grid_Uint8(): JSX.Element {
     </PanelSetup>
   );
 }
-function rgba(r: number, g: number, b: number, a: number) {
-  return (
-    (Math.trunc(r * 255) << 24) |
-    (Math.trunc(g * 255) << 16) |
-    (Math.trunc(b * 255) << 8) |
-    Math.trunc(a * 255)
-  );
-}
 
 function f(x: number, y: number, size = 128) {
   return (x / size - 0.5) ** 2 + (y / size - 0.5) ** 2;
 }
-function jet(x: number, a: number): number {
+function jet(x: number, a: number) {
   const i = Math.trunc(x * 255);
   const r = Math.max(0, Math.min(255, 4 * (i - 96), 255 - 4 * (i - 224)));
   const g = Math.max(0, Math.min(255, 4 * (i - 32), 255 - 4 * (i - 160)));
   const b = Math.max(0, Math.min(255, 4 * i + 127, 255 - 4 * (i - 96)));
-  return rgba(r / 255, g / 255, b / 255, a);
+  return { r, g, b, a };
 }
 function Foxglove_Grid_RGBA(): JSX.Element {
   const topics: Topic[] = [
@@ -319,7 +311,11 @@ function Foxglove_Grid_RGBA(): JSX.Element {
   for (let i = 0; i < rowCount; i++) {
     for (let j = 0; j < column_count; j++) {
       const offset = i * column_count + j;
-      view.setUint32(offset * 4, jet(f(i, j) * 2, i / rowCount), true);
+      const { r, g, b, a } = jet(f(i, j) * 2, i / rowCount);
+      view.setUint8(offset * 4 + 0, r);
+      view.setUint8(offset * 4 + 1, g);
+      view.setUint8(offset * 4 + 2, b);
+      view.setUint8(offset * 4 + 3, a);
     }
   }
   const cell_size = {
@@ -345,7 +341,12 @@ function Foxglove_Grid_RGBA(): JSX.Element {
       column_count,
       cell_stride,
       row_stride,
-      fields: [{ name: "color", offset: 0, type: NumericType.UINT32 }],
+      fields: [
+        { name: "red", offset: 0, type: NumericType.UINT8 },
+        { name: "green", offset: 1, type: NumericType.UINT8 },
+        { name: "blue", offset: 2, type: NumericType.UINT8 },
+        { name: "alpha", offset: 3, type: NumericType.UINT8 },
+      ],
       data,
     },
     sizeInBytes: 0,
@@ -371,8 +372,7 @@ function Foxglove_Grid_RGBA(): JSX.Element {
           topics: {
             "/grid": {
               visible: true,
-              colorField: "color",
-              colorMode: "rgba",
+              colorMode: "rgba-fields",
             } as LayerSettingsFoxgloveGrid,
           },
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -47,7 +47,7 @@ function Foxglove_PointCloud({
   rgbaFieldName,
   pointShape = "circle",
 }: {
-  rgbaFieldName: string;
+  rgbaFieldName: "rgb" | "rgba";
   pointShape?: "circle" | "square";
 }): JSX.Element {
   const topics: Topic[] = [
@@ -153,7 +153,6 @@ function Foxglove_PointCloud({
               pointShape,
               colorMode: rgbaFieldName,
               colorField: rgbaFieldName,
-              rgbByteOrder: "rgba",
             },
           },
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -22,32 +22,15 @@ export default {
   },
 };
 
-function rgba(r: number, g: number, b: number, a: number) {
-  return (
-    (Math.trunc(r * 255) << 24) |
-    (Math.trunc(g * 255) << 16) |
-    (Math.trunc(b * 255) << 8) |
-    Math.trunc(a * 255)
-  );
-}
+export const Foxglove_PointCloud_RGBA = (): JSX.Element => <Foxglove_PointCloud />;
 
-export const Foxglove_PointCloud_RGBA = (): JSX.Element => (
-  <Foxglove_PointCloud rgbaFieldName="rgba" />
-);
-
-export const Foxglove_PointCloud_RGB = (): JSX.Element => (
-  <Foxglove_PointCloud rgbaFieldName="rgb" />
-);
-
-export const Foxglove_PointCloud_RGB_Square = (): JSX.Element => (
-  <Foxglove_PointCloud rgbaFieldName="rgb" pointShape="square" />
+export const Foxglove_PointCloud_RGBA_Square = (): JSX.Element => (
+  <Foxglove_PointCloud pointShape="square" />
 );
 
 function Foxglove_PointCloud({
-  rgbaFieldName,
   pointShape = "circle",
 }: {
-  rgbaFieldName: "rgb" | "rgba";
   pointShape?: "circle" | "square";
 }): JSX.Element {
   const topics: Topic[] = [
@@ -89,12 +72,12 @@ function Foxglove_PointCloud({
     return (x / 128 - 0.5) ** 2 + (y / 128 - 0.5) ** 2;
   }
 
-  function jet(x: number, a: number): number {
+  function jet(x: number, a: number) {
     const i = Math.trunc(x * 255);
     const r = Math.max(0, Math.min(255, 4 * (i - 96), 255 - 4 * (i - 224)));
     const g = Math.max(0, Math.min(255, 4 * (i - 32), 255 - 4 * (i - 160)));
     const b = Math.max(0, Math.min(255, 4 * i + 127, 255 - 4 * (i - 96)));
-    return rgba(r / 255, g / 255, b / 255, a);
+    return { r, g, b, a };
   }
 
   const data = new Uint8Array(128 * 128 * 16);
@@ -105,7 +88,11 @@ function Foxglove_PointCloud({
       view.setFloat32(i + 0, x * SCALE - 5, true);
       view.setFloat32(i + 4, y * SCALE - 5, true);
       view.setFloat32(i + 8, f(x, y) * 5, true);
-      view.setUint32(i + 12, jet(f(x, y) * 2, x / 128), true);
+      const { r, g, b, a } = jet(f(x, y) * 2, x / 128);
+      view.setUint8(i + 12, r);
+      view.setUint8(i + 13, g);
+      view.setUint8(i + 14, b);
+      view.setUint8(i + 15, (a * 255) | 0);
     }
   }
 
@@ -121,7 +108,10 @@ function Foxglove_PointCloud({
         { name: "x", offset: 0, type: 7 },
         { name: "y", offset: 4, type: 7 },
         { name: "z", offset: 8, type: 7 },
-        { name: rgbaFieldName, offset: 12, type: 6 },
+        { name: "red", offset: 12, type: 1 },
+        { name: "green", offset: 13, type: 1 },
+        { name: "blue", offset: 14, type: 1 },
+        { name: "alpha", offset: 15, type: 1 },
       ],
       data,
     },
@@ -151,8 +141,8 @@ function Foxglove_PointCloud({
               visible: true,
               pointSize: 10,
               pointShape,
-              colorMode: rgbaFieldName,
-              colorField: rgbaFieldName,
+              colorMode: "rgba-fields",
+              colorField: "x",
             },
           },
           layers: {


### PR DESCRIPTION
**User-Facing Changes**
- [3D] For foxglove.PointCloud and foxglove.Grid topics, the packed "RGB"/"RGBA" color modes are no longer supported. A new "RGBA (separate fields)" mode has been added, which reads RGBA values from four separate "red", "green", "blue", and "alpha" fields.
- [3D] For ROS sensor_msgs/PointCloud2 topics, the "RGB Byte Order" setting has been removed, and the byte order has been made compatible with RViz. The "RGB" and "RGBA" color modes have been renamed to "BGR"/"BGRA" to accurately reflect the actual byte order.

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/14237/200391108-04f8e7c9-98ef-4728-be4a-ee52f44329c4.png">

**Description**
Resolves #4483 

- Fixed a bug with Grids not updating immediately when you change the flatColor in settings.
- Fixed sRGB conversion for rgba Grids (I think?)
