### PR TITLE
Color plot paths by series color in tooltip

### DIFF
--- a/packages/studio-base/src/components/Chart/types.ts
+++ b/packages/studio-base/src/components/Chart/types.ts
@@ -22,6 +22,7 @@ export type RpcScales = {
 
 export type RpcElement = {
   data?: ScatterDataPoint;
+  datasetIndex: number;
   view: {
     x: number;
     y: number;

--- a/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
+++ b/packages/studio-base/src/components/Chart/worker/ChartJSManager.ts
@@ -289,11 +289,12 @@ export default class ChartJSManager {
 
       // turn into an object we can send over the rpc
       out.push({
+        data,
+        datasetIndex: element.datasetIndex,
         view: {
           x: element.element.x,
           y: element.element.y,
         },
-        data,
       });
     }
 

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.stories.tsx
@@ -119,8 +119,9 @@ export const MultipleItemsSingleDatasetLight = Object.assign(
   { parameters: { colorScheme: "light" } },
 );
 
-export function MultipleItemsMultieDataset(): JSX.Element {
+export function MultipleItemsMultipleDataset(): JSX.Element {
   const data: TimeBasedChartTooltipData = {
+    datasetIndex: 0,
     x: 0,
     y: 0,
     path: "/some/topic.path",
@@ -130,7 +131,13 @@ export function MultipleItemsMultieDataset(): JSX.Element {
   return (
     <Tooltip
       open
-      title={<TimeBasedChartTooltipContent multiDataset={true} content={[data, data]} />}
+      title={
+        <TimeBasedChartTooltipContent
+          multiDataset={true}
+          content={[data, data]}
+          colorsByDatasetIndex={{ "0": "chartreuse" }}
+        />
+      }
       placement="top"
       arrow
       PopperProps={{
@@ -145,9 +152,9 @@ export function MultipleItemsMultieDataset(): JSX.Element {
     </Tooltip>
   );
 }
-MultipleItemsMultieDataset.parameters = { colorScheme: "dark" };
+MultipleItemsMultipleDataset.parameters = { colorScheme: "dark" };
 
 export const MultipleItemsMultiDatasetLight = Object.assign(
-  MultipleItemsMultieDataset.bind(undefined),
+  MultipleItemsMultipleDataset.bind(undefined),
   { parameters: { colorScheme: "light" } },
 );

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -11,7 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { take } from "lodash";
+import { sortBy, take } from "lodash";
 import { PropsWithChildren, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
@@ -20,6 +20,7 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { TimeBasedChartTooltipData } from "./index";
 
 type Props = {
+  colorsByDatasetIndex?: Record<string, undefined | string>;
   content: TimeBasedChartTooltipData[];
   // Flag indicating the containing chart has multiple datasets
   multiDataset: boolean;
@@ -39,7 +40,7 @@ const useStyles = makeStyles()((theme) => ({
     fontStyle: "italic",
   },
   path: {
-    opacity: 0.6,
+    opacity: 0.9,
     whiteSpace: "nowrap",
   },
 }));
@@ -53,7 +54,7 @@ function OverflowMessage() {
 export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
-  const { content, multiDataset } = props;
+  const { colorsByDatasetIndex, content, multiDataset } = props;
   const { classes } = useStyles();
 
   const itemsByPath = useMemo(() => {
@@ -102,12 +103,24 @@ export default function TimeBasedChartTooltipContent(
     );
   }
 
+  const sortedItems = sortBy(
+    [...itemsByPath.out.entries()],
+    ([_, items]) => items[0]?.datasetIndex ?? 0,
+  );
+
   return (
     <div className={classes.root} data-testid="TimeBasedChartTooltipContent">
-      {Array.from(itemsByPath.out.entries(), ([path, items], idx) => {
+      {sortedItems.map(([path, items], idx) => {
+        const firstItem = items[0];
+        const color =
+          firstItem?.datasetIndex != undefined
+            ? colorsByDatasetIndex?.[firstItem.datasetIndex]
+            : "auto";
         return (
           <div key={idx}>
-            <div className={classes.path}>{path}</div>
+            <div className={classes.path} style={{ color: color ?? "auto" }}>
+              {path}
+            </div>
             {take(items, 1).map((item, itemIdx) => {
               const value =
                 typeof item.value === "string"

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -103,6 +103,7 @@ export default function TimeBasedChartTooltipContent(
     );
   }
 
+  // Sort items by their dataset index to maintain the same ordering as the series in the legend.
   const sortedItems = sortBy(
     [...itemsByPath.out.entries()],
     ([_, items]) => items[0]?.datasetIndex ?? 0,

--- a/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.stories.tsx
@@ -25,12 +25,17 @@ import type { Props } from "./index";
 
 const dataX = 0.000057603000000000004;
 const dataY = 5.544444561004639;
-const tooltipData: TimeBasedChartTooltipData = {
-  x: dataX,
-  y: dataY,
-  path: "/turtle1/pose.x",
-  value: 5.544444561004639,
-};
+const tooltipData = new Map<string, TimeBasedChartTooltipData>([
+  [
+    `${dataX}:${dataY}:0`,
+    {
+      x: dataX,
+      y: dataY,
+      path: "/turtle1/pose.x",
+      value: 5.544444561004639,
+    },
+  ],
+]);
 
 const commonProps: Props = {
   isSynced: true,
@@ -69,7 +74,7 @@ const commonProps: Props = {
       },
     ],
   },
-  tooltips: [tooltipData],
+  tooltips: tooltipData,
   annotations: [],
   type: "scatter",
   xAxes: {

--- a/packages/studio-base/src/panels/Plot/PlotChart.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotChart.tsx
@@ -63,7 +63,7 @@ type PlotChartProps = {
   showXAxisLabels: boolean;
   showYAxisLabels: boolean;
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
-  tooltips: TimeBasedChartTooltipData[];
+  tooltips: Map<string, TimeBasedChartTooltipData>;
   xAxisVal: PlotXAxisVal;
   currentTime?: number;
   defaultView?: ChartDefaultView;

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -63,7 +63,7 @@ import PlotChart from "./PlotChart";
 import PlotLegend from "./PlotLegend";
 import { downloadCSV } from "./csv";
 import { getDatasets } from "./datasets";
-import { PlotDataByPath, PlotDataItem } from "./internalTypes";
+import { DataSet, PlotDataByPath, PlotDataItem } from "./internalTypes";
 import { usePlotPanelSettings } from "./settings";
 import { PlotConfig } from "./types";
 
@@ -123,6 +123,16 @@ const getMessagePathItemsForBlock = memoizeWeak(
 const ZERO_TIME = { sec: 0, nsec: 0 };
 
 const performance = window.performance;
+
+function buildTooltipLookupMap(datasets: DataSet[]): Map<string, TimeBasedChartTooltipData> {
+  const lookup = new Map<string, TimeBasedChartTooltipData>();
+  for (const [index, dataset] of datasets.entries()) {
+    for (const datum of dataset.data) {
+      lookup.set(`${datum.x}:${datum.y}:${index}`, datum);
+    }
+  }
+  return lookup;
+}
 
 function getBlockItemsByPath(
   decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
@@ -451,15 +461,9 @@ function Plot(props: Props) {
 
   const tooltips = useMemo(() => {
     if (showLegend && showPlotValuesInLegend) {
-      return [];
+      return new Map();
     }
-    const allTooltips: TimeBasedChartTooltipData[] = [];
-    for (const dataset of datasets) {
-      for (const datum of dataset.data) {
-        allTooltips.push(datum);
-      }
-    }
-    return allTooltips;
+    return buildTooltipLookupMap(datasets);
   }, [datasets, showLegend, showPlotValuesInLegend]);
 
   const messagePipeline = useMessagePipelineGetter();

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -124,6 +124,10 @@ const ZERO_TIME = { sec: 0, nsec: 0 };
 
 const performance = window.performance;
 
+/**
+ * Builds a lookup map of a compound x:y:index key to a datum, used to map hovered positions
+ * on screen to a data point for tooltip display.
+ */
 function buildTooltipLookupMap(datasets: DataSet[]): Map<string, TimeBasedChartTooltipData> {
   const lookup = new Map<string, TimeBasedChartTooltipData>();
   for (const [index, dataset] of datasets.entries()) {

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -344,7 +344,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   useStateTransitionsPanelSettings(config, saveConfig);
 
-  const tooltipLookup = useMemo(() => {
+  const pointToDatumTooltipMap = useMemo(() => {
     const lookup = new Map<string, TimeBasedChartTooltipData>();
     for (const tip of tooltips) {
       lookup.set(`${tip.x}:${tip.y}:${tip.datasetIndex}`, tip);
@@ -387,7 +387,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
             xAxisIsPlaybackTime
             yAxes={yScale}
             plugins={plugins}
-            tooltips={tooltipLookup}
+            tooltips={pointToDatumTooltipMap}
             onClick={onClick}
             currentTime={currentTimeSinceStart}
           />

--- a/packages/studio-base/src/panels/StateTransitions/index.tsx
+++ b/packages/studio-base/src/panels/StateTransitions/index.tsx
@@ -344,6 +344,14 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
 
   useStateTransitionsPanelSettings(config, saveConfig);
 
+  const tooltipLookup = useMemo(() => {
+    const lookup = new Map<string, TimeBasedChartTooltipData>();
+    for (const tip of tooltips) {
+      lookup.set(`${tip.x}:${tip.y}:${tip.datasetIndex}`, tip);
+    }
+    return lookup;
+  }, [tooltips]);
+
   return (
     <Stack ref={rootRef} flexGrow={1} overflow="hidden" style={{ zIndex: 0 }}>
       <PanelToolbar />
@@ -379,7 +387,7 @@ const StateTransitions = React.memo(function StateTransitions(props: Props) {
             xAxisIsPlaybackTime
             yAxes={yScale}
             plugins={plugins}
-            tooltips={tooltips}
+            tooltips={tooltipLookup}
             onClick={onClick}
             currentTime={currentTimeSinceStart}
           />

--- a/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
+++ b/packages/studio-base/src/panels/StateTransitions/messagesToDatasets.ts
@@ -103,6 +103,7 @@ export default function messagesToDatasets(args: Args): DatasetInfo {
       const x = toSec(subtractTimes(timestamp, startTime));
 
       const tooltip: TimeBasedChartTooltipData = {
+        datasetIndex,
         x,
         y,
         path: path.value,


### PR DESCRIPTION
**User-Facing Changes**
Use series colors to color paths in the plot panel tooltips.

**Description**
This makes a few changes:
1. Includes the dataset index in the value returned in the rpc hover message.
2. Lifts the construction of the point -> data tooltip lookup one level and includes the dataset index in the lookup key.
3. Passes a datsetindex -> color lookup to the tooltip content to color the path.

This is an alternate approach to https://github.com/foxglove/studio/pull/4955 that requires some extra effort to avoid another object allocation in the tooltip array which could  be expensive since we currently construct a tooltip for every point in the potentially large dataset. 

This also allows us to always display the values in the tooltip in the same order as the series definitions, which is not currently the case on main. By lifting the construction of the lookup map up one level we also skip the construction of the intermediate concatenated array of all tooltips.

<img width="773" alt="Screenshot 2023-01-13 at 9 58 47 AM" src="https://user-images.githubusercontent.com/93935560/212212744-e9254314-1c3c-43a2-9610-4718ec2d52b9.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
