### PR TITLE
[3D] Fix projected image dimensions, configurable planar projection factor

### DIFF
--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { CameraInfo } from "./CameraInfo";
+import { PinholeCameraModel } from "./PinholeCameraModel";
+
+// Example real-world plumb_bob distortion parameters
+const D1 = [
+  -0.363528858080088, 0.16117037733986861, -8.1109585007538829e-5, -0.00044776712298447841, 0.0,
+];
+
+const closeTo = (expected: number, precision = 2) => ({
+  asymmetricMatch: (actual: number) => Math.abs(expected - actual) < Math.pow(10, -precision) / 2,
+});
+
+function makeCameraInfo(
+  width: number,
+  height: number,
+  fov: number,
+  distortionModel = "",
+  D = [0, 0, 0, 0, 0, 0, 0, 0],
+): CameraInfo {
+  const cx = width / 2;
+  const cy = height / 2;
+  const fx = width / (2 * Math.tan((fov * Math.PI) / 360));
+  const fy = fx;
+  return {
+    D,
+    // prettier-ignore
+    K: [
+      fx, 0, cx,
+      0, fy, cy,
+      0, 0, 1,
+    ],
+    R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    // prettier-ignore
+    P: [
+      fx, 0, cx, 0,
+      0, fy, cy, 0,
+      0,  0,  1, 0,
+    ],
+    width,
+    height,
+    binning_x: 0,
+    binning_y: 0,
+    distortion_model: distortionModel,
+    roi: { x_offset: 0, y_offset: 0, do_rectify: false, height: 0, width: 0 },
+  };
+}
+
+describe("PinholeCameraModel", () => {
+  it("projectPixelTo3dRay", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 90));
+    const ray = { x: 0, y: 0, z: 0 };
+
+    expect(model.projectPixelTo3dRay(ray, { x: 320, y: 240 })).toBe(true);
+    expect(ray).toEqual({ x: 0, y: 0, z: 1 });
+
+    expect(model.projectPixelTo3dRay(ray, { x: 100, y: 100 })).toBe(true);
+    expect(ray).toMatchObject({
+      x: closeTo(-0.5329517414226601),
+      y: closeTo(-0.33915110817805644),
+      z: closeTo(0.7752025329784149),
+    });
+  });
+
+  it("rectifyPixel - no distortion", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 45));
+    const rectified = { x: 0, y: 0 };
+
+    model.rectifyPixel(rectified, { x: 320, y: 240 });
+    expect(rectified).toEqual({ x: 320, y: 240 });
+
+    model.rectifyPixel(rectified, { x: 100, y: 100 });
+    expect(rectified).toMatchObject({ x: closeTo(100), y: closeTo(100) });
+  });
+
+  it("rectifyPixel - plumb_bob", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 60, "plumb_bob", D1));
+    const rectified = { x: 0, y: 0 };
+
+    model.rectifyPixel(rectified, { x: 320, y: 240 });
+    expect(rectified).toEqual({ x: 320, y: 240 });
+
+    model.rectifyPixel(rectified, { x: 0, y: 0 });
+    expect(rectified).toMatchObject({
+      x: closeTo(-72.45696739),
+      y: closeTo(-54.4783923),
+    });
+  });
+
+  it("unrectifyPixel - no distortion", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 45));
+    const unrectified = { x: 0, y: 0 };
+
+    model.unrectifyPixel(unrectified, { x: 320, y: 240 });
+    expect(unrectified).toEqual({ x: 320, y: 240 });
+
+    model.unrectifyPixel(unrectified, { x: 0, y: 0 });
+    expect(unrectified).toMatchObject({
+      x: closeTo(0),
+      y: closeTo(0),
+    });
+  });
+
+  it("unrectifyPixel - plumb_bob", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 60, "plumb_bob", D1));
+    const rectified = { x: 0, y: 0 };
+    const unrectified = { x: 0, y: 0 };
+
+    model.rectifyPixel(rectified, { x: 0, y: 0 });
+    model.unrectifyPixel(unrectified, rectified);
+    expect(unrectified).toMatchObject({
+      // low precision comparison since we're approximating a nonlinear function
+      x: closeTo(0, 1),
+      y: closeTo(0, 1),
+    });
+  });
+});

--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -49,7 +49,7 @@ const D1 = [
 // print("rectifyPoint((0.0, 0.0))", model.rectifyPoint((0.0, 0.0)))
 // ```
 
-const closeTo = (expected: number, precision = 2) => ({
+const closeTo = (expected: number, precision = 8) => ({
   asymmetricMatch: (actual: number) => Math.abs(expected - actual) < Math.pow(10, -precision) / 2,
 });
 

--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -10,6 +10,45 @@ const D1 = [
   -0.363528858080088, 0.16117037733986861, -8.1109585007538829e-5, -0.00044776712298447841, 0.0,
 ];
 
+// The values in these tests are taken from the ROS Noetic Python implementation of image_geometry
+// using the following script:
+// ```python
+// from image_geometry import PinholeCameraModel
+// from sensor_msgs.msg import CameraInfo
+
+// import math
+
+// width = 640.0
+// height = 480.0
+// fov = 60
+// cx = width / 2.0
+// cy = height / 2.0
+// fx = width / (2.0 * math.tan((fov * math.pi) / 360.0))
+// fy = fx
+
+// msg = CameraInfo()
+// msg.height = height
+// msg.width = width
+// msg.distortion_model = ''
+// msg.K = [fx,  0.0, cx, 0.0, fy,  cy, 0.0, 0.0, 1.0]
+// msg.R = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+// msg.P = [fx,  0.0, cx,  0.0, 0.0, fx,  cy,  0.0, 0.0, 0.0, 1.0, 0.0]
+
+// model = PinholeCameraModel()
+// model.fromCameraInfo(msg)
+// print("projectPixelTo3dRay((100.0, 100.0))", model.projectPixelTo3dRay((100.0, 100.0)))
+// print("projectPixelTo3dRay((0.0, 0.0))", model.projectPixelTo3dRay((0.0, 0.0)))
+// print("rectifyPoint((320.0, 240.0))", model.rectifyPoint((320.0, 240.0)))
+// print("rectifyPoint((100.0, 100.0))", model.rectifyPoint((100.0, 100.0)))
+
+// msg.distortion_model = "plumb_bob"
+// msg.D = [-0.363528858080088, 0.16117037733986861, -8.1109585007538829e-05, -0.00044776712298447841, 0.0]
+// model.fromCameraInfo(msg)
+// print("projectPixelTo3dRay((100.0, 100.0))", model.projectPixelTo3dRay((100.0, 100.0)))
+// print("rectifyPoint((320.0, 240.0))", model.rectifyPoint((320.0, 240.0)))
+// print("rectifyPoint((0.0, 0.0))", model.rectifyPoint((0.0, 0.0)))
+// ```
+
 const closeTo = (expected: number, precision = 2) => ({
   asymmetricMatch: (actual: number) => Math.abs(expected - actual) < Math.pow(10, -precision) / 2,
 });

--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -89,6 +89,21 @@ function makeCameraInfo(
 }
 
 describe("PinholeCameraModel", () => {
+  it("projectPixelTo3dPlane", () => {
+    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 90));
+    const point = { x: 0, y: 0, z: 0 };
+
+    expect(model.projectPixelTo3dPlane(point, { x: 320, y: 240 })).toBe(true);
+    expect(point).toEqual({ x: 0, y: 0, z: 1 });
+
+    expect(model.projectPixelTo3dPlane(point, { x: 100, y: 100 })).toBe(true);
+    expect(point).toMatchObject({
+      x: closeTo(-0.6875),
+      y: closeTo(-0.4375),
+      z: 1,
+    });
+  });
+
   it("projectPixelTo3dRay", () => {
     let model = new PinholeCameraModel(makeCameraInfo(640, 480, 90));
     const ray = { x: 0, y: 0, z: 0 };

--- a/packages/den/image/PinholeCameraModel.test.ts
+++ b/packages/den/image/PinholeCameraModel.test.ts
@@ -51,7 +51,7 @@ function makeCameraInfo(
 
 describe("PinholeCameraModel", () => {
   it("projectPixelTo3dRay", () => {
-    const model = new PinholeCameraModel(makeCameraInfo(640, 480, 90));
+    let model = new PinholeCameraModel(makeCameraInfo(640, 480, 90));
     const ray = { x: 0, y: 0, z: 0 };
 
     expect(model.projectPixelTo3dRay(ray, { x: 320, y: 240 })).toBe(true);
@@ -62,6 +62,14 @@ describe("PinholeCameraModel", () => {
       x: closeTo(-0.5329517414226601),
       y: closeTo(-0.33915110817805644),
       z: closeTo(0.7752025329784149),
+    });
+
+    model = new PinholeCameraModel(makeCameraInfo(640, 480, 60));
+    expect(model.projectPixelTo3dRay(ray, { x: 0, y: 0 })).toBe(true);
+    expect(ray).toMatchObject({
+      x: closeTo(-0.4681645887845223),
+      y: closeTo(-0.3511234415883917),
+      z: closeTo(0.8108848540793832),
     });
   });
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -1,15 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
 
 import type { CameraInfo } from "./CameraInfo";
 
@@ -28,27 +19,68 @@ type Matrix3x4 = [
 
 type Vec8 = [number, number, number, number, number, number, number, number];
 
-// Essentially a copy of ROSPinholeCameraModel
-// but only the relevant methods, i.e.
-// fromCameraInfo() and unrectifyPixel()
-// http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html
+/**
+ * A pinhole camera model that can be used to rectify, unrectify, and project pixel coordinates.
+ * Based on `ROSPinholeCameraModel` from the ROS `image_geometry` package. See
+ * <http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html>
+ */
 export class PinholeCameraModel {
-  // [k1, k2, p1, p2, k3, ?, ?, ?]
+  /**
+   * Distortion parameters `[k1, k2, p1, p2, k3, k4, k5, k6]`. For `rational_polynomial`, all eight
+   * parameters are set. For `plumb_bob`, the last three parameters are set to zero. For no
+   * distortion model, all eight parameters are set to zero.
+   */
   public D: Readonly<Vec8>;
-  //     [fx  0 cx]
-  // K = [ 0 fy cy]
-  //     [ 0  0  1]
+  /**
+   * Intrinsic camera matrix for the raw (distorted) images. 3x3 row-major matrix.
+   * ```
+   *     [fx  0 cx]
+   * K = [ 0 fy cy]
+   *     [ 0  0  1]
+   * ```
+   * Projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal
+   * lengths `(fx, fy)` and principal point `(cx, cy)`.
+   */
   public K: Readonly<Matrix3>;
-  //     [fx'  0  cx' Tx]
-  // P = [ 0  fy' cy' Ty]
-  //     [ 0   0   1   0]
+  /**
+   * Projection/camera matrix. 3x4 row-major matrix.
+   * This matrix specifies the intrinsic (camera) matrix of the processed (rectified) image. That
+   * is, the left 3x3 portion is the normal camera intrinsic matrix for the rectified image.
+   *
+   * It projects 3D points in the camera coordinate frame to 2D pixel coordinates using the focal
+   * lengths `(fx', fy')` and principal point `(cx', cy')` - these may differ from the values in K.
+   * For monocular cameras, `Tx = Ty = 0`. Normally, monocular cameras will also have R = the
+   * identity and `P[1:3,1:3] = K`.
+   *
+   * For a stereo pair, the fourth column `[Tx Ty 0]'` is related to the position of the optical
+   * center of the second camera in the first camera's frame. We assume `Tz = 0` so both cameras are
+   * in the same stereo image plane. The first camera always has `Tx = Ty = 0`. For the right
+   * (second) camera of a horizontal stereo pair, `Ty = 0 and Tx = -fx' * B`, where `B` is the
+   * baseline between the cameras.
+   *
+   * Given a 3D point `[X Y Z]'`, the projection `(x, y)` of the point onto the rectified image is
+   * given by:
+   * ```
+   * [u v w]' = P * [X Y Z 1]'
+   *        x = u / w
+   *        y = v / w
+   * ```
+   * This holds for both images of a stereo pair.
+   */
   public P: Readonly<Matrix3x4> | undefined;
+  /**
+   * Rectification matrix (stereo cameras only). 3x3 row-major matrix.
+   * A rotation matrix aligning the camera coordinate system to the ideal stereo image plane so
+   * that epipolar lines in both stereo images are parallel.
+   */
   public R: Readonly<Matrix3>;
+  /** The full camera image width in pixels. */
   public readonly width: number;
+  /** The full camera image height in pixels. */
   public readonly height: number;
 
   // Mostly copied from `fromCameraInfo`
-  // http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html#l00062
+  // <http://docs.ros.org/diamondback/api/image_geometry/html/c++/pinhole__camera__model_8cpp_source.html#l00064>
   public constructor(info: CameraInfo) {
     const { binning_x, binning_y, roi, distortion_model: model, D, K, P, R, width, height } = info;
     const fx = P[0];
@@ -98,6 +130,14 @@ export class PinholeCameraModel {
     }
   }
 
+  /**
+   * Projects a 2D image pixel into a 3D ray in world coordinates.
+   *
+   * @param out - The output vector to receive the 3D ray direction.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns `true` if the projection was successful, or `false` if the camera
+   *   projection matrix `P` is not set.
+   */
   public projectPixelTo3dRay(out: Vector3, pixel: Readonly<Vector2>): boolean {
     const P = this.P;
     if (!P) {
@@ -117,6 +157,14 @@ export class PinholeCameraModel {
     return true;
   }
 
+  /**
+   * Rectifies the given pixel 2D coordinate.
+   *
+   * @param out - The output rectified 2D pixel coordinate.
+   * @param point - The input unrectified 2D pixel to rectify.
+   * @param iterations - The number of iterations to use in the iterative optimization.
+   * @returns The rectified pixel, a reference to `out`.
+   */
   public rectifyPixel(out: Vector2, point: Readonly<Vector2>, iterations = 3): Vector2 {
     if (!this.P) {
       out.x = point.x;
@@ -133,9 +181,15 @@ export class PinholeCameraModel {
     const cy = P[6];
 
     // This method does three things:
-    //   1. Undo the camera matrix
-    //   2. Iterative optimization to undo distortion
-    //   3. Reapply the camera matrix
+    //   1. Convert the input 2D point from pixel coordinates to normalized
+    //      coordinates by subtracting the principal point (cx, cy) and dividing
+    //      by the focal lengths (fx, fy).
+    //   2. Apply the distortion model to the normalized point using an
+    //      iterative optimization algorithm. This undoes the distortion that
+    //      was applied to the original image and yields an approximation of the
+    //      rectified point.
+    //   3. Convert the rectified point back to pixel coordinates by multiplying
+    //      by the focal lengths and adding the principal point.
     // The distortion model is non-linear, so we use fixed-point iteration to
     // incrementally iterate to an approximation of the solution. This approach
     // is described at <http://peterabeles.com/blog/?p=73>. The Jacobi method is
@@ -165,11 +219,18 @@ export class PinholeCameraModel {
       y = (y0 - delta_y) * k_inv;
     }
 
-    out.x = x * this.width + cx;
-    out.y = y * this.height + cy;
+    out.x = x * fx + cx;
+    out.y = y * fy + cy;
     return out;
   }
 
+  /**
+   * Unrectifies the given 2D pixel coordinate.
+   *
+   * @param out - The output unrectified 2D pixel coordinate
+   * @param point - The input rectified 2D pixel coordinate
+   * @returns The unrectified pixel, a reference to `out`
+   */
   public unrectifyPixel(out: Vector2, point: Readonly<Vector2>): Vector2 {
     if (!this.P) {
       out.x = point.x;

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -240,7 +240,7 @@ export class PinholeCameraModel {
     const count = k1 !== 0 || k2 !== 0 || p1 !== 0 || p2 !== 0 || k3 !== 0 ? iterations : 1;
     for (let i = 0; i < count; i++) {
       const r2 = x * x + y * y; // squared distance in the image projected by the pinhole model
-      const k_inv = 1 / (1 + k1 * r2 + k2 * r2 ** 2 + k3 * r2 ** 3);
+      const k_inv = 1 / (1 + k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2);
       const delta_x = 2 * p1 * x * y + p2 * (r2 + 2 * x * x);
       const delta_y = p1 * (r2 + 2 * y * y) + 2 * p2 * x * y;
       x = (x0 - delta_x) * k_inv;

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -165,7 +165,7 @@ export class PinholeCameraModel {
    * @param iterations - The number of iterations to use in the iterative optimization.
    * @returns The rectified pixel, a reference to `out`.
    */
-  public rectifyPixel(out: Vector2, point: Readonly<Vector2>, iterations = 3): Vector2 {
+  public rectifyPixel(out: Vector2, point: Readonly<Vector2>, iterations = 5): Vector2 {
     if (!this.P) {
       out.x = point.x;
       out.y = point.y;
@@ -210,8 +210,9 @@ export class PinholeCameraModel {
 
     const x0 = x;
     const y0 = y;
-    for (let i = 0; i < iterations; i++) {
-      const r2 = x ** 2 + y ** 2; // squared distance in the image projected by the pinhole model
+    const count = k1 !== 0 || k2 !== 0 || p1 !== 0 || p2 !== 0 || k3 !== 0 ? iterations : 1;
+    for (let i = 0; i < count; i++) {
+      const r2 = x * x + y * y; // squared distance in the image projected by the pinhole model
       const k_inv = 1 / (1 + k1 * r2 + k2 * r2 ** 2 + k3 * r2 ** 3);
       const delta_x = 2 * p1 * x * y + p2 * (r2 + 2 * x ** 2);
       const delta_y = p1 * (r2 + 2 * y ** 2) + 2 * p2 * x * y;

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -154,6 +154,13 @@ export class PinholeCameraModel {
     out.x = (pixel.x - cx - tx) / fx;
     out.y = (pixel.y - cy - ty) / fy;
     out.z = 1.0;
+
+    // Normalize the ray direction
+    const invNorm = 1.0 / Math.sqrt(out.x * out.x + out.y * out.y + out.z * out.z);
+    out.x *= invNorm;
+    out.y *= invNorm;
+    out.z *= invNorm;
+
     return true;
   }
 

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -131,14 +131,16 @@ export class PinholeCameraModel {
   }
 
   /**
-   * Projects a 2D image pixel into a 3D ray in world coordinates.
+   * Projects a 2D image pixel to a point on a plane in 3D world coordinates a
+   * unit distance along the Z axis. This is equivalent to `projectPixelTo3dRay`
+   * before normalizing.
    *
-   * @param out - The output vector to receive the 3D ray direction.
+   * @param out - The output vector to receive the 3D point.
    * @param pixel - The 2D image pixel coordinate.
    * @returns `true` if the projection was successful, or `false` if the camera
    *   projection matrix `P` is not set.
    */
-  public projectPixelTo3dRay(out: Vector3, pixel: Readonly<Vector2>): boolean {
+  public projectPixelTo3dPlane(out: Vector3, pixel: Readonly<Vector2>): boolean {
     const P = this.P;
     if (!P) {
       return false;
@@ -154,6 +156,24 @@ export class PinholeCameraModel {
     out.x = (pixel.x - cx - tx) / fx;
     out.y = (pixel.y - cy - ty) / fy;
     out.z = 1.0;
+
+    return true;
+  }
+
+  /**
+   * Projects a 2D image pixel into a 3D ray in world coordinates. This is
+   * equivalent to normalizing the result of `projectPixelTo3dPlane` to get a
+   * direction vector.
+   *
+   * @param out - The output vector to receive the 3D ray direction.
+   * @param pixel - The 2D image pixel coordinate.
+   * @returns `true` if the projection was successful, or `false` if the camera
+   *   projection matrix `P` is not set.
+   */
+  public projectPixelTo3dRay(out: Vector3, pixel: Readonly<Vector2>): boolean {
+    if (!this.projectPixelTo3dPlane(out, pixel)) {
+      return false;
+    }
 
     // Normalize the ray direction
     const invNorm = 1.0 / Math.sqrt(out.x * out.x + out.y * out.y + out.z * out.z);

--- a/packages/den/image/PinholeCameraModel.ts
+++ b/packages/den/image/PinholeCameraModel.ts
@@ -221,8 +221,8 @@ export class PinholeCameraModel {
     for (let i = 0; i < count; i++) {
       const r2 = x * x + y * y; // squared distance in the image projected by the pinhole model
       const k_inv = 1 / (1 + k1 * r2 + k2 * r2 ** 2 + k3 * r2 ** 3);
-      const delta_x = 2 * p1 * x * y + p2 * (r2 + 2 * x ** 2);
-      const delta_y = p1 * (r2 + 2 * y ** 2) + 2 * p2 * x * y;
+      const delta_x = 2 * p1 * x * y + p2 * (r2 + 2 * x * x);
+      const delta_y = p1 * (r2 + 2 * y * y) + 2 * p2 * x * y;
       x = (x0 - delta_x) * k_inv;
       y = (y0 - delta_y) * k_inv;
     }
@@ -255,7 +255,7 @@ export class PinholeCameraModel {
     const ty = P[7];
 
     // Formulae from docs for cv::initUndistortRectifyMap,
-    // http://opencv.willowgarage.com/documentation/cpp/camera_calibration_and_3d_reconstruction.html
+    // <https://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html>
 
     // x <- (u - c'x) / f'x
     // y <- (v - c'y) / f'y

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -553,7 +553,7 @@ function buildSettingsFields(
       value: ageValue,
     },
     historySize: {
-      label: "History size",
+      label: "History Size",
       input: "string",
       readonly: true,
       value: historySizeValue,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -97,7 +97,7 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
         maxColor: { label: "Max Color", input: "rgba", value: config.maxColor ?? DEFAULT_MAX_COLOR_STR },
         unknownColor: { label: "Unknown Color", input: "rgba", value: config.unknownColor ?? DEFAULT_UNKNOWN_COLOR_STR },
         invalidColor: { label: "Invalid Color", input: "rgba", value: config.invalidColor ?? DEFAULT_INVALID_COLOR_STR },
-        frameLocked: { label: "Frame lock", input: "boolean", value: config.frameLocked ?? false },
+        frameLocked: { label: "Frame Lock", input: "boolean", value: config.frameLocked ?? false },
       };
 
       entries.push({

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/projections.ts
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PinholeCameraModel } from "@foxglove/den/image";
+
+import { Vector2, Vector3 } from "../ros";
+
+const tempVec2 = { x: 0, y: 0 };
+const tempVec3a = { x: 0, y: 0, z: 0 };
+const tempVec3b = { x: 0, y: 0, z: 0 };
+
+export function projectPixel(
+  out: Vector3,
+  uv: Readonly<Vector2>,
+  cameraModel: PinholeCameraModel,
+  settings: { distance: number; planarProjectionFactor: number },
+): Vector3 {
+  cameraModel.rectifyPixel(tempVec2, uv);
+
+  if (settings.planarProjectionFactor === 0) {
+    cameraModel.projectPixelTo3dRay(out, tempVec2);
+  } else if (settings.planarProjectionFactor === 1) {
+    cameraModel.projectPixelTo3dPlane(out, tempVec2);
+  } else {
+    cameraModel.projectPixelTo3dRay(tempVec3a, tempVec2);
+    cameraModel.projectPixelTo3dPlane(tempVec3b, tempVec2);
+    lerpVec3(out, tempVec3a, tempVec3b, settings.planarProjectionFactor);
+  }
+
+  multiplyScalar(out, settings.distance);
+  return out;
+}
+
+function lerpVec3(out: Vector3, a: Readonly<Vector3>, b: Readonly<Vector3>, t: number): void {
+  out.x = a.x + (b.x - a.x) * t;
+  out.y = a.y + (b.y - a.y) * t;
+  out.z = a.z + (b.z - a.z) * t;
+}
+
+function multiplyScalar(vec: Vector3, scalar: number): void {
+  vec.x *= scalar;
+  vec.y *= scalar;
+  vec.z *= scalar;
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ros.ts
@@ -63,6 +63,11 @@ export type RosTime = Time;
 
 export type RosDuration = RosTime;
 
+export type Vector2 = {
+  x: number;
+  y: number;
+};
+
 export type Vector3 = {
   x: number;
   y: number;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -137,6 +137,9 @@ export function CameraInfoRender(): JSX.Element {
         overrideConfig={{
           ...ThreeDeeRender.defaultConfig,
           followTf: SENSOR_FRAME_ID,
+          scene: {
+            labelScaleFactor: 0.1,
+          },
           cameraState: {
             distance: 1.85,
             perspective: true,
@@ -159,6 +162,7 @@ export function CameraInfoRender(): JSX.Element {
               visible: true,
               color: "rgba(0, 255, 255, 1)",
               distance: 0.5,
+              planarProjectionFactor: 1,
             },
             "/empty": {
               visible: true,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -190,6 +190,7 @@ export function ImageRender(): JSX.Element {
               visible: true,
               color: "rgba(0, 255, 0, 1)",
               distance: 0.5,
+              planarProjectionFactor: 1,
             },
             "/cam2/info": {
               visible: true,
@@ -378,6 +379,7 @@ export function FoxgloveImageRender(): JSX.Element {
               visible: true,
               color: "rgba(0, 255, 0, 1)",
               distance: 0.5,
+              planarProjectionFactor: 1,
             },
             "/cam2/info": {
               visible: true,


### PR DESCRIPTION
**User-Facing Changes**
- [3D] Fixed aspect ratio for camera frustums and images
- [3D] Configurable "Planar Projection Factor" for camera frustums and images

**Description**
This PR makes a few changes to the math in PinholeCameraModel to make the results match the ROS PinholeCameraModel as closely as possible. Tests have been added with ground truth from ROS Noetic. Rectification correctly normalizes by focal length instead of image dimensions. Five Jacobi iterations are used instead of three, with a bypass if the distortion model is empty, to match OpenCV behavior. The output of projectPixelTo3dRay is normalized to match the ROS version, and a separate projectPixelTo3dPlane is added to preserve the previous behavior. The planar projection factor is a new setting for cameras and images to control how curved or flat the projection into 3D space is.

Fixes #4852

<img width="1136" alt="Screenshot 2022-12-09 at 8 56 48 AM" src="https://user-images.githubusercontent.com/195374/206759126-ea65cb56-4b00-4798-8c1b-78b5480ef252.png">

https://user-images.githubusercontent.com/195374/206807548-be24e914-947e-4965-8e89-a7dea841df58.mp4
