### PR TITLE
Fix creation of duplicate user script messages for preloaded output topics

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -320,6 +320,12 @@ export default class UserNodePlayer implements Player {
         .sort((a, b) => compare(a.receiveTime, b.receiveTime));
       for (const nodeRegistration of fullRegistrations) {
         const outTopic = nodeRegistration.output.name;
+        // Clear out any previously processed messages that were previously in the output topic.
+        // otherwise it will contain duplicates.
+        if (messagesByTopic[outTopic] != undefined) {
+          messagesByTopic[outTopic] = [];
+        }
+
         for (const message of blockMessages) {
           if (nodeRegistration.inputs.includes(message.topic)) {
             const outputMessage = await nodeRegistration.processMessage(message, globalVariables);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - fix bug where plots would contain old messages from user scripts

**Description**
 - fix duplicate output message in blocks


<!-- link relevant GitHub issues -->
#5115
FG-1302
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
