### PR TITLE
Add Amplitude metric tracking when users close the Welcome Dialog

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -8,10 +8,12 @@ import { useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { useMountedState } from "react-use";
 
 import Stack from "@foxglove/studio-base/components/Stack";
+import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import {
   IDataSourceFactory,
   usePlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 
 import Connection from "./Connection";
 import Remote from "./Remote";
@@ -52,6 +54,15 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   const onSelectView = useCallback((view: OpenDialogViews) => {
     setActiveView(view);
   }, []);
+
+  const analytics = useAnalytics();
+
+  const onModalClose = useCallback(() => {
+    if (onDismiss) {
+      onDismiss();
+      void analytics.logEvent(AppEvent.DIALOG_CLOSE, { view: activeView });
+    }
+  }, [analytics, activeView, onDismiss]);
 
   useLayoutEffect(() => {
     if (activeView === "file") {
@@ -105,7 +116,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
           component: (
             <Connection
               onBack={() => onSelectView("start")}
-              onCancel={onDismiss}
+              onCancel={onModalClose}
               availableSources={connectionSources}
               activeSource={activeDataSource}
             />
@@ -117,7 +128,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
           component: (
             <Remote
               onBack={() => onSelectView("start")}
-              onCancel={onDismiss}
+              onCancel={onModalClose}
               availableSources={remoteFileSources}
             />
           ),
@@ -139,15 +150,15 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
     activeView,
     connectionSources,
     localFileSources,
-    onDismiss,
     onSelectView,
     remoteFileSources,
+    onModalClose,
   ]);
 
   return (
     <Dialog
       open
-      onClose={onDismiss}
+      onClose={onModalClose}
       fullWidth
       maxWidth="md"
       PaperProps={{
@@ -157,7 +168,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
     >
       <StyledDialogTitle>
         {view.title}
-        <IconButton onClick={onDismiss} edge="end">
+        <IconButton onClick={onModalClose} edge="end">
           <CloseIcon />
         </IconButton>
       </StyledDialogTitle>

--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -60,7 +60,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
   const onModalClose = useCallback(() => {
     if (onDismiss) {
       onDismiss();
-      void analytics.logEvent(AppEvent.DIALOG_CLOSE, { view: activeView });
+      void analytics.logEvent(AppEvent.DIALOG_CLOSE, { activeView });
     }
   }, [analytics, activeView, onDismiss]);
 

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -17,6 +17,7 @@ enum AppEvent {
 
   // Dialog events
   DIALOG_SELECT_VIEW = "DIALOG_SELECT_VIEW",
+  DIALOG_CLOSE = "DIALOG_CLOSE",
 
   // Player events
   PLAYER_CONSTRUCTED = "PLAYER_CONSTRUCTED",
@@ -73,6 +74,7 @@ export function getEventCategory(event: AppEvent): AppEventCategory {
       return AppEventCategory.LIFECYCLE;
 
     case AppEvent.DIALOG_SELECT_VIEW:
+    case AppEvent.DIALOG_CLOSE:
       return AppEventCategory.DIALOG;
 
     case AppEvent.PLAYER_CONSTRUCTED:
@@ -118,6 +120,9 @@ export function getEventBreadcrumbType(event: AppEvent): SentryBreadcrumbType {
 
     case AppEvent.DIALOG_SELECT_VIEW:
       return SentryBreadcrumbType.TRANSACTION;
+
+    case AppEvent.DIALOG_CLOSE:
+      return SentryBreadcrumbType.USER;
 
     case AppEvent.PLAYER_CONSTRUCTED:
       return SentryBreadcrumbType.TRANSACTION;


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Add Amplitude metrics tracking:
- when users close the Welcome Dialog
- the view they are dismissing when they do so
 
