### PR TITLE
3D: published point/pose should use render frame, not fixed frame

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -817,9 +817,9 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   useEffect(() => {
     const onStart = () => setPublishActive(true);
     const onSubmit = (event: PublishClickEvent & { type: "foxglove.publish-submit" }) => {
-      const frameId = renderer?.fixedFrameId;
+      const frameId = renderer?.renderFrameId;
       if (frameId == undefined) {
-        log.warn("Unable to publish, fixedFrameId is not set");
+        log.warn("Unable to publish, renderFrameId is not set");
         return;
       }
       if (!context.publish) {
@@ -872,7 +872,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     context,
     latestPublishConfig,
     publishTopics,
-    renderer?.fixedFrameId,
+    renderer?.renderFrameId,
     renderer?.publishClickTool,
   ]);
 


### PR DESCRIPTION
**User-Facing Changes**
- Fixed an issue where click-to-publish in the 3D panel was always publishing using the fixed frame while coordinates were in the display frame.

**Description**
Fixes https://github.com/foxglove/studio/issues/4890