### PR TITLE
Fix diagnostic status message coloring

### DIFF
--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatus.tsx
@@ -33,7 +33,7 @@ import { openSiblingPlotPanel } from "@foxglove/studio-base/panels/Plot";
 import { openSiblingStateTransitionsPanel } from "@foxglove/studio-base/panels/StateTransitions";
 import { OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
 
-import { DiagnosticInfo, KeyValue, DiagnosticStatusMessage } from "./util";
+import { DiagnosticInfo, KeyValue, DiagnosticStatusMessage, LEVELS } from "./util";
 
 const MIN_SPLIT_FRACTION = 0.1;
 
@@ -279,11 +279,11 @@ export default function DiagnosticStatus(props: Props): JSX.Element {
     });
   }, [info.status, openSiblingPanel, renderKeyValueCell, topicToRender]);
 
-  const STATUS_COLORS: { [key: number]: string } = {
-    0: "success.main",
-    1: "error.main",
-    2: "warning.main",
-    3: "info.main",
+  const STATUS_COLORS: Record<number, string> = {
+    [LEVELS.OK]: "success.main",
+    [LEVELS.ERROR]: "error.main",
+    [LEVELS.WARN]: "warning.main",
+    [LEVELS.STALE]: "info.main",
   };
 
   return (

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.stories.tsx
@@ -25,6 +25,10 @@ const fixture: Fixture = {
           { key: "key <b>with html</b>", value: "value <tt>with html</tt>" },
         ],
       ),
+      makeDiagnosticMessage(LEVELS.ERROR, "name1", "levels_id", ["error message"]),
+      makeDiagnosticMessage(LEVELS.OK, "name2", "levels_id", ["ok message"]),
+      makeDiagnosticMessage(LEVELS.STALE, "name3", "levels_id", ["stale message"]),
+      makeDiagnosticMessage(LEVELS.WARN, "name4", "levels_id", ["warn message"]),
     ],
   },
 };
@@ -33,6 +37,19 @@ export function Empty(): JSX.Element {
   return (
     <PanelSetup fixture={fixture}>
       <DiagnosticStatusPanel />
+    </PanelSetup>
+  );
+}
+
+export function Default(): JSX.Element {
+  return (
+    <PanelSetup fixture={fixture}>
+      <DiagnosticStatusPanel
+        overrideConfig={{
+          topicToRender: "/diagnostics",
+          selectedHardwareId: "levels_id",
+        }}
+      />
     </PanelSetup>
   );
 }
@@ -50,6 +67,9 @@ export function WithSettings(): JSX.Element {
     </PanelSetup>
   );
 }
+WithSettings.parameters = {
+  colorScheme: "light",
+};
 
 export function SelectedHardwareIDOnly(): JSX.Element {
   return (


### PR DESCRIPTION
**User-Facing Changes**
Fixes message coloring in the diagnostic status panel.

**Description**
Fixes message coloring by level and adds a new story to catch regressions.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4806