### PR TITLE
Improve plot panel settings API integration

### DIFF
--- a/packages/studio-base/src/panels/Plot/NewPlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegend.stories.tsx
@@ -23,8 +23,16 @@ export default {
   decorators: [Wrapper],
 };
 
+const labeledPaths = paths.map((path, index) => {
+  if (index % 2 === 0) {
+    return path;
+  } else {
+    return { ...path, label: `Label ${index}` };
+  }
+});
+
 const exampleConfig: PlotConfig = {
-  paths,
+  paths: labeledPaths,
   xAxisVal: "timestamp",
   showLegend: true,
   isSynced: true,

--- a/packages/studio-base/src/panels/Plot/NewPlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegend.tsx
@@ -2,14 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import ArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import ArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
-import ArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
-import ArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
-import ListIcon from "@mui/icons-material/List";
-import { SvgIconProps, ToggleButton } from "@mui/material";
 import { clamp } from "lodash";
-import { ComponentProps, useCallback, useMemo, useRef } from "react";
+import { ComponentProps, useCallback, useRef } from "react";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
@@ -108,7 +102,7 @@ const useStyles = makeStyles<StyleProps, "container" | "toggleButton">()(
       alignItems: "center",
       overflow: "auto",
       display: "grid",
-      gridTemplateColumns: "auto minmax(max-content, 1fr) 1fr auto",
+      gridTemplateColumns: "auto minmax(max-content, 1fr) 1fr",
     },
     dragHandle: {
       userSelect: "none",
@@ -139,26 +133,6 @@ export function NewPlotLegend(props: Props): JSX.Element {
     showPlotValuesInLegend,
   } = props;
   const { classes, cx } = useStyles({ legendDisplay, sidebarDimension });
-
-  const toggleLegend = useCallback(
-    () => saveConfig({ showLegend: !showLegend }),
-    [showLegend, saveConfig],
-  );
-
-  const toggleIcon = useMemo(() => {
-    const iconProps = {
-      fontSize: "inherit",
-    } as Partial<SvgIconProps>;
-
-    switch (legendDisplay) {
-      case "floating":
-        return <ListIcon {...iconProps} />;
-      case "left":
-        return showLegend ? <ArrowLeftIcon {...iconProps} /> : <ArrowRightIcon {...iconProps} />;
-      case "top":
-        return showLegend ? <ArrowUpIcon {...iconProps} /> : <ArrowDownIcon {...iconProps} />;
-    }
-  }, [legendDisplay, showLegend]);
 
   const dragStart = useRef({ x: 0, y: 0, sidebarDimension: 0 });
 
@@ -208,82 +182,66 @@ export function NewPlotLegend(props: Props): JSX.Element {
         [classes.rootTop]: legendDisplay === "top",
       })}
     >
-      <Stack
-        direction={legendDisplay === "top" ? "column" : "row"}
-        alignItems={legendDisplay === "floating" ? "flex-start" : undefined}
-        gap={0.5}
-        fullHeight
-      >
-        <ToggleButton
-          className={classes.toggleButton}
-          aria-label={showLegend ? "Show legend" : "Hide legend"}
-          value={showLegend ? "show" : "hide"}
-          onClick={toggleLegend}
-          size="small"
+      {showLegend && (
+        <Stack
+          flexGrow={1}
+          gap={0.5}
+          overflow="auto"
+          fullHeight={legendDisplay === "floating"}
+          style={{
+            height: legendDisplay === "top" ? Math.round(sidebarDimension) : undefined,
+            width: legendDisplay === "left" ? Math.round(sidebarDimension) : undefined,
+          }}
         >
-          {toggleIcon}
-        </ToggleButton>
-        {showLegend && (
           <Stack
-            flexGrow={1}
-            gap={0.5}
-            overflow="auto"
+            flex="auto"
+            fullWidth
             fullHeight={legendDisplay === "floating"}
-            style={{
-              height: legendDisplay === "top" ? Math.round(sidebarDimension) : undefined,
-              width: legendDisplay === "left" ? Math.round(sidebarDimension) : undefined,
-            }}
+            overflow={legendDisplay === "floating" ? "auto" : undefined}
           >
-            <Stack
-              flex="auto"
-              fullWidth
-              fullHeight={legendDisplay === "floating"}
-              overflow={legendDisplay === "floating" ? "auto" : undefined}
-            >
-              <div className={classes.container}>
-                {paths.map((path, index) => (
-                  <NewPlotLegendRow
-                    key={index}
-                    index={index}
-                    path={path}
-                    paths={paths}
-                    hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
-                    datasets={datasets}
-                    currentTime={currentTime}
-                    savePaths={savePaths}
-                    showPlotValuesInLegend={showPlotValuesInLegend}
-                  />
-                ))}
-              </div>
-            </Stack>
+            <div className={classes.container}>
+              {paths.map((path, index) => (
+                <NewPlotLegendRow
+                  key={index}
+                  index={index}
+                  path={path}
+                  paths={paths}
+                  hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}
+                  datasets={datasets}
+                  currentTime={currentTime}
+                  savePaths={savePaths}
+                  showPlotValuesInLegend={showPlotValuesInLegend}
+                />
+              ))}
+            </div>
           </Stack>
-        )}
-        {legendDisplay !== "floating" && (
-          <div
-            className={classes.dragHandle}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
-            style={
-              legendDisplay === "left"
-                ? {
-                    marginLeft: -6,
-                    cursor: "ew-resize",
-                    borderRightWidth: 2,
-                    height: "100%",
-                    width: 4,
-                  }
-                : {
-                    marginTop: -6,
-                    cursor: "ns-resize",
-                    borderBottomWidth: 2,
-                    width: "100%",
-                    height: 4,
-                  }
-            }
-          />
-        )}
-      </Stack>
+        </Stack>
+      )}
+      {legendDisplay !== "floating" && (
+        <div
+          className={classes.dragHandle}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          style={
+            legendDisplay === "left"
+              ? {
+                  marginLeft: -6,
+                  cursor: "ew-resize",
+                  borderRightWidth: 2,
+                  height: "100%",
+                  width: 4,
+                }
+              : {
+                  marginTop: -6,
+                  cursor: "ns-resize",
+                  borderBottomWidth: 2,
+                  width: "100%",
+                  height: 4,
+                }
+          }
+        />
+      )}
     </div>
   );
 }

--- a/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
@@ -5,7 +5,6 @@
 import CircleIcon from "@mui/icons-material/Circle";
 import CircleOutlinedIcon from "@mui/icons-material/CircleOutlined";
 import CircleTwoToneIcon from "@mui/icons-material/CircleTwoTone";
-import CloseIcon from "@mui/icons-material/Close";
 import ErrorIcon from "@mui/icons-material/Error";
 import { IconButton, Tooltip, Typography } from "@mui/material";
 import { ComponentProps, useMemo, useState } from "react";
@@ -32,11 +31,23 @@ type PlotLegendRowProps = {
   showPlotValuesInLegend: boolean;
 };
 
+/**
+ * Coalesces null, undefined and empty string to undefined.
+ */
+function presence<T>(value: undefined | T): undefined | T {
+  if (value === "") {
+    return undefined;
+  }
+
+  return value == undefined ? undefined : value;
+}
+
 const ROW_HEIGHT = 28;
 
 const useStyles = makeStyles<void, "plotName">()((theme, _params, classes) => ({
   root: {
     display: "contents",
+    cursor: "pointer",
 
     "&:hover, &:focus-within": {
       "& > *:last-child": {
@@ -70,6 +81,9 @@ const useStyles = makeStyles<void, "plotName">()((theme, _params, classes) => ({
     marginLeft: theme.spacing(0.125),
     fontSize: theme.typography.pxToRem(14),
   },
+  disabledPathLabel: {
+    opacity: 0.5,
+  },
   plotName: {
     display: "flex",
     alignItems: "center",
@@ -82,29 +96,6 @@ const useStyles = makeStyles<void, "plotName">()((theme, _params, classes) => ({
     alignItems: "center",
     height: ROW_HEIGHT,
     padding: theme.spacing(0.25),
-  },
-  actionButton: {
-    padding: `${theme.spacing(0.25)} !important`,
-    color: theme.palette.text.secondary,
-
-    "&:hover": {
-      color: theme.palette.text.primary,
-    },
-  },
-  actions: {
-    height: ROW_HEIGHT,
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
-    gap: theme.spacing(0.25),
-    padding: theme.spacing(0.25),
-    position: "sticky",
-    right: 0,
-    opacity: 0,
-
-    "&:hover": {
-      opacity: 1,
-    },
   },
 }));
 
@@ -198,8 +189,13 @@ export function NewPlotLegendRow({
         className={classes.plotName}
         style={{ gridColumn: !showPlotValuesInLegend ? "span 2" : undefined }}
       >
-        <Typography noWrap={true} flex="auto" variant="subtitle2">
-          {path.label ?? `Series ${index + 1}`}
+        <Typography
+          noWrap={true}
+          flex="auto"
+          variant="subtitle2"
+          className={cx({ [classes.disabledPathLabel]: !path.enabled })}
+        >
+          {presence(path.label) ?? presence(path.value) ?? `Series ${index + 1}`}
         </Typography>
         {hasMismatchedDataLength && (
           <Tooltip
@@ -222,20 +218,6 @@ export function NewPlotLegendRow({
           </Typography>
         </div>
       )}
-      <div className={classes.actions}>
-        <IconButton
-          className={classes.actionButton}
-          size="small"
-          title={`Remove ${path.value}`}
-          onClick={() => {
-            const newPaths = paths.slice();
-            newPaths.splice(index, 1);
-            savePaths(newPaths);
-          }}
-        >
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </div>
     </div>
   );
 }

--- a/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
@@ -16,6 +16,7 @@ import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useHoverValue } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { plotPathDisplayName } from "@foxglove/studio-base/panels/Plot/types";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 
 import { PlotPath } from "./internalTypes";
@@ -30,17 +31,6 @@ type PlotLegendRowProps = {
   savePaths: (paths: PlotPath[]) => void;
   showPlotValuesInLegend: boolean;
 };
-
-/**
- * Coalesces null, undefined and empty string to undefined.
- */
-function presence<T>(value: undefined | T): undefined | T {
-  if (value === "") {
-    return undefined;
-  }
-
-  return value == undefined ? undefined : value;
-}
 
 const ROW_HEIGHT = 28;
 
@@ -195,7 +185,7 @@ export function NewPlotLegendRow({
           variant="subtitle2"
           className={cx({ [classes.disabledPathLabel]: !path.enabled })}
         >
-          {presence(path.label) ?? presence(path.value) ?? `Series ${index + 1}`}
+          {plotPathDisplayName(path, index)}
         </Typography>
         {hasMismatchedDataLength && (
           <Tooltip

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -15,12 +15,12 @@ import { usePanelSettingsTreeUpdate } from "@foxglove/studio-base/providers/Pane
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { lineColors } from "@foxglove/studio-base/util/plotColors";
 
-import { plotableRosTypes, PlotConfig } from "./types";
+import { plotableRosTypes, PlotConfig, plotPathDisplayName } from "./types";
 
 const makeSeriesNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNode => {
   return {
     actions: [{ type: "action", id: "delete-series", label: "Delete" }],
-    label: path.label ?? `Series ${index + 1}`,
+    label: plotPathDisplayName(path, index),
     visible: path.enabled,
     fields: {
       label: {

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -21,9 +21,13 @@ const makeSeriesNode = memoizeWeak((path: PlotPath, index: number): SettingsTree
   return {
     actions: [{ type: "action", id: "delete-series", label: "Delete" }],
     label: path.label ?? `Series ${index + 1}`,
-    renamable: true,
     visible: path.enabled,
     fields: {
+      label: {
+        input: "string",
+        label: "Label",
+        value: path.label,
+      },
       value: {
         input: "messagepath",
         label: "Path",
@@ -93,8 +97,13 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
             { value: "top", label: "Top" },
           ],
         },
+        showLegend: {
+          label: "Show legend",
+          input: "boolean",
+          value: config.showLegend,
+        },
         showPlotValuesInLegend: {
-          label: "Show plot values",
+          label: "Show values",
           input: "boolean",
           value: config.showPlotValuesInLegend,
         },

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -11,6 +11,21 @@ export type PlotXAxisVal =
   | "custom" // Message path data. Preloaded.
   | "currentCustom"; // Message path data. One "current" message at playback time.
 
+/**
+ * Coalesces null, undefined and empty string to undefined.
+ */
+function presence<T>(value: undefined | T): undefined | T {
+  if (value === "") {
+    return undefined;
+  }
+
+  return value == undefined ? undefined : value;
+}
+
+export function plotPathDisplayName(path: Readonly<PlotPath>, index: number): string {
+  return presence(path.label) ?? presence(path.value) ?? `Series ${index + 1}`;
+}
+
 type DeprecatedPlotConfig = {
   showSidebar?: boolean;
   sidebarWidth?: number;


### PR DESCRIPTION
**User-Facing Changes**
This improves the existing integration of the plot panel and the settings API.

**Description**
This makes the following changes to the plot panel's use of the settings API:

* Add Label to series, default to empty string, if empty use Path as label
* Remove existing "Rename" pencil icon from series settings
* Remove legend series X
* Make the series name grey in the legend when hidden
* Remove legend hamburger menu and adds a separate `Show legend` toggle setting.
* Rename Show plot values to Show values 

Note that I have opted to make `Show legend` a separate boolean instead of a new `None` option in the position setting because this maps directly to the existing plot panel config schema and allows us to seamlessly switch back and forth between the existing UI and the new experimental UI without any conversion or migration.

<img width="382" alt="Screenshot 2023-01-26 at 9 01 07 AM" src="https://user-images.githubusercontent.com/93935560/214741070-b676d6a1-89f3-4cd2-aa7f-c66a0e64294a.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
