### PR TITLE
Fix decay issues with PointClouds and LaserScans

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -198,6 +198,7 @@ export class PointCloudRenderable extends PointsHistoryRenderable<PointCloudUser
 
     latestEntry.receiveTime = receiveTime;
     latestEntry.messageTime = messageTime;
+    latestEntry.points.userData.pose = getPose(pointCloud);
 
     const pointCount = Math.trunc(pointCloud.data.length / getStride(pointCloud));
     latestEntry.points.geometry.resize(pointCount);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -395,7 +395,7 @@ export class PointsHistoryRenderable<
     // Update the pose on each THREE.Points entry
     let hadTfError = false;
     for (const entry of pointsHistory) {
-      const srcTime = entry.messageTime;
+      const srcTime = entry.messageTime; // frameLocked is false, so use TFs from the original message timestamp
       const frameId = this.userData.frameId;
       const updated = updatePose(
         entry.points,


### PR DESCRIPTION
**User-Facing Changes**
Fixed issues with PointCloud and LaserScan messages displaying incorrectly in the 3D panel when their `pose` changed, or when the Decay Time setting was used.

**Description**
Fixes #4892
Fixes FG-967

Issues fixed:
- The `pose` of the latest history item was not being updated after it was initially created.
- LaserScans needs `itemSize=1` for the `position` attribute, but it was sometimes using the shared `createGeometry` function which uses `itemSize=3`

Test data: [gh4892_decay_time.mcap.zip](https://github.com/foxglove/studio/files/10240214/gh4892_decay_time.mcap.zip)
Test data with VelodyneScans: Udacity-CHX_001-cal_loop.bag

<details>
<summary>Test script:</summary>

```python
import math
import struct
from os import path
from tqdm import tqdm
from mcap_protobuf.writer import Writer
from foxglove_schemas_protobuf.LaserScan_pb2 import LaserScan
from foxglove_schemas_protobuf.PointCloud_pb2 import PointCloud
from foxglove_schemas_protobuf.FrameTransform_pb2 import FrameTransform
from foxglove_schemas_protobuf.PackedElementField_pb2 import PackedElementField
from pyquaternion import Quaternion


with open(path.splitext(path.basename(__file__))[0] + ".mcap", "wb") as stream:
    writer = Writer(stream)

    duration_ns = 10_000_000_000
    nframes = 100
    for frame in tqdm(range(0, nframes)):
        t = int(frame * duration_ns / nframes)

        if frame%10==0:
            q = Quaternion(axis=[0, 0, 1], angle=math.pi/4 * frame/nframes)
            scan = LaserScan()
            scan.frame_id = "sensor1"
            scan.timestamp.FromNanoseconds(t)
            scan.start_angle = 0
            scan.end_angle = 0.2
            scan.pose.position.x = 1 * frame/nframes
            scan.pose.orientation.x = q.x
            scan.pose.orientation.y = q.y
            scan.pose.orientation.z = q.z
            scan.pose.orientation.w = q.w
            scan.ranges[:] = [1, 1, 1, 1, 1, 1, 1]
            scan.intensities[:] = [1, 2, 3, 4, 5, 6, 7]
            writer.write_message("scan", scan, t)

            cloud = PointCloud()
            cloud.frame_id = "sensor2"
            cloud.timestamp.FromNanoseconds(t)
            cloud.fields.add(
                name = "x",
                offset = 0,
                type = PackedElementField.FLOAT32
            )
            cloud.fields.add(
                name = "y",
                offset = 4,
                type = PackedElementField.FLOAT32
            )
            cloud.fields.add(
                name = "z",
                offset = 8,
                type = PackedElementField.FLOAT32
            )
            cloud.fields.add(
                name = "i",
                offset = 12,
                type = PackedElementField.UINT8
            )
            data = bytearray(13 * 7)
            cloud.point_stride = 13
            for i in range(0, 7):
                struct.pack_into("<fffB", data, i * 13, 1, 0.3*i/7, 0, i)
            cloud.pose.position.x = 1 * frame/nframes
            q = Quaternion(axis=[0, 0, 1], angle=-math.pi/4 * frame/nframes)
            cloud.pose.orientation.x = q.x
            cloud.pose.orientation.y = q.y
            cloud.pose.orientation.z = q.z
            cloud.pose.orientation.w = q.w
            cloud.data = bytes(data)
            writer.write_message("cloud", cloud, t)

        tf = FrameTransform()
        tf.parent_frame_id = "base"
        tf.child_frame_id = "sensor1"
        tf.timestamp.FromNanoseconds(t)
        tf.translation.y = 3 * frame/nframes
        tf.rotation.w = 1
        writer.write_message("tf", tf, t)

        tf = FrameTransform()
        tf.parent_frame_id = "base"
        tf.child_frame_id = "sensor2"
        tf.timestamp.FromNanoseconds(t)
        tf.translation.y = -3 * frame/nframes
        tf.rotation.w = 1
        writer.write_message("tf", tf, t)

        tf = FrameTransform()
        tf.parent_frame_id = "world"
        tf.child_frame_id = "base"
        tf.timestamp.FromNanoseconds(t)
        tf.translation.x = frame/nframes
        tf.rotation.w = 1
        writer.write_message("tf", tf, t)

    writer.finish()
    stream.close()
```

</details>