### PR TITLE
Improve consistency of renderable disposing

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderable.ts
@@ -7,6 +7,7 @@ import * as THREE from "three";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import type { Renderer } from "./Renderer";
+import { disposeMeshesRecursive } from "./dispose";
 import type { BaseSettings } from "./settings";
 import type { Pose } from "./transforms";
 
@@ -61,6 +62,7 @@ export class Renderable<TUserData extends BaseUserData = BaseUserData> extends T
    * such as GPU buffers.
    */
   public dispose(): void {
+    disposeMeshesRecursive(this);
     this.children.length = 0;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
@@ -4,8 +4,6 @@
 
 import * as THREE from "three";
 
-import { Renderable } from "./Renderable";
-
 export function disposeMaterial(material: THREE.Material): void {
   if (material instanceof THREE.MeshStandardMaterial) {
     material.map?.dispose();
@@ -25,8 +23,9 @@ export function disposeMaterial(material: THREE.Material): void {
 
 export function disposeMeshesRecursive(object: THREE.Object3D): void {
   const disposeAny = (obj: THREE.Object3D) => {
-    if (obj instanceof Renderable) {
-      obj.dispose();
+    const maybeDisposable = obj as { dispose?: () => void };
+    if (maybeDisposable.dispose) {
+      maybeDisposable.dispose();
     } else if (obj instanceof THREE.Mesh) {
       obj.geometry.dispose();
       if (Array.isArray(obj.material)) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/dispose.ts
@@ -4,6 +4,8 @@
 
 import * as THREE from "three";
 
+import { Renderable } from "./Renderable";
+
 export function disposeMaterial(material: THREE.Material): void {
   if (material instanceof THREE.MeshStandardMaterial) {
     material.map?.dispose();
@@ -22,18 +24,24 @@ export function disposeMaterial(material: THREE.Material): void {
 }
 
 export function disposeMeshesRecursive(object: THREE.Object3D): void {
-  object.traverse((child) => {
-    if (child instanceof THREE.Mesh) {
-      child.geometry.dispose();
-      if (Array.isArray(child.material)) {
-        for (const material of child.material) {
+  const disposeAny = (obj: THREE.Object3D) => {
+    if (obj instanceof Renderable) {
+      obj.dispose();
+    } else if (obj instanceof THREE.Mesh) {
+      obj.geometry.dispose();
+      if (Array.isArray(obj.material)) {
+        for (const material of obj.material) {
           if (material instanceof THREE.Material) {
             disposeMaterial(material);
           }
         }
-      } else if (child.material instanceof THREE.Material) {
-        disposeMaterial(child.material);
+      } else if (obj.material instanceof THREE.Material) {
+        disposeMaterial(obj.material);
       }
     }
-  });
+  };
+
+  object.traverse(disposeAny);
+  disposeAny(object);
+  object.removeFromParent();
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/MeasurementTool.ts
@@ -138,7 +138,6 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
   }
 
   public override dispose(): void {
-    super.dispose();
     this.renderer.labelPool.release(this.label);
     this.circleGeometry.dispose();
     this.circleMaterial.dispose();
@@ -148,6 +147,7 @@ export class MeasurementTool extends SceneExtension<Renderable<BaseUserData>, Me
     this.lineOccluded.material.dispose();
     this.renderer.input.removeListener("click", this._handleClick);
     this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+    super.dispose();
   }
 
   public startMeasuring(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PublishClickTool.ts
@@ -96,11 +96,11 @@ export class PublishClickTool extends SceneExtension<Renderable<BaseUserData>, P
   }
 
   public override dispose(): void {
-    super.dispose();
     this.arrow.dispose();
     this.sphere.dispose();
     this.renderer.input.removeListener("click", this._handleClick);
     this.renderer.input.removeListener("mousemove", this._handleMouseMove);
+    super.dispose();
   }
 
   public setPublishClickType(type: PublishClickType): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/SceneEntities.ts
@@ -177,8 +177,8 @@ export class FoxgloveSceneEntities extends SceneExtension<TopicEntities> {
   }
 
   public override dispose(): void {
-    super.dispose();
     this.primitivePool.dispose();
+    super.dispose();
   }
 }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicEntities.ts
@@ -66,6 +66,7 @@ export class TopicEntities extends Renderable<EntityTopicUserData> {
   public override dispose(): void {
     this.children.length = 0;
     this._deleteAllEntities();
+    super.dispose();
   }
 
   public updateSettings(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -60,6 +60,7 @@ export class TopicMarkers extends Renderable<MarkerTopicUserData> {
     }
     this.children.length = 0;
     this.namespaces.clear();
+    super.dispose();
   }
 
   public addMarkerMessage(marker: Marker, receiveTime: bigint): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCube.ts
@@ -8,6 +8,7 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { Renderer } from "../../Renderer";
 import { rgbToThreeColor } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
 
 export class RenderableCube extends RenderableMarker {
@@ -45,7 +46,8 @@ export class RenderableCube extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    disposeMeshesRecursive(this.mesh);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCubeList.ts
@@ -9,6 +9,7 @@ import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
 import { DynamicInstancedMesh } from "../../DynamicInstancedMesh";
 import type { Renderer } from "../../Renderer";
+import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
 
 export class RenderableCubeList extends RenderableMarker {
@@ -35,7 +36,8 @@ export class RenderableCubeList extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    disposeMeshesRecursive(this.mesh);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableCylinder.ts
@@ -8,6 +8,7 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { Renderer } from "../../Renderer";
 import { rgbToThreeColor } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { cylinderSubdivisions, DetailLevel } from "../../lod";
 import { Marker } from "../../ros";
 
@@ -47,7 +48,8 @@ export class RenderableCylinder extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    disposeMeshesRecursive(this.mesh);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableLineList.ts
@@ -68,6 +68,8 @@ export class RenderableLineList extends RenderableMarker {
     pickingMaterial.dispose();
 
     this.geometry.dispose();
+
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableMeshResource.ts
@@ -41,8 +41,10 @@ export class RenderableMeshResource extends RenderableMarker {
   public override dispose(): void {
     if (this.mesh) {
       disposeMeshesRecursive(this.mesh);
+      this.mesh = undefined;
     }
     this.material.dispose();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderablePoints.ts
@@ -34,6 +34,8 @@ export class RenderablePoints extends RenderableMarker {
 
   public override dispose(): void {
     this.points.material.dispose();
+    this.geometry.dispose();
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphere.ts
@@ -8,6 +8,7 @@ import { RenderableMarker } from "./RenderableMarker";
 import { makeStandardMaterial } from "./materials";
 import type { Renderer } from "../../Renderer";
 import { rgbToThreeColor } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { DetailLevel, sphereSubdivisions } from "../../lod";
 import { Marker } from "../../ros";
 
@@ -36,7 +37,8 @@ export class RenderableSphere extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    disposeMeshesRecursive(this.mesh);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableSphereList.ts
@@ -9,6 +9,7 @@ import { createGeometry as createSphereGeometry } from "./RenderableSphere";
 import { markerHasTransparency, makeStandardInstancedMaterial } from "./materials";
 import { DynamicInstancedMesh } from "../../DynamicInstancedMesh";
 import type { Renderer } from "../../Renderer";
+import { disposeMeshesRecursive } from "../../dispose";
 import { Marker } from "../../ros";
 
 export class RenderableSphereList extends RenderableMarker {
@@ -37,7 +38,8 @@ export class RenderableSphereList extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
+    disposeMeshesRecursive(this.mesh);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTextViewFacing.ts
@@ -29,6 +29,7 @@ export class RenderableTextViewFacing extends RenderableMarker {
 
   public override dispose(): void {
     this.renderer.labelPool.release(this.label);
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/markers/RenderableTriangleList.ts
@@ -8,6 +8,7 @@ import { RenderableMarker } from "./RenderableMarker";
 import { markerHasTransparency, makeStandardVertexColorMaterial } from "./materials";
 import type { Renderer } from "../../Renderer";
 import { rgbaToLinear } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { Marker, Vector3 } from "../../ros";
 
 const NOT_DIVISIBLE_ERR = "NOT_DIVISIBLE";
@@ -43,10 +44,10 @@ export class RenderableTriangleList extends RenderableMarker {
   }
 
   public override dispose(): void {
-    this.mesh.material.dispose();
-    this.mesh.geometry.dispose();
+    disposeMeshesRecursive(this.mesh);
     this.vertices = new Float32Array();
     this.colors = new Float32Array();
+    super.dispose();
   }
 
   public override update(newMarker: Marker, receiveTime: bigint | undefined): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableArrows.ts
@@ -248,6 +248,7 @@ export class RenderableArrows extends RenderablePrimitive {
     this.headGeometry.dispose();
     this.shaftOutlineGeometry.dispose();
     this.headOutlineGeometry.dispose();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCubes.ts
@@ -11,6 +11,7 @@ import { emptyPose } from "@foxglove/studio-base/util/Pose";
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { Renderer } from "../../Renderer";
 import { makeRgba, rgbToThreeColor, stringToRgba } from "../../color";
+import { disposeMeshesRecursive } from "../../dispose";
 import { LayerSettingsEntity } from "../SceneEntities";
 import { MeshStandardMaterialWithInstanceOpacity } from "../materials/MeshStandardMaterialWithInstanceOpacity";
 
@@ -163,10 +164,11 @@ export class RenderableCubes extends RenderablePrimitive {
   }
 
   public override dispose(): void {
-    this.mesh.dispose();
+    disposeMeshesRecursive(this.mesh);
     this.geometry.dispose();
     this.material.dispose();
     this.outlineGeometry.dispose();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableCylinders.ts
@@ -209,6 +209,7 @@ export class RenderableCylinders extends RenderablePrimitive {
     this.pickingMaterial.dispose();
     this.outlineMaterial.dispose();
     this.outlineGeometry.dispose();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableLines.ts
@@ -168,6 +168,7 @@ export class RenderableLines extends RenderablePrimitive {
       line.material.dispose();
       line.userData.pickingMaterial.dispose();
     }
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -132,6 +132,7 @@ export class RenderableModels extends RenderablePrimitive {
       }
     }
     this.renderablesByUrl.clear();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableSpheres.ts
@@ -137,6 +137,7 @@ export class RenderableSpheres extends RenderablePrimitive {
     this.mesh.dispose();
     this.geometry.dispose();
     this.material.dispose();
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTexts.ts
@@ -96,6 +96,7 @@ export class RenderableTexts extends RenderablePrimitive {
     for (const label of this.labels) {
       this.labelPool.release(label);
     }
+    super.dispose();
   }
 
   public override update(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -214,6 +214,7 @@ export class RenderableTriangles extends RenderablePrimitive {
     this.clear();
     this._triangleMeshes.length = 0;
     this.clearErrors();
+    super.dispose();
   }
 
   public override update(


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
Consistently call `super.dispose()` from renderables, and do a more exhaustive disposing of children from `Renderable.dispose()` to ensure the default behavior of renderables is to clean up after themselves. This probably won't fix anything in the current codebase, but will set up future renderables to not leak memory by default.
