### PR TITLE
Fix react render error in map panel

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -157,8 +157,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   // an existing resize observation.
   // https://github.com/maslianok/react-resize-detector/issues/45
   const {
-    width: mapWidth,
-    height: mapHeight,
+    width: panelWidth,
+    height: panelHeight,
     ref: sizeRef,
   } = useResizeDetector({
     refreshRate: 0,
@@ -166,11 +166,11 @@ function MapPanel(props: MapPanelProps): JSX.Element {
   });
 
   useEffect(() => {
-    // We depend on changes in the resized dimensions to tell the Leaflet map to
+    // We depend on changes in the resized panel dimensions to tell the Leaflet map to
     // recalculate its size.
-    void { mapWidth, mapHeight };
+    void { panelWidth, panelHeight };
     currentMap?.invalidateSize();
-  }, [mapWidth, mapHeight, currentMap]);
+  }, [panelWidth, panelHeight, currentMap]);
 
   // panel extensions must notify when they've completed rendering
   // onRender will setRenderDone to a done callback which we can invoke after we've rendered

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -167,7 +167,9 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   useEffect(() => {
     // We depend on changes in the resized panel dimensions to tell the Leaflet map to
-    // recalculate its size.
+    // recalculate its size. We do this inside a separate useEffect instead of directly
+    // in the map's change callbacks to avoid a react error from calling setState
+    // during a render.
     void { panelWidth, panelHeight };
     currentMap?.invalidateSize();
   }, [panelWidth, panelHeight, currentMap]);

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -153,18 +153,24 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const [currentMap, setCurrentMap] = useState<LeafMap | undefined>(undefined);
 
-  const onResize = useCallback(() => {
-    currentMap?.invalidateSize();
-  }, [currentMap]);
-
   // Use a debounce and 0 refresh rate to avoid triggering a resize observation while handling
   // an existing resize observation.
   // https://github.com/maslianok/react-resize-detector/issues/45
-  const { ref: sizeRef } = useResizeDetector({
+  const {
+    width: mapWidth,
+    height: mapHeight,
+    ref: sizeRef,
+  } = useResizeDetector({
     refreshRate: 0,
     refreshMode: "debounce",
-    onResize,
   });
+
+  useEffect(() => {
+    // We depend on changes in the resized dimensions to tell the Leaflet map to
+    // recalculate its size.
+    void { mapWidth, mapHeight };
+    currentMap?.invalidateSize();
+  }, [mapWidth, mapHeight, currentMap]);
 
   // panel extensions must notify when they've completed rendering
   // onRender will setRenderDone to a done callback which we can invoke after we've rendered


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes a react render warning in the map panel by using a useEffect that depends on the size returned by the resize observer to invalidate the map size instead of trying to write the new size into the layout directly in the resize handler.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4854