### PR TITLE
Apply scene entity deletions before adding new entities

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
@@ -136,6 +136,13 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
     const topic = messageEvent.topic;
     const sceneUpdates = messageEvent.message;
 
+    for (const deletionMsg of sceneUpdates.deletions ?? []) {
+      if (deletionMsg) {
+        const deletion = normalizeSceneEntityDeletion(deletionMsg);
+        this._getTopicEntities(topic).deleteEntities(deletion);
+      }
+    }
+
     for (const entityMsg of sceneUpdates.entities ?? []) {
       if (entityMsg) {
         const entity = normalizeSceneEntity(entityMsg);
@@ -143,13 +150,6 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
           entity,
           toNanoSec(messageEvent.receiveTime),
         );
-      }
-    }
-
-    for (const deletionMsg of sceneUpdates.deletions ?? []) {
-      if (deletionMsg) {
-        const deletion = normalizeSceneEntityDeletion(deletionMsg);
-        this._getTopicEntities(topic).deleteEntities(deletion);
       }
     }
   };


### PR DESCRIPTION
**User-Facing Changes**
Changed: SceneUpdate `deletions` are now processed before adding new `entities`.

**Description**
Fixes #5175