### PR TITLE
Add Amplitude event tracking for data source selection

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -71,7 +71,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
   const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
     const foundIdx = availableSources.findIndex((source) => source === activeSource);
     const selectedIdx = foundIdx < 0 ? 0 : foundIdx;
-    void analytics.logEvent(AppEvent.DATASOURCE_CLICK, {
+    void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, {
       type: "live",
       data: enabledSourcesFirst[selectedIdx]?.id,
     });
@@ -123,7 +123,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             orientation="vertical"
             onChange={(_event, newValue: number) => {
               setSelectedConnectionIdx(newValue);
-              void analytics.logEvent(AppEvent.DATASOURCE_CLICK, {
+              void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, {
                 type: "live",
                 data: enabledSourcesFirst[newValue]?.id,
               });

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -71,8 +71,9 @@ export default function Connection(props: ConnectionProps): JSX.Element {
   const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
     const foundIdx = availableSources.findIndex((source) => source === activeSource);
     const selectedIdx = foundIdx < 0 ? 0 : foundIdx;
-    void analytics.logEvent(AppEvent.DATA_LIVE, {
-      type: enabledSourcesFirst[selectedIdx]?.id,
+    void analytics.logEvent(AppEvent.DATASOURCE_CLICK, {
+      type: "live",
+      data: enabledSourcesFirst[selectedIdx]?.id,
     });
     return selectedIdx;
   });
@@ -122,8 +123,9 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             orientation="vertical"
             onChange={(_event, newValue: number) => {
               setSelectedConnectionIdx(newValue);
-              void analytics.logEvent(AppEvent.DATA_LIVE, {
-                type: enabledSourcesFirst[newValue]?.id,
+              void analytics.logEvent(AppEvent.DATASOURCE_CLICK, {
+                type: "live",
+                data: enabledSourcesFirst[newValue]?.id,
               });
             }}
             value={selectedConnectionIdx}

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -71,7 +71,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
   const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
     const foundIdx = availableSources.findIndex((source) => source === activeSource);
     const selectedIdx = foundIdx < 0 ? 0 : foundIdx;
-    void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, {
+    void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
       type: "live",
       data: enabledSourcesFirst[selectedIdx]?.id,
     });
@@ -123,7 +123,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             orientation="vertical"
             onChange={(_event, newValue: number) => {
               setSelectedConnectionIdx(newValue);
-              void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, {
+              void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, {
                 type: "live",
                 data: enabledSourcesFirst[newValue]?.id,
               });

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -8,10 +8,12 @@ import { makeStyles } from "tss-react/mui";
 
 import { BuiltinIcon } from "@foxglove/studio-base/components/BuiltinIcon";
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import {
   IDataSourceFactory,
   usePlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 
 import { FormField } from "./FormField";
 import View from "./View";
@@ -57,10 +59,7 @@ export default function Connection(props: ConnectionProps): JSX.Element {
   const { classes } = useStyles();
 
   const { selectSource } = usePlayerSelection();
-  const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
-    const foundIdx = availableSources.findIndex((source) => source === activeSource);
-    return foundIdx < 0 ? 0 : foundIdx;
-  });
+  const analytics = useAnalytics();
 
   // List enabled sources before disabled sources so the default selected item is an available source
   const enabledSourcesFirst = useMemo(() => {
@@ -68,6 +67,15 @@ export default function Connection(props: ConnectionProps): JSX.Element {
     const disabledSources = availableSources.filter((source) => source.disabledReason);
     return [...enabledSources, ...disabledSources];
   }, [availableSources]);
+
+  const [selectedConnectionIdx, setSelectedConnectionIdx] = useState<number>(() => {
+    const foundIdx = availableSources.findIndex((source) => source === activeSource);
+    const selectedIdx = foundIdx < 0 ? 0 : foundIdx;
+    void analytics.logEvent(AppEvent.DATA_LIVE, {
+      type: enabledSourcesFirst[selectedIdx]?.id,
+    });
+    return selectedIdx;
+  });
 
   const selectedSource = useMemo(
     () => enabledSourcesFirst[selectedConnectionIdx],
@@ -112,7 +120,12 @@ export default function Connection(props: ConnectionProps): JSX.Element {
             classes={{ indicator: classes.indicator }}
             textColor="inherit"
             orientation="vertical"
-            onChange={(_event, newValue: number) => setSelectedConnectionIdx(newValue)}
+            onChange={(_event, newValue: number) => {
+              setSelectedConnectionIdx(newValue);
+              void analytics.logEvent(AppEvent.DATA_LIVE, {
+                type: enabledSourcesFirst[newValue]?.id,
+              });
+            }}
             value={selectedConnectionIdx}
           >
             {enabledSourcesFirst.map((source, idx) => {

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -15,8 +15,10 @@ import { useMemo } from "react";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
+import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 
 import ActionList, { ActionListItem } from "./ActionList";
 import { OpenDialogViews } from "./types";
@@ -95,6 +97,7 @@ export default function Start(props: IStartProps): JSX.Element {
     onSelectView,
   } = props;
   const { recentSources, selectRecent } = usePlayerSelection();
+  const analytics = useAnalytics();
 
   const [showOnStartup = true, setShowOnStartup] = useAppConfigurationValue<boolean>(
     AppSetting.SHOW_OPEN_DIALOG_ON_STARTUP,
@@ -118,7 +121,10 @@ export default function Start(props: IStartProps): JSX.Element {
             <path d="M1955 1533l-163-162v677h-128v-677l-163 162-90-90 317-317 317 317-90 90zM256 1920h1280v128H128V0h1115l549 549v475h-128V640h-512V128H256v1792zM1280 512h293l-293-293v293z" />
           </SvgIcon>
         ),
-        onClick: () => onSelectView("file"),
+        onClick: () => {
+          onSelectView("file");
+          void analytics.logEvent(AppEvent.DATA_LOCAL);
+        },
       },
       {
         key: "open-url",
@@ -130,7 +136,10 @@ export default function Start(props: IStartProps): JSX.Element {
           </SvgIcon>
         ),
         iconProps: { iconName: "FileASPX" },
-        onClick: () => onSelectView("remote"),
+        onClick: () => {
+          onSelectView("remote");
+          void analytics.logEvent(AppEvent.DATA_REMOTE);
+        },
       },
       {
         key: "open-connection",
@@ -141,7 +150,10 @@ export default function Start(props: IStartProps): JSX.Element {
             <path d="M1408 256h640v640h-640V640h-120l-449 896H640v256H0v-640h640v256h120l449-896h199V256zM512 1664v-384H128v384h384zm1408-896V384h-384v384h384z" />
           </SvgIcon>
         ),
-        onClick: () => onSelectView("connection"),
+        onClick: () => {
+          onSelectView("connection");
+          void analytics.logEvent(AppEvent.DATA_LIVE);
+        },
       },
       {
         key: "sample-data",
@@ -153,10 +165,13 @@ export default function Start(props: IStartProps): JSX.Element {
             <path d="M6.5 2A2.5 2.5 0 004 4.5v15A2.5 2.5 0 006.5 22h13.25a.75.75 0 000-1.5H6.5a1 1 0 01-1-1h14.25c.41 0 .75-.34.75-.75V4.5A2.5 2.5 0 0018 2H6.5zM19 18H5.5V4.5a1 1 0 011-1H18a1 1 0 011 1V18z" />
           </SvgIcon>
         ),
-        onClick: () => onSelectView("demo"),
+        onClick: () => {
+          onSelectView("demo");
+          void analytics.logEvent(AppEvent.DATA_DEMO);
+        },
       },
     ];
-  }, [onSelectView, supportedLocalFileExtensions, supportedRemoteFileExtensions]);
+  }, [analytics, onSelectView, supportedLocalFileExtensions, supportedRemoteFileExtensions]);
 
   const recentItems: ActionListItem[] = useMemo(() => {
     return recentSources.map((recent) => {

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -123,7 +123,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("file");
-          void analytics.logEvent(AppEvent.DATA_LOCAL);
+          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "local" });
         },
       },
       {
@@ -138,7 +138,7 @@ export default function Start(props: IStartProps): JSX.Element {
         iconProps: { iconName: "FileASPX" },
         onClick: () => {
           onSelectView("remote");
-          void analytics.logEvent(AppEvent.DATA_REMOTE);
+          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "remote" });
         },
       },
       {
@@ -152,7 +152,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("connection");
-          void analytics.logEvent(AppEvent.DATA_LIVE);
+          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "live" });
         },
       },
       {
@@ -167,7 +167,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("demo");
-          void analytics.logEvent(AppEvent.DATA_DEMO);
+          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "demo" });
         },
       },
     ];

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -123,7 +123,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("file");
-          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "local" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "local" });
         },
       },
       {
@@ -138,7 +138,7 @@ export default function Start(props: IStartProps): JSX.Element {
         iconProps: { iconName: "FileASPX" },
         onClick: () => {
           onSelectView("remote");
-          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "remote" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "remote" });
         },
       },
       {
@@ -152,7 +152,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("connection");
-          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "live" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "live" });
         },
       },
       {
@@ -167,7 +167,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("demo");
-          void analytics.logEvent(AppEvent.DATASOURCE_CLICK, { type: "demo" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "demo" });
         },
       },
     ];

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -123,7 +123,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("file");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "local" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "local" });
         },
       },
       {
@@ -138,7 +138,7 @@ export default function Start(props: IStartProps): JSX.Element {
         iconProps: { iconName: "FileASPX" },
         onClick: () => {
           onSelectView("remote");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "remote" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "remote" });
         },
       },
       {
@@ -152,7 +152,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("connection");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "live" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "live" });
         },
       },
       {
@@ -167,7 +167,7 @@ export default function Start(props: IStartProps): JSX.Element {
         ),
         onClick: () => {
           onSelectView("demo");
-          void analytics.logEvent(AppEvent.DIALOG_SELECT_DATASOURCE, { type: "demo" });
+          void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "demo" });
         },
       },
     ];

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -4,6 +4,7 @@
 
 enum AppEventCategory {
   LIFECYCLE = "LIFECYCLE",
+  DATA = "DATA",
   PLAYERS = "PLAYERS",
   LAYOUTS = "LAYOUTS",
   PANELS = "PANELS",
@@ -12,6 +13,12 @@ enum AppEventCategory {
 
 enum AppEvent {
   APP_INIT = "APP_INIT",
+
+  // Data source events
+  DATA_LOCAL = "DATA_LOCAL",
+  DATA_REMOTE = "DATA_REMOTE",
+  DATA_LIVE = "DATA_LIVE",
+  DATA_DEMO = "DATA_DEMO",
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
@@ -64,6 +71,12 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
     case AppEvent.APP_INIT:
       return AppEventCategory.LIFECYCLE;
 
+    case AppEvent.DATA_LOCAL:
+    case AppEvent.DATA_REMOTE:
+    case AppEvent.DATA_LIVE:
+    case AppEvent.DATA_DEMO:
+      return AppEventCategory.DATA;
+
     case AppEvent.PLAYER_CONSTRUCTED:
     case AppEvent.PLAYER_INITIALIZED:
     case AppEvent.PLAYER_PLAY:
@@ -101,6 +114,12 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
   switch (event) {
     case AppEvent.APP_INIT:
       return SentryBreadcrumbType.DEFAULT;
+
+    case AppEvent.DATA_LOCAL:
+    case AppEvent.DATA_REMOTE:
+    case AppEvent.DATA_LIVE:
+    case AppEvent.DATA_DEMO:
+      return SentryBreadcrumbType.TRANSACTION;
 
     case AppEvent.PLAYER_CONSTRUCTED:
     case AppEvent.PLAYER_INITIALIZED:

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -4,7 +4,7 @@
 
 enum AppEventCategory {
   LIFECYCLE = "LIFECYCLE",
-  DATASOURCE = "DATASOURCE",
+  DIALOG = "DIALOG",
   PLAYERS = "PLAYERS",
   LAYOUTS = "LAYOUTS",
   PANELS = "PANELS",
@@ -14,8 +14,8 @@ enum AppEventCategory {
 enum AppEvent {
   APP_INIT = "APP_INIT",
 
-  // Data source events
-  DATASOURCE_CLICK = "DATASOURCE_CLICK",
+  // Dialog events
+  DIALOG_SELECT_DATASOURCE = "DIALOG_SELECT_DATASOURCE",
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
@@ -68,8 +68,8 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
     case AppEvent.APP_INIT:
       return AppEventCategory.LIFECYCLE;
 
-    case AppEvent.DATASOURCE_CLICK:
-      return AppEventCategory.DATASOURCE;
+    case AppEvent.DIALOG_SELECT_DATASOURCE:
+      return AppEventCategory.DIALOG;
 
     case AppEvent.PLAYER_CONSTRUCTED:
     case AppEvent.PLAYER_INITIALIZED:
@@ -109,7 +109,7 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
     case AppEvent.APP_INIT:
       return SentryBreadcrumbType.DEFAULT;
 
-    case AppEvent.DATASOURCE_CLICK:
+    case AppEvent.DIALOG_SELECT_DATASOURCE:
       return SentryBreadcrumbType.TRANSACTION;
 
     case AppEvent.PLAYER_CONSTRUCTED:

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -4,7 +4,7 @@
 
 enum AppEventCategory {
   LIFECYCLE = "LIFECYCLE",
-  DATA = "DATA",
+  DATASOURCE = "DATASOURCE",
   PLAYERS = "PLAYERS",
   LAYOUTS = "LAYOUTS",
   PANELS = "PANELS",
@@ -15,10 +15,7 @@ enum AppEvent {
   APP_INIT = "APP_INIT",
 
   // Data source events
-  DATA_LOCAL = "DATA_LOCAL",
-  DATA_REMOTE = "DATA_REMOTE",
-  DATA_LIVE = "DATA_LIVE",
-  DATA_DEMO = "DATA_DEMO",
+  DATASOURCE_CLICK = "DATASOURCE_CLICK",
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
@@ -71,11 +68,8 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
     case AppEvent.APP_INIT:
       return AppEventCategory.LIFECYCLE;
 
-    case AppEvent.DATA_LOCAL:
-    case AppEvent.DATA_REMOTE:
-    case AppEvent.DATA_LIVE:
-    case AppEvent.DATA_DEMO:
-      return AppEventCategory.DATA;
+    case AppEvent.DATASOURCE_CLICK:
+      return AppEventCategory.DATASOURCE;
 
     case AppEvent.PLAYER_CONSTRUCTED:
     case AppEvent.PLAYER_INITIALIZED:
@@ -115,10 +109,7 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
     case AppEvent.APP_INIT:
       return SentryBreadcrumbType.DEFAULT;
 
-    case AppEvent.DATA_LOCAL:
-    case AppEvent.DATA_REMOTE:
-    case AppEvent.DATA_LIVE:
-    case AppEvent.DATA_DEMO:
+    case AppEvent.DATASOURCE_CLICK:
       return SentryBreadcrumbType.TRANSACTION;
 
     case AppEvent.PLAYER_CONSTRUCTED:

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -15,7 +15,7 @@ enum AppEvent {
   APP_INIT = "APP_INIT",
 
   // Dialog events
-  DIALOG_SELECT_DATASOURCE = "DIALOG_SELECT_DATASOURCE",
+  DIALOG_SELECT_VIEW = "DIALOG_SELECT_VIEW",
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
@@ -68,7 +68,7 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
     case AppEvent.APP_INIT:
       return AppEventCategory.LIFECYCLE;
 
-    case AppEvent.DIALOG_SELECT_DATASOURCE:
+    case AppEvent.DIALOG_SELECT_VIEW:
       return AppEventCategory.DIALOG;
 
     case AppEvent.PLAYER_CONSTRUCTED:
@@ -109,7 +109,7 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
     case AppEvent.APP_INIT:
       return SentryBreadcrumbType.DEFAULT;
 
-    case AppEvent.DIALOG_SELECT_DATASOURCE:
+    case AppEvent.DIALOG_SELECT_VIEW:
       return SentryBreadcrumbType.TRANSACTION;
 
     case AppEvent.PLAYER_CONSTRUCTED:


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
- Add metrics for data source selections in the Welcome dialog: Local, remote, live connection (Rosbridge, FG WebSocket, ROS 1, ROS 2, Velodyne), or sample data

