### PR TITLE
Hide sidebar help button when top nav is enabled

### DIFF
--- a/packages/studio-base/src/components/Sidebar/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.stories.tsx
@@ -2,11 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { screen } from "@testing-library/dom";
-import userEvent from "@testing-library/user-event";
 import { useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 
 import Sidebar, { SidebarItem } from ".";
 
@@ -35,13 +36,22 @@ const BOTTOM_ITEMS = new Map<string, SidebarItem>([
 function Story({
   clickKey,
   defaultSelectedKey,
+  enableAppBar,
   height = 300,
 }: {
   clickKey?: string;
   defaultSelectedKey?: string | undefined;
+  enableAppBar?: boolean;
   height?: number;
 }) {
   const [selectedKey, setSelectedKey] = useState<string | undefined>(defaultSelectedKey);
+  const [_, setAppBarEnabled] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
+
+  useEffect(() => {
+    if (enableAppBar === true) {
+      void setAppBarEnabled(true);
+    }
+  }, [enableAppBar, setAppBarEnabled]);
 
   useEffect(() => {
     if (clickKey != undefined) {
@@ -89,12 +99,4 @@ export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
 export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;
 export const OverflowBSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="b" />;
 
-export const HelpMenuOpen = (): JSX.Element => <Story />;
-HelpMenuOpen.play = async () => {
-  const user = userEvent.setup();
-  const helpButton = await screen.findByRole("tab", { name: /Help menu button/ });
-  await user.click(helpButton);
-};
-HelpMenuOpen.parameters = {
-  colorScheme: "light",
-};
+export const WithAppBarEnabled = (): JSX.Element => <Story enableAppBar />;

--- a/packages/studio-base/src/components/Sidebar/index.tsx
+++ b/packages/studio-base/src/components/Sidebar/index.tsx
@@ -104,6 +104,7 @@ export default function Sidebar<K extends string>(props: SidebarProps<K>): JSX.E
   const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
+  const [enableNewTopNav = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<"sidebar" | "children">>("children");
   const { classes } = useStyles();
   const prevSelectedKey = useRef<string | undefined>(undefined);
@@ -230,17 +231,19 @@ export default function Sidebar<K extends string>(props: SidebarProps<K>): JSX.E
         >
           {topTabs}
           <TabSpacer />
-          <Tab
-            className={classes.tab}
-            color="inherit"
-            id="help-button"
-            aria-label="Help menu button"
-            aria-controls={helpMenuOpen ? "help-menu" : undefined}
-            aria-haspopup="true"
-            aria-expanded={helpMenuOpen ? "true" : undefined}
-            onClick={(event) => handleHelpClick(event)}
-            icon={<HelpOutlineIcon color={helpMenuOpen ? "primary" : "inherit"} />}
-          />
+          {!enableNewTopNav && (
+            <Tab
+              className={classes.tab}
+              color="inherit"
+              id="help-button"
+              aria-label="Help menu button"
+              aria-controls={helpMenuOpen ? "help-menu" : undefined}
+              aria-haspopup="true"
+              aria-expanded={helpMenuOpen ? "true" : undefined}
+              onClick={(event) => handleHelpClick(event)}
+              icon={<HelpOutlineIcon color={helpMenuOpen ? "primary" : "inherit"} />}
+            />
+          )}
           {bottomTabs}
           {enableMemoryUseIndicator && <MemoryUseIndicator />}
         </Tabs>


### PR DESCRIPTION
**User-Facing Changes**
Hide the sidebar help button if the experimental top navigation is enabled.

**Description**
There's a help button in the top nav bar so the sidebar help button is redundant if top nav is enabled.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
