### PR TITLE
sample layout: add explicit followTf

### DIFF
--- a/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
+++ b/packages/studio-base/src/dataSources/SampleNuscenesLayout.json
@@ -131,7 +131,8 @@
         "poseEstimateYDeviation": 0.5,
         "poseEstimateThetaDeviation": 0.26179939
       },
-      "followMode": "follow-pose"
+      "followMode": "follow-pose",
+      "followTf": "base_link"
     },
     "map!2vkib4e": {
       "disabledTopics": [],
@@ -198,7 +199,8 @@
         "poseEstimateYDeviation": 0.5,
         "poseEstimateThetaDeviation": 0.26179939
       },
-      "followMode": "follow-pose"
+      "followMode": "follow-pose",
+      "followTf": "base_link"
     },
     "Plot!2pb7zl7": {
       "paths": [


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Fixed an issue where the sample layout would appear modified immediately after it was created. The 3D panel would trigger a save with `followTf: undefined`, which would result in the same layout after JSON.stringify, but is considered unequal by this equality check:

https://github.com/foxglove/studio/blob/ecf5c4b2a20937f7ba115acc444878e7bb69f848/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx#L173-L177

Fixes #4985 
Fixes FG-996