### PR TITLE
map panel: Do not reset center location when no new nav messages have been received

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -500,7 +500,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
         }
       }
 
-      return;
+      return old;
     });
   }, [allNavMessages, currentNavMessages, config]);
 


### PR DESCRIPTION
**User-Facing Changes**
- Fix map following point being reset

**Description**
In the case when there have been no new messages received since the last center has been calculated, we want to keep the current center and not reset it.

Fixes #5135 ([FG-1401](https://linear.app/foxglove/issue/FG-1401/2d-map-panel-flickering-with-message-waiting-for-gps-for-live))
