### PR TITLE
 Fix freeze after receiving tf message with identical parent and child ids

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -31,4 +31,8 @@ describe("TransformTree", () => {
     // c <- a <- b <- c  ERROR - cycle created
     expect(tfTree.addTransform("a", "c", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
   });
+  it("detects a cycle when adding a transform with a parent as itself", () => {
+    const tfTree = new TransformTree();
+    expect(tfTree.addTransform("a", "a", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
+  });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -160,6 +160,9 @@ export class TransformTree {
     return output;
   }
   private _checkParentForCycle(frameId: string, parentFrameId: string): boolean {
+    if (frameId === parentFrameId) {
+      return true;
+    }
     // walk up tree from parent Frame to check if it eventually crosses the frame
     let frame = this.frame(parentFrameId);
     while (frame?.parent()) {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - fix freeze after receiving tf message with identical parent and child ids

**Description**
 - cycle detection wasn't checking for frameId being the same as parentId



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
