### PR TITLE
Enable help button on app sidebar

### DIFF
--- a/packages/studio-base/src/components/Sidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.stories.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { screen } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import { useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
@@ -86,3 +88,13 @@ ClickToDeselect.parameters = { colorScheme: "dark" };
 export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
 export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;
 export const OverflowBSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="b" />;
+
+export const HelpMenuOpen = (): JSX.Element => <Story />;
+HelpMenuOpen.play = async () => {
+  const user = userEvent.setup();
+  const helpButton = await screen.findByRole("tab", { name: /Help menu button/ });
+  await user.click(helpButton);
+};
+HelpMenuOpen.parameters = {
+  colorScheme: "light",
+};

--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -104,7 +104,6 @@ export default function Sidebar<K extends string>(props: SidebarProps<K>): JSX.E
   const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
-  const [enableNewTopNav = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<"sidebar" | "children">>("children");
   const { classes } = useStyles();
   const prevSelectedKey = useRef<string | undefined>(undefined);
@@ -245,21 +244,19 @@ export default function Sidebar<K extends string>(props: SidebarProps<K>): JSX.E
           {bottomTabs}
           {enableMemoryUseIndicator && <MemoryUseIndicator />}
         </Tabs>
-        {enableNewTopNav && (
-          <HelpMenu
-            anchorEl={helpAnchorEl}
-            open={helpMenuOpen}
-            handleClose={handleHelpClose}
-            anchorOrigin={{
-              horizontal: "right",
-              vertical: "bottom",
-            }}
-            transformOrigin={{
-              vertical: "bottom",
-              horizontal: "left",
-            }}
-          />
-        )}
+        <HelpMenu
+          anchorEl={helpAnchorEl}
+          open={helpMenuOpen}
+          handleClose={handleHelpClose}
+          anchorOrigin={{
+            horizontal: "right",
+            vertical: "bottom",
+          }}
+          transformOrigin={{
+            vertical: "bottom",
+            horizontal: "left",
+          }}
+        />
       </Stack>
       {
         // By always rendering the mosaic, even if we are only showing children, we can prevent the


### PR DESCRIPTION
**User-Facing Changes**
Re-enable the help button on the app sidebar.

**Description**
The help button on the app sidebar should be enabled whether or not the new app bar is enabled.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
