### PR TITLE
Retry subscription when websocket connection is established

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -399,10 +399,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   public setSubscriptions(subscriptions: SubscribePayload[]): void {
+    const newTopics = new Set(subscriptions.map(({ topic }) => topic));
+
     if (!this._client || this._closed) {
+      // Remember requested subscriptions so we can retry subscribing when
+      // the client is available.
+      this._unresolvedSubscriptions = newTopics;
       return;
     }
-    const newTopics = new Set(subscriptions.map(({ topic }) => topic));
 
     for (const topic of newTopics) {
       if (!this._resolvedSubscriptionsByTopic.has(topic)) {


### PR DESCRIPTION
**User-Facing Changes**
Fixes resubscribing to topics when a ws-protocol connection is broken and reestablished.

**Description**
Currently when we receive subscription requests while the player is disconnected we simply discard them. This makes an effort to remember the requested topics and re-subscribe once the connection is established, in a similar manner to the ROS1 player.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4834