### PR TITLE
Rename URDF layer menu item

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Urdfs.ts
@@ -161,7 +161,7 @@ export class Urdfs extends SceneExtension<UrdfRenderable> {
     renderer.on("parametersChange", this.handleParametersChange);
     renderer.addCustomLayerAction({
       layerId: LAYER_ID,
-      label: "Add Unified Robot Description Format (URDF)",
+      label: "Add URDF",
       icon: "PrecisionManufacturing",
       handler: this.handleAddUrdf,
     });


### PR DESCRIPTION
**User-Facing Changes**
Minor change: rename URDF layer menu item

**Description**
I disagree with spelling out the full file format acronym here. For example please see the Portable Network Graphics (PNG) below.

Before:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/637671/213845017-fbf0415b-86d4-455b-82f7-c59d1c16e084.png">

After:

<img width="507" alt="image" src="https://user-images.githubusercontent.com/637671/213845022-91099ad7-2a93-4c3b-a506-d58fbd61a689.png">
