### PR TITLE
Significantly reduce memory impact of leaked players across sources

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -158,6 +158,11 @@ class BufferedIterableSource implements IIterableSource {
     log.debug("producer done");
   }
 
+  public async terminate(): Promise<void> {
+    this.cache.clear();
+    await this.source.terminate();
+  }
+
   public async stopProducer(): Promise<void> {
     this.aborted = true;
     this.writeSignal.notifyAll();

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -92,6 +92,11 @@ class CachingIterableSource implements IIterableSource {
     return this.initResult;
   }
 
+  public async terminate(): Promise<void> {
+    this.cache.length = 0;
+    this.cachedTopics.length = 0;
+  }
+
   public loadedRanges(): Range[] {
     return this.loadedRangesCache;
   }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -995,6 +995,7 @@ export class IterablePlayer implements Player {
     await this._blockLoader?.stopLoading();
     await this._blockLoadingProcess;
     await this._bufferedSource.stopProducer();
+    await this._bufferedSource.terminate();
     await this._playbackIterator?.return?.();
     this._playbackIterator = undefined;
     await this._iterableSource.terminate?.();


### PR DESCRIPTION
**User-Facing Changes**
 - Significantly reduce memory impact of leaked players across sources

**Description**
In the event that part of application is holding onto old IterablePlayers, now on `close()` we will clear the buffer caches to eliminate the majority of the memory leak. This will significantly reduce the impact of this kind of memory leak in the future to a near negligible size.
Retained sizes before -> after: 308428529 bytes -> 5024 bytes 
<img width="586" alt="image" src="https://user-images.githubusercontent.com/10187776/206552464-a4fe5106-65e4-437e-af73-4ad538857ec5.png">



<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
