### PR TITLE
Fix color picker text input not updating values

### DIFF
--- a/packages/studio-base/src/components/ColorPicker/index.tsx
+++ b/packages/studio-base/src/components/ColorPicker/index.tsx
@@ -106,7 +106,12 @@ export default function ColorPicker({
           horizontal: "center",
         }}
       >
-        <ColorPickerControl alphaType={alphaType} value={hexColor} onChange={onChangeCallback} />
+        <ColorPickerControl
+          alphaType={alphaType}
+          value={hexColor}
+          onChange={onChangeCallback}
+          onEnterKey={handleClose}
+        />
       </Popover>
     </div>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorGradientInput.tsx
@@ -97,6 +97,7 @@ export function ColorGradientInput({
           value={leftColor}
           alphaType="alpha"
           onChange={(newValue) => onChange([newValue, rightColor])}
+          onEnterKey={handleClose}
         />
       </Popover>
       <Popover
@@ -116,6 +117,7 @@ export function ColorGradientInput({
           value={rightColor}
           alphaType="alpha"
           onChange={(newValue) => onChange([leftColor, newValue])}
+          onEnterKey={handleClose}
         />
       </Popover>
     </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -41,6 +41,7 @@ type ColorPickerInputProps = {
   alphaType: "none" | "alpha";
   value: undefined | string;
   onChange: (value: string) => void;
+  onEnterKey?: () => void;
 };
 
 function isValidHexColor(color: string, alphaType: "none" | "alpha") {
@@ -48,7 +49,7 @@ function isValidHexColor(color: string, alphaType: "none" | "alpha") {
 }
 
 export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
-  const { alphaType, onChange, value } = props;
+  const { alphaType, onChange, value, onEnterKey } = props;
 
   const { classes } = useStyles();
 
@@ -70,7 +71,7 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
       setEditedValue(newValue);
 
       if (isValidHexColor(newValue, alphaType)) {
-        onChange(newValue);
+        onChange(`#${newValue}`);
       }
     },
     [alphaType, onChange],
@@ -106,6 +107,7 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
         }}
         placeholder={alphaType === "alpha" ? "RRGGBBAA" : "RRGGBB"}
         value={editedValue}
+        onKeyDown={(event) => event.key === "Enter" && onEnterKey && onEnterKey()}
         onChange={(event) => updateEditedValue(event.target.value)}
       />
     </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerControl.tsx
@@ -107,7 +107,7 @@ export function ColorPickerControl(props: ColorPickerInputProps): JSX.Element {
         }}
         placeholder={alphaType === "alpha" ? "RRGGBBAA" : "RRGGBB"}
         value={editedValue}
-        onKeyDown={(event) => event.key === "Enter" && onEnterKey && onEnterKey()}
+        onKeyDown={(event) => event.key === "Enter" && onEnterKey?.()}
         onChange={(event) => updateEditedValue(event.target.value)}
       />
     </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/ColorPickerInput.tsx
@@ -109,7 +109,12 @@ export function ColorPickerInput(props: ColorPickerInputProps): JSX.Element {
           horizontal: "center",
         }}
       >
-        <ColorPickerControl alphaType={alphaType} value={value} onChange={onChange} />
+        <ColorPickerControl
+          alphaType={alphaType}
+          value={value}
+          onChange={onChange}
+          onEnterKey={handleClose}
+        />
       </Popover>
     </Stack>
   );


### PR DESCRIPTION
**User-Facing Changes**
 - Fix color picker text input not updating panels

**Description**
- close color picker on enter key text input
- fix text input values being invalid for consumption by panels by adding `#` to beginning of value string for consumption elsewhere in UI

<!-- link relevant github issues -->
Fixes: #4667
<!-- add `docs` label if this PR requires documentation updates -->
