### PR TITLE
Bypass debounce for interactive settings edits in 3d

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -169,8 +169,11 @@ function FieldInput({
           min={field.min}
           precision={field.precision}
           step={field.step}
-          onChange={(value) =>
-            actionHandler({ action: "update", payload: { path, input: "number", value } })
+          onChange={(value, interaction) =>
+            actionHandler({
+              action: "update",
+              payload: { path, input: "number", value, interaction },
+            })
           }
         />
       );
@@ -360,8 +363,11 @@ function FieldInput({
           readOnly={field.readonly}
           min={field.min}
           max={field.max}
-          onChange={(value) =>
-            actionHandler({ action: "update", payload: { path, input: "vec3", value } })
+          onChange={(value, interaction) =>
+            actionHandler({
+              action: "update",
+              payload: { path, input: "vec3", value, interaction },
+            })
           }
         />
       );
@@ -376,8 +382,11 @@ function FieldInput({
           readOnly={field.readonly}
           min={field.min}
           max={field.max}
-          onChange={(value) =>
-            actionHandler({ action: "update", payload: { path, input: "vec2", value } })
+          onChange={(value, interaction) =>
+            actionHandler({
+              action: "update",
+              payload: { path, input: "vec2", value, interaction },
+            })
           }
         />
       );

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/NumberInput.tsx
@@ -57,6 +57,8 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
+type Interaction = "direct" | "scrubbing";
+
 export function NumberInput(
   props: {
     iconUp?: ReactNode;
@@ -67,7 +69,7 @@ export function NumberInput(
     readOnly?: boolean;
     step?: number;
     value?: number;
-    onChange: (value: undefined | number) => void;
+    onChange: (value: undefined | number, interaction: Interaction) => void;
   } & Omit<TextFieldProps, "onChange">,
 ): JSX.Element {
   const { classes, cx } = useStyles();
@@ -96,7 +98,7 @@ export function NumberInput(
     : undefined;
 
   const updateValue = useCallback(
-    (newValue: undefined | number) => {
+    (newValue: undefined | number, interaction: Interaction) => {
       if (disabled === true || readOnly === true) {
         return;
       }
@@ -105,7 +107,7 @@ export function NumberInput(
         newValue == undefined
           ? undefined
           : clamp(newValue, min ?? Number.NEGATIVE_INFINITY, max ?? Number.POSITIVE_INFINITY);
-      onChange(clampedValue);
+      onChange(clampedValue, interaction);
     },
     [disabled, readOnly, min, max, onChange],
   );
@@ -136,7 +138,7 @@ export function NumberInput(
           step *
           scale;
         scrubValue.current += delta;
-        updateValue(scrubValue.current);
+        updateValue(scrubValue.current, "scrubbing");
       }
     },
     [step, updateValue],
@@ -150,7 +152,10 @@ export function NumberInput(
       {...props}
       value={displayValue ?? ""}
       onChange={(event) =>
-        updateValue(event.target.value.length > 0 ? Number(event.target.value) : undefined)
+        updateValue(
+          event.target.value.length > 0 ? Number(event.target.value) : undefined,
+          "direct",
+        )
       }
       type="number"
       className={cx(classes.textField, { [classes.textFieldReadonly]: readOnly })}
@@ -170,7 +175,10 @@ export function NumberInput(
             edge="start"
             tabIndex={-1} // Disable tabbing to the step buttons.
             onClick={(event: React.MouseEvent) =>
-              updateValue((value ?? placeHolderValue ?? 0) - (event.shiftKey ? step * 10 : step))
+              updateValue(
+                (value ?? placeHolderValue ?? 0) - (event.shiftKey ? step * 10 : step),
+                "direct",
+              )
             }
           >
             {iconDown ?? <ChevronLeftIcon fontSize="small" />}
@@ -183,7 +191,10 @@ export function NumberInput(
             edge="end"
             tabIndex={-1} // Disable tabbing to the step buttons.
             onClick={(event: React.MouseEvent) =>
-              updateValue((value ?? placeHolderValue ?? 0) + (event.shiftKey ? step * 10 : step))
+              updateValue(
+                (value ?? placeHolderValue ?? 0) + (event.shiftKey ? step * 10 : step),
+                "direct",
+              )
             }
           >
             {iconUp ?? <ChevronRightIcon fontSize="small" />}

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec2Input.tsx
@@ -4,13 +4,17 @@
 
 import { useCallback } from "react";
 
+import { SettingsTreeNumberInputInteraction } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NumberInput } from "./NumberInput";
 
 type Vec2Props = {
   disabled?: boolean;
-  onChange: (value: undefined | [undefined | number, undefined | number]) => void;
+  onChange: (
+    value: undefined | [undefined | number, undefined | number],
+    interaction: SettingsTreeNumberInputInteraction,
+  ) => void;
   precision?: number;
   readOnly?: boolean;
   step?: number;
@@ -34,10 +38,14 @@ export function Vec2Input(props: Vec2Props): JSX.Element {
   } = props;
 
   const onChangeCallback = useCallback(
-    (position: number, inputValue: undefined | number) => {
+    (
+      position: number,
+      inputValue: undefined | number,
+      interaction: SettingsTreeNumberInputInteraction,
+    ) => {
       const newValue: [undefined | number, undefined | number] = [...(value ?? [0, 0])];
       newValue[position] = inputValue;
-      onChange(newValue);
+      onChange(newValue, interaction);
     },
     [onChange, value],
   );
@@ -56,7 +64,7 @@ export function Vec2Input(props: Vec2Props): JSX.Element {
         value={value?.[0]}
         min={min}
         max={max}
-        onChange={(newValue) => onChangeCallback(0, newValue)}
+        onChange={(newValue, interaction) => onChangeCallback(0, newValue, interaction)}
       />
       <NumberInput
         size="small"
@@ -70,7 +78,7 @@ export function Vec2Input(props: Vec2Props): JSX.Element {
         value={value?.[1]}
         min={min}
         max={max}
-        onChange={(newValue) => onChangeCallback(1, newValue)}
+        onChange={(newValue, interaction) => onChangeCallback(1, newValue, interaction)}
       />
     </Stack>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/inputs/Vec3Input.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback } from "react";
 
+import { SettingsTreeNumberInputInteraction } from "@foxglove/studio";
 import Stack from "@foxglove/studio-base/components/Stack";
 
 import { NumberInput } from "./NumberInput";
@@ -12,6 +13,7 @@ type Vec3Props = {
   disabled?: boolean;
   onChange: (
     value: undefined | [undefined | number, undefined | number, undefined | number],
+    interaction: SettingsTreeNumberInputInteraction,
   ) => void;
   precision?: number;
   readOnly?: boolean;
@@ -36,12 +38,16 @@ export function Vec3Input(props: Vec3Props): JSX.Element {
   } = props;
 
   const onChangeCallback = useCallback(
-    (position: number, inputValue: undefined | number) => {
+    (
+      position: number,
+      inputValue: undefined | number,
+      interaction: SettingsTreeNumberInputInteraction,
+    ) => {
       const newValue: [undefined | number, undefined | number, undefined | number] = [
         ...(value ?? [0, 0, 0]),
       ];
       newValue[position] = inputValue;
-      onChange(newValue);
+      onChange(newValue, interaction);
     },
     [onChange, value],
   );
@@ -60,7 +66,7 @@ export function Vec3Input(props: Vec3Props): JSX.Element {
         value={value?.[0]}
         min={min}
         max={max}
-        onChange={(newValue) => onChangeCallback(0, newValue)}
+        onChange={(newValue, interaction) => onChangeCallback(0, newValue, interaction)}
       />
       <NumberInput
         size="small"
@@ -74,7 +80,7 @@ export function Vec3Input(props: Vec3Props): JSX.Element {
         value={value?.[1]}
         min={min}
         max={max}
-        onChange={(newValue) => onChangeCallback(1, newValue)}
+        onChange={(newValue, interaction) => onChangeCallback(1, newValue, interaction)}
       />
       <NumberInput
         size="small"
@@ -88,7 +94,7 @@ export function Vec3Input(props: Vec3Props): JSX.Element {
         value={value?.[2]}
         min={min}
         max={max}
-        onChange={(newValue) => onChangeCallback(2, newValue)}
+        onChange={(newValue, interaction) => onChangeCallback(2, newValue, interaction)}
       />
     </Stack>
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/SceneExtension.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { debounce, set, unset } from "lodash";
+import { set, unset } from "lodash";
 import * as THREE from "three";
 import { DeepPartial } from "ts-essentials";
 
@@ -18,8 +18,6 @@ import { updatePose } from "./updatePose";
 export type PartialMessage<T> = DeepPartial<T>;
 
 export type PartialMessageEvent<T> = MessageEvent<DeepPartial<T>>;
-
-const SETTINGS_DEBOUNCE_MS = 100;
 
 /**
  * SceneExtension is a base class for extending the 3D scene. It extends THREE.Object3D and is a
@@ -54,12 +52,6 @@ export class SceneExtension<
    * renderable per topic.
    */
   public readonly renderables = new Map<string, TRenderable>();
-
-  private _settingsUpdateDebounced = debounce(
-    () => this.renderer.settings.setNodesForKey(this.extensionId, this.settingsNodes()),
-    SETTINGS_DEBOUNCE_MS,
-    { leading: true, trailing: true, maxWait: SETTINGS_DEBOUNCE_MS },
-  );
 
   /**
    * @param extensionId A unique identifier for this SceneExtension, such as `foxglove.Markers`.
@@ -123,7 +115,7 @@ export class SceneExtension<
    * `settingsNodes()` method will be called to retrieve the latest nodes.
    */
   public updateSettingsTree(): void {
-    this._settingsUpdateDebounced();
+    this.renderer.settings.setNodesForKey(this.extensionId, this.settingsNodes());
   }
 
   /**

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -450,11 +450,42 @@ declare module "@foxglove/studio" {
     | "Walk"
     | "World";
 
-  /**
-   * A settings tree field specifies the input type and the value of a field
-   * in the settings editor.
-   */
-  export type SettingsTreeFieldValue =
+  type SettingsTreeVec3Value = {
+    input: "vec3";
+    value?: [undefined | number, undefined | number, undefined | number];
+    placeholder?: [undefined | string, undefined | string, undefined | string];
+    step?: number;
+    precision?: number;
+    labels?: [string, string, string];
+    max?: number;
+    min?: number;
+  };
+
+  type SettingsTreeVec2Value = {
+    input: "vec2";
+    value?: [undefined | number, undefined | number];
+    placeholder?: [undefined | string, undefined | string];
+    step?: number;
+    precision?: number;
+    labels?: [string, string];
+    max?: number;
+    min?: number;
+  };
+
+  type SettingsTreeNumericFieldValue = {
+    input: "number";
+    value?: number;
+    step?: number;
+    max?: number;
+    min?: number;
+    precision?: number;
+    /**
+     * Optional placeholder text displayed in the field input when value is undefined
+     */
+    placeholder?: string;
+  };
+
+  type NonNumericSettingsTreeFieldValue =
     | { input: "autocomplete"; value?: string; items: string[] }
     | { input: "boolean"; value?: boolean }
     | {
@@ -488,19 +519,6 @@ declare module "@foxglove/studio" {
     | { input: "gradient"; value?: [string, string] }
     | { input: "messagepath"; value?: string; validTypes?: string[] }
     | {
-        input: "number";
-        value?: number;
-        step?: number;
-        max?: number;
-        min?: number;
-        precision?: number;
-
-        /**
-         * Optional placeholder text displayed in the field input when value is undefined
-         */
-        placeholder?: string;
-      }
-    | {
         input: "select";
         value?: number | number[];
         options: Array<{ label: string; value: undefined | number }>;
@@ -523,27 +541,13 @@ declare module "@foxglove/studio" {
         input: "toggle";
         value?: string;
         options: string[] | Array<{ label: string; value: undefined | string }>;
-      }
-    | {
-        input: "vec3";
-        value?: [undefined | number, undefined | number, undefined | number];
-        placeholder?: [undefined | string, undefined | string, undefined | string];
-        step?: number;
-        precision?: number;
-        labels?: [string, string, string];
-        max?: number;
-        min?: number;
-      }
-    | {
-        input: "vec2";
-        value?: [undefined | number, undefined | number];
-        placeholder?: [undefined | string, undefined | string];
-        step?: number;
-        precision?: number;
-        labels?: [string, string];
-        max?: number;
-        min?: number;
       };
+
+  export type SettingsTreeFieldValue =
+    | NonNumericSettingsTreeFieldValue
+    | SettingsTreeNumericFieldValue
+    | SettingsTreeVec2Value
+    | SettingsTreeVec3Value;
 
   export type SettingsTreeField = SettingsTreeFieldValue & {
     /**
@@ -684,13 +688,29 @@ declare module "@foxglove/studio" {
    * Represents actions that can be dispatched to source of the SettingsTree to implement
    * edits and updates.
    */
+  export type SettingsTreeNumberInputInteraction = "direct" | "scrubbing";
+  export type SettingsTreeActionUpdatePayload = { path: readonly string[] } & (
+    | {
+        input: "number";
+        value?: number;
+        interaction: SettingsTreeNumberInputInteraction;
+      }
+    | {
+        input: "vec2";
+        value?: undefined | [undefined | number, undefined | number];
+        interaction: SettingsTreeNumberInputInteraction;
+      }
+    | {
+        input: "vec3";
+        value?: undefined | [undefined | number, undefined | number, undefined | number];
+        interaction: SettingsTreeNumberInputInteraction;
+      }
+    | DistributivePick<NonNumericSettingsTreeFieldValue, "input" | "value">
+  );
   export type SettingsTreeAction =
     | {
         action: "update";
-        payload: { path: readonly string[] } & DistributivePick<
-          SettingsTreeFieldValue,
-          "input" | "value"
-        >;
+        payload: SettingsTreeActionUpdatePayload;
       }
     | {
         action: "perform-node-action";


### PR DESCRIPTION
**User-Facing Changes**
Improves interactivity of edits to 3d panel settings fields.

**Description**
Makes the following changes:
1. Adds a new `interaction` property to settings tree action update payloads for number, vec2, and vec3 inputs that can be either `direct` for direct user interactions with the input or `scrubbing` for rapid scrubbing interactions.
2. Lifts the debounced settings update out of individual scene extensions to the 3d panel itself.
3. For non-scrubbing interactions, the 3d panel action handler immediately flushes settings tree updates to the sidebar to prevent writing debounced updates to a react controlled input, which results in loss of caret position.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
