### PR TITLE
Leave label of new plot series blank by default

### DIFF
--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -242,7 +242,6 @@ export function usePlotPanelSettings(
               draft.paths.push({
                 timestampMethod: "receiveTime",
                 value: "",
-                label: `Series ${draft.paths.length + 1}`,
                 enabled: true,
               });
             }),


### PR DESCRIPTION
**User-Facing Changes**
Leave the `Label` of new plot panel series blank by default.

**Description**
When adding a new series, leave the label blank instead of giving it a default like `Series 1`.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
