### PR TITLE
Add error when protobuf schema name is not fully qualified

### DIFF
--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -11,7 +11,7 @@ import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serializat
 
 import { parseFlatbufferSchema } from "./parseFlatbufferSchema";
 import { parseJsonSchema } from "./parseJsonSchema";
-import { protobufDefinitionsToDatatypes } from "./protobufDefinitionsToDatatypes";
+import { protobufDefinitionsToDatatypes, stripLeadingDot } from "./protobufDefinitionsToDatatypes";
 import { RosDatatypes } from "./types";
 
 type Channel = {
@@ -136,6 +136,14 @@ export function parseChannel(channel: Channel): ParsedChannel {
 
     const datatypes: RosDatatypes = new Map();
     protobufDefinitionsToDatatypes(datatypes, type);
+
+    if (!datatypes.has(channel.schema.name)) {
+      throw new Error(
+        `Protobuf schema does not contain an entry for '${
+          channel.schema.name
+        }'. The schema name should be fully-qualified, e.g. '${stripLeadingDot(type.fullName)}'.`,
+      );
+    }
 
     return { deserializer, datatypes };
   }


### PR DESCRIPTION
**User-Facing Changes**
Improved error message when Protobuf data contains an incorrect `schemaName`.

**Description**
Certain components of Studio like the Raw Message panel depend on having "RosDatatypes" available for each message in order to parse & evaluate message paths. The process that extracts these RosDatatypes from a protobuf schema always uses the fully-qualified name (e.g. `foxglove.Foo`) in order to avoid potential conflicts if nested messages have the same name. However, the initial lookup using the `schemaName` allows a non-fully-qualified name. This results in problems later when the schemaName does not match an entry in the RosDatatypes.

This PR adds an error message immediately after extracting the RosDatatypes if the schemaName is not present, to provide a clear message instead of waiting for problems to occur later downstream.

Related to https://github.com/foxglove/studio/issues/2304

Fixes #5174.

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/14237/213549236-de31094b-d51b-4677-a55f-55ce0f900418.png">


