### PR TITLE
Allow for TF Preloading

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -452,17 +452,17 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addSchemaSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.handleFrameTransform,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? false,
     });
     this.addSchemaSubscriptions(TF_DATATYPES, {
       handler: this.handleTFMessage,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? false,
     });
     this.addSchemaSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
       handler: this.handleTransformStamped,
       shouldSubscribe: () => true,
-      preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? false,
     });
 
     this.addSceneExtension(this.coreSettings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -998,7 +998,7 @@ export class Renderer extends EventEmitter<RendererEvents> {
       this.settings.errors.add(
         ["transforms", `frame:${childFrameId}`],
         TF_OVERFLOW,
-        `Transform history is at capacity (${frame.maxCapacity}), TFs will be dropped`,
+        `[Warning] Transform history is at capacity (${frame.maxCapacity}), old TFs will be dropped`,
       );
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -452,21 +452,17 @@ export class Renderer extends EventEmitter<RendererEvents> {
     this.addSchemaSubscriptions(FRAME_TRANSFORM_DATATYPES, {
       handler: this.handleFrameTransform,
       shouldSubscribe: () => true,
-      // Disabled until we can efficiently preload transforms. See
-      // <https://github.com/foxglove/studio/issues/4657> for more details.
-      // preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addSchemaSubscriptions(TF_DATATYPES, {
       handler: this.handleTFMessage,
       shouldSubscribe: () => true,
-      // Disabled until we can efficiently preload transforms
-      // preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
     this.addSchemaSubscriptions(TRANSFORM_STAMPED_DATATYPES, {
       handler: this.handleTransformStamped,
       shouldSubscribe: () => true,
-      // Disabled until we can efficiently preload transforms
-      // preload: config.scene.transforms?.enablePreloading ?? true,
+      preload: config.scene.transforms?.enablePreloading ?? true,
     });
 
     this.addSceneExtension(this.coreSettings);

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -733,7 +733,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
     // if a seek occurred and the new time is before the current cursor time, reset the cursor for this read
     if (didSeek) {
-      if (cursorTimeReached && isGreaterThan(currentTime, cursorTimeReached)) {
+      if (cursorTimeReached && isGreaterThan(cursorTimeReached, currentTime)) {
         cursorTimeReached = undefined;
         cursor = -1;
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -838,12 +838,16 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   // Render a new frame if requested
   useEffect(() => {
     const { cursorTimeReached } = allFramesCursorRef.current;
+    const cursorActive = cursorTimeReached != undefined;
+    const cursorTimeReachedCurrentTime =
+      cursorActive && currentTime != undefined && compare(cursorTimeReached, currentTime) === 0;
+
     if (
       renderer &&
       renderRef.current.needsRender &&
-      (cursorTimeReached != undefined && currentTime != undefined
-        ? compare(cursorTimeReached, currentTime) === 0
-        : true)
+      // if the allFrames cursor is active (time is defined), and has a reached time equal to the current time, then render
+      // if the allFrames cursor is not active, then render on usual `needsRender` condition
+      (cursorActive ? cursorTimeReachedCurrentTime : true)
     ) {
       renderer.animationFrame();
       renderRef.current.needsRender = false;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -774,9 +774,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         hasAddedMessageEvents = true;
         // transform tree specific optimization - adding to tree before it's highest cache time is expensive
         // so we clear it to avoid adding to the tree before the highest cache time
-        // This is why we want to process the current frame's messages after the preloaded messages. This way if preloading
-        // hasn't completed then we can still show the current frame's messages. Though it will clear any recent transforms
-        // prior to the current frame's messages.
         renderer.transformTree.clearAfter(toNanoSec(message.receiveTime));
       }
 
@@ -799,7 +796,6 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   }, [allFramesCursor, renderer, currentTime, allFrames, didSeek]);
 
   // Handle messages and render a frame if new messages are available
-  // Should be handled after allFrames
   useEffect(() => {
     if (!renderer || !messages) {
       return;
@@ -848,7 +844,13 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
   // Render a new frame if requested
   useEffect(() => {
-    if (renderer && renderRef.current.needsRender) {
+    if (
+      renderer &&
+      renderRef.current.needsRender &&
+      (allFramesCursor.cursorTimeReached != undefined && currentTime != undefined
+        ? compare(allFramesCursor.cursorTimeReached, currentTime) === 0
+        : true)
+    ) {
       renderer.animationFrame();
       renderRef.current.needsRender = false;
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/CoreSettings.ts
@@ -43,6 +43,9 @@ export class CoreSettings extends SceneExtension {
       "foxglove.publish-type-change",
       this.handlePublishToolChange,
     );
+    renderer.settings.errors.on("update", this.handleErrorChange);
+    renderer.settings.errors.on("clear", this.handleErrorChange);
+    renderer.settings.errors.on("remove", this.handleErrorChange);
 
     renderer.labelPool.scaleFactor =
       renderer.config.scene.labelScaleFactor ?? DEFAULT_LABEL_SCALE_FACTOR;
@@ -51,6 +54,9 @@ export class CoreSettings extends SceneExtension {
   public override dispose(): void {
     this.renderer.off("transformTreeUpdated", this.handleTransformTreeUpdated);
     this.renderer.off("cameraMove", this.handleCameraMove);
+    this.renderer.settings.errors.off("update", this.handleErrorChange);
+    this.renderer.settings.errors.off("clear", this.handleErrorChange);
+    this.renderer.settings.errors.off("remove", this.handleErrorChange);
     this.renderer.publishClickTool.removeEventListener(
       "foxglove.publish-type-change",
       this.handlePublishToolChange,
@@ -407,6 +413,9 @@ export class CoreSettings extends SceneExtension {
   };
 
   private handleCameraMove = (): void => {
+    this.updateSettingsTree();
+  };
+  private handleErrorChange = (): void => {
     this.updateSettingsTree();
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -173,12 +173,11 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
             input: "rgb",
             value: config.scene.transforms?.lineColor ?? DEFAULT_LINE_COLOR_STR,
           },
-          // Disabled until we can efficiently preload transforms
-          // enablePreloading: {
-          //   label: "Enable preloading",
-          //   input: "boolean",
-          //   value: config.scene.transforms?.enablePreloading ?? true,
-          // },
+          enablePreloading: {
+            label: "Enable preloading",
+            input: "boolean",
+            value: config.scene.transforms?.enablePreloading ?? true,
+          },
         },
       },
     };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FrameAxes.ts
@@ -176,7 +176,7 @@ export class FrameAxes extends SceneExtension<FrameAxisRenderable> {
           enablePreloading: {
             label: "Enable preloading",
             input: "boolean",
-            value: config.scene.transforms?.enablePreloading ?? true,
+            value: config.scene.transforms?.enablePreloading ?? false,
           },
         },
       },


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - [3D Panel] TF preloading will now be enabled by default in the `Transform` Settings. This will guarantee that the TransformTree is accurate up to the current time in the file after preloading has completed. 

**Description**
There is an up-front performance cost, but it should result in low-frequency transforms always being included without the need for playback. After initial preloading, for most cases (<250Hz TFs, and < 1hr long files) seek experience won't appear degraded. However as these files reach outside of this range, they might experience longer seek times toward the end of the file in addition to longer preloading time. Outside of preloading, normal playback performance should be the same. Most costly operation outside of preloading is seeking to slightly before the cursor at the end of the file or from the very beginning to very end of file. This feature can be disabled in the Transform settings in the 3D Panel settings if a user wishes to return to the previous behavior. 

Also this PR addressed an issue where the Display Frame wasn't being updated when errors were added or removed. 

<!-- link relevant GitHub issues -->
FG-1494
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
