### PR TITLE
Fix `selectRecent` memory leak keeping old players in memory

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -41,7 +41,7 @@ import PlayerSelectionContext, {
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useUserNodeState } from "@foxglove/studio-base/context/UserNodeStateContext";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
-import useIndexedDbRecents from "@foxglove/studio-base/hooks/useIndexedDbRecents";
+import useIndexedDbRecents, { RecentRecord } from "@foxglove/studio-base/hooks/useIndexedDbRecents";
 import useWarnImmediateReRender from "@foxglove/studio-base/hooks/useWarnImmediateReRender";
 import AnalyticsMetricsCollector from "@foxglove/studio-base/players/AnalyticsMetricsCollector";
 import UserNodePlayer from "@foxglove/studio-base/players/UserNodePlayer";
@@ -282,31 +282,10 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   );
 
   // Select a recent entry by id
+  // necessary to pull out callback creation to avoid capturing the initial player in context
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectRecent = useCallback(
-    (recentId: string) => {
-      // find the recent from the list and initialize
-      const foundRecent = recents.find((value) => value.id === recentId);
-      if (!foundRecent) {
-        enqueueSnackbar(`Failed to restore recent: ${recentId}`, { variant: "error" });
-        return;
-      }
-
-      switch (foundRecent.type) {
-        case "connection": {
-          void selectSource(foundRecent.sourceId, {
-            type: "connection",
-            params: foundRecent.extra,
-          });
-          break;
-        }
-        case "file": {
-          void selectSource(foundRecent.sourceId, {
-            type: "file",
-            handle: foundRecent.handle,
-          });
-        }
-      }
-    },
+    createSelectRecentCallback(recents, selectSource, enqueueSnackbar),
     [recents, enqueueSnackbar, selectSource],
   );
 
@@ -333,4 +312,37 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       </PlayerSelectionContext.Provider>
     </>
   );
+}
+
+// fixes memory leak across > 2 data sources without reloading
+// otherwise we would get memory leak from keeping initial player around
+function createSelectRecentCallback(
+  recents: RecentRecord[],
+  selectSource: (sourceId: string, dataSourceArgs: DataSourceArgs) => Promise<void>,
+  enqueueSnackbar: ReturnType<typeof useSnackbar>["enqueueSnackbar"],
+) {
+  return (recentId: string) => {
+    // find the recent from the list and initialize
+    const foundRecent = recents.find((value) => value.id === recentId);
+    if (!foundRecent) {
+      enqueueSnackbar(`Failed to restore recent: ${recentId}`, { variant: "error" });
+      return;
+    }
+
+    switch (foundRecent.type) {
+      case "connection": {
+        void selectSource(foundRecent.sourceId, {
+          type: "connection",
+          params: foundRecent.extra,
+        });
+        break;
+      }
+      case "file": {
+        void selectSource(foundRecent.sourceId, {
+          type: "file",
+          handle: foundRecent.handle,
+        });
+      }
+    }
+  };
 }

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -282,7 +282,7 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   );
 
   // Select a recent entry by id
-  // necessary to pull out callback creation to avoid capturing the initial player in context
+  // necessary to pull out callback creation to avoid capturing the initial player in closure context
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectRecent = useCallback(
     createSelectRecentCallback(recents, selectSource, enqueueSnackbar),
@@ -314,8 +314,15 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   );
 }
 
-// fixes memory leak across > 2 data sources without reloading
-// otherwise we would get memory leak from keeping initial player around
+/**
+ * This was moved out of the PlayerManager function due to a memory leak occurring in memoized state of Start.tsx
+ * that was retaining old player instances. Having this callback be defined within the PlayerManager makes it store the
+ * player at instantiation within the closure context. That callback is then stored in the memoized state with its closure context.
+ * The callback is updated when the player changes but part of the `Start.tsx` holds onto the formerly memoized state for an
+ * unknown reason.
+ * To make this function safe from storing old closure contexts in old memoized state in components where it
+ * is used, it has been moved out of the PlayerManager function.
+ */
 function createSelectRecentCallback(
   recents: RecentRecord[],
   selectSource: (sourceId: string, dataSourceArgs: DataSourceArgs) => Promise<void>,

--- a/packages/studio-base/src/hooks/useIndexedDbRecents.ts
+++ b/packages/studio-base/src/hooks/useIndexedDbRecents.ts
@@ -42,7 +42,7 @@ type RecentFileRecord = RecentRecordCommon & {
 
 type UnsavedRecentRecord = Omit<RecentConnectionRecord, "id"> | Omit<RecentFileRecord, "id">;
 
-type RecentRecord = RecentConnectionRecord | RecentFileRecord;
+export type RecentRecord = RecentConnectionRecord | RecentFileRecord;
 
 interface IRecentsStore {
   // Recent records


### PR DESCRIPTION
**User-Facing Changes**
 - fix frequent memory leak where `selectRecent` would keep the players in memory after selecting a new source

**Description**

Because the callback is exposed to the larger PlayerManager closure context it captures the player in it. This function is used in memoized state in `Start.tsx`, but the `OpenDialog` that contains it isn't cleaned up by react on unmount for an unknown reason. `selectSource` does not seem to have the same problem with its usage. As a workaround, moving the definition of the `selectRecent` callback to an outside function will prevent it from keeping the player in its closure context this way.

The `stateNode` holding onto the detached element is the mui-modal in `OpenDialog` which is unmounted, but it's still stored in react internal state functions (ie: `stateNode` and `lastEffect`), which makes me think this might be a react issue. When we update react we should probably check to see whether this is still the case because apparently cleanup in react 18 is more aggressive. 

Retainer stack:
<img width="892" alt="image" src="https://user-images.githubusercontent.com/10187776/205985251-d815fccb-4ab8-45dd-8192-5a6131b6ceb5.png">


To reproduce prior to fix:
(with memory panel open in chrome devtools)
1. use studio default layout
2. Refresh the page and select a local file source
3. Wait for buffering to finish
4. Go to data source tab and select the same local source
5. Take a snapshot in the memory panel
6. See two iterable players in memory, the old IterablePlayer will be the one that has a greater distance, click to inspect its retainers
7. It's primary retainers should resemble the screenshot above


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->

