### PR TITLE
Clamp values outside range for PointCloud and Grid coloring

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -795,7 +795,7 @@ function createMaterial(texture: THREE.DataTexture, topic: string): GridShaderMa
           // input color was already converted to linear by getColorConverter
           float delta = max(maxValue - minValue, 0.00001);
           float colorValue = color.r;
-          float normalizedColorValue = (colorValue - minValue) / delta;
+          float normalizedColorValue = clamp((colorValue - minValue) / delta, 0.0, 1.0);
           if(colorMode == COLOR_MODE_GRADIENT) {
             /**
             * Computes a gradient step from colors a to b using pre-multiplied alpha to

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -52,7 +52,7 @@ export function getColorConverter<
       rgbaToLinear(minColor, minColor);
       rgbaToLinear(maxColor, maxColor);
       return (output: ColorRGBA, colorValue: number) => {
-        const t = (colorValue - minValue) / valueDelta;
+        const t = Math.max(0, Math.min((colorValue - minValue) / valueDelta, 1));
         rgbaGradient(output, minColor, maxColor, t);
       };
     }
@@ -61,13 +61,13 @@ export function getColorConverter<
       switch (settings.colorMap) {
         case "turbo":
           return (output: ColorRGBA, colorValue: number) => {
-            const t = (colorValue - minValue) / valueDelta;
+            const t = Math.max(0, Math.min((colorValue - minValue) / valueDelta, 1));
             turboLinearCached(output, t);
             output.a = settings.explicitAlpha;
           };
         case "rainbow":
           return (output: ColorRGBA, colorValue: number) => {
-            const t = (colorValue - minValue) / valueDelta;
+            const t = Math.max(0, Math.min((colorValue - minValue) / valueDelta, 1));
             rainbowLinear(output, t);
             output.a = settings.explicitAlpha;
           };

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -57,7 +57,13 @@ function copyGridAtPosition(
   };
 }
 
-function Foxglove_Grid_Uint8(): JSX.Element {
+function Foxglove_Grid_Uint8({
+  minValue,
+  maxValue,
+}: {
+  minValue?: number;
+  maxValue?: number;
+}): JSX.Element {
   const topics: Topic[] = [
     { name: "/grid", schemaName: "foxglove.Grid" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -216,24 +222,32 @@ function Foxglove_Grid_Uint8(): JSX.Element {
               colorField: "checkerboard",
               colorMode: "gradient",
               gradient: ["#ff0000ff", "#00ff0001"],
+              minValue,
+              maxValue,
             } as LayerSettingsFoxgloveGrid,
             "/grid2": {
               visible: true,
               colorField: "gradient",
               colorMode: "colormap",
               colorMap: "rainbow",
+              minValue,
+              maxValue,
             } as LayerSettingsFoxgloveGrid,
             "/grid3": {
               visible: true,
               colorField: "gradient",
               colorMode: "colormap",
               colorMap: "turbo",
+              minValue,
+              maxValue,
             } as LayerSettingsFoxgloveGrid,
             "/grid4": {
               visible: true,
               colorField: "colStripes",
               colorMode: "colormap",
               colorMap: "turbo",
+              minValue,
+              maxValue,
             } as LayerSettingsFoxgloveGrid,
           },
           layers: {
@@ -397,7 +411,13 @@ function Foxglove_Grid_RGBA(): JSX.Element {
   );
 }
 
-function Foxglove_Grid_Float(): JSX.Element {
+function Foxglove_Grid_Float({
+  minValue,
+  maxValue,
+}: {
+  minValue?: number;
+  maxValue?: number;
+}): JSX.Element {
   const topics: Topic[] = [
     { name: "/grid", schemaName: "foxglove.Grid" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -496,8 +516,8 @@ function Foxglove_Grid_Float(): JSX.Element {
               colorField: "height",
               colorMode: "gradient",
               gradient: ["#ffffffFF", "#ff00bb80"],
-              minValue: -0.25,
-              maxValue: 0.25,
+              minValue: minValue ?? -0.25,
+              maxValue: maxValue ?? 0.25,
             } as LayerSettingsFoxgloveGrid,
           },
           layers: {
@@ -645,6 +665,12 @@ function Row_Stride_Grid(): JSX.Element {
   );
 }
 export const Foxglove_Grid_Uint8_Values = (): JSX.Element => <Foxglove_Grid_Uint8 />;
+export const Foxglove_Grid_Uint8_Values_Clamped = (): JSX.Element => (
+  <Foxglove_Grid_Uint8 minValue={30} maxValue={80} />
+);
 export const Foxglove_Grid_RGBA_Values = (): JSX.Element => <Foxglove_Grid_RGBA />;
 export const Foxglove_Grid_Float_Values = (): JSX.Element => <Foxglove_Grid_Float />;
+export const Foxglove_Grid_Float_Values_Clamped = (): JSX.Element => (
+  <Foxglove_Grid_Float minValue={0.05} maxValue={0.1} />
+);
 export const Foxglove_Grid_Padded_Row = (): JSX.Element => <Row_Stride_Grid />;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -27,11 +27,23 @@ export const Foxglove_PointCloud_RGBA = (): JSX.Element => <Foxglove_PointCloud 
 export const Foxglove_PointCloud_RGBA_Square = (): JSX.Element => (
   <Foxglove_PointCloud pointShape="square" />
 );
+export const Foxglove_PointCloud_Gradient = (): JSX.Element => (
+  <Foxglove_PointCloud colorMode="gradient" />
+);
+export const Foxglove_PointCloud_Gradient_Clamped = (): JSX.Element => (
+  <Foxglove_PointCloud colorMode="gradient" minValue={-2} maxValue={2} />
+);
 
 function Foxglove_PointCloud({
   pointShape = "circle",
+  colorMode = "rgba-fields",
+  minValue,
+  maxValue,
 }: {
   pointShape?: "circle" | "square";
+  colorMode?: "gradient" | "rgba-fields";
+  minValue?: number;
+  maxValue?: number;
 }): JSX.Element {
   const topics: Topic[] = [
     { name: "/pointcloud", schemaName: "foxglove.PointCloud" },
@@ -141,8 +153,11 @@ function Foxglove_PointCloud({
               visible: true,
               pointSize: 10,
               pointShape,
-              colorMode: "rgba-fields",
+              colorMode,
               colorField: "x",
+              gradient: ["#17b3f6", "#09e609d5"],
+              minValue,
+              maxValue,
             },
           },
           layers: {
@@ -166,7 +181,13 @@ function Foxglove_PointCloud({
   );
 }
 
-export function Foxglove_PointCloud_Intensity(): JSX.Element {
+export function Foxglove_PointCloud_Intensity({
+  minValue,
+  maxValue,
+}: {
+  minValue?: number;
+  maxValue?: number;
+}): JSX.Element {
   const topics: Topic[] = [
     { name: "/pointcloud", schemaName: "foxglove.PointCloud" },
     { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
@@ -313,6 +334,8 @@ export function Foxglove_PointCloud_Intensity(): JSX.Element {
             "/pointcloud": {
               visible: true,
               pointSize: 5,
+              minValue,
+              maxValue,
             },
           },
           layers: {
@@ -335,6 +358,11 @@ export function Foxglove_PointCloud_Intensity(): JSX.Element {
     </PanelSetup>
   );
 }
+
+export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensity.bind(undefined, {
+  minValue: 80,
+  maxValue: 130,
+});
 
 // Render a flat plane if we only have two dimensions
 export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -181,7 +181,7 @@ function Foxglove_PointCloud({
   );
 }
 
-export function Foxglove_PointCloud_Intensity({
+function Foxglove_PointCloud_Intensity_Base({
   minValue,
   maxValue,
 }: {
@@ -359,10 +359,15 @@ export function Foxglove_PointCloud_Intensity({
   );
 }
 
-export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensity.bind(undefined, {
-  minValue: 80,
-  maxValue: 130,
-});
+export const Foxglove_PointCloud_Intensity = Foxglove_PointCloud_Intensity_Base.bind(undefined, {});
+
+export const Foxglove_PointCloud_Intensity_Clamped = Foxglove_PointCloud_Intensity_Base.bind(
+  undefined,
+  {
+    minValue: 80,
+    maxValue: 130,
+  },
+);
 
 // Render a flat plane if we only have two dimensions
 export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {


### PR DESCRIPTION
**User-Facing Changes**
Fixed: Colors for PointCloud and Grid messages are now clamped to minimum and maximum values, rather than displaying incorrect colors when a value is outside the selected range.

**Description**
Fixes https://github.com/foxglove/studio/issues/4832
