### PR TITLE
Cancel animation frame requests on component unmount to prevent memory. leaks

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/Snow.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Snow.tsx
@@ -21,7 +21,7 @@ export default function Snow({ effect }: { effect: "snow" | "confetti" }): JSX.E
   const containerRef = useRef<HTMLDivElement>(ReactNull);
 
   useLayoutEffect(() => {
-    let requestID: ReturnType <typeof requestAnimationFrame>;
+    let requestID: ReturnType<typeof requestAnimationFrame>;
     const container = containerRef.current;
     if (!container) {
       return;

--- a/packages/studio-base/src/components/OpenDialog/Snow.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Snow.tsx
@@ -21,6 +21,7 @@ export default function Snow({ effect }: { effect: "snow" | "confetti" }): JSX.E
   const containerRef = useRef<HTMLDivElement>(ReactNull);
 
   useLayoutEffect(() => {
+    let requestID: ReturnType <typeof requestAnimationFrame>;
     const container = containerRef.current;
     if (!container) {
       return;
@@ -121,7 +122,7 @@ export default function Snow({ effect }: { effect: "snow" | "confetti" }): JSX.E
         return;
       }
 
-      requestAnimationFrame(animate);
+      requestID = requestAnimationFrame(animate);
       render();
     }
 
@@ -133,6 +134,7 @@ export default function Snow({ effect }: { effect: "snow" | "confetti" }): JSX.E
       material.dispose();
       renderer.dispose();
       container.removeChild(renderer.domElement);
+      cancelAnimationFrame(requestID);
     };
   }, [effect]);
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -141,6 +141,7 @@ export type Props = {
 // component. Uses chart.js internally, with a zoom/pan plugin, and with our
 // standard tooltips.
 export default function TimeBasedChart(props: Props): JSX.Element {
+  const requestID = useRef<number>(0);
   const {
     datasetId,
     type,
@@ -195,7 +196,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
     if (current) {
       // allow the chart offscreen canvas to render to screen before calling done
-      requestAnimationFrame(current);
+      requestID.current = requestAnimationFrame(current);
     }
   }, []);
 
@@ -203,6 +204,7 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     // cleanup paused frames on unmount or dataset changes
     return () => {
       onFinishRender();
+      cancelAnimationFrame(requestID.current);
     };
   }, [pauseFrame, onFinishRender]);
 


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of foxglove's studio, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some uncancelled animation frame requests, causing the memory to leak (screenshots below).

[before]
<img width="1007" alt="before Screen Shot 2023-02-14 at 1 30 36 AM" src="https://user-images.githubusercontent.com/56495631/218606523-56f2d24b-7e7e-4adf-8f39-1c9491e2080c.png">

Hence we added the fix by cancelling the requests on component unload, and you can see the count of leaks reducing noticeably:
 <br />

<img width="1008" alt="after anim Screen Shot 2023-02-14 at 1 35 47 AM" src="https://user-images.githubusercontent.com/56495631/218608245-0dae27cc-42b3-4118-9909-1be02d9295b0.png">

We executed the unit test suite after the fixes in this PR and it successfully passed 120 of 120 total (in watch + non-watch mode); we also ensured all the changes passed the lint.

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering maximum count of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[foxglove-scenario-memlab.txt](https://github.com/foxglove/studio/files/10727459/foxglove-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from React's internal objects, and hence were ignored.