### PR TITLE
Remove MockPanelContextProvider from stories which do not need it

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -15,7 +15,6 @@ import { Stack } from "@mui/material";
 import { screen, waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 
-import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 import { basicDatatypes } from "@foxglove/studio-base/util/basicDatatypes";
@@ -54,19 +53,17 @@ function MessagePathInputStory(props: {
   const [path, setPath] = React.useState(props.path);
 
   return (
-    <MockPanelContextProvider>
-      <PanelSetup fixture={MessagePathInputStoryFixture} onMount={clickInput}>
-        <Stack direction="row" flex="auto" margin={1.25}>
-          <MessagePathInput
-            autoSize={false}
-            path={path}
-            validTypes={props.validTypes}
-            prioritizedDatatype={props.prioritizedDatatype}
-            onChange={(newPath) => setPath(newPath)}
-          />
-        </Stack>
-      </PanelSetup>
-    </MockPanelContextProvider>
+    <PanelSetup fixture={MessagePathInputStoryFixture} onMount={clickInput}>
+      <Stack direction="row" flex="auto" margin={1.25}>
+        <MessagePathInput
+          autoSize={false}
+          path={path}
+          validTypes={props.validTypes}
+          prioritizedDatatype={props.prioritizedDatatype}
+          onChange={(newPath) => setPath(newPath)}
+        />
+      </Stack>
+    </PanelSetup>
   );
 }
 
@@ -74,18 +71,16 @@ function MessagePathPerformanceStory(props: { path: string; prioritizedDatatype?
   const [path, setPath] = React.useState(props.path);
 
   return (
-    <MockPanelContextProvider>
-      <PanelSetup fixture={heavyFixture} onMount={clickInput}>
-        <Stack direction="row" flex="auto" margin={1.25}>
-          <MessagePathInput
-            autoSize={false}
-            path={path}
-            prioritizedDatatype={props.prioritizedDatatype}
-            onChange={(newPath) => setPath(newPath)}
-          />
-        </Stack>
-      </PanelSetup>
-    </MockPanelContextProvider>
+    <PanelSetup fixture={heavyFixture} onMount={clickInput}>
+      <Stack direction="row" flex="auto" margin={1.25}>
+        <MessagePathInput
+          autoSize={false}
+          path={path}
+          prioritizedDatatype={props.prioritizedDatatype}
+          onChange={(newPath) => setPath(newPath)}
+        />
+      </Stack>
+    </PanelSetup>
   );
 }
 

--- a/packages/studio-base/src/components/PanelLayout.stories.tsx
+++ b/packages/studio-base/src/components/PanelLayout.stories.tsx
@@ -16,7 +16,6 @@ import { fireEvent, screen } from "@testing-library/dom";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
-import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
 import LayoutStorageContext from "@foxglove/studio-base/context/LayoutStorageContext";
@@ -112,9 +111,7 @@ export const PanelNotFound = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
         omitDragAndDrop
       >
-        <MockPanelContextProvider>
-          <PanelLayout />
-        </MockPanelContextProvider>
+        <PanelLayout />
       </PanelSetup>
     </DndProvider>
   );
@@ -135,9 +132,7 @@ export const PanelWithError = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample2!4co6n9d" }}
         omitDragAndDrop
       >
-        <MockPanelContextProvider>
-          <PanelLayout />
-        </MockPanelContextProvider>
+        <PanelLayout />
       </PanelSetup>
     </DndProvider>
   );
@@ -150,9 +145,7 @@ export const RemoveUnknownPanel = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "UnknownPanel!4co6n9d" }}
         omitDragAndDrop
       >
-        <MockPanelContextProvider>
-          <PanelLayout />
-        </MockPanelContextProvider>
+        <PanelLayout />
       </PanelSetup>
     </DndProvider>
   );
@@ -170,9 +163,7 @@ export const PanelLoading = (): JSX.Element => {
         fixture={{ topics: [], datatypes: new Map(), frame: {}, layout: "Sample1!4co6n9d" }}
         omitDragAndDrop
       >
-        <MockPanelContextProvider>
-          <PanelLayout />
-        </MockPanelContextProvider>
+        <PanelLayout />
       </PanelSetup>
     </DndProvider>
   );
@@ -195,9 +186,7 @@ export const FullScreen = (): JSX.Element => {
         }}
         omitDragAndDrop
       >
-        <MockPanelContextProvider>
-          <PanelLayout />
-        </MockPanelContextProvider>
+        <PanelLayout />
       </PanelSetup>
     </DndProvider>
   );

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -16,7 +16,6 @@ import {
   SettingsTreeAction,
 } from "@foxglove/studio";
 import { MessagePathInputStoryFixture } from "@foxglove/studio-base/components/MessagePathSyntax/fixture";
-import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -772,19 +771,17 @@ function Wrapper({ nodes }: { nodes: SettingsTreeNodes }): JSX.Element {
   }, [dynamicNodes]);
 
   return (
-    <MockPanelContextProvider>
-      <PanelSetup fixture={MessagePathInputStoryFixture}>
-        <Box
-          display="flex"
-          flexDirection="column"
-          width="100%"
-          bgcolor="background.paper"
-          overflow="auto"
-        >
-          <SettingsTreeEditor settings={settingsTree} />
-        </Box>
-      </PanelSetup>
-    </MockPanelContextProvider>
+    <PanelSetup fixture={MessagePathInputStoryFixture}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        width="100%"
+        bgcolor="background.paper"
+        overflow="auto"
+      >
+        <SettingsTreeEditor settings={settingsTree} />
+      </Box>
+    </PanelSetup>
   );
 }
 

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -14,7 +14,6 @@
 import { Story } from "@storybook/react";
 import { fireEvent } from "@testing-library/dom";
 
-import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelLayout from "@foxglove/studio-base/components/PanelLayout";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
@@ -523,17 +522,16 @@ export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
           const dragHandle = document.querySelector(
             '[data-testid~="Sample1"] [data-testid="mosaic-drag-handle"]',
           );
+
           const target = document
-            .querySelector('[data-testid~="unknown!inner4"]')
-            ?.parentElement?.parentElement?.querySelector(".drop-target.left");
+            .querySelector('[data-testid="unknown!inner4"]')
+            ?.parentElement?.parentElement?.parentElement?.querySelector(".drop-target.left");
 
           dragAndDrop(dragHandle!, target!);
         }, DEFAULT_TIMEOUT);
       }}
     >
-      <MockPanelContextProvider>
-        <PanelLayout />
-      </MockPanelContextProvider>
+      <PanelLayout />
     </PanelSetup>
   );
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -14,7 +14,6 @@
 import { Stack } from "@mui/material";
 import { storiesOf } from "@storybook/react";
 
-import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
 
@@ -273,12 +272,10 @@ function PanelSetupWithData({
   children,
   title,
   onMount,
-  disableAutoOpenClickedObject = true,
 }: {
   children: React.ReactNode;
   title: React.ReactNode;
   onMount?: (el: HTMLDivElement) => void;
-  disableAutoOpenClickedObject?: boolean;
 }) {
   return (
     <PanelSetup
@@ -295,21 +292,19 @@ function PanelSetupWithData({
         },
       }}
     >
-      <MockPanelContextProvider config={{ disableAutoOpenClickedObject }}>
-        <div
-          style={{ margin: 16 }}
-          ref={(el) => {
-            if (el && onMount) {
-              onMount(el);
-            }
-          }}
-        >
-          <p>{title}</p>
-          <Stack direction="row" flex="auto">
-            {children}
-          </Stack>
-        </div>
-      </MockPanelContextProvider>
+      <div
+        style={{ margin: 16 }}
+        ref={(el) => {
+          if (el && onMount) {
+            onMount(el);
+          }
+        }}
+      >
+        <p>{title}</p>
+        <Stack direction="row" flex="auto">
+          {children}
+        </Stack>
+      </div>
     </PanelSetup>
   );
 }


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Over-use of this provider hid a bug with PanelLayout which caused crashes in real-world use.


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
