### PR TITLE
Foxglove websocket: Fix datatype updates not being communicated

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -630,7 +630,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         topics: _topics,
         // Always copy topic stats since message counts and timestamps are being updated
         topicStats: new Map(this._topicsStats),
-        datatypes: _datatypes,
+        datatypes: new Map(_datatypes),
         parameters: new Map(this._parameters),
         services: new Map(this._services),
       },

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -83,7 +83,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _closed: boolean = false; // Whether the player has been completely closed using close().
   private _topics?: Topic[]; // Topics as published by the WebSocket.
   private _topicsStats = new Map<string, TopicStats>(); // Topic names to topic statistics.
-  private _datatypes?: RosDatatypes; // Datatypes as published by the WebSocket.
+  private _datatypes: RosDatatypes = new Map(); // Datatypes as published by the WebSocket.
   private _parsedMessages: MessageEvent<unknown>[] = []; // Queue of messages that we'll send in next _emitState() call.
   private _receivedBytes: number = 0;
   private _metricsCollector: PlayerMetricsCollectorInterface;
@@ -186,7 +186,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._serverCapabilities = [];
       this._playerCapabilities = [];
       this._supportedEncodings = undefined;
-      this._datatypes = undefined;
+      this._datatypes = new Map();
 
       for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
         this._unresolvedSubscriptions.add(topic);
@@ -243,6 +243,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
           this._datatypes.set(dataType, msgDef);
           this._datatypes.set(dataTypeToFullName(dataType), msgDef);
         }
+        this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
       }
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
@@ -506,8 +507,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
         // Add type definitions for service response and request
         for (const [name, types] of [...parsedRequest.datatypes, ...parsedResponse.datatypes]) {
-          this._datatypes?.set(name, types);
+          this._datatypes.set(name, types);
         }
+        this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
 
         const resolvedService: ResolvedService = {
           service,
@@ -563,14 +565,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     this._topics = topics;
 
-    if (this._datatypes) {
-      // Update the _datatypes map;
-      for (const { parsedChannel } of this._channelsById.values()) {
-        for (const [name, types] of parsedChannel.datatypes) {
-          this._datatypes.set(name, types);
-        }
+    // Update the _datatypes map;
+    for (const { parsedChannel } of this._channelsById.values()) {
+      for (const [name, types] of parsedChannel.datatypes) {
+        this._datatypes.set(name, types);
       }
     }
+    this._datatypes = new Map(this._datatypes); // Signal that datatypes changed.
     this._emitState();
   }
 
@@ -582,7 +583,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
 
     const { _topics, _datatypes } = this;
-    if (!_topics || !_datatypes) {
+    if (!_topics) {
       return this._listener({
         name: this._name,
         presence: this._presence,
@@ -630,7 +631,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         topics: _topics,
         // Always copy topic stats since message counts and timestamps are being updated
         topicStats: new Map(this._topicsStats),
-        datatypes: new Map(_datatypes),
+        datatypes: _datatypes,
         parameters: new Map(this._parameters),
         services: new Map(this._services),
       },


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Fix datatype updates not being communicated

**Description**
This PR fixes an issue with messages of new channels not being visible in the Raw message panel. 

Fixes FG-1856