### PR TITLE
Add message converter support to Image panel

### DIFF
--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -13,14 +13,14 @@
 
 import { Typography } from "@mui/material";
 import produce from "immer";
-import { difference, set, union } from "lodash";
+import { difference, keyBy, set, union } from "lodash";
 import { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import ReactDOM from "react-dom";
 import { useUpdateEffect } from "react-use";
 import { DeepPartial } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
-import { PanelExtensionContext, SettingsTreeAction, Topic } from "@foxglove/studio";
+import { PanelExtensionContext, SettingsTreeAction, Subscription, Topic } from "@foxglove/studio";
 import {
   PanelContextMenu,
   PanelContextMenuItem,
@@ -30,7 +30,6 @@ import inScreenshotTests from "@foxglove/studio-base/stories/inScreenshotTests";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { CameraInfo } from "@foxglove/studio-base/types/Messages";
 import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActuallyBePartial";
-import { getTopicsByTopicName } from "@foxglove/studio-base/util/selectors";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
@@ -45,6 +44,24 @@ import type { Config, PixelData, RawMarkerData } from "./types";
 type Props = {
   context: PanelExtensionContext;
 };
+
+const SUPPORTED_IMAGE_SCHEMAS = new Set(NORMALIZABLE_IMAGE_DATATYPES);
+const SUPPORTED_ANNOTATION_SCHEMAS = new Set(ANNOTATION_DATATYPES);
+
+function topicIsConvertibleToSchema(topic: Topic, supportedSchemaNames: Set<string>): boolean {
+  return (
+    supportedSchemaNames.has(topic.schemaName) ||
+    (topic.convertibleTo?.some((name) => supportedSchemaNames.has(name)) ?? false)
+  );
+}
+
+function pickConvertToSchema(topic: Topic, supportedSchemaNames: Set<string>): string | undefined {
+  if (supportedSchemaNames.has(topic.schemaName)) {
+    // This topic schema is supported, don't use a conversion
+    return undefined;
+  }
+  return topic.convertibleTo?.find((name) => supportedSchemaNames.has(name));
+}
 
 const useStyles = makeStyles<void, "timestamp">()((theme, _params, classes) => ({
   timestamp: {
@@ -96,22 +113,59 @@ export function ImageView({ context }: Props): JSX.Element {
   });
 
   const { cameraTopic, enabledMarkerTopics, transformMarkers } = config;
+  const topicsByTopicName = useMemo(() => keyBy(topics, ({ name }) => name), [topics]);
   const cameraTopicFullObject = useMemo(
-    () => getTopicsByTopicName(topics)[cameraTopic],
-    [cameraTopic, topics],
+    () => topicsByTopicName[cameraTopic],
+    [cameraTopic, topicsByTopicName],
   );
   const [activePixelData, setActivePixelData] = useState<PixelData | undefined>();
 
   const shouldSynchronize = config.synchronize && enabledMarkerTopics.length > 0;
 
   const cameraInfoTopic = useMemo(() => getCameraInfoTopic(cameraTopic), [cameraTopic]);
-  const subscriptions = useMemo(() => {
-    const subs = [cameraTopic, ...enabledMarkerTopics];
-    if (cameraInfoTopic != undefined) {
-      subs.push(cameraInfoTopic);
+  const cameraInfoTopicFullObject = useMemo(
+    () => (cameraInfoTopic != undefined ? topicsByTopicName[cameraInfoTopic] : undefined),
+    [cameraInfoTopic, topicsByTopicName],
+  );
+
+  const enabledMarkerTopicsFullObjects = useMemo(
+    () => enabledMarkerTopics.map((topic) => topicsByTopicName[topic]),
+    [enabledMarkerTopics, topicsByTopicName],
+  );
+
+  const subscriptions = useMemo<Subscription[]>(() => {
+    const subs: Subscription[] = [];
+    if (
+      cameraTopicFullObject &&
+      topicIsConvertibleToSchema(cameraTopicFullObject, SUPPORTED_IMAGE_SCHEMAS)
+    ) {
+      subs.push({
+        topic: cameraTopicFullObject.name,
+        preload: false,
+        convertTo: pickConvertToSchema(cameraTopicFullObject, SUPPORTED_IMAGE_SCHEMAS),
+      });
     }
-    return subs.map((topic) => ({ topic, preload: false }));
-  }, [cameraTopic, cameraInfoTopic, enabledMarkerTopics]);
+    if (
+      cameraInfoTopicFullObject &&
+      topicIsConvertibleToSchema(cameraInfoTopicFullObject, SUPPORTED_IMAGE_SCHEMAS)
+    ) {
+      subs.push({
+        topic: cameraInfoTopicFullObject.name,
+        preload: false,
+        convertTo: pickConvertToSchema(cameraInfoTopicFullObject, SUPPORTED_IMAGE_SCHEMAS),
+      });
+    }
+    for (const topic of enabledMarkerTopicsFullObjects) {
+      if (topic && topicIsConvertibleToSchema(topic, SUPPORTED_ANNOTATION_SCHEMAS)) {
+        subs.push({
+          topic: topic.name,
+          preload: false,
+          convertTo: pickConvertToSchema(topic, SUPPORTED_ANNOTATION_SCHEMAS),
+        });
+      }
+    }
+    return subs;
+  }, [cameraTopicFullObject, cameraInfoTopicFullObject, enabledMarkerTopicsFullObjects]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light">("light");
 
@@ -157,7 +211,7 @@ export function ImageView({ context }: Props): JSX.Element {
   }, [context, actions]);
 
   const imageTopics = useMemo(() => {
-    return topics.filter(({ schemaName }) => NORMALIZABLE_IMAGE_DATATYPES.includes(schemaName));
+    return topics.filter((topic) => topicIsConvertibleToSchema(topic, SUPPORTED_IMAGE_SCHEMAS));
   }, [topics]);
 
   // If no cameraTopic is selected, automatically select the first available image topic
@@ -229,7 +283,7 @@ export function ImageView({ context }: Props): JSX.Element {
 
   const markerTopics = useMemo(() => {
     return topics
-      .filter((topic) => (ANNOTATION_DATATYPES as readonly string[]).includes(topic.schemaName))
+      .filter((topic) => topicIsConvertibleToSchema(topic, SUPPORTED_ANNOTATION_SCHEMAS))
       .map((topic) => topic.name);
   }, [topics]);
 


### PR DESCRIPTION
**User-Facing Changes**
- Message converters are supported in the Image panel for Image, CameraInfo, and 
ImageMarker/ImageAnnotation message types

**Description**

<img width="1312" alt="Screenshot 2023-02-16 at 3 57 34 PM" src="https://user-images.githubusercontent.com/195374/219514798-40a26ddf-1654-470e-a610-e8fc14c29409.png">

Tested with this MCAP that uses `foxgrove` messages, and the message converter extension below.
[foxgrove.mcap.zip](https://github.com/foxglove/studio/files/10761908/foxgrove.mcap.zip)

```typescript
import { ExtensionContext } from "@foxglove/studio";

export function activate(extensionContext: ExtensionContext): void {
  extensionContext.registerMessageConverter({
    fromSchemaName: "foxgrove.RawImage",
    toSchemaName: "foxglove.RawImage",
    converter: (src) => src,
  });

  extensionContext.registerMessageConverter({
    fromSchemaName: "foxgrove.CameraCalibration",
    toSchemaName: "foxglove.CameraCalibration",
    converter: (src) => src,
  });

  extensionContext.registerMessageConverter({
    fromSchemaName: "foxgrove.ImageAnnotations",
    toSchemaName: "foxglove.ImageAnnotations",
    converter: (src) => src,
  });
}
```