### PR TITLE
fix: Avoid layout import and migration race conditions

### DIFF
--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -133,8 +133,6 @@ export default class LayoutManager implements ILayoutManager {
           ? LayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX + remote.namespace
           : LayoutManager.LOCAL_STORAGE_NAMESPACE,
         {
-          migrateUnnamespacedLayouts: true,
-
           // Convert existing local layouts into cloud personal layouts
           importFromNamespace: remote ? LayoutManager.LOCAL_STORAGE_NAMESPACE : undefined,
         },


### PR DESCRIPTION
**User-Facing Changes**
If a user imports layouts directly into local storage anytime after the `NamespacedLayoutStorage` is initialized, there is no mechanism to ensure those layouts are migrated into the layouts indexed db. This forces the user to either synchronously block the init of `NamespacedLayoutStorage` and await importing all layouts to local storage or risk a race condition.

**Description**
- Removes `migrateUnnamespacedLayouts` flag, its always set to true anyway
- Attempts an import/migration whenever the user interacts with the layout sidebar
- Reduces likelihood of a race condition for layout import/migrations

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
