### PR TITLE
Issue template: Add question option

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "🙋‍♀️ Question"
+    url: https://github.com/orgs/foxglove/discussions/categories/studio
+    about: Search discussions or ask our community for help
   - name: "🚀 Feature request"
-    url: https://github.com/orgs/foxglove/discussions/new?category=studio&body=%3C!---%20Remember%20to%20include%20code%2C%20screenshots%2C%20and%20example%20data%20(e.g.%20bag%20or%20mcap%20file)%20if%20relevant%20--%3E%0A
-    about: Share a new feature request or idea
+    url: https://github.com/orgs/foxglove/discussions/categories/studio
+    about: Search existing feature requests or share a new idea
   - name: "🐞 Bug report"
     url: https://github.com/foxglove/studio/issues/new?labels=bug&body=**Description**%0A%0A%0A-%20Version%3A%0A-%20OS%3A%0A-%20Data%20source%20(e.g.%20bag%20or%20mcap%20file%2C%20rosbridge%2C%20websocket)%3A%0A-%20ROS%20distro%20(if%20applicable)%3A%0A%0A**Steps%20To%20Reproduce**%0A%3C!---%20Remember%20to%20include%20code%2C%20screenshots%2C%20and%20example%20data%20(e.g.%20bag%20or%20mcap%20file)%20if%20relevant%20--%3E%0A%0A%0A**Expected%20Behavior**%0A%0A%0A**Actual%20Behavior**%0A
     about: Report broken functionality or incorrect documentation
@@ -11,4 +14,4 @@ contact_links:
     about: Get help from the robotics community
   - name: "💬 Live chat"
     url: https://foxglove.dev/slack
-    about: Join the discussion in our Slack channel
+    about: Join the discussion in our Slack community


### PR DESCRIPTION
**Description**
Restored "Question" option linking to our discussion forum with a different label. Only sending feature requests to the discussion board seemed a bit too restrictive.

I also updated the discussion links to point to the list view (rather than new discussion page), since people hitting this page probably are not aware of our discussion board.