### PR TITLE
Fix setState hook in PanelExtensionAdapter for React 18

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -352,6 +352,9 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
         }
         setWatchedFields((old) => {
           if (old.has(field)) {
+            // In React 18 we noticed that this setter function would be called in an infinite loop
+            // even though watch() was not called repeatedly. Adding this early return of the old
+            // value fixed the issue.
             return old;
           }
           const newWatchedFields = new Set(old);

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -351,8 +351,12 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
           return;
         }
         setWatchedFields((old) => {
-          old.add(field);
-          return new Set(old);
+          if (old.has(field)) {
+            return old;
+          }
+          const newWatchedFields = new Set(old);
+          newWatchedFields.add(field);
+          return newWatchedFields;
         });
       },
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
This fixes a freeze when using the 3D panel with React 18.
I'm not sure why the `.has()` check is necessary — it should be fine if multiple calls to this setter function return different Set instances. But in practice it is necessary 🤷 