### PR TITLE
Fixed `nav_msgs/OccupancyGrid` negative color values

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -455,7 +455,7 @@ function normalizeOccupancyGrid(message: PartialMessage<OccupancyGrid>): Occupan
 let costmapPalette: [number, number, number, number][] | undefined;
 
 function costmapColorCached(output: ColorRGBA, value: number) {
-  const unsignedValue = value > 0 ? value : Math.abs(value) + 127;
+  const unsignedValue = value > 0 ? value : value + 255;
   if (unsignedValue < 0 || unsignedValue > 255) {
     output.r = 0;
     output.g = 0;
@@ -499,10 +499,10 @@ function createCostmapPalette() {
 
   // illegal negative (char) values in shades of red/yellow
   for (let i = 128; i <= 254; i++) {
-    palette[index++] = [255, (255 * (i - 128)) / (254 - 128), 0, 255];
+    palette[index++] = [255, Math.trunc((255 * (i - 128)) / (254 - 128)), 0, 255];
   }
 
   // legal -1 value is tasteful blueish greenish grayish color
-  palette[index++] = [70, 137, 134, 255];
+  palette[index++] = [112, 137, 134, 255];
   return palette;
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**

When using the costmap palette for `nav_msgs/OccupancyGrid` , the negative colors are reversed.

This is what all the `nav_msgs/OccupancyGrid` colors look like in Rviz.  It's a map generated with values going from -128 to 127 from left to right on each column.

![](https://user-images.githubusercontent.com/1470630/218890890-44114a61-7612-4326-a5fc-c61c734f5b57.png)

Here's what it looks like in Foxglove before the fix.  Notice the red-yellow gradient is flipped.  This is because the negative values are being miscalculated:

![original](https://user-images.githubusercontent.com/1470630/218890645-54e01a04-0bd0-49d4-9c51-96dc337e9de8.png)

I corrected that.  Here's what it looks like now:

![foxglove-fixed](https://user-images.githubusercontent.com/1470630/218890667-8bcb96ad-39f1-4f63-b958-c660cb27f2ad.png)