### PR TITLE
Support inline actions on settings nodes

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -7,15 +7,24 @@ import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import ErrorIcon from "@mui/icons-material/Error";
-import { Divider, IconButton, TextField, Tooltip, Typography, useTheme } from "@mui/material";
+import {
+  Button,
+  Divider,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import { partition } from "lodash";
 import memoizeWeak from "memoize-weak";
-import { ChangeEvent, useCallback } from "react";
+import { ChangeEvent, useCallback, useMemo } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 import { useImmer } from "use-immer";
 
 import { filterMap } from "@foxglove/den/collection";
-import { SettingsTreeAction, SettingsTreeNode } from "@foxglove/studio";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodeActionItem } from "@foxglove/studio";
 import { HighlightedText } from "@foxglove/studio-base/components/HighlightedText";
 import Stack from "@foxglove/studio-base/components/Stack";
 
@@ -266,6 +275,16 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     [toggleEditing],
   );
 
+  const [inlineActions, menuActions] = useMemo(
+    () =>
+      partition(
+        settings.actions,
+        (action): action is SettingsTreeNodeActionItem =>
+          action.type === "action" && action.display === "inline",
+      ),
+    [settings.actions],
+  );
+
   return (
     <>
       <div className={cx(classes.nodeHeader, { [classes.nodeHeaderVisible]: visible })}>
@@ -353,6 +372,23 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               disabled={!allowVisibilityToggle}
             />
           )}
+          {inlineActions.map((action) => {
+            const Icon = action.icon ? icons[action.icon] : undefined;
+            const handler = () =>
+              actionHandler({
+                action: "perform-node-action",
+                payload: { id: action.id, path: props.path },
+              });
+            return Icon ? (
+              <IconButton key={action.id} onClick={handler} title={action.label}>
+                <Icon fontSize="small" />
+              </IconButton>
+            ) : (
+              <Button key={action.id} onClick={handler} size="small" color="inherit">
+                {action.label}
+              </Button>
+            );
+          })}
           {props.settings?.error && (
             <Tooltip
               arrow
@@ -367,8 +403,9 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               </IconButton>
             </Tooltip>
           )}
-          {settings.actions && (
-            <NodeActionsMenu actions={settings.actions} onSelectAction={handleNodeAction} />
+
+          {menuActions.length > 0 && (
+            <NodeActionsMenu actions={menuActions} onSelectAction={handleNodeAction} />
           )}
         </Stack>
       </div>

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -45,7 +45,7 @@ export type NodeEditorProps = {
 export const NODE_HEADER_MIN_HEIGHT = 35;
 
 const useStyles = makeStyles()((theme) => ({
-  editButton: {
+  actionButton: {
     padding: theme.spacing(0.5),
   },
   editNameField: {
@@ -322,7 +322,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
               InputProps={{
                 endAdornment: (
                   <IconButton
-                    className={classes.editButton}
+                    className={classes.actionButton}
                     title="Rename"
                     data-node-function="edit-label"
                     color="primary"
@@ -351,7 +351,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
         <Stack alignItems="center" direction="row">
           {settings.renamable === true && !state.editing && (
             <IconButton
-              className={classes.editButton}
+              className={classes.actionButton}
               title="Rename"
               data-node-function="edit-label"
               color="primary"
@@ -380,11 +380,22 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
                 payload: { id: action.id, path: props.path },
               });
             return Icon ? (
-              <IconButton key={action.id} onClick={handler} title={action.label}>
+              <IconButton
+                key={action.id}
+                onClick={handler}
+                title={action.label}
+                className={classes.actionButton}
+              >
                 <Icon fontSize="small" />
               </IconButton>
             ) : (
-              <Button key={action.id} onClick={handler} size="small" color="inherit">
+              <Button
+                key={action.id}
+                onClick={handler}
+                size="small"
+                color="inherit"
+                className={classes.actionButton}
+              >
                 {action.label}
               </Button>
             );

--- a/packages/studio-base/src/components/SettingsTreeEditor/icons.ts
+++ b/packages/studio-base/src/components/SettingsTreeEditor/icons.ts
@@ -4,9 +4,11 @@
 
 import Clock from "@mui/icons-material/AccessTime";
 import Add from "@mui/icons-material/Add";
+import Addchart from "@mui/icons-material/Addchart";
 import Points from "@mui/icons-material/BlurOn";
 import Check from "@mui/icons-material/Check";
 import Circle from "@mui/icons-material/Circle";
+import Clear from "@mui/icons-material/Clear";
 import Delete from "@mui/icons-material/Delete";
 import Walk from "@mui/icons-material/DirectionsWalk";
 import Flag from "@mui/icons-material/Flag";
@@ -43,11 +45,13 @@ import { SettingsIcon } from "@foxglove/studio";
 
 const icons: Record<SettingsIcon, typeof Add> = {
   Add,
+  Addchart,
   Background,
   Camera,
   Cells,
   Check,
   Circle,
+  Clear,
   Clock,
   Collapse,
   Cube,

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -449,6 +449,14 @@ const IconExamplesSettings: SettingsTreeNodes = {
   grid: {
     label: "Grid",
     icon: "Grid",
+    error: "Also an error!",
+    visible: true,
+    actions: [
+      { type: "action", id: "action1", label: "Action 1", display: "inline", icon: "Camera" },
+      { type: "action", id: "action2", label: "Action 2", display: "inline", icon: "Clock" },
+      { type: "action", id: "action3", label: "Action 3", display: "inline" },
+      { type: "action", id: "action4", label: "Action 4", display: "menu" },
+    ],
     fields: {
       color: {
         label: "Color",

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -19,7 +19,15 @@ import { plotableRosTypes, PlotConfig, plotPathDisplayName } from "./types";
 
 const makeSeriesNode = memoizeWeak((path: PlotPath, index: number): SettingsTreeNode => {
   return {
-    actions: [{ type: "action", id: "delete-series", label: "Delete" }],
+    actions: [
+      {
+        type: "action",
+        id: "delete-series",
+        label: "Delete series",
+        display: "inline",
+        icon: "Clear",
+      },
+    ],
     label: plotPathDisplayName(path, index),
     visible: path.enabled,
     fields: {
@@ -59,7 +67,15 @@ const makeRootSeriesNode = memoizeWeak((paths: PlotPath[]): SettingsTreeNode => 
   return {
     label: "Series",
     children,
-    actions: [{ type: "action", id: "add-series", label: "Add series" }],
+    actions: [
+      {
+        type: "action",
+        id: "add-series",
+        label: "Add series",
+        display: "inline",
+        icon: "Addchart",
+      },
+    ],
   };
 });
 

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -412,11 +412,13 @@ declare module "@foxglove/studio" {
 
   export type SettingsIcon =
     | "Add"
+    | "Addchart"
     | "Background"
     | "Camera"
     | "Cells"
     | "Check"
     | "Circle"
+    | "Clear"
     | "Clock"
     | "Collapse"
     | "Cube"

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -591,6 +591,13 @@ declare module "@foxglove/studio" {
      * Optional icon to display with the action.
      */
     icon?: SettingsIcon;
+
+    /**
+     * Specifies whether the item is rendered as an inline action or as an item in the
+     * context menu. Defaults to "menu" if not specified. Inline items will be rendered
+     * as an icon only if their icon is specified.
+     */
+    display?: "menu" | "inline";
   };
 
   export type SettingsTreeNodeActionDivider = { type: "divider" };


### PR DESCRIPTION
**User-Facing Changes**
Make it possible for panel authors to request that node actions be rendered inline instead of in the context menu.

**Description**
Expands the `SettingsTreeNodeActionItem` to include an optional `display` property, which can be set to `inline` or `menu`. If `inline` it will be rendered inline alongside the node label instead of in the context menu. This should make frequently used actions more efficient and discoverable.

https://user-images.githubusercontent.com/93935560/215614093-e5ab70f4-efbd-4b67-a597-45f468c9ea8a.mov

Some open questions:
1. Should these always be shown or only on hover?
2. Should we render them in the primary color?

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
