### PR TITLE
remove fullSchemaName, adhere to name from data source

### DIFF
--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -19,7 +19,6 @@ describe("parseChannel", () => {
         ),
       },
     });
-    expect(channel.fullSchemaName).toEqual("X");
     expect(channel.deserializer(new TextEncoder().encode(JSON.stringify({ value: "hi" })))).toEqual(
       { value: "hi" },
     );
@@ -31,7 +30,6 @@ describe("parseChannel", () => {
       messageEncoding: "flatbuffer",
       schema: { name: "reflection.Schema", encoding: "flatbuffer", data: reflectionSchema },
     });
-    expect(channel.fullSchemaName).toEqual("reflection.Schema");
     const deserialized = channel.deserializer(reflectionSchema) as {
       objects: Record<string, unknown>[];
     };
@@ -45,7 +43,6 @@ describe("parseChannel", () => {
       messageEncoding: "protobuf",
       schema: { name: "google.protobuf.FileDescriptorSet", encoding: "protobuf", data: fds },
     });
-    expect(channel.fullSchemaName).toEqual("google.protobuf.FileDescriptorSet");
     const deserialized = channel.deserializer(fds) as IFileDescriptorSet;
     expect(deserialized.file[0]!.name).toEqual("google_protobuf.proto");
   });
@@ -77,7 +74,6 @@ describe("parseChannel", () => {
         ),
       },
     });
-    expect(channel.fullSchemaName).toEqual("ExampleMessage");
     expect(channel.deserializer(Buffer.from("0A0101", "hex"))).toEqual({ data: [1] });
   });
 
@@ -90,7 +86,6 @@ describe("parseChannel", () => {
         data: new TextEncoder().encode("string data"),
       },
     });
-    expect(channel.fullSchemaName).toEqual("foo_msgs/Bar");
 
     const obj = channel.deserializer(new Uint8Array([4, 0, 0, 0, 65, 66, 67, 68]));
     expect(obj).toEqual({ data: "ABCD" });
@@ -105,7 +100,6 @@ describe("parseChannel", () => {
         data: new TextEncoder().encode("string data"),
       },
     });
-    expect(channel.fullSchemaName).toEqual("foo_msgs/Bar");
 
     const obj = channel.deserializer(new Uint8Array([0, 1, 0, 0, 5, 0, 0, 0, 65, 66, 67, 68, 0]));
     expect(obj).toEqual({ data: "ABCD" });

--- a/packages/mcap-support/src/parseFlatbufferSchema.test.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.test.ts
@@ -316,11 +316,10 @@ describe("parseFlatbufferSchema", () => {
     // $ flatc -b --schema reflection/reflection.fbs
     // In https://github.com/google/flatbuffers
     const reflectionSchemaBuffer: Buffer = fs.readFileSync(`${__dirname}/fixtures/reflection.bfbs`);
-    const { fullSchemaName, datatypes, deserializer } = parseFlatbufferSchema(
+    const { datatypes, deserializer } = parseFlatbufferSchema(
       "reflection.Schema",
       reflectionSchemaBuffer,
     );
-    expect(fullSchemaName).toEqual("reflection.Schema");
     const deserialized: any = deserializer(reflectionSchemaBuffer);
     const reflectionSchemaByteBuffer: ByteBuffer = new ByteBuffer(reflectionSchemaBuffer);
     const schema = Schema.getRootAsSchema(reflectionSchemaByteBuffer);
@@ -338,11 +337,10 @@ describe("parseFlatbufferSchema", () => {
   });
   it("parses non-root table schema", () => {
     const reflectionSchemaBuffer: Buffer = fs.readFileSync(`${__dirname}/fixtures/reflection.bfbs`);
-    const { fullSchemaName, datatypes, deserializer } = parseFlatbufferSchema(
+    const { datatypes, deserializer } = parseFlatbufferSchema(
       "reflection.Type",
       reflectionSchemaBuffer,
     );
-    expect(fullSchemaName).toEqual("reflection.Type");
     expect(datatypes.keys()).toContain("reflection.Type");
     expect(datatypes.get("reflection.Type")).toEqual(typeSchema);
 
@@ -380,11 +378,7 @@ describe("parseFlatbufferSchema", () => {
     const byteVectorBin = Uint8Array.from(builder.asUint8Array());
 
     const byteVectorSchemaArray = fs.readFileSync(`${__dirname}/fixtures/ByteVector.bfbs`);
-    const { fullSchemaName, deserializer } = parseFlatbufferSchema(
-      "ByteVector",
-      byteVectorSchemaArray,
-    );
-    expect(fullSchemaName).toEqual("ByteVector");
+    const { deserializer } = parseFlatbufferSchema("ByteVector", byteVectorSchemaArray);
     expect(deserializer(byteVectorBin)).toEqual({ data: new Uint8Array([1, 2, 3]) });
   });
 });

--- a/packages/mcap-support/src/parseFlatbufferSchema.ts
+++ b/packages/mcap-support/src/parseFlatbufferSchema.ts
@@ -153,10 +153,9 @@ function typeForField(schema: SchemaT, field: FieldT): RosMsgField[] {
 // Note: Currently this does not support "lazy" message reading in the style of the ros1 message
 // reader, and so will relatively inefficiently deserialize the entire flatbuffer message.
 export function parseFlatbufferSchema(
-  fullSchemaName: string,
+  schemaName: string,
   schemaArray: Uint8Array,
 ): {
-  fullSchemaName: string;
   datatypes: RosDatatypes;
   deserializer: (buffer: ArrayBufferView) => unknown;
 } {
@@ -168,7 +167,7 @@ export function parseFlatbufferSchema(
   let typeIndex = -1;
   for (let schemaIndex = 0; schemaIndex < schema.objects.length; ++schemaIndex) {
     const object = schema.objects[schemaIndex];
-    if (object?.name === fullSchemaName) {
+    if (object?.name === schemaName) {
       typeIndex = schemaIndex;
     }
     let fields: RosMsgField[] = [];
@@ -181,9 +180,9 @@ export function parseFlatbufferSchema(
     datatypes.set(flatbufferString(object.name), { definitions: fields });
   }
   if (typeIndex === -1) {
-    if (schema.rootTable?.name !== fullSchemaName) {
+    if (schema.rootTable?.name !== schemaName) {
       throw new Error(
-        `Type "${fullSchemaName}" is not available in the schema for "${schema.rootTable?.name}".`,
+        `Type "${schemaName}" is not available in the schema for "${schema.rootTable?.name}".`,
       );
     }
   }
@@ -200,5 +199,5 @@ export function parseFlatbufferSchema(
     const obj = parser.toObject(table);
     return obj;
   };
-  return { fullSchemaName, datatypes, deserializer };
+  return { datatypes, deserializer };
 }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -309,7 +309,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     // Build a new topics array from this._channelsById
     const topics: Topic[] = Array.from(this._channelsById.values(), (chanInfo) => ({
       name: chanInfo.channel.topic,
-      schemaName: chanInfo.parsedChannel.fullSchemaName,
+      schemaName: chanInfo.channel.schemaName,
     }));
 
     // Remove stats entries for removed topics

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -82,7 +82,7 @@ export class McapIndexedIterableSource implements IIterableSource {
 
       let topic = topicsByName.get(channel.topic);
       if (!topic) {
-        topic = { name: channel.topic, schemaName: parsedChannel.fullSchemaName };
+        topic = { name: channel.topic, schemaName: schema.name };
         topicsByName.set(channel.topic, topic);
 
         const numMessages = this.reader.statistics?.channelMessageCounts.get(channel.id);

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -173,8 +173,8 @@ export class McapStreamingIterableSource implements IIterableSource {
     const topicStats = new Map<string, TopicStats>();
     const datatypes: RosDatatypes = new Map();
 
-    for (const { channel, parsedChannel } of channelInfoById.values()) {
-      topics.push({ name: channel.topic, schemaName: parsedChannel.fullSchemaName });
+    for (const { channel, parsedChannel, schemaName } of channelInfoById.values()) {
+      topics.push({ name: channel.topic, schemaName });
       const numMessages = messagesByChannel.get(channel.id)?.length;
       if (numMessages != undefined) {
         topicStats.set(channel.topic, { numMessages });

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -169,7 +169,7 @@ export class DataPlatformIterableSource implements IIterableSource {
           schema: { name: schemaName, data: schema, encoding: schemaEncoding },
         });
 
-        topics.push({ name: topic, schemaName: parsedChannel.fullSchemaName });
+        topics.push({ name: topic, schemaName });
         parsedChannels.push({ messageEncoding, schemaEncoding, schema, parsedChannel });
 
         // Final datatypes is an unholy union of schemas across all channels


### PR DESCRIPTION
**User-Facing Changes**
- Changed: Studio no longer modifies or normalizes schema names from the underlying data source. When using foxglove schemas, schema names must be fully-qualified (`foxglove.X` rather than just `X`)

**Description**
Removes `fullSchemaName` (introduced in https://github.com/foxglove/studio/pull/2167) in favor of just using the schema name from the data source.
Fixes https://github.com/foxglove/studio/issues/4909