### PR TITLE
Fix initial player memory leak for layouts with no tabs

### DIFF
--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -14,7 +14,7 @@ import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext
 import { EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import { AppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
@@ -22,34 +22,23 @@ const selectSelectEvent = (store: EventsStore) => store.selectEvent;
 
 const log = Log.getLogger(__filename);
 
-/**
- * Restores our session state from any deep link we were passed on startup.
+/*
+ * Sync functions necessary to keep separate to prevent memory leak from context kept in
+ * useEffect closures. Notably `seekPlayback` being attached to the context of the `useEffect` closures
+ * and that keeping the initial player in memory because the context is never updated because it doesn't depend
+ * on the player.
  */
-export function useInitialDeepLinkState(deepLinks: readonly string[]): {
-  currentUserRequired: boolean;
-} {
-  const { selectSource } = usePlayerSelection();
-  const { setSelectedLayoutId } = useCurrentLayoutActions();
 
-  const seekPlayback = useMessagePipeline(selectSeek);
-  const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const { currentUser } = useCurrentUser();
-  const selectEvent = useEvents(selectSelectEvent);
-
-  const targetUrlState = useMemo(
-    () => (deepLinks[0] ? parseAppURLState(new URL(deepLinks[0])) : undefined),
-    [deepLinks],
-  );
-
-  // Maybe this should be abstracted somewhere but that would require a
-  // more intimate interface with this hook and the player selection logic.
-  const currentUserRequired = targetUrlState?.ds === "foxglove-data-platform";
-
-  // Tracks what portions of the URL state we have yet to apply to the current session.
+function useSyncSourceFromUrl(
+  targetUrlState: AppURLState | undefined,
+  { currentUserRequired }: { currentUserRequired: boolean },
+) {
   const [unappliedUrlState, setUnappliedUrlState] = useState(
-    targetUrlState ? { ...targetUrlState } : undefined,
+    targetUrlState ? { ds: targetUrlState.ds, dsParams: targetUrlState.dsParams } : undefined,
   );
-
+  const { selectSource } = usePlayerSelection();
+  const selectEvent = useEvents(selectSelectEvent);
+  const { currentUser } = useCurrentUser();
   // Load data source from URL.
   useEffect(() => {
     if (!unappliedUrlState) {
@@ -69,10 +58,26 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
         params: unappliedUrlState.dsParams,
       });
       selectEvent(unappliedUrlState.dsParams?.eventId);
-      setUnappliedUrlState((oldState) => ({ ...oldState, ds: undefined, dsParams: undefined }));
+      setUnappliedUrlState({ ds: undefined, dsParams: undefined });
     }
-  }, [currentUser, currentUserRequired, selectEvent, selectSource, unappliedUrlState]);
-
+  }, [
+    currentUser,
+    currentUserRequired,
+    selectEvent,
+    selectSource,
+    unappliedUrlState,
+    setUnappliedUrlState,
+  ]);
+}
+function useSyncLayoutFromUrl(
+  targetUrlState: AppURLState | undefined,
+  { currentUserRequired }: { currentUserRequired: boolean },
+) {
+  const { setSelectedLayoutId } = useCurrentLayoutActions();
+  const playerPresence = useMessagePipeline(selectPlayerPresence);
+  const [unappliedUrlState, setUnappliedUrlState] = useState(
+    targetUrlState ? { layoutId: targetUrlState.layoutId } : undefined,
+  );
   // Select layout from URL.
   useEffect(() => {
     if (!unappliedUrlState?.layoutId) {
@@ -88,9 +93,16 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
 
     log.debug(`Initializing layout from url: ${unappliedUrlState.layoutId}`);
     setSelectedLayoutId(unappliedUrlState.layoutId);
-    setUnappliedUrlState((oldState) => ({ ...oldState, layoutId: undefined }));
+    setUnappliedUrlState({ layoutId: undefined });
   }, [currentUserRequired, playerPresence, setSelectedLayoutId, unappliedUrlState?.layoutId]);
+}
 
+function useSyncTimeFromUrl(targetUrlState: AppURLState | undefined) {
+  const seekPlayback = useMessagePipeline(selectSeek);
+  const playerPresence = useMessagePipeline(selectPlayerPresence);
+  const [unappliedUrlState, setUnappliedUrlState] = useState(
+    targetUrlState ? { time: targetUrlState.time } : undefined,
+  );
   // Seek to time in URL.
   useEffect(() => {
     if (unappliedUrlState?.time == undefined || !seekPlayback) {
@@ -104,8 +116,29 @@ export function useInitialDeepLinkState(deepLinks: readonly string[]): {
 
     log.debug(`Seeking to url time:`, unappliedUrlState.time);
     seekPlayback(unappliedUrlState.time);
-    setUnappliedUrlState((oldState) => ({ ...oldState, time: undefined }));
+    setUnappliedUrlState({ time: undefined });
   }, [playerPresence, seekPlayback, unappliedUrlState]);
+}
 
-  return useMemo(() => ({ currentUserRequired }), [currentUserRequired]);
+/**
+ * Restores our session state from any deep link we were passed on startup.
+ */
+export function useInitialDeepLinkState(deepLinks: readonly string[]): {
+  currentUserRequired: boolean;
+} {
+  const targetUrlState = useMemo(
+    () => (deepLinks[0] ? parseAppURLState(new URL(deepLinks[0])) : undefined),
+    [deepLinks],
+  );
+
+  // Maybe this should be abstracted somewhere but that would require a
+  // more intimate interface with this hook and the player selection logic.
+  const currentUserRequiredParam = useMemo(
+    () => ({ currentUserRequired: targetUrlState?.ds === "foxglove-data-platform" }),
+    [targetUrlState?.ds],
+  );
+  useSyncSourceFromUrl(targetUrlState, currentUserRequiredParam);
+  useSyncLayoutFromUrl(targetUrlState, currentUserRequiredParam);
+  useSyncTimeFromUrl(targetUrlState);
+  return currentUserRequiredParam;
 }

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -23,17 +23,18 @@ const selectSelectEvent = (store: EventsStore) => store.selectEvent;
 const log = Log.getLogger(__filename);
 
 /*
- * Sync functions necessary to keep separate to prevent memory leak from context kept in
- * useEffect closures. Notably `seekPlayback` being attached to the context of the `useEffect` closures
- * and that keeping the initial player in memory because the context is never updated because it doesn't depend
- * on the player.
+ * Separation of sync functions is necessary to prevent memory leak from context kept in
+ * useEffect closures. Notably `seekPlayback` being attached to the context of the `useEffect`
+ * closures that don't use it and aren't updated when it changes. Otherwise the old memoized callbacks
+ * of these functions are kept in React state with the context that includes the old player, preventing
+ * garbage collection of the old player.
  */
 
 function useSyncSourceFromUrl(
   targetUrlState: AppURLState | undefined,
   { currentUserRequired }: { currentUserRequired: boolean },
 ) {
-  const [unappliedUrlState, setUnappliedUrlState] = useState(
+  const [unappliedSourceArgs, setUnappliedSourceArgs] = useState(
     targetUrlState ? { ds: targetUrlState.ds, dsParams: targetUrlState.dsParams } : undefined,
   );
   const { selectSource } = usePlayerSelection();
@@ -41,7 +42,7 @@ function useSyncSourceFromUrl(
   const { currentUser } = useCurrentUser();
   // Load data source from URL.
   useEffect(() => {
-    if (!unappliedUrlState) {
+    if (!unappliedSourceArgs) {
       return;
     }
 
@@ -51,22 +52,22 @@ function useSyncSourceFromUrl(
     }
 
     // Apply any available datasource args
-    if (unappliedUrlState.ds) {
-      log.debug("Initialising source from url", unappliedUrlState);
-      selectSource(unappliedUrlState.ds, {
+    if (unappliedSourceArgs.ds) {
+      log.debug("Initialising source from url", unappliedSourceArgs);
+      selectSource(unappliedSourceArgs.ds, {
         type: "connection",
-        params: unappliedUrlState.dsParams,
+        params: unappliedSourceArgs.dsParams,
       });
-      selectEvent(unappliedUrlState.dsParams?.eventId);
-      setUnappliedUrlState({ ds: undefined, dsParams: undefined });
+      selectEvent(unappliedSourceArgs.dsParams?.eventId);
+      setUnappliedSourceArgs({ ds: undefined, dsParams: undefined });
     }
   }, [
     currentUser,
     currentUserRequired,
     selectEvent,
     selectSource,
-    unappliedUrlState,
-    setUnappliedUrlState,
+    unappliedSourceArgs,
+    setUnappliedSourceArgs,
   ]);
 }
 function useSyncLayoutFromUrl(
@@ -75,12 +76,12 @@ function useSyncLayoutFromUrl(
 ) {
   const { setSelectedLayoutId } = useCurrentLayoutActions();
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const [unappliedUrlState, setUnappliedUrlState] = useState(
+  const [unappliedLayoutArgs, setUnappliedLayoutArgs] = useState(
     targetUrlState ? { layoutId: targetUrlState.layoutId } : undefined,
   );
   // Select layout from URL.
   useEffect(() => {
-    if (!unappliedUrlState?.layoutId) {
+    if (!unappliedLayoutArgs?.layoutId) {
       return;
     }
 
@@ -91,21 +92,21 @@ function useSyncLayoutFromUrl(
       return;
     }
 
-    log.debug(`Initializing layout from url: ${unappliedUrlState.layoutId}`);
-    setSelectedLayoutId(unappliedUrlState.layoutId);
-    setUnappliedUrlState({ layoutId: undefined });
-  }, [currentUserRequired, playerPresence, setSelectedLayoutId, unappliedUrlState?.layoutId]);
+    log.debug(`Initializing layout from url: ${unappliedLayoutArgs.layoutId}`);
+    setSelectedLayoutId(unappliedLayoutArgs.layoutId);
+    setUnappliedLayoutArgs({ layoutId: undefined });
+  }, [currentUserRequired, playerPresence, setSelectedLayoutId, unappliedLayoutArgs?.layoutId]);
 }
 
 function useSyncTimeFromUrl(targetUrlState: AppURLState | undefined) {
   const seekPlayback = useMessagePipeline(selectSeek);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const [unappliedUrlState, setUnappliedUrlState] = useState(
+  const [unappliedTime, setUnappliedTime] = useState(
     targetUrlState ? { time: targetUrlState.time } : undefined,
   );
   // Seek to time in URL.
   useEffect(() => {
-    if (unappliedUrlState?.time == undefined || !seekPlayback) {
+    if (unappliedTime?.time == undefined || !seekPlayback) {
       return;
     }
 
@@ -114,10 +115,10 @@ function useSyncTimeFromUrl(targetUrlState: AppURLState | undefined) {
       return;
     }
 
-    log.debug(`Seeking to url time:`, unappliedUrlState.time);
-    seekPlayback(unappliedUrlState.time);
-    setUnappliedUrlState({ time: undefined });
-  }, [playerPresence, seekPlayback, unappliedUrlState]);
+    log.debug(`Seeking to url time:`, unappliedTime.time);
+    seekPlayback(unappliedTime.time);
+    setUnappliedTime({ time: undefined });
+  }, [playerPresence, seekPlayback, unappliedTime]);
 }
 
 /**


### PR DESCRIPTION
**User-Facing Changes**
 - Fix initial player memory leak for layouts with no tabs and no 3D panel

**Description**
 - tested with two raw message panels over multiple loading of the same source local file. 
 - useInitialDeeplinkState was keeping the initial player around in the context of the useEffect functions via `seekPlayback` since the context of those functions would not update when the player changes. To solve this, I moved each `useEffect` sync into their own functions so that only the `useEffect` that actually needs `seekPlayback` will be exposed to it. 



<!-- link relevant github issues -->
Part of https://github.com/foxglove/studio/pull/4898
<!-- add `docs` label if this PR requires documentation updates -->
