### PR TITLE
Render map panel current messages on top of allframes messages

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -524,6 +524,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       });
 
       topicLayer.allFrames.addLayer(pointLayer);
+      pointLayer.bringToBack();
 
       allGeoMessages
         .filter((message) => message.topic === topic)

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -524,6 +524,8 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       });
 
       topicLayer.allFrames.addLayer(pointLayer);
+
+      // Push this layer to the back so it renders under the current messages.
       pointLayer.bringToBack();
 
       allGeoMessages


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the highlighting of current messages in the map panel.

**Description**
The map layers for allFrames messages and current messages are added in two separate hooks so the order of insertion depends on which order react executes the two `useEffect` hooks.

This changes the allFrames effect hook to always push the current messages layer to the back of the layer group so that current messages are rendered on top of it.

https://user-images.githubusercontent.com/93935560/218346570-7c64cdb7-0c68-48ec-b90c-346b74aaf943.mov

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
