### PR TITLE
Improve long text handling in playback tooltip

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.stories.tsx
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useTheme } from "@mui/material";
+import { Story } from "@storybook/react";
+import { useEffect } from "react";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import { PlaybackControlsTooltipContent } from "@foxglove/studio-base/components/PlaybackControls/PlaybackControlsTooltipContent";
+import { useTimelineInteractionState } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
+import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+
+function Wrapper(StoryFn: Story): JSX.Element {
+  const theme = useTheme();
+  return (
+    <TimelineInteractionStateProvider>
+      <MockMessagePipelineProvider>
+        <div
+          style={{
+            maxWidth: "16rem",
+            marginInline: "auto",
+            backgroundColor: theme.palette.background.paper,
+          }}
+        >
+          <StoryFn />
+        </div>
+      </MockMessagePipelineProvider>
+    </TimelineInteractionStateProvider>
+  );
+}
+
+export default {
+  component: PlaybackControlsTooltipContent,
+  title: "components/PlaybackControls/TooltipContent",
+  decorators: [Wrapper],
+};
+
+export function Default(): JSX.Element {
+  return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+}
+
+export function WithEvents(): JSX.Element {
+  const setEvents = useTimelineInteractionState((store) => store.setEventsAtHoverValue);
+
+  useEffect(() => {
+    setEvents([
+      {
+        event: {
+          createdAt: "1",
+          id: "1",
+          deviceId: "dev1",
+          durationNanos: "1",
+          endTime: { sec: 1, nsec: 1 },
+          endTimeInSeconds: 1,
+          metadata: {
+            "meta 1": "value 1",
+            "meta 2": "value 2",
+            "long event metadata key that might overflow":
+              "long event metadata value that might also overflow",
+          },
+          startTime: { sec: 0, nsec: 0 },
+          startTimeInSeconds: 1,
+          timestampNanos: "1",
+          updatedAt: "1",
+        },
+        startPosition: 0,
+        endPosition: 0.1,
+        secondsSinceStart: 0,
+      },
+    ]);
+  }, [setEvents]);
+
+  return <PlaybackControlsTooltipContent stamp={{ sec: 1, nsec: 1 }} />;
+}

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackControlsTooltipContent.tsx
@@ -36,7 +36,8 @@ const useStyles = makeStyles()((theme) => ({
     columnGap: theme.spacing(0.5),
     display: "grid",
     alignItems: "center",
-    gridTemplateColumns: "auto 1fr",
+    gridTemplateColumns: "auto auto",
+    width: "100%",
     flexDirection: "column",
   },
   itemKey: {
@@ -109,8 +110,12 @@ export function PlaybackControlsTooltipContent(params: { stamp: Time }): ReactNu
         }
         return (
           <Fragment key={`${item.title}_${idx}`}>
-            <Typography className={classes.itemKey}>{item.title}</Typography>
-            <Typography variant="subtitle2">{item.value}</Typography>
+            <Typography className={classes.itemKey} noWrap>
+              {item.title}
+            </Typography>
+            <Typography variant="subtitle2" noWrap>
+              {item.value}
+            </Typography>
           </Fragment>
         );
       })}


### PR DESCRIPTION
**User-Facing Changes**
Improves text handling in the playback controls tooltip.

**Description**
Wraps long text that would overflow the container and adds a story to catch regressions.

Fixes #5040 