### PR TITLE
 Add rviz costmap colorMode to occupancy grid settings

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -465,7 +465,7 @@ function costmapColorCached(output: ColorRGBA, value: number) {
   if (!costmapPalette) {
     costmapPalette = createCostmapPalette();
   }
-  // console.log({ unsignedValue, costmapPalette });
+
   const colorRaw = costmapPalette[Math.trunc(unsignedValue)]!;
   output.r = colorRaw[0];
   output.g = colorRaw[1];
@@ -473,6 +473,8 @@ function costmapColorCached(output: ColorRGBA, value: number) {
   output.a = colorRaw[3];
 }
 
+// Based off of rviz costmap implementation
+// https://github.com/ros-visualization/rviz/blob/1f622b8c95b8e188841b5505db2f97394d3e9c6c/src/rviz/default_plugin/map_display.cpp#L322
 function createCostmapPalette() {
   let index = 0;
   const palette = new Array(256).fill([0, 0, 0, 0]);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -463,7 +463,7 @@ function costmapColorCached(output: ColorRGBA, value: number) {
     output.a = 0;
   }
   if (!costmapPalette) {
-    costmapPalette = createCostmapPallette();
+    costmapPalette = createCostmapPalette();
   }
   // console.log({ unsignedValue, costmapPalette });
   const colorRaw = costmapPalette[Math.trunc(unsignedValue)]!;
@@ -473,7 +473,7 @@ function costmapColorCached(output: ColorRGBA, value: number) {
   output.a = colorRaw[3];
 }
 
-function createCostmapPallette() {
+function createCostmapPalette() {
   let index = 0;
   const palette = new Array(256).fill([0, 0, 0, 0]);
   // zero values have alpha=0

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -23,12 +23,15 @@ import { ColorRGBA, OccupancyGrid, OCCUPANCY_GRID_DATATYPES } from "../ros";
 import { BaseSettings } from "../settings";
 import { topicIsConvertibleToSchema } from "../topicIsConvertibleToSchema";
 
+type ColorModes = "custom" | "costmap";
+
 export type LayerSettingsOccupancyGrid = BaseSettings & {
   frameLocked: boolean;
   minColor: string;
   maxColor: string;
   unknownColor: string;
   invalidColor: string;
+  colorMode: ColorModes;
 };
 
 const INVALID_OCCUPANCY_GRID = "INVALID_OCCUPANCY_GRID";
@@ -46,6 +49,7 @@ const DEFAULT_INVALID_COLOR_STR = rgbaToCssString(DEFAULT_INVALID_COLOR);
 const DEFAULT_SETTINGS: LayerSettingsOccupancyGrid = {
   visible: false,
   frameLocked: false,
+  colorMode: "custom",
   minColor: DEFAULT_MIN_COLOR_STR,
   maxColor: DEFAULT_MAX_COLOR_STR,
   unknownColor: DEFAULT_UNKNOWN_COLOR_STR,
@@ -91,14 +95,32 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
       }
       const config = (configTopics[topic.name] ?? {}) as Partial<LayerSettingsOccupancyGrid>;
 
-      // prettier-ignore
-      const fields: SettingsTreeFields = {
-        minColor: { label: "Min Color", input: "rgba", value: config.minColor ?? DEFAULT_MIN_COLOR_STR },
-        maxColor: { label: "Max Color", input: "rgba", value: config.maxColor ?? DEFAULT_MAX_COLOR_STR },
-        unknownColor: { label: "Unknown Color", input: "rgba", value: config.unknownColor ?? DEFAULT_UNKNOWN_COLOR_STR },
-        invalidColor: { label: "Invalid Color", input: "rgba", value: config.invalidColor ?? DEFAULT_INVALID_COLOR_STR },
-        frameLocked: { label: "Frame Lock", input: "boolean", value: config.frameLocked ?? false },
+      let fields: SettingsTreeFields = {
+        colorMode: {
+          label: "Color mode",
+          input: "select",
+          value: config.colorMode ?? "custom",
+          options: [
+            { label: "Custom", value: "custom" },
+            { label: "Costmap", value: "costmap" },
+          ],
+        },
       };
+
+      if (config.colorMode === "custom") {
+        // prettier-ignore
+        const customFields: SettingsTreeFields = {
+          minColor: { label: "Min Color", input: "rgba", value: config.minColor ?? DEFAULT_MIN_COLOR_STR },
+          maxColor: { label: "Max Color", input: "rgba", value: config.maxColor ?? DEFAULT_MAX_COLOR_STR },
+          unknownColor: { label: "Unknown Color", input: "rgba", value: config.unknownColor ?? DEFAULT_UNKNOWN_COLOR_STR },
+          invalidColor: { label: "Invalid Color", input: "rgba", value: config.invalidColor ?? DEFAULT_INVALID_COLOR_STR },
+          frameLocked: { label: "Frame Lock", input: "boolean", value: config.frameLocked ?? false },
+        };
+        fields = {
+          ...fields,
+          ...customFields,
+        };
+      }
 
       entries.push({
         path: ["topics", topic.name],
@@ -286,6 +308,7 @@ function createMesh(
   return mesh;
 }
 
+const tempColor = { r: 0, g: 0, b: 0, a: 0 };
 const tempUnknownColor = { r: 0, g: 0, b: 0, a: 0 };
 const tempInvalidColor = { r: 0, g: 0, b: 0, a: 0 };
 const tempMinColor = { r: 0, g: 0, b: 0, a: 0 };
@@ -312,32 +335,40 @@ function updateTexture(
   for (let i = 0; i < size; i++) {
     const value = data[i]! | 0;
     const offset = i * 4;
-    if (value === -1) {
-      // Unknown (-1)
-      rgba[offset + 0] = tempUnknownColor.r;
-      rgba[offset + 1] = tempUnknownColor.g;
-      rgba[offset + 2] = tempUnknownColor.b;
-      rgba[offset + 3] = tempUnknownColor.a;
-    } else if (value >= 0 && value <= 100) {
-      // Valid [0-100]
-      const t = value / 100;
-      if (t === 1) {
-        rgba[offset + 0] = 0;
-        rgba[offset + 1] = 0;
-        rgba[offset + 2] = 0;
-        rgba[offset + 3] = 0;
+    if (settings.colorMode === "custom") {
+      if (value === -1) {
+        // Unknown (-1)
+        rgba[offset + 0] = tempUnknownColor.r;
+        rgba[offset + 1] = tempUnknownColor.g;
+        rgba[offset + 2] = tempUnknownColor.b;
+        rgba[offset + 3] = tempUnknownColor.a;
+      } else if (value >= 0 && value <= 100) {
+        // Valid [0-100]
+        const t = value / 100;
+        if (t === 1) {
+          rgba[offset + 0] = 0;
+          rgba[offset + 1] = 0;
+          rgba[offset + 2] = 0;
+          rgba[offset + 3] = 0;
+        } else {
+          rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
+          rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;
+          rgba[offset + 2] = tempMinColor.b + (tempMaxColor.b - tempMinColor.b) * t;
+          rgba[offset + 3] = tempMinColor.a + (tempMaxColor.a - tempMinColor.a) * t;
+        }
       } else {
-        rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
-        rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;
-        rgba[offset + 2] = tempMinColor.b + (tempMaxColor.b - tempMinColor.b) * t;
-        rgba[offset + 3] = tempMinColor.a + (tempMaxColor.a - tempMinColor.a) * t;
+        // Invalid (< -1 or > 100)
+        rgba[offset + 0] = tempInvalidColor.r;
+        rgba[offset + 1] = tempInvalidColor.g;
+        rgba[offset + 2] = tempInvalidColor.b;
+        rgba[offset + 3] = tempInvalidColor.a;
       }
     } else {
-      // Invalid (< -1 or > 100)
-      rgba[offset + 0] = tempInvalidColor.r;
-      rgba[offset + 1] = tempInvalidColor.g;
-      rgba[offset + 2] = tempInvalidColor.b;
-      rgba[offset + 3] = tempInvalidColor.a;
+      costmapColorCached(tempColor, value);
+      rgba[offset + 0] = tempColor.r;
+      rgba[offset + 1] = tempColor.g;
+      rgba[offset + 2] = tempColor.b;
+      rgba[offset + 3] = tempColor.a;
     }
   }
 
@@ -419,4 +450,57 @@ function normalizeOccupancyGrid(message: PartialMessage<OccupancyGrid>): Occupan
     },
     data: normalizeInt8Array(message.data),
   };
+}
+
+let costmapPalette: [number, number, number, number][] | undefined;
+
+function costmapColorCached(output: ColorRGBA, value: number) {
+  const unsignedValue = value > 0 ? value : Math.abs(value) + 127;
+  if (unsignedValue < 0 || unsignedValue > 255) {
+    output.r = 0;
+    output.g = 0;
+    output.b = 0;
+    output.a = 0;
+  }
+  if (!costmapPalette) {
+    costmapPalette = createCostmapPallette();
+  }
+  // console.log({ unsignedValue, costmapPalette });
+  const colorRaw = costmapPalette[Math.trunc(unsignedValue)]!;
+  output.r = colorRaw[0];
+  output.g = colorRaw[1];
+  output.b = colorRaw[2];
+  output.a = colorRaw[3];
+}
+
+function createCostmapPallette() {
+  let index = 0;
+  const palette = new Array(256).fill([0, 0, 0, 0]);
+  // zero values have alpha=0
+  palette[index++] = [0, 0, 0, 0];
+
+  // Blue to red spectrum for most normal cost values
+  for (let i = 1; i <= 98; i++) {
+    const v = (255 * i) / 100;
+    palette[index++] = [v, 0, 255 - v, 255];
+  }
+  // inscribed obstacle values (99) in cyan
+  palette[index++] = [0, 255, 255, 255];
+
+  // lethal obstacle values (100) in purple
+  palette[index++] = [255, 0, 255, 255];
+
+  // illegal positive values in green
+  for (let i = 101; i <= 127; i++) {
+    palette[index++] = [0, 255, 0, 255];
+  }
+
+  // illegal negative (char) values in shades of red/yellow
+  for (let i = 128; i <= 254; i++) {
+    palette[index++] = [255, (255 * (i - 128)) / (254 - 128), 0, 255];
+  }
+
+  // legal -1 value is tasteful blueish greenish grayish color
+  palette[index++] = [70, 137, 134, 255];
+  return palette;
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 -  Add rviz costmap colorMode to occupancy grid settings

**Description**
 Add `costmap` colormode for occupancy grid. Based off of rviz implementation: https://github.com/ros-visualization/rviz/blob/1f622b8c95b8e188841b5505db2f97394d3e9c6c/src/rviz/default_plugin/map_display.cpp#L322


<!-- link relevant GitHub issues -->
FG-1761
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
