### PR TITLE
Upgrade react-use and patch useThrottle

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -45,7 +45,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-refresh-typescript": "2.0.3",
-    "react-use": "17.3.1",
+    "react-use": "17.4.0",
     "tinycolor2": "1.4.2",
     "tss-react": "3.7.1",
     "utif": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-dnd": "14.0.2",
     "@storybook/react": "patch:@storybook/react@6.5.15#./patches/storybook-react.patch",
     "react-dom": "patch:react-dom@npm:17.0.2#./patches/react-dom.patch",
-    "react-use": "patch:react-use@17.3.1#./patches/react-use.patch"
+    "react-use": "patch:react-use@17.4.0#./patches/react-use.patch"
   },
   "devDependencies": {
     "@actions/core": "1.9.1",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -168,7 +168,7 @@
     "react-svg-loader": "3.0.3",
     "react-table": "7.7.0",
     "react-transition-group": "4.4.2",
-    "react-use": "17.3.1",
+    "react-use": "17.4.0",
     "react-virtualized": "9.22.3",
     "react-window": "1.8.8",
     "readable-stream": "3.6.0",

--- a/patches/react-use.patch
+++ b/patches/react-use.patch
@@ -14,6 +14,22 @@ index bb20b9649ddaef1015e027ef14ce9a557eabc1b3..9f9173a7d7308d9c573947305976d88c
 -declare const useThrottle: <T>(value: T, ms?: number) => T;
 +declare const useThrottle: <T>(value: T | (() => T), ms?: number) => T;
  export default useThrottle;
+diff --git a/esm/useThrottle.js b/esm/useThrottle.js
+index 86e5dbd6620c73836be70d25c5078dbc2c2e20cc..07e796aa20cf7ccc81119373aed96feea378e2a6 100644
+--- a/esm/useThrottle.js
++++ b/esm/useThrottle.js
+@@ -27,7 +27,10 @@ var useThrottle = function (value, ms) {
+         }
+     }, [value]);
+     useUnmount(function () {
+-        timeout.current && clearTimeout(timeout.current);
++        if (timeout.current) {
++            clearTimeout(timeout.current);
++            timeout.current = undefined;
++        }
+     });
+     return state;
+ };
 diff --git a/esm/useLocalStorage.js b/esm/useLocalStorage.js
 index e9e192611c0c8407a0f8147304dcc366c0d074d9..434c1d5ddc5284d033a92ff487cabf2279bb2063 100644
 --- a/esm/useLocalStorage.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,7 +2495,7 @@ __metadata:
     react-svg-loader: 3.0.3
     react-table: 7.7.0
     react-transition-group: 4.4.2
-    react-use: 17.3.1
+    react-use: 17.4.0
     react-virtualized: 9.22.3
     react-window: 1.8.8
     readable-stream: 3.6.0
@@ -10546,7 +10546,7 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     react-refresh-typescript: 2.0.3
-    react-use: 17.3.1
+    react-use: 17.4.0
     tinycolor2: 1.4.2
     tss-react: 3.7.1
     utif: 3.1.0
@@ -20618,9 +20618,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.3.1":
-  version: 17.3.1
-  resolution: "react-use@npm:17.3.1"
+"react-use@npm:17.4.0":
+  version: 17.4.0
+  resolution: "react-use@npm:17.4.0"
   dependencies:
     "@types/js-cookie": ^2.2.6
     "@xobotyi/scrollbar-width": ^1.9.5
@@ -20637,15 +20637,15 @@ __metadata:
     ts-easing: ^0.2.0
     tslib: ^2.1.0
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-    react-dom: ^16.8.0  || ^17.0.0
-  checksum: 0489a2603dc1a5e2666ae7643b42ec82d747a70476087b0965ee67048940a8dee912cd982d568ff97af703365914c8d8208216301b8489082be61d86561fb858
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  checksum: 0889da919b49a186de375ec15d2778b954ae981c523acd17dd496e4a4da7b6190efe7993491e1b85fdd6de3e745d08a4eaba4caa35408d570b5f1de550f35d11
   languageName: node
   linkType: hard
 
-"react-use@patch:react-use@17.3.1#./patches/react-use.patch::locator=foxglove-studio%40workspace%3A.":
-  version: 17.3.1
-  resolution: "react-use@patch:react-use@npm%3A17.3.1#./patches/react-use.patch::version=17.3.1&hash=37189e&locator=foxglove-studio%40workspace%3A."
+"react-use@patch:react-use@17.4.0#./patches/react-use.patch::locator=foxglove-studio%40workspace%3A.":
+  version: 17.4.0
+  resolution: "react-use@patch:react-use@npm%3A17.4.0#./patches/react-use.patch::version=17.4.0&hash=95d442&locator=foxglove-studio%40workspace%3A."
   dependencies:
     "@types/js-cookie": ^2.2.6
     "@xobotyi/scrollbar-width": ^1.9.5
@@ -20662,9 +20662,9 @@ __metadata:
     ts-easing: ^0.2.0
     tslib: ^2.1.0
   peerDependencies:
-    react: ^16.8.0  || ^17.0.0
-    react-dom: ^16.8.0  || ^17.0.0
-  checksum: 719d6a7f888e95c3c5f90527e09bb10b25fa5c9f08b36f756ebf21d360b9ad52be54a65a1027929bbce0acafe49e12a5f9eabbf19c04fe2a63b8c26b077d2b4a
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  checksum: 1f7268aa7948f9099935d458533bf8e5e059c8592ec98acb4a68c162455e54b04572287aa05ba7e248e39e9ef952264a4a5fb14dcbf2fd764b210ad02c59a037
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Applies the patch to `useThrottle` from https://github.com/streamich/react-use/issues/2343. This will be necessary for React 18 compatibility.
Split from #4052  (see https://github.com/foxglove/studio/pull/4052#pullrequestreview-1225049157)