### PR TITLE
add target=_blank to DeviceCodeDialog link

### DIFF
--- a/packages/studio-base/src/components/DeviceCodeDialog.tsx
+++ b/packages/studio-base/src/components/DeviceCodeDialog.tsx
@@ -126,6 +126,7 @@ export default function DeviceCodeDialog(props: DeviceCodePanelProps): JSX.Eleme
               variant="inherit"
               color="primary"
               href={`${verificationUri}?user_code=${userCode}`}
+              target="_blank"
             >
               click here
             </Link>{" "}


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
Add missing `target="_blank"` to fallback link in DeviceCodeDialog.