### PR TITLE
Fix erroneous duplicate channel warning in websocket player

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -3,23 +3,24 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as base64 from "@protobufjs/base64";
+import { isEqual } from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
 import { debouncePromise } from "@foxglove/den/async";
 import Log from "@foxglove/log";
 import { parseChannel, ParsedChannel } from "@foxglove/mcap-support";
-import { Time, fromNanoSec, isLessThan, isGreaterThan } from "@foxglove/rostime";
+import { fromNanoSec, isGreaterThan, isLessThan, Time } from "@foxglove/rostime";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
 import {
+  AdvertiseOptions,
   MessageEvent,
   Player,
   PlayerCapabilities,
+  PlayerMetricsCollectorInterface,
+  PlayerPresence,
   PlayerState,
   SubscribePayload,
   Topic,
-  PlayerPresence,
-  PlayerMetricsCollectorInterface,
-  AdvertiseOptions,
   TopicStats,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
@@ -35,14 +36,6 @@ const CAPABILITIES: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][]
 const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 
 type ResolvedChannel = { channel: Channel; parsedChannel: ParsedChannel };
-
-function areChannelsEqual(channelA: Readonly<Channel>, channelB: Readonly<Channel>) {
-  return (
-    channelA.id === channelB.id &&
-    channelA.topic === channelB.topic &&
-    channelA.schemaName === channelB.schemaName
-  );
-}
 
 export default class FoxgloveWebSocketPlayer implements Player {
   private _url: string; // WebSocket URL.
@@ -198,7 +191,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           continue;
         }
         const existingChannel = this._channelsByTopic.get(channel.topic);
-        if (existingChannel && !areChannelsEqual(channel, existingChannel.channel)) {
+        if (existingChannel && !isEqual(channel, existingChannel.channel)) {
           this._problems.addProblem(`duplicate-topic:${channel.topic}`, {
             severity: "error",
             message: `Multiple channels advertise the same topic: ${channel.topic} (${existingChannel.channel.id} and ${channel.id})`,

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -36,6 +36,14 @@ const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 
 type ResolvedChannel = { channel: Channel; parsedChannel: ParsedChannel };
 
+function areChannelsEqual(channelA: Readonly<Channel>, channelB: Readonly<Channel>) {
+  return (
+    channelA.id === channelB.id &&
+    channelA.topic === channelB.topic &&
+    channelA.schemaName === channelB.schemaName
+  );
+}
+
 export default class FoxgloveWebSocketPlayer implements Player {
   private _url: string; // WebSocket URL.
   private _name: string;
@@ -190,7 +198,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           continue;
         }
         const existingChannel = this._channelsByTopic.get(channel.topic);
-        if (existingChannel) {
+        if (existingChannel && !areChannelsEqual(channel, existingChannel.channel)) {
           this._problems.addProblem(`duplicate-topic:${channel.topic}`, {
             severity: "error",
             message: `Multiple channels advertise the same topic: ${channel.topic} (${existingChannel.channel.id} and ${channel.id})`,


### PR DESCRIPTION
**User-Facing Changes**
Fixes an extraneous warning shown for some websocket datasources.

**Description**
The existing logic adds a player problem if we see an advertised channel twice. We really only need to show this if two different channels are advertised on the same topic. The change here is to compare the new and previous channels to catch any changes in the channel id or schema name. 

I didn't include the content of the schemas in this equality check since they could be larger objects but maybe they should be included for correctness?

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4788