### PR TITLE
Add flatbuffer support to FoxgloveWebsocketPlayer

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -243,6 +243,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
             if (base64.decode(channel.schema, schemaData, 0) !== schemaData.byteLength) {
               throw new Error(`Failed to decode base64 schema on channel ${channel.id}`);
             }
+          } else if (channel.encoding === "flatbuffer") {
+            schemaEncoding = "flatbuffer";
+            schemaData = new Uint8Array(base64.length(channel.schema));
+            if (base64.decode(channel.schema, schemaData, 0) !== schemaData.byteLength) {
+              throw new Error(`Failed to decode base64 schema on channel ${channel.id}`);
+            }
           } else if (channel.encoding === "ros1") {
             schemaEncoding = "ros1msg";
             schemaData = new TextEncoder().encode(channel.schema);


### PR DESCRIPTION
**User-Facing Changes**
Foxglove websocket connection now supports channels using flatbuffers.

The schema should be a base64 encoded flatbuffer reflection schema.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
