### PR TITLE
Remove settings icon for transforms

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -130,7 +130,6 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
     const children: SettingsTreeChildren = {
       settings: {
         label: "Settings",
-        icon: "Settings",
         defaultExpansionState: "collapsed",
         order: 0,
         fields: {


### PR DESCRIPTION
**User-Facing Changes**
Remove cog icon for 3d panel transforms - no other entries in this sidebar have it.