### PR TITLE
Update local file help text

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
+++ b/packages/studio-base/src/components/OpenDialog/OpenDialog.tsx
@@ -108,14 +108,7 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
     });
   }, [availableSources]);
 
-  const localFileSources = useMemo(() => {
-    return availableSources.filter((source) => source.type === "file");
-  }, [availableSources]);
-
   const view = useMemo(() => {
-    const supportedLocalFileTypes = localFileSources.flatMap(
-      (source) => source.supportedFileTypes ?? [],
-    );
     switch (activeView) {
       case "demo": {
         return {
@@ -138,22 +131,10 @@ export default function OpenDialog(props: OpenDialogProps): JSX.Element {
       default:
         return {
           title: "Get started",
-          component: (
-            <Start
-              onSelectView={onSelectView}
-              supportedLocalFileExtensions={supportedLocalFileTypes}
-            />
-          ),
+          component: <Start onSelectView={onSelectView} />,
         };
     }
-  }, [
-    activeDataSource,
-    activeView,
-    connectionSources,
-    localFileSources,
-    onModalClose,
-    onSelectView,
-  ]);
+  }, [activeDataSource, activeView, connectionSources, onModalClose, onSelectView]);
 
   return (
     <Dialog

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -18,7 +18,6 @@ import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { OpenDialogViews } from "./types";
 
 export type IStartProps = {
-  supportedLocalFileExtensions?: string[];
   onSelectView: (newValue: OpenDialogViews) => void;
 };
 
@@ -410,21 +409,17 @@ function SidebarItems(props: { onSelectView: (newValue: OpenDialogViews) => void
 }
 
 export default function Start(props: IStartProps): JSX.Element {
-  const { supportedLocalFileExtensions = [], onSelectView } = props;
+  const { onSelectView } = props;
   const { recentSources, selectRecent } = usePlayerSelection();
   const { classes } = useStyles();
   const analytics = useAnalytics();
 
   const startItems = useMemo(() => {
-    const formatter = new Intl.ListFormat("en-US", { style: "long" });
-    const supportedLocalFiles = formatter.format(
-      Array.from(new Set(supportedLocalFileExtensions)).sort(),
-    );
     return [
       {
         key: "open-local-file",
         text: "Open local file",
-        secondaryText: `Supports ${supportedLocalFiles} files.`,
+        secondaryText: "Visualize directly from your local filesystem.",
         icon: (
           <SvgIcon fontSize="large" color="primary" viewBox="0 0 2048 2048">
             <path d="M1955 1533l-163-162v677h-128v-677l-163 162-90-90 317-317 317 317-90 90zM256 1920h1280v128H128V0h1115l549 549v475h-128V640h-512V128H256v1792zM1280 512h293l-293-293v293z" />
@@ -465,7 +460,7 @@ export default function Start(props: IStartProps): JSX.Element {
         },
       },
     ];
-  }, [analytics, onSelectView, supportedLocalFileExtensions]);
+  }, [analytics, onSelectView]);
 
   return (
     <Stack className={classes.grid}>

--- a/packages/studio-base/src/components/OpenDialog/Start.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Start.tsx
@@ -419,7 +419,7 @@ export default function Start(props: IStartProps): JSX.Element {
       {
         key: "open-local-file",
         text: "Open local file",
-        secondaryText: "Visualize directly from your local filesystem.",
+        secondaryText: "Visualize data directly from your local filesystem.",
         icon: (
           <SvgIcon fontSize="large" color="primary" viewBox="0 0 2048 2048">
             <path d="M1955 1533l-163-162v677h-128v-677l-163 162-90-90 317-317 317 317-90 90zM256 1920h1280v128H128V0h1115l549 549v475h-128V640h-512V128H256v1792zM1280 512h293l-293-293v293z" />


### PR DESCRIPTION
**User-Facing Changes**
Update text below `Open local file` in welcome dialog.

<img width="599" alt="image" src="https://user-images.githubusercontent.com/637671/214757542-b5b2267f-8796-47a4-9a14-0dcfb5fb855f.png">


**Description**
We had some feedback from users that they were confused whether `Open local file` would upload the file to Foxglove. This is an attempt at improving the text to reassure folks.

FG-989