### PR TITLE
Use SharedGeometry class instead of static variables in 3D Panel

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -35,6 +35,7 @@ import type { Renderable } from "./Renderable";
 import { SceneExtension } from "./SceneExtension";
 import { ScreenOverlay } from "./ScreenOverlay";
 import { SettingsManager, SettingsTreeEntry } from "./SettingsManager";
+import { SharedGeometry } from "./SharedGeometry";
 import { CameraState } from "./camera";
 import { DARK_OUTLINE, LIGHT_OUTLINE, stringToRgb } from "./color";
 import { FRAME_TRANSFORM_DATATYPES } from "./foxglove";
@@ -322,16 +323,17 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
   public labelPool = new LabelPool({ fontFamily: fonts.MONOSPACE });
   public markerPool = new MarkerPool(this);
+  public sharedGeometry = new SharedGeometry();
 
   private _prevResolution = new THREE.Vector2();
   private _pickingEnabled = false;
   private _isUpdatingCameraState = false;
   private _animationFrame?: number;
   private _cameraSyncError: undefined | string;
+  private _devicePixelRatioMediaQuery?: MediaQueryList;
 
   public constructor(canvas: HTMLCanvasElement, config: RendererConfig) {
     super();
-
     // NOTE: Global side effect
     THREE.Object3D.DefaultUp = new THREE.Vector3(0, 0, 1);
 
@@ -427,7 +429,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
 
     this.picker = new Picker(this.gl, this.scene, { debug: DEBUG_PICKING });
 
-    this.selectionBackdrop = new ScreenOverlay();
+    this.selectionBackdrop = new ScreenOverlay(this);
     this.selectionBackdrop.visible = false;
     this.scene.add(this.selectionBackdrop);
 
@@ -482,37 +484,45 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addSceneExtension(this.measurementTool);
     this.addSceneExtension(this.publishClickTool);
 
+    this._devicePixelRatioMediaQuery = window.matchMedia(
+      `(resolution: ${window.devicePixelRatio}dppx)`,
+    );
     this._watchDevicePixelRatio();
 
     this._updateCameras(config.cameraState);
     this.animationFrame();
   }
 
-  private _watchDevicePixelRatio() {
-    window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`).addEventListener(
-      "change",
-      () => {
-        log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
-        this.resizeHandler(this.input.canvasSize);
-        this._watchDevicePixelRatio();
-      },
-      { once: true },
+  private _onDevicePixelRatioChange = () => {
+    log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
+    this.resizeHandler(this.input.canvasSize);
+    this._devicePixelRatioMediaQuery = window.matchMedia(
+      `(resolution: ${window.devicePixelRatio}dppx)`,
     );
+    this._watchDevicePixelRatio();
+  };
+
+  private _watchDevicePixelRatio() {
+    this._devicePixelRatioMediaQuery?.addEventListener("change", this._onDevicePixelRatioChange, {
+      once: true,
+    });
   }
 
   public dispose(): void {
     log.warn(`Disposing renderer`);
+    this._devicePixelRatioMediaQuery?.removeEventListener("change", this._onDevicePixelRatioChange);
     this.removeAllListeners();
 
-    this.settings.off("update");
-    this.input.off("resize", this.resizeHandler);
-    this.input.off("click", this.clickHandler);
+    this.settings.removeAllListeners();
+    this.input.removeAllListeners();
+
     this.controls.dispose();
 
     for (const extension of this.sceneExtensions.values()) {
       extension.dispose();
     }
     this.sceneExtensions.clear();
+    this.sharedGeometry.dispose();
 
     this.labelPool.dispose();
     this.markerPool.dispose();

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -484,9 +484,6 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addSceneExtension(this.measurementTool);
     this.addSceneExtension(this.publishClickTool);
 
-    this._devicePixelRatioMediaQuery = window.matchMedia(
-      `(resolution: ${window.devicePixelRatio}dppx)`,
-    );
     this._watchDevicePixelRatio();
 
     this._updateCameras(config.cameraState);
@@ -496,14 +493,14 @@ export class Renderer extends EventEmitter<RendererEvents> {
   private _onDevicePixelRatioChange = () => {
     log.debug(`devicePixelRatio changed to ${window.devicePixelRatio}`);
     this.resizeHandler(this.input.canvasSize);
-    this._devicePixelRatioMediaQuery = window.matchMedia(
-      `(resolution: ${window.devicePixelRatio}dppx)`,
-    );
     this._watchDevicePixelRatio();
   };
 
   private _watchDevicePixelRatio() {
-    this._devicePixelRatioMediaQuery?.addEventListener("change", this._onDevicePixelRatioChange, {
+    this._devicePixelRatioMediaQuery = window.matchMedia(
+      `(resolution: ${window.devicePixelRatio}dppx)`,
+    );
+    this._devicePixelRatioMediaQuery.addEventListener("change", this._onDevicePixelRatioChange, {
       once: true,
     });
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ScreenOverlay.ts
@@ -4,14 +4,14 @@
 
 import * as THREE from "three";
 
+import { Renderer } from "./Renderer";
+
 type vec4 = [number, number, number, number];
 
 export class ScreenOverlay extends THREE.Object3D {
-  private static geometry: THREE.PlaneGeometry | undefined;
-
   private material: THREE.ShaderMaterial;
 
-  public constructor() {
+  public constructor(renderer: Renderer) {
     super();
 
     this.material = new THREE.ShaderMaterial({
@@ -29,7 +29,8 @@ export class ScreenOverlay extends THREE.Object3D {
       `,
     });
 
-    const mesh = new THREE.Mesh(ScreenOverlay.Geometry(), this.material);
+    const geometry = renderer.sharedGeometry.getGeometry(this.constructor.name, createGeometry);
+    const mesh = new THREE.Mesh(geometry, this.material);
     mesh.frustumCulled = false;
     this.add(mesh);
   }
@@ -41,11 +42,9 @@ export class ScreenOverlay extends THREE.Object3D {
     colorUniform[2] = color.b;
     colorUniform[3] = opacity;
   }
+}
 
-  private static Geometry(): THREE.PlaneGeometry {
-    if (!ScreenOverlay.geometry) {
-      ScreenOverlay.geometry = new THREE.PlaneGeometry(2, 2, 1, 1);
-    }
-    return ScreenOverlay.geometry;
-  }
+function createGeometry(): THREE.PlaneGeometry {
+  const geometry = new THREE.PlaneGeometry(2, 2, 1, 1);
+  return geometry;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
@@ -4,12 +4,12 @@
 
 import * as THREE from "three";
 
+/**
+ * Class for storing a single instance of each geometry to reuse across scene extensions
+ * Callers of `getGeometry` will need to specify a unique key from which to extract the
+ * singleton geometry.
+ */
 export class SharedGeometry {
-  /**
-   * Store a single instance of each geometry to reuse across scene extensions
-   * Callers of `getGeometry` will need to specify a unique key from which to extract the
-   * singleton geometry.
-   */
   private _geometryMap = new Map<string, THREE.BufferGeometry>();
 
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SharedGeometry.ts
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as THREE from "three";
+
+export class SharedGeometry {
+  /**
+   * Store a single instance of each geometry to reuse across scene extensions
+   * Callers of `getGeometry` will need to specify a unique key from which to extract the
+   * singleton geometry.
+   */
+  private _geometryMap = new Map<string, THREE.BufferGeometry>();
+
+  /**
+   * Get a geometry from the map, or create it if it doesn't exist.
+   * Note that this map will not allow overwriting of existing geometries.
+   * @param key unique key to identify the geometry
+   * @param createGeometry - function to create the geometry if it does not exist
+   * @returns - created geometry if it doesn't exist or the existing geometry from the map
+   */
+  public getGeometry<T extends THREE.BufferGeometry>(key: string, createGeometry: () => T): T {
+    let geometry = this._geometryMap.get(key);
+    if (!geometry) {
+      geometry = createGeometry();
+      this._geometryMap.set(key, geometry);
+    }
+    return geometry as T;
+  }
+  // disposes of all geometries and clears the map
+  public dispose(): void {
+    for (const geometry of this._geometryMap.values()) {
+      geometry.dispose();
+    }
+    this._geometryMap.clear();
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -37,7 +37,6 @@ import {
 import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
-import useCleanup from "@foxglove/studio-base/hooks/useCleanup";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import { DebugGui } from "./DebugGui";
@@ -548,9 +547,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     { leading: false, trailing: true, maxWait: 1000 },
   );
   useEffect(() => throttledSave(config), [config, throttledSave]);
-
-  // Dispose of the renderer (and associated GPU resources) on teardown
-  useCleanup(() => renderer?.dispose());
 
   // Establish a connection to the message pipeline with context.watch and context.onRender
   useLayoutEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -80,13 +80,12 @@ const tempEuler = new THREE.Euler();
 const tempTfPath: [string, string] = ["transforms", ""];
 
 export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
-  private static lineGeometry: LineGeometry | undefined;
-
   private lineMaterial: LineMaterial;
   private linePickingMaterial: THREE.ShaderMaterial;
 
   private labelForegroundColor = 1;
   private labelBackgroundColor = new THREE.Color();
+  private lineGeometry: LineGeometry;
 
   public constructor(renderer: Renderer) {
     super("foxglove.FrameAxes", renderer);
@@ -100,6 +99,12 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     this.lineMaterial.color = color;
 
     const options = { resolution: renderer.input.canvasSize, worldUnits: false };
+
+    this.lineGeometry = this.renderer.sharedGeometry.getGeometry(
+      this.constructor.name,
+      createLineGeometry,
+    );
+
     this.linePickingMaterial = makeLinePickingMaterial(PICKING_LINE_SIZE, options);
 
     renderer.on("transformTreeUpdated", this.handleTransformTreeUpdated);
@@ -437,7 +442,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const settings = { ...DEFAULT_SETTINGS, ...userSettings };
 
     // Parent line
-    const parentLine = new Line2(FrameAxes.LineGeometry(), this.lineMaterial);
+    const parentLine = new Line2(this.lineGeometry, this.lineMaterial);
     parentLine.castShadow = true;
     parentLine.receiveShadow = false;
     parentLine.userData.pickingMaterial = this.linePickingMaterial;
@@ -492,14 +497,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     frame.offsetPosition = getOffset(this.renderer.config.transforms[frameKey]?.xyzOffset);
     frame.offsetEulerDegrees = getOffset(this.renderer.config.transforms[frameKey]?.rpyOffset);
   }
-
-  private static LineGeometry(): LineGeometry {
-    if (!FrameAxes.lineGeometry) {
-      FrameAxes.lineGeometry = new LineGeometry();
-      FrameAxes.lineGeometry.setPositions([0, 0, 0, 1, 0, 0]);
-    }
-    return FrameAxes.lineGeometry;
-  }
+}
+function createLineGeometry(): LineGeometry {
+  const lineGeometry = new LineGeometry();
+  lineGeometry.setPositions([0, 0, 0, 1, 0, 0]);
+  return lineGeometry;
 }
 
 function buildSettingsFields(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
@@ -7,7 +7,7 @@ import * as THREE from "three";
 import { DynamicInstancedMesh } from "../../DynamicInstancedMesh";
 import type { Renderer } from "../../Renderer";
 import { Marker } from "../../ros";
-import { RenderableCube } from "./RenderableCube";
+import { createGeometry as createCubeGeometry } from "./RenderableCube";
 import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
 
@@ -25,7 +25,8 @@ export class RenderableCubeList extends RenderableMarker {
 
     // Cube instanced mesh
     const material = makeStandardInstancedMaterial(marker);
-    this.mesh = new DynamicInstancedMesh(RenderableCube.Geometry(), material, marker.points.length);
+    const geometry = renderer.sharedGeometry.getGeometry("RenderableCube", createCubeGeometry);
+    this.mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
     this.mesh.castShadow = true;
     this.mesh.receiveShadow = true;
     this.add(this.mesh);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -12,10 +12,6 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 
 export class RenderableCylinder extends RenderableMarker {
-  private static lod: DetailLevel | undefined;
-  private static cylinderGeometry: THREE.CylinderGeometry | undefined;
-  private static cylinderEdgesGeometry: THREE.EdgesGeometry | undefined;
-
   private mesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
   private outline: THREE.LineSegments | undefined;
 
@@ -29,14 +25,20 @@ export class RenderableCylinder extends RenderableMarker {
 
     // Cylinder mesh
     const material = makeStandardMaterial(marker.color);
-    const cylinderGeometry = RenderableCylinder.Geometry(renderer.maxLod);
+    const cylinderGeometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-${renderer.maxLod}`,
+      () => createGeometry(renderer.maxLod),
+    );
     this.mesh = new THREE.Mesh(cylinderGeometry, material);
     this.mesh.castShadow = true;
     this.mesh.receiveShadow = true;
     this.add(this.mesh);
 
     // Cylinder outline
-    const edgesGeometry = RenderableCylinder.EdgesGeometry(renderer.maxLod);
+    const edgesGeometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-${renderer.maxLod}`,
+      () => createEdgesGeometry(cylinderGeometry),
+    );
     this.outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);
     this.outline.userData.picking = false;
     this.mesh.add(this.outline);
@@ -64,24 +66,17 @@ export class RenderableCylinder extends RenderableMarker {
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }
+}
+function createGeometry(lod: DetailLevel): THREE.CylinderGeometry {
+  const subdivisions = cylinderSubdivisions(lod);
+  const cylinderGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivisions);
+  cylinderGeometry.rotateX(Math.PI / 2); // Make the cylinder geometry stand upright
+  cylinderGeometry.computeBoundingSphere();
+  return cylinderGeometry;
+}
 
-  private static Geometry(lod: DetailLevel): THREE.CylinderGeometry {
-    if (!RenderableCylinder.cylinderGeometry || lod !== RenderableCylinder.lod) {
-      const subdivisions = cylinderSubdivisions(lod);
-      RenderableCylinder.cylinderGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, subdivisions);
-      RenderableCylinder.cylinderGeometry.rotateX(Math.PI / 2); // Make the cylinder geometry stand upright
-      RenderableCylinder.cylinderGeometry.computeBoundingSphere();
-      RenderableCylinder.lod = lod;
-    }
-    return RenderableCylinder.cylinderGeometry;
-  }
-
-  private static EdgesGeometry(lod: DetailLevel): THREE.EdgesGeometry {
-    if (!RenderableCylinder.cylinderEdgesGeometry) {
-      const geometry = RenderableCylinder.Geometry(lod);
-      RenderableCylinder.cylinderEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
-      RenderableCylinder.cylinderEdgesGeometry.computeBoundingSphere();
-    }
-    return RenderableCylinder.cylinderEdgesGeometry;
-  }
+function createEdgesGeometry(geometry: THREE.CylinderGeometry): THREE.EdgesGeometry {
+  const cylinderEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
+  cylinderEdgesGeometry.computeBoundingSphere();
+  return cylinderEdgesGeometry;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -26,7 +26,7 @@ export class RenderableCylinder extends RenderableMarker {
     // Cylinder mesh
     const material = makeStandardMaterial(marker.color);
     const cylinderGeometry = renderer.sharedGeometry.getGeometry(
-      `${this.constructor.name}-${renderer.maxLod}`,
+      `${this.constructor.name}-cylinder-${renderer.maxLod}`,
       () => createGeometry(renderer.maxLod),
     );
     this.mesh = new THREE.Mesh(cylinderGeometry, material);
@@ -36,7 +36,7 @@ export class RenderableCylinder extends RenderableMarker {
 
     // Cylinder outline
     const edgesGeometry = renderer.sharedGeometry.getGeometry(
-      `${this.constructor.name}-${renderer.maxLod}`,
+      `${this.constructor.name}-edges-${renderer.maxLod}`,
       () => createEdgesGeometry(cylinderGeometry),
     );
     this.outline = new THREE.LineSegments(edgesGeometry, renderer.outlineMaterial);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -12,9 +12,6 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 
 export class RenderableSphere extends RenderableMarker {
-  private static lod: DetailLevel | undefined;
-  private static sphereGeometry: THREE.SphereGeometry | undefined;
-
   public mesh: THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
 
   public constructor(
@@ -26,7 +23,10 @@ export class RenderableSphere extends RenderableMarker {
     super(topic, marker, receiveTime, renderer);
 
     // Sphere mesh
-    const geometry = RenderableSphere.Geometry(renderer.maxLod);
+    const geometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-${renderer.maxLod}`,
+      () => createGeometry(renderer.maxLod),
+    );
     this.mesh = new THREE.Mesh(geometry, makeStandardMaterial(marker.color));
     this.mesh.castShadow = true;
     this.mesh.receiveShadow = true;
@@ -55,14 +55,11 @@ export class RenderableSphere extends RenderableMarker {
 
     this.scale.set(marker.scale.x, marker.scale.y, marker.scale.z);
   }
+}
 
-  public static Geometry(lod: DetailLevel): THREE.SphereGeometry {
-    if (!RenderableSphere.sphereGeometry || lod !== RenderableSphere.lod) {
-      const subdivisions = sphereSubdivisions(lod);
-      RenderableSphere.sphereGeometry = new THREE.SphereGeometry(0.5, subdivisions, subdivisions);
-      RenderableSphere.sphereGeometry.computeBoundingSphere();
-      RenderableSphere.lod = lod;
-    }
-    return RenderableSphere.sphereGeometry;
-  }
+export function createGeometry(lod: DetailLevel): THREE.SphereGeometry {
+  const subdivisions = sphereSubdivisions(lod);
+  const sphereGeometry = new THREE.SphereGeometry(0.5, subdivisions, subdivisions);
+  sphereGeometry.computeBoundingSphere();
+  return sphereGeometry;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
@@ -8,7 +8,7 @@ import { DynamicInstancedMesh } from "../../DynamicInstancedMesh";
 import type { Renderer } from "../../Renderer";
 import { Marker } from "../../ros";
 import { RenderableMarker } from "./RenderableMarker";
-import { RenderableSphere } from "./RenderableSphere";
+import { createGeometry as createSphereGeometry } from "./RenderableSphere";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
 
 export class RenderableSphereList extends RenderableMarker {
@@ -23,7 +23,10 @@ export class RenderableSphereList extends RenderableMarker {
     super(topic, marker, receiveTime, renderer);
 
     // Sphere instanced mesh
-    const geometry = RenderableSphere.Geometry(renderer.maxLod);
+    const geometry = renderer.sharedGeometry.getGeometry(
+      `RenderableSphere-${renderer.maxLod}`,
+      () => createSphereGeometry(renderer.maxLod),
+    );
     const material = makeStandardInstancedMaterial(marker);
     this.mesh = new DynamicInstancedMesh(geometry, material, marker.points.length);
     this.mesh.castShadow = true;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -22,13 +22,17 @@ const tempQuat = new THREE.Quaternion();
 const tempRgba = makeRgba();
 
 export class RenderableArrows extends RenderablePrimitive {
-  // Each needs its own geometry because we attach additional custom attributes to it.
+  // Each needs its own geometries because we attach additional custom attributes to them.
+  // so we will need to clone or copy when assigning from shared geometry
   private shaftGeometry: THREE.CylinderGeometry;
+  private headGeometry: THREE.ConeGeometry;
+  private shaftOutlineGeometry: THREE.InstancedBufferGeometry;
+  private headOutlineGeometry: THREE.InstancedBufferGeometry;
+
   private shaftMesh: THREE.InstancedMesh<
     THREE.CylinderGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
-  private headGeometry: THREE.ConeGeometry;
   private headMesh: THREE.InstancedMesh<
     THREE.ConeGeometry,
     MeshStandardMaterialWithInstanceOpacity
@@ -46,9 +50,7 @@ export class RenderableArrows extends RenderablePrimitive {
    */
   private maxInstances: number;
 
-  private shaftOutlineGeometry: THREE.InstancedBufferGeometry;
   private shaftOutline: THREE.LineSegments;
-  private headOutlineGeometry: THREE.InstancedBufferGeometry;
   private headOutline: THREE.LineSegments;
 
   public constructor(renderer: Renderer) {
@@ -68,7 +70,6 @@ export class RenderableArrows extends RenderablePrimitive {
       1,
     );
 
-    // because we are adding a attributes to these geometries we will need to clone it
     this.shaftGeometry = renderer.sharedGeometry
       .getGeometry(`${this.constructor.name}-shaft`, createShaftGeometry)
       .clone() as THREE.CylinderGeometry;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -22,18 +22,13 @@ const tempQuat = new THREE.Quaternion();
 const tempRgba = makeRgba();
 
 export class RenderableArrows extends RenderablePrimitive {
-  private static shaftGeometry: THREE.CylinderGeometry | undefined;
-  private static shaftEdgesGeometry: THREE.EdgesGeometry | undefined;
-  private static headGeometry: THREE.CylinderGeometry | undefined;
-  private static headEdgesGeometry: THREE.EdgesGeometry | undefined;
-
-  // Each RenderableArrows needs its own geometry because we attach additional custom attributes to it.
-  private shaftGeometry = RenderableArrows.ShaftGeometry().clone() as THREE.CylinderGeometry;
+  // Each needs its own geometry because we attach additional custom attributes to it.
+  private shaftGeometry: THREE.CylinderGeometry;
   private shaftMesh: THREE.InstancedMesh<
     THREE.CylinderGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
-  private headGeometry = RenderableArrows.HeadGeometry().clone() as THREE.ConeGeometry;
+  private headGeometry: THREE.ConeGeometry;
   private headMesh: THREE.InstancedMesh<
     THREE.ConeGeometry,
     MeshStandardMaterialWithInstanceOpacity
@@ -72,20 +67,29 @@ export class RenderableArrows extends RenderablePrimitive {
       new Float32Array(this.maxInstances),
       1,
     );
-    this.shaftGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
-    this.headGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
 
+    // because we are adding a attributes to these geometries we will need to clone it
+    this.shaftGeometry = renderer.sharedGeometry
+      .getGeometry(`${this.constructor.name}-shaft`, createShaftGeometry)
+      .clone() as THREE.CylinderGeometry;
+    this.shaftGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
     this.shaftMesh = new THREE.InstancedMesh(this.shaftGeometry, this.material, this.maxInstances);
     this.shaftMesh.count = 0;
     this.add(this.shaftMesh);
 
+    this.headGeometry = renderer.sharedGeometry
+      .getGeometry(`${this.constructor.name}-head`, createHeadGeometry)
+      .clone() as THREE.ConeGeometry;
+    this.headGeometry.setAttribute("instanceOpacity", this.instanceOpacity);
     this.headMesh = new THREE.InstancedMesh(this.headGeometry, this.material, this.maxInstances);
     this.headMesh.count = 0;
     this.add(this.headMesh);
 
-    this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(
-      RenderableArrows.ShaftEdgesGeometry(),
+    const shaftEdgesGeometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-shaftedges`,
+      () => createShaftEdgesGeometry(this.shaftGeometry),
     );
+    this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
     this.shaftOutlineGeometry.setAttribute("instanceMatrix", this.shaftMesh.instanceMatrix);
     this.shaftOutline = new THREE.LineSegments(
       this.shaftOutlineGeometry,
@@ -95,9 +99,11 @@ export class RenderableArrows extends RenderablePrimitive {
     this.shaftOutline.userData.picking = false;
     this.add(this.shaftOutline);
 
-    this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(
-      RenderableArrows.HeadEdgesGeometry(),
+    const headEdgesGeometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-headedges`,
+      () => createHeadEdgesGeometry(this.headGeometry),
     );
+    this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
     this.headOutlineGeometry.setAttribute("instanceMatrix", this.headMesh.instanceMatrix);
     this.headOutline = new THREE.LineSegments(
       this.headOutlineGeometry,
@@ -138,17 +144,21 @@ export class RenderableArrows extends RenderablePrimitive {
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
 
       this.shaftOutlineGeometry.dispose();
-      this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(
-        RenderableArrows.ShaftEdgesGeometry(),
+      const shaftEdgesGeometry = this.renderer.sharedGeometry.getGeometry(
+        `${this.constructor.name}-shaftedges`,
+        () => createShaftEdgesGeometry(this.shaftGeometry),
       );
+      this.shaftOutlineGeometry = new THREE.InstancedBufferGeometry().copy(shaftEdgesGeometry);
       this.shaftOutlineGeometry.instanceCount = newCapacity;
       this.shaftOutlineGeometry.setAttribute("instanceMatrix", this.shaftMesh.instanceMatrix);
       this.shaftOutline.geometry = this.shaftOutlineGeometry;
 
       this.headOutlineGeometry.dispose();
-      this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(
-        RenderableArrows.HeadEdgesGeometry(),
+      const headEdgesGeometry = this.renderer.sharedGeometry.getGeometry(
+        `${this.constructor.name}-headedges`,
+        () => createHeadEdgesGeometry(this.headGeometry),
       );
+      this.headOutlineGeometry = new THREE.InstancedBufferGeometry().copy(headEdgesGeometry);
       this.headOutlineGeometry.instanceCount = newCapacity;
       this.headOutlineGeometry.setAttribute("instanceMatrix", this.headMesh.instanceMatrix);
       this.headOutline.geometry = this.headOutlineGeometry;
@@ -257,46 +267,32 @@ export class RenderableArrows extends RenderablePrimitive {
   public updateSettings(settings: LayerSettingsEntity): void {
     this.update(this.userData.entity, settings, this.userData.receiveTime);
   }
+}
 
-  private static ShaftGeometry() {
-    if (!RenderableArrows.shaftGeometry) {
-      RenderableArrows.shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
-      // Adjust cylinder so ends are centered on (0,0,0) and (1,0,0)
-      RenderableArrows.shaftGeometry.rotateZ(-Math.PI / 2).translate(0.5, 0, 0);
-      RenderableArrows.shaftGeometry.computeBoundingSphere();
-    }
-    return RenderableArrows.shaftGeometry;
-  }
+function createShaftGeometry() {
+  const shaftGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
+  // Adjust cylinder so ends are centered on (0,0,0) and (1,0,0)
+  shaftGeometry.rotateZ(-Math.PI / 2).translate(0.5, 0, 0);
+  shaftGeometry.computeBoundingSphere();
+  return shaftGeometry;
+}
 
-  private static ShaftEdgesGeometry() {
-    if (!RenderableArrows.shaftEdgesGeometry) {
-      RenderableArrows.shaftEdgesGeometry = new THREE.EdgesGeometry(
-        RenderableArrows.ShaftGeometry(),
-        40,
-      );
-      RenderableArrows.shaftEdgesGeometry.computeBoundingSphere();
-    }
-    return RenderableArrows.shaftEdgesGeometry;
-  }
+function createShaftEdgesGeometry(geometry: THREE.CylinderGeometry) {
+  const shaftEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
+  shaftEdgesGeometry.computeBoundingSphere();
+  return shaftEdgesGeometry;
+}
 
-  private static HeadGeometry() {
-    if (!RenderableArrows.headGeometry) {
-      RenderableArrows.headGeometry = new THREE.ConeGeometry(0.5, 1, 16);
-      // Adjust cone so base is centered on (0,0,0) and tip is at (1,0,0)
-      RenderableArrows.headGeometry.rotateZ(-Math.PI / 2).translate(0.5, 0, 0);
-      RenderableArrows.headGeometry.computeBoundingSphere();
-    }
-    return RenderableArrows.headGeometry;
-  }
+function createHeadGeometry() {
+  const headGeometry = new THREE.ConeGeometry(0.5, 1, 16);
+  // Adjust cone so base is centered on (0,0,0) and tip is at (1,0,0)
+  headGeometry.rotateZ(-Math.PI / 2).translate(0.5, 0, 0);
+  headGeometry.computeBoundingSphere();
+  return headGeometry;
+}
 
-  private static HeadEdgesGeometry() {
-    if (!RenderableArrows.headEdgesGeometry) {
-      RenderableArrows.headEdgesGeometry = new THREE.EdgesGeometry(
-        RenderableArrows.HeadGeometry(),
-        40,
-      );
-      RenderableArrows.headEdgesGeometry.computeBoundingSphere();
-    }
-    return RenderableArrows.headEdgesGeometry;
-  }
+function createHeadEdgesGeometry(geometry: THREE.ConeGeometry) {
+  const headEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
+  headEdgesGeometry.computeBoundingSphere();
+  return headEdgesGeometry;
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -22,15 +22,15 @@ const tempQuat = new THREE.Quaternion();
 const tempRgba = makeRgba();
 
 export class RenderableCylinders extends RenderablePrimitive {
-  private static cylinderGeometry: THREE.CylinderGeometry | undefined;
-  private static cylinderEdgesGeometry: THREE.EdgesGeometry | undefined;
-
   // Each RenderableCylinders needs its own geometry because we attach additional custom attributes to it.
-  private geometry = RenderableCylinders.Geometry().clone() as THREE.CylinderGeometry;
   private mesh: THREE.InstancedMesh<
     THREE.CylinderGeometry,
     MeshStandardMaterialWithInstanceOpacity
   >;
+  private geometry: THREE.CylinderGeometry;
+  // actual shared geometry across instances, only copy -- do not modify
+  // stored for ease of use
+  private sharedEdgesGeometry: THREE.EdgesGeometry<THREE.BufferGeometry>;
   private instanceOpacity: THREE.InstancedBufferAttribute;
   private instanceTopScale: THREE.InstancedBufferAttribute;
   private instanceBottomScale: THREE.InstancedBufferAttribute;
@@ -58,6 +58,9 @@ export class RenderableCylinders extends RenderablePrimitive {
       entity: undefined,
     });
 
+    this.geometry = renderer.sharedGeometry
+      .getGeometry(`${this.constructor.name}-cylinder`, createGeometry)
+      .clone() as THREE.CylinderGeometry;
     this.maxInstances = 16;
     this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
     this.mesh.userData.pickingMaterial = this.pickingMaterial;
@@ -79,9 +82,11 @@ export class RenderableCylinders extends RenderablePrimitive {
     this.mesh.count = 0;
     this.add(this.mesh);
 
-    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(
-      RenderableCylinders.EdgesGeometry(),
+    this.sharedEdgesGeometry = renderer.sharedGeometry.getGeometry(
+      `${this.constructor.name}-edges`,
+      () => createEdgesGeometry(this.geometry),
     );
+    this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
     this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
     this.outlineGeometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
     this.outlineGeometry.setAttribute("instanceTopScale", this.instanceTopScale);
@@ -126,9 +131,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       // THREE.js doesn't correctly recompute the new max instance count when dynamically
       // reassigning the attribute of InstancedBufferGeometry, so we just create a new geometry
       this.outlineGeometry.dispose();
-      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(
-        RenderableCylinders.EdgesGeometry(),
-      );
+      this.outlineGeometry = new THREE.InstancedBufferGeometry().copy(this.sharedEdgesGeometry);
       this.outlineGeometry.instanceCount = newCapacity;
       this.outlineGeometry.setAttribute("instanceMatrix", this.mesh.instanceMatrix);
       this.outlineGeometry.setAttribute("instanceBottomScale", this.instanceBottomScale);
@@ -226,26 +229,18 @@ export class RenderableCylinders extends RenderablePrimitive {
   public updateSettings(settings: LayerSettingsEntity): void {
     this.update(this.userData.entity, settings, this.userData.receiveTime);
   }
+}
+function createGeometry() {
+  const cylinderGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
+  cylinderGeometry.rotateX(Math.PI / 2);
+  cylinderGeometry.computeBoundingSphere();
+  return cylinderGeometry;
+}
 
-  private static Geometry() {
-    if (!RenderableCylinders.cylinderGeometry) {
-      RenderableCylinders.cylinderGeometry = new THREE.CylinderGeometry(0.5, 0.5, 1, 16);
-      RenderableCylinders.cylinderGeometry.rotateX(Math.PI / 2);
-      RenderableCylinders.cylinderGeometry.computeBoundingSphere();
-    }
-    return RenderableCylinders.cylinderGeometry;
-  }
-
-  private static EdgesGeometry() {
-    if (!RenderableCylinders.cylinderEdgesGeometry) {
-      RenderableCylinders.cylinderEdgesGeometry = new THREE.EdgesGeometry(
-        RenderableCylinders.Geometry(),
-        40,
-      );
-      RenderableCylinders.cylinderEdgesGeometry.computeBoundingSphere();
-    }
-    return RenderableCylinders.cylinderEdgesGeometry;
-  }
+function createEdgesGeometry(geometry: THREE.CylinderGeometry) {
+  const cylinderEdgesGeometry = new THREE.EdgesGeometry(geometry, 40);
+  cylinderEdgesGeometry.computeBoundingSphere();
+  return cylinderEdgesGeometry;
 }
 
 /** Modify the given vertex shader so it transforms positions to support bottom_scale and top_scale. */

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -22,9 +22,7 @@ const tempQuat = new THREE.Quaternion();
 const tempRgba = makeRgba();
 
 export class RenderableSpheres extends RenderablePrimitive {
-  private static sphereGeometry: THREE.SphereGeometry | undefined;
-
-  private geometry = new THREE.SphereGeometry(0.5, 16, 16);
+  private geometry: THREE.SphereGeometry;
   private mesh: THREE.InstancedMesh<THREE.SphereGeometry, MeshStandardMaterialWithInstanceOpacity>;
   private instanceOpacity: THREE.InstancedBufferAttribute;
   private material = new MeshStandardMaterialWithInstanceOpacity({
@@ -51,13 +49,15 @@ export class RenderableSpheres extends RenderablePrimitive {
     });
 
     // Sphere mesh
+    this.geometry = renderer.sharedGeometry
+      .getGeometry(this.constructor.name, createGeometry)
+      .clone() as THREE.SphereGeometry;
     this.maxInstances = 16;
     this.mesh = new THREE.InstancedMesh(this.geometry, this.material, this.maxInstances);
     this.instanceOpacity = new THREE.InstancedBufferAttribute(
       new Float32Array(this.maxInstances),
       1,
     );
-    this.geometry.copy(RenderableSpheres.Geometry());
     this.geometry.setAttribute("instanceOpacity", this.instanceOpacity);
     this.mesh.count = 0;
     this.add(this.mesh);
@@ -157,12 +157,10 @@ export class RenderableSpheres extends RenderablePrimitive {
   public updateSettings(settings: LayerSettingsEntity): void {
     this.update(this.userData.entity, settings, this.userData.receiveTime);
   }
+}
 
-  private static Geometry(): THREE.SphereGeometry {
-    if (!RenderableSpheres.sphereGeometry) {
-      RenderableSpheres.sphereGeometry = new THREE.SphereGeometry(0.5, 16, 16);
-      RenderableSpheres.sphereGeometry.computeBoundingSphere();
-    }
-    return RenderableSpheres.sphereGeometry;
-  }
+function createGeometry(): THREE.SphereGeometry {
+  const sphereGeometry = new THREE.SphereGeometry(0.5, 16, 16);
+  sphereGeometry.computeBoundingSphere();
+  return sphereGeometry;
 }


### PR DESCRIPTION
**User-Facing Changes**
 - fix renderer memory leak where it would be kept around by static members attached to an old webgl context
 - fix renderer memory leak not removing the devicePixelRatio event listener

**Description**
- Created SharedGeometry class that holds a key/value map of geometries to be used across Renderable and SceneExtension classes. All of it's contained geometries are disposed when the renderer is disposed.
 - remove event listener for devicePixelRatio that would keep the renderer after the panel was unmounted

<!-- link relevant github issues -->
Addresses: #4899
Part of fixing: #4824
<!-- add `docs` label if this PR requires documentation updates -->
