### PR TITLE
Fix cursor jump in user scripts editor

### DIFF
--- a/packages/studio-base/src/panels/NodePlayground/Editor.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Editor.tsx
@@ -286,8 +286,9 @@ const Editor = ({
     });
   }, []);
 
+  // Refer to setScriptCode by reference so that the onChange callback isn't invalidated
+  // on every edit.
   const latestSetScriptCode = useLatest(setScriptCode);
-
   const onChange = React.useCallback(
     (srcCode: string) => latestSetScriptCode.current(srcCode),
     [latestSetScriptCode],

--- a/packages/studio-base/src/panels/NodePlayground/Editor.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Editor.tsx
@@ -19,6 +19,7 @@ import * as path from "path";
 import { ReactElement, useCallback, useRef } from "react";
 import MonacoEditor, { EditorDidMount, EditorWillMount } from "react-monaco-editor";
 import { useResizeDetector } from "react-resize-detector";
+import { useLatest } from "react-use";
 
 import getPrettifiedCode from "@foxglove/studio-base/panels/NodePlayground/getPrettifiedCode";
 import { Script } from "@foxglove/studio-base/panels/NodePlayground/script";
@@ -285,7 +286,12 @@ const Editor = ({
     });
   }, []);
 
-  const onChange = React.useCallback((srcCode: string) => setScriptCode(srcCode), [setScriptCode]);
+  const latestSetScriptCode = useLatest(setScriptCode);
+
+  const onChange = React.useCallback(
+    (srcCode: string) => latestSetScriptCode.current(srcCode),
+    [latestSetScriptCode],
+  );
 
   const onResize = useCallback((width?: number, height?: number) => {
     if (width != undefined && height != undefined) {

--- a/packages/studio-base/src/panels/NodePlayground/Editor.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/Editor.tsx
@@ -289,7 +289,7 @@ const Editor = ({
   // Refer to setScriptCode by reference so that the onChange callback isn't invalidated
   // on every edit.
   const latestSetScriptCode = useLatest(setScriptCode);
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (srcCode: string) => latestSetScriptCode.current(srcCode),
     [latestSetScriptCode],
   );


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the loss of cursor position in the user scripts editor during edits.

**Description**
The `onChange` handler transitively depended on the script content and was being reset during edits. Changing this to use a stable ref to the update function instead of depending directly on `setScriptCode` fixes this behavior.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
Fixes #5303 
