### PR TITLE
Clean up and clarify data source options in welcome dialog

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
@@ -15,8 +15,21 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
   public displayName = "Foxglove WebSocket";
   public iconName: IDataSourceFactory["iconName"] = "Flow";
   public description =
-    "Connect to a ROS 1, ROS 2, or custom system using the Foxglove WebSocket protocol.";
-  public docsLinks = [{ url: "https://foxglove.dev/docs/studio/connection/foxglove-websocket" }];
+    "Connect to a ROS 1, ROS 2, or custom system using the Foxglove WebSocket protocol. For ROS systems, be sure to first install the foxglove_bridge ROS package.";
+  public docsLinks = [
+    {
+      label: "ROS 1",
+      url: "https://foxglove.dev/docs/studio/connection/ros1#foxglove-websocket",
+    },
+    {
+      label: "ROS 2",
+      url: "https://foxglove.dev/docs/studio/connection/ros2#foxglove-websocket",
+    },
+    {
+      label: "custom data",
+      url: "https://foxglove.dev/docs/studio/connection/custom#foxglove-websocket",
+    },
+  ];
 
   public formConfig = {
     fields: [

--- a/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/RosbridgeDataSourceFactory.ts
@@ -12,7 +12,7 @@ import { Player } from "@foxglove/studio-base/players/types";
 class RosbridgeDataSourceFactory implements IDataSourceFactory {
   public id = "rosbridge-websocket";
   public type: IDataSourceFactory["type"] = "connection";
-  public displayName = "Rosbridge (ROS 1 & 2)";
+  public displayName = "Rosbridge";
   public iconName: IDataSourceFactory["iconName"] = "Flow";
   public docsLinks = [{ url: "https://foxglove.dev/docs/studio/connection/rosbridge" }];
   public description = "Connect to a ROS 1 or ROS 2 system using the Rosbridge WebSocket protocol.";


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Not important to include in changelog

**Description**
- Removed "(ROS 1 and ROS 2)" from the Rosbridge connection option, per Adrian's suggestion
- Added docs links for ROS 1 and ROS 2 to the Foxglove WebSocket option
- Mentioned the `foxglove_bridge` ROS package in the Foxglove WebSocket tab

<img width="920" alt="Screen Shot 2023-02-13 at 11 02 23 AM" src="https://user-images.githubusercontent.com/6993359/218550281-52190d6b-fd75-4803-809e-48d8a3875f28.png">


FG-1770
