### PR TITLE
Foxglove websocket: Use server published time as message receive timestamps

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -56,7 +56,7 @@
     "@foxglove/ulog": "2.1.2",
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.0",
-    "@foxglove/ws-protocol": "0.0.8",
+    "@foxglove/ws-protocol": "0.2.0",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "0.2.2",
     "@mdi/svg": "6.5.95",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -268,7 +268,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       try {
-        const receiveTime = fromNanoSec(timestamp);
+        const receiveTime = this._serverPublishesTime
+          ? this._clockTime ?? ZERO_TIME
+          : fromNanoSec(timestamp);
         const topic = chanInfo.channel.topic;
         // If time goes backwards, increment lastSeekTime and discard unemitted messages from before
         // the discontinuity. This prevents us from queueing an unbounded number of messages when

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -24,7 +24,13 @@ import {
   TopicStats,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
-import { Channel, ChannelId, FoxgloveClient, SubscriptionId } from "@foxglove/ws-protocol";
+import {
+  Channel,
+  ChannelId,
+  FoxgloveClient,
+  ServerCapability,
+  SubscriptionId,
+} from "@foxglove/ws-protocol";
 
 const log = Log.getLogger(__dirname);
 
@@ -61,6 +67,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _currentTime?: Time;
   /** Latest time seen */
   private _endTime?: Time;
+  /* The most recent published time, if available */
+  private _clockTime?: Time;
+  /* Flag indicating if the server publishes time messages */
+  private _serverPublishesTime = false;
 
   private _unresolvedSubscriptions = new Set<string>();
   private _resolvedSubscriptionsByTopic = new Map<string, SubscriptionId>();
@@ -123,6 +133,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._startTime = undefined;
       this._currentTime = undefined;
       this._endTime = undefined;
+      this._clockTime = undefined;
+      this._serverPublishesTime = false;
 
       for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
         this._unresolvedSubscriptions.add(topic);
@@ -145,6 +157,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     client.on("serverInfo", (event) => {
       this._name = `${this._url}\n${event.name}`;
+      this._serverPublishesTime = event.capabilities.includes(ServerCapability.time);
       this._emitState();
     });
 
@@ -301,6 +314,21 @@ export default class FoxgloveWebSocketPlayer implements Player {
           error,
         });
       }
+      this._emitState();
+    });
+
+    client.on("time", ({ timestamp }) => {
+      if (!this._serverPublishesTime) {
+        return;
+      }
+
+      const time = fromNanoSec(timestamp);
+      if (this._clockTime != undefined && isLessThan(time, this._clockTime)) {
+        ++this._lastSeekTime;
+        this._parsedMessages = [];
+      }
+
+      this._clockTime = time;
       this._emitState();
     });
   };

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -282,12 +282,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
           this._parsedMessages = [];
         }
         this._currentTime = receiveTime;
-        if (!this._startTime || isLessThan(receiveTime, this._startTime)) {
-          this._startTime = receiveTime;
-        }
-        if (!this._endTime || isGreaterThan(receiveTime, this._endTime)) {
-          this._endTime = receiveTime;
-        }
         this._parsedMessages.push({
           topic,
           receiveTime,
@@ -330,7 +324,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._parsedMessages = [];
       }
 
-      this._clockTime = time;
+      this._clockTime = this._currentTime = time;
       this._emitState();
     });
   };
@@ -383,6 +377,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
       });
     }
 
+    const currentTime = this._currentTime;
+    if (currentTime && (!this._startTime || isLessThan(currentTime, this._startTime))) {
+      this._startTime = currentTime;
+    }
+    if (currentTime && (!this._endTime || isGreaterThan(currentTime, this._endTime))) {
+      this._endTime = currentTime;
+    }
+
     const messages = this._parsedMessages;
     this._parsedMessages = [];
     return this._listener({
@@ -403,7 +405,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         totalBytesReceived: this._receivedBytes,
         startTime: this._startTime ?? ZERO_TIME,
         endTime: this._endTime ?? ZERO_TIME,
-        currentTime: this._currentTime ?? ZERO_TIME,
+        currentTime: currentTime ?? ZERO_TIME,
         isPlaying: true,
         speed: 1,
         lastSeekTime: this._lastSeekTime,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,7 +2383,7 @@ __metadata:
     "@foxglove/ulog": 2.1.2
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.0
-    "@foxglove/ws-protocol": 0.0.8
+    "@foxglove/ws-protocol": 0.2.0
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 0.2.2
     "@mdi/svg": 6.5.95
@@ -2582,14 +2582,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.0.8":
-  version: 0.0.8
-  resolution: "@foxglove/ws-protocol@npm:0.0.8"
+"@foxglove/ws-protocol@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@foxglove/ws-protocol@npm:0.2.0"
   dependencies:
     debug: ^4
     eventemitter3: ^4.0.7
     tslib: ^2
-  checksum: 4876d206d4b0b5d677c301182f15505a85f78357edd78c48bfab6652abff723ec1804482630be5efe0a9166d22d5770daa0d7a9c9ff4772c1ca80a9dce1831d7
+  checksum: 4d086e6d26adb6ceb6cac0789dc4fef20c64abb24fa3bbd917072443f919368a86db4fbe0debaa4c4336b9384f9c9a21927a017c030477ba8bbaa86d2f42c3ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Use server published time as message receive timestamps, if available

**Description**
Since https://github.com/foxglove/ws-protocol/pull/299, the foxglove websocket server may send time messages to clients. If this is the case, Studio will use the server-published time as the message receive timestamp instead of the actual message receive time. This helps in preventing undesired “clearing” issues caused by messages being out of order across channels. The player behavior remains the same if the server does not provide time information to clients.

Supersedes #4984 #5008 

Fixes FG-1113

Related issues:
- https://github.com/foxglove/community/issues/239
- https://github.com/foxglove/studio/issues/4917
- https://github.com/foxglove/studio/issues/4908

---

**No time published - noticeable flickering**

[No time published - noticeable flickering](https://user-images.githubusercontent.com/9250155/208963660-568147f8-bf86-44c6-bb53-c261fed7643c.webm)

**Server publishes time - flickering is gone**

[Server publishes time - flickering is gone](https://user-images.githubusercontent.com/9250155/208964276-831b8bc1-cb88-423f-b9bd-58bc5b0f0d6f.webm)

