### PR TITLE
Remove unnecessary Image Panel preloading

### DIFF
--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -98,7 +98,7 @@ export function ImageView({ context }: Props): JSX.Element {
     if (cameraInfoTopic != undefined) {
       subs.push(cameraInfoTopic);
     }
-    return subs;
+    return subs.map((topic) => ({ topic, preload: false }));
   }, [cameraTopic, cameraInfoTopic, enabledMarkerTopics]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light">("light");

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -92,6 +92,7 @@ export class BlockLoader {
     this.abortController.abort();
     this.topics = topics;
     this.activeChangeCondvar.notifyAll();
+    log.debug(`Preloaded topics: ${[...topics].join(", ")}`);
 
     // Update all the blocks with any missing topics
     for (const block of this.blocks) {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- remove unnecessary preloaded image topics

**Description**
- remove unnecessary preloaded image topics
- add debug log to show what topics are being preloaded



<!-- link relevant GitHub issues -->
FG-1698
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
