### PR TITLE
Remove deprecated `datatype` field in MapPanel

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -192,7 +192,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       if (topic.convertibleTo) {
         for (const schemaName of topic.convertibleTo) {
           if (isSupportedSchema(schemaName)) {
-            return { name: topic.name, schemaName, datatype: schemaName };
+            return { name: topic.name, schemaName };
           }
         }
       }

--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -30,7 +30,10 @@ export function validateCustomUrl(url: string): Error | undefined {
   return undefined;
 }
 
-export function buildSettingsTree(config: Config, eligibleTopics: Topic[]): SettingsTreeNodes {
+export function buildSettingsTree(
+  config: Config,
+  eligibleTopics: Omit<Topic, "datatype">[],
+): SettingsTreeNodes {
   const topics: SettingsTreeNodes = transform(
     eligibleTopics,
     (result, topic) => {


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
I cannot collapse this logic down to only subscriptions because we need the list of eligible topics for showing the settings with all topics. I did remove the datatype field by updating the expected type for building the settings tree. I have to omit the field because it is required in the @foxglove/studio type definitions.

Fixes: #4879


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
