### PR TITLE
Fix `nav_msgs/OccupancyGrid` value showing up as transparent

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -345,17 +345,11 @@ function updateTexture(
       } else if (value >= 0 && value <= 100) {
         // Valid [0-100]
         const t = value / 100;
-        if (t === 1) {
-          rgba[offset + 0] = 0;
-          rgba[offset + 1] = 0;
-          rgba[offset + 2] = 0;
-          rgba[offset + 3] = 255;
-        } else {
-          rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
-          rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;
-          rgba[offset + 2] = tempMinColor.b + (tempMaxColor.b - tempMinColor.b) * t;
-          rgba[offset + 3] = tempMinColor.a + (tempMaxColor.a - tempMinColor.a) * t;
-        }
+
+        rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
+        rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;
+        rgba[offset + 2] = tempMinColor.b + (tempMaxColor.b - tempMinColor.b) * t;
+        rgba[offset + 3] = tempMinColor.a + (tempMaxColor.a - tempMinColor.a) * t;
       } else {
         // Invalid (< -1 or > 100)
         rgba[offset + 0] = tempInvalidColor.r;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -349,7 +349,7 @@ function updateTexture(
           rgba[offset + 0] = 0;
           rgba[offset + 1] = 0;
           rgba[offset + 2] = 0;
-          rgba[offset + 3] = 0;
+          rgba[offset + 3] = 255;
         } else {
           rgba[offset + 0] = tempMinColor.r + (tempMaxColor.r - tempMinColor.r) * t;
           rgba[offset + 1] = tempMinColor.g + (tempMaxColor.g - tempMinColor.g) * t;

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -1,0 +1,152 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@foxglove/studio";
+import { LayerSettingsOccupancyGrid } from "@foxglove/studio-base/panels/ThreeDeeRender/renderables/OccupancyGrids";
+import { Topic } from "@foxglove/studio-base/players/types";
+import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
+
+import { QUAT_IDENTITY, rad2deg } from "./common";
+import useDelayedFixture from "./useDelayedFixture";
+import ThreeDeeRender from "../index";
+import { OccupancyGrid, TransformStamped } from "../ros";
+
+export default {
+  title: "panels/ThreeDeeRender",
+  component: ThreeDeeRender,
+  parameters: { colorScheme: "light" },
+};
+
+function makeGridData({ width, height }: { width: number; height: number }) {
+  const grid = new Int8Array(width * height);
+  const view = new DataView(grid.buffer, grid.byteOffset, grid.byteLength);
+  for (let i = 0; i < height; i++) {
+    for (let j = 0; j < width; j++) {
+      view.setInt8(i * width + j, (j - 128) % 256);
+    }
+  }
+  return grid;
+}
+
+export function Occupancy_Grid_Costmap(): JSX.Element {
+  const topics: Topic[] = [
+    { name: "/grid", schemaName: "nav_msgs/OccupancyGrid" },
+    { name: "/tf", schemaName: "geometry_msgs/TransformStamped" },
+  ];
+  const tf1: MessageEvent<TransformStamped> = {
+    topic: "/tf",
+    schemaName: "geometry_msgs/TransformStamped",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "map" },
+      child_frame_id: "base_link",
+      transform: {
+        translation: { x: 1e7, y: 0, z: 0 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+  const tf2: MessageEvent<TransformStamped> = {
+    topic: "/tf",
+    schemaName: "geometry_msgs/TransformStamped",
+    receiveTime: { sec: 10, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "base_link" },
+      child_frame_id: "sensor",
+      transform: {
+        translation: { x: 0, y: 0, z: 1 },
+        rotation: QUAT_IDENTITY,
+      },
+    },
+    sizeInBytes: 0,
+  };
+
+  const costmap: MessageEvent<OccupancyGrid> = {
+    topic: "/costmap",
+    schemaName: "nav_msgs/OccupancyGrid",
+    receiveTime: { sec: 0, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      info: {
+        map_load_time: { sec: 0, nsec: 0 },
+        resolution: 0.02,
+        width: 256,
+        height: 256,
+        origin: { position: { x: -5.5, y: -2.5, z: 0 }, orientation: QUAT_IDENTITY },
+      },
+      data: makeGridData({ width: 256, height: 256 }),
+    },
+    sizeInBytes: 0,
+  };
+
+  topics.push({ name: "/costmap", schemaName: "nav_msgs/OccupancyGrid" });
+
+  const custom: MessageEvent<OccupancyGrid> = {
+    topic: "/custom",
+    schemaName: "nav_msgs/OccupancyGrid",
+    receiveTime: { sec: 0, nsec: 0 },
+    message: {
+      header: { seq: 0, stamp: { sec: 0, nsec: 0 }, frame_id: "sensor" },
+      info: {
+        map_load_time: { sec: 0, nsec: 0 },
+        resolution: 0.02,
+        width: 256,
+        height: 256,
+        origin: { position: { x: 0.5, y: -2.5, z: 0 }, orientation: QUAT_IDENTITY },
+      },
+      data: makeGridData({ width: 256, height: 256 }),
+    },
+    sizeInBytes: 0,
+  };
+
+  topics.push({ name: "/custom", schemaName: "nav_msgs/OccupancyGrid" });
+  const fixture = useDelayedFixture({
+    topics,
+    frame: {
+      "/costmap": [costmap],
+      "/custom": [custom],
+      "/tf": [tf1, tf2],
+    },
+    capabilities: [],
+    activeData: {
+      currentTime: { sec: 0, nsec: 0 },
+    },
+  });
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <ThreeDeeRender
+        overrideConfig={{
+          followTf: "base_link",
+          topics: {
+            "/costmap": {
+              visible: true,
+              colorMode: "costmap",
+            } as LayerSettingsOccupancyGrid,
+            "/custom": {
+              visible: true,
+              colorMode: "custom",
+            } as LayerSettingsOccupancyGrid,
+          },
+          layers: {
+            grid: { layerId: "foxglove.Grid" },
+          },
+          cameraState: {
+            distance: 13.5,
+            perspective: true,
+            phi: 0.1,
+            targetOffset: [0.25, -0.5, 0],
+            thetaOffset: 0,
+            fovy: rad2deg(0.75),
+            near: 0.01,
+            far: 5000,
+            target: [0, 0, 0],
+            targetOrientation: [0, 0, 0, 1],
+          },
+        }}
+      />
+    </PanelSetup>
+  );
+}


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix `nav_msgs/OccupancyGrid` value === 100 showing up as transparent instead of black

**Description**
- occupancy grid show value === 100 as black instead of transparent
- add story to for occupancy grids


<!-- link relevant GitHub issues -->
FG-1862
Fixes #5320
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
