### PR TITLE
Add setDefaultPanelTitle to extension API, and ability to edit panel titles

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -112,15 +112,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const isPanelInitializedRef = useRef(false);
 
   const [slowRender, setSlowRender] = useState(false);
-  const [defaultPanelTitle, setDefaultPanelTitle] = useDefaultPanelTitle();
-  const customPanelTitle =
-    config != undefined &&
-    typeof config === "object" &&
-    "foxglove.panel-title" in config &&
-    typeof config["foxglove.panel-title"] === "string" &&
-    config["foxglove.panel-title"].length > 0
-      ? config["foxglove.panel-title"]
-      : defaultPanelTitle;
+  const [, setDefaultPanelTitle] = useDefaultPanelTitle();
 
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
 
@@ -568,7 +560,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
         ...style,
       }}
     >
-      <PanelToolbar title={customPanelTitle} />
+      <PanelToolbar />
       <div style={{ flex: 1, overflow: "hidden" }} ref={panelContainerRef} />
     </div>
   );

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -47,6 +47,7 @@ import {
 import {
   usePanelSettingsTreeUpdate,
   useSharedPanelState,
+  useDefaultPanelTitle,
 } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import { PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { assertNever } from "@foxglove/studio-base/util/assertNever";
@@ -111,6 +112,15 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const isPanelInitializedRef = useRef(false);
 
   const [slowRender, setSlowRender] = useState(false);
+  const [defaultPanelTitle, setDefaultPanelTitle] = useDefaultPanelTitle();
+  const customPanelTitle =
+    config != undefined &&
+    typeof config === "object" &&
+    "foxglove.panel-title" in config &&
+    typeof config["foxglove.panel-title"] === "string" &&
+    config["foxglove.panel-title"].length > 0
+      ? config["foxglove.panel-title"]
+      : defaultPanelTitle;
 
   const { globalVariables, setGlobalVariables } = useGlobalVariables();
 
@@ -456,6 +466,13 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
         }
         updatePanelSettingsTree(settings);
       },
+
+      setDefaultPanelTitle: (title: string) => {
+        if (!isMounted()) {
+          return;
+        }
+        setDefaultPanelTitle(title);
+      },
     };
   }, [
     capabilities,
@@ -468,6 +485,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     panelId,
     saveConfig,
     seekPlayback,
+    setDefaultPanelTitle,
     setGlobalVariables,
     setHoverValue,
     setSharedPanelState,
@@ -550,7 +568,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
         ...style,
       }}
     >
-      <PanelToolbar />
+      <PanelToolbar title={customPanelTitle} />
       <div style={{ flex: 1, overflow: "hidden" }} ref={panelContainerRef} />
     </div>
   );

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -34,7 +34,7 @@ import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 const useStyles = makeStyles()((theme) => ({
   fieldGrid: {
     display: "grid",
-    // gridTemplateColumns: "minmax(20%, 20ch) auto",
+    gridTemplateColumns: "minmax(20%, 20ch) auto",
     columnGap: theme.spacing(1),
   },
 }));

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -5,10 +5,13 @@
 import { Link, Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useUnmount } from "react-use";
+import { makeStyles } from "tss-react/mui";
 
+import { SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { ActionMenu } from "@foxglove/studio-base/components/PanelSettings/ActionMenu";
-import SettingsEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
+import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
+import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
 import ShareJsonModal from "@foxglove/studio-base/components/ShareJsonModal";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -27,6 +30,14 @@ import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
+
+const useStyles = makeStyles()((theme) => ({
+  fieldGrid: {
+    display: "grid",
+    // gridTemplateColumns: "minmax(20%, 20ch) auto",
+    columnGap: theme.spacing(1),
+  },
+}));
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 
@@ -112,7 +123,7 @@ export default function PanelSettings({
     incrementSequenceNumber,
   ]);
 
-  const [config] = useConfigById(selectedPanelId);
+  const [config, saveConfig] = useConfigById(selectedPanelId);
 
   const settingsTree = usePanelStateStore((state) =>
     selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
@@ -126,6 +137,32 @@ export default function PanelSettings({
       incrementSequenceNumber(selectedPanelId);
     }
   }, [incrementSequenceNumber, savePanelConfigs, selectedPanelId]);
+
+  const defaultPanelTitle = usePanelStateStore((state) =>
+    selectedPanelId ? state.defaultTitles[selectedPanelId] : undefined,
+  );
+  const { classes } = useStyles();
+  const customPanelTitle =
+    typeof config?.["foxglove.panel-title"] === "string"
+      ? config["foxglove.panel-title"]
+      : undefined;
+  const panelNameField = useMemo<SettingsTreeField>(
+    () => ({
+      input: "string",
+      label: "Title",
+      placeholder: defaultPanelTitle ?? panelInfo?.title,
+      value: customPanelTitle,
+    }),
+    [customPanelTitle, defaultPanelTitle, panelInfo?.title],
+  );
+  const handleTitleChange = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action === "update" && action.payload.path[0] === "foxglove.panel-title") {
+        saveConfig({ "foxglove.panel-title": action.payload.value });
+      }
+    },
+    [saveConfig],
+  );
 
   if (selectedLayoutId == undefined) {
     return (
@@ -177,7 +214,14 @@ export default function PanelSettings({
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
         <div>
-          {settingsTree && <SettingsEditor key={selectedPanelId} settings={settingsTree} />}
+          <div className={classes.fieldGrid}>
+            <FieldEditor
+              field={panelNameField}
+              path={["foxglove.panel-title"]}
+              actionHandler={handleTitleChange}
+            />
+          </div>
+          {settingsTree && <SettingsTreeEditor key={selectedPanelId} settings={settingsTree} />}
           {!settingsTree && (
             <Typography color="text.secondary">No additional settings available.</Typography>
           )}

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -29,7 +29,7 @@ import {
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
-import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
+import { getPanelTypeFromId, PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
 
 const useStyles = makeStyles()((theme) => ({
   fieldGrid: {
@@ -143,8 +143,8 @@ export default function PanelSettings({
   );
   const { classes } = useStyles();
   const customPanelTitle =
-    typeof config?.["foxglove.panel-title"] === "string"
-      ? config["foxglove.panel-title"]
+    typeof config?.[PANEL_TITLE_CONFIG_KEY] === "string"
+      ? config[PANEL_TITLE_CONFIG_KEY]
       : undefined;
   const panelNameField = useMemo<SettingsTreeField>(
     () => ({
@@ -157,8 +157,8 @@ export default function PanelSettings({
   );
   const handleTitleChange = useCallback(
     (action: SettingsTreeAction) => {
-      if (action.action === "update" && action.payload.path[0] === "foxglove.panel-title") {
-        saveConfig({ "foxglove.panel-title": action.payload.value });
+      if (action.action === "update" && action.payload.path[0] === PANEL_TITLE_CONFIG_KEY) {
+        saveConfig({ [PANEL_TITLE_CONFIG_KEY]: action.payload.value });
       }
     },
     [saveConfig],
@@ -217,7 +217,7 @@ export default function PanelSettings({
           <div className={classes.fieldGrid}>
             <FieldEditor
               field={panelNameField}
-              path={["foxglove.panel-title"]}
+              path={[PANEL_TITLE_CONFIG_KEY]}
               actionHandler={handleTitleChange}
             />
           </div>

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -5,13 +5,10 @@
 import { Link, Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useUnmount } from "react-use";
-import { makeStyles } from "tss-react/mui";
 
-import { SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { ActionMenu } from "@foxglove/studio-base/components/PanelSettings/ActionMenu";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
-import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
 import ShareJsonModal from "@foxglove/studio-base/components/ShareJsonModal";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -29,15 +26,7 @@ import {
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
-import { getPanelTypeFromId, PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
-
-const useStyles = makeStyles()((theme) => ({
-  fieldGrid: {
-    display: "grid",
-    gridTemplateColumns: "minmax(20%, 20ch) auto",
-    columnGap: theme.spacing(1),
-  },
-}));
+import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 
@@ -123,7 +112,7 @@ export default function PanelSettings({
     incrementSequenceNumber,
   ]);
 
-  const [config, saveConfig] = useConfigById(selectedPanelId);
+  const [config] = useConfigById(selectedPanelId);
 
   const settingsTree = usePanelStateStore((state) =>
     selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
@@ -137,32 +126,6 @@ export default function PanelSettings({
       incrementSequenceNumber(selectedPanelId);
     }
   }, [incrementSequenceNumber, savePanelConfigs, selectedPanelId]);
-
-  const defaultPanelTitle = usePanelStateStore((state) =>
-    selectedPanelId ? state.defaultTitles[selectedPanelId] : undefined,
-  );
-  const { classes } = useStyles();
-  const customPanelTitle =
-    typeof config?.[PANEL_TITLE_CONFIG_KEY] === "string"
-      ? config[PANEL_TITLE_CONFIG_KEY]
-      : undefined;
-  const panelNameField = useMemo<SettingsTreeField>(
-    () => ({
-      input: "string",
-      label: "Title",
-      placeholder: defaultPanelTitle ?? panelInfo?.title,
-      value: customPanelTitle,
-    }),
-    [customPanelTitle, defaultPanelTitle, panelInfo?.title],
-  );
-  const handleTitleChange = useCallback(
-    (action: SettingsTreeAction) => {
-      if (action.action === "update" && action.payload.path[0] === PANEL_TITLE_CONFIG_KEY) {
-        saveConfig({ [PANEL_TITLE_CONFIG_KEY]: action.payload.value });
-      }
-    },
-    [saveConfig],
-  );
 
   if (selectedLayoutId == undefined) {
     return (
@@ -214,13 +177,6 @@ export default function PanelSettings({
       {shareModal}
       <Stack gap={2} justifyContent="flex-start">
         <div>
-          <div className={classes.fieldGrid}>
-            <FieldEditor
-              field={panelNameField}
-              path={[PANEL_TITLE_CONFIG_KEY]}
-              actionHandler={handleTitleChange}
-            />
-          </div>
           {settingsTree && <SettingsTreeEditor key={selectedPanelId} settings={settingsTree} />}
           {!settingsTree && (
             <Typography color="text.secondary">No additional settings available.</Typography>

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -17,6 +17,8 @@ import { useContext, useMemo, CSSProperties } from "react";
 
 import PanelContext from "@foxglove/studio-base/components/PanelContext";
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
+import { useDefaultPanelTitle } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import { PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
 
 import { PanelToolbarControls } from "./PanelToolbarControls";
 
@@ -27,8 +29,6 @@ type Props = {
   backgroundColor?: CSSProperties["backgroundColor"];
   children?: React.ReactNode;
   isUnknownPanel?: boolean;
-  /** Optional override of the default title */
-  title?: string;
 };
 
 const PanelToolbarRoot = muiStyled("div", {
@@ -58,9 +58,12 @@ export default React.memo<Props>(function PanelToolbar({
   backgroundColor,
   children,
   isUnknownPanel = false,
-  title: customTitle,
 }: Props) {
-  const { isFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
+  const {
+    isFullscreen,
+    exitFullscreen,
+    config: { [PANEL_TITLE_CONFIG_KEY]: customTitle = undefined } = {},
+  } = useContext(PanelContext) ?? {};
 
   const panelContext = useContext(PanelContext);
 
@@ -91,7 +94,13 @@ export default React.memo<Props>(function PanelToolbar({
   const controlsDragRef =
     isUnknownPanel || children == undefined ? undefined : panelContext?.connectToolbarDragHandle;
 
-  const title = customTitle ?? panelContext?.title;
+  const [defaultPanelTitle] = useDefaultPanelTitle();
+  const customPanelTitle =
+    customTitle != undefined && typeof customTitle === "string" && customTitle.length > 0
+      ? customTitle
+      : defaultPanelTitle;
+
+  const title = customPanelTitle ?? panelContext?.title;
   return (
     <PanelToolbarRoot
       backgroundColor={backgroundColor}

--- a/packages/studio-base/src/components/PanelToolbar/index.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.tsx
@@ -27,6 +27,8 @@ type Props = {
   backgroundColor?: CSSProperties["backgroundColor"];
   children?: React.ReactNode;
   isUnknownPanel?: boolean;
+  /** Optional override of the default title */
+  title?: string;
 };
 
 const PanelToolbarRoot = muiStyled("div", {
@@ -56,6 +58,7 @@ export default React.memo<Props>(function PanelToolbar({
   backgroundColor,
   children,
   isUnknownPanel = false,
+  title: customTitle,
 }: Props) {
   const { isFullscreen, exitFullscreen } = useContext(PanelContext) ?? {};
 
@@ -88,6 +91,7 @@ export default React.memo<Props>(function PanelToolbar({
   const controlsDragRef =
     isUnknownPanel || children == undefined ? undefined : panelContext?.connectToolbarDragHandle;
 
+  const title = customTitle ?? panelContext?.title;
   return (
     <PanelToolbarRoot
       backgroundColor={backgroundColor}
@@ -96,9 +100,9 @@ export default React.memo<Props>(function PanelToolbar({
       ref={rootDragRef}
     >
       {children ??
-        (panelContext != undefined && (
+        (title && (
           <Typography noWrap variant="body2" color="text.secondary" flex="auto">
-            {panelContext.title}
+            {title}
           </Typography>
         ))}
       <PanelToolbarControls

--- a/packages/studio-base/src/context/PanelCatalogContext.ts
+++ b/packages/studio-base/src/context/PanelCatalogContext.ts
@@ -18,6 +18,9 @@ export type PanelInfo = {
   thumbnail?: string;
   help?: React.ReactNode;
 
+  /** Set this to true if a panel has custom toolbar items and so cannot be renamed. */
+  hasCustomToolbar?: boolean;
+
   /**
    * Tooltip to show on the settings button to help new users find the panel settings. Shown on
    * panels of this type across the whole app until the settings button is clicked.

--- a/packages/studio-base/src/context/PanelStateContext.ts
+++ b/packages/studio-base/src/context/PanelStateContext.ts
@@ -28,6 +28,9 @@ export type PanelStateStore = {
    */
   settingsTrees: Record<string, ImmutableSettingsTree | undefined>;
 
+  /** Per-panel default titles. */
+  defaultTitles: Record<string, string | undefined>;
+
   /**
    * Transient state shared between panels, keyed by panel type.
    */
@@ -42,6 +45,9 @@ export type PanelStateStore = {
    * Updates the settings UI for the given panel.
    */
   updateSettingsTree: (panelId: string, settingsTree: ImmutableSettingsTree | undefined) => void;
+
+  /** Updates the default title for the given panel. */
+  updateDefaultTitle: (panelId: string, title: string | undefined) => void;
 
   /**
    * Update the transient state associated with a particular panel type.

--- a/packages/studio-base/src/panels/Gauge/Gauge.tsx
+++ b/packages/studio-base/src/panels/Gauge/Gauge.tsx
@@ -201,6 +201,7 @@ export function Gauge({ context }: Props): JSX.Element {
 
   useEffect(() => {
     context.saveState(config);
+    context.setDefaultPanelTitle(config.path === "" ? undefined : config.path);
   }, [config, context]);
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/Indicator/Indicator.tsx
+++ b/packages/studio-base/src/panels/Indicator/Indicator.tsx
@@ -167,6 +167,7 @@ export function Indicator({ context }: Props): JSX.Element {
 
   useEffect(() => {
     context.saveState(config);
+    context.setDefaultPanelTitle(config.path === "" ? undefined : config.path);
   }, [config, context]);
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -12,8 +12,8 @@
 //   You may not use this file except in compliance with the License.
 
 import DownloadIcon from "@mui/icons-material/Download";
-import { Typography, useTheme } from "@mui/material";
-import { compact, isEmpty, isNumber, uniq } from "lodash";
+import { useTheme } from "@mui/material";
+import { compact, isNumber, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { useEffect, useCallback, useMemo, ComponentProps } from "react";
 
@@ -57,6 +57,7 @@ import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { NewPlotLegend } from "@foxglove/studio-base/panels/Plot/NewPlotLegend";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
+import { PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
 import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import PlotChart from "./PlotChart";
@@ -214,7 +215,7 @@ function selectEndTime(ctx: MessagePipelineContext) {
 function Plot(props: Props) {
   const { saveConfig, config } = props;
   const {
-    title,
+    title: legacyTitle,
     followingViewWidth,
     paths: yAxisPaths,
     minXValue,
@@ -231,6 +232,18 @@ function Plot(props: Props) {
     xAxisPath,
     sidebarDimension = config.sidebarWidth ?? defaultSidebarDimension,
   } = config;
+
+  useEffect(() => {
+    if (legacyTitle) {
+      // Migrate legacy Plot-specific title setting to new global title setting
+      // https://github.com/foxglove/studio/pull/5225
+      saveConfig({
+        title: undefined,
+        [PANEL_TITLE_CONFIG_KEY]: legacyTitle,
+      } as Partial<PlotConfig>);
+    }
+  }, [legacyTitle, saveConfig]);
+
   const theme = useTheme();
 
   useEffect(() => {
@@ -516,11 +529,7 @@ function Plot(props: Props) {
             <DownloadIcon fontSize="small" />
           </ToolbarIconButton>
         }
-      >
-        <Typography noWrap variant="body2" color="text.secondary" flex="auto">
-          {isEmpty(title) ? "Plot" : title}
-        </Typography>
-      </PanelToolbar>
+      />
       <Stack
         direction={stackDirection}
         flex="auto"

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -76,7 +76,6 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
       label: "General",
       icon: "Settings",
       fields: {
-        title: { label: "Title", input: "string", value: config.title, placeholder: "Plot" },
         isSynced: { label: "Sync with other plots", input: "boolean", value: config.isSynced },
       },
     },

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -16,6 +16,7 @@ type DeprecatedPlotConfig = {
   sidebarWidth?: number;
 };
 export type PlotConfig = DeprecatedPlotConfig & {
+  /** @deprecated Replaced by global panel rename functionality https://github.com/foxglove/studio/pull/5225 */
   title?: string;
   paths: PlotPath[];
   minXValue?: number;

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -41,6 +41,7 @@ const builtin: PanelInfo[] = [
     description: "Display ROS DiagnosticArray messages for a specific hardware_id.",
     thumbnail: diagnosticStatusThumbnail,
     module: async () => await import("./diagnostics/DiagnosticStatusPanel"),
+    hasCustomToolbar: true,
   },
   {
     title: `Diagnostics – Summary (ROS)`,
@@ -48,6 +49,7 @@ const builtin: PanelInfo[] = [
     description: "Display a summary of all ROS DiagnosticArray messages.",
     thumbnail: diagnosticSummaryThumbnail,
     module: async () => await import("./diagnostics/DiagnosticSummary"),
+    hasCustomToolbar: true,
   },
   {
     title: "Image",
@@ -55,6 +57,7 @@ const builtin: PanelInfo[] = [
     description: "Display annotated images.",
     thumbnail: imageViewThumbnail,
     module: async () => await import("./Image"),
+    hasCustomToolbar: true,
   },
   {
     title: "Indicator",
@@ -111,6 +114,7 @@ const builtin: PanelInfo[] = [
     description: "Inspect topic messages.",
     thumbnail: rawMessagesThumbnail,
     module: async () => await import("./RawMessages"),
+    hasCustomToolbar: true,
   },
   {
     title: "Log",
@@ -118,6 +122,7 @@ const builtin: PanelInfo[] = [
     description: "Display logs by node and severity level.",
     thumbnail: logThumbnail,
     module: async () => await import("./Log"),
+    hasCustomToolbar: true,
   },
   {
     title: "State Transitions",
@@ -132,6 +137,7 @@ const builtin: PanelInfo[] = [
     description: "Display topic messages in a tabular format.",
     thumbnail: tableThumbnail,
     module: async () => await import("./Table"),
+    hasCustomToolbar: true,
   },
   {
     title: "URDF Viewer",

--- a/packages/studio-base/src/providers/PanelStateContextProvider.tsx
+++ b/packages/studio-base/src/providers/PanelStateContextProvider.tsx
@@ -28,6 +28,7 @@ function createPanelStateStore(): StoreApi<PanelStateStore> {
       sequenceNumbers: {},
       settingsTrees: {},
       sharedPanelState: {},
+      defaultTitles: {},
 
       incrementSequenceNumber: (panelId: string) => {
         set((state) => {
@@ -47,6 +48,10 @@ function createPanelStateStore(): StoreApi<PanelStateStore> {
             [panelId]: settingsTree,
           },
         }));
+      },
+
+      updateDefaultTitle: (panelId, defaultTitle) => {
+        set((state) => ({ defaultTitles: { ...state.defaultTitles, [panelId]: defaultTitle } }));
       },
 
       updateSharedPanelState: (type: string, data: SharedPanelState) => {
@@ -88,6 +93,7 @@ export function usePanelSettingsTreeUpdate(): (newTree: ImmutableSettingsTree) =
 }
 
 const updateSharedDataSelector = (store: PanelStateStore) => store.updateSharedPanelState;
+const updateDefaultTitleSelector = (store: PanelStateStore) => store.updateDefaultTitle;
 
 /**
  * Returns a [state, setState] pair that can be used to read and update shared transient
@@ -117,6 +123,29 @@ export function useSharedPanelState(): [
   );
 
   return [sharedData, update];
+}
+
+/**
+ * Returns a [state, setState] pair that can be used to read and update a panel's default title.
+ */
+export function useDefaultPanelTitle(): [
+  string | undefined,
+  (defaultTitle: string | undefined) => void,
+] {
+  const panelId = usePanelContext().id;
+
+  const selector = useCallback((store: PanelStateStore) => store.defaultTitles[panelId], [panelId]);
+
+  const updateDefaultTitle = usePanelStateStore(updateDefaultTitleSelector);
+  const defaultTitle = usePanelStateStore(selector);
+  const update = useCallback(
+    (newValue: string | undefined) => {
+      updateDefaultTitle(panelId, newValue);
+    },
+    [panelId, updateDefaultTitle],
+  );
+
+  return [defaultTitle, update];
 }
 
 /**

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -40,6 +40,9 @@ import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 
 const log = Logger.getLogger(__filename);
 
+/** Key injected into panel configs for user-selected title (overrides setDefaultPanelTitle) */
+export const PANEL_TITLE_CONFIG_KEY = "foxglovePanelTitle";
+
 // given a panel type, create a unique id for a panel
 // with the type embedded within the id
 // we need this because react-mosaic

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -362,6 +362,12 @@ declare module "@foxglove/studio" {
      * the representation of the panel settings in the editor.
      */
     updatePanelSettingsEditor(settings: Readonly<SettingsTree>): void;
+
+    /**
+     * Updates the panel's default title. Users can always override the default title by editing it
+     * manually. A value of `undefined` will display the panel's name in the title bar.
+     */
+    setDefaultPanelTitle(defaultTitle: string | undefined): void;
   };
 
   export type ExtensionPanelRegistration = {


### PR DESCRIPTION
**User-Facing Changes**
- Added `setDefaultPanelTitle()` to `PanelExtensionContext` API
- Added ability to edit the title of most panels in panel settings.

**Description**
- Adds `setDefaultPanelTitle` for panel to override its default title (e.g. based on configured message path)
- Inject a text field in settings sidebar to edit a hard-coded settings key, `foxglovePanelTitle` for a custom title override
- Use the overridden title if set, otherwise the default title if set, otherwise fall back to the panel name (as we already do today)

Resolves https://linear.app/foxglove/issue/FG-1488/allow-user-to-rename-any-panel

https://user-images.githubusercontent.com/14237/214679560-350d5fbe-4687-4aeb-8458-1bd2ea012694.mov
