### PR TITLE
Update README to add real link instead of enlarging image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Accelerate your robotics development](https://user-images.githubusercontent.com/14011012/195918769-5aaeedf3-5de2-48fb-951e-7399f2b9e190.png)
+[![Accelerate your robotics development](https://user-images.githubusercontent.com/14011012/195918769-5aaeedf3-5de2-48fb-951e-7399f2b9e190.png)](https://foxglove.dev)
 
 <br/>
 


### PR DESCRIPTION
README tweak so that clicking on the header image does not enlarge the image, but goes to the Foxglove website.