### PR TITLE
patch: minor typo for unindexed warning

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -201,7 +201,7 @@ export class McapStreamingIterableSource implements IIterableSource {
     }
 
     problems.push({
-      message: "This file unindexed. Unindexed files may have degraded performance.",
+      message: "This file is unindexed. Unindexed files may have degraded performance.",
       tip: "See the mcap spec: https://mcap.dev/specification/index.html#summary-section",
       severity: "warn",
     });


### PR DESCRIPTION
**User-Facing Changes**
Minor typo: "This file unindexed." -> "This file is unindexed."