### PR TITLE
Run foxglove websocket connection in web worker

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdapter.ts
@@ -6,7 +6,7 @@ import { IWebSocket } from "@foxglove/ws-protocol";
 
 import { FromWorkerMessage, ToWorkerMessage } from "./worker";
 
-export default class WorkerSocketAdaptor implements IWebSocket {
+export default class WorkerSocketAdapter implements IWebSocket {
   private worker: Worker;
   public binaryType: string = "";
   public protocol: string = "";

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdaptor.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/WorkerSocketAdaptor.ts
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { IWebSocket } from "@foxglove/ws-protocol";
+
+import { FromWorkerMessage, ToWorkerMessage } from "./worker";
+
+export default class WorkerSocketAdaptor implements IWebSocket {
+  private worker: Worker;
+  public binaryType: string = "";
+  public protocol: string = "";
+  public onerror: ((event: unknown) => void) | undefined = undefined;
+  public onopen: ((event: unknown) => void) | undefined = undefined;
+  public onclose: ((event: unknown) => void) | undefined = undefined;
+  public onmessage: ((event: unknown) => void) | undefined = undefined;
+
+  public constructor(wsUrl: string, protocols?: string[] | string) {
+    this.worker = new Worker(new URL("./worker", import.meta.url));
+    this.sendToWorker({ type: "open", data: { wsUrl, protocols } });
+
+    this.worker.onerror = (ev) => {
+      if (this.onerror) {
+        this.onerror(ev);
+      }
+    };
+
+    this.worker.onmessage = (event: MessageEvent<FromWorkerMessage>) => {
+      switch (event.data.type) {
+        case "open":
+          if (this.onopen) {
+            this.protocol = event.data.protocol;
+            this.onopen(event.data);
+          }
+          break;
+        case "close":
+          if (this.onclose) {
+            this.onclose(event.data);
+          }
+          break;
+        case "error":
+          if (this.onerror) {
+            this.onerror(event.data);
+          }
+          break;
+        case "message":
+          if (this.onmessage) {
+            this.onmessage(event.data);
+          }
+          break;
+      }
+    };
+  }
+
+  public close(): void {
+    this.sendToWorker({
+      type: "close",
+      data: undefined,
+    });
+    this.worker.terminate();
+  }
+
+  public send(data: string | ArrayBuffer | ArrayBufferView): void {
+    this.sendToWorker({ type: "data", data });
+  }
+
+  private sendToWorker(msg: ToWorkerMessage): void {
+    this.worker.postMessage(msg);
+  }
+}

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -40,7 +40,7 @@ import {
   SubscriptionId,
 } from "@foxglove/ws-protocol";
 
-import WorkerSocketAdaptor from "./WorkerSocketAdaptor";
+import WorkerSocketAdapter from "./WorkerSocketAdapter";
 
 const log = Log.getLogger(__dirname);
 
@@ -130,7 +130,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._client = new FoxgloveClient({
       ws:
         typeof Worker !== "undefined"
-          ? new WorkerSocketAdaptor(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
+          ? new WorkerSocketAdapter(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
           : new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
     });
 

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -125,11 +125,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
     log.info(`Opening connection to ${this._url}`);
 
-    const client = new FoxgloveClient({
+    this._client = new FoxgloveClient({
       ws: new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
     });
 
-    client.on("open", () => {
+    this._client.on("open", () => {
       if (this._closed) {
         return;
       }
@@ -137,15 +137,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._problems.clear();
       this._channelsById.clear();
       this._channelsByTopic.clear();
-      this._client = client;
       this._setupPublishers();
     });
 
-    client.on("error", (err) => {
+    this._client.on("error", (err) => {
       log.error(err);
     });
 
-    client.on("close", (event) => {
+    this._client.on("close", (event) => {
       log.info("Connection closed:", event);
       this._presence = PlayerPresence.RECONNECTING;
       this._startTime = undefined;
@@ -166,6 +165,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this._getParameterInterval != undefined) {
         clearInterval(this._getParameterInterval);
       }
+      this._client?.close();
       delete this._client;
 
       this._problems.addProblem("ws:connection-failed", {
@@ -180,7 +180,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       setTimeout(this._open, 3000);
     });
 
-    client.on("serverInfo", (event) => {
+    this._client.on("serverInfo", (event) => {
       this._name = `${this._url}\n${event.name}`;
       this._serverCapabilities = event.capabilities;
       this._serverPublishesTime = event.capabilities.includes(ServerCapability.time);
@@ -215,20 +215,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
         // Periodically request all available parameters.
         this._getParameterInterval = setInterval(() => {
-          client.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
+          this._client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
         }, GET_ALL_PARAMS_PERIOD_MS);
 
-        client.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
+        this._client?.getParameters([], GET_ALL_PARAMS_REQUEST_ID);
       }
 
       this._emitState();
     });
 
-    client.on("status", (event) => {
+    this._client.on("status", (event) => {
       log.info("Status:", event);
     });
 
-    client.on("advertise", (newChannels) => {
+    this._client.on("advertise", (newChannels) => {
       for (const channel of newChannels) {
         let parsedChannel;
         try {
@@ -290,7 +290,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._processUnresolvedSubscriptions();
     });
 
-    client.on("unadvertise", (removedChannels) => {
+    this._client.on("unadvertise", (removedChannels) => {
       for (const id of removedChannels) {
         const chanInfo = this._channelsById.get(id);
         if (!chanInfo) {
@@ -307,7 +307,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           if (channel.id === id) {
             this._resolvedSubscriptionsById.delete(subId);
             this._resolvedSubscriptionsByTopic.delete(channel.topic);
-            client.unsubscribe(subId);
+            this._client?.unsubscribe(subId);
             this._unresolvedSubscriptions.add(channel.topic);
           }
         }
@@ -318,7 +318,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    client.on("message", ({ subscriptionId, data }) => {
+    this._client.on("message", ({ subscriptionId, data }) => {
       if (!this._hasReceivedMessage) {
         this._hasReceivedMessage = true;
         this._metricsCollector.recordTimeToFirstMsgs();
@@ -371,7 +371,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    client.on("time", ({ timestamp }) => {
+    this._client.on("time", ({ timestamp }) => {
       if (!this._serverPublishesTime) {
         return;
       }
@@ -386,7 +386,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._emitState();
     });
 
-    client.on("parameterValues", ({ parameters, id }) => {
+    this._client.on("parameterValues", ({ parameters, id }) => {
       const newParameters = parameters.filter((p) => !this._parameters.has(p.name));
 
       if (id === GET_ALL_PARAMS_REQUEST_ID) {
@@ -404,7 +404,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._serverCapabilities.includes(ServerCapability.parametersSubscribe)
       ) {
         // Subscribe to value updates of new parameters
-        client.subscribeParameterUpdates(newParameters.map((p) => p.name));
+        this._client?.subscribeParameterUpdates(newParameters.map((p) => p.name));
       }
     });
   };

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -40,6 +40,8 @@ import {
   SubscriptionId,
 } from "@foxglove/ws-protocol";
 
+import WorkerSocketAdaptor from "./WorkerSocketAdaptor";
+
 const log = Log.getLogger(__dirname);
 
 /** Suppress warnings about messages on unknown subscriptions if the susbscription was recently canceled. */
@@ -126,7 +128,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
     log.info(`Opening connection to ${this._url}`);
 
     this._client = new FoxgloveClient({
-      ws: new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
+      ws:
+        typeof Worker !== "undefined"
+          ? new WorkerSocketAdaptor(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL])
+          : new WebSocket(this._url, [FoxgloveClient.SUPPORTED_SUBPROTOCOL]),
     });
 
     this._client.on("open", () => {


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
If supported, a dedicated web worker will be created for managing the foxglove websocket connection, to reduce the load on the main thread. 

Summary:
- Make sure that we call `close()` on the `FoxgloveClient`, otherwise the worker will not be destroyed (memory leak)
- Create `WorkerSocketAdaptor` which creates a regular websocket connection in a webworker. It implements the [IWebSocket interface](https://github.com/foxglove/ws-protocol/blob/f6c95b059b7ef87cbf1058252f5cb32a61ccf22c/typescript/ws-protocol/src/types.ts#L143-L156) and can therefore be passed to `FoxgloveClient` instead of a regular websocket

FG-1250
