### PR TITLE
foxglove websocket: Add callService capability

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -57,7 +57,7 @@
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",
-    "@foxglove/ws-protocol": "0.3.3",
+    "@foxglove/ws-protocol": "0.4.0",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "0.3.0",
     "@mdi/svg": "7.1.96",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -57,7 +57,7 @@
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",
-    "@foxglove/ws-protocol": "0.4.0",
+    "@foxglove/ws-protocol": "0.4.1",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "0.3.0",
     "@mdi/svg": "7.1.96",

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -38,6 +38,10 @@ import {
   FoxgloveClient,
   ServerCapability,
   SubscriptionId,
+  Service,
+  ServiceCallPayload,
+  ServiceCallRequest,
+  ServiceCallResponse,
 } from "@foxglove/ws-protocol";
 
 import WorkerSocketAdapter from "./WorkerSocketAdapter";
@@ -53,6 +57,8 @@ const GET_ALL_PARAMS_PERIOD_MS = 15000;
 const ROS_ENCODINGS = ["ros1", "cdr"];
 const SUPPORTED_PUBLICATION_ENCODINGS = ["json", ...ROS_ENCODINGS];
 const FALLBACK_PUBLICATION_ENCODING = "json";
+const SUPPORTED_SERVICE_ENCODINGS = ["json", ...ROS_ENCODINGS];
+const FALLBACK_SERVICE_ENCODING = "json";
 
 type ResolvedChannel = { channel: Channel; parsedChannel: ParsedChannel };
 type Publication = ClientChannel & { messageWriter?: Ros1MessageWriter | Ros2MessageWriter };
@@ -100,6 +106,12 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _getParameterInterval?: ReturnType<typeof setInterval>;
   private _unresolvedPublications: AdvertiseOptions[] = [];
   private _publicationsByTopic = new Map<string, Publication>();
+  private _services = new Map<string, Set<string>>();
+  private _servicesByName = new Map<string, Service>();
+  private _serviceResponseCbs = new Map<
+    ServiceCallRequest["callId"],
+    (response: ServiceCallResponse) => void
+  >();
 
   public constructor({
     url,
@@ -144,6 +156,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._channelsById.clear();
       this._channelsByTopic.clear();
       this._setupPublishers();
+      this._services.clear();
+      this._servicesByName.clear();
+      this._serviceResponseCbs.clear();
       this._profile = undefined;
     });
 
@@ -210,8 +225,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
         const rosDataTypes = isRos1
           ? CommonRosTypes.ros1
           : ["foxy", "galactic"].includes(rosDistro)
-          ? CommonRosTypes.ros2galactic
-          : CommonRosTypes.ros2humble;
+            ? CommonRosTypes.ros2galactic
+            : CommonRosTypes.ros2humble;
 
         for (const dataType in rosDataTypes) {
           const msgDef = (rosDataTypes as Record<string, RosMsgDefinition>)[dataType]!;
@@ -222,6 +237,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
         this._playerCapabilities.push(PlayerCapabilities.advertise);
+      }
+      if (event.capabilities.includes(ServerCapability.services)) {
+        this._playerCapabilities.push(PlayerCapabilities.callServices);
       }
 
       if (event.capabilities.includes(ServerCapability.parameters)) {
@@ -418,6 +436,27 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._client?.subscribeParameterUpdates(newParameters.map((p) => p.name));
       }
     });
+
+    this._client.on("advertiseServices", (services) => {
+      for (const service of services) {
+        this._servicesByName.set(service.name, service);
+        this._services.set(service.name, new Set([service.name]));
+      }
+      this._emitState();
+    });
+
+    this._client.on("serviceCallResponse", (response) => {
+      const responseCallback = this._serviceResponseCbs.get(response.callId);
+      if (!responseCallback) {
+        this._problems.addProblem(`callService:${response.callId}`, {
+          severity: "error",
+          message: `Received a response for a service for which no callback was registered`,
+        });
+        return;
+      }
+      responseCallback(response);
+      this._serviceResponseCbs.delete(response.callId);
+    });
   };
 
   private _updateTopicsAndDatatypes() {
@@ -506,6 +545,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         topicStats: new Map(this._topicsStats),
         datatypes: _datatypes,
         parameters: new Map(this._parameters),
+        services: new Map(this._services),
       },
     });
   });
@@ -627,11 +667,103 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
   }
 
-  public async callService(): Promise<unknown> {
-    throw new Error("Service calls are not supported by the Foxglove WebSocket connection");
+  public async callService(serviceName: string, request: unknown): Promise<unknown> {
+    if (!this._client) {
+      throw new Error(
+        `Attempted to call service ${serviceName} without a valid Foxglove WebSocket connection.`,
+      );
+    }
+
+    if (request == undefined || typeof request !== "object") {
+      throw new Error("FoxgloveWebSocketPlayer#callService request must be an object.");
+    }
+
+    const service = this._servicesByName.get(serviceName);
+    if (!service) {
+      throw new Error(
+        `Tried to call service '${serviceName}' that has not been advertised before.`,
+      );
+    }
+
+    const encoding = this._supportedEncodings
+      ? this._supportedEncodings.find((e) => SUPPORTED_SERVICE_ENCODINGS.includes(e))
+      : FALLBACK_SERVICE_ENCODING;
+    if (!encoding) {
+      throw new Error(`Can not call service '${serviceName}': No supported encoding.`);
+    }
+
+    const serviceCallRequest: ServiceCallPayload = {
+      serviceId: service.id,
+      callId: Date.now(),
+      encoding,
+      data: new DataView(new Uint8Array().buffer),
+    };
+
+    if (encoding === "json") {
+      const message = new Uint8Array(Buffer.from(JSON.stringify(request) ?? ""));
+      serviceCallRequest.data = new DataView(message.buffer);
+    } else if (ROS_ENCODINGS.includes(encoding)) {
+      try {
+        const datatypes: RosDatatypes = new Map();
+        const msgdef = rosDatatypesToMessageDefinition(datatypes, service.requestSchema);
+        const messageWriter =
+          encoding === "ros1" ? new Ros1MessageWriter(msgdef) : new Ros2MessageWriter(msgdef);
+        const message = messageWriter.writeMessage(request);
+        serviceCallRequest.data = new DataView(message);
+      } catch (error) {
+        log.debug(error);
+        this._problems.addProblem(`serviceCall:msgdef:${service.name}`, {
+          severity: "error",
+          message: `Unknown message definition for "${service.name}"`,
+          tip: `Try subscribing to the topic "${service.name}" before publishing to it`,
+        });
+      }
+    } else {
+      throw new Error(`Failed to encode service call request for service '${serviceName}'.`);
+    }
+    this._client.sendCallServiceRequest(serviceCallRequest);
+
+    return await new Promise<Record<string, unknown>>((resolve, reject) => {
+      this._serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {
+        console.assert(
+          response.callId === serviceCallRequest.callId,
+          "Service request/response call id mismatch",
+        );
+        try {
+          let schemaEncoding;
+          let schemaData;
+          if (response.encoding === "json") {
+            schemaEncoding = "jsonschema";
+            schemaData = new TextEncoder().encode(service.responseSchema);
+          } else if (response.encoding === "ros1") {
+            schemaEncoding = "ros1msg";
+            schemaData = new TextEncoder().encode(service.responseSchema);
+          } else if (response.encoding === "cdr") {
+            schemaEncoding = "ros2msg";
+            schemaData = new TextEncoder().encode(service.responseSchema);
+          } else {
+            throw new Error(`Unsupported encoding ${response.encoding}`);
+          }
+          const parsedResponse = parseChannel({
+            messageEncoding: response.encoding,
+            schema: { name: service.type, encoding: schemaEncoding, data: schemaData },
+          });
+
+          const data = parsedResponse.deserializer(response.data);
+          resolve(data as Record<string, unknown>);
+        } catch (error) {
+          this._problems.addProblem(`schema:${service.type}`, {
+            severity: "error",
+            message: `Failed to parse service response for service "${service.name}"`,
+            error,
+          });
+          reject(error);
+        }
+      });
+    });
   }
 
-  public setGlobalVariables(): void {}
+  public setGlobalVariables(): void { }
 
   private _getCurrentTime(): Time {
     return this._serverPublishesTime ? this._clockTime ?? ZERO_TIME : fromMillis(Date.now());

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -58,10 +58,17 @@ const ROS_ENCODINGS = ["ros1", "cdr"];
 const SUPPORTED_PUBLICATION_ENCODINGS = ["json", ...ROS_ENCODINGS];
 const FALLBACK_PUBLICATION_ENCODING = "json";
 const SUPPORTED_SERVICE_ENCODINGS = ["json", ...ROS_ENCODINGS];
-const FALLBACK_SERVICE_ENCODING = "json";
 
+interface MessageWriter {
+  writeMessage(message: unknown): Uint8Array;
+}
 type ResolvedChannel = { channel: Channel; parsedChannel: ParsedChannel };
 type Publication = ClientChannel & { messageWriter?: Ros1MessageWriter | Ros2MessageWriter };
+type ResolvedService = {
+  service: Service;
+  parsedResponse: ParsedChannel;
+  requestMessageWriter: MessageWriter;
+};
 
 export default class FoxgloveWebSocketPlayer implements Player {
   private _url: string; // WebSocket URL.
@@ -106,12 +113,14 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _getParameterInterval?: ReturnType<typeof setInterval>;
   private _unresolvedPublications: AdvertiseOptions[] = [];
   private _publicationsByTopic = new Map<string, Publication>();
+  private _serviceCallEncoding?: string;
   private _services = new Map<string, Set<string>>();
-  private _servicesByName = new Map<string, Service>();
+  private _servicesByName = new Map<string, ResolvedService>();
   private _serviceResponseCbs = new Map<
     ServiceCallRequest["callId"],
     (response: ServiceCallResponse) => void
   >();
+  private _nextServiceCallId = 0;
 
   public constructor({
     url,
@@ -239,7 +248,20 @@ export default class FoxgloveWebSocketPlayer implements Player {
         this._playerCapabilities.push(PlayerCapabilities.advertise);
       }
       if (event.capabilities.includes(ServerCapability.services)) {
-        this._playerCapabilities.push(PlayerCapabilities.callServices);
+        this._serviceCallEncoding = event.supportedEncodings?.find((e) =>
+          SUPPORTED_SERVICE_ENCODINGS.includes(e),
+        );
+
+        const problemId = "callService:unsupportedEncoding";
+        if (this._serviceCallEncoding) {
+          this._playerCapabilities.push(PlayerCapabilities.callServices);
+          this._problems.removeProblem(problemId);
+        } else {
+          this._problems.addProblem(problemId, {
+            severity: "warn",
+            message: `calling services is disabled as no compatible encoding could be found`,
+          });
+        }
       }
 
       if (event.capabilities.includes(ServerCapability.parameters)) {
@@ -438,11 +460,73 @@ export default class FoxgloveWebSocketPlayer implements Player {
     });
 
     this._client.on("advertiseServices", (services) => {
+      if (!this._serviceCallEncoding) {
+        return;
+      }
+
+      let schemaEncoding: string;
+      if (this._serviceCallEncoding === "json") {
+        schemaEncoding = "jsonschema";
+      } else if (this._serviceCallEncoding === "ros1") {
+        schemaEncoding = "ros1msg";
+      } else if (this._serviceCallEncoding === "cdr") {
+        schemaEncoding = "ros2msg";
+      } else {
+        throw new Error(`Unsupported encoding ${this._serviceCallEncoding}`);
+      }
+
       for (const service of services) {
-        this._servicesByName.set(service.name, service);
+        const requestType = `${service.type}_Request`;
+        const responseType = `${service.type}_Response`;
+        const parsedRequest = parseChannel({
+          messageEncoding: this._serviceCallEncoding,
+          schema: {
+            name: requestType,
+            encoding: schemaEncoding,
+            data: new TextEncoder().encode(service.requestSchema),
+          },
+        });
+        const parsedResponse = parseChannel({
+          messageEncoding: this._serviceCallEncoding,
+          schema: {
+            name: responseType,
+            encoding: schemaEncoding,
+            data: new TextEncoder().encode(service.responseSchema),
+          },
+        });
+        const requestMsgDef = rosDatatypesToMessageDefinition(parsedRequest.datatypes, requestType);
+        const requestMessageWriter = ROS_ENCODINGS.includes(this._serviceCallEncoding)
+          ? this._serviceCallEncoding === "ros1"
+            ? new Ros1MessageWriter(requestMsgDef)
+            : new Ros2MessageWriter(requestMsgDef)
+          : new JsonMessageWriter();
+
+        // Add type definitions for service response and request
+        for (const [name, types] of [...parsedRequest.datatypes, ...parsedResponse.datatypes]) {
+          this._datatypes?.set(name, types);
+        }
+
+        const resolvedService: ResolvedService = {
+          service,
+          parsedResponse,
+          requestMessageWriter,
+        };
+        this._servicesByName.set(service.name, resolvedService);
         this._services.set(service.name, new Set([service.name]));
       }
       this._emitState();
+    });
+
+    this._client.on("unadvertiseServices", (serviceIds) => {
+      for (const serviceId of serviceIds) {
+        const service: ResolvedService | undefined = Object.values(this._servicesByName).find(
+          (s) => s.service.id === serviceId,
+        );
+        if (service) {
+          this._servicesByName.delete(service.service.name);
+          this._services.delete(service.service.name);
+        }
+      }
     });
 
     this._client.on("serviceCallResponse", (response) => {
@@ -678,85 +762,32 @@ export default class FoxgloveWebSocketPlayer implements Player {
       throw new Error("FoxgloveWebSocketPlayer#callService request must be an object.");
     }
 
-    const service = this._servicesByName.get(serviceName);
-    if (!service) {
+    const resolvedService = this._servicesByName.get(serviceName);
+    if (!resolvedService) {
       throw new Error(
         `Tried to call service '${serviceName}' that has not been advertised before.`,
       );
     }
 
-    const encoding = this._supportedEncodings
-      ? this._supportedEncodings.find((e) => SUPPORTED_SERVICE_ENCODINGS.includes(e))
-      : FALLBACK_SERVICE_ENCODING;
-    if (!encoding) {
-      throw new Error(`Can not call service '${serviceName}': No supported encoding.`);
-    }
+    const { service, parsedResponse, requestMessageWriter } = resolvedService;
 
     const serviceCallRequest: ServiceCallPayload = {
       serviceId: service.id,
-      callId: Date.now(),
-      encoding,
+      callId: ++this._nextServiceCallId,
+      encoding: this._serviceCallEncoding!,
       data: new DataView(new Uint8Array().buffer),
     };
 
-    if (encoding === "json") {
-      const message = new Uint8Array(Buffer.from(JSON.stringify(request) ?? ""));
-      serviceCallRequest.data = new DataView(message.buffer);
-    } else if (ROS_ENCODINGS.includes(encoding)) {
-      try {
-        const datatypes: RosDatatypes = new Map();
-        const msgdef = rosDatatypesToMessageDefinition(datatypes, service.requestSchema);
-        const messageWriter =
-          encoding === "ros1" ? new Ros1MessageWriter(msgdef) : new Ros2MessageWriter(msgdef);
-        const message = messageWriter.writeMessage(request);
-        serviceCallRequest.data = new DataView(message);
-      } catch (error) {
-        log.debug(error);
-        this._problems.addProblem(`serviceCall:msgdef:${service.name}`, {
-          severity: "error",
-          message: `Unknown message definition for "${service.name}"`,
-          tip: `Try subscribing to the topic "${service.name}" before publishing to it`,
-        });
-      }
-    } else {
-      throw new Error(`Failed to encode service call request for service '${serviceName}'.`);
-    }
+    const message = requestMessageWriter.writeMessage(request);
+    serviceCallRequest.data = new DataView(message.buffer);
     this._client.sendCallServiceRequest(serviceCallRequest);
 
     return await new Promise<Record<string, unknown>>((resolve, reject) => {
       this._serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {
-        console.assert(
-          response.callId === serviceCallRequest.callId,
-          "Service request/response call id mismatch",
-        );
         try {
-          let schemaEncoding;
-          let schemaData;
-          if (response.encoding === "json") {
-            schemaEncoding = "jsonschema";
-            schemaData = new TextEncoder().encode(service.responseSchema);
-          } else if (response.encoding === "ros1") {
-            schemaEncoding = "ros1msg";
-            schemaData = new TextEncoder().encode(service.responseSchema);
-          } else if (response.encoding === "cdr") {
-            schemaEncoding = "ros2msg";
-            schemaData = new TextEncoder().encode(service.responseSchema);
-          } else {
-            throw new Error(`Unsupported encoding ${response.encoding}`);
-          }
-          const parsedResponse = parseChannel({
-            messageEncoding: response.encoding,
-            schema: { name: service.type, encoding: schemaEncoding, data: schemaData },
-          });
-
           const data = parsedResponse.deserializer(response.data);
           resolve(data as Record<string, unknown>);
         } catch (error) {
-          this._problems.addProblem(`schema:${service.type}`, {
-            severity: "error",
-            message: `Failed to parse service response for service "${service.name}"`,
-            error,
-          });
           reject(error);
         }
       });
@@ -842,4 +873,10 @@ function dataTypeToFullName(dataType: string): string {
     return `${parts[0]}/msg/${parts[1]}`;
   }
   return dataType;
+}
+
+class JsonMessageWriter implements MessageWriter {
+  public writeMessage(message: unknown): Uint8Array {
+    return new Uint8Array(Buffer.from(JSON.stringify(message) ?? ""));
+  }
 }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -47,6 +47,7 @@ import {
 import WorkerSocketAdapter from "./WorkerSocketAdapter";
 
 const log = Log.getLogger(__dirname);
+const textEncoder = new TextEncoder();
 
 /** Suppress warnings about messages on unknown subscriptions if the susbscription was recently canceled. */
 const SUBSCRIPTION_WARNING_SUPPRESSION_MS = 2000;
@@ -259,7 +260,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
         } else {
           this._problems.addProblem(problemId, {
             severity: "warn",
-            message: `calling services is disabled as no compatible encoding could be found`,
+            message: `Calling services is disabled as no compatible encoding could be found. \
+            The server supports [${event.supportedEncodings?.join(", ")}], \
+            but Studio only supports [${SUPPORTED_SERVICE_ENCODINGS.join(", ")}]`,
           });
         }
       }
@@ -293,7 +296,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           let schemaData;
           if (channel.encoding === "json") {
             schemaEncoding = "jsonschema";
-            schemaData = new TextEncoder().encode(channel.schema);
+            schemaData = textEncoder.encode(channel.schema);
           } else if (channel.encoding === "protobuf") {
             schemaEncoding = "protobuf";
             schemaData = new Uint8Array(base64.length(channel.schema));
@@ -308,10 +311,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
             }
           } else if (channel.encoding === "ros1") {
             schemaEncoding = "ros1msg";
-            schemaData = new TextEncoder().encode(channel.schema);
+            schemaData = textEncoder.encode(channel.schema);
           } else if (channel.encoding === "cdr") {
             schemaEncoding = "ros2msg";
-            schemaData = new TextEncoder().encode(channel.schema);
+            schemaData = textEncoder.encode(channel.schema);
           } else {
             throw new Error(`Unsupported encoding ${channel.encoding}`);
           }
@@ -472,7 +475,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       } else if (this._serviceCallEncoding === "cdr") {
         schemaEncoding = "ros2msg";
       } else {
-        throw new Error(`Unsupported encoding ${this._serviceCallEncoding}`);
+        throw new Error(`Unsupported encoding "${this._serviceCallEncoding}"`);
       }
 
       for (const service of services) {
@@ -483,7 +486,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           schema: {
             name: requestType,
             encoding: schemaEncoding,
-            data: new TextEncoder().encode(service.requestSchema),
+            data: textEncoder.encode(service.requestSchema),
           },
         });
         const parsedResponse = parseChannel({
@@ -491,7 +494,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           schema: {
             name: responseType,
             encoding: schemaEncoding,
-            data: new TextEncoder().encode(service.responseSchema),
+            data: textEncoder.encode(service.responseSchema),
           },
         });
         const requestMsgDef = rosDatatypesToMessageDefinition(parsedRequest.datatypes, requestType);
@@ -780,7 +783,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     const message = requestMessageWriter.writeMessage(request);
     serviceCallRequest.data = new DataView(message.buffer);
-    this._client.sendCallServiceRequest(serviceCallRequest);
+    this._client.sendServiceCallRequest(serviceCallRequest);
 
     return await new Promise<Record<string, unknown>>((resolve, reject) => {
       this._serviceResponseCbs.set(serviceCallRequest.callId, (response: ServiceCallResponse) => {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -234,8 +234,8 @@ export default class FoxgloveWebSocketPlayer implements Player {
         const rosDataTypes = isRos1
           ? CommonRosTypes.ros1
           : ["foxy", "galactic"].includes(rosDistro)
-            ? CommonRosTypes.ros2galactic
-            : CommonRosTypes.ros2humble;
+          ? CommonRosTypes.ros2galactic
+          : CommonRosTypes.ros2humble;
 
         for (const dataType in rosDataTypes) {
           const msgDef = (rosDataTypes as Record<string, RosMsgDefinition>)[dataType]!;
@@ -520,7 +520,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._client.on("unadvertiseServices", (serviceIds) => {
       for (const serviceId of serviceIds) {
         const service: ResolvedService | undefined = Object.values(this._servicesByName).find(
-          (s) => s.service.id === serviceId,
+          (srv) => srv.service.id === serviceId,
         );
         if (service) {
           this._servicesByName.delete(service.service.name);
@@ -794,7 +794,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     });
   }
 
-  public setGlobalVariables(): void { }
+  public setGlobalVariables(): void {}
 
   private _getCurrentTime(): Time {
     return this._serverPublishesTime ? this._clockTime ?? ZERO_TIME : fromMillis(Date.now());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,7 +2535,7 @@ __metadata:
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
-    "@foxglove/ws-protocol": 0.3.3
+    "@foxglove/ws-protocol": 0.4.0
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 0.3.0
     "@mdi/svg": 7.1.96
@@ -2742,14 +2742,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.3.3":
-  version: 0.3.3
-  resolution: "@foxglove/ws-protocol@npm:0.3.3"
+"@foxglove/ws-protocol@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@foxglove/ws-protocol@npm:0.4.0"
   dependencies:
     debug: ^4
     eventemitter3: ^5.0.0
     tslib: ^2
-  checksum: 9401d167ae66b0209e1cc9d47c003812e871777d50a071737bce19ba1ac070148dccc78b99c345d3a927993ae43d29433c23b42544d94f384d29394c91476e72
+  checksum: 028882f98659f859812b34ac15079d152ab7dd2bc15f8ec5701123d3fa74b43c7fe9285c1136b81d4e62f1cde7351c0d3f12bfa7a9339bae8cc96747a0e809ce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,7 +2535,7 @@ __metadata:
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
-    "@foxglove/ws-protocol": 0.4.0
+    "@foxglove/ws-protocol": 0.4.1
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 0.3.0
     "@mdi/svg": 7.1.96
@@ -2742,14 +2742,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@foxglove/ws-protocol@npm:0.4.0"
+"@foxglove/ws-protocol@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@foxglove/ws-protocol@npm:0.4.1"
   dependencies:
     debug: ^4
     eventemitter3: ^5.0.0
     tslib: ^2
-  checksum: 028882f98659f859812b34ac15079d152ab7dd2bc15f8ec5701123d3fa74b43c7fe9285c1136b81d4e62f1cde7351c0d3f12bfa7a9339bae8cc96747a0e809ce
+  checksum: 2aed1bbca50222d8e9c1419d7d1063fabac8ee47a87106d6120f92af0695efec26616d7fe469c4257d6318dbc9d896c2c03034064da6befc0422b6b5634f79ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
- foxglove websocket: Add callService capability

**Description**
Adds the `callService` capability to the foxglove websocket connection, implementing https://github.com/foxglove/ws-protocol/pull/344

Can be tested with the example call-service panel (https://github.com/foxglove/create-foxglove-extension/pull/92)
