### PR TITLE
Remove player initialized event

### DIFF
--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -35,12 +35,6 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
     this.logEvent(AppEvent.PLAYER_CONSTRUCTED);
   }
 
-  public initialized(args?: { isSampleDataSource: boolean }): void {
-    this.logEvent(AppEvent.PLAYER_INITIALIZED, {
-      isSampleDataSource: args?.isSampleDataSource === true,
-    });
-  }
-
   public play(speed: number): void {
     this.logEvent(AppEvent.PLAYER_PLAY, { speed });
   }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -230,7 +230,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
     client.on("message", ({ subscriptionId, timestamp, data }) => {
       if (!this._hasReceivedMessage) {
         this._hasReceivedMessage = true;
-        this._metricsCollector.initialized();
         this._metricsCollector.recordTimeToFirstMsgs();
       }
       const chanInfo = this._resolvedSubscriptionsById.get(subscriptionId);

--- a/packages/studio-base/src/players/NoopMetricsCollector.ts
+++ b/packages/studio-base/src/players/NoopMetricsCollector.ts
@@ -23,9 +23,6 @@ export default class NoopMetricsCollector implements PlayerMetricsCollectorInter
   public playerConstructed(): void {
     // no-op
   }
-  public initialized(_args?: { isSampleDataSource: boolean }): void {
-    // no-op
-  }
   public play(_speed: number): void {
     // no-op
   }

--- a/packages/studio-base/src/players/Ros1Player.ts
+++ b/packages/studio-base/src/players/Ros1Player.ts
@@ -217,10 +217,6 @@ export default class Ros1Player implements Player {
       // Sort them for easy comparison
       const sortedTopics = sortBy(topics, "name");
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
-      }
-
       if (this._topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));

--- a/packages/studio-base/src/players/Ros2Player.ts
+++ b/packages/studio-base/src/players/Ros2Player.ts
@@ -216,10 +216,6 @@ export default class Ros2Player implements Player {
       // Sort them for easy comparison
       const sortedTopics: Topic[] = sortBy(topics, "name");
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
-      }
-
       if (this._topicsChanged(sortedTopics)) {
         // Remove stats entries for removed topics
         const topicsSet = new Set<string>(topics.map((topic) => topic.name));

--- a/packages/studio-base/src/players/RosbridgePlayer.ts
+++ b/packages/studio-base/src/players/RosbridgePlayer.ts
@@ -302,10 +302,6 @@ export default class RosbridgePlayer implements Player {
         });
       }
 
-      if (this._providerTopics == undefined) {
-        this._metricsCollector.initialized();
-      }
-
       // Remove stats entries for removed topics
       const topicsSet = new Set<string>(topics.map((topic) => topic.name));
       for (const topic of this._providerTopicsStats.keys()) {

--- a/packages/studio-base/src/players/VelodynePlayer.ts
+++ b/packages/studio-base/src/players/VelodynePlayer.ts
@@ -149,7 +149,6 @@ export default class VelodynePlayer implements Player {
     this._clearProblem(PROBLEM_SOCKET_ERROR, { skipEmit: true });
 
     if (this._seq === 0) {
-      this._metricsCollector.initialized();
       this._metricsCollector.recordTimeToFirstMsgs();
     }
 

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -314,7 +314,6 @@ export const PlayerCapabilities = {
 export interface PlayerMetricsCollectorInterface {
   setProperty(key: string, value: string | number | boolean): void;
   playerConstructed(): void;
-  initialized(args?: { isSampleDataSource: boolean }): void;
   play(speed: number): void;
   seek(time: Time): void;
   setSpeed(speed: number): void;

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -15,7 +15,6 @@ enum AppEvent {
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
-  PLAYER_INITIALIZED = "PLAYER_INITIALIZED",
   PLAYER_PLAY = "PLAYER_PLAY",
   PLAYER_SEEK = "PLAYER_SEEK",
   PLAYER_SET_SPEED = "PLAYER_SET_SPEED",
@@ -65,7 +64,6 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
       return AppEventCategory.LIFECYCLE;
 
     case AppEvent.PLAYER_CONSTRUCTED:
-    case AppEvent.PLAYER_INITIALIZED:
     case AppEvent.PLAYER_PLAY:
     case AppEvent.PLAYER_SEEK:
     case AppEvent.PLAYER_SET_SPEED:
@@ -103,7 +101,6 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
       return SentryBreadcrumbType.DEFAULT;
 
     case AppEvent.PLAYER_CONSTRUCTED:
-    case AppEvent.PLAYER_INITIALIZED:
       return SentryBreadcrumbType.TRANSACTION;
 
     case AppEvent.PLAYER_PLAY:


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
We don't need both "Player Constructed" and "Player Initialized". Of the two, initialized seems to happen about 50% less, so I assume the data is bad. Therefore, keeping "constructed" and removing "initialized".