### PR TITLE
Upgrade @mcap/core; update references to "mcap0" and remove pre0 support

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "@foxglove/mcap-support": "workspace:*",
     "@foxglove/rosbag": "0.2.3",
     "@foxglove/rostime": "1.1.2",
-    "@mcap/core": "0.2.2",
+    "@mcap/core": "0.3.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "@sentry/electron": "4.0.0",
     "@sentry/tracing": "7.10.0",

--- a/desktop/quicklook/getIndexedMcapInfo.ts
+++ b/desktop/quicklook/getIndexedMcapInfo.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0IndexedReader, Mcap0Types } from "@mcap/core";
+import { McapIndexedReader, McapTypes } from "@mcap/core";
 
 import { fromNanoSec } from "@foxglove/rostime";
 
@@ -10,9 +10,9 @@ import { FileInfo, TopicInfo } from "./types";
 
 export default async function getIndexedMcapInfo(
   file: File,
-  decompressHandlers: Mcap0Types.DecompressHandlers,
+  decompressHandlers: McapTypes.DecompressHandlers,
 ): Promise<FileInfo> {
-  const reader = await Mcap0IndexedReader.Initialize({
+  const reader = await McapIndexedReader.Initialize({
     readable: {
       size: async () => BigInt(file.size),
       read: async (offset, length) => {

--- a/desktop/quicklook/getMcapInfo.ts
+++ b/desktop/quicklook/getMcapInfo.ts
@@ -2,69 +2,43 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import {
-  Mcap0StreamReader,
-  McapPre0Reader,
-  detectVersion,
-  DETECT_VERSION_BYTES_REQUIRED,
-} from "@mcap/core";
+import { McapStreamReader, hasMcapPrefix, McapConstants } from "@mcap/core";
 
 import Logger from "@foxglove/log";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
 
 import getIndexedMcapInfo from "./getIndexedMcapInfo";
-import getStreamedMcapInfo, {
-  processMcap0Record,
-  processMcapPre0Record,
-} from "./getStreamedMcapInfo";
+import getStreamedMcapInfo, { processMcapRecord } from "./getStreamedMcapInfo";
 import { FileInfo } from "./types";
 
 const log = Logger.getLogger(__filename);
 
 export async function getMcapInfo(file: File): Promise<FileInfo> {
-  const mcapVersion = detectVersion(
-    new DataView(await file.slice(0, DETECT_VERSION_BYTES_REQUIRED).arrayBuffer()),
+  const isValidMcap = hasMcapPrefix(
+    new DataView(await file.slice(0, McapConstants.MCAP_MAGIC.length).arrayBuffer()),
   );
 
-  const decompressHandlers = await loadDecompressHandlers();
-  switch (mcapVersion) {
-    case undefined:
-      throw new Error("Not a valid MCAP file");
-    case "0":
-      // Try indexed read
-      try {
-        return await getIndexedMcapInfo(file, decompressHandlers);
-      } catch (error) {
-        log.info("Failed to read MCAP file as indexed:", error);
-      }
-
-      return {
-        fileType: "MCAP v0, unindexed",
-        loadMoreInfo: async (reportProgress) =>
-          await getStreamedMcapInfo(
-            file,
-            new Mcap0StreamReader({ includeChunks: true, decompressHandlers, validateCrcs: true }),
-            processMcap0Record,
-            "MCAP v0, unindexed",
-            reportProgress,
-          ),
-      };
-
-    case "pre0":
-      return {
-        fileType: "MCAP pre-v0",
-        loadMoreInfo: async (reportProgress) =>
-          await getStreamedMcapInfo(
-            file,
-            new McapPre0Reader({
-              includeChunks: true,
-              validateChunkCrcs: false,
-              decompressHandlers,
-            }),
-            processMcapPre0Record,
-            "MCAP pre-v0",
-            reportProgress,
-          ),
-      };
+  if (!isValidMcap) {
+    throw new Error("Not a valid MCAP file");
   }
+
+  const decompressHandlers = await loadDecompressHandlers();
+  // Try indexed read
+  try {
+    return await getIndexedMcapInfo(file, decompressHandlers);
+  } catch (error) {
+    log.info("Failed to read MCAP file as indexed:", error);
+  }
+
+  return {
+    fileType: "MCAP v0, unindexed",
+    loadMoreInfo: async (reportProgress) =>
+      await getStreamedMcapInfo(
+        file,
+        new McapStreamReader({ includeChunks: true, decompressHandlers, validateCrcs: true }),
+        processMcapRecord,
+        "MCAP v0, unindexed",
+        reportProgress,
+      ),
+  };
 }

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@foxglove/schemas": "0.7.0",
-    "@mcap/core": "0.2.2",
+    "@mcap/core": "0.3.0",
     "@types/protobufjs": "workspace:*",
     "@types/zstd-codec": "workspace:*",
     "typescript": "4.8.2"

--- a/packages/mcap-support/src/decompressHandlers.ts
+++ b/packages/mcap-support/src/decompressHandlers.ts
@@ -2,16 +2,16 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0Types } from "@mcap/core";
+import { McapTypes } from "@mcap/core";
 import type { ZstdModule, ZstdStreaming } from "zstd-codec";
 
-let handlersPromise: Promise<Mcap0Types.DecompressHandlers> | undefined;
-export async function loadDecompressHandlers(): Promise<Mcap0Types.DecompressHandlers> {
+let handlersPromise: Promise<McapTypes.DecompressHandlers> | undefined;
+export async function loadDecompressHandlers(): Promise<McapTypes.DecompressHandlers> {
   return await (handlersPromise ??= _loadDecompressHandlers());
 }
 
 // eslint-disable-next-line no-underscore-dangle
-async function _loadDecompressHandlers(): Promise<Mcap0Types.DecompressHandlers> {
+async function _loadDecompressHandlers(): Promise<McapTypes.DecompressHandlers> {
   const [zstd, decompressLZ4, bzip2] = await Promise.all([
     import("zstd-codec").then(async ({ ZstdCodec }) => {
       return await new Promise<ZstdModule>((resolve) => ZstdCodec.run(resolve));

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -58,7 +58,7 @@
     "@foxglove/wasm-bz2": "0.1.0",
     "@foxglove/ws-protocol": "0.2.0",
     "@foxglove/xmlrpc": "1.3.0",
-    "@mcap/core": "0.2.2",
+    "@mcap/core": "0.3.0",
     "@mdi/svg": "7.1.96",
     "@mui/icons-material": "5.11.0",
     "@mui/material": "5.4.1",

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIndexedIterableSource.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0IndexedReader, Mcap0Types } from "@mcap/core";
+import { McapIndexedReader, McapTypes } from "@mcap/core";
 
 import Logger from "@foxglove/log";
 import { ParsedChannel, parseChannel } from "@foxglove/mcap-support";
@@ -21,15 +21,15 @@ import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 const log = Logger.getLogger(__filename);
 
 export class McapIndexedIterableSource implements IIterableSource {
-  private reader: Mcap0IndexedReader;
+  private reader: McapIndexedReader;
   private channelInfoById = new Map<
     number,
-    { channel: Mcap0Types.Channel; parsedChannel: ParsedChannel; schemaName: string }
+    { channel: McapTypes.Channel; parsedChannel: ParsedChannel; schemaName: string }
   >();
   private start?: Time;
   private end?: Time;
 
-  public constructor(reader: Mcap0IndexedReader) {
+  public constructor(reader: McapIndexedReader) {
     this.reader = reader;
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0IndexedReader, Mcap0Types } from "@mcap/core";
+import { McapIndexedReader, McapTypes } from "@mcap/core";
 
 import Log from "@foxglove/log";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
@@ -25,10 +25,10 @@ const log = Log.getLogger(__filename);
 
 type McapSource = { type: "file"; file: File } | { type: "url"; url: string };
 
-async function tryCreateIndexedReader(readable: Mcap0Types.IReadable) {
+async function tryCreateIndexedReader(readable: McapTypes.IReadable) {
   const decompressHandlers = await loadDecompressHandlers();
   try {
-    const reader = await Mcap0IndexedReader.Initialize({ readable, decompressHandlers });
+    const reader = await McapIndexedReader.Initialize({ readable, decompressHandlers });
 
     if (reader.chunkIndexes.length === 0 || reader.channelsById.size === 0) {
       return undefined;

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0StreamReader, Mcap0Types } from "@mcap/core";
+import { McapStreamReader, McapTypes } from "@mcap/core";
 import { isEqual } from "lodash";
 
 import { loadDecompressHandlers, parseChannel, ParsedChannel } from "@foxglove/mcap-support";
@@ -56,16 +56,16 @@ export class McapStreamingIterableSource implements IIterableSource {
     const channelIdsWithErrors = new Set<number>();
 
     const messagesByChannel = new Map<number, MessageEvent<unknown>[]>();
-    const schemasById = new Map<number, Mcap0Types.TypedMcapRecords["Schema"]>();
+    const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
     const channelInfoById = new Map<
       number,
-      { channel: Mcap0Types.Channel; parsedChannel: ParsedChannel; schemaName: string }
+      { channel: McapTypes.Channel; parsedChannel: ParsedChannel; schemaName: string }
     >();
 
     let startTime: Time | undefined;
     let endTime: Time | undefined;
     let profile: string | undefined;
-    function processRecord(record: Mcap0Types.TypedMcapRecord) {
+    function processRecord(record: McapTypes.TypedMcapRecord) {
       switch (record.type) {
         default:
           break;
@@ -159,7 +159,7 @@ export class McapStreamingIterableSource implements IIterableSource {
       }
     }
 
-    const reader = new Mcap0StreamReader({ decompressHandlers });
+    const reader = new McapStreamReader({ decompressHandlers });
     for (let result; (result = await streamReader.read()), !result.done; ) {
       reader.append(result.value);
       for (let record; (record = reader.nextRecord()); ) {

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/streamMessages.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Mcap0StreamReader, Mcap0Types } from "@mcap/core";
+import { McapStreamReader, McapTypes } from "@mcap/core";
 import { captureException } from "@sentry/core";
 import { isEqual } from "lodash";
 
@@ -88,17 +88,17 @@ export async function* streamMessages({
 
   let totalMessages = 0;
   let messages: MessageEvent<unknown>[] = [];
-  const schemasById = new Map<number, Mcap0Types.TypedMcapRecords["Schema"]>();
+  const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
   const channelInfoById = new Map<
     number,
     {
-      channel: Mcap0Types.TypedMcapRecords["Channel"];
+      channel: McapTypes.TypedMcapRecords["Channel"];
       parsedChannel: ParsedChannel;
       schemaName: string;
     }
   >();
 
-  function processRecord(record: Mcap0Types.TypedMcapRecord) {
+  function processRecord(record: McapTypes.TypedMcapRecord) {
     switch (record.type) {
       default:
         return;
@@ -210,7 +210,7 @@ export async function* streamMessages({
 
     let normalReturn = false;
     parseLoop: try {
-      const reader = new Mcap0StreamReader({ decompressHandlers });
+      const reader = new McapStreamReader({ decompressHandlers });
       for (let result; (result = await streamReader.read()), !result.done; ) {
         reader.append(result.value);
         for (let record; (record = reader.nextRecord()); ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,7 +2187,7 @@ __metadata:
     "@foxglove/rosmsg2-serialization": 1.0.7
     "@foxglove/schemas": 0.7.0
     "@foxglove/wasm-bz2": 0.1.0
-    "@mcap/core": 0.2.2
+    "@mcap/core": 0.3.0
     "@protobufjs/base64": 1.1.2
     "@types/protobufjs": "workspace:*"
     "@types/zstd-codec": "workspace:*"
@@ -2398,7 +2398,7 @@ __metadata:
     "@foxglove/wasm-bz2": 0.1.0
     "@foxglove/ws-protocol": 0.2.0
     "@foxglove/xmlrpc": 1.3.0
-    "@mcap/core": 0.2.2
+    "@mcap/core": 0.3.0
     "@mdi/svg": 7.1.96
     "@mui/icons-material": 5.11.0
     "@mui/material": 5.4.1
@@ -3051,14 +3051,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mcap/core@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@mcap/core@npm:0.2.2"
+"@mcap/core@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@mcap/core@npm:0.3.0"
   dependencies:
     "@foxglove/crc": ^0.0.3
     heap-js: ^2.1.6
     tslib: ^2
-  checksum: b7b5f6fd8c33b064abf0d4d71a026c804caf5f4e6bc50a0c60aad9a0c85f7a0acc92511a1385b47ae8ca1faef5ef820af2822c5861a4f2cb84e91aeaee1003d4
+  checksum: de2bc1e9f9eee35485216085d18efcc5a6abe01671aab3d42a42e8f7a0d7caf6bc899076623788c758910a9c1f20cd65a9c0efac2fb088cb78c367f5381c26e3
   languageName: node
   linkType: hard
 
@@ -10664,7 +10664,7 @@ __metadata:
     "@foxglove/rosbag": 0.2.3
     "@foxglove/rostime": 1.1.2
     "@foxglove/studio-base": "workspace:*"
-    "@mcap/core": 0.2.2
+    "@mcap/core": 0.3.0
     "@pmmmwh/react-refresh-webpack-plugin": 0.5.4
     "@sentry/electron": 4.0.0
     "@sentry/tracing": 7.10.0


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Supersedes / closes https://github.com/foxglove/studio/pull/5084
Removes pre-v0 support from the quicklook preview plugin.