### PR TITLE
Revise sidebar icons for readability

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -518,12 +518,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       ],
       ["layouts", { iconName: "FiveTileGrid", title: "Layouts", component: LayoutBrowser }],
       ["add-panel", { iconName: "RectangularClipping", title: "Add panel", component: AddPanel }],
-      [
-        "panel-settings",
-        { iconName: "PanelSettings", title: "Panel settings", component: PanelSettings },
-      ],
+      ["panel-settings", { iconName: "Edit", title: "Panel settings", component: PanelSettings }],
       ["variables", { iconName: "Variable2", title: "Variables", component: VariablesSidebar }],
-      ["extensions", { iconName: "AddIn", title: "Extensions", component: ExtensionsSidebar }],
+      ["extensions", { iconName: "Puzzle", title: "Extensions", component: ExtensionsSidebar }],
     ]);
 
     if (enableStudioLogsSidebar) {

--- a/packages/studio-base/src/theme/icons.tsx
+++ b/packages/studio-base/src/theme/icons.tsx
@@ -40,6 +40,7 @@ import {
   InfoIcon,
   MoreVerticalIcon,
   OpenFileIcon,
+  PuzzleIcon,
   RectangularClippingIcon,
   Variable2Icon,
 } from "@fluentui/react-icons-mdl2";
@@ -95,6 +96,7 @@ const icons: {
   MoreVertical: <MoreVerticalIcon />,
   OpenFile: <OpenFileIcon />,
   PanelSettings: <PanelSettings />,
+  Puzzle: <PuzzleIcon />,
   QuestionCircle: <QuestionCircle20Regular />,
   RectangularClipping: <RectangularClippingIcon />,
   Search: <SearchIcon />,

--- a/packages/studio-base/src/types/Icons.ts
+++ b/packages/studio-base/src/types/Icons.ts
@@ -37,6 +37,7 @@ export type RegisteredIconNames =
   | "MoreVertical"
   | "OpenFile"
   | "PanelSettings"
+  | "Puzzle"
   | "QuestionCircle"
   | "RectangularClipping"
   | "Search"


### PR DESCRIPTION
**User-Facing Changes**
- Revised "Panel settings" and "Extensions" sidebar icons for easier differentiation
<img width="56" alt="Screen Shot 2023-01-09 at 12 16 52 PM" src="https://user-images.githubusercontent.com/6993359/211401989-f3f03b44-3bfe-4852-b46f-8ccd0bb5d998.png">


**Description**
- Based on user and team feedback about rectangular-ish icons being hard to differentiate

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
