### PR TITLE
Parameter panel: Add button to submit parameter changes

### DIFF
--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -21,6 +21,7 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { isEqual, isObject, union } from "lodash";
@@ -134,12 +135,16 @@ function SubmittableJsonInput(props: {
         }}
       />
       {!isEqual(value, props.value) && [
-        <IconButton key="submit" onClick={() => props.onSubmit(value)}>
-          <CheckIcon />
-        </IconButton>,
-        <IconButton key="reset" onClick={() => setValue(editableValue(props.value))}>
-          <ClearIcon />
-        </IconButton>,
+        <Tooltip key="submit" title="Submit change">
+          <IconButton onClick={() => props.onSubmit(value)}>
+            <CheckIcon />
+          </IconButton>
+        </Tooltip>,
+        <Tooltip key="reset" title="Reset">
+          <IconButton key="reset" onClick={() => setValue(editableValue(props.value))}>
+            <ClearIcon />
+          </IconButton>
+        </Tooltip>,
       ]}
     </Stack>
   );

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -11,7 +11,10 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import CheckIcon from "@mui/icons-material/Check";
+import ClearIcon from "@mui/icons-material/Clear";
 import {
+  IconButton,
   Table,
   TableBody,
   TableCell,
@@ -116,6 +119,32 @@ function displayableValue(value: unknown): string {
   }
 }
 
+function SubmittableJsonInput(props: {
+  value: unknown;
+  onSubmit: (newVal: unknown) => void;
+}): ReactElement {
+  const [value, setValue] = useState<unknown>(editableValue(props.value));
+
+  return (
+    <Stack direction="row">
+      <JsonInput
+        value={value}
+        onChange={(newVal) => {
+          setValue(newVal);
+        }}
+      />
+      {!isEqual(value, props.value) && [
+        <IconButton key="submit" onClick={() => props.onSubmit(value)}>
+          <CheckIcon />
+        </IconButton>,
+        <IconButton key="reset" onClick={() => setValue(editableValue(props.value))}>
+          <ClearIcon />
+        </IconButton>,
+      ]}
+    </Stack>
+  );
+}
+
 function Parameters(): ReactElement {
   const { classes } = useStyles();
 
@@ -190,7 +219,6 @@ function Parameters(): ReactElement {
           <TableBody>
             {parameterNames.map((name) => {
               const displayValue = displayableValue(parameters.get(name));
-              const editValue = editableValue(parameters.get(name));
 
               return (
                 <TableRow
@@ -207,10 +235,9 @@ function Parameters(): ReactElement {
 
                   {canSetParams ? (
                     <TableCell padding="none">
-                      <JsonInput
-                        dataTestId={`parameter-value-input-${displayValue}`}
-                        value={editValue}
-                        onChange={(newVal) => {
+                      <SubmittableJsonInput
+                        value={parameters.get(name)}
+                        onSubmit={(newVal) => {
                           setParameter(name, newVal as ParameterValue);
                         }}
                       />

--- a/packages/studio-base/src/panels/Parameters/index.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.tsx
@@ -20,7 +20,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { isObject, union } from "lodash";
+import { isEqual, isObject, union } from "lodash";
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useDebouncedCallback } from "use-debounce";
@@ -128,7 +128,7 @@ function Parameters(): ReactElement {
       (name: string, value: ParameterValue) => setParameterUnbounced(name, value),
       [setParameterUnbounced],
     ),
-    200,
+    500,
   );
 
   const [changedParameters, setChangedParameters] = useState<string[]>([]);
@@ -157,7 +157,7 @@ function Parameters(): ReactElement {
       Array.from(previousParametersRef.current?.keys() ?? []),
     ).filter((name) => {
       const previousValue = previousParametersRef.current?.get(name);
-      return previousValue !== parameters.get(name);
+      return !isEqual(previousValue, parameters.get(name));
     });
 
     setChangedParameters(newChangedParameters);
@@ -196,7 +196,7 @@ function Parameters(): ReactElement {
                 <TableRow
                   hover
                   className={classes.tableRow}
-                  key={`parameter-${name}`}
+                  key={`parameter-${name}-${displayValue}`}
                   selected={!skipAnimation.current && changedParameters.includes(name)}
                 >
                   <TableCell variant="head">


### PR DESCRIPTION
**User-Facing Changes**
- Parameter panel: Add button to submit parameter changes

**Description**
In #5095 I had several issues with the parameter panel:
- When the server rejects parameter updates, the parameter panel should reflect that. However, the last user-set value is shown
- There is no dedicated submit button and new parameter values are send while typing, often leading to invalid or incomplete parameter values being send to the server

This PR adds a dedicated submit button to send paramter updates only when the user is presses it. Additionally, the parameter row is re-rendered if the value changes.

![image](https://user-images.githubusercontent.com/9250155/211087861-52a1b5bd-5d35-47ae-a312-78dbd7ac0f56.png)


