### PR TITLE
fix: Update Renderable name when reusing it

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/MarkerPool.ts
@@ -8,7 +8,7 @@ import { RenderableCubeList } from "./RenderableCubeList";
 import { RenderableCylinder } from "./RenderableCylinder";
 import { RenderableLineList } from "./RenderableLineList";
 import { RenderableLineStrip } from "./RenderableLineStrip";
-import { RenderableMarker } from "./RenderableMarker";
+import { RenderableMarker, getMarkerId } from "./RenderableMarker";
 import { RenderableMeshResource } from "./RenderableMeshResource";
 import { RenderablePoints } from "./RenderablePoints";
 import { RenderableSphere } from "./RenderableSphere";
@@ -54,6 +54,7 @@ export class MarkerPool {
         renderable.userData.settingsPath = ["topics", topic];
         renderable.userData.settings = { visible: true, frameLocked: marker.frame_locked };
         renderable.userData.topic = topic;
+        renderable.name = getMarkerId(topic, marker.ns, marker.id);
         renderable.update(marker, receiveTime);
         return renderable;
       }


### PR DESCRIPTION
Fixes the mismatch between the name of the renderable and the marker data