### PR TITLE
feat: Persist series plot color to tooltip value text

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { take } from "lodash";
-import { PropsWithChildren, useMemo } from "react";
+import { CSSProperties, PropsWithChildren, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -84,6 +84,7 @@ export default function TimeBasedChartTooltipContent(
     return (
       <div className={classes.root} data-testid="TimeBasedChartTooltipContent">
         {take(content, 1).map((item, idx) => {
+          const style: CSSProperties = { color: item.color };
           const value =
             typeof item.value === "string"
               ? item.value
@@ -91,7 +92,7 @@ export default function TimeBasedChartTooltipContent(
               ? item.value.toString()
               : JSON.stringify(item.value);
           return (
-            <div key={idx}>
+            <div key={idx} style={style}>
               {value}
               {item.constantName != undefined ? ` (${item.constantName})` : ""}
             </div>
@@ -109,6 +110,7 @@ export default function TimeBasedChartTooltipContent(
           <div key={idx}>
             <div className={classes.path}>{path}</div>
             {take(items, 1).map((item, itemIdx) => {
+              const style: CSSProperties = { color: item.color };
               const value =
                 typeof item.value === "string"
                   ? item.value
@@ -116,7 +118,7 @@ export default function TimeBasedChartTooltipContent(
                   ? item.value.toString()
                   : JSON.stringify(item.value);
               return (
-                <div key={itemIdx}>
+                <div key={itemIdx} style={style}>
                   {value}
                   {item.constantName != undefined ? ` (${item.constantName})` : ""}
                 </div>

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -58,6 +58,7 @@ export type TimeBasedChartTooltipData = {
   path: string;
   value: number | bigint | boolean | string;
   constantName?: string;
+  color?: string;
 };
 
 const useStyles = makeStyles()((theme) => ({

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -448,7 +448,7 @@ function Plot(props: Props) {
     const allTooltips: TimeBasedChartTooltipData[] = [];
     for (const dataset of datasets) {
       for (const datum of dataset.data) {
-        allTooltips.push(datum);
+        allTooltips.push({ ...datum, color: dataset.borderColor?.toString() });
       }
     }
     return allTooltips;


### PR DESCRIPTION
**User-Facing Changes**
When a user views multiple dataset series in a Plot panel, there are customizable colors which correspond to each dataset. This feature will persist that custom color through to the tooltip so it is applied to the value text. Some users may find this color coding easier to understand at a glance than plain white text for all values.

**Description**
- Adds `color` as an optional property on `TimeBasedChartTooltipData`
- Persists the `borderColor` property of the dataset onto the tooltip data
- Applies the new `color` property as text style for the value of the tooltip datum

<!-- link relevant github issues -->
<!-- add `docs` label if this PR requires documentation updates -->
