### PR TITLE
Fix Studio Snap package not being able to access `$HOME/.foxglove-studio`

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -248,7 +248,21 @@
   "snap": {
     "confinement": "strict",
     "grade": "stable",
-    "summary": "Integrated visualization and diagnosis tool for robotics"
+    "summary": "Integrated visualization and diagnosis tool for robotics",
+    "plugs": [
+      "default",
+      {
+        "dot-foxglove-studio": {
+          "interface": "personal-files",
+          "read": ["$HOME/.foxglove-studio"],
+          "write": ["$HOME/.foxglove-studio"]
+        }
+      }
+    ],
+    "environment": {
+      "HOME": "$SNAP_REAL_HOME",
+      "TMPDIR": "$XDG_RUNTIME_DIR"
+    }
   },
   "publish": [
     {


### PR DESCRIPTION
**User-Facing Changes**
- Fix Studio Snap package not being able to access `$HOME/.foxglove-studio`

**Description**
This PR adds a snap plug for the `personal-files` interface, which allows accessing hidden files in the user's home directory. This fixes https://github.com/foxglove/create-foxglove-extension/issues/89

Details:
> 
> The Studio snap does have the home interface, but not the personal-files interface:
> 
> - The Snap ['home' interface](https://forum.snapcraft.io/t/the-home-interface/7838) permits access only to **non-hidden** files and directories in a user's /home (and nowhere else).
> 
> - The Snap ['personal-files' interface](https://snapcraft.io/docs/personal-files-interface) permits access to **all files** and directories in a user's /home (and nowhere else).
> 
> ```
> $ snap connections foxglove-studio
> Interface                 Plug                             Slot                             Notes
> home                      foxglove-studio:home             :home                            -
> 
> $ snap connections firefox 
> Interface                 Plug                            Slot                             Notes
> home                      firefox:home                    :home                            -
> personal-files            firefox:dot-mozilla-firefox     :personal-files                  -
> ```
> 

Before merging this PR, we have to request permission to use the `personal-files` for the studio snap:

- [ ] `personal-files` is super-privileged, permission to use it has to [be requested](https://snapcraft.io/docs/auto-connection-mechanism#heading--super)
- [ ] `personal-files` does not automatically connect but can be enabled for a specific snap by request ([instructions](https://snapcraft.io/docs/process-for-aliases-auto-connections-and-tracks))
