### PR TITLE
Remove duplicate layout types from ConsoleApi

### DIFF
--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -14,7 +14,7 @@ import {
   LayoutData,
 } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
-import { LayoutID } from "@foxglove/studio-base/services/ConsoleApi";
+import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 
 import panelsReducer from "./reducers";
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -36,9 +36,9 @@ import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerCon
 import { useUserProfileStorage } from "@foxglove/studio-base/context/UserProfileStorageContext";
 import { defaultLayout } from "@foxglove/studio-base/providers/CurrentLayoutProvider/defaultLayout";
 import panelsReducer from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
-import { LayoutID } from "@foxglove/studio-base/services/ConsoleApi";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { LayoutManagerEventTypes } from "@foxglove/studio-base/services/ILayoutManager";
+import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import { PanelConfig, UserNodes, PlaybackConfig } from "@foxglove/studio-base/types/panels";
 import { windowAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { getPanelTypeFromId } from "@foxglove/studio-base/util/layout";

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -5,7 +5,7 @@
 import * as base64 from "@protobufjs/base64";
 
 import { add, fromNanoSec, Time, toRFC3339String, toSec } from "@foxglove/rostime";
-import { LayoutID, ISO8601Timestamp } from "@foxglove/studio-base";
+import { LayoutID, ISO8601Timestamp } from "@foxglove/studio-base/services/ILayoutStorage";
 
 export type User = {
   id: string;

--- a/packages/studio-base/src/services/ConsoleApi.ts
+++ b/packages/studio-base/src/services/ConsoleApi.ts
@@ -5,6 +5,7 @@
 import * as base64 from "@protobufjs/base64";
 
 import { add, fromNanoSec, Time, toRFC3339String, toSec } from "@foxglove/rostime";
+import { LayoutID, ISO8601Timestamp } from "@foxglove/studio-base";
 
 export type User = {
   id: string;
@@ -105,9 +106,6 @@ type DeviceResponse = {
   id: string;
   name: string;
 };
-
-export type LayoutID = string & { __brand: "LayoutID" };
-export type ISO8601Timestamp = string & { __brand: "ISO8601Timestamp" };
 
 export type ConsoleApiLayout = {
   id: LayoutID;

--- a/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/LayoutManager.ts
@@ -9,7 +9,6 @@ import { v4 as uuidv4 } from "uuid";
 import { MutexLocked } from "@foxglove/den/async";
 import Logger from "@foxglove/log";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
-import { ISO8601Timestamp } from "@foxglove/studio-base/services/ConsoleApi";
 import {
   ILayoutManager,
   LayoutManagerChangeEvent,
@@ -23,6 +22,7 @@ import {
   layoutIsShared,
   LayoutPermission,
   layoutPermissionIsShared,
+  ISO8601Timestamp,
 } from "@foxglove/studio-base/services/ILayoutStorage";
 import {
   IRemoteLayoutStorage,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
The LayoutID and ISO8601Timestamp were duplicated in ConsoleApi.ts. This change updates ConsoleApi to use the eixsting types from ILayoutStorage.
