### PR TITLE
Fix foxglove.Grid default auto-select colorMode behavior

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -478,7 +478,8 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
         | Partial<LayerSettingsFoxgloveGrid>
         | undefined;
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
-      if (settings.colorField == undefined) {
+      // only want to autoselect if it's in flatcolor mode (without colorfield) and previously didn't have fields
+      if (settings.colorField == undefined && this.fieldsByTopic.get(topic) == undefined) {
         autoSelectColorField(settings, foxgloveGrid.fields, { supportsPackedRgbModes: false });
         // Update user settings with the newly selected color field
         this.renderer.updateConfig((draft) => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -14,9 +14,10 @@ import {
   baseColorModeSettingsNode,
   ColorModeSettings,
   getColorConverter,
-  autoSelectColorField,
   NEEDS_MIN_MAX,
   FS_SRGB_TO_LINEAR,
+  RGBA_PACKED_FIELDS,
+  hasSeparateRgbaFields,
 } from "./pointClouds/colors";
 import { FieldReader, getReader } from "./pointClouds/fieldReaders";
 import { BaseUserData, Renderable } from "../Renderable";
@@ -900,3 +901,43 @@ const NumericTypeMinMaxValueMap: Record<NumericType, [number, number]> = {
   [NumericType.FLOAT32]: [0, 1.0],
   [NumericType.FLOAT64]: [0, 1.0],
 };
+
+function autoSelectColorField<Settings extends ColorModeSettings>(
+  output: Settings,
+  fields: PackedElementField[],
+  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
+): void {
+  // Prefer color fields first
+  if (supportsPackedRgbModes) {
+    for (const field of fields) {
+      const fieldNameLower = field.name.toLowerCase();
+      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
+        output.colorField = field.name;
+        switch (fieldNameLower) {
+          case "rgb":
+            output.colorMode = "rgb";
+            break;
+          default:
+          case "rgba":
+            output.colorMode = "rgba";
+            break;
+        }
+        return;
+      }
+    }
+  }
+
+  if (hasSeparateRgbaFields(fields.map((f) => f.name))) {
+    output.colorMode = "rgba-fields";
+    return;
+  }
+
+  // Fall back to using the first field
+  if (fields.length > 0) {
+    const firstField = fields[0]!;
+    output.colorField = firstField.name;
+    output.colorMode = "colormap";
+    output.colorMap = "turbo";
+    return;
+  }
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -4,7 +4,6 @@
 
 import * as THREE from "three";
 
-import { PackedElementField } from "@foxglove/schemas";
 import { SettingsTreeFields, SettingsTreeNode, Topic } from "@foxglove/studio";
 import { BaseSettings } from "@foxglove/studio-base/panels/ThreeDeeRender/settings";
 
@@ -180,46 +179,6 @@ function turboLinearCached(output: ColorRGBA, pct: number): void {
 export const RGBA_PACKED_FIELDS = new Set<string>(["rgb", "rgba"]);
 export const INTENSITY_FIELDS = new Set<string>(["intensity", "i"]);
 
-export function autoSelectColorField<Settings extends ColorModeSettings>(
-  output: Settings,
-  fields: PackedElementField[],
-  { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
-): void {
-  // Prefer color fields first
-  if (supportsPackedRgbModes) {
-    for (const field of fields) {
-      const fieldNameLower = field.name.toLowerCase();
-      if (RGBA_PACKED_FIELDS.has(fieldNameLower)) {
-        output.colorField = field.name;
-        switch (fieldNameLower) {
-          case "rgb":
-            output.colorMode = "rgb";
-            break;
-          default:
-          case "rgba":
-            output.colorMode = "rgba";
-            break;
-        }
-        return;
-      }
-    }
-  }
-
-  if (hasSeparateRgbaFields(fields.map((f) => f.name))) {
-    output.colorMode = "rgba-fields";
-    return;
-  }
-
-  // Fall back to using the first field
-  if (fields.length > 0) {
-    const firstField = fields[0]!;
-    output.colorField = firstField.name;
-    output.colorMode = "colormap";
-    output.colorMap = "turbo";
-    return;
-  }
-}
-
 function bestColorByField(
   fields: string[],
   { supportsPackedRgbModes }: { supportsPackedRgbModes: boolean },
@@ -239,7 +198,7 @@ function bestColorByField(
   return fields.find((field) => field === "x") || fields[0] ? fields[0]! : "";
 }
 
-function hasSeparateRgbaFields(fields: string[]) {
+export function hasSeparateRgbaFields(fields: string[]): boolean {
   let r = false;
   let g = false;
   let b = false;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointClouds/colors.ts
@@ -205,6 +205,11 @@ export function autoSelectColorField<Settings extends ColorModeSettings>(
     }
   }
 
+  if (hasSeparateRgbaFields(fields.map((f) => f.name))) {
+    output.colorMode = "rgba-fields";
+    return;
+  }
+
   // Fall back to using the first field
   if (fields.length > 0) {
     const firstField = fields[0]!;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix foxglove.Grid default auto-select colorMode behavior to use separate RGBA-fields when available

**Description**
`autoSelectColorField` formerly did not account for separate RGBA fields. Now it should. 

<!-- link relevant GitHub issues -->
Fixes FG-1718

<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
