### PR TITLE
Exclude GeoJSON topics from map panel follow list

### DIFF
--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -30,6 +30,17 @@ export function validateCustomUrl(url: string): Error | undefined {
   return undefined;
 }
 
+function isGeoJSONSchema(schemaName: string) {
+  switch (schemaName) {
+    case "foxglove_msgs/GeoJSON":
+    case "foxglove_msgs/msg/GeoJSON":
+    case "foxglove.GeoJSON":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export function buildSettingsTree(
   config: Config,
   eligibleTopics: Omit<Topic, "datatype">[],
@@ -69,7 +80,7 @@ export function buildSettingsTree(
   );
 
   const eligibleFollowTopicOptions = filterMap(eligibleTopics, (topic) =>
-    config.disabledTopics.includes(topic.name)
+    config.disabledTopics.includes(topic.name) || isGeoJSONSchema(topic.schemaName)
       ? undefined
       : { label: topic.name, value: topic.name },
   );

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Story, StoryContext } from "@storybook/react";
+import userEvent from "@testing-library/user-event";
 import { cloneDeep, tap } from "lodash";
 import { useState } from "react";
 import { useTimeoutFn } from "react-use";
@@ -426,7 +427,7 @@ export const GeoJSON = (): JSX.Element => {
   }, 1000);
 
   return (
-    <PanelSetup fixture={fixture}>
+    <PanelSetup fixture={fixture} includeSettings>
       <MapPanel
         overrideConfig={{
           topicColors: { "/geo": "#00ffaa", "/geo2": "#aa00ff" },
@@ -441,4 +442,11 @@ GeoJSON.parameters = {
     delay: 2000,
   },
   colorScheme: "light",
+};
+GeoJSON.play = async () => {
+  const user = userEvent.setup();
+  const followSelect = document.querySelectorAll("div[role=button][aria-haspopup=listbox]")[1];
+  if (followSelect) {
+    await user.click(followSelect);
+  }
 };


### PR DESCRIPTION
**User-Facing Changes**
Exclude GeoJSON topics from the list of followable topics in the map panel.

**Description**
We don't currently support following GeoJSON topics so for now they should be excluded from the list of followable topics in the map panel.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->

Fixes https://github.com/foxglove/studio/issues/5286
