### PR TITLE
When adding a panel, don't select the new panel

### DIFF
--- a/packages/studio-base/src/hooks/useAddPanel.ts
+++ b/packages/studio-base/src/hooks/useAddPanel.ts
@@ -4,21 +4,16 @@
 import { useCallback } from "react";
 
 import { PanelSelection } from "@foxglove/studio-base/components/PanelList";
-import {
-  useCurrentLayoutActions,
-  useSelectedPanels,
-} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { getPanelIdForType } from "@foxglove/studio-base/util/layout";
 
 export default function useAddPanel(): (selection: PanelSelection) => void {
   const { addPanel } = useCurrentLayoutActions();
-  const { setSelectedPanelIds } = useSelectedPanels();
   return useCallback(
     ({ type, config, relatedConfigs }: PanelSelection) => {
       const id = getPanelIdForType(type);
       addPanel({ id, config, relatedConfigs });
-      setSelectedPanelIds([id]);
     },
-    [addPanel, setSelectedPanelIds],
+    [addPanel],
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
The new panel was selected so that its settings editor could be shown. However, we stopped showing the settings editor in #2143, so the purple-border selection is strange and unnecessary.

Resolves https://github.com/foxglove/studio/issues/4811