### PR TITLE
Sync 3d panel camera states

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -44,7 +44,10 @@ import {
   PlayerCapabilities,
   SubscribePayload,
 } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import {
+  usePanelSettingsTreeUpdate,
+  useSharedPanelState,
+} from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { assertNever } from "@foxglove/studio-base/util/assertNever";
 
@@ -141,6 +144,8 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   // Spiritually its like a reducer
   const [buildRenderState, setBuildRenderState] = useState(() => initRenderStateBuilder());
 
+  const [sharedPanelState, setSharedPanelState] = useSharedPanelState();
+
   // Register handlers to update the app settings we subscribe to
   useEffect(() => {
     const handlers = new Map<string, (newValue: AppSettingValue) => void>();
@@ -188,16 +193,17 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     }
 
     const renderState = buildRenderState({
-      watchedFields,
+      appSettings,
+      colorScheme,
+      currentFrame: messageEvents,
       globalVariables,
       hoverValue,
-      playerState,
-      colorScheme,
-      appSettings,
-      subscriptions: localSubscriptions,
-      currentFrame: messageEvents,
-      sortedTopics,
       messageConverters,
+      playerState,
+      sharedPanelState,
+      sortedTopics,
+      subscriptions: localSubscriptions,
+      watchedFields,
     });
 
     if (!renderState) {
@@ -231,20 +237,21 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
       setError(err);
     }
   }, [
+    appSettings,
+    buildRenderState,
+    colorScheme,
+    globalVariables,
+    hoverValue,
+    localSubscriptions,
+    messageConverters,
+    messageEvents,
     panelId,
     pauseFrame,
-    localSubscriptions,
-    watchedFields,
-    appSettings,
-    hoverValue,
     playerState,
-    messageEvents,
-    messageConverters,
     renderFn,
-    colorScheme,
-    buildRenderState,
-    globalVariables,
+    sharedPanelState,
     sortedTopics,
+    watchedFields,
   ]);
 
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
@@ -328,6 +335,8 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
           });
         }
       },
+
+      setSharedPanelState,
 
       watch: (field: keyof RenderState) => {
         if (!isMounted()) {
@@ -449,6 +458,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     seekPlayback,
     setGlobalVariables,
     setHoverValue,
+    setSharedPanelState,
     setSubscriptions,
     updatePanelSettingsTree,
   ]);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -15,6 +15,7 @@ describe("renderState", () => {
       colorScheme: undefined,
       globalVariables: {},
       hoverValue: undefined,
+      sharedPanelState: {},
       sortedTopics: [{ name: "test", schemaName: "schema" }],
       subscriptions: [],
       messageConverters: [
@@ -49,6 +50,7 @@ describe("renderState", () => {
       colorScheme: undefined,
       globalVariables: {},
       hoverValue: undefined,
+      sharedPanelState: {},
       sortedTopics: [{ name: "test", schemaName: "schema" }],
       subscriptions: [{ topic: "test", convertTo: "schema" }],
       messageConverters: [],
@@ -93,6 +95,7 @@ describe("renderState", () => {
       colorScheme: undefined,
       globalVariables: {},
       hoverValue: undefined,
+      sharedPanelState: {},
       sortedTopics: [
         { name: "another", schemaName: "schema" },
         { name: "test", schemaName: "schema" },
@@ -136,6 +139,7 @@ describe("renderState", () => {
       colorScheme: undefined,
       globalVariables: {},
       hoverValue: undefined,
+      sharedPanelState: {},
       sortedTopics: [{ name: "test", schemaName: "schema" }],
       subscriptions: [{ topic: "test" }, { topic: "test", convertTo: "otherSchema" }],
       messageConverters: [
@@ -199,6 +203,7 @@ describe("renderState", () => {
       colorScheme: undefined,
       globalVariables: {},
       hoverValue: undefined,
+      sharedPanelState: {},
       sortedTopics: [
         { name: "another", schemaName: "srcschema" },
         { name: "test", schemaName: "srcschemade" },

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -25,16 +25,17 @@ const log = Log.getLogger(__filename);
 const EmptyParameters = new Map<string, ParameterValue>();
 
 type BuilderRenderStateInput = {
-  watchedFields: Set<string>;
-  playerState: PlayerState | undefined;
   appSettings: Map<string, AppSettingValue> | undefined;
-  currentFrame: MessageEvent<unknown>[] | undefined;
   colorScheme: RenderState["colorScheme"] | undefined;
+  currentFrame: MessageEvent<unknown>[] | undefined;
   globalVariables: GlobalVariables;
   hoverValue: HoverValue | undefined;
+  messageConverters?: RegisterMessageConverterArgs<unknown>[];
+  playerState: PlayerState | undefined;
+  sharedPanelState: Record<string, unknown> | undefined;
   sortedTopics: readonly PlayerTopic[];
   subscriptions: Subscription[];
-  messageConverters?: RegisterMessageConverterArgs<unknown>[];
+  watchedFields: Set<string>;
 };
 
 type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderState> | undefined;
@@ -64,6 +65,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   let prevSubscriptions: BuilderRenderStateInput["subscriptions"];
   let prevSortedTopics: BuilderRenderStateInput["sortedTopics"] | undefined;
   let prevMessageConverters: BuilderRenderStateInput["messageConverters"] | undefined;
+  let prevSharedPanelState: BuilderRenderStateInput["sharedPanelState"];
 
   // Topics which we are subscribed without a conversion, these are topics we want to receive the original message
   const topicNoConversions: Set<string> = new Set();
@@ -78,16 +80,17 @@ function initRenderStateBuilder(): BuildRenderStateFn {
 
   return function buildRenderState(input: BuilderRenderStateInput) {
     const {
-      playerState,
-      watchedFields,
       appSettings,
-      currentFrame,
       colorScheme,
+      currentFrame,
       globalVariables,
       hoverValue,
-      sortedTopics,
       messageConverters,
+      playerState,
+      sharedPanelState,
+      sortedTopics,
       subscriptions,
+      watchedFields,
     } = input;
 
     // If the player has loaded all the blocks, the blocks reference won't change so our message
@@ -141,6 +144,14 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       if (parameters !== renderState.parameters) {
         shouldRender = true;
         renderState.parameters = parameters;
+      }
+    }
+
+    if (watchedFields.has("sharedPanelState")) {
+      if (sharedPanelState !== prevSharedPanelState) {
+        shouldRender = true;
+        prevSharedPanelState = sharedPanelState;
+        renderState.sharedPanelState = { ...sharedPanelState };
       }
     }
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -151,7 +151,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       if (sharedPanelState !== prevSharedPanelState) {
         shouldRender = true;
         prevSharedPanelState = sharedPanelState;
-        renderState.sharedPanelState = { ...sharedPanelState };
+        renderState.sharedPanelState = sharedPanelState;
       }
     }
 

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -29,7 +29,7 @@ export type PanelStateStore = {
   settingsTrees: Record<string, ImmutableSettingsTree>;
 
   /**
-   * Transient state shared between panels of the same type.
+   * Transient state shared between panels, keyed by panel type.
    */
   sharedPanelState: Record<PanelType, SharedPanelState>;
 

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -6,10 +6,14 @@ import { createContext } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { useStore, StoreApi } from "zustand";
 
-import { SettingsTree } from "@foxglove/studio";
+import { RenderState, SettingsTree } from "@foxglove/studio";
 import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
 
 export type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
+
+export type SharedPanelState = RenderState["sharedPanelState"];
+
+type PanelType = string;
 
 export type PanelStateStore = {
   /**
@@ -25,6 +29,11 @@ export type PanelStateStore = {
   settingsTrees: Record<string, ImmutableSettingsTree>;
 
   /**
+   * Transient state shared between panels of the same type.
+   */
+  sharedPanelState: Record<PanelType, SharedPanelState>;
+
+  /**
    * Increments the sequence number for the panel, forcing a remount.
    */
   incrementSequenceNumber: (panelId: string) => void;
@@ -33,6 +42,11 @@ export type PanelStateStore = {
    * Updates the settings UI for the given panel.
    */
   updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
+
+  /**
+   * Update the transient state associated with a particular panel type.
+   */
+  updateSharedPanelState: (type: PanelType, data: SharedPanelState) => void;
 };
 
 export const PanelStateContext = createContext<undefined | StoreApi<PanelStateStore>>(undefined);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -136,6 +136,8 @@ export type RendererConfig = {
       /** Enable transform preloading */
       enablePreloading?: boolean;
     };
+    /** Sync camera with other 3d panels */
+    syncCamera?: boolean;
     /** Toggles visibility of all topics */
     topicsVisible?: boolean;
   };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -327,6 +327,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
   private _pickingEnabled = false;
   private _isUpdatingCameraState = false;
   private _animationFrame?: number;
+  private _cameraSyncError: undefined | string;
 
   public constructor(canvas: HTMLCanvasElement, config: RendererConfig) {
     super();
@@ -518,6 +519,15 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.picker.dispose();
     this.input.dispose();
     this.gl.dispose();
+  }
+
+  public cameraSyncError(): undefined | string {
+    return this._cameraSyncError;
+  }
+
+  public setCameraSyncError(error: undefined | string): void {
+    this._cameraSyncError = error;
+    this.updateCoreSettings();
   }
 
   public getPixelRatio(): number {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -711,7 +711,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
   // Sync camera with shared state, if enabled.
   useEffect(() => {
-    if (!renderer || sharedPanelState == undefined || config.scene.syncCamera === false) {
+    if (!renderer || sharedPanelState == undefined || config.scene.syncCamera !== true) {
       return;
     }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -716,10 +716,12 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     }
 
     if (sharedPanelState.followMode !== renderer.followMode) {
-      renderer.setCameraSyncError(`Follow mode must be ${renderer.followMode} to sync camera.`);
+      renderer.setCameraSyncError(
+        `Follow mode must be ${sharedPanelState.followMode} to sync camera.`,
+      );
     } else if (sharedPanelState.followTf !== renderer.followFrameId) {
       renderer.setCameraSyncError(
-        `Display frame must be ${renderer.followFrameId} to sync camera.`,
+        `Display frame must be ${sharedPanelState.followTf} to sync camera.`,
       );
     } else {
       const newCameraState = sharedPanelState.cameraState;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -37,7 +37,6 @@ import {
 import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
-import { SharedPanelState } from "@foxglove/studio-base/context/PanelStateContext";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
@@ -45,7 +44,13 @@ import { DebugGui } from "./DebugGui";
 import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
 import type { PickedRenderable } from "./Picker";
 import type { Renderable } from "./Renderable";
-import { Renderer, RendererConfig, RendererEvents, RendererSubscription } from "./Renderer";
+import {
+  FollowMode,
+  Renderer,
+  RendererConfig,
+  RendererEvents,
+  RendererSubscription,
+} from "./Renderer";
 import { RendererContext, useRenderer, useRendererEvent } from "./RendererContext";
 import { Stats } from "./Stats";
 import { CameraState, DEFAULT_CAMERA_STATE, MouseEventObject } from "./camera";
@@ -61,6 +66,12 @@ import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
 
 const log = Logger.getLogger(__filename);
+
+type Shared3DPanelState = {
+  cameraState: CameraState;
+  followMode: FollowMode;
+  followTf: undefined | string;
+};
 
 const SHOW_DEBUG: true | false = false;
 const SELECTED_ID_VARIABLE = "selected_id";
@@ -406,7 +417,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [messages, setMessages] = useState<ReadonlyArray<MessageEvent<unknown>> | undefined>();
   const [currentTime, setCurrentTime] = useState<Time | undefined>();
   const [didSeek, setDidSeek] = useState<boolean>(false);
-  const [sharedPanelState, setSharedPanelState] = useState<SharedPanelState>();
+  const [sharedPanelState, setSharedPanelState] = useState<undefined | Shared3DPanelState>();
 
   const renderRef = useRef({ needsRender: false });
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
@@ -435,7 +446,11 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         setConfig((prevConfig) => ({ ...prevConfig, cameraState: newCameraState }));
 
         if (config.scene.syncCamera === true) {
-          context.setSharedPanelState(newCameraState);
+          context.setSharedPanelState({
+            cameraState: newCameraState,
+            followMode: renderer.followMode,
+            followTf: renderer.followFrameId,
+          });
         }
       }
     };
@@ -451,12 +466,18 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       // renderer.updateConfig to read out the new config value and configure their renderables
       // before the render occurs.
       ReactDOM.unstable_batchedUpdates(() => {
-        const initialCameraState = renderer?.getCameraState();
-        renderer?.settings.handleAction(action);
-        const updatedCameraState = renderer?.getCameraState();
-        // Communicate camera changes from settings to the global state if syncing.
-        if (updatedCameraState !== initialCameraState && config.scene.syncCamera === true) {
-          context.setSharedPanelState(updatedCameraState);
+        if (renderer) {
+          const initialCameraState = renderer.getCameraState();
+          renderer.settings.handleAction(action);
+          const updatedCameraState = renderer.getCameraState();
+          // Communicate camera changes from settings to the global state if syncing.
+          if (updatedCameraState !== initialCameraState && config.scene.syncCamera === true) {
+            context.setSharedPanelState({
+              cameraState: updatedCameraState,
+              followMode: renderer.followMode,
+              followTf: renderer.followFrameId,
+            });
+          }
         }
       }),
     [config.scene.syncCamera, context, renderer],
@@ -552,7 +573,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         // the current frame, topics may not have changed
         setTopics(renderState.topics);
 
-        setSharedPanelState(renderState.sharedPanelState);
+        setSharedPanelState(renderState.sharedPanelState as Shared3DPanelState);
 
         // Watch for any changes in the map of observed parameters
         setParameters(renderState.parameters);
@@ -688,15 +709,27 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     }
   }, [cameraState, renderer]);
 
+  // Sync camera with shared state, if enabled.
   useEffect(() => {
-    if (sharedPanelState != undefined && config.scene.syncCamera === true) {
-      const newCameraState = sharedPanelState as CameraState;
-      renderer?.setCameraState(newCameraState);
+    if (!renderer || sharedPanelState == undefined || config.scene.syncCamera === false) {
+      return;
+    }
+
+    if (sharedPanelState.followMode !== renderer.followMode) {
+      renderer.setCameraSyncError(`Follow mode must be ${renderer.followMode} to sync camera.`);
+    } else if (sharedPanelState.followTf !== renderer.followFrameId) {
+      renderer.setCameraSyncError(
+        `Display frame must be ${renderer.followFrameId} to sync camera.`,
+      );
+    } else {
+      const newCameraState = sharedPanelState.cameraState;
+      renderer.setCameraState(newCameraState);
       renderRef.current.needsRender = true;
       setConfig((prevConfig) => ({
         ...prevConfig,
         cameraState: newCameraState,
       }));
+      renderer.setCameraSyncError(undefined);
     }
   }, [config.scene.syncCamera, renderer, sharedPanelState]);
 
@@ -848,11 +881,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   }, [publishActive, renderer]);
 
   const onTogglePerspective = useCallback(() => {
-    // setConfig((prevConfig) => ({
-    //   ...prevConfig,
-    //   cameraState: { ...prevConfig.cameraState, perspective: !prevConfig.cameraState.perspective },
-    // }));
-    // Wait for the setConfig to propagate to the renderer before updating the settings tree
     const currentState = renderer?.getCameraState().perspective ?? false;
     actionHandler({
       action: "update",

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -13,8 +13,8 @@ import {
   Paper,
   useTheme,
 } from "@mui/material";
-import { isEqual, cloneDeep, merge } from "lodash";
-import React, { useCallback, useLayoutEffect, useEffect, useState, useMemo, useRef } from "react";
+import { cloneDeep, isEqual, merge } from "lodash";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { useLatest, useLongPress } from "react-use";
 import { DeepPartial } from "ts-essentials";
@@ -37,11 +37,12 @@ import {
 import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
+import { SharedPanelState } from "@foxglove/studio-base/context/PanelStateContext";
 import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import { DebugGui } from "./DebugGui";
-import { Interactions, InteractionContextMenu, SelectionObject, TabType } from "./Interactions";
+import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
 import type { PickedRenderable } from "./Picker";
 import type { Renderable } from "./Renderable";
 import { Renderer, RendererConfig, RendererEvents, RendererSubscription } from "./Renderer";
@@ -49,11 +50,11 @@ import { RendererContext, useRenderer, useRendererEvent } from "./RendererContex
 import { Stats } from "./Stats";
 import { CameraState, DEFAULT_CAMERA_STATE, MouseEventObject } from "./camera";
 import {
-  PublishRos1Datatypes,
-  PublishRos2Datatypes,
   makePointMessage,
   makePoseEstimateMessage,
   makePoseMessage,
+  PublishRos1Datatypes,
+  PublishRos2Datatypes,
 } from "./publish";
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/CoreSettings";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
@@ -405,6 +406,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [messages, setMessages] = useState<ReadonlyArray<MessageEvent<unknown>> | undefined>();
   const [currentTime, setCurrentTime] = useState<Time | undefined>();
   const [didSeek, setDidSeek] = useState<boolean>(false);
+  const [sharedPanelState, setSharedPanelState] = useState<SharedPanelState>();
 
   const renderRef = useRef({ needsRender: false });
   const [renderDone, setRenderDone] = useState<(() => void) | undefined>();
@@ -431,11 +433,15 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         // non-follow mode playback
         renderer.setCameraState(newCameraState);
         setConfig((prevConfig) => ({ ...prevConfig, cameraState: newCameraState }));
+
+        if (config.scene.syncCamera === true) {
+          context.setSharedPanelState(newCameraState);
+        }
       }
     };
     renderer?.addListener("cameraMove", listener);
     return () => void renderer?.removeListener("cameraMove", listener);
-  }, [renderer]);
+  }, [config.scene.syncCamera, context, renderer]);
 
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
@@ -444,8 +450,16 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       // function has finished executing. This allows scene extensions that call
       // renderer.updateConfig to read out the new config value and configure their renderables
       // before the render occurs.
-      ReactDOM.unstable_batchedUpdates(() => renderer?.settings.handleAction(action)),
-    [renderer],
+      ReactDOM.unstable_batchedUpdates(() => {
+        const initialCameraState = renderer?.getCameraState();
+        renderer?.settings.handleAction(action);
+        const updatedCameraState = renderer?.getCameraState();
+        // Communicate camera changes from settings to the global state if syncing.
+        if (updatedCameraState !== initialCameraState && config.scene.syncCamera === true) {
+          context.setSharedPanelState(updatedCameraState);
+        }
+      }),
+    [config.scene.syncCamera, context, renderer],
   );
 
   // Maintain the settings tree
@@ -538,6 +552,8 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         // the current frame, topics may not have changed
         setTopics(renderState.topics);
 
+        setSharedPanelState(renderState.sharedPanelState);
+
         // Watch for any changes in the map of observed parameters
         setParameters(renderState.parameters);
 
@@ -556,9 +572,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     context.watch("currentTime");
     context.watch("didSeek");
     context.watch("parameters");
+    context.watch("sharedPanelState");
     context.watch("variables");
     context.watch("topics");
-  }, [context]);
+  }, [context, renderer]);
 
   // Build a list of topics to subscribe to
   const [topicsToSubscribe, setTopicsToSubscribe] = useState<Subscription[] | undefined>(undefined);
@@ -624,7 +641,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     if (renderer && variables) {
       renderer.setVariables(variables);
     }
-  }, [variables, renderer, context]);
+  }, [variables, renderer]);
 
   // Keep the renderer currentTime up to date
   useEffect(() => {
@@ -670,6 +687,18 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       renderRef.current.needsRender = true;
     }
   }, [cameraState, renderer]);
+
+  useEffect(() => {
+    if (sharedPanelState != undefined && config.scene.syncCamera === true) {
+      const newCameraState = sharedPanelState as CameraState;
+      renderer?.setCameraState(newCameraState);
+      renderRef.current.needsRender = true;
+      setConfig((prevConfig) => ({
+        ...prevConfig,
+        cameraState: newCameraState,
+      }));
+    }
+  }, [config.scene.syncCamera, renderer, sharedPanelState]);
 
   // Render a new frame if requested
   useEffect(() => {
@@ -819,13 +848,21 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   }, [publishActive, renderer]);
 
   const onTogglePerspective = useCallback(() => {
-    setConfig((prevConfig) => ({
-      ...prevConfig,
-      cameraState: { ...prevConfig.cameraState, perspective: !prevConfig.cameraState.perspective },
-    }));
+    // setConfig((prevConfig) => ({
+    //   ...prevConfig,
+    //   cameraState: { ...prevConfig.cameraState, perspective: !prevConfig.cameraState.perspective },
+    // }));
     // Wait for the setConfig to propagate to the renderer before updating the settings tree
-    setTimeout(() => renderer?.updateCoreSettings(), 0);
-  }, [renderer]);
+    const currentState = renderer?.getCameraState().perspective ?? false;
+    actionHandler({
+      action: "update",
+      payload: {
+        input: "boolean",
+        path: ["scene", "cameraState", "perspective"],
+        value: !currentState,
+      },
+    });
+  }, [actionHandler, renderer]);
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -435,6 +435,9 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     () => new Map(),
   );
 
+  // The frame we care about for syncing purposes can be either of these.
+  const effectiveRendererFrameId = renderer?.followFrameId ?? renderer?.renderFrameId;
+
   // Config cameraState
   useEffect(() => {
     const listener = () => {
@@ -449,14 +452,14 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
           context.setSharedPanelState({
             cameraState: newCameraState,
             followMode: renderer.followMode,
-            followTf: renderer.followFrameId,
+            followTf: effectiveRendererFrameId,
           });
         }
       }
     };
     renderer?.addListener("cameraMove", listener);
     return () => void renderer?.removeListener("cameraMove", listener);
-  }, [config.scene.syncCamera, context, renderer]);
+  }, [config.scene.syncCamera, context, effectiveRendererFrameId, renderer]);
 
   // Handle user changes in the settings sidebar
   const actionHandler = useCallback(
@@ -719,7 +722,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       renderer.setCameraSyncError(
         `Follow mode must be ${sharedPanelState.followMode} to sync camera.`,
       );
-    } else if (sharedPanelState.followTf !== renderer.followFrameId) {
+    } else if (sharedPanelState.followTf !== effectiveRendererFrameId) {
       renderer.setCameraSyncError(
         `Display frame must be ${sharedPanelState.followTf} to sync camera.`,
       );
@@ -733,7 +736,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
       }));
       renderer.setCameraSyncError(undefined);
     }
-  }, [config.scene.syncCamera, renderer, sharedPanelState]);
+  }, [config.scene.syncCamera, effectiveRendererFrameId, renderer, sharedPanelState]);
 
   // Render a new frame if requested
   useEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -153,6 +153,7 @@ export class CoreSettings extends SceneExtension {
             syncCamera: {
               label: "Sync camera",
               input: "boolean",
+              error: this.renderer.cameraSyncError(),
               value: config.scene.syncCamera ?? false,
             },
             meshUpAxis: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -155,6 +155,7 @@ export class CoreSettings extends SceneExtension {
               input: "boolean",
               error: this.renderer.cameraSyncError(),
               value: config.scene.syncCamera ?? false,
+              help: "Sync the camera with other panels that also have this setting enabled.",
             },
             meshUpAxis: {
               label: "Mesh up axis",

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -150,6 +150,11 @@ export class CoreSettings extends SceneExtension {
                   ? "This setting requires a restart to take effect"
                   : undefined,
             },
+            syncCamera: {
+              label: "Sync camera",
+              input: "boolean",
+              value: config.scene.syncCamera ?? false,
+            },
             meshUpAxis: {
               label: "Mesh up axis",
               help: "The direction to use as “up” when loading meshes without orientation info (STL and OBJ)",

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -4,10 +4,10 @@
 
 import { pick, uniq } from "lodash";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { createSelector, createSelectorCreator, defaultMemoize } from "reselect";
 import { DeepReadonly } from "ts-essentials";
 import { createStore, StoreApi } from "zustand";
 
-import { useShallowMemo } from "@foxglove/hooks";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   LayoutState,
@@ -107,19 +107,59 @@ export function useSharedPanelState(): [
   return [sharedData, update];
 }
 
+/**
+ * True if both objects have the same keys, ignoring values.
+ */
+function hasSameKeys(
+  a: undefined | Record<string, unknown>,
+  b: undefined | Record<string, unknown>,
+) {
+  if (a === b) {
+    return true;
+  }
+
+  if (a == undefined && b != undefined) {
+    return false;
+  }
+  if (a != undefined && b == undefined) {
+    return false;
+  }
+
+  if (a != undefined && b != undefined) {
+    for (const keyA in a) {
+      if (!Object.prototype.hasOwnProperty.call(b, keyA)) {
+        return false;
+      }
+    }
+
+    for (const keyB in b) {
+      if (!Object.prototype.hasOwnProperty.call(a, keyB)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+const createHasSameKeySelector = createSelectorCreator(defaultMemoize, hasSameKeys);
+
 const selectCurrentLayoutId = (state: LayoutState) => state.selectedLayout?.id;
-const selectLayoutData = (state: LayoutState) => state.selectedLayout?.data?.configById;
+
+const selectLayoutConfigById = createHasSameKeySelector(
+  (state: LayoutState) => state.selectedLayout?.data?.configById,
+  (config) => config,
+);
+
+const selectPanelTypesInUse = createSelector(selectLayoutConfigById, (config) => {
+  return uniq(Object.keys(config ?? {}).map(getPanelTypeFromId));
+});
 
 export function PanelStateContextProvider({ children }: { children?: ReactNode }): JSX.Element {
   const [store] = useState(createPanelStateStore());
 
   // discared shared panel state for panel types that are no longer in the layout
-  const layoutData = useCurrentLayoutSelector(selectLayoutData);
-  const memoPanelData = useShallowMemo(layoutData);
-  const panelTypesInUse = useMemo(
-    () => uniq(Object.keys(memoPanelData ?? {}).map(getPanelTypeFromId)),
-    [memoPanelData],
-  );
+  const panelTypesInUse = useCurrentLayoutSelector(selectPanelTypesInUse);
   useEffect(() => {
     store.setState((old) => ({ sharedPanelState: pick(old.sharedPanelState, panelTypesInUse) }));
   }, [panelTypesInUse, store]);

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -73,7 +73,6 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
   return updateSettingsTree;
 }
 
-const sharedDataSelector = (store: PanelStateStore) => store.sharedPanelState;
 const updateSharedDataSelector = (store: PanelStateStore) => store.updateSharedPanelState;
 
 /**
@@ -84,10 +83,18 @@ export function useSharedPanelState(): [
   DeepReadonly<SharedPanelState>,
   (data: DeepReadonly<SharedPanelState>) => void,
 ] {
-  const updateSharedData = usePanelStateStore(updateSharedDataSelector);
-  const sharedData = usePanelStateStore(sharedDataSelector);
   const panelId = usePanelContext().id;
   const panelType = useMemo(() => getPanelTypeFromId(panelId), [panelId]);
+
+  const selector = useCallback(
+    (store: PanelStateStore) => {
+      return store.sharedPanelState[panelType];
+    },
+    [panelType],
+  );
+
+  const updateSharedData = usePanelStateStore(updateSharedDataSelector);
+  const sharedData = usePanelStateStore(selector);
   const update = useCallback(
     (data: DeepReadonly<SharedPanelState>) => {
       updateSharedData(panelType, data);
@@ -95,7 +102,7 @@ export function useSharedPanelState(): [
     [panelType, updateSharedData],
   );
 
-  return [sharedData[panelType], update];
+  return [sharedData, update];
 }
 
 const selectCurrentLayoutId = (state: LayoutState) => state.selectedLayout?.id;

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -76,6 +76,10 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
 const sharedDataSelector = (store: PanelStateStore) => store.sharedPanelState;
 const updateSharedDataSelector = (store: PanelStateStore) => store.updateSharedPanelState;
 
+/**
+ * Returns a [state, setState] pair that can be used to read and update shared transient
+ * panel state.
+ */
 export function useSharedPanelState(): [
   DeepReadonly<SharedPanelState>,
   (data: DeepReadonly<SharedPanelState>) => void,

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -2,11 +2,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { ReactNode, useCallback, useMemo, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { createStore, StoreApi } from "zustand";
 
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
+import {
+  LayoutState,
+  useCurrentLayoutSelector,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
 import {
   ImmutableSettingsTree,
   PanelStateContext,
@@ -90,8 +94,18 @@ export function useSharedPanelState(): [
   return [sharedData[panelType], update];
 }
 
+const selectCurrentLayoutId = (state: LayoutState) => state.selectedLayout?.id;
+
 export function PanelStateContextProvider({ children }: { children?: ReactNode }): JSX.Element {
   const [store] = useState(createPanelStateStore());
+
+  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
+
+  // clear shared panel state on layout change
+  useEffect(() => {
+    void currentLayoutId;
+    store.setState({ sharedPanelState: {} });
+  }, [currentLayoutId, store]);
 
   return <PanelStateContext.Provider value={store}>{children}</PanelStateContext.Provider>;
 }

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -2,7 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { ReactNode, useCallback, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
+import { DeepReadonly } from "ts-essentials";
 import { createStore, StoreApi } from "zustand";
 
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
@@ -10,14 +11,17 @@ import {
   ImmutableSettingsTree,
   PanelStateContext,
   PanelStateStore,
+  SharedPanelState,
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
+import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 function createPanelStateStore(): StoreApi<PanelStateStore> {
   return createStore((set) => {
     return {
       sequenceNumbers: {},
       settingsTrees: {},
+      sharedPanelState: {},
 
       incrementSequenceNumber: (panelId: string) => {
         set((state) => {
@@ -37,6 +41,10 @@ function createPanelStateStore(): StoreApi<PanelStateStore> {
             [panelId]: settingsTree,
           },
         }));
+      },
+
+      updateSharedPanelState: (type: string, data: SharedPanelState) => {
+        set((old) => ({ sharedPanelState: { ...old.sharedPanelState, [type]: data } }));
       },
     };
   });
@@ -59,6 +67,27 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
   );
 
   return updateSettingsTree;
+}
+
+const sharedDataSelector = (store: PanelStateStore) => store.sharedPanelState;
+const updateSharedDataSelector = (store: PanelStateStore) => store.updateSharedPanelState;
+
+export function useSharedPanelState(): [
+  DeepReadonly<SharedPanelState>,
+  (data: DeepReadonly<SharedPanelState>) => void,
+] {
+  const updateSharedData = usePanelStateStore(updateSharedDataSelector);
+  const sharedData = usePanelStateStore(sharedDataSelector);
+  const panelId = usePanelContext().id;
+  const panelType = useMemo(() => getPanelTypeFromId(panelId), [panelId]);
+  const update = useCallback(
+    (data: DeepReadonly<SharedPanelState>) => {
+      updateSharedData(panelType, data);
+    },
+    [panelType, updateSharedData],
+  );
+
+  return [sharedData[panelType], update];
 }
 
 export function PanelStateContextProvider({ children }: { children?: ReactNode }): JSX.Element {

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -2,10 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { pick, uniq } from "lodash";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { createStore, StoreApi } from "zustand";
 
+import { useShallowMemo } from "@foxglove/hooks";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   LayoutState,
@@ -106,13 +108,24 @@ export function useSharedPanelState(): [
 }
 
 const selectCurrentLayoutId = (state: LayoutState) => state.selectedLayout?.id;
+const selectLayoutData = (state: LayoutState) => state.selectedLayout?.data?.configById;
 
 export function PanelStateContextProvider({ children }: { children?: ReactNode }): JSX.Element {
   const [store] = useState(createPanelStateStore());
 
-  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
+  // discared shared panel state for panel types that are no longer in the layout
+  const layoutData = useCurrentLayoutSelector(selectLayoutData);
+  const memoPanelData = useShallowMemo(layoutData);
+  const panelTypesInUse = useMemo(
+    () => uniq(Object.keys(memoPanelData ?? {}).map(getPanelTypeFromId)),
+    [memoPanelData],
+  );
+  useEffect(() => {
+    store.setState((old) => ({ sharedPanelState: pick(old.sharedPanelState, panelTypesInUse) }));
+  }, [panelTypesInUse, store]);
 
   // clear shared panel state on layout change
+  const currentLayoutId = useCurrentLayoutSelector(selectCurrentLayoutId);
   useEffect(() => {
     void currentLayoutId;
     store.setState({ sharedPanelState: {} });

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -184,6 +184,12 @@ declare module "@foxglove/studio" {
     parameters?: ReadonlyMap<string, ParameterValue>;
 
     /**
+     * Transient panel state shared between panels of the same type. This can be any data a
+     * panel author wishes to share between panels.
+     */
+    sharedPanelState?: Readonly<Record<string, unknown>>;
+
+    /**
      * Map of current Studio variables. Variables are key/value pairs that are globally accessible
      * to panels and scripts in the current layout. See
      * <https://foxglove.dev/docs/studio/app-concepts/variables> for more information.
@@ -260,6 +266,11 @@ declare module "@foxglove/studio" {
      * @param value The new value of the parameter.
      */
     setParameter: (name: string, value: ParameterValue) => void;
+
+    /**
+     * Set the transient state shared by panels of the same type as the caller of this function.
+     */
+    setSharedPanelState: (state: undefined | Readonly<string, unknown>) => void;
 
     /**
      * Set the value of variable name to value.

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -269,6 +269,7 @@ declare module "@foxglove/studio" {
 
     /**
      * Set the transient state shared by panels of the same type as the caller of this function.
+     * This will not be persisted in the layout.
      */
     setSharedPanelState: (state: undefined | Readonly<string, unknown>) => void;
 


### PR DESCRIPTION
**User-Facing Changes**
Adds a new panel setting to sync camera states across multiple 3d panels.

**Description**
This adds a new setting and new panel extension context features to sync the camera states of multiple 3d panels. This is accomplished via a new `sharedPanelState` property in the `PanelExtensionContext` `RenderState`.

Panels that wish to use shared state can watch `sharedPanelState` in the render state and call `setSharedPanelState` to update the shared state, which is typed as an opaque record type.

```typescript
    setSharedPanelState: (state: undefined | Readonly<string, unknown>) => void;
```

The shared state is scoped to the panel type, so, for example, the 3d panel will only see shared state for the 3d panel.

<img width="376" alt="Screenshot 2022-11-21 at 12 08 13 PM" src="https://user-images.githubusercontent.com/93935560/202955434-6e1c128a-f42d-49d4-913f-3df7d786c5fc.png">

https://user-images.githubusercontent.com/93935560/202955310-91eeb167-b6b5-4bd9-a21c-74d410e781d7.mov

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4846