### PR TITLE
[Top nav] Use custom title bar buttons on windows & linux

### DIFF
--- a/desktop/common/types.ts
+++ b/desktop/common/types.ts
@@ -16,7 +16,11 @@ export type ForwardedMenuEvent =
   | "open-help"
   | "open-account";
 
-export type ForwardedWindowEvent = "enter-full-screen" | "leave-full-screen";
+export type ForwardedWindowEvent =
+  | "enter-full-screen"
+  | "leave-full-screen"
+  | "maximize"
+  | "unmaximize";
 
 interface NativeMenuBridge {
   // Events from the native window are available in the main process but not the renderer, so we forward them through the bridge.
@@ -85,6 +89,12 @@ interface Desktop {
   // Uninstall an extension. Returns true if the extension was found and uninstalled, or false if it
   // was not found (i.e. already uninstalled)
   uninstallExtension: (id: string) => Promise<boolean>;
+
+  isMaximized(): boolean;
+  minimizeWindow(): void;
+  maximizeWindow(): void;
+  unmaximizeWindow(): void;
+  closeWindow(): void;
 }
 
 export type { NativeMenuBridge, Storage, StorageContent, Desktop, DesktopExtension };

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -29,6 +29,7 @@ import { getTelemetrySettings } from "./telemetry";
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
 const isMac = process.platform === "darwin";
+const isLinux = process.platform === "linux";
 const isProduction = process.env.NODE_ENV === "production";
 const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 
@@ -108,7 +109,8 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     minHeight: 250,
     autoHideMenuBar: true,
     title: pkgInfo.productName,
-    titleBarStyle: isMac && enableNewUI ? "hidden" : "default",
+    frame: enableNewUI && isLinux ? false : true,
+    titleBarStyle: enableNewUI ? "hidden" : "default",
     trafficLightPosition:
       isMac && enableNewUI ? { x: macTrafficLightInset, y: macTrafficLightInset } : undefined,
     webPreferences: {
@@ -141,15 +143,18 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
   browserWindow.addListener("enter-full-screen", () =>
     browserWindow.webContents.send("enter-full-screen"),
   );
-
   browserWindow.addListener("leave-full-screen", () =>
     browserWindow.webContents.send("leave-full-screen"),
   );
+  browserWindow.addListener("maximize", () => browserWindow.webContents.send("maximize"));
+
+  browserWindow.addListener("unmaximize", () => browserWindow.webContents.send("unmaximize"));
 
   browserWindow.webContents.once("dom-ready", () => {
     if (!isProduction) {
       browserWindow.webContents.openDevTools();
     }
+    browserWindow.webContents.send(browserWindow.isMaximized() ? "maximize" : "unmaximize");
   });
 
   // Open all new windows in an external browser
@@ -167,6 +172,25 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     if (isExternal) {
       event.preventDefault();
       void shell.openExternal(reqUrl);
+    }
+  });
+
+  browserWindow.webContents.on("ipc-message", (_event, channel) => {
+    switch (channel) {
+      case "minimizeWindow":
+        browserWindow.minimize();
+        break;
+      case "maximizeWindow":
+        browserWindow.maximize();
+        break;
+      case "unmaximizeWindow":
+        browserWindow.unmaximize();
+        break;
+      case "closeWindow":
+        browserWindow.close();
+        break;
+      default:
+        break;
     }
   });
 

--- a/desktop/main/StudioWindow.ts
+++ b/desktop/main/StudioWindow.ts
@@ -16,7 +16,11 @@ import path from "path";
 
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/src/AppSetting";
-import { APP_BAR_HEIGHT } from "@foxglove/studio-base/src/components/AppBar/constants";
+import {
+  APP_BAR_BACKGROUND_COLOR,
+  APP_BAR_HEIGHT,
+  APP_BAR_FOREGROUND_COLOR,
+} from "@foxglove/studio-base/src/components/AppBar/constants";
 
 import pkgInfo from "../../package.json";
 import { encodeRendererArg } from "../common/rendererArgs";
@@ -30,6 +34,7 @@ declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
 
 const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
+const isWindows = process.platform === "win32";
 const isProduction = process.env.NODE_ENV === "production";
 const rendererPath = MAIN_WINDOW_WEBPACK_ENTRY;
 
@@ -113,6 +118,13 @@ function newStudioWindow(deepLinks: string[] = []): BrowserWindow {
     titleBarStyle: enableNewUI ? "hidden" : "default",
     trafficLightPosition:
       isMac && enableNewUI ? { x: macTrafficLightInset, y: macTrafficLightInset } : undefined,
+    titleBarOverlay: isWindows
+      ? {
+          height: APP_BAR_HEIGHT,
+          color: APP_BAR_BACKGROUND_COLOR,
+          symbolColor: APP_BAR_FOREGROUND_COLOR,
+        }
+      : undefined,
     webPreferences: {
       contextIsolation: true,
       sandbox: false, // Allow preload script to access Node builtins

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -103,6 +103,12 @@ const ctx: OsContext = {
   },
 };
 
+// Keep track of maximized state in the preload script because the initial ipc event sent from main
+// may occur before the app is fully rendered.
+let isMaximized = false;
+ipcRenderer.on("maximize", () => (isMaximized = true));
+ipcRenderer.on("unmaximize", () => (isMaximized = false));
+
 const desktopBridge: Desktop = {
   addIpcEventListener(eventName: ForwardedWindowEvent, handler: () => void) {
     ipcRenderer.on(eventName, () => handler());
@@ -139,6 +145,21 @@ const desktopBridge: Desktop = {
     const homePath = (await ipcRenderer.invoke("getHomePath")) as string;
     const userExtensionRoot = pathJoin(homePath, ".foxglove-studio", "extensions");
     return await uninstallExtension(id, userExtensionRoot);
+  },
+  isMaximized() {
+    return isMaximized;
+  },
+  minimizeWindow() {
+    ipcRenderer.send("minimizeWindow");
+  },
+  maximizeWindow() {
+    ipcRenderer.send("maximizeWindow");
+  },
+  unmaximizeWindow() {
+    ipcRenderer.send("unmaximizeWindow");
+  },
+  closeWindow() {
+    ipcRenderer.send("closeWindow");
   },
 };
 

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useMemo, useEffect, useState } from "react";
+import { useMemo, useEffect, useState, useCallback } from "react";
 
 import {
   App,
@@ -97,15 +97,27 @@ export default function Root({
   });
 
   const [isFullScreen, setFullScreen] = useState(false);
+  const [isMaximized, setMaximized] = useState(nativeWindow.isMaximized());
+
+  const onMinimizeWindow = useCallback(() => nativeWindow.minimize(), [nativeWindow]);
+  const onMaximizeWindow = useCallback(() => nativeWindow.maximize(), [nativeWindow]);
+  const onUnmaximizeWindow = useCallback(() => nativeWindow.unmaximize(), [nativeWindow]);
+  const onCloseWindow = useCallback(() => nativeWindow.close(), [nativeWindow]);
 
   useEffect(() => {
-    const onEnter = () => setFullScreen(true);
-    const onLeave = () => setFullScreen(false);
-    desktopBridge.addIpcEventListener("enter-full-screen", onEnter);
-    desktopBridge.addIpcEventListener("leave-full-screen", onLeave);
+    const onEnterFullScreen = () => setFullScreen(true);
+    const onLeaveFullScreen = () => setFullScreen(false);
+    const onMaximize = () => setMaximized(true);
+    const onUnmaximize = () => setMaximized(false);
+    desktopBridge.addIpcEventListener("enter-full-screen", onEnterFullScreen);
+    desktopBridge.addIpcEventListener("leave-full-screen", onLeaveFullScreen);
+    desktopBridge.addIpcEventListener("maximize", onMaximize);
+    desktopBridge.addIpcEventListener("unmaximize", onUnmaximize);
     return () => {
-      desktopBridge.removeIpcEventListener("enter-full-screen", onEnter);
-      desktopBridge.removeIpcEventListener("leave-full-screen", onLeave);
+      desktopBridge.removeIpcEventListener("enter-full-screen", onEnterFullScreen);
+      desktopBridge.removeIpcEventListener("leave-full-screen", onLeaveFullScreen);
+      desktopBridge.removeIpcEventListener("maximize", onMaximize);
+      desktopBridge.removeIpcEventListener("unmaximize", onUnmaximize);
     };
   }, []);
 
@@ -123,6 +135,12 @@ export default function Root({
         nativeWindow={nativeWindow}
         enableGlobalCss
         appBarLeftInset={ctxbridge?.platform === "darwin" && !isFullScreen ? 72 : undefined}
+        showCustomWindowControls={ctxbridge?.platform !== "darwin"}
+        isMaximized={isMaximized}
+        onMinimizeWindow={onMinimizeWindow}
+        onMaximizeWindow={onMaximizeWindow}
+        onUnmaximizeWindow={onUnmaximizeWindow}
+        onCloseWindow={onCloseWindow}
       />
     </>
   );

--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -135,7 +135,7 @@ export default function Root({
         nativeWindow={nativeWindow}
         enableGlobalCss
         appBarLeftInset={ctxbridge?.platform === "darwin" && !isFullScreen ? 72 : undefined}
-        showCustomWindowControls={ctxbridge?.platform !== "darwin"}
+        showCustomWindowControls={ctxbridge?.platform === "linux"}
         isMaximized={isMaximized}
         onMinimizeWindow={onMinimizeWindow}
         onMaximizeWindow={onMaximizeWindow}

--- a/desktop/renderer/services/NativeWindow.ts
+++ b/desktop/renderer/services/NativeWindow.ts
@@ -24,4 +24,20 @@ export class NativeWindow implements INativeWindow {
   public off(name: NativeWindowEvent, listener: Handler): void {
     this.bridge?.removeIpcEventListener(name, listener);
   }
+
+  public isMaximized(): boolean {
+    return this.bridge?.isMaximized() ?? false;
+  }
+  public minimize(): void {
+    this.bridge?.minimizeWindow();
+  }
+  public maximize(): void {
+    this.bridge?.maximizeWindow();
+  }
+  public unmaximize(): void {
+    this.bridge?.unmaximizeWindow();
+  }
+  public close(): void {
+    this.bridge?.closeWindow();
+  }
 }

--- a/packages/studio-base/jest.config.json
+++ b/packages/studio-base/jest.config.json
@@ -10,7 +10,9 @@
   "//": "Enable transpilation of node_modules to support ESM-only packages",
   "transformIgnorePatterns": [],
   "globals": {
-    "ReactNull": null
+    "ReactNull": null,
+    "FOXGLOVE_STUDIO_VERSION": "TEST",
+    "FOXGLOVE_USER_AGENT": "TEST"
   },
   "setupFiles": ["<rootDir>/src/test/setup.ts", "jest-canvas-mock", "fake-indexeddb/auto"],
   "setupFilesAfterEnv": ["<rootDir>/src/test/setupTestFramework.ts"],

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -12,6 +12,7 @@ import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/Stud
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 
 import Workspace from "./Workspace";
+import { CustomWindowControlsProps } from "./components/AppBar";
 import { ColorSchemeThemeProvider } from "./components/ColorSchemeThemeProvider";
 import CssBaseline from "./components/CssBaseline";
 import DocumentTitleAdapter from "./components/DocumentTitleAdapter";
@@ -44,7 +45,7 @@ import { ExtensionLoader } from "./services/ExtensionLoader";
 import { ILayoutStorage } from "./services/ILayoutStorage";
 import URDFAssetLoader from "./services/URDFAssetLoader";
 
-type AppProps = {
+type AppProps = CustomWindowControlsProps & {
   deepLinks: string[];
   appConfiguration: IAppConfiguration;
   dataSources: IDataSourceFactory[];
@@ -147,6 +148,12 @@ export function App(props: AppProps): JSX.Element {
                         deepLinks={deepLinks}
                         disableSignin={disableSignin}
                         appBarLeftInset={props.appBarLeftInset}
+                        showCustomWindowControls={props.showCustomWindowControls}
+                        isMaximized={props.isMaximized}
+                        onMinimizeWindow={props.onMinimizeWindow}
+                        onMaximizeWindow={props.onMaximizeWindow}
+                        onUnmaximizeWindow={props.onUnmaximizeWindow}
+                        onCloseWindow={props.onCloseWindow}
                       />
                     </PanelCatalogProvider>
                   </Suspense>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -76,6 +76,7 @@ import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialD
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const log = Logger.getLogger(__filename);
 
@@ -198,7 +199,11 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     AppSetting.SHOW_DEBUG_PANELS,
   );
 
-  const [enableNewUI = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_UI);
+  // Since we can't toggle the title bar on an electron window, keep the setting at its initial
+  // value until the app is reloaded/relaunched.
+  const [currentEnableNewUI = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_UI);
+  const [initialEnableNewUI] = useState(currentEnableNewUI);
+  const enableNewUI = isDesktopApp() ? initialEnableNewUI : currentEnableNewUI;
 
   const showSignInForm = currentUserRequired && currentUser == undefined;
 

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -27,7 +27,7 @@ import { makeStyles } from "tss-react/mui";
 import Logger from "@foxglove/log";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import AccountSettings from "@foxglove/studio-base/components/AccountSettingsSidebar/AccountSettings";
-import { AppBar } from "@foxglove/studio-base/components/AppBar";
+import { AppBar, CustomWindowControlsProps } from "@foxglove/studio-base/components/AppBar";
 import { DataSourceSidebar } from "@foxglove/studio-base/components/DataSourceSidebar";
 import DocumentDropListener from "@foxglove/studio-base/components/DocumentDropListener";
 import ExtensionsSidebar from "@foxglove/studio-base/components/ExtensionsSidebar";
@@ -139,7 +139,7 @@ function AddPanel() {
   );
 }
 
-type WorkspaceProps = {
+type WorkspaceProps = CustomWindowControlsProps & {
   deepLinks?: string[];
   disableSignin?: boolean;
   appBarLeftInset?: number;
@@ -599,6 +599,12 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
             disableSignin={props.disableSignin}
             signIn={signIn}
             leftInset={props.appBarLeftInset}
+            showCustomWindowControls={props.showCustomWindowControls}
+            isMaximized={props.isMaximized}
+            onMinimizeWindow={props.onMinimizeWindow}
+            onMaximizeWindow={props.onMaximizeWindow}
+            onUnmaximizeWindow={props.onUnmaximizeWindow}
+            onCloseWindow={props.onCloseWindow}
           />
         )}
         <Sidebar

--- a/packages/studio-base/src/components/AppBar/constants.ts
+++ b/packages/studio-base/src/components/AppBar/constants.ts
@@ -2,4 +2,6 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export const APP_BAR_HEIGHT = 49;
+export const APP_BAR_HEIGHT = 48;
+export const APP_BAR_BACKGROUND_COLOR = "#27272b";
+export const APP_BAR_FOREGROUND_COLOR = "#ffffff";

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -13,6 +13,9 @@ export default {
   title: "components/AppBar",
   component: AppBar,
   decorators: [Wrapper],
+  parameters: {
+    colorScheme: "both-column",
+  },
 };
 
 class FakeConsoleApi extends ConsoleApi {
@@ -36,12 +39,14 @@ function Wrapper(StoryFn: Story): JSX.Element {
 export function Default(): JSX.Element {
   return <AppBar />;
 }
-Default.parameters = { colorScheme: "both-column" };
+
+export function CustomWindowControls(): JSX.Element {
+  return <AppBar showCustomWindowControls />;
+}
 
 export function SignInDisabled(): JSX.Element {
   return <AppBar disableSignin />;
 }
-SignInDisabled.parameters = { colorScheme: "both-column" };
 
 export function UserPresent(): JSX.Element {
   const org: User["org"] = {
@@ -72,4 +77,3 @@ export function UserPresent(): JSX.Element {
     />
   );
 }
-UserPresent.parameters = { colorScheme: "both-column" };

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -44,6 +44,10 @@ export function CustomWindowControls(): JSX.Element {
   return <AppBar showCustomWindowControls />;
 }
 
+export function CustomWindowControlsDragRegion(): JSX.Element {
+  return <AppBar showCustomWindowControls debugDragRegion />;
+}
+
 export function SignInDisabled(): JSX.Element {
   return <AppBar disableSignin />;
 }

--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
+import StudioToastProvider from "@foxglove/studio-base/components/StudioToastProvider";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
+import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
+import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+import { AppBar } from ".";
+
+const fakeConsoleApi = new ConsoleApi("");
+
+function Wrapper({ children }: React.PropsWithChildren<unknown>): JSX.Element {
+  const appConfiguration = makeMockAppConfiguration();
+  const providers = [
+    /* eslint-disable react/jsx-key */
+    <AppConfigurationContext.Provider value={appConfiguration} />,
+    <StudioToastProvider />,
+    <TimelineInteractionStateProvider />,
+    <UserNodeStateProvider />,
+    <MockMessagePipelineProvider />,
+    <ConsoleApiContext.Provider value={fakeConsoleApi} />,
+    /* eslint-enable react/jsx-key */
+  ];
+  return <MultiProvider providers={providers}>{children}</MultiProvider>;
+}
+
+describe("<AppBar />", () => {
+  it("calls functions for custom window controls", async () => {
+    const mockMinimize = jest.fn();
+    const mockMaximize = jest.fn();
+    const mockUnmaximize = jest.fn();
+    const mockClose = jest.fn();
+
+    const root = render(
+      <Wrapper>
+        <AppBar
+          showCustomWindowControls
+          onMinimizeWindow={mockMinimize}
+          onMaximizeWindow={mockMaximize}
+          onUnmaximizeWindow={mockUnmaximize}
+          onCloseWindow={mockClose}
+        />
+      </Wrapper>,
+    );
+
+    const minButton = await root.findByTestId("win-minimize");
+    minButton.click();
+    expect(mockMinimize).toHaveBeenCalled();
+
+    const maxButton = await root.findByTestId("win-maximize");
+    maxButton.click();
+    expect(mockMaximize).toHaveBeenCalled();
+    expect(mockUnmaximize).not.toHaveBeenCalled();
+
+    root.rerender(
+      <Wrapper>
+        <AppBar
+          showCustomWindowControls
+          onMinimizeWindow={mockMinimize}
+          onMaximizeWindow={mockMaximize}
+          onUnmaximizeWindow={mockUnmaximize}
+          onCloseWindow={mockClose}
+          isMaximized
+        />
+      </Wrapper>,
+    );
+    maxButton.click();
+    expect(mockUnmaximize).toHaveBeenCalled();
+
+    const closeButton = await root.findByTestId("win-close");
+    closeButton.click();
+    expect(mockClose).toHaveBeenCalled();
+
+    root.unmount();
+  });
+});

--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -3,7 +3,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render } from "@testing-library/react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -2,6 +2,10 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank";
+import CloseIcon from "@mui/icons-material/Close";
+import FilterNoneIcon from "@mui/icons-material/FilterNone";
+import MinimizeIcon from "@mui/icons-material/Minimize";
 import { AppBar as MuiAppBar, Button, IconButton, Toolbar, Typography } from "@mui/material";
 import { MouseEvent, useCallback, useContext, useState } from "react";
 import { makeStyles } from "tss-react/mui";
@@ -39,7 +43,7 @@ const useStyles = makeStyles<{ leftInset?: number }>()((theme, { leftInset }) =>
     color: theme.palette.common.white,
     height: APP_BAR_HEIGHT,
     paddingLeft: leftInset,
-    "-webkit-app-region": "drag", // make custom window title bar draggable for desktop app
+    WebkitAppRegion: "drag", // make custom window title bar draggable for desktop app
   },
   toolbar: {
     display: "grid",
@@ -74,22 +78,43 @@ const useStyles = makeStyles<{ leftInset?: number }>()((theme, { leftInset }) =>
   },
   end: {
     gridArea: "end",
-    display: "flex",
-    flexDirection: "row-reverse",
-    marginInlineEnd: theme.spacing(-2),
     flex: 1,
-    alignItems: "center",
-    gap: theme.spacing(0.5),
-
+    display: "flex",
+    justifyContent: "flex-end",
+    marginInlineEnd: theme.spacing(-2),
     [theme.breakpoints.down("sm")]: {
       marginInlineEnd: theme.spacing(-1),
+    },
+  },
+  endInner: {
+    display: "flex",
+    alignItems: "center",
+    gap: theme.spacing(0.5),
+    WebkitAppRegion: "no-drag", // make buttons clickable for desktop app
+  },
+  noDrag: {
+    WebkitAppRegion: "no-drag", // make buttons clickable for desktop app
+  },
+
+  closeButton: {
+    ":hover": {
+      backgroundColor: theme.palette.error.main,
     },
   },
 }));
 
 const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
 
-type AppBarProps = {
+export type CustomWindowControlsProps = {
+  showCustomWindowControls?: boolean;
+  isMaximized?: boolean;
+  onMinimizeWindow?: () => void;
+  onMaximizeWindow?: () => void;
+  onUnmaximizeWindow?: () => void;
+  onCloseWindow?: () => void;
+};
+
+type AppBarProps = CustomWindowControlsProps & {
   currentUser?: User;
   disableSignin?: boolean;
   signIn?: CurrentUser["signIn"];
@@ -97,8 +122,19 @@ type AppBarProps = {
 };
 
 export function AppBar(props: AppBarProps): JSX.Element {
-  const { currentUser, disableSignin, signIn } = props;
-  const { classes } = useStyles({ leftInset: props.leftInset });
+  const {
+    currentUser,
+    disableSignin,
+    signIn,
+    leftInset,
+    showCustomWindowControls = false,
+    isMaximized = false,
+    onMinimizeWindow,
+    onMaximizeWindow,
+    onUnmaximizeWindow,
+    onCloseWindow,
+  } = props;
+  const { classes, cx } = useStyles({ leftInset });
   const playerName = useMessagePipeline(selectPlayerName);
   const currentUserType = useCurrentUserType();
   const analytics = useAnalytics();
@@ -147,7 +183,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
         <MuiAppBar className={classes.appBar} position="sticky" color="inherit" elevation={0}>
           <Toolbar variant="dense" className={classes.toolbar}>
             <div className={classes.start}>
-              <IconButton className={classes.logo} size="large" color="inherit">
+              <IconButton className={cx(classes.logo, classes.noDrag)} size="large" color="inherit">
                 <FoxgloveLogo fontSize="inherit" color="inherit" />
               </IconButton>
               {currentUser != undefined && (
@@ -164,66 +200,103 @@ export function AppBar(props: AppBarProps): JSX.Element {
             )}
 
             <div className={classes.end}>
-              {supportsAccountSettings &&
-                (currentUser ? (
-                  <UserIconButton
-                    aria-label="User profile menu button"
-                    color="inherit"
-                    id="user-profile-button"
-                    aria-controls={userMenuOpen ? "user-profile-menu" : undefined}
-                    aria-haspopup="true"
-                    aria-expanded={userMenuOpen ? "true" : undefined}
-                    onClick={handleUserMenuClick}
-                    size="small"
-                  />
-                ) : (
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => {
-                      if (signIn) {
-                        signIn();
-                        void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
-                          user: "unauthenticated",
-                          cta: "sign-in",
-                        });
-                      }
-                    }}
-                  >
-                    Sign in
-                  </Button>
-                ))}
-              <PreferencesIconButton
-                color="inherit"
-                id="preferences-button"
-                aria-label="Preferences dialog button"
-                aria-controls={prefsDialogOpen ? "preferences-dialog" : undefined}
-                aria-haspopup="true"
-                aria-expanded={prefsDialogOpen ? "true" : undefined}
-                onClick={() => {
-                  void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
-                    user: currentUserType,
-                    cta: "preferences-dialog",
-                  });
-                  openPreferences();
-                }}
-              />
-              <HelpIconButton
-                color="inherit"
-                id="help-button"
-                aria-label="Help menu button"
-                aria-controls={helpMenuOpen ? "help-menu" : undefined}
-                aria-haspopup="true"
-                aria-expanded={helpMenuOpen ? "true" : undefined}
-                size="large"
-                onClick={(event) => {
-                  void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
-                    user: currentUserType,
-                    cta: "help-menu",
-                  });
-                  handleHelpClick(event);
-                }}
-              />
+              <div className={classes.endInner}>
+                <HelpIconButton
+                  color="inherit"
+                  id="help-button"
+                  aria-label="Help menu button"
+                  aria-controls={helpMenuOpen ? "help-menu" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={helpMenuOpen ? "true" : undefined}
+                  size="large"
+                  onClick={(event) => {
+                    void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
+                      user: currentUserType,
+                      cta: "help-menu",
+                    });
+                    handleHelpClick(event);
+                  }}
+                />
+                <PreferencesIconButton
+                  color="inherit"
+                  id="preferences-button"
+                  aria-label="Preferences dialog button"
+                  aria-controls={prefsDialogOpen ? "preferences-dialog" : undefined}
+                  aria-haspopup="true"
+                  aria-expanded={prefsDialogOpen ? "true" : undefined}
+                  onClick={() => {
+                    void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
+                      user: currentUserType,
+                      cta: "preferences-dialog",
+                    });
+                    openPreferences();
+                  }}
+                />
+                {supportsAccountSettings &&
+                  (currentUser ? (
+                    <UserIconButton
+                      aria-label="User profile menu button"
+                      color="inherit"
+                      id="user-profile-button"
+                      aria-controls={userMenuOpen ? "user-profile-menu" : undefined}
+                      aria-haspopup="true"
+                      aria-expanded={userMenuOpen ? "true" : undefined}
+                      onClick={handleUserMenuClick}
+                      size="small"
+                    />
+                  ) : (
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={() => {
+                        if (signIn) {
+                          signIn();
+                          void analytics.logEvent(AppEvent.APP_BAR_CLICK_CTA, {
+                            user: "unauthenticated",
+                            cta: "sign-in",
+                          });
+                        }
+                      }}
+                    >
+                      Sign in
+                    </Button>
+                  ))}
+                {showCustomWindowControls && (
+                  <>
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      onClick={onMinimizeWindow}
+                      data-testid="win-minimize"
+                    >
+                      <MinimizeIcon fontSize="inherit" color="inherit" />
+                    </IconButton>
+
+                    <IconButton
+                      size="small"
+                      color="inherit"
+                      onClick={isMaximized ? onUnmaximizeWindow : onMaximizeWindow}
+                      data-testid="win-maximize"
+                    >
+                      {isMaximized ? (
+                        <FilterNoneIcon fontSize="inherit" color="inherit" />
+                      ) : (
+                        <CheckBoxOutlineBlankIcon fontSize="inherit" color="inherit" />
+                      )}
+                    </IconButton>
+
+                    <IconButton
+                      className={classes.closeButton}
+                      size="small"
+                      color="inherit"
+                      onClick={onCloseWindow}
+                      data-testid="win-close"
+                    >
+                      <CloseIcon fontSize="inherit" color="inherit" />
+                    </IconButton>
+                  </>
+                )}
+              </div>
             </div>
           </Toolbar>
         </MuiAppBar>

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -32,76 +32,97 @@ import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import { HelpIconButton, HelpMenu } from "./Help";
 import { UserIconButton, UserMenu } from "./User";
-import { APP_BAR_HEIGHT } from "./constants";
+import { APP_BAR_HEIGHT, APP_BAR_BACKGROUND_COLOR, APP_BAR_FOREGROUND_COLOR } from "./constants";
 
-const useStyles = makeStyles<{ leftInset?: number }>()((theme, { leftInset }) => ({
-  appBar: {
-    gridArea: "appbar",
-    boxShadow: "none",
-    backgroundColor: "#27272b",
-    borderBottom: `${theme.palette.divider} 1px solid`,
-    color: theme.palette.common.white,
-    height: APP_BAR_HEIGHT,
-    paddingLeft: leftInset,
-    WebkitAppRegion: "drag", // make custom window title bar draggable for desktop app
-  },
-  toolbar: {
-    display: "grid",
-    width: "100%",
-    gridTemplateAreas: `"start middle end"`,
-    gridTemplateColumns: "1fr auto 1fr",
-  },
-  logo: {
-    padding: 0,
-    fontSize: "2.25rem",
-    color: "#9480ed",
-  },
-  start: {
-    gridArea: "start",
-    marginInlineStart: theme.spacing(-2),
-    display: "flex",
-    flex: 1,
-    alignItems: "center",
-    gap: theme.spacing(0.5),
+const useStyles = makeStyles<{ leftInset?: number; debugDragRegion?: boolean }>()(
+  (theme, { leftInset, debugDragRegion = false }) => {
+    const DRAGGABLE_STYLE: Record<string, string> = { WebkitAppRegion: "drag" };
+    const NOT_DRAGGABLE_STYLE: Record<string, string> = { WebkitAppRegion: "no-drag" };
+    if (debugDragRegion) {
+      DRAGGABLE_STYLE.backgroundColor = "green";
+      NOT_DRAGGABLE_STYLE.backgroundColor = "red";
+    }
+    return {
+      appBar: {
+        gridArea: "appbar",
+        boxShadow: "none",
+        backgroundColor: APP_BAR_BACKGROUND_COLOR,
+        borderBottom: `${theme.palette.divider} 1px solid`,
+        color: APP_BAR_FOREGROUND_COLOR,
+        height: APP_BAR_HEIGHT + 1 /*border*/,
 
-    [theme.breakpoints.down("sm")]: {
-      marginInlineStart: theme.spacing(-1),
-    },
-  },
-  middle: {
-    gridArea: "middle",
-    justifySelf: "center",
+        // Leave space for system window controls on the right on Windows.
+        // Use hard-coded padding for Mac because it looks better than env(titlebar-area-x).
+        paddingLeft: leftInset,
+        paddingRight: "calc(100% - env(titlebar-area-x) - env(titlebar-area-width))",
+        ...DRAGGABLE_STYLE, // make custom window title bar draggable for desktop app
+      },
 
-    [theme.breakpoints.down("md")]: {
-      display: "none",
-    },
-  },
-  end: {
-    gridArea: "end",
-    flex: 1,
-    display: "flex",
-    justifyContent: "flex-end",
-    marginInlineEnd: theme.spacing(-2),
-    [theme.breakpoints.down("sm")]: {
-      marginInlineEnd: theme.spacing(-1),
-    },
-  },
-  endInner: {
-    display: "flex",
-    alignItems: "center",
-    gap: theme.spacing(0.5),
-    WebkitAppRegion: "no-drag", // make buttons clickable for desktop app
-  },
-  noDrag: {
-    WebkitAppRegion: "no-drag", // make buttons clickable for desktop app
-  },
+      toolbar: {
+        display: "grid",
+        width: "100%",
+        gridTemplateAreas: `"start middle end"`,
+        gridTemplateColumns: "1fr auto 1fr",
+      },
 
-  closeButton: {
-    ":hover": {
-      backgroundColor: theme.palette.error.main,
-    },
+      logo: {
+        padding: 0,
+        fontSize: "2.25rem",
+        color: "#9480ed",
+      },
+
+      start: {
+        gridArea: "start",
+        marginInlineStart: theme.spacing(-2),
+        display: "flex",
+        flex: 1,
+        alignItems: "center",
+        gap: theme.spacing(0.5),
+
+        [theme.breakpoints.down("sm")]: {
+          marginInlineStart: theme.spacing(-1),
+        },
+      },
+
+      middle: {
+        gridArea: "middle",
+        justifySelf: "center",
+
+        [theme.breakpoints.down("md")]: {
+          display: "none",
+        },
+      },
+
+      end: {
+        gridArea: "end",
+        flex: 1,
+        display: "flex",
+        justifyContent: "flex-end",
+        marginInlineEnd: theme.spacing(-2),
+        [theme.breakpoints.down("sm")]: {
+          marginInlineEnd: theme.spacing(-1),
+        },
+      },
+
+      endInner: {
+        display: "flex",
+        alignItems: "center",
+        gap: theme.spacing(0.5),
+        ...NOT_DRAGGABLE_STYLE, // make buttons clickable for desktop app
+      },
+
+      noDrag: {
+        ...NOT_DRAGGABLE_STYLE, // make buttons clickable for desktop app
+      },
+
+      closeButton: {
+        ":hover": {
+          backgroundColor: theme.palette.error.main,
+        },
+      },
+    };
   },
-}));
+);
 
 const selectPlayerName = (ctx: MessagePipelineContext) => ctx.playerState.name;
 
@@ -119,6 +140,7 @@ type AppBarProps = CustomWindowControlsProps & {
   disableSignin?: boolean;
   signIn?: CurrentUser["signIn"];
   leftInset?: number;
+  debugDragRegion?: boolean;
 };
 
 export function AppBar(props: AppBarProps): JSX.Element {
@@ -133,8 +155,9 @@ export function AppBar(props: AppBarProps): JSX.Element {
     onMaximizeWindow,
     onUnmaximizeWindow,
     onCloseWindow,
+    debugDragRegion,
   } = props;
-  const { classes, cx } = useStyles({ leftInset });
+  const { classes, cx } = useStyles({ leftInset, debugDragRegion });
   const playerName = useMessagePipeline(selectPlayerName);
   const currentUserType = useCurrentUserType();
   const analytics = useAnalytics();

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -150,7 +150,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
     signIn,
     leftInset,
     showCustomWindowControls = false,
-    isMaximized = false,
+    isMaximized,
     onMinimizeWindow,
     onMaximizeWindow,
     onUnmaximizeWindow,
@@ -285,39 +285,13 @@ export function AppBar(props: AppBarProps): JSX.Element {
                     </Button>
                   ))}
                 {showCustomWindowControls && (
-                  <>
-                    <IconButton
-                      size="small"
-                      color="inherit"
-                      onClick={onMinimizeWindow}
-                      data-testid="win-minimize"
-                    >
-                      <MinimizeIcon fontSize="inherit" color="inherit" />
-                    </IconButton>
-
-                    <IconButton
-                      size="small"
-                      color="inherit"
-                      onClick={isMaximized ? onUnmaximizeWindow : onMaximizeWindow}
-                      data-testid="win-maximize"
-                    >
-                      {isMaximized ? (
-                        <FilterNoneIcon fontSize="inherit" color="inherit" />
-                      ) : (
-                        <CheckBoxOutlineBlankIcon fontSize="inherit" color="inherit" />
-                      )}
-                    </IconButton>
-
-                    <IconButton
-                      className={classes.closeButton}
-                      size="small"
-                      color="inherit"
-                      onClick={onCloseWindow}
-                      data-testid="win-close"
-                    >
-                      <CloseIcon fontSize="inherit" color="inherit" />
-                    </IconButton>
-                  </>
+                  <CustomWindowControls
+                    onMinimizeWindow={onMinimizeWindow}
+                    isMaximized={isMaximized}
+                    onUnmaximizeWindow={onUnmaximizeWindow}
+                    onMaximizeWindow={onMaximizeWindow}
+                    onCloseWindow={onCloseWindow}
+                  />
                 )}
               </div>
             </div>
@@ -343,6 +317,51 @@ export function AppBar(props: AppBarProps): JSX.Element {
         open={prefsDialogOpen}
         onClose={closePreferences}
       />
+    </>
+  );
+}
+
+function CustomWindowControls({
+  isMaximized = false,
+  onMinimizeWindow,
+  onMaximizeWindow,
+  onUnmaximizeWindow,
+  onCloseWindow,
+}: Omit<CustomWindowControlsProps, "showCustomWindowControls">) {
+  const { classes } = useStyles({});
+  return (
+    <>
+      <IconButton
+        size="small"
+        color="inherit"
+        onClick={onMinimizeWindow}
+        data-testid="win-minimize"
+      >
+        <MinimizeIcon fontSize="inherit" color="inherit" />
+      </IconButton>
+
+      <IconButton
+        size="small"
+        color="inherit"
+        onClick={isMaximized ? onUnmaximizeWindow : onMaximizeWindow}
+        data-testid="win-maximize"
+      >
+        {isMaximized ? (
+          <FilterNoneIcon fontSize="inherit" color="inherit" />
+        ) : (
+          <CheckBoxOutlineBlankIcon fontSize="inherit" color="inherit" />
+        )}
+      </IconButton>
+
+      <IconButton
+        className={classes.closeButton}
+        size="small"
+        color="inherit"
+        onClick={onCloseWindow}
+        data-testid="win-close"
+      >
+        <CloseIcon fontSize="inherit" color="inherit" />
+      </IconButton>
     </>
   );
 }

--- a/packages/studio-base/src/components/DropOverlay.tsx
+++ b/packages/studio-base/src/components/DropOverlay.tsx
@@ -22,6 +22,7 @@ const useStyles = makeStyles()((theme) => ({
     pointerEvents: "none",
     padding: theme.spacing(5),
     boxShadow: "none",
+    maxHeight: "none", // override inset for titlebar area on Windows desktop app
   },
   inner: {
     borderRadius: 16,

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -19,6 +19,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const useStyles = makeStyles()({
   checkbox: {
@@ -63,7 +64,12 @@ const features: Feature[] = [
   {
     key: AppSetting.ENABLE_NEW_UI,
     name: "Enable new user interface",
-    description: <>Try our redesigned navigation and layout.</>,
+    description: (
+      <>
+        Try our redesigned navigation and layout.
+        {isDesktopApp() && " Close and reopen the app for changes to take effect."}
+      </>
+    ),
   },
 ];
 if (process.env.NODE_ENV === "development") {

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -235,6 +235,12 @@ export default function muiComponents(theme: Theme): ThemeOptions["components"] 
             backgroundColor: alpha(theme.palette.common.black, 0.4),
           },
         },
+        paper: {
+          // Prevent dialog from going underneath window title bar controls on Windows
+          maxHeight: `calc(100% - 2 * (env(titlebar-area-height, ${theme.spacing(
+            2,
+          )}) + ${theme.spacing(2)}))`,
+        },
       },
     },
     MuiDialogActions: {


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Fixes FG-1293

Use custom window controls on Linux, and [window controls overlay](https://www.electronjs.org/docs/latest/tutorial/window-customization#window-controls-overlay-macos-windows) on Windows.

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/14237/212204892-f775be33-0ac9-41ff-8f95-498d2719925f.png">

