### PR TITLE
Fix Windows deep link handling by encoding with base64

### DIFF
--- a/desktop/common/rendererArgs.test.ts
+++ b/desktop/common/rendererArgs.test.ts
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { decodeRendererArg, encodeRendererArg } from "./rendererArgs";
+
+describe("encodeRendererArg & decodeRendererArg", () => {
+  it("encodes and decodes", () => {
+    const encoded = encodeRendererArg("deepLinks", ["foxglove://example"]);
+    expect(encoded).toEqual("--deepLinks=WyJmb3hnbG92ZTovL2V4YW1wbGUiXQ==");
+    expect(decodeRendererArg("deepLinks", ["arg1", encoded, "arg2"])).toEqual([
+      "foxglove://example",
+    ]);
+  });
+});

--- a/desktop/common/rendererArgs.ts
+++ b/desktop/common/rendererArgs.ts
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Logger from "@foxglove/log";
+
+const log = Logger.getLogger(__filename);
+
+type RendererArgTypes = {
+  deepLinks: string[];
+};
+
+/**
+ * Encode arguments passed from main to renderer process using base64,
+ * to avoid breaking on Windows when the values contain special characters like ":".
+ *
+ * https://github.com/foxglove/studio/issues/4896
+ * https://github.com/electron/electron/issues/32064
+ * https://github.com/electron/electron/issues/31168
+ */
+export function encodeRendererArg<K extends keyof RendererArgTypes>(
+  argName: K,
+  value: RendererArgTypes[K],
+): string {
+  return `--${argName}=${btoa(JSON.stringify(value))}`;
+}
+
+export function decodeRendererArg<K extends keyof RendererArgTypes>(
+  argName: K,
+  args: string[],
+): RendererArgTypes[K] | undefined {
+  const argPrefix = `--${argName}=`;
+  const argValue = args.find((str) => str.startsWith(argPrefix))?.substring(argPrefix.length);
+  try {
+    return argValue ? JSON.parse(atob(argValue)) : undefined;
+  } catch (error) {
+    log.error(error);
+    return undefined;
+  }
+}

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -106,7 +106,11 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
       additionalArguments: [
         `--allowCrashReporting=${crashReportingEnabled ? "1" : "0"}`,
         `--allowTelemetry=${telemetryEnabled ? "1" : "0"}`,
-        ...deepLinks,
+        // Encode using base64 to avoid breaking on Windows when the values contain special characters like ":".
+        // https://github.com/foxglove/studio/issues/4896
+        // https://github.com/electron/electron/issues/32064
+        // https://github.com/electron/electron/issues/31168
+        `--deepLinks=${btoa(JSON.stringify(deepLinks))}`,
       ],
       // Disable webSecurity in development so we can make XML-RPC calls, load
       // remote data, etc. In production, the app is served from file:// URLs so

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -17,6 +17,7 @@ import path from "path";
 import Logger from "@foxglove/log";
 
 import pkgInfo from "../../package.json";
+import { encodeRendererArg } from "../common/rendererArgs";
 import getDevModeIcon from "./getDevModeIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
@@ -106,11 +107,7 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
       additionalArguments: [
         `--allowCrashReporting=${crashReportingEnabled ? "1" : "0"}`,
         `--allowTelemetry=${telemetryEnabled ? "1" : "0"}`,
-        // Encode using base64 to avoid breaking on Windows when the values contain special characters like ":".
-        // https://github.com/foxglove/studio/issues/4896
-        // https://github.com/electron/electron/issues/32064
-        // https://github.com/electron/electron/issues/31168
-        `--deepLinks=${btoa(JSON.stringify(deepLinks))}`,
+        encodeRendererArg("deepLinks", deepLinks),
       ],
       // Disable webSecurity in development so we can make XML-RPC calls, load
       // remote data, etc. In production, the app is served from file:// URLs so

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -13,6 +13,7 @@ import Logger from "@foxglove/log";
 import { NetworkInterface, OsContext } from "@foxglove/studio-base/src/OsContext";
 
 import pkgInfo from "../../package.json";
+import { decodeRendererArg } from "../common/rendererArgs";
 import { Desktop, ForwardedMenuEvent, NativeMenuBridge, Storage } from "../common/types";
 import LocalFileStorage from "./LocalFileStorage";
 import { getExtensions, loadExtension, installExtension, uninstallExtension } from "./extensions";
@@ -104,11 +105,7 @@ const desktopBridge: Desktop = {
     await ipcRenderer.invoke("updateNativeColorScheme");
   },
   getDeepLinks(): string[] {
-    const deepLinksArg = window.process.argv
-      .find((arg) => arg.startsWith("--deepLinks="))
-      ?.replace(/^--deepLinks=/, "");
-    // See comment in StudioWindow.ts
-    return deepLinksArg ? JSON.parse(atob(deepLinksArg)) : undefined;
+    return decodeRendererArg("deepLinks", window.process.argv) ?? [];
   },
   async getExtensions() {
     const homePath = (await ipcRenderer.invoke("getHomePath")) as string;

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -104,7 +104,11 @@ const desktopBridge: Desktop = {
     await ipcRenderer.invoke("updateNativeColorScheme");
   },
   getDeepLinks(): string[] {
-    return window.process.argv.filter((arg) => arg.startsWith("foxglove://"));
+    const deepLinksArg = window.process.argv
+      .find((arg) => arg.startsWith("--deepLinks="))
+      ?.replace(/^--deepLinks=/, "");
+    // See comment in StudioWindow.ts
+    return deepLinksArg ? JSON.parse(atob(deepLinksArg)) : undefined;
   },
   async getExtensions() {
     const homePath = (await ipcRenderer.invoke("getHomePath")) as string;

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@foxglove/tsconfig/base",
   "include": ["*.ts", "common/**/*", "integration-test/**/*.ts", "../package.json"],
   "compilerOptions": {
+    "lib": ["dom", "es2020"],
     "module": "commonjs",
     "noEmit": true
   }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue on Windows where `foxglove://` links would open a blank Foxglove Studio window.

**Description**
Fixes #4896 

It seems like passing arbitrary arguments to the renderer is not safe on windows for some reason. We work around the problem by base64-encoding.

See: https://github.com/electron/electron/issues/31168, https://github.com/electron/electron/issues/32064