### PR TITLE
Fix extension id collisions across multiple loaders

### DIFF
--- a/packages/studio-base/src/context/ExtensionCatalogContext.ts
+++ b/packages/studio-base/src/context/ExtensionCatalogContext.ts
@@ -21,7 +21,6 @@ export type ExtensionCatalog = {
     namespace: ExtensionNamespace,
     foxeFileData: Uint8Array,
   ) => Promise<ExtensionInfo>;
-  loadExtension(id: string): Promise<string>;
   refreshExtensions: () => Promise<void>;
   uninstallExtension: (namespace: ExtensionNamespace, id: string) => Promise<void>;
 

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -72,6 +72,76 @@ describe("ExtensionCatalogProvider", () => {
     ]);
   });
 
+  it("handles extensions with the same id in different loaders", async () => {
+    const source1 = `
+        module.exports = { activate: function() { return 1; } }
+    `;
+    const source2 = `
+        module.exports = { activate: function() { return 2; } }
+    `;
+
+    const loadExtension1 = jest.fn().mockResolvedValue(source1);
+    const loadExtension2 = jest.fn().mockResolvedValue(source2);
+    const mockPrivateLoader1: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "org", name: "sample", version: "1" })]),
+      loadExtension: loadExtension1,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+    const mockPrivateLoader2: ExtensionLoader = {
+      namespace: "org",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValue([fakeExtension({ namespace: "local", name: "sample", version: "2" })]),
+      loadExtension: loadExtension2,
+      installExtension: jest.fn(),
+      uninstallExtension: jest.fn(),
+    };
+
+    const { result, waitFor } = renderHook(() => useExtensionCatalog((state) => state), {
+      initialProps: {},
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[mockPrivateLoader1, mockPrivateLoader2]}>
+          {children}
+        </ExtensionCatalogProvider>
+      ),
+    });
+
+    await waitFor(() => expect(loadExtension1).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(loadExtension2).toHaveBeenCalledTimes(1));
+    expect(result.current.installedExtensions).toEqual([
+      {
+        description: "description",
+        displayName: "display name",
+        homepage: "homepage",
+        id: "id",
+        keywords: ["keyword1", "keyword2"],
+        license: "license",
+        name: "sample",
+        namespace: "org",
+        publisher: "publisher",
+        qualifiedName: "qualified name",
+        version: "1",
+      },
+      {
+        description: "description",
+        displayName: "display name",
+        homepage: "homepage",
+        id: "id",
+        keywords: ["keyword1", "keyword2"],
+        license: "license",
+        name: "sample",
+        namespace: "local",
+        publisher: "publisher",
+        qualifiedName: "qualified name",
+        version: "2",
+      },
+    ]);
+  });
+
   it("should register a message converter", async () => {
     const source = `
         module.exports = {


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug that prevented the use of org-wide extensions and locally-installed extensions with the same ID.

**Description**
We were calling `getExtensions()` and then calling `loadExtension(id)` on a different loader.
This bug seems to have been present since the introduction of multiple loaders (https://github.com/foxglove/studio/pull/3836).

[View diff ignoring whitespace](https://github.com/foxglove/studio/pull/5072/files?diff=split&w=1)

Fixes #4967 
Fixes FG-934