### PR TITLE
Fix Playback Performance sparkline resolution

### DIFF
--- a/packages/studio-base/src/components/AutoSizingCanvas/index.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { useRef, useLayoutEffect } from "react";
+import { useRef, useLayoutEffect, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
 
 type Draw = (context: CanvasRenderingContext2D, width: number, height: number) => void;
@@ -36,7 +36,17 @@ const AutoSizingCanvas = ({
     targetRef: canvasRef,
   });
 
-  const ratio = overrideDevicePixelRatioForTest ?? 1;
+  const [pixelRatio, setPixelRatio] = useState(window.devicePixelRatio);
+  useLayoutEffect(() => {
+    const listener = () => setPixelRatio(window.devicePixelRatio);
+    const query = window.matchMedia(`(resolution: ${pixelRatio}dppx)`);
+    query.addEventListener("change", listener, { once: true });
+    return () => {
+      query.removeEventListener("change", listener);
+    };
+  }, [pixelRatio]);
+
+  const ratio = overrideDevicePixelRatioForTest ?? pixelRatio;
 
   const actualWidth = ratio * (width ?? 0);
   const actualHeight = ratio * (height ?? 0);


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Fixes https://github.com/foxglove/studio/issues/1177 (regressed in #555) by watching window.devicePixelRatio.

Before:
<img width="222" alt="image" src="https://user-images.githubusercontent.com/14237/207221357-60972493-00d7-4f72-be3f-2566328b2610.png">

After:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/14237/207221257-48f4ede7-ce78-440b-940b-388733fd33b3.png">
