### PR TITLE
`renderState.allFrames` no longer includes topics that the panel didn't request to be preloaded

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -378,7 +378,16 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
           };
         });
 
-        setLocalSubscriptions(subscribePayloads);
+        // ExtensionPanel-Facing subscription type
+        const localSubs = topics.map<Subscription>((item) => {
+          if (typeof item === "string") {
+            return { topic: item, preload: true };
+          }
+
+          return item;
+        });
+
+        setLocalSubscriptions(localSubs);
         setSubscriptions(panelId, subscribePayloads);
       },
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -169,7 +169,10 @@ describe("renderState", () => {
       hoverValue: undefined,
       sharedPanelState: {},
       sortedTopics: [{ name: "test", schemaName: "schema" }],
-      subscriptions: [{ topic: "test" }, { topic: "test", convertTo: "otherSchema" }],
+      subscriptions: [
+        { topic: "test" },
+        { topic: "test", convertTo: "otherSchema", preload: true },
+      ],
       messageConverters: [
         {
           fromSchemaName: "schema",

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
 import { toSec } from "@foxglove/rostime";
 import {
@@ -279,12 +280,11 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         shouldRender = true;
         const frames: MessageEvent<unknown>[] = (renderState.allFrames = []);
         // only populate allFrames with topics that the panel wants to preload
-        const topicsToPreloadForPanel = new Set<string>();
-        for (const sub of subscriptions) {
-          if (sub.preload === true) {
-            topicsToPreloadForPanel.add(sub.topic);
-          }
-        }
+        const topicsToPreloadForPanel = new Set<string>(
+          Array.from(
+            filterMap(subscriptions, (sub) => (sub.preload === true ? sub.topic : undefined)),
+          ),
+        );
         for (const block of newBlocks) {
           if (!block) {
             continue;

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -278,12 +278,23 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       if (newBlocks && prevBlocks !== newBlocks) {
         shouldRender = true;
         const frames: MessageEvent<unknown>[] = (renderState.allFrames = []);
+        // only populate allFrames with topics that the panel wants to preload
+        const topicsToPreloadForPanel = new Set<string>();
+        for (const sub of subscriptions) {
+          if (sub.preload === true) {
+            topicsToPreloadForPanel.add(sub.topic);
+          }
+        }
         for (const block of newBlocks) {
           if (!block) {
             continue;
           }
 
-          for (const messageEvents of Object.values(block.messagesByTopic)) {
+          for (const topic of topicsToPreloadForPanel) {
+            const messageEvents = block.messagesByTopic[topic];
+            if (!messageEvents) {
+              continue;
+            }
             for (const messageEvent of messageEvents) {
               // Message blocks may contain topics that we are not subscribed to so we need to filter those out.
               // We use the topicNoConversions and topicConversions to determine if we should include the message event


### PR DESCRIPTION
**User-Facing Changes**
 - [extension-panels] `renderState.allFrames` no longer includes topics that the panel didn't request to be preloaded
<!-- will be used as a changelog entry -->

**Description**
Filter topics that the panel doesn't want preloaded out of `allFrames`. This allows extension panels to not have to iterate through messages that they didn't ask to have preloaded. Previously `allFrames` was constructed from all topics that the panel subscribed to that had loaded blocks regardless of whether they were preloaded. 

<!-- link relevant GitHub issues -->
FG-1625
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
