### PR TITLE
Adding support for YUYV(YUV2) aside from YUV422(UYVY) along with UYVY alias

### DIFF
--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -12,23 +12,24 @@
 //   You may not use this file except in compliance with the License.
 
 function yuvToRGBA8(
-  y1: number, 
-  u: number, 
-  y2: number, 
-  v: number, 
-  c: number, 
-  output: Uint8ClampedArray): void {
-    // rgba
-    output[c] = y1 + 1.402 * v;
-    output[c + 1] = y1 - 0.34414 * u - 0.71414 * v;
-    output[c + 2] = y1 + 1.772 * u;
-    output[c + 3] = 255;
+  y1: number,
+  u: number,
+  y2: number,
+  v: number,
+  c: number,
+  output: Uint8ClampedArray,
+): void {
+  // rgba
+  output[c] = y1 + 1.402 * v;
+  output[c + 1] = y1 - 0.34414 * u - 0.71414 * v;
+  output[c + 2] = y1 + 1.772 * u;
+  output[c + 3] = 255;
 
-    // rgba
-    output[c + 4] = y2 + 1.402 * v;
-    output[c + 5] = y2 - 0.34414 * u - 0.71414 * v;
-    output[c + 6] = y2 + 1.772 * u;
-    output[c + 7] = 255;
+  // rgba
+  output[c + 4] = y2 + 1.402 * v;
+  output[c + 5] = y2 - 0.34414 * u - 0.71414 * v;
+  output[c + 6] = y2 + 1.772 * u;
+  output[c + 7] = 255;
 }
 
 export function decodeYUV(
@@ -67,7 +68,7 @@ export function decodeYUYV(
   const max = height * width;
   for (let r = 0; r <= max; r += 2) {
     const y1 = yuyv[off]!;
-    const u = yuyv[off+1]! - 128;
+    const u = yuyv[off + 1]! - 128;
     const y2 = yuyv[off + 2]!;
     const v = yuyv[off + 3]! - 128;
     yuvToRGBA8(y1, u, y2, v, c, output);

--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -11,6 +11,26 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+function yuvToRGBA8(
+  y1: number, 
+  u: number, 
+  y2: number, 
+  v: number, 
+  c: number, 
+  output: Uint8ClampedArray): void {
+    // rgba
+    output[c] = y1 + 1.402 * v;
+    output[c + 1] = y1 - 0.34414 * u - 0.71414 * v;
+    output[c + 2] = y1 + 1.772 * u;
+    output[c + 3] = 255;
+
+    // rgba
+    output[c + 4] = y2 + 1.402 * v;
+    output[c + 5] = y2 - 0.34414 * u - 0.71414 * v;
+    output[c + 6] = y2 + 1.772 * u;
+    output[c + 7] = 255;
+}
+
 export function decodeYUV(
   yuv: Int8Array,
   width: number,
@@ -26,20 +46,31 @@ export function decodeYUV(
     const u = yuv[off]! - 128;
     const y1 = yuv[off + 1]!;
     const v = yuv[off + 2]! - 128;
-    const y2 = yuv[off + 3];
+    const y2 = yuv[off + 3]!;
+    yuvToRGBA8(y1, u, y2, v, c, output);
+    c += 8;
+    off += 4;
+  }
+}
 
-    // rgba
-    output[c] = y1 + 1.402 * v;
-    output[c + 1] = y1 - 0.34414 * u - 0.71414 * v;
-    output[c + 2] = y1 + 1.772 * u;
-    output[c + 3] = 255;
+// change name in the future do something more distinct
+export function decodeYUYV(
+  yuyv: Int8Array,
+  width: number,
+  height: number,
+  output: Uint8ClampedArray,
+): void {
+  let c = 0;
+  let off = 0;
 
-    // rgba
-    output[c + 4] = y2! + 1.402 * v;
-    output[c + 5] = y2! - 0.34414 * u - 0.71414 * v;
-    output[c + 6] = y2! + 1.772 * u;
-    output[c + 7] = 255;
-
+  // populate 2 pixels at a time
+  const max = height * width;
+  for (let r = 0; r <= max; r += 2) {
+    const y1 = yuyv[off]!;
+    const u = yuyv[off+1]! - 128;
+    const y2 = yuyv[off + 2]!;
+    const v = yuyv[off + 3]! - 128;
+    yuvToRGBA8(y1, u, y2, v, c, output);
     c += 8;
     off += 4;
   }

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -14,6 +14,7 @@
 import {
   PinholeCameraModel,
   decodeYUV,
+  decodeYUYV,
   decodeRGB8,
   decodeRGBA8,
   decodeBGRA8,
@@ -137,6 +138,10 @@ function decodeMessageToBitmap(
       switch (encoding) {
         case "yuv422":
           decodeYUV(rawData as unknown as Int8Array, width, height, image.data);
+          break;
+        // change name in the future
+        case "yuyv":
+          decodeYUYV(rawData as unknown as Int8Array, width, height, image.data);
           break;
         case "rgb8":
           decodeRGB8(rawData, width, height, image.data);

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -139,6 +139,10 @@ function decodeMessageToBitmap(
         case "yuv422":
           decodeYUV(rawData as unknown as Int8Array, width, height, image.data);
           break;
+        // same thing as yuv422, but a distinct decoding from yuv422 and yuyv
+        case "uyuv":
+          decodeYUV(rawData as unknown as Int8Array, width, height, image.data);
+          break;
         // change name in the future
         case "yuyv":
           decodeYUYV(rawData as unknown as Int8Array, width, height, image.data);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -19,6 +19,7 @@ import {
   decodeBayerGRBG8,
   decodeMono8,
   decodeMono16,
+  decodeYUYV,
 } from "@foxglove/den/image";
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
@@ -661,6 +662,10 @@ function rawImageToDataTexture(
   switch (encoding) {
     case "yuv422":
       decodeYUV(image.data as Int8Array, width, height, output.image.data);
+      break;
+    // change name in the future
+    case "yuyv":
+      decodeYUYV(image.data as Int8Array, width, height, output.image.data);
       break;
     case "rgb8":
       decodeRGB8(rawData, width, height, output.image.data);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -663,6 +663,10 @@ function rawImageToDataTexture(
     case "yuv422":
       decodeYUV(image.data as Int8Array, width, height, output.image.data);
       break;
+    // same thing as yuv422, but a distinct decoding from yuv422 and yuyv
+    case "uyuv":
+      decodeYUV(image.data as Int8Array, width, height, output.image.data);
+      break;
     // change name in the future
     case "yuyv":
       decodeYUYV(image.data as Int8Array, width, height, output.image.data);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
This commit is to add support for YUYV(YUV2) encoding aside from YUV422 which is encoded in the UYVY format. Our cameras take pictures in the YUYV format and this commit is to make it directly compatible with our images without having to do conversions with the data. The name might need to be changed in the future as YUV422 is supposed to be YUYV, not UYUV, but we did not want to mess up other people's programs through this change.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
