### PR TITLE
[3D] Customize "selected_id" variable for SceneEntity and Marker topics

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
@@ -10,6 +10,8 @@ import type { Renderer } from "./Renderer";
 import type { BaseSettings } from "./settings";
 import type { Pose } from "./transforms";
 
+export const SELECTED_ID_VARIABLE = "selected_id";
+
 export type BaseUserData = {
   /** Timestamp when the associated `MessageEvent` was received */
   receiveTime: bigint;
@@ -61,7 +63,21 @@ export class Renderable<TUserData extends BaseUserData = BaseUserData> extends T
   }
 
   /**
-   * Return a Plain Old JavaScript Object (POJO) representation of this Renderable
+   * A unique identifier for this Renderable, taken from the associated message.
+   */
+  public idFromMessage(): number | string | undefined {
+    return undefined;
+  }
+
+  /**
+   * The name of the variable that will be set to `idFromMessage()` on user selection.
+   */
+  public selectedIdVariable(): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * Return a Plain Old JavaScript Object (POJO) representation of this Renderable.
    */
   public details(): Record<string, RosValue> {
     return {};
@@ -70,7 +86,6 @@ export class Renderable<TUserData extends BaseUserData = BaseUserData> extends T
   /**
    * Return a Plain Old JavaScript Object (POJO) representation of a specific
    * visual instance rendered by this Renderable.
-   * @param instanceId
    */
   public instanceDetails(instanceId: number): Record<string, RosValue> | undefined {
     void instanceId;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -42,7 +42,7 @@ import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { DebugGui } from "./DebugGui";
 import { InteractionContextMenu, Interactions, SelectionObject, TabType } from "./Interactions";
 import type { PickedRenderable } from "./Picker";
-import type { Renderable } from "./Renderable";
+import { Renderable, SELECTED_ID_VARIABLE } from "./Renderable";
 import {
   FollowMode,
   Renderer,
@@ -73,7 +73,7 @@ type Shared3DPanelState = {
 };
 
 const SHOW_DEBUG: true | false = false;
-const SELECTED_ID_VARIABLE = "selected_id";
+
 const PANEL_STYLE: React.CSSProperties = {
   width: "100%",
   height: "100%",
@@ -500,7 +500,11 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   // Write to a global variable when the current selection changes
   const updateSelectedRenderable = useCallback(
     (selection: PickedRenderable | undefined) => {
-      const id = (selection?.renderable.details() as { id?: number | string } | undefined)?.id;
+      const id = selection?.renderable.idFromMessage();
+      const customVariable = selection?.renderable.selectedIdVariable();
+      if (customVariable) {
+        context.setVariable(customVariable, id ?? ReactNull);
+      }
       context.setVariable(SELECTED_ID_VARIABLE, id ?? ReactNull);
     },
     [context],

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -7,6 +7,7 @@ import { set } from "lodash";
 import { toNanoSec } from "@foxglove/rostime";
 import { SettingsTreeAction } from "@foxglove/studio";
 
+import { SELECTED_ID_VARIABLE } from "../Renderable";
 import { Renderer } from "../Renderer";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
@@ -27,12 +28,14 @@ import { LayerSettingsMarkerNamespace, TopicMarkers } from "./TopicMarkers";
 
 export type LayerSettingsMarker = BaseSettings & {
   color: string | undefined;
+  selectedIdVariable: string | undefined;
   namespaces: Record<string, LayerSettingsMarkerNamespace>;
 };
 
 const DEFAULT_SETTINGS: LayerSettingsMarker = {
   visible: false,
   color: undefined,
+  selectedIdVariable: undefined,
   namespaces: {},
 };
 
@@ -64,6 +67,13 @@ export class Markers extends SceneExtension<TopicMarkers> {
         order: topic.name.toLocaleLowerCase(),
         fields: {
           color: { label: "Color", input: "rgba", value: config.color },
+          selectedIdVariable: {
+            label: "Selection Variable",
+            input: "string",
+            help: "When selecting a marker, this global variable will be set to the marker ID",
+            value: config.selectedIdVariable,
+            placeholder: SELECTED_ID_VARIABLE,
+          },
         },
         visible: config.visible ?? DEFAULT_SETTINGS.visible,
         handler: this.handleSettingsAction,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
@@ -20,6 +20,7 @@ import {
 } from "@foxglove/schemas";
 import { SettingsTreeAction } from "@foxglove/studio";
 
+import { SELECTED_ID_VARIABLE } from "../Renderable";
 import { Renderer } from "../Renderer";
 import { PartialMessage, PartialMessageEvent, SceneExtension } from "../SceneExtension";
 import { SettingsTreeEntry, SettingsTreeNodeWithActionHandler } from "../SettingsManager";
@@ -40,11 +41,13 @@ import { PrimitivePool } from "./primitives/PrimitivePool";
 
 export type LayerSettingsEntity = BaseSettings & {
   color: string | undefined;
+  selectedIdVariable: string | undefined;
 };
 
 const DEFAULT_SETTINGS: LayerSettingsEntity = {
   visible: false,
   color: undefined,
+  selectedIdVariable: undefined,
 };
 
 export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
@@ -71,6 +74,13 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
         order: topic.name.toLocaleLowerCase(),
         fields: {
           color: { label: "Color", input: "rgba", value: config.color },
+          selectedIdVariable: {
+            label: "Selection Variable",
+            input: "string",
+            help: "When selecting a SceneEntity, this global variable will be set to the entity ID",
+            value: config.selectedIdVariable,
+            placeholder: SELECTED_ID_VARIABLE,
+          },
         },
         visible: config.visible ?? DEFAULT_SETTINGS.visible,
         handler: this.handleSettingsAction,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -154,7 +154,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
           renderables[primitiveType] = renderable;
           this.add(renderable);
         }
-        renderable.update(entity, this.userData.settings, receiveTime);
+        renderable.update(this.userData.topic, entity, this.userData.settings, receiveTime);
       } else if (renderable) {
         this.remove(renderable);
         delete renderables[primitiveType];

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMarker.ts
@@ -52,6 +52,17 @@ export class RenderableMarker extends Renderable<MarkerUserData> {
     });
   }
 
+  public override idFromMessage(): number | string | undefined {
+    return this.userData.marker.id;
+  }
+
+  public override selectedIdVariable(): string | undefined {
+    const settings = this.renderer.config.topics[this.userData.topic] as
+      | LayerSettingsMarker
+      | undefined;
+    return settings?.selectedIdVariable;
+  }
+
   public override details(): Record<string, RosValue> {
     return this.userData.originalMarker;
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -59,7 +59,7 @@ export class RenderableArrows extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -251,13 +251,12 @@ export class RenderableArrows extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -266,7 +265,7 @@ export class RenderableArrows extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -50,7 +50,7 @@ export class RenderableCubes extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -170,13 +170,12 @@ export class RenderableCubes extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -185,7 +184,7 @@ export class RenderableCubes extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -53,7 +53,7 @@ export class RenderableCylinders extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -212,13 +212,12 @@ export class RenderableCylinders extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -227,7 +226,7 @@ export class RenderableCylinders extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 function createGeometry() {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -28,7 +28,7 @@ export class RenderableLines extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -171,13 +171,12 @@ export class RenderableLines extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -186,7 +185,7 @@ export class RenderableLines extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -39,7 +39,7 @@ export class RenderableModels extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -135,13 +135,12 @@ export class RenderableModels extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -150,7 +149,7 @@ export class RenderableModels extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 
   private async _loadCachedModel(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderablePrimitive.ts
@@ -9,6 +9,7 @@ import { RosValue } from "@foxglove/studio-base/players/types";
 import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
 export type EntityRenderableUserData = BaseUserData & {
+  topic?: string;
   entity?: SceneEntity;
   expiresAt?: bigint;
   settings?: LayerSettingsEntity;
@@ -16,13 +17,29 @@ export type EntityRenderableUserData = BaseUserData & {
 
 export class RenderablePrimitive extends Renderable<EntityRenderableUserData> {
   public update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    void entity;
-    void settings;
-    void receiveTime;
+    this.userData.topic = topic;
+    this.userData.entity = entity;
+    this.userData.settings = settings;
+    this.userData.receiveTime = receiveTime;
+  }
+
+  public override idFromMessage(): number | string | undefined {
+    return this.userData.entity?.id;
+  }
+
+  public override selectedIdVariable(): string | undefined {
+    if (this.userData.topic == undefined) {
+      return undefined;
+    }
+    const settings = this.renderer.config.topics[this.userData.topic] as
+      | LayerSettingsEntity
+      | undefined;
+    return settings?.selectedIdVariable;
   }
 
   public override details(): Record<string, RosValue> {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -43,7 +43,7 @@ export class RenderableSpheres extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -140,13 +140,12 @@ export class RenderableSpheres extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -155,7 +154,7 @@ export class RenderableSpheres extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
@@ -24,7 +24,7 @@ export class RenderableTexts extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -99,13 +99,12 @@ export class RenderableTexts extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -114,6 +113,6 @@ export class RenderableTexts extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -30,7 +30,7 @@ export class RenderableTriangles extends RenderablePrimitive {
       messageTime: -1n,
       frameId: "",
       pose: emptyPose(),
-      settings: { visible: true, color: undefined },
+      settings: { visible: true, color: undefined, selectedIdVariable: undefined },
       settingsPath: [],
       entity: undefined,
     });
@@ -217,13 +217,12 @@ export class RenderableTriangles extends RenderablePrimitive {
   }
 
   public override update(
+    topic: string | undefined,
     entity: SceneEntity | undefined,
     settings: LayerSettingsEntity,
     receiveTime: bigint,
   ): void {
-    this.userData.entity = entity;
-    this.userData.settings = settings;
-    this.userData.receiveTime = receiveTime;
+    super.update(topic, entity, settings, receiveTime);
     if (entity) {
       const lifetimeNs = toNanoSec(entity.lifetime);
       this.userData.expiresAt = lifetimeNs === 0n ? undefined : receiveTime + lifetimeNs;
@@ -232,7 +231,7 @@ export class RenderableTriangles extends RenderablePrimitive {
   }
 
   public updateSettings(settings: LayerSettingsEntity): void {
-    this.update(this.userData.entity, settings, this.userData.receiveTime);
+    this.update(this.userData.topic, this.userData.entity, settings, this.userData.receiveTime);
   }
 }
 


### PR DESCRIPTION
**User-Facing Changes**
- [3D] Set another global variable in addition to "selected_id" when selecting a SceneEntity or Marker

**Description**

SceneEntity and Marker topic settings now have an additional field to customize the global variable that is updated when 
selecting an entity or marker. This global variable is sticky, and is set in addition to `selected_id` to preserve the 
existing behavior.
