### PR TITLE
Fix `settingsTree` memory leak

### DIFF
--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -26,7 +26,7 @@ export type PanelStateStore = {
   /**
    * Per-panel settings UI trees.
    */
-  settingsTrees: Record<string, ImmutableSettingsTree>;
+  settingsTrees: Record<string, ImmutableSettingsTree | undefined>;
 
   /**
    * Transient state shared between panels, keyed by panel type.
@@ -41,7 +41,7 @@ export type PanelStateStore = {
   /**
    * Updates the settings UI for the given panel.
    */
-  updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree) => void;
+  updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree | undefined) => void;
 
   /**
    * Update the transient state associated with a particular panel type.

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -72,6 +72,18 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
     [id, updateStoreTree],
   );
 
+  /** Cleanup unmounted panels
+   * `actionHandler` can capture panel variables in closure context and keep them in memory
+   * even after unmounting. To prevent this we set the panelSettingsTree entry to undefined,
+   * allowing the actionHandler and its captured closure context from the unmounted panel to
+   * be garbage collected.
+   */
+  useEffect(() => {
+    return () => {
+      updateStoreTree(id, undefined);
+    };
+  }, [id, updateStoreTree]);
+
   return updateSettingsTree;
 }
 


### PR DESCRIPTION
**User-Facing Changes**
- plug another memory leak keeping old `IterablePlayer`'s in state

**Description**
- fix `settingsTree` keeping panel variables including former `IterablePlayers` in memory after unmount
<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
