### PR TITLE
3D Panel TransformTree addTransform performance optimization

### DIFF
--- a/packages/den/collection/ArrayMap.test.ts
+++ b/packages/den/collection/ArrayMap.test.ts
@@ -94,4 +94,39 @@ describe("ArrayMap", () => {
     expect(list.binarySearch(5n)).toBe(~3);
     expect(list.binarySearch(6n)).toBe(~3);
   });
+
+  it("removes elements after key", () => {
+    const list = new ArrayMap<number, string>();
+    const data = [...Array(10).keys()];
+    data.forEach((val) => list.set(val, String(val)));
+    list.removeAfter(4.5);
+    expect(list.size).toBe(5);
+    expect(list.binarySearch(0)).toBe(0);
+    expect(list.binarySearch(1)).toBe(1);
+    expect(list.binarySearch(2)).toBe(2);
+    expect(list.binarySearch(3)).toBe(3);
+    expect(list.binarySearch(4)).toBe(4);
+    expect(list.binarySearch(5)).toBe(~5);
+    expect(list.binarySearch(6)).toBe(~5);
+    expect(list.binarySearch(7)).toBe(~5);
+    expect(list.binarySearch(8)).toBe(~5);
+    expect(list.binarySearch(9)).toBe(~5);
+  });
+  it("removes elements before key", () => {
+    const list = new ArrayMap<number, string>();
+    const data = [...Array(10).keys()];
+    data.forEach((val) => list.set(val, String(val)));
+    list.removeBefore(4.5);
+    expect(list.size).toBe(5);
+    expect(list.binarySearch(0)).toBe(-1);
+    expect(list.binarySearch(1)).toBe(-1);
+    expect(list.binarySearch(2)).toBe(-1);
+    expect(list.binarySearch(3)).toBe(-1);
+    expect(list.binarySearch(4)).toBe(-1);
+    expect(list.binarySearch(5)).toBe(0);
+    expect(list.binarySearch(6)).toBe(1);
+    expect(list.binarySearch(7)).toBe(2);
+    expect(list.binarySearch(8)).toBe(3);
+    expect(list.binarySearch(9)).toBe(4);
+  });
 });

--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -60,6 +60,12 @@ export class ArrayMap<K, V> {
     this._list.length = greaterThanIndex;
   }
 
+  /** Removes all elements with keys less than the given key. */
+  public removeBefore(key: K): void {
+    const index = this.binarySearch(key);
+    this._list.splice(0, index);
+  }
+
   /** Access the first key/value tuple in the list, without modifying the list. */
   public minEntry(): [K, V] | undefined {
     return this._list[0];

--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -63,7 +63,8 @@ export class ArrayMap<K, V> {
   /** Removes all elements with keys less than the given key. */
   public removeBefore(key: K): void {
     const index = this.binarySearch(key);
-    this._list.splice(0, index);
+    const lessThanIndex = index >= 0 ? index : ~index;
+    this._list.splice(0, lessThanIndex);
   }
 
   /** Access the first key/value tuple in the list, without modifying the list. */

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -39,6 +39,8 @@ export class CoordinateFrame {
   public readonly id: string;
   public maxStorageTime: Duration;
   public maxCapacity: number;
+  // The percentage of maxCapacity that can be exceeded before overfilled frames in history are cleared
+  public capacityOverfillPercentage: number;
   public offsetPosition: vec3 | undefined;
   public offsetEulerDegrees: vec3 | undefined;
 
@@ -50,10 +52,12 @@ export class CoordinateFrame {
     parent: CoordinateFrame | undefined,
     maxStorageTime: Duration,
     maxCapacity: number,
+    capacityOverfillPercentage = 0.1,
   ) {
     this.id = id;
     this.maxStorageTime = maxStorageTime;
     this.maxCapacity = maxCapacity;
+    this.capacityOverfillPercentage = capacityOverfillPercentage;
     this._parent = parent;
     this._transforms = new ArrayMap<Time, Transform>();
   }
@@ -118,9 +122,10 @@ export class CoordinateFrame {
   }
 
   /**
-   * Add a transform to the transform history maintained by this frame. The
-   * difference between the newest and oldest timestamps cannot be more than
-   * `this.maxStorageTime`, so this addition may purge older transforms.
+   * Add a transform to the transform history maintained by this frame. When the overfill
+   * limit has been reached, the history is trimmed by removing the larger portion of either
+   * frames that are outside of the `maxStorageTime` or the oldest frames over `maxCapacity`.
+   * This is to amortize the cost of trimming the history ever time a new transform is added.
    *
    * If a transform with an identical timestamp already exists, it is replaced.
    */
@@ -128,15 +133,23 @@ export class CoordinateFrame {
     this._transforms.set(time, transform);
 
     // Remove transforms that are too old
-    const endTime = this._transforms.maxKey()!;
-    const startTime = endTime - this.maxStorageTime;
-    while (this._transforms.size > 1 && this._transforms.minKey()! < startTime) {
-      this._transforms.shift();
-    }
+    // percent over the maxCapacity
+    const overfillPercent =
+      Math.max(0, this._transforms.size - this.maxCapacity) / this.maxCapacity;
 
-    // Trim down to the maximum history size
-    while (this._transforms.size > this.maxCapacity) {
-      this._transforms.shift();
+    // Trim down to the maximum history size if we've exceeded the overfill
+    if (overfillPercent > this.capacityOverfillPercentage) {
+      const overfillIndex = this._transforms.size - this.maxCapacity;
+      // guaranteed to be more than minKey
+      let removeBeforeTime = this._transforms.at(overfillIndex)![0];
+      const endTime = this._transforms.maxKey()!;
+      // not guaranteed to be more than minKey
+      const startTime = endTime - this.maxStorageTime;
+      // at the very least we remove the overfill, but if the maxStorageTime enforces a  larger trim we take that
+      // we can't afford to check maxStorageTime every time we add a transform, so we only check it when overfill is full
+      removeBeforeTime = startTime > removeBeforeTime ? startTime : removeBeforeTime;
+
+      this._transforms.removeBefore(removeBeforeTime);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -40,6 +40,7 @@ export class CoordinateFrame {
   public maxStorageTime: Duration;
   public maxCapacity: number;
   // The percentage of maxCapacity that can be exceeded before overfilled frames in history are cleared
+  // allows for better perf by amortizing trimming of frames every few thousand transforms rather than every new transform
   public capacityOverfillPercentage: number;
   public offsetPosition: vec3 | undefined;
   public offsetEulerDegrees: vec3 | undefined;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- 3D panel performance improvement after transform history capacity has been exceeded.

**Description**
 Optimize addTransform performance by amortizing trimming of arraymap. CoordinateTransform takes optional parameter specifying percentage of overfill the history has before trimming it to size. This makes it so that the transform history is trimmed every few thousand transforms instead of every transform, which was building up time-cost with high-frequency transforms. 

Optimization work needed for transform preloading. 

<!-- link relevant GitHub issues -->
FG-1492

<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
