### PR TITLE
Add a yarn cache clean step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY . ./
 
 RUN corepack enable
+RUN yarn cache clean
 RUN yarn install --immutable
 
 ENV FOXGLOVE_DISABLE_SIGN_IN=true


### PR DESCRIPTION
Simply adds one line to the Foxglove studio `Dockerfile` to clean the yarn cache prior to installing, which gets around an error I had encountered when trying to build and run foxglove with `docker compose up`,

Signed-off-by: Andrew Symington <andrew.c.symington@gmail.com>

**User-Facing Changes**

None

**Description**

This is the error I had encountered:

```
asymingt@mars:~/development/grids$ docker compose run foxglove
[+] Building 4.2s (12/14)                                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                           0.0s
 => => transferring dockerfile: 32B                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                              0.0s
 => => transferring context: 34B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/caddy:2.5.2-alpine                                                                                                          0.4s
 => [internal] load metadata for docker.io/library/node:16                                                                                                                     0.4s
 => [internal] load build context                                                                                                                                              0.1s
 => => transferring context: 3.07MB                                                                                                                                            0.1s
 => [build 1/6] FROM docker.io/library/node:16@sha256:27fab5920246070cf13449cf44c25bc4f5adef18ca7482b2bda90b7cf9e64481                                                         0.0s
 => [stage-1 1/3] FROM docker.io/library/caddy:2.5.2-alpine@sha256:b31ff95e98737b849d6af1fb9d9cb54a66ba3684564b3310541f60b12b1dd619                                            0.0s
 => CACHED [stage-1 2/3] WORKDIR /src                                                                                                                                          0.0s
 => CACHED [build 2/6] WORKDIR /src                                                                                                                                            0.0s
 => [build 3/6] COPY . ./                                                                                                                                                      1.1s
 => [build 4/6] RUN corepack enable                                                                                                                                            0.4s
 => ERROR [build 5/6] RUN yarn install --immutable                                                                                                                             2.1s
------
 > [build 5/6] RUN yarn install --immutable:
#0 2.047 Internal Error: Unable to deserialize cloned data due to invalid or unsupported version.
#0 2.047     at Object.deserialize (node:v8:380:7)
#0 2.047     at Ke.restoreInstallState (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:447:965)
#0 2.047     at processTicksAndRejections (node:internal/process/task_queues:96:5)
#0 2.047     at async wC.execute (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:486:14746)
#0 2.047     at async wC.validateAndExecute (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:337:620)
#0 2.047     at async oo.run (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:351:1846)
#0 2.047     at async oo.runExit (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:351:2013)
#0 2.047     at async i (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:448:12377)
#0 2.047     at async r (/root/.cache/node/corepack/yarn/3.1.0/yarn.js:448:10617)
------
failed to solve: executor failed running [/bin/sh -c yarn install --immutable]: exit code: 1
```
The addition of the new line fixes it.
