### PR TITLE
Support parsing Uint8Arrays from flatbuffer encoded messages

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -34,7 +34,7 @@
     "@foxglove/wasm-bz2": "0.1.0",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "2.0.6",
-    "flatbuffers_reflection": "0.0.1",
+    "flatbuffers_reflection": "patch:flatbuffers_reflection@0.0.1#../../patches/flatbuffers_reflection.patch",
     "protobufjs": "7.1.2",
     "wasm-lz4": "2.0.0",
     "zstd-codec": "patch:zstd-codec@0.1.4#../../patches/zstd-codec.patch"

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -39,6 +39,20 @@ describe("parseChannel", () => {
     expect(deserialized.objects[0]!.name).toEqual("reflection.Enum");
   });
 
+  it("works with flatbuffers", () => {
+    const reflectionSchema = fs.readFileSync(`${__dirname}/fixtures/reflection.bfbs`);
+    const channel = parseChannel({
+      messageEncoding: "flatbuffers",
+      schema: { name: "reflection.Schema", encoding: "flatbuffers", data: reflectionSchema },
+    });
+    expect(channel.fullSchemaName).toEqual("reflection.Schema");
+    const deserialized = channel.deserializer(reflectionSchema) as {
+      objects: Record<string, unknown>[];
+    };
+    expect(deserialized.objects.length).toEqual(10);
+    expect(deserialized.objects[0]!.name).toEqual("reflection.Enum");
+  });
+
   it("works with protobuf", () => {
     const fds = FileDescriptorSet.encode(FileDescriptorSet.root.toDescriptor("proto3")).finish();
     const channel = parseChannel({

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -39,20 +39,6 @@ describe("parseChannel", () => {
     expect(deserialized.objects[0]!.name).toEqual("reflection.Enum");
   });
 
-  it("works with flatbuffers", () => {
-    const reflectionSchema = fs.readFileSync(`${__dirname}/fixtures/reflection.bfbs`);
-    const channel = parseChannel({
-      messageEncoding: "flatbuffers",
-      schema: { name: "reflection.Schema", encoding: "flatbuffers", data: reflectionSchema },
-    });
-    expect(channel.fullSchemaName).toEqual("reflection.Schema");
-    const deserialized = channel.deserializer(reflectionSchema) as {
-      objects: Record<string, unknown>[];
-    };
-    expect(deserialized.objects.length).toEqual(10);
-    expect(deserialized.objects[0]!.name).toEqual("reflection.Enum");
-  });
-
   it("works with protobuf", () => {
     const fds = FileDescriptorSet.encode(FileDescriptorSet.root.toDescriptor("proto3")).finish();
     const channel = parseChannel({

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -81,16 +81,14 @@ export function parseChannel(channel: Channel): ParsedChannel {
     return { fullSchemaName: channel.schema.name, deserializer, datatypes };
   }
 
-  if (channel.messageEncoding === "flatbuffer" || channel.messageEncoding === "flatbuffers") {
-    if (
-      !(channel.schema?.encoding === "flatbuffer" || channel.schema?.encoding === "flatbuffers")
-    ) {
+  if (channel.messageEncoding === "flatbuffer") {
+    if (channel.schema?.encoding !== "flatbuffer") {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
             ? "no encoding"
             : `schema encoding '${channel.schema.encoding}'`
-        } is not supported (expected 'flatbuffer' or 'flatbuffers')`,
+        } is not supported (expected 'flatbuffer')`,
       );
     }
     return parseFlatbufferSchema(channel.schema.name, channel.schema.data);

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -81,14 +81,16 @@ export function parseChannel(channel: Channel): ParsedChannel {
     return { fullSchemaName: channel.schema.name, deserializer, datatypes };
   }
 
-  if (channel.messageEncoding === "flatbuffer") {
-    if (channel.schema?.encoding !== "flatbuffer") {
+  if (channel.messageEncoding === "flatbuffer" || channel.messageEncoding === "flatbuffers") {
+    if (
+      !(channel.schema?.encoding === "flatbuffer" || channel.schema?.encoding === "flatbuffers")
+    ) {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
             ? "no encoding"
             : `schema encoding '${channel.schema.encoding}'`
-        } is not supported (expected flatbuffer)`,
+        } is not supported (expected 'flatbuffer' or 'flatbuffers')`,
       );
     }
     return parseFlatbufferSchema(channel.schema.name, channel.schema.data);

--- a/patches/flatbuffers_reflection.patch
+++ b/patches/flatbuffers_reflection.patch
@@ -1,0 +1,61 @@
+diff --git a/src/reflection.ts b/src/reflection.ts
+index 6d946100786d9d207aa9a917ff946928a30af19d..eb468c3ad03ea0672d4067fa57416ccfdf965009 100644
+--- a/src/reflection.ts
++++ b/src/reflection.ts
+@@ -409,17 +409,14 @@ export class Parser {
+   }
+   // Reads a vector of scalars (like readScalar, may return a vector of BigInt's
+   // instead). Also, will return null if the vector is not set.
+-  // TODO(jkuszmaul): Allow this to return a slice into the underlying
+-  // ByteBuffer to avoid excessive memory allocation (at least for vectors of
+-  // bytes, which is a common way to transmit images).
+-  readVectorOfScalars(table: Table, fieldName: string): (number | BigInt)[] | null {
++  readVectorOfScalars(table: Table, fieldName: string): (number | BigInt)[] | Uint8Array | null {
+     return this.readVectorOfScalarsLambda(table.typeIndex, fieldName)(table);
+   }
+
+   readVectorOfScalarsLambda(
+     typeIndex: number,
+     fieldName: string,
+-  ): (t: Table) => (number | BigInt)[] | null {
++  ): (t: Table) => (number | BigInt)[] | Uint8Array | null {
+     const field = this.getField(fieldName, typeIndex);
+     const fieldType = field.type();
+     if (fieldType === null) {
+@@ -428,21 +425,32 @@ export class Parser {
+     if (fieldType.baseType() !== reflection.BaseType.Vector) {
+       throw new Error("Field " + fieldName + " is not an vector.");
+     }
+-    if (!isScalar(fieldType.element())) {
++    const elementType = fieldType.element();
++    if (!isScalar(elementType)) {
+       throw new Error("Field " + fieldName + " is not an vector of scalars.");
+     }
++    const isByteVector =
++      elementType === reflection.BaseType.UByte || elementType === reflection.BaseType.Byte;
+
+     return (table: Table) => {
+       const offsetToOffset = table.offset + table.bb.__offset(table.offset, field.offset());
+       if (offsetToOffset === table.offset) {
+         return null;
+       }
++
+       const numElements = table.bb.__vector_len(offsetToOffset);
+-      const result = [];
+       const baseOffset = table.bb.__vector(offsetToOffset);
+       const scalarSize = typeSize(fieldType.element());
+-      for (let ii = 0; ii < numElements; ++ii) {
+-        result.push(table.readScalar(fieldType.element(), baseOffset + scalarSize * ii));
++
++      let result: (number | BigInt)[] | Uint8Array;
++      // If the vector is a byte vector, we can return a slice into the buffer
++      if (isByteVector) {
++        result = new Uint8Array(table.bb.bytes().buffer, baseOffset, numElements);
++      } else {
++        result = [];
++        for (let ii = 0; ii < numElements; ++ii) {
++          result.push(table.readScalar(fieldType.element(), baseOffset + scalarSize * ii));
++        }
+       }
+       return result;
+     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,7 +2308,7 @@ __metadata:
     "@types/protobufjs": "workspace:*"
     "@types/zstd-codec": "workspace:*"
     flatbuffers: 2.0.6
-    flatbuffers_reflection: 0.0.1
+    flatbuffers_reflection: "patch:flatbuffers_reflection@0.0.1#../../patches/flatbuffers_reflection.patch"
     protobufjs: 7.1.2
     typescript: 4.8.2
     wasm-lz4: 2.0.0
@@ -12720,6 +12720,13 @@ __metadata:
   version: 0.0.1
   resolution: "flatbuffers_reflection@npm:0.0.1"
   checksum: 6ea9cceade8f25d4f7d564efe93c7c513869aa85c6d55884f6cc5462097e115d36d311a0acbeedd655c346721a5cc699676a20ea215cad07ab71d637e0b96227
+  languageName: node
+  linkType: hard
+
+"flatbuffers_reflection@patch:flatbuffers_reflection@0.0.1#../../patches/flatbuffers_reflection.patch::locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support":
+  version: 0.0.1
+  resolution: "flatbuffers_reflection@patch:flatbuffers_reflection@npm%3A0.0.1#../../patches/flatbuffers_reflection.patch::version=0.0.1&hash=4e4600&locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support"
+  checksum: 281e5eadd897f02a12beb024610656fa634165af15acf4d945a3ac099ecc3c1aee5e84ce033011b5bd5204695a924c6c0f51675a7eabca7f13e0648316c16fa6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
- support 'flatbuffers' encoding (in addition to 'flatbuffer') to be consistent with `flatbuffers` library

**Description**
 - flatbuffers and flatbuffer are used mostly interchangably in code, but to be consistent with the library name and prevent headaches in the future it is probably wise for us to support both

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
