### PR TITLE
Move consoleApi from PlayerSelectionContext to FoxgloveDataPlatformDataSourceFactory

### DIFF
--- a/desktop/renderer/Root.tsx
+++ b/desktop/renderer/Root.tsx
@@ -42,25 +42,6 @@ export default function Root({
 }: {
   appConfiguration: IAppConfiguration;
 }): JSX.Element {
-  const dataSources: IDataSourceFactory[] = useMemo(() => {
-    const sources = [
-      new FoxgloveWebSocketDataSourceFactory(),
-      new RosbridgeDataSourceFactory(),
-      new Ros1SocketDataSourceFactory(),
-      new Ros1LocalBagDataSourceFactory(),
-      new Ros2SocketDataSourceFactory(),
-      new Ros2LocalBagDataSourceFactory(),
-      new UlogLocalDataSourceFactory(),
-      new VelodyneDataSourceFactory(),
-      new FoxgloveDataPlatformDataSourceFactory(),
-      new SampleNuscenesDataSourceFactory(),
-      new McapLocalDataSourceFactory(),
-      new RemoteDataSourceFactory(),
-    ];
-
-    return sources;
-  }, []);
-
   if (!storageBridge) {
     throw new Error("storageBridge is missing");
   }
@@ -84,6 +65,25 @@ export default function Root({
   const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL ?? ""), []);
   const nativeAppMenu = useMemo(() => new NativeAppMenu(menuBridge), []);
   const nativeWindow = useMemo(() => new NativeWindow(desktopBridge), []);
+
+  const dataSources: IDataSourceFactory[] = useMemo(() => {
+    const sources = [
+      new FoxgloveWebSocketDataSourceFactory(),
+      new RosbridgeDataSourceFactory(),
+      new Ros1SocketDataSourceFactory(),
+      new Ros1LocalBagDataSourceFactory(),
+      new Ros2SocketDataSourceFactory(),
+      new Ros2LocalBagDataSourceFactory(),
+      new UlogLocalDataSourceFactory(),
+      new VelodyneDataSourceFactory(),
+      new FoxgloveDataPlatformDataSourceFactory(consoleApi),
+      new SampleNuscenesDataSourceFactory(),
+      new McapLocalDataSourceFactory(),
+      new RemoteDataSourceFactory(),
+    ];
+
+    return sources;
+  }, [consoleApi]);
 
   // App url state in window.location will represent the user's current session state
   // better than the initial deep link so we prioritize the current window.location

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -12,21 +12,13 @@
 //   You may not use this file except in compliance with the License.
 
 import { useSnackbar } from "notistack";
-import {
-  PropsWithChildren,
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from "react";
+import { PropsWithChildren, useCallback, useLayoutEffect, useMemo, useState } from "react";
 import { useLatest, useMountedState } from "react-use";
 
 import { useShallowMemo } from "@foxglove/hooks";
 import Logger from "@foxglove/log";
 import { MessagePipelineProvider } from "@foxglove/studio-base/components/MessagePipeline";
 import { useAnalytics } from "@foxglove/studio-base/context/AnalyticsContext";
-import ConsoleApiContext from "@foxglove/studio-base/context/ConsoleApiContext";
 import {
   LayoutState,
   useCurrentLayoutActions,
@@ -83,9 +75,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
   const analytics = useAnalytics();
   const metricsCollector = useMemo(() => new AnalyticsMetricsCollector(analytics), [analytics]);
 
-  // When we implement per-data-connector UI settings we will move this into the foxglove data platform source.
-  const consoleApi = useContext(ConsoleApiContext);
-
   const layoutStorage = useLayoutManager();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
 
@@ -138,7 +127,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       // Sample sources don't need args or prompts to initialize
       if (foundSource.type === "sample") {
         const newPlayer = foundSource.initialize({
-          consoleApi,
           metricsCollector,
         });
 
@@ -176,7 +164,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
         switch (args.type) {
           case "connection": {
             const newPlayer = foundSource.initialize({
-              consoleApi,
               metricsCollector,
               params: args.params,
             });
@@ -274,7 +261,6 @@ export default function PlayerManager(props: PropsWithChildren<PlayerManagerProp
       playerSources,
       metricsCollector,
       enqueueSnackbar,
-      consoleApi,
       layoutStorage,
       isMounted,
       setSelectedLayoutId,

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -6,7 +6,6 @@ import { createContext, useContext } from "react";
 
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { Player, PlayerMetricsCollectorInterface } from "@foxglove/studio-base/players/types";
-import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 import { RegisteredIconNames } from "@foxglove/studio-base/types/Icons";
 
 export type DataSourceFactoryInitializeArgs = {
@@ -14,7 +13,6 @@ export type DataSourceFactoryInitializeArgs = {
   file?: File;
   files?: File[];
   params?: Record<string, string | undefined>;
-  consoleApi?: ConsoleApi;
 };
 
 export type DataSourceFactoryType = "file" | "connection" | "sample";

--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.ts
@@ -8,6 +8,7 @@ import {
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { IterablePlayer, WorkerIterableSource } from "@foxglove/studio-base/players/IterablePlayer";
 import { Player } from "@foxglove/studio-base/players/types";
+import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
 
 class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
   public id = "foxglove-data-platform";
@@ -16,18 +17,19 @@ class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
   public iconName: IDataSourceFactory["iconName"] = "FileASPX";
   public hidden = true;
 
-  public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
-    const consoleApi = args.consoleApi;
-    if (!consoleApi) {
-      return;
-    }
+  #consoleApi: ConsoleApi;
 
+  public constructor(consoleApi: ConsoleApi) {
+    this.#consoleApi = consoleApi;
+  }
+
+  public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     const source = new WorkerIterableSource({
       sourceType: "foxgloveDataPlatform",
       initArgs: {
         api: {
-          baseUrl: consoleApi.getBaseUrl(),
-          auth: consoleApi.getAuthHeader(),
+          baseUrl: this.#consoleApi.getBaseUrl(),
+          auth: this.#consoleApi.getAuthHeader(),
         },
         params: args.params,
       },

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -27,6 +27,13 @@ import VelodyneUnavailableDataSourceFactory from "./dataSources/VelodyneUnavaila
 import { IdbLayoutStorage } from "./services/IdbLayoutStorage";
 
 export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration }): JSX.Element {
+  const layoutStorage = useMemo(() => new IdbLayoutStorage(), []);
+  const [extensionLoaders] = useState(() => [
+    new IdbExtensionLoader("org"),
+    new IdbExtensionLoader("local"),
+  ]);
+  const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL ?? ""), []);
+
   const dataSources: IDataSourceFactory[] = useMemo(() => {
     const sources = [
       new Ros1UnavailableDataSourceFactory(),
@@ -37,21 +44,14 @@ export function Root({ appConfiguration }: { appConfiguration: IAppConfiguration
       new RosbridgeDataSourceFactory(),
       new UlogLocalDataSourceFactory(),
       new VelodyneUnavailableDataSourceFactory(),
-      new FoxgloveDataPlatformDataSourceFactory(),
+      new FoxgloveDataPlatformDataSourceFactory(consoleApi),
       new SampleNuscenesDataSourceFactory(),
       new McapLocalDataSourceFactory(),
       new RemoteDataSourceFactory(),
     ];
 
     return sources;
-  }, []);
-
-  const layoutStorage = useMemo(() => new IdbLayoutStorage(), []);
-  const [extensionLoaders] = useState(() => [
-    new IdbExtensionLoader("org"),
-    new IdbExtensionLoader("local"),
-  ]);
-  const consoleApi = useMemo(() => new ConsoleApi(process.env.FOXGLOVE_API_URL ?? ""), []);
+  }, [consoleApi]);
 
   // Enable dialog auth in development since using cookie auth does not work between
   // localhost and the hosted dev deployment due to browser cookie/host security.


### PR DESCRIPTION


**User-Facing Changes**
<!-- will be used as a changelog entry -->
None.

**Description**
The only data source which needs the console api is the foxglove data platform source. This change removes the consoleApi field from player initialization args and moves this responsibility to the FoxgloveDataPlatformDataSourceFactory.

The factory is initialized with the consoleApi instance at the Root level for web and desktop.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
