### PR TITLE
Update userscript messages when global variables change

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.test.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.test.ts
@@ -1560,6 +1560,57 @@ describe("UserNodePlayer", () => {
           },
         ]);
       });
+      it("should re-compute message after global variable change with no new messages in active data", async () => {
+        const fakePlayer = new FakePlayer();
+        const userNodePlayer = new UserNodePlayer(fakePlayer, defaultUserNodeActions);
+        const [done, done2] = setListenerHelper(userNodePlayer, 2);
+
+        userNodePlayer.setGlobalVariables({ globalValue: "aaa" });
+        userNodePlayer.setSubscriptions([{ topic: `${DEFAULT_STUDIO_NODE_PREFIX}1` }]);
+        await userNodePlayer.setUserNodes({
+          [nodeId]: {
+            name: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
+            sourceCode: nodeUserCodeWithGlobalVars,
+          },
+        });
+
+        const activeData: PlayerStateActiveData = {
+          ...basicPlayerState,
+          messages: [upstreamFirst],
+          currentTime: upstreamFirst.receiveTime,
+          topics: [{ name: "/np_input", schemaName: "std_msgs/Header" }],
+          datatypes: new Map(Object.entries({ foo: { definitions: [] } })),
+        };
+        await fakePlayer.emit({ activeData });
+
+        const { messages } = (await done)!;
+        expect(messages).toEqual([
+          upstreamFirst,
+          {
+            topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
+            receiveTime: upstreamFirst.receiveTime,
+            message: { custom_np_field: "aaa", value: "aaa" },
+            schemaName: "/studio_script/1",
+            sizeInBytes: 0,
+          },
+        ]);
+
+        userNodePlayer.setGlobalVariables({ globalValue: "bbb" });
+        activeData.messages = [];
+        await fakePlayer.emit({ activeData });
+
+        const { messages: messages2 } = (await done2)!;
+        expect(messages2).toEqual([
+          upstreamFirst,
+          {
+            topic: `${DEFAULT_STUDIO_NODE_PREFIX}1`,
+            receiveTime: upstreamFirst.receiveTime,
+            message: { custom_np_field: "bbb", value: "bbb" },
+            schemaName: "/studio_script/1",
+            sizeInBytes: 0,
+          },
+        ]);
+      });
     });
   });
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -134,6 +134,7 @@ export default class UserNodePlayer implements Player {
   // keep track of last message on all topics to recompute output topic messages when user nodes change
   private _lastMessageByInputTopic = new Map<string, MessageEvent<unknown>>();
   private _userNodeIdsNeedUpdate = new Set<string>();
+  private _globalVariablesChanged = false;
 
   private _protectedState = new MutexLocked<ProtectedState>({
     userNodes: {},
@@ -348,8 +349,9 @@ export default class UserNodePlayer implements Player {
     return outputBlocks;
   }
 
-  public setGlobalVariables(globalVariables: GlobalVariables): void {
+  public async setGlobalVariables(globalVariables: GlobalVariables): Promise<void> {
     this._globalVariables = globalVariables;
+    this._globalVariablesChanged = true;
   }
 
   // Called when userNode state is updated.
@@ -413,7 +415,6 @@ export default class UserNodePlayer implements Player {
     // a specific node. A node may have a problem that may later clear. Using the key we can add/remove
     // problems for specific userspace nodes independently of other userspace nodes.
     const problemKey = `node-id-${nodeId}`;
-
     const buildMessageProcessor = (): NodeRegistration["processMessage"] => {
       return async (msgEvent: MessageEvent<unknown>, globalVariables: GlobalVariables) => {
         const terminateSignal = terminateCondvar.wait();
@@ -830,6 +831,15 @@ export default class UserNodePlayer implements Player {
 
           for (const topic of inputTopics) {
             inputTopicsForRecompute.add(topic);
+          }
+        }
+
+        // if the globalVariables have changed recompute all last messages for the current frame
+        // there's no way to know which nodes are affected by the globalVariables change to make this more specific
+        if (this._globalVariablesChanged) {
+          this._globalVariablesChanged = false;
+          for (const inputTopic of this._lastMessageByInputTopic.keys()) {
+            inputTopicsForRecompute.add(inputTopic);
           }
         }
 

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -349,7 +349,7 @@ export default class UserNodePlayer implements Player {
     return outputBlocks;
   }
 
-  public async setGlobalVariables(globalVariables: GlobalVariables): Promise<void> {
+  public setGlobalVariables(globalVariables: GlobalVariables): void {
     this._globalVariables = globalVariables;
     this._globalVariablesChanged = true;
   }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- userscript messages recomputed on global variables change

**Description**
Utilized `lastMessagesByInputTopic` to recalculate user script messages for the current frame. 
Will capture functionality with a test.

<!-- link relevant GitHub issues -->
FG-1071
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
