### PR TITLE
Raise dependabot.yml limit to 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     labels: [] # disable default labels
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Raise the number of allowed dependabot updates to 5 so we can feel out the waters with a few more dependabot PRs.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
