### PR TITLE
foxglove websocket: Fix change in player capabilities not being detected

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -246,7 +246,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
-        this._playerCapabilities.push(PlayerCapabilities.advertise);
+        this._playerCapabilities = this._playerCapabilities.concat(PlayerCapabilities.advertise);
       }
       if (event.capabilities.includes(ServerCapability.services)) {
         this._serviceCallEncoding = event.supportedEncodings?.find((e) =>
@@ -255,7 +255,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
         const problemId = "callService:unsupportedEncoding";
         if (this._serviceCallEncoding) {
-          this._playerCapabilities.push(PlayerCapabilities.callServices);
+          this._playerCapabilities = this._playerCapabilities.concat(
+            PlayerCapabilities.callServices,
+          );
           this._problems.removeProblem(problemId);
         } else {
           this._problems.addProblem(problemId, {
@@ -268,7 +270,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       }
 
       if (event.capabilities.includes(ServerCapability.parameters)) {
-        this._playerCapabilities.push(
+        this._playerCapabilities = this._playerCapabilities.concat(
           PlayerCapabilities.getParameters,
           PlayerCapabilities.setParameters,
         );


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
This PR fixes changes in the foxglove websocket player capabilities not being detected by React. I learned that when updating arrays, new arrays should be created rather than modifying existing ones.

From https://beta.reactjs.org/learn/updating-arrays-in-state:

> Arrays are mutable in JavaScript, but you should treat them as immutable when you store them in state. Just like with objects, when you want to update an array stored in state, you need to create a new one (or make a copy of an existing one), and then set state to use the new array.

This fixes #5297 (FG-1791)
