### PR TITLE
Fix a typo of 'usually' in the WebSocket panel

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
@@ -15,7 +15,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   public displayName = "Foxglove WebSocket";
   public iconName: IDataSourceFactory["iconName"] = "Flow";
   public description =
-    "Connect live to your custom data via an encoding-agnostic WebSocket connection. Using this data source usualy requires writing a custom server.";
+    "Connect live to your custom data via an encoding-agnostic WebSocket connection. Using this data source usually requires writing a custom server.";
   public docsLinks = [{ url: "https://foxglove.dev/docs/studio/connection/foxglove-websocket" }];
 
   public formConfig = {


### PR DESCRIPTION
**User-Facing Changes**

Updates spelling in the "Open new connection" pop-up, "Foxglove WebSocket" panel.

**Description**

Simple typo fix that changes 'usualy' to 'usually'.