### PR TITLE
Add publishing support to foxglove websocket connection

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@foxglove/rosmsg": "3.1.0",
     "@foxglove/rosmsg-serialization": "1.5.3",
-    "@foxglove/rosmsg2-serialization": "1.0.7",
+    "@foxglove/rosmsg2-serialization": "1.1.1",
     "@foxglove/wasm-bz2": "0.1.1",
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "22.12.6",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -56,7 +56,7 @@
     "@foxglove/ulog": "2.1.2",
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.1",
-    "@foxglove/ws-protocol": "0.3.1",
+    "@foxglove/ws-protocol": "0.3.3",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "0.3.0",
     "@mdi/svg": "7.1.96",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -46,7 +46,7 @@
     "@foxglove/rosmsg": "3.1.0",
     "@foxglove/rosmsg-msgs-common": "2.1.0",
     "@foxglove/rosmsg-serialization": "1.5.3",
-    "@foxglove/rosmsg2-serialization": "1.0.7",
+    "@foxglove/rosmsg2-serialization": "1.1.1",
     "@foxglove/rostime": "1.1.2",
     "@foxglove/rtps": "1.6.0",
     "@foxglove/schemas": "0.7.3",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -37,7 +37,6 @@ import {
   ClientChannel,
   FoxgloveClient,
   ServerCapability,
-  ServerInfo,
   SubscriptionId,
 } from "@foxglove/ws-protocol";
 
@@ -193,7 +192,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         const rosDistro = event.metadata["ROS_DISTRO"] as string;
         const rosDataTypes = ["melodic", "noetic"].includes(rosDistro)
           ? CommonRosTypes.ros1
-          : rosDistro === "galactic"
+          : ["foxy", "galactic"].includes(rosDistro)
           ? CommonRosTypes.ros2galactic
           : CommonRosTypes.ros2humble;
 
@@ -421,10 +420,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     this._topics = topics;
 
-    // Update the _datatypes map;
-    for (const { parsedChannel } of this._channelsById.values()) {
-      for (const [name, types] of parsedChannel.datatypes) {
-        this._datatypes?.set(name, types);
+    if (this._datatypes) {
+      // Update the _datatypes map;
+      for (const { parsedChannel } of this._channelsById.values()) {
+        for (const [name, types] of parsedChannel.datatypes) {
+          this._datatypes.set(name, types);
+        }
       }
     }
     this._emitState();

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -9,6 +9,9 @@ import { v4 as uuidv4 } from "uuid";
 import { debouncePromise } from "@foxglove/den/async";
 import Log from "@foxglove/log";
 import { parseChannel, ParsedChannel } from "@foxglove/mcap-support";
+import { RosMsgDefinition } from "@foxglove/rosmsg";
+import { MessageWriter as Ros1MessageWriter } from "@foxglove/rosmsg-serialization";
+import { MessageWriter as Ros2MessageWriter } from "@foxglove/rosmsg2-serialization";
 import { fromMillis, fromNanoSec, isGreaterThan, isLessThan, Time } from "@foxglove/rostime";
 import { ParameterValue } from "@foxglove/studio";
 import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemManager";
@@ -20,14 +23,17 @@ import {
   PlayerMetricsCollectorInterface,
   PlayerPresence,
   PlayerState,
+  PublishPayload,
   SubscribePayload,
   Topic,
   TopicStats,
 } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
+import rosDatatypesToMessageDefinition from "@foxglove/studio-base/util/rosDatatypesToMessageDefinition";
 import {
   Channel,
   ChannelId,
+  ClientChannel,
   FoxgloveClient,
   ServerCapability,
   SubscriptionId,
@@ -41,8 +47,12 @@ const SUBSCRIPTION_WARNING_SUPPRESSION_MS = 2000;
 const ZERO_TIME = Object.freeze({ sec: 0, nsec: 0 });
 const GET_ALL_PARAMS_REQUEST_ID = "get-all-params";
 const GET_ALL_PARAMS_PERIOD_MS = 15000;
+const ROS_ENCODINGS = ["ros1", "cdr"];
+const SUPPORTED_PUBLICATION_ENCODINGS = ["json", ...ROS_ENCODINGS];
+const FALLBACK_PUBLICATION_ENCODING = "json";
 
 type ResolvedChannel = { channel: Channel; parsedChannel: ParsedChannel };
+type Publication = ClientChannel & { messageWriter?: Ros1MessageWriter | Ros2MessageWriter };
 
 export default class FoxgloveWebSocketPlayer implements Player {
   private _url: string; // WebSocket URL.
@@ -50,7 +60,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _client?: FoxgloveClient; // The client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player.
   private _serverCapabilities: string[] = [];
-  private _playerCapabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
+  private _playerCapabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
+  private _supportedEncodings?: string[];
   private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
   private _closed: boolean = false; // Whether the player has been completely closed using close().
   private _topics?: Topic[]; // Topics as published by the WebSocket.
@@ -83,6 +94,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _parameters = new Map<string, ParameterValue>();
   private readonly _sourceId: string;
   private _getParameterInterval?: ReturnType<typeof setInterval>;
+  private _unresolvedPublications: AdvertiseOptions[] = [];
+  private _publicationsByTopic = new Map<string, Publication>();
 
   public constructor({
     url,
@@ -124,6 +137,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._channelsById.clear();
       this._channelsByTopic.clear();
       this._client = client;
+      this._setupPublishers();
     });
 
     client.on("error", (err) => {
@@ -139,6 +153,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._serverPublishesTime = false;
       this._serverCapabilities = [];
       this._playerCapabilities = [];
+      this._supportedEncodings = undefined;
 
       for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
         this._unresolvedSubscriptions.add(topic);
@@ -167,6 +182,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._name = `${this._url}\n${event.name}`;
       this._serverCapabilities = event.capabilities;
       this._serverPublishesTime = event.capabilities.includes(ServerCapability.time);
+      this._supportedEncodings = event.supportedEncodings;
+
+      if (event.capabilities.includes(ServerCapability.clientPublish)) {
+        this._playerCapabilities.push(PlayerCapabilities.advertise);
+      }
 
       if (event.capabilities.includes(ServerCapability.parameters)) {
         this._playerCapabilities.push(
@@ -525,9 +545,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
   }
 
   public setPublishers(publishers: AdvertiseOptions[]): void {
-    if (publishers.length > 0) {
-      throw new Error("Publishing is not supported by the Foxglove WebSocket connection");
+    // Since `setPublishers` is rarely called, we can get away with just unadvertising existing
+    // channels und re-advertising them again
+    for (const channel of this._publicationsByTopic.values()) {
+      this._client?.unadvertise(channel.id);
     }
+    this._publicationsByTopic.clear();
+    this._unresolvedPublications = publishers;
+    this._setupPublishers();
   }
 
   public setParameter(key: string, value: ParameterValue): void {
@@ -543,8 +568,26 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._emitState();
   }
 
-  public publish(): void {
-    throw new Error("Publishing is not supported by the Foxglove WebSocket connection");
+  public publish({ topic, msg }: PublishPayload): void {
+    if (!this._client) {
+      throw new Error(`Attempted to publish without a valid Foxglove WebSocket connection`);
+    }
+
+    const clientChannel = this._publicationsByTopic.get(topic);
+    if (!clientChannel) {
+      throw new Error(`Tried to publish on topic '${topic}' that has not been advertised before.`);
+    }
+
+    if (clientChannel.encoding === "json") {
+      const message = new Uint8Array(Buffer.from(JSON.stringify(msg) ?? ""));
+      this._client.sendMessage(clientChannel.id, message);
+    } else if (
+      ROS_ENCODINGS.includes(clientChannel.encoding) &&
+      clientChannel.messageWriter != undefined
+    ) {
+      const message = clientChannel.messageWriter.writeMessage(msg);
+      this._client.sendMessage(clientChannel.id, message);
+    }
   }
 
   public async callService(): Promise<unknown> {
@@ -555,5 +598,71 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
   private _getCurrentTime(): Time {
     return this._serverPublishesTime ? this._clockTime ?? ZERO_TIME : fromMillis(Date.now());
+  }
+
+  private _setupPublishers(): void {
+    // This function will be called again once a connection is established
+    if (!this._client || this._closed) {
+      return;
+    }
+
+    if (this._unresolvedPublications.length === 0) {
+      return;
+    }
+
+    this._problems.removeProblems((id) => id.startsWith("pub:"));
+
+    const encoding = this._supportedEncodings
+      ? this._supportedEncodings.find((e) => SUPPORTED_PUBLICATION_ENCODINGS.includes(e))
+      : FALLBACK_PUBLICATION_ENCODING;
+
+    for (const { topic, schemaName, options } of this._unresolvedPublications) {
+      const encodingProblemId = `pub:encoding:${topic}`;
+      const msgdefProblemId = `pub:msgdef:${topic}`;
+
+      if (!encoding) {
+        this._problems.addProblem(encodingProblemId, {
+          severity: "warn",
+          message: `Cannot advertise topic '${topic}': Server does not support one of the following encodings for client-side publishing: ${SUPPORTED_PUBLICATION_ENCODINGS}`,
+        });
+        continue;
+      }
+
+      let messageWriter: Publication["messageWriter"] = undefined;
+      if (ROS_ENCODINGS.includes(encoding)) {
+        // Try to retrieve the ROS message definition for this topic
+        let msgdef: RosMsgDefinition[];
+        try {
+          const datatypes = options?.["datatypes"] as RosDatatypes | undefined;
+          if (!datatypes || !(datatypes instanceof Map)) {
+            throw new Error("The datatypes option is required for publishing");
+          }
+          msgdef = rosDatatypesToMessageDefinition(datatypes, schemaName);
+        } catch (error) {
+          log.debug(error);
+          this._problems.addProblem(msgdefProblemId, {
+            severity: "warn",
+            message: `Unknown message definition for "${topic}"`,
+            tip: `Try subscribing to the topic "${topic}" before publishing to it`,
+          });
+          continue;
+        }
+
+        messageWriter =
+          encoding === "ros1" ? new Ros1MessageWriter(msgdef) : new Ros2MessageWriter(msgdef);
+      }
+
+      const channelId = this._client.advertise(topic, encoding, schemaName);
+      this._publicationsByTopic.set(topic, {
+        id: channelId,
+        topic,
+        encoding,
+        schemaName,
+        messageWriter,
+      });
+    }
+
+    this._unresolvedPublications = [];
+    this._emitState();
   }
 }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -61,7 +61,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _client?: FoxgloveClient; // The client when we're connected.
   private _id: string = uuidv4(); // Unique ID for this player.
   private _serverCapabilities: string[] = [];
-  private _playerCapabilities: typeof PlayerCapabilities[keyof typeof PlayerCapabilities][] = [];
+  private _playerCapabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
   private _supportedEncodings?: string[];
   private _listener?: (arg0: PlayerState) => Promise<void>; // Listener for _emitState().
   private _closed: boolean = false; // Whether the player has been completely closed using close().
@@ -187,7 +187,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._supportedEncodings = event.supportedEncodings;
       this._datatypes = new Map();
 
-      if (event.metadata != undefined && Object.keys(event.metadata).includes("ROS_DISTRO")) {
+      if (event.metadata != undefined && "ROS_DISTRO" in event.metadata) {
         // Add common ROS message definitions
         const rosDistro = event.metadata["ROS_DISTRO"] as string;
         const rosDataTypes = ["melodic", "noetic"].includes(rosDistro)
@@ -599,7 +599,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
 
     if (clientChannel.encoding === "json") {
-      const message = new Uint8Array(Buffer.from(JSON.stringify(msg) ?? ""));
+      const message = Buffer.from(JSON.stringify(msg) ?? "");
       this._client.sendMessage(clientChannel.id, message);
     } else if (
       ROS_ENCODINGS.includes(clientChannel.encoding) &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,7 +2299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg2-serialization@npm:1.0.7, @foxglove/rosmsg2-serialization@npm:^1.0.7":
+"@foxglove/rosmsg2-serialization@npm:1.0.7":
   version: 1.0.7
   resolution: "@foxglove/rosmsg2-serialization@npm:1.0.7"
   dependencies:
@@ -2310,7 +2310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg2-serialization@npm:1.1.1":
+"@foxglove/rosmsg2-serialization@npm:1.1.1, @foxglove/rosmsg2-serialization@npm:^1.0.7":
   version: 1.1.1
   resolution: "@foxglove/rosmsg2-serialization@npm:1.1.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,7 +2401,7 @@ __metadata:
     "@foxglove/ulog": 2.1.2
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.1
-    "@foxglove/ws-protocol": 0.3.1
+    "@foxglove/ws-protocol": 0.3.3
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 0.3.0
     "@mdi/svg": 7.1.96
@@ -2603,14 +2603,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.3.1":
-  version: 0.3.1
-  resolution: "@foxglove/ws-protocol@npm:0.3.1"
+"@foxglove/ws-protocol@npm:0.3.3":
+  version: 0.3.3
+  resolution: "@foxglove/ws-protocol@npm:0.3.3"
   dependencies:
     debug: ^4
     eventemitter3: ^5.0.0
     tslib: ^2
-  checksum: f6bbbc120e998504e83bd2bc0609720a645ade4770ddb0e047385bfbac761e486bd531c028c2a8a5bdb52706ff38bfb494a2a5f40543f6a045787d305c60d072
+  checksum: 9401d167ae66b0209e1cc9d47c003812e871777d50a071737bce19ba1ac070148dccc78b99c345d3a927993ae43d29433c23b42544d94f384d29394c91476e72
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2178,7 +2178,7 @@ __metadata:
   dependencies:
     "@foxglove/rosmsg": 3.1.0
     "@foxglove/rosmsg-serialization": 1.5.3
-    "@foxglove/rosmsg2-serialization": 1.0.7
+    "@foxglove/rosmsg2-serialization": 1.1.1
     "@foxglove/schemas": 0.7.3
     "@foxglove/wasm-bz2": 0.1.1
     "@mcap/core": 0.3.0
@@ -2296,17 +2296,6 @@ __metadata:
   dependencies:
     "@foxglove/rosmsg": ^3.1.0
   checksum: fdb665763b84f9af30d5161368aaf8ad662615cbb65ee648a7398c940f679baaeaca2eb569f573d2cedbdb171a0a1dabbdad14d0f2b70eff5c1afc337e58752b
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg2-serialization@npm:1.0.7":
-  version: 1.0.7
-  resolution: "@foxglove/rosmsg2-serialization@npm:1.0.7"
-  dependencies:
-    "@foxglove/cdr": ^2.0.0
-    "@foxglove/rosmsg": ^3.1.0
-    "@foxglove/rostime": ^1.1.2
-  checksum: fddb256ae6a6da5a34be4cb45261fe24d0bece667d674ba73f84416f7b42190b94172c699bffd3a9e57b9efc311b1c845e33caaffdccb3e9ac0e5f4cb3756592
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2310,6 +2310,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@foxglove/rosmsg2-serialization@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@foxglove/rosmsg2-serialization@npm:1.1.1"
+  dependencies:
+    "@foxglove/cdr": ^2.0.0
+    "@foxglove/rosmsg": ^3.1.0
+    "@foxglove/rostime": ^1.1.2
+  checksum: 657ca1298a266002edfd19af5d198a8db78b11a71b6a9aa1ab034b7a0200cb6e12cdd6109a21509fa138090659f2e05c0ff1a4bc3d5d84ff85155313ce4da41f
+  languageName: node
+  linkType: hard
+
 "@foxglove/rosmsg@npm:3.1.0, @foxglove/rosmsg@npm:^3.1.0":
   version: 3.1.0
   resolution: "@foxglove/rosmsg@npm:3.1.0"
@@ -2380,7 +2391,7 @@ __metadata:
     "@foxglove/rosmsg": 3.1.0
     "@foxglove/rosmsg-msgs-common": 2.1.0
     "@foxglove/rosmsg-serialization": 1.5.3
-    "@foxglove/rosmsg2-serialization": 1.0.7
+    "@foxglove/rosmsg2-serialization": 1.1.1
     "@foxglove/rostime": 1.1.2
     "@foxglove/rtps": 1.6.0
     "@foxglove/schemas": 0.7.3


### PR DESCRIPTION
**User-Facing Changes**
- Add publishing support to foxglove websocket connection

**Description**
Supersedes #4938 (was already approved but got closed automatically as the base branch got deleted)

- Adds publishing capability to foxglove websocket player
- There are currently 3 supported message encodings: `json`, `cdr` (ROS 2) and `ros1`
  - If the server communicates supported encodings  (https://github.com/foxglove/ws-protocol/pull/326), we use the first matching one
  - Otherwise, `json` is used as the fallback encoding

FG-1216

