### PR TITLE
Use configured timezone in data source info start/end time

### DIFF
--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -7,13 +7,14 @@ import { MutableRefObject, useEffect, useRef } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { Time } from "@foxglove/rostime";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import Timestamp from "@foxglove/studio-base/components/Timestamp";
-import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { useAppConfigurationValue, useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { formatDate, formatDuration } from "@foxglove/studio-base/util/formatTime";
@@ -42,6 +43,7 @@ function DataSourceInfoContent(props: {
 }): JSX.Element {
   const { durationRef, endTimeRef, playerName, playerPresence, startTime } = props;
   const { classes } = useStyles();
+  const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
 
   return (
     <Stack gap={1.5} paddingX={2} paddingBottom={2}>
@@ -73,7 +75,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : startTime ? (
-          <Timestamp horizontal time={startTime} />
+          <Timestamp horizontal time={startTime} timezone={timezone} />
         ) : (
           <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
             &mdash;
@@ -122,6 +124,7 @@ export function DataSourceInfoView(): JSX.Element {
   const durationRef = useRef<HTMLDivElement>(ReactNull);
   const endTimeRef = useRef<HTMLDivElement>(ReactNull);
   const { formatTime } = useAppTimeFormat();
+  const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
 
   // We bypass react and update the DOM elements directly for better performance here.
   useEffect(() => {
@@ -136,7 +139,7 @@ export function DataSourceInfoView(): JSX.Element {
     }
     if (endTimeRef.current) {
       if (endTime) {
-        const date = formatDate(endTime, undefined);
+        const date = formatDate(endTime, timezone);
         endTimeRef.current.innerText = !isAbsoluteTime(endTime)
           ? `${formatTimeRaw(endTime)}`
           : `${date} ${formatTime(endTime)}`;
@@ -144,7 +147,7 @@ export function DataSourceInfoView(): JSX.Element {
         endTimeRef.current.innerHTML = EmDash;
       }
     }
-  }, [endTime, formatTime, startTime, playerPresence]);
+  }, [endTime, formatTime, startTime, playerPresence, timezone]);
 
   return (
     <MemoDataSourceInfoContent

--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -7,17 +7,16 @@ import { MutableRefObject, useEffect, useRef } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { Time } from "@foxglove/rostime";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import Timestamp from "@foxglove/studio-base/components/Timestamp";
-import { useAppConfigurationValue, useAppTimeFormat } from "@foxglove/studio-base/hooks";
+import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { subtractTimes } from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/userUtils/time";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
-import { formatDate, formatDuration } from "@foxglove/studio-base/util/formatTime";
+import { formatDuration } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { formatTimeRaw, isAbsoluteTime } from "@foxglove/studio-base/util/time";
 
@@ -43,7 +42,6 @@ function DataSourceInfoContent(props: {
 }): JSX.Element {
   const { durationRef, endTimeRef, playerName, playerPresence, startTime } = props;
   const { classes } = useStyles();
-  const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
 
   return (
     <Stack gap={1.5} paddingX={2} paddingBottom={2}>
@@ -75,7 +73,7 @@ function DataSourceInfoContent(props: {
         {playerPresence === PlayerPresence.INITIALIZING ? (
           <Skeleton animation="wave" width="50%" />
         ) : startTime ? (
-          <Timestamp horizontal time={startTime} timezone={timezone} />
+          <Timestamp horizontal time={startTime} />
         ) : (
           <Typography className={classes.numericValue} variant="inherit" color="text.secondary">
             &mdash;
@@ -123,8 +121,7 @@ export function DataSourceInfoView(): JSX.Element {
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const durationRef = useRef<HTMLDivElement>(ReactNull);
   const endTimeRef = useRef<HTMLDivElement>(ReactNull);
-  const { formatTime } = useAppTimeFormat();
-  const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
+  const { formatDate, formatTime } = useAppTimeFormat();
 
   // We bypass react and update the DOM elements directly for better performance here.
   useEffect(() => {
@@ -139,7 +136,7 @@ export function DataSourceInfoView(): JSX.Element {
     }
     if (endTimeRef.current) {
       if (endTime) {
-        const date = formatDate(endTime, timezone);
+        const date = formatDate(endTime);
         endTimeRef.current.innerText = !isAbsoluteTime(endTime)
           ? `${formatTimeRaw(endTime)}`
           : `${date} ${formatTime(endTime)}`;
@@ -147,7 +144,7 @@ export function DataSourceInfoView(): JSX.Element {
         endTimeRef.current.innerHTML = EmDash;
       }
     }
-  }, [endTime, formatTime, startTime, playerPresence, timezone]);
+  }, [endTime, formatTime, startTime, playerPresence, formatDate]);
 
   return (
     <MemoDataSourceInfoContent

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.stories.tsx
@@ -4,10 +4,13 @@
 
 import { Box } from "@mui/material";
 import { Story } from "@storybook/react";
+import { useEffect } from "react";
 
 import { fromDate } from "@foxglove/rostime";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import CurrentUserContext, { User } from "@foxglove/studio-base/context/CurrentUserContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { PlayerPresence, Topic } from "@foxglove/studio-base/players/types";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 
@@ -136,6 +139,27 @@ export const PlayerPresent = (): JSX.Element => {
     <MockMessagePipelineProvider
       startTime={START_TIME}
       endTime={END_TIME}
+      topics={TOPICS}
+      presence={PlayerPresence.PRESENT}
+    >
+      <Box height="100%" bgcolor="background.paper">
+        <DataSourceSidebar onSelectDataSourceAction={() => {}} />
+      </Box>
+    </MockMessagePipelineProvider>
+  );
+};
+
+export const PlayerPresentWithCustomTimezone = (): JSX.Element => {
+  const [_, setTimezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
+
+  useEffect(() => {
+    setTimezone("Pacific/Ponape").catch(console.error);
+  }, [setTimezone]);
+
+  return (
+    <MockMessagePipelineProvider
+      startTime={fromDate(new Date(2022, 1, 22, 21, 22, 11))}
+      endTime={fromDate(new Date(2022, 1, 22, 23, 22, 22))}
       topics={TOPICS}
       presence={PlayerPresence.PRESENT}
     >

--- a/packages/studio-base/src/components/Timestamp.tsx
+++ b/packages/studio-base/src/components/Timestamp.tsx
@@ -8,7 +8,6 @@ import { useMemo } from "react";
 import { Time } from "@foxglove/rostime";
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
-import { formatDate } from "@foxglove/studio-base/util/formatTime";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { isAbsoluteTime, formatTimeRaw } from "@foxglove/studio-base/util/time";
 
@@ -16,15 +15,14 @@ type Props = {
   disableDate?: boolean;
   horizontal?: boolean;
   time: Time;
-  timezone?: string;
 };
 
 export default function Timestamp(props: Props): JSX.Element {
-  const { disableDate = false, horizontal = false, time, timezone } = props;
-  const { formatTime } = useAppTimeFormat();
+  const { disableDate = false, horizontal = false, time } = props;
+  const { formatDate, formatTime } = useAppTimeFormat();
   const currentTimeStr = useMemo(() => formatTime(time), [time, formatTime]);
   const rawTimeStr = useMemo(() => formatTimeRaw(time), [time]);
-  const date = useMemo(() => formatDate(time, timezone), [time, timezone]);
+  const date = useMemo(() => formatDate(time), [formatDate, time]);
 
   if (!isAbsoluteTime(time)) {
     return (

--- a/packages/studio-base/src/hooks/useAppTimeFormat.ts
+++ b/packages/studio-base/src/hooks/useAppTimeFormat.ts
@@ -8,12 +8,13 @@ import { useCallback, useMemo } from "react";
 import { Time } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
-import { formatTime } from "@foxglove/studio-base/util/formatTime";
+import { formatDate, formatTime } from "@foxglove/studio-base/util/formatTime";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 import { useAppConfigurationValue } from "./useAppConfigurationValue";
 
 export interface IAppTimeFormat {
+  formatDate: (date: Time) => string;
   formatTime: (stamp: Time) => string;
   formatDuration: (duration: Time) => string;
   timeFormat: TimeDisplayMethod;
@@ -28,6 +29,13 @@ export function useAppTimeFormat(): IAppTimeFormat {
   const effectiveFormat: TimeDisplayMethod = useMemo(
     () => (timeFormat === "SEC" ? "SEC" : "TOD"),
     [timeFormat],
+  );
+
+  const formatDateCallback = useCallback(
+    (date: Time) => {
+      return formatDate(date, timeZone);
+    },
+    [timeZone],
   );
 
   const formatTimeCallback = useCallback(
@@ -56,6 +64,7 @@ export function useAppTimeFormat(): IAppTimeFormat {
   );
 
   return {
+    formatDate: formatDateCallback,
     formatTime: formatTimeCallback,
     formatDuration: formatDurationCallback,
     setTimeFormat,


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with the start and end date displayed in the data source sidebar.

**Description**
Respects the configured timezone when calculating start and end times of a data source in the sidebar.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
