### PR TITLE
Implement focused path in settings API

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -16,10 +16,11 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { partition } from "lodash";
+import { isEqual, partition } from "lodash";
 import memoizeWeak from "memoize-weak";
-import { ChangeEvent, useCallback, useMemo } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from "react";
 import { DeepReadonly } from "ts-essentials";
+import { keyframes } from "tss-react";
 import { makeStyles } from "tss-react/mui";
 import { useImmer } from "use-immer";
 
@@ -38,11 +39,21 @@ export type NodeEditorProps = {
   actionHandler: (action: SettingsTreeAction) => void;
   defaultOpen?: boolean;
   filter?: string;
+  focusedPath?: readonly string[];
   path: readonly string[];
   settings?: DeepReadonly<SettingsTreeNode>;
 };
 
 export const NODE_HEADER_MIN_HEIGHT = 35;
+
+const focusAnimation = keyframes`
+from {
+  background-color: yellow;
+}
+to {
+  background-color: transparent;
+}
+`;
 
 const useStyles = makeStyles()((theme) => ({
   actionButton: {
@@ -57,6 +68,9 @@ const useStyles = makeStyles()((theme) => ({
       fontSize: "0.75rem",
       padding: theme.spacing(0.75, 1),
     },
+  },
+  focusedNode: {
+    animation: `${focusAnimation} 0.3s 2 ease-in-out`,
   },
   fieldPadding: {
     gridColumn: "span 2",
@@ -169,11 +183,19 @@ const SelectVisibilityFilterField = {
   options: SelectVisibilityFilterOptions,
 } as const;
 
+type State = {
+  editing: boolean;
+  focusedPath: undefined | readonly string[];
+  open: boolean;
+  visibilityFilter: SelectVisibilityFilterValue;
+};
+
 function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
-  const { actionHandler, defaultOpen = true, filter, settings = {} } = props;
-  const [state, setState] = useImmer({
-    open: defaultOpen,
+  const { actionHandler, defaultOpen = true, filter, focusedPath, settings = {} } = props;
+  const [state, setState] = useImmer<State>({
     editing: false,
+    focusedPath: undefined,
+    open: defaultOpen,
     visibilityFilter: "all",
   });
 
@@ -204,9 +226,28 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
     actionHandler({ action: "perform-node-action", payload: { id: actionId, path: props.path } });
   };
 
+  const isFocused = isEqual(focusedPath, props.path);
+
+  useEffect(() => {
+    const isOnFocusedPath =
+      focusedPath != undefined && isEqual(props.path, focusedPath.slice(0, props.path.length));
+
+    if (isOnFocusedPath) {
+      setState((draft) => {
+        draft.open = true;
+      });
+    }
+
+    if (isFocused) {
+      rootRef.current?.scrollIntoView();
+    }
+  }, [focusedPath, isFocused, props.path, setState]);
+
   const { fields, children } = settings;
   const hasChildren = children != undefined && Object.keys(children).length > 0;
   const hasProperties = fields != undefined || hasChildren;
+
+  const rootRef = useRef<HTMLDivElement>(ReactNull);
 
   const fieldEditors = filterMap(Object.entries(fields ?? {}), ([key, field]) => {
     return field ? (
@@ -231,6 +272,7 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
         actionHandler={actionHandler}
         defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
         filter={filter}
+        focusedPath={focusedPath}
         key={key}
         settings={child}
         path={makeStablePath(props.path, key)}
@@ -287,7 +329,13 @@ function NodeEditorComponent(props: NodeEditorProps): JSX.Element {
 
   return (
     <>
-      <div className={cx(classes.nodeHeader, { [classes.nodeHeaderVisible]: visible })}>
+      <div
+        className={cx(classes.nodeHeader, {
+          [classes.focusedNode]: isFocused,
+          [classes.nodeHeaderVisible]: visible,
+        })}
+        ref={rootRef}
+      >
         <div
           className={cx(classes.nodeHeaderToggle, {
             [classes.nodeHeaderToggleHasProperties]: hasProperties,

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -19,6 +19,7 @@ import {
 import { isEqual, partition } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef } from "react";
+import tinycolor from "tinycolor2";
 import { DeepReadonly } from "ts-essentials";
 import { keyframes } from "tss-react";
 import { makeStyles } from "tss-react/mui";
@@ -46,15 +47,6 @@ export type NodeEditorProps = {
 
 export const NODE_HEADER_MIN_HEIGHT = 35;
 
-const focusAnimation = keyframes`
-from {
-  background-color: yellow;
-}
-to {
-  background-color: transparent;
-}
-`;
-
 const useStyles = makeStyles()((theme) => ({
   actionButton: {
     padding: theme.spacing(0.5),
@@ -70,7 +62,15 @@ const useStyles = makeStyles()((theme) => ({
     },
   },
   focusedNode: {
-    animation: `${focusAnimation} 0.3s 2 ease-in-out`,
+    animation: `${keyframes`
+      from {
+        background-color: ${tinycolor(theme.palette.primary.main).setAlpha(0.3).toRgbString()};
+      }
+      to {
+        background-color: transparent;
+      }`}
+      0.5s ease-in-out
+    `,
   },
   fieldPadding: {
     gridColumn: "span 2",

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -44,7 +44,7 @@ export default function SettingsTreeEditor({
   settings: DeepReadonly<SettingsTree>;
 }): JSX.Element {
   const { classes } = useStyles();
-  const { actionHandler } = settings;
+  const { actionHandler, focusedPath } = settings;
   const [filterText, setFilterText] = useState<string>("");
 
   const filteredNodes = useMemo(() => {
@@ -143,6 +143,7 @@ export default function SettingsTreeEditor({
             actionHandler={actionHandler}
             defaultOpen={root.defaultExpansionState === "collapsed" ? false : true}
             filter={filterText}
+            focusedPath={focusedPath}
             path={makeStablePath(key)}
             settings={root}
           />

--- a/packages/studio-base/src/panels/Plot/NewPlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegend.tsx
@@ -22,6 +22,7 @@ type Props = {
   paths: PlotPath[];
   datasets: ComponentProps<typeof TimeBasedChart>["data"]["datasets"];
   currentTime?: number;
+  onClickPath: (index: number) => void;
   saveConfig: SaveConfig<PlotConfig>;
   showLegend: boolean;
   pathsWithMismatchedDataLengths: string[];
@@ -122,6 +123,7 @@ const useStyles = makeStyles<StyleProps, "container" | "toggleButton">()(
 
 export function NewPlotLegend(props: Props): JSX.Element {
   const {
+    onClickPath,
     paths,
     saveConfig,
     datasets,
@@ -204,6 +206,7 @@ export function NewPlotLegend(props: Props): JSX.Element {
                 <NewPlotLegendRow
                   key={index}
                   index={index}
+                  onClickPath={() => onClickPath(index)}
                   path={path}
                   paths={paths}
                   hasMismatchedDataLength={pathsWithMismatchedDataLengths.includes(path.value)}

--- a/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/NewPlotLegendRow.tsx
@@ -23,6 +23,7 @@ import { PlotPath } from "./internalTypes";
 
 type PlotLegendRowProps = {
   index: number;
+  onClickPath: () => void;
   path: PlotPath;
   paths: PlotPath[];
   hasMismatchedDataLength: boolean;
@@ -91,6 +92,7 @@ const useStyles = makeStyles<void, "plotName">()((theme, _params, classes) => ({
 
 export function NewPlotLegendRow({
   index,
+  onClickPath,
   path,
   paths,
   hasMismatchedDataLength,
@@ -143,6 +145,7 @@ export function NewPlotLegendRow({
       onClick={() => {
         setSelectedPanelIds([panelId]);
         openPanelSettings();
+        onClickPath();
       }}
     >
       <div className={classes.listIcon}>

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -15,7 +15,7 @@ import DownloadIcon from "@mui/icons-material/Download";
 import { useTheme } from "@mui/material";
 import { compact, isNumber, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
-import { useEffect, useCallback, useMemo, ComponentProps } from "react";
+import { useEffect, useCallback, useMemo, ComponentProps, useState } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
@@ -502,7 +502,9 @@ function Plot(props: Props) {
     [messagePipeline, xAxisVal],
   );
 
-  usePlotPanelSettings(config, saveConfig);
+  const [focusedPath, setFocusedPath] = useState<undefined | string[]>(undefined);
+
+  usePlotPanelSettings(config, saveConfig, focusedPath);
 
   const [seriesSettings = false] = useAppConfigurationValue(
     AppSetting.ENABLE_PLOT_PANEL_SERIES_SETTINGS,
@@ -554,6 +556,7 @@ function Plot(props: Props) {
         )}
         {seriesSettings === true && (
           <NewPlotLegend
+            onClickPath={(index: number) => setFocusedPath(["paths", String(index)])}
             paths={yAxisPaths}
             datasets={datasets}
             currentTime={currentTimeSinceStart}

--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -201,7 +201,11 @@ function buildSettingsTree(config: PlotConfig, enableSeries: boolean): SettingsT
   };
 }
 
-export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<PlotConfig>): void {
+export function usePlotPanelSettings(
+  config: PlotConfig,
+  saveConfig: SaveConfig<PlotConfig>,
+  focusedPath?: readonly string[],
+): void {
   const updatePanelSettingsTree = usePanelSettingsTreeUpdate();
   const [enableSeries = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_PLOT_PANEL_SERIES_SETTINGS,
@@ -262,7 +266,8 @@ export function usePlotPanelSettings(config: PlotConfig, saveConfig: SaveConfig<
   useEffect(() => {
     updatePanelSettingsTree({
       actionHandler,
+      focusedPath,
       nodes: buildSettingsTree(config, enableSeries),
     });
-  }, [actionHandler, config, enableSeries, updatePanelSettingsTree]);
+  }, [actionHandler, config, enableSeries, focusedPath, updatePanelSettingsTree]);
 }

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -702,6 +702,35 @@ declare module "@foxglove/studio" {
   /**
    * A settings tree is a tree of panel settings that can be displayed and edited in
    * the panel settings sidebar.
+   *
+   * Nodes and fields in the tree can be referred to by a string path, which collects
+   * the keys of each node on the path from the root to the child node or field.
+   *
+   * For example, for the following tree:
+   *
+   *  root: {
+   *    children: {
+   *      a: {
+   *        children: {
+   *          b: {
+   *            fields: {
+   *              toggleMe: {
+   *                label: "Toggle me",
+   *                input: "boolean",
+   *                value: false,
+   *              },
+   *            },
+   *          },
+   *        },
+   *      },
+   *    },
+   *  },
+   *
+   * the path to the node at b would be ["a", "b"] and the path to the toggleMe
+   * field would be ["a", "b", "toggleMe"]. These paths are used in the
+   * actionHandler, which responds to updates to values in the tree, and also in
+   * the focusedPath, which is used to focus the editor UI at a particular node
+   * in the tree.
    */
   export type SettingsTree = {
     /**
@@ -715,13 +744,15 @@ declare module "@foxglove/studio" {
     enableFilter?: boolean;
 
     /**
-     * If set the editor will scroll to and highlight the node at this path.
+     * Setting this will have a one-time effect of scrolling the editor to the
+     * node at the path and highlighting it. This is a transient effect so it is
+     * not necessary to subsequently unset this.
      */
     focusedPath?: readonly string[];
 
     /**
-     * The settings tree root nodes. Updates to these will automatically be reflected in the
-     * editor UI.
+     * The settings tree root nodes. Updates to these will automatically be
+     * reflected in the editor UI.
      */
     nodes: SettingsTreeNodes;
   };

--- a/packages/studio/index.d.ts
+++ b/packages/studio/index.d.ts
@@ -715,6 +715,11 @@ declare module "@foxglove/studio" {
     enableFilter?: boolean;
 
     /**
+     * If set the editor will scroll to and highlight the node at this path.
+     */
+    focusedPath?: readonly string[];
+
+    /**
      * The settings tree root nodes. Updates to these will automatically be reflected in the
      * editor UI.
      */


### PR DESCRIPTION
**User-Facing Changes**
Allows extension panel authors to focus and highlight a particular node in their settings UI.

**Description**
Adds a new focusedPath property to `SettingsTree`. When set the settings UI will expand all nodes up to and including the node at the path, scroll the node at the path into view, and flash the header in yellow.

The immediate need for this feature is improving ergonomics and discoverability for the new plot settings, https://github.com/foxglove/studio/pull/5287.

https://user-images.githubusercontent.com/93935560/216885715-ff9578fb-8b7c-44db-a2df-fd5a74d0284d.mov

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
