### PR TITLE
Clear timers when components unmount to prevent memory leak

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -161,7 +161,7 @@ export default function PlaybackTimeDisplayMethod({
   onPause,
   isPlaying,
 }: PlaybackTimeDisplayMethodProps): JSX.Element {
-  const timeOutID: any = useRef(undefined);
+  const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const timeFormat = useAppTimeFormat();
   const timeRawString = useMemo(
     () => (currentTime ? formatTimeRaw(currentTime) : undefined),
@@ -225,7 +225,9 @@ export default function PlaybackTimeDisplayMethod({
     }
 
     return () => {
-      clearTimeout(timeOutID.current);
+      if (timeOutID.current != undefined) {
+        clearTimeout(timeOutID.current);
+      }
     };
   }, [hasError, inputText, isPlaying]);
 

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -14,7 +14,7 @@ import {
   ListItemText,
   styled as muiStyled,
 } from "@mui/material";
-import { useState, useCallback, useMemo, useEffect, MouseEvent } from "react";
+import { useState, useCallback, useMemo, useEffect, MouseEvent, useRef } from "react";
 
 import { Time, isTimeInRangeInclusive } from "@foxglove/rostime";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -161,6 +161,7 @@ export default function PlaybackTimeDisplayMethod({
   onPause,
   isPlaying,
 }: PlaybackTimeDisplayMethodProps): JSX.Element {
+  const timeOutID: any = useRef(undefined);
   const timeFormat = useAppTimeFormat();
   const timeRawString = useMemo(
     () => (currentTime ? formatTimeRaw(currentTime) : undefined),
@@ -222,6 +223,10 @@ export default function PlaybackTimeDisplayMethod({
       setIsEditing(false);
       setHasError(false);
     }
+
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
   }, [hasError, inputText, isPlaying]);
 
   return (
@@ -260,7 +265,7 @@ export default function PlaybackTimeDisplayMethod({
             onBlur={(e) => {
               onSubmit(e);
               setIsEditing(false);
-              setTimeout(() => setHasError(false), 600);
+              timeOutID.current = setTimeout(() => setHasError(false), 600);
             }}
             onChange={(event) => setInputText(event.target.value)}
           />

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -15,13 +15,15 @@ export default {
 };
 
 function useHoverOnPanel(andThen?: () => void) {
+  const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => {
     return () => {
-      clearTimeout(timeOutID.current);
+      if (timeOutID.current != undefined) {
+        clearTimeout(timeOutID.current);
+      }
     };
   }, []);
 
-  const timeOutID: any = useRef(undefined);
   const callback = useRef(andThen); // should not change
   return () => {
     const container = document.querySelector("[data-testid~='panel-mouseenter-container']");

--- a/packages/studio-base/src/panels/Image/index.stories.tsx
+++ b/packages/studio-base/src/panels/Image/index.stories.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
@@ -15,6 +15,13 @@ export default {
 };
 
 function useHoverOnPanel(andThen?: () => void) {
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
+
+  const timeOutID: any = useRef(undefined);
   const callback = useRef(andThen); // should not change
   return () => {
     const container = document.querySelector("[data-testid~='panel-mouseenter-container']");
@@ -24,7 +31,7 @@ function useHoverOnPanel(andThen?: () => void) {
     TestUtils.Simulate.mouseEnter(container);
 
     // wait for hover to complete
-    setTimeout(() => callback.current?.(), 10);
+    timeOutID.current = setTimeout(() => callback.current?.(), 10);
   };
 }
 

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -196,12 +196,14 @@ export const EmptyTopic: Story = () => {
 };
 
 export const WithTooltip: Story = () => {
-  const timeOutID: any = useRef(undefined);
+  const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const readySignal = useReadySignal();
 
   useEffect(() => {
     return () => {
-      clearTimeout(timeOutID.current);
+      if (timeOutID.current != undefined) {
+        clearTimeout(timeOutID.current);
+      }
     };
   }, []);
 

--- a/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
+++ b/packages/studio-base/src/panels/LegacyPlot/index.stories.tsx
@@ -12,7 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Story } from "@storybook/react";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useEffect } from "react";
 
 import PanelSetup, { Fixture, triggerWheel } from "@foxglove/studio-base/stories/PanelSetup";
 import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
@@ -196,12 +196,20 @@ export const EmptyTopic: Story = () => {
 };
 
 export const WithTooltip: Story = () => {
+  const timeOutID: any = useRef(undefined);
   const readySignal = useReadySignal();
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
+
   return (
     <div
       style={{ width: 300, height: 300 }}
       ref={() => {
-        setTimeout(() => {
+        timeOutID.current = setTimeout(() => {
           const [canvas] = document.getElementsByTagName("canvas");
           const x = 105;
           const y = 190;

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -77,7 +77,7 @@ const emptyAction: ValueActionItem = {
 const MAX_ACTION_ITEMS = 4;
 
 export default function Value(props: ValueProps): JSX.Element {
-  const timeOutID: any = useRef(undefined);
+  const timeOutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const {
     arrLabel,
     basePath,
@@ -190,7 +190,9 @@ export default function Value(props: ValueProps): JSX.Element {
 
   useEffect(() => {
     return () => {
-      clearTimeout(timeOutID.current);
+      if (timeOutID.current != undefined) {
+        clearTimeout(timeOutID.current);
+      }
     };
   }, []);
 

--- a/packages/studio-base/src/panels/RawMessages/Value.tsx
+++ b/packages/studio-base/src/panels/RawMessages/Value.tsx
@@ -10,7 +10,7 @@ import StateTransitionsIcon from "@mui/icons-material/PowerInput";
 import ScatterPlotIcon from "@mui/icons-material/ScatterPlot";
 import LineChartIcon from "@mui/icons-material/ShowChart";
 import { IconButtonProps, Tooltip, TooltipProps } from "@mui/material";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, useRef, useEffect } from "react";
 import { withStyles, makeStyles } from "tss-react/mui";
 
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
@@ -77,6 +77,7 @@ const emptyAction: ValueActionItem = {
 const MAX_ACTION_ITEMS = 4;
 
 export default function Value(props: ValueProps): JSX.Element {
+  const timeOutID: any = useRef(undefined);
   const {
     arrLabel,
     basePath,
@@ -110,7 +111,7 @@ export default function Value(props: ValueProps): JSX.Element {
       .copy(value)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        timeOutID.current = setTimeout(() => setCopied(false), 1500);
       })
       .catch((e) => console.warn(e));
   }, []);
@@ -186,6 +187,12 @@ export default function Value(props: ValueProps): JSX.Element {
     return actions;
   }, [availableActions.length]);
   const { classes, cx } = useStyles();
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeOutID.current);
+    };
+  }, []);
 
   return (
     <Stack inline flexWrap="wrap" direction="row" alignItems="center" gap={0.25}>

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -230,7 +230,10 @@ export default function CurrentLayoutProvider({
       }
     };
     layoutManager.on("change", listener);
-    return () => layoutManager.off("change", listener);
+    return () => {
+      layoutManager.off("change", listener);
+      clearTimeout(debouncedSaveTimeout.current);
+    };
   }, [layoutManager, setLayoutState]);
 
   // Make sure our layout still exists after changes. If not deselect it.

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -158,7 +158,7 @@ export default function CurrentLayoutProvider({
 
   // When the user performs an action, we immediately setLayoutState to update the UI. Saving back
   // to the LayoutManager is debounced.
-  const debouncedSaveTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const debouncedSaveTimeout = useRef<ReturnType<typeof setTimeout> | undefined>();
   const performAction = useCallback(
     (action: PanelsActions) => {
       if (
@@ -232,7 +232,9 @@ export default function CurrentLayoutProvider({
     layoutManager.on("change", listener);
     return () => {
       layoutManager.off("change", listener);
-      clearTimeout(debouncedSaveTimeout.current);
+      if (debouncedSaveTimeout.current) {
+        clearTimeout(debouncedSaveTimeout.current);
+      }
     };
   }, [layoutManager, setLayoutState]);
 


### PR DESCRIPTION
Disclaimer: This PR has not passed linting as it makes use of `any` type.

This is a followup of PR # [5341](https://github.com/foxglove/studio/pull/5341#pullrequestreview-1296725784)
That PR fixes uncleared timers in some files, while also passing test cases and linting checks. This PR is created on the suggestion of @jtbandes to clear timers in the remainder of the files (however linting issues need to be manually addressed in this one). 

Note. Typescript is currently logging the warning `Argument of type 'Timeout | undefined' is not assignable to parameter of type 'number | undefined'.` I believe this is because it is wrongly assuming the environment of Node when running Storybook in the browser. [1]

Reference: 
[1] https://github.com/Microsoft/TypeScript/issues/30128

