### PR TITLE
Add back option to explore sample data for all signed-in Team/Enterprise users

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -191,47 +191,47 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
   const analytics = useAnalytics();
   const { classes } = useStyles();
 
-  const { freeUser, teamOrEnterpriseUser } = useMemo(
-    () => ({
-      freeUser: [
-        {
-          id: "new",
-          title: "New to Foxglove Studio?",
-          text: "Start by exploring a sample dataset or checking out our documentation.",
-          actions: (
-            <>
-              <Button
-                onClick={() => {
-                  onSelectView("demo");
-                  void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "demo" });
-                  void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
-                    user: currentUserType,
-                    cta: "demo",
-                  });
-                }}
-                className={classes.button}
-                variant="outlined"
-              >
-                Explore sample data
-              </Button>
-              <Button
-                href="https://foxglove.dev/docs/studio"
-                target="_blank"
-                className={classes.button}
-                onClick={() => {
-                  void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
-                    user: currentUserType,
-                    cta: "docs",
-                  });
-                }}
-              >
-                View our docs
-              </Button>
-            </>
-          ),
-        },
-      ],
+  const { freeUser, teamOrEnterpriseUser } = useMemo(() => {
+    const demoItem = {
+      id: "new",
+      title: "New to Foxglove Studio?",
+      text: "Start by exploring a sample dataset or checking out our documentation.",
+      actions: (
+        <>
+          <Button
+            onClick={() => {
+              onSelectView("demo");
+              void analytics.logEvent(AppEvent.DIALOG_SELECT_VIEW, { type: "demo" });
+              void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
+                user: currentUserType,
+                cta: "demo",
+              });
+            }}
+            className={classes.button}
+            variant="outlined"
+          >
+            Explore sample data
+          </Button>
+          <Button
+            href="https://foxglove.dev/docs/studio"
+            target="_blank"
+            className={classes.button}
+            onClick={() => {
+              void analytics.logEvent(AppEvent.DIALOG_CLICK_CTA, {
+                user: currentUserType,
+                cta: "docs",
+              });
+            }}
+          >
+            View our docs
+          </Button>
+        </>
+      ),
+    };
+    return {
+      freeUser: [demoItem],
       teamOrEnterpriseUser: [
+        demoItem,
         {
           id: "join-community",
           title: "Join our community",
@@ -304,9 +304,8 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
           ),
         },
       ],
-    }),
-    [analytics, classes.button, currentUserType, onSelectView],
-  );
+    };
+  }, [analytics, classes.button, currentUserType, onSelectView]);
 
   const sidebarItems: SidebarItem[] = useMemo(() => {
     switch (currentUserType) {


### PR DESCRIPTION
**User-Facing Changes**
- None (part of previous PR's edits - #4905)

<img width="914" alt="Screen Shot 2022-12-12 at 7 02 50 PM" src="https://user-images.githubusercontent.com/6993359/207216628-6438c4cf-bbcc-400c-8fcc-8205d4528584.png">

**Description**
- Add back Welcome dialog option to explore sample data for all signed-in Team/Enterprise users

