### PR TITLE
Remove access of `renderable.userData` from `ThreeDeeRender`

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
@@ -25,6 +25,8 @@ export type BaseUserData = {
   settingsPath: ReadonlyArray<string>;
   /** User-customizable settings for this Renderable */
   settings: BaseSettings;
+  /** Topic that the Renderable belongs to, if applicable*/
+  topic?: string;
 };
 
 /**
@@ -83,6 +85,21 @@ export class Renderable<TUserData extends BaseUserData = BaseUserData> extends T
     return {};
   }
 
+  /**
+   * Return topic if one exists on the userData.
+   */
+  // eslint-disable-next-line no-restricted-syntax
+  public get topic(): TUserData["topic"] {
+    return this.userData.topic;
+  }
+
+  /**
+   * Return pose as defined in userData
+   */
+  // eslint-disable-next-line no-restricted-syntax
+  public get pose(): Pose {
+    return this.userData.pose;
+  }
   /**
    * Return a Plain Old JavaScript Object (POJO) representation of a specific
    * visual instance rendered by this Renderable.

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -151,7 +151,7 @@ function RendererOverlay(props: {
     () =>
       selectedRenderables.map((selection) => ({
         object: {
-          pose: selection.renderable.userData.pose,
+          pose: selection.renderable.pose,
           scale: selection.renderable.scale,
           color: undefined,
           interactionData: {
@@ -172,9 +172,9 @@ function RendererOverlay(props: {
       selectedRenderable
         ? {
             object: {
-              pose: selectedRenderable.renderable.userData.pose,
+              pose: selectedRenderable.renderable.pose,
               interactionData: {
-                topic: (selectedRenderable.renderable.userData as { topic?: string }).topic,
+                topic: selectedRenderable.renderable.topic,
                 highlighted: true,
                 originalMessage: selectedRenderable.renderable.details(),
                 instanceDetails:

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -63,11 +63,6 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
     super(name, renderer, userData);
   }
 
-  // eslint-disable-next-line no-restricted-syntax
-  public get topic(): string {
-    return this.userData.topic;
-  }
-
   public override dispose(): void {
     this.children.length = 0;
     this._deleteAllEntities();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -52,11 +52,6 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
   public override pickable = false;
   public namespaces = new Map<string, MarkersNamespace>();
 
-  // eslint-disable-next-line no-restricted-syntax
-  public get topic(): string {
-    return this.userData.topic;
-  }
-
   public override dispose(): void {
     for (const ns of this.namespaces.values()) {
       for (const marker of ns.markersById.values()) {


### PR DESCRIPTION

**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - none

**Description**
 - created top level `Renderable` API for accessing `pose` and `topic` of a renderable to allow access without going through `userData`

<!-- link relevant GitHub issues -->
Fixes #4842
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
