### PR TITLE
Prevent memory leak by DRACOLoader

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -522,6 +522,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
     this.sceneExtensions.clear();
     this.sharedGeometry.dispose();
+    this.modelCache.dispose();
 
     this.labelPool.dispose();
     this.markerPool.dispose();


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- n/a

**Description**
 - `THREE.DRACOLoader` launches a webworker that needs to be properly disposed of. Not disposing causes the worker and it's loaded meshes to build up over time across models. There should only be one DRACOLoader at a time. 


<!-- link relevant GitHub issues -->
Fixes #5002
Fixes FG-1089
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
