### PR TITLE
Foxglove websocket: Fix error when server sends invalid `serverInfo` message

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -189,7 +189,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (!Array.isArray(event.capabilities)) {
         this._problems.addProblem("ws:invalid-capabilities", {
           severity: "warn",
-          message: `Server capabilities communicated by server must be an array (server sent '${event.capabilities}')`,
+          message: `Server sent an invalid or missing capabilities field: '${event.capabilities}'`,
         });
       }
       this._name = `${this._url}\n${event.name}`;

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -186,9 +186,15 @@ export default class FoxgloveWebSocketPlayer implements Player {
     });
 
     this._client.on("serverInfo", (event) => {
+      if (!Array.isArray(event.capabilities)) {
+        this._problems.addProblem("ws:invalid-capabilities", {
+          severity: "warn",
+          message: `Server capabilities communicated by server must be an array (server sent '${event.capabilities}')`,
+        });
+      }
       this._name = `${this._url}\n${event.name}`;
-      this._serverCapabilities = event.capabilities;
-      this._serverPublishesTime = event.capabilities.includes(ServerCapability.time);
+      this._serverCapabilities = Array.isArray(event.capabilities) ? event.capabilities : [];
+      this._serverPublishesTime = this._serverCapabilities.includes(ServerCapability.time);
       this._supportedEncodings = event.supportedEncodings;
       this._datatypes = new Map();
 


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Fix error when server sends invalid `serverInfo` message

**Description**
This PR handles the special case when the server sends a [serverInfo](https://github.com/foxglove/ws-protocol/blob/e2ad9af97694d00bbd50dc2aba91740e486f5c9b/docs/spec.md#server-info) message with `capabilities` being `null` or `undefined` (or anything else that is not an array).  