### PR TITLE
Adjust Data Platform CTA copy for unauthenticated users

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -304,22 +304,24 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
 
   const sidebarItems: SidebarItem[] = useMemo(() => {
     switch (currentUserType) {
-      case "unauthenticated":
+      case "unauthenticated": {
+        const ulStyle = { padding: "0px" };
+        const liStyle = { margin: "0px 0px 5px 10px" };
         return [
           ...freeUser,
           {
             id: "collaborate",
-            title: "Accelerate   development with Foxglove Data Platform",
+            title: "Accelerate development with Foxglove Data Platform",
             text: (
-              <ul style={{ padding: "0px" }}>
-                <li>Securely store petabytes of ROS or custom data</li>
-                <li>
-                  Use a convenient web interface to search and retrieve data at lightning speed
+              <ul style={ulStyle}>
+                <li style={liStyle}>Securely store petabytes of ROS or custom data</li>
+                <li style={liStyle}>
+                  Use a convenient web interface to tag, search, and retrieve data at lightning
+                  speed
                 </li>
-                <li>
+                <li style={liStyle}>
                   Share data files, visualization layouts, and custom extensions with teammates
                 </li>
-                <li>Add custom metadata to enrich how you explore and analyze your data</li>
               </ul>
             ),
             actions: (
@@ -355,6 +357,7 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
             ),
           },
         ];
+      }
       case "authenticated-free":
         return [
           {

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -308,9 +308,20 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
         return [
           ...freeUser,
           {
-            id: "store-and-collaborate",
-            title: "Store and collaborate",
-            text: "Securely store petabytes of indexed data for easy discovery and analysis in Foxglove Data Platform.",
+            id: "collaborate",
+            title: "Accelerate   development with Foxglove Data Platform",
+            text: (
+              <ul style={{ padding: "0px" }}>
+                <li>Securely store petabytes of ROS or custom data</li>
+                <li>
+                  Use a convenient web interface to search and retrieve data at lightning speed
+                </li>
+                <li>
+                  Share data files, visualization layouts, and custom extensions with teammates
+                </li>
+                <li>Add custom metadata to enrich how you explore and analyze your data</li>
+              </ul>
+            ),
             actions: (
               <>
                 <Button

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -106,6 +106,8 @@ const useStyles = makeStyles<void, "recentSourcePrimary">()((theme, _params, cla
   recentSourceSecondary: {
     color: "inherit",
   },
+  accountList: { padding: "0px" },
+  accountListItem: { margin: "0px 0px 5px 10px" },
 }));
 
 type DataSourceOptionProps = {
@@ -304,22 +306,22 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
 
   const sidebarItems: SidebarItem[] = useMemo(() => {
     switch (currentUserType) {
-      case "unauthenticated": {
-        const ulStyle = { padding: "0px" };
-        const liStyle = { margin: "0px 0px 5px 10px" };
+      case "unauthenticated":
         return [
           ...freeUser,
           {
             id: "collaborate",
             title: "Accelerate development with Foxglove Data Platform",
             text: (
-              <ul style={ulStyle}>
-                <li style={liStyle}>Securely store petabytes of ROS or custom data</li>
-                <li style={liStyle}>
+              <ul className={classes.accountList}>
+                <li className={classes.accountListItem}>
+                  Securely store petabytes of ROS or custom data
+                </li>
+                <li className={classes.accountListItem}>
                   Use a convenient web interface to tag, search, and retrieve data at lightning
                   speed
                 </li>
-                <li style={liStyle}>
+                <li className={classes.accountListItem}>
                   Share data files, visualization layouts, and custom extensions with teammates
                 </li>
               </ul>
@@ -357,7 +359,6 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
             ),
           },
         ];
-      }
       case "authenticated-free":
         return [
           {
@@ -397,7 +398,15 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
       case "authenticated-enterprise":
         return teamOrEnterpriseUser;
     }
-  }, [analytics, classes.button, currentUserType, freeUser, teamOrEnterpriseUser]);
+  }, [
+    analytics,
+    classes.accountList,
+    classes.accountListItem,
+    classes.button,
+    currentUserType,
+    freeUser,
+    teamOrEnterpriseUser,
+  ]);
 
   return (
     <>


### PR DESCRIPTION
**User-Facing Changes**
None (part of earlier commit's changes - #4905)

**Description**
- Mention both products in right panel's headers for stronger brand presence
- Revise header text to not just focus on collaboration, as we don't want to discourage single users from creating an account
- Cover all categories of benefits laid out on [the Console signup page](https://console.foxglove.dev/signin) 
- Avoid having so many pairs of words for Data Platform CTAs ("Upload and share", "Store and collaborate") – weakens messaging around DP's value props

Before:
<img width="550" alt="Screen Shot 2022-12-08 at 1 42 30 PM" src="https://user-images.githubusercontent.com/6993359/206576000-eab94152-470c-471d-85c6-c136c2c8b9df.png">

After:
<img width="550" alt="Screen Shot 2022-12-08 at 3 00 16 PM" src="https://user-images.githubusercontent.com/6993359/206584938-038abed7-46d1-4203-8fd8-6db0ab2a347a.png">

