### PR TITLE
Move GlobalCss back into <App> under a prop

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -106,7 +106,7 @@ export default function Root({
         extensionLoaders={extensionLoaders}
         nativeAppMenu={nativeAppMenu}
         nativeWindow={nativeWindow}
-        enableGlobalCss={true}
+        enableGlobalCss
       />
     </>
   );

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -10,7 +10,6 @@ import {
   ConsoleApi,
   FoxgloveDataPlatformDataSourceFactory,
   FoxgloveWebSocketDataSourceFactory,
-  GlobalCss,
   IAppConfiguration,
   IDataSourceFactory,
   IdbExtensionLoader,
@@ -97,7 +96,6 @@ export default function Root({
 
   return (
     <>
-      <GlobalCss />
       <App
         enableDialogAuth
         deepLinks={deepLinks}
@@ -108,6 +106,7 @@ export default function Root({
         extensionLoaders={extensionLoaders}
         nativeAppMenu={nativeAppMenu}
         nativeWindow={nativeWindow}
+        enableGlobalCss={true}
       />
     </>
   );

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -6,6 +6,7 @@ import { useState, Suspense, Fragment, useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
+import GlobalCss from "@foxglove/studio-base/components/GlobalCss";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
@@ -57,6 +58,7 @@ type AppProps = {
   disableSignin?: boolean;
   enableDialogAuth?: boolean;
   enableLaunchPreferenceScreen?: boolean;
+  enableGlobalCss?: boolean;
 };
 
 // Suppress context menu for the entire app except on inputs & textareas.
@@ -84,6 +86,7 @@ export function App(props: AppProps): JSX.Element {
     enableDialogAuth,
     deepLinks,
     enableLaunchPreferenceScreen,
+    enableGlobalCss = false,
   } = props;
 
   const CurrentUserProviderComponent =
@@ -133,6 +136,7 @@ export function App(props: AppProps): JSX.Element {
   return (
     <AppConfigurationContext.Provider value={appConfiguration}>
       <ColorSchemeThemeProvider>
+        {enableGlobalCss && <GlobalCss />}
         <CssBaseline>
           <ErrorBoundary>
             <MaybeLaunchPreference>

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -33,7 +33,6 @@ export { IdbExtensionLoader } from "./services/IdbExtensionLoader";
 export type { ExtensionLoader } from "./services/ExtensionLoader";
 export type { ExtensionInfo, ExtensionNamespace } from "./types/Extensions";
 export { AppSetting } from "./AppSetting";
-export { default as GlobalCss } from "./components/GlobalCss";
 export { default as FoxgloveDataPlatformDataSourceFactory } from "./dataSources/FoxgloveDataPlatformDataSourceFactory";
 export { default as FoxgloveWebSocketDataSourceFactory } from "./dataSources/FoxgloveWebSocketDataSourceFactory";
 export { default as Ros1LocalBagDataSourceFactory } from "./dataSources/Ros1LocalBagDataSourceFactory";

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -72,7 +72,7 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
         layoutStorage={layoutStorage}
         consoleApi={consoleApi}
         extensionLoaders={extensionLoaders}
-        enableGlobalCss={true}
+        enableGlobalCss
       />
     </>
   );

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -19,7 +19,6 @@ import {
   IdbExtensionLoader,
   App,
   ConsoleApi,
-  GlobalCss,
 } from "@foxglove/studio-base";
 
 import Ros1UnavailableDataSourceFactory from "./dataSources/Ros1UnavailableDataSourceFactory";
@@ -63,7 +62,6 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
 
   return (
     <>
-      <GlobalCss />
       <App
         disableSignin={disableSignin}
         enableDialogAuth={enableDialogAuth}
@@ -74,6 +72,7 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
         layoutStorage={layoutStorage}
         consoleApi={consoleApi}
         extensionLoaders={extensionLoaders}
+        enableGlobalCss={true}
       />
     </>
   );


### PR DESCRIPTION

**User-Facing Changes**
Styling fixes for some modal text elements.

**Description**
The MuiModal root appears outside of the #root component directly within body. This means it does not inherit the styling we apply on #root (such as font family and sizes) for some components (Link seems to be one of them).

As a workaround we move <GlobalCss> back into <App> under a property to allow users of <App> to specify if they want to turn these global values on. Without these the styling might be wrong on certain elements if the user does not set the same font on the body that they use within the app.

Additionally, GlobalCss must exist within the ThemeProvider and was not before so its setting of the background color and body elements was incorrect when used outside of <App>

Fixes: #4934


<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
