### PR TITLE
Improve message frequency display for live connections

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/TopicList.stories.tsx
@@ -5,13 +5,14 @@
 import { Story } from "@storybook/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
-import { TopicStats } from "@foxglove/studio-base/players/types";
+import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
 
 import { TopicList } from "./TopicList";
 
 function Wrapper(StoryFn: Story): JSX.Element {
   return (
     <MockMessagePipelineProvider
+      capabilities={[PlayerCapabilities.playbackControl]}
       topics={[
         {
           name: "/topic_1",

--- a/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
+++ b/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
@@ -51,7 +51,7 @@ function calculateStaticItemFrequency(
   }
 }
 
-function calculateLiveitemFrequency(numMessages: number, duration: Time) {
+function calculateLiveItemFrequency(numMessages: number, duration: Time) {
   const durationSec = toSec(duration);
 
   return durationSec > 0 ? numMessages / durationSec : undefined;
@@ -95,7 +95,7 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
   const latestStats = useLatest(topicStats);
   const updateCount = useRef(0);
   const rootRef = useRef<HTMLDivElement>(ReactNull);
-  const samples = useRef<Record<string, StatSample>>({});
+  const samplesByTopic = useRef<Record<string, StatSample>>({});
 
   const playerIsStaticSource = useMemo(
     () => playerCapabilities.includes(PlayerCapabilities.playbackControl),
@@ -143,11 +143,11 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
           }
         } else {
           // For a live source we calculate a running average of frequency.
-          const sample = samples.current[topic];
+          const sample = samplesByTopic.current[topic];
           if (stat == undefined) {
             field.innerText = EM_DASH;
           } else if (sample == undefined) {
-            samples.current[topic] = {
+            samplesByTopic.current[topic] = {
               time: thisCurrentTime,
               count: stat.numMessages,
               frequency: undefined,
@@ -156,7 +156,7 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
             const messageDelta = stat.numMessages - sample.count;
             if (messageDelta > 0) {
               const timeDelta = subtractTimes(thisCurrentTime, sample.time);
-              const newFrequency = calculateLiveitemFrequency(messageDelta, timeDelta);
+              const newFrequency = calculateLiveItemFrequency(messageDelta, timeDelta);
               if (newFrequency != undefined) {
                 const smoothedFrequency = smoothValues(sample.frequency, newFrequency);
                 sample.frequency = smoothedFrequency;
@@ -181,7 +181,7 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
   // Clear previous samples on player change.
   useEffect(() => {
     void playerId;
-    samples.current = {};
+    samplesByTopic.current = {};
   }, [playerId]);
 
   useLayoutEffect(() => {

--- a/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
+++ b/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
@@ -5,63 +5,17 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useLatest } from "react-use";
 
-import { areEqual, Time, toSec } from "@foxglove/rostime";
+import { Time } from "@foxglove/rostime";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
-import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
+import { useTopicPublishFrequencies } from "@foxglove/studio-base/hooks/useTopicPublishFrequences";
 import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
 
 const EM_DASH = "\u2014";
 const EMPTY_TOPIC_STATS = new Map<string, TopicStats>();
 
-// Empirically this seems to strike a good balance between stable values
-// and reasonably quick reactions to change.
-function smoothValues(oldValue: undefined | number, newValue: number): number {
-  return 0.7 * (oldValue ?? newValue) + 0.3 * newValue;
-}
-
-function calculateStaticItemFrequency(
-  numMessages: number,
-  firstMessageTime: undefined | Time,
-  lastMessageTime: undefined | Time,
-  duration: Time,
-): undefined | number {
-  // Message count but no timestamps, use the full connection duration
-  if (firstMessageTime == undefined || lastMessageTime == undefined) {
-    const durationSec = toSec(duration);
-    if (durationSec > 0) {
-      return numMessages / durationSec;
-    } else {
-      return undefined;
-    }
-  }
-
-  // Not enough messages or time span to calculate a frequency
-  if (numMessages < 2 || areEqual(firstMessageTime, lastMessageTime)) {
-    return undefined;
-  }
-
-  const topicDurationSec = toSec(subtractTimes(lastMessageTime, firstMessageTime));
-  if (topicDurationSec > 0) {
-    return (numMessages - 1) / topicDurationSec;
-  } else {
-    return undefined;
-  }
-}
-
-function calculateLiveItemFrequency(numMessages: number, duration: Time) {
-  const durationSec = toSec(duration);
-
-  return durationSec > 0 ? numMessages / durationSec : undefined;
-}
-
-const selectCurrentTime = ({ playerState }: MessagePipelineContext) =>
-  playerState.activeData?.currentTime;
-const selectStartTime = ({ playerState }: MessagePipelineContext) =>
-  playerState.activeData?.startTime;
-const selectEndTime = ({ playerState }: MessagePipelineContext) => playerState.activeData?.endTime;
 const selectTopicStats = (ctx: MessagePipelineContext) =>
   ctx.playerState.activeData?.topicStats ?? EMPTY_TOPIC_STATS;
 const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
@@ -82,20 +36,17 @@ type StatSample = {
  * @property interval - the interval, in frames, between updates.
  */
 export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number }): JSX.Element {
-  const currentTime = useMessagePipeline(selectCurrentTime);
-  const startTime = useMessagePipeline(selectStartTime);
-  const endTime = useMessagePipeline(selectEndTime);
   const topicStats = useMessagePipeline(selectTopicStats);
   const playerCapabilities = useMessagePipeline(selectPlayerCapabilities);
   const playerId = useMessagePipeline(selectPlayerId);
-  const duration = endTime && startTime ? subtractTimes(endTime, startTime) : { sec: 0, nsec: 0 };
 
-  const latestCurrentTime = useLatest(currentTime);
-  const latestDuration = useLatest(duration);
   const latestStats = useLatest(topicStats);
   const updateCount = useRef(0);
   const rootRef = useRef<HTMLDivElement>(ReactNull);
   const samplesByTopic = useRef<Record<string, StatSample>>({});
+
+  const frequenciesByTopic = useTopicPublishFrequencies();
+  const latestFrequenciesByTopic = useLatest(frequenciesByTopic);
 
   const playerIsStaticSource = useMemo(
     () => playerCapabilities.includes(PlayerCapabilities.playbackControl),
@@ -122,55 +73,12 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
         }
       }
 
-      const thisCurrentTime = latestCurrentTime.current;
-      if (!thisCurrentTime) {
-        return;
-      }
-
       if (field.dataset.topicStat === "frequency") {
-        if (playerIsStaticSource) {
-          // For a static source we calculate frequency across all messages.
-          if (stat == undefined) {
-            field.innerText = EM_DASH;
-          } else {
-            const frequency = calculateStaticItemFrequency(
-              stat.numMessages,
-              stat.firstMessageTime,
-              stat.lastMessageTime,
-              latestDuration.current,
-            );
-            field.innerText = frequency != undefined ? `${frequency.toFixed(2)} Hz` : EM_DASH;
-          }
-        } else {
-          // For a live source we calculate a running average of frequency.
-          const sample = samplesByTopic.current[topic];
-          if (stat == undefined) {
-            field.innerText = EM_DASH;
-          } else if (sample == undefined) {
-            samplesByTopic.current[topic] = {
-              time: thisCurrentTime,
-              count: stat.numMessages,
-              frequency: undefined,
-            };
-          } else {
-            const messageDelta = stat.numMessages - sample.count;
-            if (messageDelta > 0) {
-              const timeDelta = subtractTimes(thisCurrentTime, sample.time);
-              const newFrequency = calculateLiveItemFrequency(messageDelta, timeDelta);
-              if (newFrequency != undefined) {
-                const smoothedFrequency = smoothValues(sample.frequency, newFrequency);
-                sample.frequency = smoothedFrequency;
-                sample.count = stat.numMessages;
-                sample.time = thisCurrentTime;
-              }
-            }
-            field.innerText =
-              sample.frequency != undefined ? `${sample.frequency.toFixed(2)} Hz` : EM_DASH;
-          }
-        }
+        const frequency = latestFrequenciesByTopic.current[topic];
+        field.innerText = frequency != undefined ? `${frequency.toFixed(2)} Hz` : EM_DASH;
       }
     });
-  }, [latestCurrentTime, latestDuration, latestStats, playerIsStaticSource]);
+  }, [latestFrequenciesByTopic, latestStats]);
 
   useEffect(() => {
     if (updateCount.current++ % interval === 0) {

--- a/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
+++ b/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
@@ -18,8 +18,8 @@ const EMPTY_TOPIC_STATS = new Map<string, TopicStats>();
 
 // Empirically this seems to strike a good balance between stable values
 // and reasonably quick reactions to change.
-function smoothValues(oldValue: number, newValue: number): number {
-  return 0.8 * oldValue + 0.2 * newValue;
+function smoothValues(oldValue: undefined | number, newValue: number): number {
+  return 0.7 * (oldValue ?? newValue) + 0.3 * newValue;
 }
 
 function calculateStaticItemFrequency(
@@ -67,6 +67,12 @@ const selectTopicStats = (ctx: MessagePipelineContext) =>
 const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
 const selectPlayerCapabilities = (ctx: MessagePipelineContext) => ctx.playerState.capabilities;
 
+type StatSample = {
+  time: Time;
+  count: number;
+  frequency: undefined | number;
+};
+
 /**
  * Encapsulates logic for directly updating topic stats DOM elements, bypassing
  * react for performance. To use this component mount it directly under your component
@@ -84,14 +90,12 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
   const playerId = useMessagePipeline(selectPlayerId);
   const duration = endTime && startTime ? subtractTimes(endTime, startTime) : { sec: 0, nsec: 0 };
 
-  const previousCurrentTime = useRef(currentTime);
   const latestCurrentTime = useLatest(currentTime);
   const latestDuration = useLatest(duration);
   const latestStats = useLatest(topicStats);
   const updateCount = useRef(0);
   const rootRef = useRef<HTMLDivElement>(ReactNull);
-  const previousMessageCounts = useRef<Record<string, number>>({});
-  const previousMessageFrequencies = useRef<Record<string, undefined | number>>({});
+  const samples = useRef<Record<string, StatSample>>({});
 
   const playerIsStaticSource = useMemo(
     () => playerCapabilities.includes(PlayerCapabilities.playbackControl),
@@ -104,20 +108,31 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
     }
 
     rootRef.current.parentElement?.querySelectorAll("[data-topic]").forEach((field) => {
-      if (field instanceof HTMLElement && field.dataset.topic) {
-        const topic = field.dataset.topic;
-        const stat = latestStats.current.get(topic);
-        if (field.dataset.topicStat === "count") {
-          if (stat) {
-            field.innerText = stat.numMessages.toLocaleString();
-          } else {
-            field.innerText = EM_DASH;
-          }
-        }
+      if (!(field instanceof HTMLElement) || !field.dataset.topic) {
+        return;
+      }
 
-        if (field.dataset.topicStat === "frequency") {
-          if (stat && playerIsStaticSource) {
-            // For a static source we calculate frequency across all messages.
+      const topic = field.dataset.topic;
+      const stat = latestStats.current.get(topic);
+      if (field.dataset.topicStat === "count") {
+        if (stat) {
+          field.innerText = stat.numMessages.toLocaleString();
+        } else {
+          field.innerText = EM_DASH;
+        }
+      }
+
+      const thisCurrentTime = latestCurrentTime.current;
+      if (!thisCurrentTime) {
+        return;
+      }
+
+      if (field.dataset.topicStat === "frequency") {
+        if (playerIsStaticSource) {
+          // For a static source we calculate frequency across all messages.
+          if (stat == undefined) {
+            field.innerText = EM_DASH;
+          } else {
             const frequency = calculateStaticItemFrequency(
               stat.numMessages,
               stat.firstMessageTime,
@@ -125,46 +140,37 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
               latestDuration.current,
             );
             field.innerText = frequency != undefined ? `${frequency.toFixed(2)} Hz` : EM_DASH;
-          } else if (
-            stat &&
-            !playerIsStaticSource &&
-            latestCurrentTime.current != undefined &&
-            previousCurrentTime.current != undefined
-          ) {
-            // For a live source we calculate a running average of frequency.
-            const messageDelta = stat.numMessages - (previousMessageCounts.current[topic] ?? 0);
-            const timeDelta = subtractTimes(latestCurrentTime.current, previousCurrentTime.current);
-            const newFrequency = calculateLiveitemFrequency(messageDelta, timeDelta);
-            const oldFrequency = previousMessageFrequencies.current[topic];
-            console.log(
-              topic,
-              oldFrequency?.toFixed(1),
-              newFrequency?.toFixed(2),
-              timeDelta,
-              stat.numMessages,
-            );
-            if (newFrequency != undefined && oldFrequency != undefined) {
-              // If we have a new and old value, interpolate and update display.
-              const smoothedFrequency = smoothValues(oldFrequency, newFrequency);
-              previousMessageFrequencies.current[topic] = smoothedFrequency;
-              previousMessageCounts.current[topic] = stat.numMessages;
-              previousCurrentTime.current = latestCurrentTime.current;
-              field.innerText = `${smoothedFrequency.toFixed(2)} Hz`;
-            } else if (newFrequency != undefined) {
-              // If only a new value store it for the next update.
-              previousMessageFrequencies.current[topic] = newFrequency;
-              previousMessageCounts.current[topic] = stat.numMessages;
-              previousCurrentTime.current = latestCurrentTime.current;
-            } else {
-              field.innerText = EM_DASH;
-            }
-          } else {
+          }
+        } else {
+          // For a live source we calculate a running average of frequency.
+          const sample = samples.current[topic];
+          if (stat == undefined) {
             field.innerText = EM_DASH;
+          } else if (sample == undefined) {
+            samples.current[topic] = {
+              time: thisCurrentTime,
+              count: stat.numMessages,
+              frequency: undefined,
+            };
+          } else {
+            const messageDelta = stat.numMessages - sample.count;
+            if (messageDelta > 0) {
+              const timeDelta = subtractTimes(thisCurrentTime, sample.time);
+              const newFrequency = calculateLiveitemFrequency(messageDelta, timeDelta);
+              if (newFrequency != undefined) {
+                const smoothedFrequency = smoothValues(sample.frequency, newFrequency);
+                sample.frequency = smoothedFrequency;
+                sample.count = stat.numMessages;
+                sample.time = thisCurrentTime;
+              }
+            }
+            field.innerText =
+              sample.frequency != undefined ? `${sample.frequency.toFixed(2)} Hz` : EM_DASH;
           }
         }
       }
     });
-  }, [latestCurrentTime, latestDuration, latestStats, playerIsStaticSource, previousCurrentTime]);
+  }, [latestCurrentTime, latestDuration, latestStats, playerIsStaticSource]);
 
   useEffect(() => {
     if (updateCount.current++ % interval === 0) {
@@ -172,11 +178,10 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
     }
   }, [updateStats, interval, topicStats, playerIsStaticSource]);
 
-  // Clear previous sample on player change.
+  // Clear previous samples on player change.
   useEffect(() => {
     void playerId;
-    previousMessageCounts.current = {};
-    previousMessageFrequencies.current = {};
+    samples.current = {};
   }, [playerId]);
 
   useLayoutEffect(() => {

--- a/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
+++ b/packages/studio-base/src/components/DirectTopicStatsUpdater.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useLatest } from "react-use";
 
 import { areEqual, Time, toSec } from "@foxglove/rostime";
@@ -11,35 +11,61 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
-import { TopicStats } from "@foxglove/studio-base/players/types";
+import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
 
 const EM_DASH = "\u2014";
 const EMPTY_TOPIC_STATS = new Map<string, TopicStats>();
 
-function formatItemFrequency(
+// Empirically this seems to strike a good balance between stable values
+// and reasonably quick reactions to change.
+function smoothValues(oldValue: number, newValue: number): number {
+  return 0.8 * oldValue + 0.2 * newValue;
+}
+
+function calculateStaticItemFrequency(
   numMessages: number,
   firstMessageTime: undefined | Time,
   lastMessageTime: undefined | Time,
   duration: Time,
-) {
+): undefined | number {
+  // Message count but no timestamps, use the full connection duration
   if (firstMessageTime == undefined || lastMessageTime == undefined) {
-    // Message count but no timestamps, use the full connection duration
-    return `${(numMessages / toSec(duration)).toFixed(2)} Hz`;
+    const durationSec = toSec(duration);
+    if (durationSec > 0) {
+      return numMessages / durationSec;
+    } else {
+      return undefined;
+    }
   }
+
+  // Not enough messages or time span to calculate a frequency
   if (numMessages < 2 || areEqual(firstMessageTime, lastMessageTime)) {
-    // Not enough messages or time span to calculate a frequency
-    return EM_DASH;
+    return undefined;
   }
+
   const topicDurationSec = toSec(subtractTimes(lastMessageTime, firstMessageTime));
-  return `${((numMessages - 1) / topicDurationSec).toFixed(2)} Hz`;
+  if (topicDurationSec > 0) {
+    return (numMessages - 1) / topicDurationSec;
+  } else {
+    return undefined;
+  }
 }
 
+function calculateLiveitemFrequency(numMessages: number, duration: Time) {
+  const durationSec = toSec(duration);
+
+  return durationSec > 0 ? numMessages / durationSec : undefined;
+}
+
+const selectCurrentTime = ({ playerState }: MessagePipelineContext) =>
+  playerState.activeData?.currentTime;
 const selectStartTime = ({ playerState }: MessagePipelineContext) =>
   playerState.activeData?.startTime;
 const selectEndTime = ({ playerState }: MessagePipelineContext) => playerState.activeData?.endTime;
-
 const selectTopicStats = (ctx: MessagePipelineContext) =>
   ctx.playerState.activeData?.topicStats ?? EMPTY_TOPIC_STATS;
+const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
+const selectPlayerCapabilities = (ctx: MessagePipelineContext) => ctx.playerState.capabilities;
 
 /**
  * Encapsulates logic for directly updating topic stats DOM elements, bypassing
@@ -50,15 +76,27 @@ const selectTopicStats = (ctx: MessagePipelineContext) =>
  * @property interval - the interval, in frames, between updates.
  */
 export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number }): JSX.Element {
+  const currentTime = useMessagePipeline(selectCurrentTime);
   const startTime = useMessagePipeline(selectStartTime);
   const endTime = useMessagePipeline(selectEndTime);
   const topicStats = useMessagePipeline(selectTopicStats);
+  const playerCapabilities = useMessagePipeline(selectPlayerCapabilities);
+  const playerId = useMessagePipeline(selectPlayerId);
   const duration = endTime && startTime ? subtractTimes(endTime, startTime) : { sec: 0, nsec: 0 };
 
+  const previousCurrentTime = useRef(currentTime);
+  const latestCurrentTime = useLatest(currentTime);
   const latestDuration = useLatest(duration);
   const latestStats = useLatest(topicStats);
   const updateCount = useRef(0);
   const rootRef = useRef<HTMLDivElement>(ReactNull);
+  const previousMessageCounts = useRef<Record<string, number>>({});
+  const previousMessageFrequencies = useRef<Record<string, undefined | number>>({});
+
+  const playerIsStaticSource = useMemo(
+    () => playerCapabilities.includes(PlayerCapabilities.playbackControl),
+    [playerCapabilities],
+  );
 
   const updateStats = useCallback(() => {
     if (!rootRef.current) {
@@ -76,27 +114,70 @@ export function DirectTopicStatsUpdater({ interval = 1 }: { interval?: number })
             field.innerText = EM_DASH;
           }
         }
+
         if (field.dataset.topicStat === "frequency") {
-          if (stat) {
-            field.innerText = formatItemFrequency(
+          if (stat && playerIsStaticSource) {
+            // For a static source we calculate frequency across all messages.
+            const frequency = calculateStaticItemFrequency(
               stat.numMessages,
               stat.firstMessageTime,
               stat.lastMessageTime,
               latestDuration.current,
             );
+            field.innerText = frequency != undefined ? `${frequency.toFixed(2)} Hz` : EM_DASH;
+          } else if (
+            stat &&
+            !playerIsStaticSource &&
+            latestCurrentTime.current != undefined &&
+            previousCurrentTime.current != undefined
+          ) {
+            // For a live source we calculate a running average of frequency.
+            const messageDelta = stat.numMessages - (previousMessageCounts.current[topic] ?? 0);
+            const timeDelta = subtractTimes(latestCurrentTime.current, previousCurrentTime.current);
+            const newFrequency = calculateLiveitemFrequency(messageDelta, timeDelta);
+            const oldFrequency = previousMessageFrequencies.current[topic];
+            console.log(
+              topic,
+              oldFrequency?.toFixed(1),
+              newFrequency?.toFixed(2),
+              timeDelta,
+              stat.numMessages,
+            );
+            if (newFrequency != undefined && oldFrequency != undefined) {
+              // If we have a new and old value, interpolate and update display.
+              const smoothedFrequency = smoothValues(oldFrequency, newFrequency);
+              previousMessageFrequencies.current[topic] = smoothedFrequency;
+              previousMessageCounts.current[topic] = stat.numMessages;
+              previousCurrentTime.current = latestCurrentTime.current;
+              field.innerText = `${smoothedFrequency.toFixed(2)} Hz`;
+            } else if (newFrequency != undefined) {
+              // If only a new value store it for the next update.
+              previousMessageFrequencies.current[topic] = newFrequency;
+              previousMessageCounts.current[topic] = stat.numMessages;
+              previousCurrentTime.current = latestCurrentTime.current;
+            } else {
+              field.innerText = EM_DASH;
+            }
           } else {
             field.innerText = EM_DASH;
           }
         }
       }
     });
-  }, [latestDuration, latestStats]);
+  }, [latestCurrentTime, latestDuration, latestStats, playerIsStaticSource, previousCurrentTime]);
 
   useEffect(() => {
     if (updateCount.current++ % interval === 0) {
       updateStats();
     }
-  }, [updateStats, interval, topicStats]);
+  }, [updateStats, interval, topicStats, playerIsStaticSource]);
+
+  // Clear previous sample on player change.
+  useEffect(() => {
+    void playerId;
+    previousMessageCounts.current = {};
+    previousMessageFrequencies.current = {};
+  }, [playerId]);
 
   useLayoutEffect(() => {
     updateStats();

--- a/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
+++ b/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
@@ -4,58 +4,53 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { renderHook } from "@testing-library/react";
-import { DeepPartial } from "ts-essentials";
 
-import {
-  MessagePipelineContext,
-  useMessagePipeline,
-} from "@foxglove/studio-base/components/MessagePipeline";
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { useTopicPublishFrequencies } from "@foxglove/studio-base/hooks/useTopicPublishFrequences";
 import { PlayerCapabilities, PlayerState } from "@foxglove/studio-base/players/types";
 
-jest.mock("@foxglove/studio-base/components/MessagePipeline");
-
 describe("useSynchronousMountedState", () => {
   it("calculates frequences for a static source", () => {
-    (useMessagePipeline as jest.Mock).mockImplementation(
-      (selector: (ctx: DeepPartial<MessagePipelineContext>) => unknown) =>
-        selector({
-          playerState: {
-            activeData: {
-              currentTime: { sec: 2, nsec: 0 },
-              endTime: { sec: 10, nsec: 0 },
-              startTime: { sec: 0, nsec: 0 },
-              topicStats: new Map([
-                [
-                  "topic_a",
-                  {
-                    numMessages: 10,
-                    firstMessageTime: { sec: 1, nsec: 0 },
-                    lastMessageTime: { sec: 5, nsec: 0 },
-                  },
-                ],
-                [
-                  "topic_b",
-                  {
-                    numMessages: 20,
-                    firstMessageTime: { sec: 2, nsec: 0 },
-                    lastMessageTime: { sec: 7, nsec: 0 },
-                  },
-                ],
-              ]),
-            },
-            capabilities: [PlayerCapabilities.playbackControl],
+    const activeData: Partial<PlayerState["activeData"]> = {
+      currentTime: { sec: 2, nsec: 0 },
+      endTime: { sec: 10, nsec: 0 },
+      startTime: { sec: 0, nsec: 0 },
+      topicStats: new Map([
+        [
+          "topic_a",
+          {
+            numMessages: 10,
+            firstMessageTime: { sec: 1, nsec: 0 },
+            lastMessageTime: { sec: 5, nsec: 0 },
           },
-        }),
-    );
+        ],
+        [
+          "topic_b",
+          {
+            numMessages: 20,
+            firstMessageTime: { sec: 2, nsec: 0 },
+            lastMessageTime: { sec: 7, nsec: 0 },
+          },
+        ],
+      ]),
+    };
 
-    const { result } = renderHook(useTopicPublishFrequencies);
+    const { result } = renderHook(useTopicPublishFrequencies, {
+      wrapper: ({ children }) => (
+        <MockMessagePipelineProvider
+          activeData={activeData}
+          capabilities={[PlayerCapabilities.playbackControl]}
+        >
+          {children}
+        </MockMessagePipelineProvider>
+      ),
+    });
 
     expect(result.current).toStrictEqual({ topic_a: 2.25, topic_b: 3.8 });
   });
 
   it("updates frequences for a live source", () => {
-    const activeData: DeepPartial<PlayerState["activeData"]> = {
+    let activeData: Partial<PlayerState["activeData"]> = {
       currentTime: { sec: 2, nsec: 0 },
       endTime: { sec: 10, nsec: 0 },
       startTime: { sec: 0, nsec: 0 },
@@ -65,25 +60,25 @@ describe("useSynchronousMountedState", () => {
       ]),
     };
 
-    (useMessagePipeline as jest.Mock).mockImplementation(
-      (selector: (ctx: DeepPartial<MessagePipelineContext>) => unknown) =>
-        selector({
-          playerState: {
-            activeData,
-            capabilities: [],
-          },
-        }),
-    );
-
-    const { result, rerender } = renderHook(useTopicPublishFrequencies);
+    const { result, rerender } = renderHook(useTopicPublishFrequencies, {
+      wrapper: ({ children }) => (
+        <MockMessagePipelineProvider activeData={activeData}>
+          {children}
+        </MockMessagePipelineProvider>
+      ),
+    });
 
     expect(result.current).toStrictEqual({});
 
-    activeData.currentTime = { sec: 3, nsec: 0 };
-    activeData.topicStats = new Map([
-      ["topic_a", { numMessages: 20 }],
-      ["topic_b", { numMessages: 40 }],
-    ]);
+    activeData = {
+      currentTime: { sec: 3, nsec: 0 },
+      endTime: { sec: 10, nsec: 0 },
+      startTime: { sec: 0, nsec: 0 },
+      topicStats: new Map([
+        ["topic_a", { numMessages: 20 }],
+        ["topic_b", { numMessages: 40 }],
+      ]),
+    };
     rerender();
 
     expect(result.current).toStrictEqual({ topic_a: 10, topic_b: 20 });

--- a/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
+++ b/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook } from "@testing-library/react";
+import { DeepPartial } from "ts-essentials";
+
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { useTopicPublishFrequencies } from "@foxglove/studio-base/hooks/useTopicPublishFrequences";
+import { PlayerCapabilities, PlayerState } from "@foxglove/studio-base/players/types";
+
+jest.mock("@foxglove/studio-base/components/MessagePipeline");
+
+describe("useSynchronousMountedState", () => {
+  it("calculates frequences for a static source", () => {
+    (useMessagePipeline as jest.Mock).mockImplementation(
+      (selector: (ctx: DeepPartial<MessagePipelineContext>) => unknown) =>
+        selector({
+          playerState: {
+            activeData: {
+              currentTime: { sec: 2, nsec: 0 },
+              endTime: { sec: 10, nsec: 0 },
+              startTime: { sec: 0, nsec: 0 },
+              topicStats: new Map([
+                [
+                  "topic_a",
+                  {
+                    numMessages: 10,
+                    firstMessageTime: { sec: 1, nsec: 0 },
+                    lastMessageTime: { sec: 5, nsec: 0 },
+                  },
+                ],
+                [
+                  "topic_b",
+                  {
+                    numMessages: 20,
+                    firstMessageTime: { sec: 2, nsec: 0 },
+                    lastMessageTime: { sec: 7, nsec: 0 },
+                  },
+                ],
+              ]),
+            },
+            capabilities: [PlayerCapabilities.playbackControl],
+          },
+        }),
+    );
+
+    const { result } = renderHook(useTopicPublishFrequencies);
+
+    expect(result.current).toStrictEqual({ topic_a: 2.25, topic_b: 3.8 });
+  });
+
+  it("updates frequences for a live source", () => {
+    const activeData: DeepPartial<PlayerState["activeData"]> = {
+      currentTime: { sec: 2, nsec: 0 },
+      endTime: { sec: 10, nsec: 0 },
+      startTime: { sec: 0, nsec: 0 },
+      topicStats: new Map([
+        ["topic_a", { numMessages: 10 }],
+        ["topic_b", { numMessages: 20 }],
+      ]),
+    };
+
+    (useMessagePipeline as jest.Mock).mockImplementation(
+      (selector: (ctx: DeepPartial<MessagePipelineContext>) => unknown) =>
+        selector({
+          playerState: {
+            activeData,
+            capabilities: [],
+          },
+        }),
+    );
+
+    const { result, rerender } = renderHook(useTopicPublishFrequencies);
+
+    expect(result.current).toStrictEqual({});
+
+    activeData.currentTime = { sec: 3, nsec: 0 };
+    activeData.topicStats = new Map([
+      ["topic_a", { numMessages: 20 }],
+      ["topic_b", { numMessages: 40 }],
+    ]);
+    rerender();
+
+    expect(result.current).toStrictEqual({ topic_a: 10, topic_b: 20 });
+  });
+});

--- a/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
+++ b/packages/studio-base/src/hooks/useTopicPublishFrequences.test.tsx
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { useTopicPublishFrequencies } from "@foxglove/studio-base/hooks/useTopicPublishFrequences";

--- a/packages/studio-base/src/hooks/useTopicPublishFrequences.ts
+++ b/packages/studio-base/src/hooks/useTopicPublishFrequences.ts
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useMemo, useRef } from "react";
+import { DeepReadonly } from "ts-essentials";
+
+import { areEqual, Time, toSec } from "@foxglove/rostime";
+import {
+  MessagePipelineContext,
+  useMessagePipeline,
+} from "@foxglove/studio-base/components/MessagePipeline";
+import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
+import { PlayerCapabilities, TopicStats } from "@foxglove/studio-base/players/types";
+
+const EMPTY_TOPIC_STATS = new Map<string, TopicStats>();
+
+// Empirically this seems to strike a good balance between stable values
+// and reasonably quick reactions to change.
+function smoothValues(oldValue: undefined | number, newValue: number): number {
+  return 0.7 * (oldValue ?? newValue) + 0.3 * newValue;
+}
+
+function calculateStaticItemFrequency(
+  numMessages: number,
+  firstMessageTime: undefined | Time,
+  lastMessageTime: undefined | Time,
+  duration: Time,
+): undefined | number {
+  // Message count but no timestamps, use the full connection duration
+  if (firstMessageTime == undefined || lastMessageTime == undefined) {
+    const durationSec = toSec(duration);
+    if (durationSec > 0) {
+      return numMessages / durationSec;
+    } else {
+      return undefined;
+    }
+  }
+
+  // Not enough messages or time span to calculate a frequency
+  if (numMessages < 2 || areEqual(firstMessageTime, lastMessageTime)) {
+    return undefined;
+  }
+
+  const topicDurationSec = toSec(subtractTimes(lastMessageTime, firstMessageTime));
+  if (topicDurationSec > 0) {
+    return (numMessages - 1) / topicDurationSec;
+  } else {
+    return undefined;
+  }
+}
+
+function calculateLiveItemFrequency(numMessages: number, duration: Time) {
+  const durationSec = toSec(duration);
+
+  return durationSec > 0 ? numMessages / durationSec : undefined;
+}
+
+const selectCurrentTime = ({ playerState }: MessagePipelineContext) =>
+  playerState.activeData?.currentTime;
+const selectStartTime = ({ playerState }: MessagePipelineContext) =>
+  playerState.activeData?.startTime;
+const selectEndTime = ({ playerState }: MessagePipelineContext) => playerState.activeData?.endTime;
+const selectTopicStats = (ctx: MessagePipelineContext) =>
+  ctx.playerState.activeData?.topicStats ?? EMPTY_TOPIC_STATS;
+const selectPlayerCapabilities = (ctx: MessagePipelineContext) => ctx.playerState.capabilities;
+
+type StatSample = {
+  time: Time;
+  count: number;
+  frequency: undefined | number;
+};
+
+type FrequenciesByTopic = Record<string, undefined | number>;
+const EMPTY_FREQUENCIES: FrequenciesByTopic = {};
+
+/**
+ * Encapsulates logic for directly updating topic stats DOM elements, bypassing
+ * react for performance. To use this component mount it directly under your component
+ * containing topics you want to update. Tag each topic stat field with data-topic
+ * and data-topic-stat attributes.
+ *
+ * @property interval - the interval, in frames, between updates.
+ */
+export function useTopicPublishFrequencies(): DeepReadonly<FrequenciesByTopic> {
+  const currentTime = useMessagePipeline(selectCurrentTime);
+  const startTime = useMessagePipeline(selectStartTime);
+  const endTime = useMessagePipeline(selectEndTime);
+  const topicStats = useMessagePipeline(selectTopicStats);
+  const playerCapabilities = useMessagePipeline(selectPlayerCapabilities);
+  const duration = useMemo(
+    () => (endTime && startTime ? subtractTimes(endTime, startTime) : { sec: 0, nsec: 0 }),
+    [endTime, startTime],
+  );
+
+  const samplesByTopic = useRef<Record<string, StatSample>>({});
+
+  const playerIsStaticSource = useMemo(
+    () => playerCapabilities.includes(PlayerCapabilities.playbackControl),
+    [playerCapabilities],
+  );
+
+  const frequencies = useMemo(() => {
+    if (!currentTime) {
+      return EMPTY_FREQUENCIES;
+    }
+
+    const result: FrequenciesByTopic = {};
+    for (const [topic, stat] of topicStats) {
+      if (playerIsStaticSource) {
+        // For a static source we calculate frequency across all messages.
+        const frequency = calculateStaticItemFrequency(
+          stat.numMessages,
+          stat.firstMessageTime,
+          stat.lastMessageTime,
+          duration,
+        );
+        result[topic] = frequency;
+      } else {
+        // For a live source we calculate a running average of frequency.
+        const sample = samplesByTopic.current[topic];
+        if (sample == undefined) {
+          samplesByTopic.current[topic] = {
+            time: currentTime,
+            count: stat.numMessages,
+            frequency: undefined,
+          };
+        } else {
+          const messageDelta = stat.numMessages - sample.count;
+          if (messageDelta > 0) {
+            const timeDelta = subtractTimes(currentTime, sample.time);
+            const newFrequency = calculateLiveItemFrequency(messageDelta, timeDelta);
+            if (newFrequency != undefined) {
+              const smoothedFrequency = smoothValues(sample.frequency, newFrequency);
+              sample.frequency = smoothedFrequency;
+              sample.count = stat.numMessages;
+              sample.time = currentTime;
+            }
+          }
+          result[topic] = sample.frequency;
+        }
+      }
+    }
+
+    return result;
+  }, [currentTime, duration, playerIsStaticSource, topicStats]);
+
+  return frequencies;
+}


### PR DESCRIPTION
**User-Facing Changes**
Improves calculation of topic publishing frequencies for live connections.

**Description**
This replaces the static calculation of n / time for live messages with a moving average of frequency for topics of live connections. This gives better results for cases where messages are missed for any period of time, at the cost of some jitter in the actual displayed values.

We don't seem to explicitly mark a player as live so I'm inferring that from the absence of the `playbackControl` player capability.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
Fixes https://github.com/foxglove/studio/issues/4799