### PR TITLE
Cap plot legend size at 80% of container

### DIFF
--- a/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.stories.tsx
@@ -119,3 +119,17 @@ export function Dark(): JSX.Element {
 }
 Dark.storyName = "Plot Legend (Dark)";
 Dark.parameters = { useReadySignal: true, colorScheme: "dark" };
+
+export function LimitWidth(): JSX.Element {
+  return (
+    <div
+      style={{
+        height: "100%",
+        width: "100%",
+      }}
+    >
+      <Plot overrideConfig={{ ...exampleConfig, legendDisplay: "left", sidebarDimension: 4096 }} />
+    </div>
+  );
+}
+LimitWidth.parameters = { useReadySignal: true, colorScheme: "light" };

--- a/packages/studio-base/src/panels/Plot/PlotLegend.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegend.tsx
@@ -183,6 +183,10 @@ export function PlotLegend(props: Props): JSX.Element {
         [classes.rootLeft]: legendDisplay === "left",
         [classes.rootTop]: legendDisplay === "top",
       })}
+      style={{
+        maxHeight: legendDisplay === "top" ? "80%" : "none",
+        maxWidth: legendDisplay === "left" ? "80%" : "none",
+      }}
     >
       {showLegend && (
         <Stack


### PR DESCRIPTION
**User-Facing Changes**
Limit the size of the plot legend to prevent it from completing displacing the plot.

**Description**
Cap plot legend size at 80% of container size to guarantee there is always some room to display the plot itself.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
