### PR TITLE
Update missing message defs warning for RosDb3IterableSource

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -80,7 +80,7 @@ export class RosDb3IterableSource implements IIterableSource {
         problems.push({
           severity: "warn",
           message: `Topic "${topicDef.name}" has unsupported datatype "${topicDef.type}"`,
-          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Foxglove Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://foxglove.dev/docs/studio/connection/local-file",
+          tip: "ROS 2 .db3 files do not contain message definitions, so only well-known ROS types are supported in Foxglove Studio. As a workaround, you can convert the db3 file to mcap using the mcap CLI. For more information, see: https://foxglove.dev/docs/studio/connection/ros2",
         });
         continue;
       }


### PR DESCRIPTION

**User-Facing Changes**
Updates the db3 missing message definition tip to point to the correct documentation for converting db3 files to mcap.


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
