### PR TITLE
add non-dismissible deprecation banner to URDF Viewer panel

### DIFF
--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -186,7 +186,7 @@ function URDFViewer({ config, saveConfig }: Props) {
     <div className={classes.root}>
       <PanelToolbar />
       <Alert severity="warning">
-        The URDF Viewer panel is now deprecated. See the{" "}
+        The URDF Viewer panel is deprecated. See the{" "}
         <Link
           href="https://foxglove.dev/docs/studio/panels/3d#add-unified-robot-description-format-urdf"
           target="_blank"

--- a/packages/studio-base/src/panels/URDFViewer/index.tsx
+++ b/packages/studio-base/src/panels/URDFViewer/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Button } from "@mui/material";
+import { Alert, Button, Link } from "@mui/material";
 import { differenceBy, first, isEmpty } from "lodash";
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { useResizeDetector } from "react-resize-detector";
@@ -185,6 +185,16 @@ function URDFViewer({ config, saveConfig }: Props) {
   return (
     <div className={classes.root}>
       <PanelToolbar />
+      <Alert severity="warning">
+        The URDF Viewer panel is now deprecated. See the{" "}
+        <Link
+          href="https://foxglove.dev/docs/studio/panels/3d#add-unified-robot-description-format-urdf"
+          target="_blank"
+        >
+          3D panel docs
+        </Link>{" "}
+        to visualize URDFs.
+      </Alert>
       <div className={classes.content}>
         {messageBar}
         {model == undefined ? (


### PR DESCRIPTION
**User-Facing Changes**
The URDF Viewer panel is now deprecated and will be removed in a future release. [Use the 3D panel](https://foxglove.dev/docs/studio/panels/3d#add-unified-robot-description-format-urdf) to visualize URDFs instead.

**Description**
<img width="398" alt="image" src="https://user-images.githubusercontent.com/14237/213836206-7353b5c4-d302-4992-947d-491cfa6fa139.png">
Resolves FG-1118