### PR TITLE
Remove InitialRefreshAdapter from ExtensionCatalogProvider

### DIFF
--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -12,7 +12,6 @@ import {
   ExtensionCatalog,
   ExtensionCatalogContext,
   RegisteredPanel,
-  useExtensionCatalog,
 } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { ExtensionLoader } from "@foxglove/studio-base/services/ExtensionLoader";
 import { ExtensionInfo, ExtensionNamespace } from "@foxglove/studio-base/types/Extensions";
@@ -141,25 +140,19 @@ export function createExtensionRegistryStore(
   }));
 }
 
-function InitialRefreshAdapter(): ReactNull {
-  const refreshExtensions = useExtensionCatalog((state) => state.refreshExtensions);
-  useEffect(() => {
-    refreshExtensions().catch((err) => log.error(err));
-  }, [refreshExtensions]);
-
-  return ReactNull;
-}
-
 export default function ExtensionCatalogProvider({
   children,
   loaders,
 }: PropsWithChildren<{ loaders: readonly ExtensionLoader[] }>): JSX.Element {
   const [store] = useState(createExtensionRegistryStore(loaders));
 
+  // Request an initial refresh on first mount
+  const refreshExtensions = store.getState().refreshExtensions;
+  useEffect(() => {
+    refreshExtensions().catch((err) => log.error(err));
+  }, [refreshExtensions]);
+
   return (
-    <ExtensionCatalogContext.Provider value={store}>
-      <InitialRefreshAdapter />
-      {children}
-    </ExtensionCatalogContext.Provider>
+    <ExtensionCatalogContext.Provider value={store}>{children}</ExtensionCatalogContext.Provider>
   );
 }


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Roll this into the ExtensionCatalogProvider component logic directly. I find this a bit cleaner to reason about.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
