### PR TITLE
Fix MUI nested title error on onboarding tooltip

### DIFF
--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -118,7 +118,10 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     }, [panelId, onDismissTooltip, setSelectedPanelIds, openPanelSettings]);
 
     let settingsButton = (
-      <ToolbarIconButton title="Settings" onClick={openSettings}>
+      <ToolbarIconButton
+        title={settingsOnboardingTooltip ? undefined : "Settings"}
+        onClick={openSettings}
+      >
         <SettingsIcon />
       </ToolbarIconButton>
     );


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fixes a MUI error related to nested `title` props related to the onboarding tooltip. We should omit the `title` attribute on the settings icon if we intend to wrap it in the onboarding tooltip.

<img width="487" alt="image" src="https://user-images.githubusercontent.com/93935560/206070532-df34e358-4431-4fb3-a628-9eb6554dc61f.png">

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
