### PR TITLE
Don't override existing custom plot title in migration

### DIFF
--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -231,10 +231,11 @@ function Plot(props: Props) {
     xAxisVal,
     xAxisPath,
     sidebarDimension = config.sidebarWidth ?? defaultSidebarDimension,
+    [PANEL_TITLE_CONFIG_KEY]: customTitle,
   } = config;
 
   useEffect(() => {
-    if (legacyTitle) {
+    if (legacyTitle && (customTitle == undefined || customTitle === "")) {
       // Migrate legacy Plot-specific title setting to new global title setting
       // https://github.com/foxglove/studio/pull/5225
       saveConfig({
@@ -242,7 +243,7 @@ function Plot(props: Props) {
         [PANEL_TITLE_CONFIG_KEY]: legacyTitle,
       } as Partial<PlotConfig>);
     }
-  }, [legacyTitle, saveConfig]);
+  }, [customTitle, legacyTitle, saveConfig]);
 
   const theme = useTheme();
 

--- a/packages/studio-base/src/panels/Plot/types.ts
+++ b/packages/studio-base/src/panels/Plot/types.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import type { BasePlotPath, PlotPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
+import { PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
 
 // X-axis values:
 export type PlotXAxisVal =
@@ -48,6 +49,7 @@ export type PlotConfig = DeprecatedPlotConfig & {
   xAxisPath?: BasePlotPath;
   followingViewWidth?: number;
   sidebarDimension: number;
+  [PANEL_TITLE_CONFIG_KEY]?: string;
 };
 
 export const plotableRosTypes = [


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with custom plot panel titles in shared layouts.

**Description**
Fix the migration logic for the plot panel title to check for an existing custom tile before overwriting it with the legacy title.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
