### PR TITLE
Add (disabled) permanent migration of all Legacy 3D panels

### DIFF
--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -21,7 +21,7 @@ export type {
   ChangeHandler,
 } from "./context/AppConfigurationContext";
 export type { Layout, LayoutID, ISO8601Timestamp, ILayoutStorage } from "./services/ILayoutStorage";
-export { migrateLayout } from "./services/ILayoutStorage";
+export { migrateLayout } from "./services/migrateLayout";
 export type { INativeAppMenu, NativeAppMenuEvent } from "./context/NativeAppMenuContext";
 export { default as NativeWindowContext } from "./context/NativeWindowContext";
 export type { INativeWindow } from "./context/NativeWindowContext";

--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -29,6 +29,7 @@ import {
   RemoteLayout,
 } from "@foxglove/studio-base/services/IRemoteLayoutStorage";
 
+import { migratePanelsState } from "../migrateLayout";
 import { NamespacedLayoutStorage } from "./NamespacedLayoutStorage";
 import WriteThroughLayoutCache from "./WriteThroughLayoutCache";
 import computeLayoutSyncOperations, { SyncOperation } from "./computeLayoutSyncOperations";
@@ -216,13 +217,14 @@ export default class LayoutManager implements ILayoutManager {
   @LayoutManager.withBusyStatus
   public async saveNewLayout({
     name,
-    data,
+    data: unmigratedData,
     permission,
   }: {
     name: string;
     data: PanelsState;
     permission: LayoutPermission;
   }): Promise<Layout> {
+    const data = migratePanelsState(unmigratedData);
     if (layoutPermissionIsShared(permission)) {
       if (!this.remote) {
         throw new Error("Shared layouts are not supported without remote layout storage");

--- a/packages/studio-base/src/services/migrateLayout.ts
+++ b/packages/studio-base/src/services/migrateLayout.ts
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MarkOptional } from "ts-essentials";
+
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+
+import { Layout, ISO8601Timestamp } from "./ILayoutStorage";
+import { migrateLegacyToNew3DPanels } from "./migrateLegacyToNew3DPanels";
+
+/**
+ * Perform any necessary migrations on old layout data.
+ */
+export function migratePanelsState(data: MarkOptional<PanelsState, "configById">): PanelsState {
+  const result: PanelsState = { ...data, configById: data.configById ?? data.savedProps ?? {} };
+  delete result.savedProps;
+
+  // To be enabled when https://github.com/foxglove/studio/pull/4450 is merged.
+  // result = migrateLegacyToNew3DPanels(result);
+  void migrateLegacyToNew3DPanels;
+
+  return result;
+}
+
+/**
+ * Import a layout from storage, transferring old properties to the current expected format.
+ *
+ * Layouts created before we stored both working/baseline copies were stored with a "data" field;
+ * migrate this to a baseline layout.
+ */
+
+export function migrateLayout(value: unknown): Layout {
+  if (typeof value !== "object" || value == undefined) {
+    throw new Error("Invariant violation - layout item is not an object");
+  }
+  const layout = value as Partial<Layout>;
+  if (!("id" in layout) || !layout.id) {
+    throw new Error("Invariant violation - layout item is missing an id");
+  }
+
+  const now = new Date().toISOString() as ISO8601Timestamp;
+
+  let baseline = layout.baseline;
+  if (!baseline) {
+    if (layout.working) {
+      baseline = layout.working;
+    } else if (layout.data) {
+      baseline = { data: layout.data, savedAt: now };
+    } else if (layout.state) {
+      baseline = { data: layout.state, savedAt: now };
+    } else {
+      throw new Error("Invariant violation - layout item is missing data");
+    }
+  }
+
+  return {
+    id: layout.id,
+    name: layout.name ?? `Unnamed (${now})`,
+    permission: layout.permission?.toUpperCase() ?? "CREATOR_WRITE",
+    working: layout.working
+      ? { ...layout.working, data: migratePanelsState(layout.working.data) }
+      : undefined,
+    baseline: { ...baseline, data: migratePanelsState(baseline.data) },
+    syncInfo: layout.syncInfo,
+  };
+}

--- a/packages/studio-base/src/services/migrateLayout.ts
+++ b/packages/studio-base/src/services/migrateLayout.ts
@@ -18,7 +18,7 @@ export function migratePanelsState(data: MarkOptional<PanelsState, "configById">
 
   // To be enabled when https://github.com/foxglove/studio/pull/4450 is merged.
   // result = migrateLegacyToNew3DPanels(result);
-  void migrateLegacyToNew3DPanels;
+  void migrateLegacyToNew3DPanels(result);
 
   return result;
 }

--- a/packages/studio-base/src/services/migrateLegacyToNew3DPanels.test.ts
+++ b/packages/studio-base/src/services/migrateLegacyToNew3DPanels.test.ts
@@ -1,0 +1,303 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { migrateLegacyToNew3DPanels } from "@foxglove/studio-base/services/migrateLegacyToNew3DPanels";
+
+let MOCK_ID = 0;
+jest.mock("@foxglove/studio-base/util/layout", () => ({
+  ...jest.requireActual("@foxglove/studio-base/util/layout"),
+  getPanelIdForType(type: string) {
+    return `${type}!${++MOCK_ID}`;
+  },
+}));
+
+describe("migrateLegacyToNew3DPanels", () => {
+  beforeEach(() => {
+    MOCK_ID = 0;
+  });
+  it("migrates legacy 3D panel config at root", () => {
+    expect(
+      migrateLegacyToNew3DPanels({
+        layout: "3D Panel!a",
+        configById: { "3D Panel!a": {} },
+        globalVariables: {},
+        userNodes: {},
+        playbackConfig: { speed: 1 },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "configById": Object {
+          "3D!1": Object {
+            "cameraState": Object {
+              "distance": 20,
+              "far": 5000,
+              "fovy": 45,
+              "near": 0.5,
+              "perspective": true,
+              "phi": 59.99999999999999,
+              "target": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOffset": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOrientation": Array [
+                0,
+                0,
+                0,
+                1,
+              ],
+              "thetaOffset": 0,
+            },
+            "followMode": "follow-none",
+            "followTf": undefined,
+            "layers": Object {},
+            "publish": Object {
+              "pointTopic": "/clicked_point",
+              "poseEstimateThetaDeviation": 0.26179939,
+              "poseEstimateTopic": "/initialpose",
+              "poseEstimateXDeviation": 0.5,
+              "poseEstimateYDeviation": 0.5,
+              "poseTopic": "/move_base_simple/goal",
+              "type": "point",
+            },
+            "scene": Object {},
+            "topics": Object {},
+            "transforms": Object {},
+          },
+        },
+        "globalVariables": Object {},
+        "layout": "3D!1",
+        "playbackConfig": Object {
+          "speed": 1,
+        },
+        "userNodes": Object {},
+      }
+    `);
+  });
+
+  it("migrates legacy 3D panel config inside layout", () => {
+    expect(
+      migrateLegacyToNew3DPanels({
+        layout: {
+          direction: "row",
+          first: { direction: "row", first: "XXX!a", second: "3D Panel!a" },
+          second: "XXX!b",
+        },
+        configById: { "3D Panel!a": {}, "XXX!a": { foo: "bar" }, "XXX!b": { foo: "baz" } },
+        globalVariables: {},
+        userNodes: {},
+        playbackConfig: { speed: 1 },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "configById": Object {
+          "3D!1": Object {
+            "cameraState": Object {
+              "distance": 20,
+              "far": 5000,
+              "fovy": 45,
+              "near": 0.5,
+              "perspective": true,
+              "phi": 59.99999999999999,
+              "target": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOffset": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOrientation": Array [
+                0,
+                0,
+                0,
+                1,
+              ],
+              "thetaOffset": 0,
+            },
+            "followMode": "follow-none",
+            "followTf": undefined,
+            "layers": Object {},
+            "publish": Object {
+              "pointTopic": "/clicked_point",
+              "poseEstimateThetaDeviation": 0.26179939,
+              "poseEstimateTopic": "/initialpose",
+              "poseEstimateXDeviation": 0.5,
+              "poseEstimateYDeviation": 0.5,
+              "poseTopic": "/move_base_simple/goal",
+              "type": "point",
+            },
+            "scene": Object {},
+            "topics": Object {},
+            "transforms": Object {},
+          },
+          "XXX!a": Object {
+            "foo": "bar",
+          },
+          "XXX!b": Object {
+            "foo": "baz",
+          },
+        },
+        "globalVariables": Object {},
+        "layout": Object {
+          "direction": "row",
+          "first": Object {
+            "direction": "row",
+            "first": "XXX!a",
+            "second": "3D!1",
+          },
+          "second": "XXX!b",
+        },
+        "playbackConfig": Object {
+          "speed": 1,
+        },
+        "userNodes": Object {},
+      }
+    `);
+  });
+
+  it("migrates legacy 3D panel config inside tab", () => {
+    expect(
+      migrateLegacyToNew3DPanels({
+        layout: {
+          direction: "row",
+          first: "Tab!a",
+          second: "XXX!b",
+        },
+        configById: {
+          "Tab!a": {
+            tabs: [
+              { title: "One", layout: "XXX!c" },
+              { title: "Two", layout: "Tab!b" },
+              { title: "Three", layout: "XXX!d" },
+            ],
+
+            activeTabIdx: 0,
+          },
+          "Tab!b": {
+            tabs: [
+              { title: "Four", layout: { direction: "row", first: "XXX!a", second: "3D Panel!a" } },
+            ],
+
+            activeTabIdx: 0,
+          },
+          "3D Panel!a": {},
+          "XXX!a": { foo: "foo" },
+          "XXX!b": { foo: "bar" },
+          "XXX!c": { foo: "baz" },
+          "XXX!d": { foo: "quux" },
+        },
+        globalVariables: {},
+        userNodes: {},
+        playbackConfig: { speed: 1 },
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "configById": Object {
+          "3D!1": Object {
+            "cameraState": Object {
+              "distance": 20,
+              "far": 5000,
+              "fovy": 45,
+              "near": 0.5,
+              "perspective": true,
+              "phi": 59.99999999999999,
+              "target": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOffset": Array [
+                0,
+                0,
+                0,
+              ],
+              "targetOrientation": Array [
+                0,
+                0,
+                0,
+                1,
+              ],
+              "thetaOffset": 0,
+            },
+            "followMode": "follow-none",
+            "followTf": undefined,
+            "layers": Object {},
+            "publish": Object {
+              "pointTopic": "/clicked_point",
+              "poseEstimateThetaDeviation": 0.26179939,
+              "poseEstimateTopic": "/initialpose",
+              "poseEstimateXDeviation": 0.5,
+              "poseEstimateYDeviation": 0.5,
+              "poseTopic": "/move_base_simple/goal",
+              "type": "point",
+            },
+            "scene": Object {},
+            "topics": Object {},
+            "transforms": Object {},
+          },
+          "Tab!a": Object {
+            "activeTabIdx": 0,
+            "tabs": Array [
+              Object {
+                "layout": "XXX!c",
+                "title": "One",
+              },
+              Object {
+                "layout": "Tab!b",
+                "title": "Two",
+              },
+              Object {
+                "layout": "XXX!d",
+                "title": "Three",
+              },
+            ],
+          },
+          "Tab!b": Object {
+            "activeTabIdx": 0,
+            "tabs": Array [
+              Object {
+                "layout": Object {
+                  "direction": "row",
+                  "first": "XXX!a",
+                  "second": "3D!1",
+                },
+                "title": "Four",
+              },
+            ],
+          },
+          "XXX!a": Object {
+            "foo": "foo",
+          },
+          "XXX!b": Object {
+            "foo": "bar",
+          },
+          "XXX!c": Object {
+            "foo": "baz",
+          },
+          "XXX!d": Object {
+            "foo": "quux",
+          },
+        },
+        "globalVariables": Object {},
+        "layout": Object {
+          "direction": "row",
+          "first": "Tab!a",
+          "second": "XXX!b",
+        },
+        "playbackConfig": Object {
+          "speed": 1,
+        },
+        "userNodes": Object {},
+      }
+    `);
+  });
+});

--- a/packages/studio-base/src/services/migrateLegacyToNew3DPanels.test.ts
+++ b/packages/studio-base/src/services/migrateLegacyToNew3DPanels.test.ts
@@ -22,6 +22,7 @@ describe("migrateLegacyToNew3DPanels", () => {
         layout: "3D Panel!a",
         configById: { "3D Panel!a": {} },
         globalVariables: {},
+        linkedGlobalVariables: [],
         userNodes: {},
         playbackConfig: { speed: 1 },
       }),
@@ -73,6 +74,7 @@ describe("migrateLegacyToNew3DPanels", () => {
         },
         "globalVariables": Object {},
         "layout": "3D!1",
+        "linkedGlobalVariables": Array [],
         "playbackConfig": Object {
           "speed": 1,
         },
@@ -91,6 +93,7 @@ describe("migrateLegacyToNew3DPanels", () => {
         },
         configById: { "3D Panel!a": {}, "XXX!a": { foo: "bar" }, "XXX!b": { foo: "baz" } },
         globalVariables: {},
+        linkedGlobalVariables: [],
         userNodes: {},
         playbackConfig: { speed: 1 },
       }),
@@ -156,6 +159,7 @@ describe("migrateLegacyToNew3DPanels", () => {
           },
           "second": "XXX!b",
         },
+        "linkedGlobalVariables": Array [],
         "playbackConfig": Object {
           "speed": 1,
         },
@@ -196,6 +200,7 @@ describe("migrateLegacyToNew3DPanels", () => {
           "XXX!d": { foo: "quux" },
         },
         globalVariables: {},
+        linkedGlobalVariables: [],
         userNodes: {},
         playbackConfig: { speed: 1 },
       }),
@@ -293,6 +298,7 @@ describe("migrateLegacyToNew3DPanels", () => {
           "first": "Tab!a",
           "second": "XXX!b",
         },
+        "linkedGlobalVariables": Array [],
         "playbackConfig": Object {
           "speed": 1,
         },

--- a/packages/studio-base/src/services/migrateLegacyToNew3DPanels.ts
+++ b/packages/studio-base/src/services/migrateLegacyToNew3DPanels.ts
@@ -1,0 +1,165 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { round } from "lodash";
+import { MosaicNode } from "react-mosaic-component";
+
+import { filterMap } from "@foxglove/den/collection";
+import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import type { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderer";
+import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
+import {
+  getAllPanelIds,
+  getPanelIdForType,
+  getPanelTypeFromId,
+  isTabPanel,
+  isTabPanelConfig,
+} from "@foxglove/studio-base/util/layout";
+
+const DEFAULT_PUBLISH_SETTINGS: RendererConfig["publish"] = {
+  type: "point",
+  poseTopic: "/move_base_simple/goal",
+  pointTopic: "/clicked_point",
+  poseEstimateTopic: "/initialpose",
+  poseEstimateXDeviation: 0.5,
+  poseEstimateYDeviation: 0.5,
+  poseEstimateThetaDeviation: round(Math.PI / 12, 8),
+};
+type LegacyCameraState = {
+  distance: number;
+  perspective: boolean;
+  phi: number;
+  target: readonly [number, number, number];
+  targetOffset: readonly [number, number, number];
+  targetOrientation: readonly [number, number, number, number];
+  thetaOffset: number;
+  fovy: number;
+  near: number;
+  far: number;
+};
+type Legacy3DConfig = {
+  cameraState: Partial<LegacyCameraState>;
+  checkedKeys: string[];
+  clickToPublishPoseTopic: string;
+  clickToPublishPointTopic: string;
+  clickToPublishPoseEstimateTopic: string;
+  clickToPublishPoseEstimateXDeviation: number;
+  clickToPublishPoseEstimateYDeviation: number;
+  clickToPublishPoseEstimateThetaDeviation: number;
+  followMode?: "follow" | "follow-orientation" | "no-follow";
+  followTf?: string;
+};
+
+function migrateLegacyToNew3DConfig(legacyConfig: Partial<Legacy3DConfig>): RendererConfig {
+  return {
+    followTf: legacyConfig.followTf,
+    followMode:
+      legacyConfig.followMode === "follow-orientation"
+        ? "follow-pose"
+        : legacyConfig.followMode === "follow"
+        ? "follow-position"
+        : "follow-none",
+    cameraState: {
+      ...DEFAULT_CAMERA_STATE,
+      ...legacyConfig.cameraState,
+      phi: ((legacyConfig.cameraState?.phi ?? Math.PI / 3) * 180) / Math.PI,
+      thetaOffset: ((legacyConfig.cameraState?.thetaOffset ?? 0) * 180) / Math.PI,
+      fovy: ((legacyConfig.cameraState?.fovy ?? Math.PI / 4) * 180) / Math.PI,
+    },
+    publish: {
+      type: "point",
+      poseTopic: legacyConfig.clickToPublishPoseTopic ?? DEFAULT_PUBLISH_SETTINGS.poseTopic,
+      pointTopic: legacyConfig.clickToPublishPointTopic ?? DEFAULT_PUBLISH_SETTINGS.pointTopic,
+      poseEstimateTopic:
+        legacyConfig.clickToPublishPoseEstimateTopic ?? DEFAULT_PUBLISH_SETTINGS.poseEstimateTopic,
+      poseEstimateXDeviation:
+        legacyConfig.clickToPublishPoseEstimateXDeviation ??
+        DEFAULT_PUBLISH_SETTINGS.poseEstimateXDeviation,
+      poseEstimateYDeviation:
+        legacyConfig.clickToPublishPoseEstimateYDeviation ??
+        DEFAULT_PUBLISH_SETTINGS.poseEstimateYDeviation,
+      poseEstimateThetaDeviation:
+        legacyConfig.clickToPublishPoseEstimateThetaDeviation ??
+        DEFAULT_PUBLISH_SETTINGS.poseEstimateThetaDeviation,
+    },
+    topics: Object.fromEntries(
+      filterMap(legacyConfig.checkedKeys ?? [], (key) =>
+        key.startsWith("t:") ? [key.substring("t:".length), { visible: true }] : undefined,
+      ),
+    ),
+    scene: {},
+    transforms: {},
+    layers: {},
+  };
+}
+
+function replacePanelInLayout(
+  layout: MosaicNode<string>,
+  oldId: string,
+  newId: string,
+): MosaicNode<string> {
+  if (typeof layout === "string") {
+    return layout === oldId ? newId : layout;
+  } else {
+    return {
+      ...layout,
+      first: replacePanelInLayout(layout.first, oldId, newId),
+      second: replacePanelInLayout(layout.second, oldId, newId),
+    };
+  }
+}
+
+function replacePanel(
+  panelsState: PanelsState,
+  oldId: string,
+  newId: string,
+  newConfig: Record<string, unknown>,
+): PanelsState {
+  const newPanelsState = {
+    ...panelsState,
+    configById: { ...panelsState.configById, [newId]: newConfig },
+  };
+  delete newPanelsState.configById[oldId];
+  if (newPanelsState.layout != undefined) {
+    newPanelsState.layout = replacePanelInLayout(newPanelsState.layout, oldId, newId);
+    const tabPanelIds = Object.keys(newPanelsState.configById).filter(isTabPanel);
+    for (const tabId of tabPanelIds) {
+      const tabConfig = newPanelsState.configById[tabId];
+      if (isTabPanelConfig(tabConfig)) {
+        newPanelsState.configById[tabId] = {
+          ...tabConfig,
+          tabs: tabConfig.tabs.map((tab) => ({
+            ...tab,
+            layout:
+              tab.layout != undefined ? replacePanelInLayout(tab.layout, oldId, newId) : undefined,
+          })),
+        };
+      }
+    }
+  }
+  return newPanelsState;
+}
+
+export function migrateLegacyToNew3DPanels(panelsState: PanelsState): PanelsState {
+  if (panelsState.layout == undefined) {
+    return panelsState;
+  }
+
+  const legacy3DPanels = getAllPanelIds(panelsState.layout, panelsState.configById).filter(
+    (id) => getPanelTypeFromId(id) === "3D Panel",
+  );
+  let newState = panelsState;
+  for (const id of legacy3DPanels) {
+    const legacyConfig = panelsState.configById[id] as Legacy3DConfig | undefined;
+    if (legacyConfig != undefined) {
+      newState = replacePanel(
+        newState,
+        id,
+        getPanelIdForType("3D"),
+        migrateLegacyToNew3DConfig(legacyConfig),
+      );
+    }
+  }
+  return newState;
+}

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -61,7 +61,7 @@ export function isTabPanel(panelId: string): boolean {
 }
 
 export function isTabPanelConfig(config: PanelConfig | undefined): config is TabPanelConfig {
-  return config != undefined && "tabs" in config && "activeTabIndex" in config;
+  return config != undefined && "tabs" in config && "activeTabIdx" in config;
 }
 
 // Traverses `tree` to find the path to the specified `node`


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds a permanent auto-migration of all Legacy 3D panels to new 3D panels.
This migration is commented out for now. It will be enabled in https://github.com/foxglove/studio/pull/4450.