### PR TITLE
Show the correct settings state when the last selected panel is deleted

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelActionsDropdown.tsx
@@ -246,7 +246,10 @@ export function PanelActionsDropdown({ isUnknownPanel }: Props): JSX.Element {
           ) : (
             <MenuItem
               key={item.key}
-              onClick={item.onClick}
+              onClick={(event) => {
+                event.stopPropagation();
+                item.onClick?.();
+              }}
               onMouseEnter={() => setSubmenuAnchorEl(undefined)}
               className={cx(classes.menuItem, item.className)}
               data-testid={item["data-testid"]}


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with the settings sidebar state after deleting the selected panel.

**Description**
We have code to deselect the panel when it's deleted:
https://github.com/foxglove/studio/blob/a95135e7f85c51809d212783e182dcc821a36856/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx#L305

But this code was firing *after* that update, reselecting a panel that is no longer in the layout:
https://github.com/foxglove/studio/blob/a95135e7f85c51809d212783e182dcc821a36856/packages/studio-base/src/components/Panel.tsx#L354-L369

The fix here is to stop event propagation from the click on the menu item so that the `onPanelRootClick` does not fire when a menu item is selected.

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
Fixes https://github.com/foxglove/studio/issues/4918