### PR TITLE
desktop: add menu command to manually check for updates

### DIFF
--- a/desktop/main/StudioAppUpdater.ts
+++ b/desktop/main/StudioAppUpdater.ts
@@ -3,11 +3,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { captureException } from "@sentry/electron/main";
-import { autoUpdater } from "electron-updater";
+import { dialog } from "electron";
+import { autoUpdater, UpdateInfo } from "electron-updater";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
 
+import pkgInfo from "../../package.json";
 import { getAppSetting } from "./settings";
 
 const log = Logger.getLogger(__filename);
@@ -36,6 +38,11 @@ class StudioAppUpdater {
   // Seconds to wait after an update check completes before starting a new check
   private updateCheckIntervalSec = 60 * 60;
 
+  public canCheckForUpdates(): boolean {
+    // Updates are disabled by default in dev mode
+    return autoUpdater.isUpdaterActive();
+  }
+
   /**
    * Start the update process.
    */
@@ -50,6 +57,39 @@ class StudioAppUpdater {
     setTimeout(() => {
       void this.maybeCheckForUpdates();
     }, this.initialUpdateDelaySec * 1000);
+  }
+
+  public async checkNow(): Promise<void> {
+    const onDisabled = () => {
+      void dialog.showMessageBox({ message: `Updates are not enabled.` });
+    };
+    const onNotAvailable = (info: UpdateInfo) => {
+      void dialog.showMessageBox({
+        message: `${pkgInfo.productName} is up to date (version ${info.version}).`,
+      });
+    };
+    const onError = (error: Error) => {
+      dialog.showErrorBox(
+        "An error occurred while checking for updates.",
+        error.stack ?? error.message,
+      );
+    };
+
+    if (!autoUpdater.isUpdaterActive()) {
+      onDisabled();
+      return;
+    }
+    try {
+      autoUpdater.on("update-not-available", onNotAvailable);
+      const result = await autoUpdater.checkForUpdatesAndNotify();
+      if (!result) {
+        onDisabled();
+      }
+    } catch (error) {
+      onError(error as Error);
+    } finally {
+      autoUpdater.off("update-not-available", onNotAvailable);
+    }
   }
 
   // Check for updates and download.

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -18,6 +18,7 @@ import Logger from "@foxglove/log";
 
 import pkgInfo from "../../package.json";
 import { encodeRendererArg } from "../common/rendererArgs";
+import StudioAppUpdater from "./StudioAppUpdater";
 import getDevModeIcon from "./getDevModeIcon";
 import { simulateUserClick } from "./simulateUserClick";
 import { getTelemetrySettings } from "./telemetry";
@@ -165,12 +166,19 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
 function buildMenu(browserWindow: BrowserWindow): Menu {
   const menuTemplate: MenuItemConstructorOptions[] = [];
 
+  const checkForUpdatesItem: MenuItemConstructorOptions = {
+    label: "Check for Updates…",
+    click: () => void StudioAppUpdater.Instance().checkNow(),
+    enabled: StudioAppUpdater.Instance().canCheckForUpdates(),
+  };
+
   if (isMac) {
     menuTemplate.push({
       role: "appMenu",
       label: app.name,
       submenu: [
         { role: "about" },
+        checkForUpdatesItem,
         { type: "separator" },
 
         {
@@ -348,6 +356,7 @@ function buildMenu(browserWindow: BrowserWindow): Menu {
                 showAboutDialog();
               },
             },
+            checkForUpdatesItem,
           ]),
     ],
   });


### PR DESCRIPTION
**User-Facing Changes**
Added menu item to manually check for updates in the desktop app.

**Description**
Relates to #3057, https://github.com/foxglove/community/issues/112, FG-219

<img width="277" alt="image" src="https://user-images.githubusercontent.com/14237/211129804-6cd0362c-3bdf-4be3-a739-36f18147c4d4.png">
<img width="372" alt="image" src="https://user-images.githubusercontent.com/14237/211129811-cc43a7d1-85d7-4c0c-8fbb-eb81a7719dfb.png">
<img width="372" alt="image" src="https://user-images.githubusercontent.com/14237/211129855-e21dd271-a44e-4acf-9c4b-33b861ba39b4.png">
