### PR TITLE
Enable ESM-only packages in jest by transpiling node_modules

### DIFF
--- a/packages/studio-base/jest.config.json
+++ b/packages/studio-base/jest.config.json
@@ -2,10 +2,13 @@
   "//": "Note: we use babel-jest rather than ts-jest for performance reasons.",
   "testMatch": ["<rootDir>/src/**/*.test.ts(x)?"],
   "transform": {
+    "\\.jsx?$": "babel-jest",
     "\\.tsx?$": "<rootDir>/src/test/transformers/typescriptTransformerWithRawImports.js",
     "\\.ne$": "<rootDir>/src/test/transformers/neTransformer.js",
     "\\.(bin|template|wasm)$": "<rootDir>/src/test/transformers/rawTransformer.js"
   },
+  "//": "Enable transpilation of node_modules to support ESM-only packages",
+  "transformIgnorePatterns": [],
   "globals": {
     "ReactNull": null
   },

--- a/packages/studio-base/src/components/TextContent.tsx
+++ b/packages/studio-base/src/components/TextContent.tsx
@@ -12,15 +12,13 @@
 //   You may not use this file except in compliance with the License.
 
 import { Link } from "@mui/material";
-import { PropsWithChildren, CSSProperties, useCallback, useContext, Suspense } from "react";
-import { useAsync } from "react-use";
+import { PropsWithChildren, CSSProperties, useCallback, useContext } from "react";
+import Markdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
 import { withStyles } from "tss-react/mui";
 
 import LinkHandlerContext from "@foxglove/studio-base/context/LinkHandlerContext";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
-
-// workaround for ESM in jest: https://github.com/foxglove/studio/issues/1854
-const Markdown = React.lazy(async () => await import("react-markdown"));
 
 const TextContentRoot = withStyles("div", (theme) => {
   const { palette, shape, spacing, typography, shadows } = theme;
@@ -187,23 +185,15 @@ export default function TextContent(
     [handleLink],
   );
 
-  // workaround for ESM in jest: https://github.com/foxglove/studio/issues/1854
-  const { value: rehypeRaw } = useAsync(async () => await import("rehype-raw"));
-  if (!rehypeRaw) {
-    return ReactNull;
-  }
-
   return (
     <TextContentRoot style={style}>
       {typeof children === "string" ? (
-        <Suspense fallback={ReactNull}>
-          <Markdown
-            rehypePlugins={allowMarkdownHtml === true ? [rehypeRaw.default] : []}
-            components={{ a: linkRenderer }}
-          >
-            {children}
-          </Markdown>
-        </Suspense>
+        <Markdown
+          rehypePlugins={allowMarkdownHtml === true ? [rehypeRaw] : []}
+          components={{ a: linkRenderer }}
+        >
+          {children}
+        </Markdown>
       ) : (
         children
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21134,11 +21134,11 @@ __metadata:
   linkType: hard
 
 "redux@npm:^4.0.5, redux@npm:^4.1.1":
-  version: 4.1.2
-  resolution: "redux@npm:4.1.2"
+  version: 4.2.0
+  resolution: "redux@npm:4.2.0"
   dependencies:
     "@babel/runtime": ^7.9.2
-  checksum: 6a839cee5bd580c5298d968e9e2302150e961318253819bcd97f9d945a5a409559eacddf6026f4118bb68b681c593d90e8a2c5bbf278f014aff9bf0d2d8fa084
+  checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Using Node's native ESM support with jest still has some problems (see https://github.com/facebook/jest/issues/13739). However, it is possible to use ESM-only packages by enabling transpilation (with babel) for `node_modules` by overriding the default `transformIgnorePatterns`.

Fixes #1854 