### PR TITLE
Split single WorkerIterableSourceWorker into separate workers

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveDataPlatformDataSourceFactory.ts
@@ -25,7 +25,14 @@ class FoxgloveDataPlatformDataSourceFactory implements IDataSourceFactory {
 
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
     const source = new WorkerIterableSource({
-      sourceType: "foxgloveDataPlatform",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: {
         api: {
           baseUrl: this.#consoleApi.getBaseUrl(),

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -23,7 +23,14 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
     }
 
     const source = new WorkerIterableSource({
-      sourceType: "mcap",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: { file },
     });
 

--- a/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/McapLocalDataSourceFactory.ts
@@ -26,7 +26,7 @@ class McapLocalDataSourceFactory implements IDataSourceFactory {
       initWorker: () => {
         return new Worker(
           new URL(
-            "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+            "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker",
             import.meta.url,
           ),
         );

--- a/packages/studio-base/src/dataSources/RemoteDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/RemoteDataSourceFactory.ts
@@ -23,7 +23,7 @@ const initWorkers: Record<string, () => Worker> = {
   ".mcap": () => {
     return new Worker(
       new URL(
-        "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+        "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker",
         import.meta.url,
       ),
     );

--- a/packages/studio-base/src/dataSources/RemoteDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/RemoteDataSourceFactory.ts
@@ -11,6 +11,25 @@ import {
 import { IterablePlayer, WorkerIterableSource } from "@foxglove/studio-base/players/IterablePlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 
+const initWorkers: Record<string, () => Worker> = {
+  ".bag": () => {
+    return new Worker(
+      new URL(
+        "@foxglove/studio-base/players/IterablePlayer/BagIterableSourceWorker.worker",
+        import.meta.url,
+      ),
+    );
+  },
+  ".mcap": () => {
+    return new Worker(
+      new URL(
+        "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+        import.meta.url,
+      ),
+    );
+  },
+};
+
 class RemoteDataSourceFactory implements IDataSourceFactory {
   public id = "remote-file";
 
@@ -50,8 +69,12 @@ class RemoteDataSourceFactory implements IDataSourceFactory {
     }
 
     const extension = path.extname(new URL(url).pathname);
-    const sourceType = { ".bag": "rosbag", ".mcap": "mcap" }[extension] ?? "";
-    const source = new WorkerIterableSource({ sourceType, initArgs: { url } });
+    const initWorker = initWorkers[extension];
+    if (!initWorker) {
+      throw new Error(`Unsupported extension: ${extension}`);
+    }
+
+    const source = new WorkerIterableSource({ initWorker, initArgs: { url } });
 
     return new IterablePlayer({
       source,

--- a/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros1LocalBagDataSourceFactory.ts
@@ -23,7 +23,14 @@ class Ros1LocalBagDataSourceFactory implements IDataSourceFactory {
     }
 
     const source = new WorkerIterableSource({
-      sourceType: "rosbag",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/BagIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: { file },
     });
 

--- a/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/Ros2LocalBagDataSourceFactory.ts
@@ -26,7 +26,14 @@ class Ros2LocalBagDataSourceFactory implements IDataSourceFactory {
     }
 
     const source = new WorkerIterableSource({
-      sourceType: "rosdb3",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: { files },
     });
 

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -24,7 +24,14 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
     const bagUrl = "https://assets.foxglove.dev/NuScenes-v1.0-mini-scene-0061-8c50124.mcap";
 
     const source = new WorkerIterableSource({
-      sourceType: "mcap",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: { url: bagUrl },
     });
 

--- a/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/SampleNuscenesDataSourceFactory.ts
@@ -27,7 +27,7 @@ class SampleNuscenesDataSourceFactory implements IDataSourceFactory {
       initWorker: () => {
         return new Worker(
           new URL(
-            "@foxglove/studio-base/players/IterablePlayer/mcap/McapIterableSourceWorker.worker",
+            "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker",
             import.meta.url,
           ),
         );

--- a/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/UlogLocalDataSourceFactory.ts
@@ -23,7 +23,14 @@ class UlogLocalDataSourceFactory implements IDataSourceFactory {
     }
 
     const source = new WorkerIterableSource({
-      sourceType: "ulog",
+      initWorker: () => {
+        return new Worker(
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/ulog/UlogIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
       initArgs: { file },
     });
 

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -26,7 +26,6 @@ import {
   Initalization,
   MessageIteratorArgs,
   GetBackfillMessagesArgs,
-  IterableSourceInitializeArgs,
 } from "./IIterableSource";
 
 type BagSource = { type: "file"; file: File } | { type: "remote"; url: string };
@@ -265,14 +264,4 @@ export class BagIterableSource implements IIterableSource {
     messages.sort((a, b) => compare(a.receiveTime, b.receiveTime));
     return messages;
   }
-}
-
-export function initialize(args: IterableSourceInitializeArgs): BagIterableSource {
-  if (args.file) {
-    return new BagIterableSource({ type: "file", file: args.file });
-  } else if (args.url) {
-    return new BagIterableSource({ type: "remote", url: args.url });
-  }
-
-  throw new Error("file or url required");
 }

--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSourceWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSourceWorker.worker.ts
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import { IterableSourceInitializeArgs } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { WorkerIterableSourceWorker } from "@foxglove/studio-base/players/IterablePlayer/WorkerIterableSourceWorker";
+
+import { BagIterableSource } from "./BagIterableSource";
+
+export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+  if (args.file) {
+    const source = new BagIterableSource({ type: "file", file: args.file });
+    const wrapped = new WorkerIterableSourceWorker(source);
+    return Comlink.proxy(wrapped);
+  } else if (args.url) {
+    const source = new BagIterableSource({ type: "remote", url: args.url });
+    const wrapped = new WorkerIterableSourceWorker(source);
+    return Comlink.proxy(wrapped);
+  }
+
+  throw new Error("file or url required");
+}
+
+Comlink.expose(initialize);

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -18,7 +18,6 @@ import {
   Initalization,
   MessageIteratorArgs,
   GetBackfillMessagesArgs,
-  IterableSourceInitializeArgs,
 } from "../IIterableSource";
 
 const log = Log.getLogger(__filename);
@@ -112,14 +111,4 @@ export class McapIterableSource implements IIterableSource {
 
     return await this._sourceImpl.getBackfillMessages(args);
   }
-}
-
-export function initialize(args: IterableSourceInitializeArgs): McapIterableSource {
-  if (args.file) {
-    return new McapIterableSource({ type: "file", file: args.file });
-  } else if (args.url) {
-    return new McapIterableSource({ type: "url", url: args.url });
-  }
-
-  throw new Error("file or url required");
 }

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker.ts
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import { IterableSourceInitializeArgs } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { WorkerIterableSourceWorker } from "@foxglove/studio-base/players/IterablePlayer/WorkerIterableSourceWorker";
+
+import { McapIterableSource } from "./McapIterableSource";
+
+export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+  if (args.file) {
+    const source = new McapIterableSource({ type: "file", file: args.file });
+    const wrapped = new WorkerIterableSourceWorker(source);
+    return Comlink.proxy(wrapped);
+  } else if (args.url) {
+    const source = new McapIterableSource({ type: "url", url: args.url });
+    const wrapped = new WorkerIterableSourceWorker(source);
+    return Comlink.proxy(wrapped);
+  }
+
+  throw new Error("file or url required");
+}
+
+Comlink.expose(initialize);

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSource.ts
@@ -33,7 +33,6 @@ import {
   MessageIteratorArgs,
   IteratorResult,
   GetBackfillMessagesArgs,
-  IterableSourceInitializeArgs,
 } from "../IIterableSource";
 
 const log = Logger.getLogger(__filename);
@@ -49,7 +48,7 @@ export type DataPlatformInterableSourceConsoleApi = Pick<
   "coverage" | "topics" | "getDevice" | "stream"
 >;
 
-type DataPlatformSourceParameters =
+export type DataPlatformSourceParameters =
   | { type: "by-device"; deviceId: string; start: Time; end: Time }
   | { type: "by-import"; importId: string; start?: Time; end?: Time };
 
@@ -390,41 +389,4 @@ export class DataPlatformIterableSource implements IIterableSource {
     }
     return messages;
   }
-}
-
-export function initialize(args: IterableSourceInitializeArgs): DataPlatformIterableSource {
-  const { api, params } = args;
-  if (!params) {
-    throw new Error("params is required for data platform source");
-  }
-
-  if (!api) {
-    throw new Error("api is required for data platfomr");
-  }
-
-  const start = params.start;
-  const end = params.end;
-  const deviceId = params.deviceId;
-  const importId = params.importId;
-
-  const startTime = start ? fromRFC3339String(start) : undefined;
-  const endTime = end ? fromRFC3339String(end) : undefined;
-
-  if (!(importId || (deviceId && startTime && endTime))) {
-    throw new Error("invalid args");
-  }
-
-  const dpSourceParams: DataPlatformSourceParameters = importId
-    ? { type: "by-import", importId, start: startTime, end: endTime }
-    : { type: "by-device", deviceId: deviceId!, start: startTime!, end: endTime! };
-
-  const consoleApi = new ConsoleApi(api.baseUrl);
-  if (api.auth) {
-    consoleApi.setAuthHeader(api.auth);
-  }
-
-  return new DataPlatformIterableSource({
-    api: consoleApi,
-    params: dpSourceParams,
-  });
 }

--- a/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSourceWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/foxglove-data-platform/DataPlatformIterableSourceWorker.worker.ts
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import { fromRFC3339String } from "@foxglove/rostime";
+import { IterableSourceInitializeArgs } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { WorkerIterableSourceWorker } from "@foxglove/studio-base/players/IterablePlayer/WorkerIterableSourceWorker";
+import ConsoleApi from "@foxglove/studio-base/services/ConsoleApi";
+
+import {
+  DataPlatformIterableSource,
+  DataPlatformSourceParameters,
+} from "./DataPlatformIterableSource";
+
+export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+  const { api, params } = args;
+  if (!params) {
+    throw new Error("params is required for data platform source");
+  }
+
+  if (!api) {
+    throw new Error("api is required for data platfomr");
+  }
+
+  const start = params.start;
+  const end = params.end;
+  const deviceId = params.deviceId;
+  const importId = params.importId;
+
+  const startTime = start ? fromRFC3339String(start) : undefined;
+  const endTime = end ? fromRFC3339String(end) : undefined;
+
+  if (!(importId || (deviceId && startTime && endTime))) {
+    throw new Error("invalid args");
+  }
+
+  const dpSourceParams: DataPlatformSourceParameters = importId
+    ? { type: "by-import", importId, start: startTime, end: endTime }
+    : { type: "by-device", deviceId: deviceId!, start: startTime!, end: endTime! };
+
+  const consoleApi = new ConsoleApi(api.baseUrl);
+  if (api.auth) {
+    consoleApi.setAuthHeader(api.auth);
+  }
+
+  const source = new DataPlatformIterableSource({
+    api: consoleApi,
+    params: dpSourceParams,
+  });
+  const wrapped = new WorkerIterableSourceWorker(source);
+  return Comlink.proxy(wrapped);
+}
+
+Comlink.expose(initialize);

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSource.ts
@@ -21,7 +21,6 @@ import {
   Initalization,
   MessageIteratorArgs,
   GetBackfillMessagesArgs,
-  IterableSourceInitializeArgs,
 } from "../IIterableSource";
 
 export class RosDb3IterableSource implements IIterableSource {
@@ -149,13 +148,4 @@ export class RosDb3IterableSource implements IIterableSource {
   ): Promise<MessageEvent<unknown>[]> {
     return [];
   }
-}
-
-export function initialize(args: IterableSourceInitializeArgs): RosDb3IterableSource {
-  const files = args.file ? [args.file] : args.files;
-  if (files) {
-    return new RosDb3IterableSource(files);
-  }
-
-  throw new Error("files required");
 }

--- a/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/rosdb3/RosDb3IterableSourceWorker.worker.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import { IterableSourceInitializeArgs } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { WorkerIterableSourceWorker } from "@foxglove/studio-base/players/IterablePlayer/WorkerIterableSourceWorker";
+
+import { RosDb3IterableSource } from "./RosDb3IterableSource";
+
+export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+  const files = args.file ? [args.file] : args.files;
+  if (!files) {
+    throw new Error("files required");
+  }
+  const source = new RosDb3IterableSource(files);
+  const wrapped = new WorkerIterableSourceWorker(source);
+  return Comlink.proxy(wrapped);
+}
+
+Comlink.expose(initialize);

--- a/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSource.ts
@@ -24,7 +24,6 @@ import {
   Initalization,
   MessageIteratorArgs,
   GetBackfillMessagesArgs,
-  IterableSourceInitializeArgs,
 } from "../IIterableSource";
 
 type UlogOptions = { type: "file"; file: File };
@@ -189,12 +188,4 @@ export class UlogIterableSource implements IIterableSource {
   ): Promise<MessageEvent<unknown>[]> {
     return [];
   }
-}
-
-export function initialize(args: IterableSourceInitializeArgs): UlogIterableSource {
-  if (args.file) {
-    return new UlogIterableSource({ type: "file", file: args.file });
-  }
-
-  throw new Error("file required");
 }

--- a/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSourceWorker.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/ulog/UlogIterableSourceWorker.worker.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "comlink";
+
+import { IterableSourceInitializeArgs } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { WorkerIterableSourceWorker } from "@foxglove/studio-base/players/IterablePlayer/WorkerIterableSourceWorker";
+
+import { UlogIterableSource } from "./UlogIterableSource";
+
+export function initialize(args: IterableSourceInitializeArgs): WorkerIterableSourceWorker {
+  if (!args.file) {
+    throw new Error("file required");
+  }
+  const source = new UlogIterableSource({ type: "file", file: args.file });
+  const wrapped = new WorkerIterableSourceWorker(source);
+  return Comlink.proxy(wrapped);
+}
+
+Comlink.expose(initialize);


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than having a single worker implementation which supports all the different types of data sources, this change splits into separate worker implementations for each data source.

Since each worker needs to property wrap and expose the source functions to the main thread. For this the WorkerIterableSourceWorker is re-purposed to provide this wrapper for each worker implementation to use to wrap their source implementations.