### PR TITLE
Rename PanelSettingsEditorStore to PanelStateStore

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -80,7 +80,7 @@ import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialD
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { HelpInfoStore, useHelpInfo } from "@foxglove/studio-base/providers/HelpInfoProvider";
-import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 
 const log = Logger.getLogger(__filename);
 
@@ -596,7 +596,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         /* eslint-disable react/jsx-key */
         <LinkHandlerContext.Provider value={handleInternalLink} />,
         <WorkspaceContext.Provider value={workspaceActions} />,
-        <PanelSettingsEditorContextProvider />,
+        <PanelStateContextProvider />,
         /* eslint-enable react/jsx-key */
       ]}
     >

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -8,7 +8,7 @@ import userEvent from "@testing-library/user-event";
 import { useMemo } from "react";
 
 import AnalyticsProvider from "@foxglove/studio-base/context/AnalyticsProvider";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import LayoutStorageContext from "@foxglove/studio-base/context/LayoutStorageContext";
 import ModalHost from "@foxglove/studio-base/context/ModalHost";
 import { UserProfileStorageContext } from "@foxglove/studio-base/context/UserProfileStorageContext";
@@ -21,7 +21,7 @@ import MockLayoutStorage from "@foxglove/studio-base/services/MockLayoutStorage"
 
 import LayoutBrowser from "./index";
 
-const DEFAULT_LAYOUT_FOR_TESTS: PanelsState = {
+const DEFAULT_LAYOUT_FOR_TESTS: LayoutData = {
   configById: {},
   globalVariables: {},
   userNodes: {},

--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -35,7 +35,7 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import LayoutStorageDebuggingContext from "@foxglove/studio-base/context/LayoutStorageDebuggingContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
@@ -330,7 +330,7 @@ export default function LayoutBrowser({
     const name = `Unnamed layout ${moment(currentDateForStorybook).format("l")} at ${moment(
       currentDateForStorybook,
     ).format("LT")}`;
-    const panelState: Omit<PanelsState, "name" | "id"> = {
+    const layoutData: Omit<LayoutData, "name" | "id"> = {
       configById: {},
       globalVariables: {},
       userNodes: {},
@@ -338,7 +338,7 @@ export default function LayoutBrowser({
     };
     const newLayout = await layoutManager.saveNewLayout({
       name,
-      data: panelState as PanelsState,
+      data: layoutData as LayoutData,
       permission: "CREATOR_WRITE",
     });
     void onSelectLayout(newLayout);
@@ -476,7 +476,7 @@ export default function LayoutBrowser({
           return;
         }
 
-        const data = parsedState as PanelsState;
+        const data = parsedState as LayoutData;
         const newLayout = await layoutManager.saveNewLayout({
           name: layoutName,
           data,

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -44,7 +44,7 @@ import {
   PlayerCapabilities,
   SubscribePayload,
 } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { assertNever } from "@foxglove/studio-base/util/assertNever";
 

--- a/packages/studio-base/src/components/PanelRemounter.tsx
+++ b/packages/studio-base/src/components/PanelRemounter.tsx
@@ -5,9 +5,9 @@
 import { Fragment, ReactNode, useCallback } from "react";
 
 import {
-  PanelSettingsEditorStore,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+  PanelStateStore,
+  usePanelStateStore,
+} from "@foxglove/studio-base/context/PanelStateContext";
 
 /**
  * Wrapper component used to force-remount the panel when key properties like the tabId
@@ -22,11 +22,8 @@ export function PanelRemounter({
   id: string;
   tabId: undefined | string;
 }): JSX.Element {
-  const selector = useCallback(
-    (store: PanelSettingsEditorStore) => store.sequenceNumbers[id] ?? 0,
-    [id],
-  );
-  const sequenceNumber = usePanelSettingsEditorStore(selector);
+  const selector = useCallback((store: PanelStateStore) => store.sequenceNumbers[id] ?? 0, [id]);
+  const sequenceNumber = usePanelStateStore(selector);
 
   return <Fragment key={`${id}${tabId ?? ""}${sequenceNumber}`}>{children}</Fragment>;
 }

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -20,9 +20,9 @@ import {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import {
-  PanelSettingsEditorStore,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+  PanelStateStore,
+  usePanelStateStore,
+} from "@foxglove/studio-base/context/PanelStateContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
@@ -35,8 +35,7 @@ const singlePanelIdSelector = (state: LayoutState) =>
     ? state.selectedLayout.data.layout
     : undefined;
 
-const selectIncrementSequenceNumber = (store: PanelSettingsEditorStore) =>
-  store.incrementSequenceNumber;
+const selectIncrementSequenceNumber = (store: PanelStateStore) => store.incrementSequenceNumber;
 
 export default function PanelSettings({
   selectedPanelIdsForTests,
@@ -83,7 +82,7 @@ export default function PanelSettings({
     [panelCatalog, panelType],
   );
 
-  const incrementSequenceNumber = usePanelSettingsEditorStore(selectIncrementSequenceNumber);
+  const incrementSequenceNumber = usePanelStateStore(selectIncrementSequenceNumber);
 
   const [showShareModal, setShowShareModal] = useState(false);
   const shareModal = useMemo(() => {
@@ -115,7 +114,7 @@ export default function PanelSettings({
 
   const [config] = useConfigById(selectedPanelId);
 
-  const settingsTree = usePanelSettingsEditorStore((state) =>
+  const settingsTree = usePanelStateStore((state) =>
     selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
   );
 

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -25,9 +25,9 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import PanelCatalogContext from "@foxglove/studio-base/context/PanelCatalogContext";
 import {
-  PanelSettingsEditorStore,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+  PanelStateStore,
+  usePanelStateStore,
+} from "@foxglove/studio-base/context/PanelStateContext";
 import { UserProfileStorageContext } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 
@@ -68,12 +68,11 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     const { classes } = useStyles();
 
     const hasSettingsSelector = useCallback(
-      (store: PanelSettingsEditorStore) =>
-        panelId ? store.settingsTrees[panelId] != undefined : false,
+      (store: PanelStateStore) => (panelId ? store.settingsTrees[panelId] != undefined : false),
       [panelId],
     );
 
-    const hasSettings = usePanelSettingsEditorStore(hasSettingsSelector);
+    const hasSettings = usePanelStateStore(hasSettingsSelector);
 
     const userProfileStorage = useContext(UserProfileStorageContext);
     const [{ value: settingsOnboardingTooltip }, loadOnboardingState] =

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -20,7 +20,7 @@ import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanel
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import HelpInfoProvider from "@foxglove/studio-base/providers/HelpInfoProvider";
-import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 
 import PanelToolbar from "./index";
 
@@ -41,7 +41,7 @@ class MosaicWrapper extends React.Component<{
             toolbarControls={<div />}
             renderPreview={() => undefined as any}
           >
-            <PanelSettingsEditorContextProvider>
+            <PanelStateContextProvider>
               <HelpInfoProvider>
                 <Box
                   width="100%"
@@ -55,7 +55,7 @@ class MosaicWrapper extends React.Component<{
                   </Box>
                 </Box>
               </HelpInfoProvider>
-            </PanelSettingsEditorContextProvider>
+            </PanelStateContextProvider>
           </MosaicWindow>
         )}
         value={this.props.layout ?? "dummy"}

--- a/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/actions.ts
@@ -23,7 +23,7 @@ import {
   MosaicDropTargetPosition,
 } from "@foxglove/studio-base/types/panels";
 
-export type PanelsState = {
+export type LayoutData = {
   layout?: MosaicNode<string>;
   // We store config for each panel in an object keyed by the panel id.
   configById: SavedProps;

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -16,7 +16,7 @@ import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import { PanelConfig, PlaybackConfig, UserNodes } from "@foxglove/studio-base/types/panels";
 
 import {
-  PanelsState,
+  LayoutData,
   AddPanelPayload,
   ChangePanelLayoutPayload,
   ClosePanelPayload,
@@ -35,7 +35,7 @@ export type LayoutState = Readonly<{
     | {
         id: LayoutID;
         loading?: boolean;
-        data: PanelsState | undefined;
+        data: LayoutData | undefined;
       }
     | undefined;
 }>;

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -11,7 +11,7 @@ import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedConte
 
 export type ImmutableSettingsTree = DeepReadonly<SettingsTree>;
 
-export type PanelSettingsEditorStore = {
+export type PanelStateStore = {
   /**
    * Used for forcing remounts on panels to make panels reload their saved configs. This is necessary
    * because panels are free to ignore updates to their config in the layout and maintain their own
@@ -35,14 +35,12 @@ export type PanelSettingsEditorStore = {
   updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
 };
 
-export const PanelSettingsEditorContext = createContext<
-  undefined | StoreApi<PanelSettingsEditorStore>
->(undefined);
+export const PanelStateContext = createContext<undefined | StoreApi<PanelStateStore>>(undefined);
 
-export function usePanelSettingsEditorStore<T>(
-  selector: (store: PanelSettingsEditorStore) => T,
+export function usePanelStateStore<T>(
+  selector: (store: PanelStateStore) => T,
   equalityFn?: (a: T, b: T) => boolean,
 ): T {
-  const context = useGuaranteedContext(PanelSettingsEditorContext);
+  const context = useGuaranteedContext(PanelStateContext);
   return useStore(context, selector, equalityFn);
 }

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -4,7 +4,7 @@
 
 import { createContext, useContext } from "react";
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { Player, PlayerMetricsCollectorInterface } from "@foxglove/studio-base/players/types";
 import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 import { RegisteredIconNames } from "@foxglove/studio-base/types/Icons";
@@ -47,7 +47,7 @@ export interface IDataSourceFactory {
   hidden?: boolean;
   warning?: string;
 
-  sampleLayout?: PanelsState;
+  sampleLayout?: LayoutData;
 
   formConfig?: {
     // Initialization args are populated with keys of the _id_ field

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -27,7 +27,7 @@ import {
 } from "@foxglove/studio-base/components/PanelContextMenu";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import { CameraInfo } from "@foxglove/studio-base/types/Messages";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -20,7 +20,7 @@ import { useDataSourceInfo, useMessagesByTopic } from "@foxglove/studio-base/Pan
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import FilterBar, { FilterBarProps } from "./FilterBar";

--- a/packages/studio-base/src/panels/NodePlayground/index.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.tsx
@@ -43,7 +43,7 @@ import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import BottomBar from "@foxglove/studio-base/panels/NodePlayground/BottomBar";
 import Sidebar from "@foxglove/studio-base/panels/NodePlayground/Sidebar";
 import { HelpInfoStore, useHelpInfo } from "@foxglove/studio-base/providers/HelpInfoProvider";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig, UserNodes } from "@foxglove/studio-base/types/panels";
 
 import Config from "./Config";

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -11,7 +11,7 @@ import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglo
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { lineColors } from "@foxglove/studio-base/util/plotColors";
 

--- a/packages/studio-base/src/panels/Publish/index.tsx
+++ b/packages/studio-base/src/panels/Publish/index.tsx
@@ -25,7 +25,7 @@ import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import usePublisher from "@foxglove/studio-base/hooks/usePublisher";
 import { PlayerCapabilities, Topic } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 

--- a/packages/studio-base/src/panels/StateTransitions/settings.ts
+++ b/packages/studio-base/src/panels/StateTransitions/settings.ts
@@ -5,7 +5,7 @@
 import { useCallback, useEffect } from "react";
 
 import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { StateTransitionConfig } from "./types";

--- a/packages/studio-base/src/panels/URDFViewer/settings.ts
+++ b/packages/studio-base/src/panels/URDFViewer/settings.ts
@@ -13,7 +13,7 @@ import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
 import { useAssets } from "@foxglove/studio-base/context/AssetsContext";
 import useRobotDescriptionAsset from "@foxglove/studio-base/panels/URDFViewer/useRobotDescriptionAsset";
 import { Topic } from "@foxglove/studio-base/players/types";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { ROBOT_DESCRIPTION_PARAM } from "@foxglove/studio-base/util/globalConstants";
 

--- a/packages/studio-base/src/panels/VariableSlider/settings.ts
+++ b/packages/studio-base/src/panels/VariableSlider/settings.ts
@@ -7,7 +7,7 @@ import { set } from "lodash";
 import { useCallback, useEffect } from "react";
 
 import { SettingsTreeAction, SettingsTreeNodes } from "@foxglove/studio";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { VariableSliderConfig } from "./types";

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticStatusPanel.tsx
@@ -23,7 +23,7 @@ import Panel from "@foxglove/studio-base/components/Panel";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import DiagnosticStatus from "./DiagnosticStatus";

--- a/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
+++ b/packages/studio-base/src/panels/diagnostics/DiagnosticSummary.tsx
@@ -37,7 +37,7 @@ import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import Stack from "@foxglove/studio-base/components/Stack";
 import helpContent from "@foxglove/studio-base/panels/diagnostics/DiagnosticSummary.help.md";
 import useDiagnostics from "@foxglove/studio-base/panels/diagnostics/useDiagnostics";
-import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import toggle from "@foxglove/studio-base/util/toggle";
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -11,7 +11,7 @@ import CurrentLayoutContext, {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import {
   PanelsActions,
-  PanelsState,
+  LayoutData,
 } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { LayoutID } from "@foxglove/studio-base/services/ConsoleApi";
@@ -28,7 +28,7 @@ export default function MockCurrentLayoutProvider({
   initialState,
   onAction,
 }: React.PropsWithChildren<{
-  initialState?: Partial<PanelsState>;
+  initialState?: Partial<LayoutData>;
   onAction?: (action: PanelsActions) => void;
 }>): JSX.Element {
   const layoutStateListeners = useRef(new Set<(_: LayoutState) => void>());

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout.ts
@@ -2,14 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 
 /**
  * This is loaded when the user has no layout selected on application launch
  * to avoid presenting the user with a blank layout.
  */
-export const defaultLayout: PanelsState = {
+export const defaultLayout: LayoutData = {
   configById: {
     "3D!18i6zy7": {
       layers: {

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -14,7 +14,7 @@ import {
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import LayoutManagerContext from "@foxglove/studio-base/context/LayoutManagerContext";
 import {
   UserProfileStorage,
@@ -24,7 +24,7 @@ import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayout
 import { ILayoutManager } from "@foxglove/studio-base/services/ILayoutManager";
 import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 
-const TEST_LAYOUT: PanelsState = {
+const TEST_LAYOUT: LayoutData = {
   layout: "ExamplePanel!1",
   configById: {},
   globalVariables: {},
@@ -112,7 +112,7 @@ function renderTest({
 
 describe("CurrentLayoutProvider", () => {
   it("uses currentLayoutId from UserProfile to load from LayoutStorage", async () => {
-    const expectedState: PanelsState = {
+    const expectedState: LayoutData = {
       layout: "Foo!bar",
       configById: { "Foo!bar": { setting: 1 } },
       globalVariables: { var: "hello" },
@@ -148,7 +148,7 @@ describe("CurrentLayoutProvider", () => {
 
   it("saves new layout selection into UserProfile", async () => {
     const mockLayoutManager = makeMockLayoutManager();
-    const newLayout: Partial<PanelsState> = {
+    const newLayout: Partial<LayoutData> = {
       ...TEST_LAYOUT,
       layout: "ExamplePanel!2",
     };

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -26,7 +26,7 @@ import {
   EndDragPayload,
   MoveTabPayload,
   PanelsActions,
-  PanelsState,
+  LayoutData,
   SaveConfigsPayload,
   SplitPanelPayload,
   StartDragPayload,
@@ -153,7 +153,7 @@ export default function CurrentLayoutProvider({
     [enqueueSnackbar, isMounted, layoutManager, setLayoutState, setUserProfile],
   );
 
-  type UpdateLayoutParams = { id: LayoutID; data: PanelsState };
+  type UpdateLayoutParams = { id: LayoutID; data: LayoutData };
   const unsavedLayoutsRef = useRef(new Map<LayoutID, UpdateLayoutParams>());
 
   // When the user performs an action, we immediately setLayoutState to update the UI. Saving back

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/reducers.test.tsx
@@ -15,7 +15,7 @@ import { getLeaves, MosaicNode, MosaicParent } from "react-mosaic-component";
 
 import {
   CreateTabPanelPayload,
-  PanelsState,
+  LayoutData,
 } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { TabPanelConfig } from "@foxglove/studio-base/types/layouts";
 import { MosaicDropTargetPosition } from "@foxglove/studio-base/types/panels";
@@ -24,7 +24,7 @@ import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import panelsReducer, { defaultPlaybackConfig } from "./reducers";
 
-const emptyLayout: PanelsState = {
+const emptyLayout: LayoutData = {
   configById: {},
   globalVariables: {},
   userNodes: {},
@@ -34,7 +34,7 @@ const emptyLayout: PanelsState = {
 describe("layout reducers", () => {
   describe("adds panel to a layout", () => {
     it("adds panel to main app layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -62,7 +62,7 @@ describe("layout reducers", () => {
       expect(panels.configById[secondStr]).toEqual(originalLayout.configById["Tab!a"]);
     });
     it("adds panel to empty Tab layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -95,7 +95,7 @@ describe("layout reducers", () => {
     });
 
     it("adds panel to uninitialized Tab layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -119,7 +119,7 @@ describe("layout reducers", () => {
 
   describe("drops panel into a layout", () => {
     it("drops panel into app layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -143,7 +143,7 @@ describe("layout reducers", () => {
       expect(getPanelTypeFromId(layout.second as string)).toEqual("Audio");
     });
     it("drops Tab panel into app layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Audio!a",
         configById: { "Audio!a": { foo: "bar" } },
@@ -175,7 +175,7 @@ describe("layout reducers", () => {
       expect(configById[newAudioId]).toEqual({ foo: "baz" });
     });
     it("drops panel into empty Tab layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -201,7 +201,7 @@ describe("layout reducers", () => {
       expect(tabs.length).toEqual(3);
     });
     it("drops panel into nested Tab layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -235,7 +235,7 @@ describe("layout reducers", () => {
       });
     });
     it("drops nested Tab panel into main layout", () => {
-      let panels: PanelsState = { ...emptyLayout, layout: "Audio!a" };
+      let panels: LayoutData = { ...emptyLayout, layout: "Audio!a" };
       panels = panelsReducer(panels, {
         type: "DROP_PANEL",
         payload: {
@@ -269,7 +269,7 @@ describe("layout reducers", () => {
 
   describe("moves tabs", () => {
     it("reorders tabs within a Tab panel", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: {
@@ -291,7 +291,7 @@ describe("layout reducers", () => {
 
     it("moves tabs between Tab panels", () => {
       const layout: MosaicParent<string> = { first: "Tab!a", second: "Tab!b", direction: "row" };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout,
         configById: {
@@ -325,7 +325,7 @@ describe("layout reducers", () => {
   });
 
   it("closes a panel in single-panel layout", () => {
-    let panels: PanelsState = {
+    let panels: LayoutData = {
       ...emptyLayout,
       layout: "Audio!a",
       configById: { "Audio!a": { foo: "bar" } },
@@ -341,7 +341,7 @@ describe("layout reducers", () => {
 
   it("closes a panel in multi-panel layout", () => {
     const layout: MosaicParent<string> = { first: "Audio!a", second: "Audio!b", direction: "row" };
-    let panels: PanelsState = {
+    let panels: LayoutData = {
       ...emptyLayout,
       layout,
       configById: { "Audio!a": { foo: "bar" }, "Audio!b": { foo: "baz" } },
@@ -355,7 +355,7 @@ describe("layout reducers", () => {
   });
 
   it("closes a panel nested inside a Tab panel", () => {
-    let panels: PanelsState = {
+    let panels: LayoutData = {
       ...emptyLayout,
       layout: "Tab!a",
       configById: {
@@ -374,7 +374,7 @@ describe("layout reducers", () => {
   });
 
   describe("creates Tab panels from existing panels correctly", () => {
-    const regularLayoutPayload: Partial<PanelsState> & { layout: MosaicNode<string> } = {
+    const regularLayoutPayload: Partial<LayoutData> & { layout: MosaicNode<string> } = {
       layout: {
         first: "Audio!a",
         second: { first: "RawMessages!a", second: "Audio!c", direction: "column" },
@@ -388,7 +388,7 @@ describe("layout reducers", () => {
       idsToRemove: ["Audio!a", "RawMessages!a"],
       singleTab: false,
     };
-    const nestedLayoutPayload: Partial<PanelsState> & { layout: MosaicNode<string> } = {
+    const nestedLayoutPayload: Partial<LayoutData> & { layout: MosaicNode<string> } = {
       layout: {
         first: "Audio!a",
         second: "Tab!z",
@@ -419,7 +419,7 @@ describe("layout reducers", () => {
     };
 
     it("will group selected panels into a Tab panel", () => {
-      let panels: PanelsState = { ...emptyLayout, ...regularLayoutPayload };
+      let panels: LayoutData = { ...emptyLayout, ...regularLayoutPayload };
       panels = panelsReducer(panels, {
         type: "CREATE_TAB_PANEL",
         payload: { ...createTabPanelPayload, singleTab: true },
@@ -443,7 +443,7 @@ describe("layout reducers", () => {
     });
 
     it("will group selected panels into a Tab panel, even when a selected panel is nested", () => {
-      let panels: PanelsState = { ...emptyLayout, ...nestedLayoutPayload };
+      let panels: LayoutData = { ...emptyLayout, ...nestedLayoutPayload };
       panels = panelsReducer(panels, {
         type: "CREATE_TAB_PANEL",
         payload: { ...nestedCreateTabPanelPayload, singleTab: true },
@@ -468,7 +468,7 @@ describe("layout reducers", () => {
     });
 
     it("will create individual tabs for selected panels in a new Tab panel", () => {
-      let panels: PanelsState = { ...emptyLayout, ...regularLayoutPayload };
+      let panels: LayoutData = { ...emptyLayout, ...regularLayoutPayload };
       panels = panelsReducer(panels, {
         type: "CREATE_TAB_PANEL",
         payload: { ...createTabPanelPayload, singleTab: false },
@@ -490,7 +490,7 @@ describe("layout reducers", () => {
     });
 
     it("will create individual tabs for selected panels in a new Tab panel, even when a selected panel is nested", () => {
-      let panels: PanelsState = { ...emptyLayout, ...nestedLayoutPayload };
+      let panels: LayoutData = { ...emptyLayout, ...nestedLayoutPayload };
       panels = panelsReducer(panels, {
         type: "CREATE_TAB_PANEL",
         payload: { ...nestedCreateTabPanelPayload, singleTab: false },
@@ -514,7 +514,7 @@ describe("layout reducers", () => {
   });
 
   it("saves and overwrites user nodes", () => {
-    let panels: PanelsState = { ...emptyLayout };
+    let panels: LayoutData = { ...emptyLayout };
     const firstPayload = { foo: { name: "foo", sourceCode: "bar" } };
     const secondPayload = { bar: { name: "bar", sourceCode: "baz" } };
 
@@ -534,7 +534,7 @@ describe("layout reducers", () => {
   describe("panel toolbar actions", () => {
     it("can split panel", () => {
       const audioConfig = { foo: "bar" };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Audio!a",
         configById: { "Audio!a": audioConfig },
@@ -561,7 +561,7 @@ describe("layout reducers", () => {
     it("can split Tab panel", () => {
       const audioConfig = { foo: "bar" };
       const tabConfig = { activeTabIdx: 0, tabs: [{ title: "A", layout: "Audio!a" }] };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: { "Tab!a": tabConfig, "Audio!a": audioConfig },
@@ -594,7 +594,7 @@ describe("layout reducers", () => {
     it("can split panel inside Tab panel", () => {
       const audioConfig = { foo: "bar" };
       const tabConfig = { activeTabIdx: 0, tabs: [{ title: "A", layout: "Audio!a" }] };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: { "Tab!a": tabConfig, "Audio!a": audioConfig },
@@ -624,7 +624,7 @@ describe("layout reducers", () => {
     it("can swap panels", () => {
       const audioConfig = { foo: "bar" };
       const rawMessagesConfig = { foo: "baz" };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Audio!a",
         configById: { "Audio!a": audioConfig },
@@ -650,7 +650,7 @@ describe("layout reducers", () => {
       const audioConfig = { foo: "bar" };
       const tabConfig = { activeTabIdx: 0, tabs: [{ title: "A", layout: "RawMessages!a" }] };
       const rawMessagesConfig = { path: "foo" };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Audio!a",
         configById: { "Audio!a": audioConfig },
@@ -678,7 +678,7 @@ describe("layout reducers", () => {
     it("can swap panel inside a Tab", () => {
       const rawMessagesConfig = { foo: "baz" };
       const tabConfig = { activeTabIdx: 0, tabs: [{ title: "A", layout: "Audio!a" }] };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: { "Tab!a": tabConfig },
@@ -714,7 +714,7 @@ describe("layout reducers", () => {
         },
       },
       configById: {},
-    } as PanelsState;
+    } as LayoutData;
     const tabPanelState = {
       layout: {
         direction: "row",
@@ -726,10 +726,10 @@ describe("layout reducers", () => {
         },
       },
       configById: {},
-    } as PanelsState;
+    } as LayoutData;
 
     it("keeps panel state identity stable when config is unchanged", () => {
-      const orig: PanelsState = {
+      const orig: LayoutData = {
         ...emptyLayout,
         layout: panelState.layout,
       };
@@ -763,7 +763,7 @@ describe("layout reducers", () => {
     });
 
     it("removes a panel's configById when it is removed from the layout", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: panelState.layout,
       };
@@ -830,7 +830,7 @@ describe("layout reducers", () => {
     });
 
     it("removes a panel's configById when it is removed from Tab panel", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: tabPanelState.layout,
       };
@@ -876,7 +876,7 @@ describe("layout reducers", () => {
     });
 
     it("does not remove old configById when trimConfigById = false", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "foo!bar",
       };
@@ -913,7 +913,7 @@ describe("layout reducers", () => {
 
   describe("handles dragging panels", () => {
     it("disallows dragging from single-panel layout", () => {
-      const panels: PanelsState = {
+      const panels: LayoutData = {
         ...emptyLayout,
         layout: "Audio!a",
       };
@@ -926,7 +926,7 @@ describe("layout reducers", () => {
     });
 
     it("hides panel from multi-panel layout when starting drag", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: { first: "Audio!a", second: "RawMessages!a", direction: "column" },
       } as const;
@@ -942,7 +942,7 @@ describe("layout reducers", () => {
       });
     });
     it("removes non-Tab panel from single-panel tab layout when starting drag", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: { first: "Tab!a", second: "RawMessages!a", direction: "column" },
         configById: {
@@ -961,7 +961,7 @@ describe("layout reducers", () => {
       });
     });
     it("hides panel from multi-panel Tab layout when starting drag", () => {
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: { first: "Tab!a", second: "RawMessages!a", direction: "column" },
         configById: {
@@ -1002,7 +1002,7 @@ describe("layout reducers", () => {
           tabs: [{ title: "A", layout: { first: "Audio!a", second: "Plot!a", direction: "row" } }],
         },
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: "Tab!a",
         configById: originalSavedProps,
@@ -1043,7 +1043,7 @@ describe("layout reducers", () => {
           tabs: [{ title: "A", layout: { first: "Audio!a", second: "Plot!a", direction: "row" } }],
         },
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
         configById: originalSavedProps,
@@ -1088,7 +1088,7 @@ describe("layout reducers", () => {
           tabs: [{ title: "A", layout: { first: "Audio!a", second: "Plot!a", direction: "row" } }],
         },
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
         configById: originalSavedProps,
@@ -1148,7 +1148,7 @@ describe("layout reducers", () => {
           ],
         },
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
         configById: originalSavedProps,
@@ -1202,7 +1202,7 @@ describe("layout reducers", () => {
           tabs: [{ title: "B", layout: "RawMessages!a" }],
         },
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
         configById: originalSavedProps,
@@ -1258,7 +1258,7 @@ describe("layout reducers", () => {
         "Tab!b": { activeTabIdx: 0, tabs: [{ title: "B" }] },
         "Tab!c": tabCConfig,
       };
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
         configById: originalSavedProps,
@@ -1298,7 +1298,7 @@ describe("layout reducers", () => {
         second: "Plot!a",
         direction: "row",
       } as MosaicParent<string>;
-      let panels: PanelsState = {
+      let panels: LayoutData = {
         ...emptyLayout,
         layout: originalLayout,
       };
@@ -1331,7 +1331,7 @@ describe("layout reducers", () => {
         second: "Plot!a",
         direction: "row",
       } as MosaicParent<string>;
-      let panels: PanelsState = { ...emptyLayout, layout: originalLayout };
+      let panels: LayoutData = { ...emptyLayout, layout: originalLayout };
       panels = panelsReducer(panels, {
         type: "START_DRAG",
         payload: { sourceTabId: undefined, path: ["first"] },

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -8,12 +8,12 @@ import { createStore, StoreApi } from "zustand";
 import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import {
   ImmutableSettingsTree,
-  PanelSettingsEditorContext,
-  PanelSettingsEditorStore,
-  usePanelSettingsEditorStore,
-} from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+  PanelStateContext,
+  PanelStateStore,
+  usePanelStateStore,
+} from "@foxglove/studio-base/context/PanelStateContext";
 
-function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
+function createPanelStateStore(): StoreApi<PanelStateStore> {
   return createStore((set) => {
     return {
       sequenceNumbers: {},
@@ -42,14 +42,14 @@ function createSettingsEditorStore(): StoreApi<PanelSettingsEditorStore> {
   });
 }
 
-const updateSettingsTreeSelector = (store: PanelSettingsEditorStore) => store.updateSettingsTree;
+const updateSettingsTreeSelector = (store: PanelStateStore) => store.updateSettingsTree;
 
 /**
  * Returns updater function for the current panels settings tree.
  */
 export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) => void {
   const { id } = usePanelContext();
-  const updateStoreTree = usePanelSettingsEditorStore(updateSettingsTreeSelector);
+  const updateStoreTree = usePanelStateStore(updateSettingsTreeSelector);
 
   const updateSettingsTree = useCallback(
     (newTree: ImmutableSettingsTree) => {
@@ -61,16 +61,8 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
   return updateSettingsTree;
 }
 
-export function PanelSettingsEditorContextProvider({
-  children,
-}: {
-  children?: ReactNode;
-}): JSX.Element {
-  const [store] = useState(createSettingsEditorStore());
+export function PanelStateContextProvider({ children }: { children?: ReactNode }): JSX.Element {
+  const [store] = useState(createPanelStateStore());
 
-  return (
-    <PanelSettingsEditorContext.Provider value={store}>
-      {children}
-    </PanelSettingsEditorContext.Provider>
-  );
+  return <PanelStateContext.Provider value={store}>{children}</PanelStateContext.Provider>;
 }

--- a/packages/studio-base/src/services/ConsoleApiRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/ConsoleApiRemoteLayoutStorage.ts
@@ -4,7 +4,7 @@
 
 import { filterMap } from "@foxglove/den/collection";
 import Logger from "@foxglove/log";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import ConsoleApi, { ConsoleApiLayout } from "@foxglove/studio-base/services/ConsoleApi";
 import { LayoutID, ISO8601Timestamp } from "@foxglove/studio-base/services/ILayoutStorage";
 import {
@@ -18,7 +18,7 @@ function convertLayout({ id, name, permission, data, savedAt }: ConsoleApiLayout
   if (data == undefined) {
     throw new Error(`Missing data for server layout ${name} (${id})`);
   }
-  return { id, name, permission, data: data as PanelsState, savedAt };
+  return { id, name, permission, data: data as LayoutData, savedAt };
 }
 
 export default class ConsoleApiRemoteLayoutStorage implements IRemoteLayoutStorage {
@@ -48,7 +48,7 @@ export default class ConsoleApiRemoteLayoutStorage implements IRemoteLayoutStora
   }: {
     id: LayoutID | undefined;
     name: string;
-    data: PanelsState;
+    data: LayoutData;
     permission: "CREATOR_WRITE" | "ORG_READ" | "ORG_WRITE";
     savedAt: ISO8601Timestamp;
   }): Promise<RemoteLayout> {
@@ -65,7 +65,7 @@ export default class ConsoleApiRemoteLayoutStorage implements IRemoteLayoutStora
   }: {
     id: LayoutID;
     name?: string;
-    data?: PanelsState;
+    data?: LayoutData;
     permission?: "CREATOR_WRITE" | "ORG_READ" | "ORG_WRITE";
     savedAt: ISO8601Timestamp;
   }): Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }> {

--- a/packages/studio-base/src/services/ILayoutManager.ts
+++ b/packages/studio-base/src/services/ILayoutManager.ts
@@ -4,7 +4,7 @@
 
 import { EventNames, EventListener } from "eventemitter3";
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { Layout, LayoutID, LayoutPermission } from "@foxglove/studio-base/services/ILayoutStorage";
 
 export type LayoutManagerChangeEvent =
@@ -71,7 +71,7 @@ export interface ILayoutManager {
 
   saveNewLayout(params: {
     name: string;
-    data: PanelsState;
+    data: LayoutData;
     permission: LayoutPermission;
   }): Promise<Layout>;
 
@@ -81,7 +81,7 @@ export interface ILayoutManager {
    * @note If the layout has not been edited before, the returned layout's id may be different from
    * the input id.
    */
-  updateLayout(params: { id: LayoutID; name?: string; data?: PanelsState }): Promise<Layout>;
+  updateLayout(params: { id: LayoutID; name?: string; data?: LayoutData }): Promise<Layout>;
 
   deleteLayout(params: { id: LayoutID }): Promise<void>;
 

--- a/packages/studio-base/src/services/ILayoutStorage.ts
+++ b/packages/studio-base/src/services/ILayoutStorage.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 
 // We use "brand" tags to prevent confusion between string types with distinct meanings
 // https://github.com/microsoft/TypeScript/issues/4895
@@ -23,13 +23,13 @@ export type Layout = {
   permission: LayoutPermission;
 
   /** @deprecated old field name, migrated to working/baseline */
-  data?: PanelsState;
+  data?: LayoutData;
   /** @deprecated old field name, migrated to working/baseline */
-  state?: PanelsState;
+  state?: LayoutData;
 
   /** The last explicitly saved version of this layout. */
   baseline: {
-    data: PanelsState;
+    data: LayoutData;
     savedAt: ISO8601Timestamp | undefined;
   };
 
@@ -38,7 +38,7 @@ export type Layout = {
    */
   working:
     | {
-        data: PanelsState;
+        data: LayoutData;
         savedAt: ISO8601Timestamp | undefined;
       }
     | undefined;

--- a/packages/studio-base/src/services/IRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/IRemoteLayoutStorage.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import {
   ISO8601Timestamp,
   LayoutID,
@@ -16,7 +16,7 @@ export type RemoteLayout = {
   id: LayoutID;
   name: string;
   permission: LayoutPermission;
-  data: PanelsState;
+  data: LayoutData;
   savedAt: ISO8601Timestamp | undefined;
 };
 
@@ -34,7 +34,7 @@ export interface IRemoteLayoutStorage {
   saveNewLayout: (params: {
     id: LayoutID | undefined;
     name: string;
-    data: PanelsState;
+    data: LayoutData;
     permission: LayoutPermission;
     savedAt: ISO8601Timestamp;
   }) => Promise<RemoteLayout>;
@@ -42,7 +42,7 @@ export interface IRemoteLayoutStorage {
   updateLayout: (params: {
     id: LayoutID;
     name?: string;
-    data?: PanelsState;
+    data?: LayoutData;
     permission?: LayoutPermission;
     savedAt: ISO8601Timestamp;
   }) => Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }>;

--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { MutexLocked } from "@foxglove/den/async";
 import Logger from "@foxglove/log";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { ISO8601Timestamp } from "@foxglove/studio-base/services/ConsoleApi";
 import {
   ILayoutManager,
@@ -221,7 +221,7 @@ export default class LayoutManager implements ILayoutManager {
     permission,
   }: {
     name: string;
-    data: PanelsState;
+    data: LayoutData;
     permission: LayoutPermission;
   }): Promise<Layout> {
     const data = migratePanelsState(unmigratedData);
@@ -277,7 +277,7 @@ export default class LayoutManager implements ILayoutManager {
   }: {
     id: LayoutID;
     name: string | undefined;
-    data: PanelsState | undefined;
+    data: LayoutData | undefined;
   }): Promise<Layout> {
     const now = new Date().toISOString() as ISO8601Timestamp;
     const localLayout = await this.local.runExclusive(async (local) => await local.get(id));

--- a/packages/studio-base/src/services/migrateLayout.ts
+++ b/packages/studio-base/src/services/migrateLayout.ts
@@ -4,7 +4,7 @@
 
 import { MarkOptional } from "ts-essentials";
 
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 
 import { Layout, ISO8601Timestamp } from "./ILayoutStorage";
 import { migrateLegacyToNew3DPanels } from "./migrateLegacyToNew3DPanels";
@@ -12,8 +12,8 @@ import { migrateLegacyToNew3DPanels } from "./migrateLegacyToNew3DPanels";
 /**
  * Perform any necessary migrations on old layout data.
  */
-export function migratePanelsState(data: MarkOptional<PanelsState, "configById">): PanelsState {
-  let result: PanelsState = { ...data, configById: data.configById ?? data.savedProps ?? {} };
+export function migratePanelsState(data: MarkOptional<LayoutData, "configById">): LayoutData {
+  let result: LayoutData = { ...data, configById: data.configById ?? data.savedProps ?? {} };
   delete result.savedProps;
 
   result = migrateLegacyToNew3DPanels(result);

--- a/packages/studio-base/src/services/migrateLegacyToNew3DPanels.ts
+++ b/packages/studio-base/src/services/migrateLegacyToNew3DPanels.ts
@@ -6,7 +6,7 @@ import { round } from "lodash";
 import { MosaicNode } from "react-mosaic-component";
 
 import { filterMap } from "@foxglove/den/collection";
-import { PanelsState } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import type { RendererConfig } from "@foxglove/studio-base/panels/ThreeDeeRender/Renderer";
 import { DEFAULT_CAMERA_STATE } from "@foxglove/studio-base/panels/ThreeDeeRender/camera";
 import {
@@ -111,11 +111,11 @@ function replacePanelInLayout(
 }
 
 function replacePanel(
-  panelsState: PanelsState,
+  panelsState: LayoutData,
   oldId: string,
   newId: string,
   newConfig: Record<string, unknown>,
-): PanelsState {
+): LayoutData {
   const newPanelsState = {
     ...panelsState,
     configById: { ...panelsState.configById, [newId]: newConfig },
@@ -141,17 +141,17 @@ function replacePanel(
   return newPanelsState;
 }
 
-export function migrateLegacyToNew3DPanels(panelsState: PanelsState): PanelsState {
-  if (panelsState.layout == undefined) {
-    return panelsState;
+export function migrateLegacyToNew3DPanels(layoutData: LayoutData): LayoutData {
+  if (layoutData.layout == undefined) {
+    return layoutData;
   }
 
-  const legacy3DPanels = getAllPanelIds(panelsState.layout, panelsState.configById).filter(
+  const legacy3DPanels = getAllPanelIds(layoutData.layout, layoutData.configById).filter(
     (id) => getPanelTypeFromId(id) === "3D Panel",
   );
-  let newState = panelsState;
+  let newState = layoutData;
   for (const id of legacy3DPanels) {
-    const legacyConfig = panelsState.configById[id] as Legacy3DConfig | undefined;
+    const legacyConfig = layoutData.configById[id] as Legacy3DConfig | undefined;
     if (legacyConfig != undefined) {
       newState = replacePanel(
         newState,

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -34,7 +34,7 @@ import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { usePanelSettingsEditorStore } from "@foxglove/studio-base/context/PanelSettingsEditorContext";
+import { usePanelStateStore } from "@foxglove/studio-base/context/PanelStateContext";
 import {
   UserNodeStateProvider,
   useUserNodeState,
@@ -51,7 +51,7 @@ import {
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import HelpInfoProvider from "@foxglove/studio-base/providers/HelpInfoProvider";
-import { PanelSettingsEditorContextProvider } from "@foxglove/studio-base/providers/PanelSettingsEditorContextProvider";
+import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
@@ -171,7 +171,7 @@ function PanelWrapper({
   children?: ReactNode;
   includeSettings?: boolean;
 }): JSX.Element {
-  const settings = usePanelSettingsEditorStore((store) => Object.values(store.settingsTrees)[0]);
+  const settings = usePanelStateStore((store) => Object.values(store.settingsTrees)[0]);
 
   return (
     <>
@@ -329,7 +329,7 @@ export default function PanelSetup(props: Props): JSX.Element {
     <UserNodeStateProvider>
       <TimelineInteractionStateProvider>
         <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
-          <PanelSettingsEditorContextProvider>
+          <PanelStateContextProvider>
             <ExtensionCatalogProvider loaders={[]}>
               <HelpInfoProvider>
                 <ThemeProvider isDark={theme.palette.mode === "dark"}>
@@ -337,7 +337,7 @@ export default function PanelSetup(props: Props): JSX.Element {
                 </ThemeProvider>
               </HelpInfoProvider>
             </ExtensionCatalogProvider>
-          </PanelSettingsEditorContextProvider>
+          </PanelStateContextProvider>
         </MockCurrentLayoutProvider>
       </TimelineInteractionStateProvider>
     </UserNodeStateProvider>


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Rename `PanelSettingsEditorStore` to `PanelStateStore` in preparation for adding more state to this store to implement inter-panel data sharing to achieve things like syncing 3d panel camera states.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
