### PR TITLE
Fix `nav_msgs/OccupancyGrid` costmap transparency

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -456,7 +456,7 @@ function normalizeOccupancyGrid(message: PartialMessage<OccupancyGrid>): Occupan
 let costmapPalette: [number, number, number, number][] | undefined;
 
 function costmapColorCached(output: ColorRGBA, value: number) {
-  const unsignedValue = value > 0 ? value : value + 255;
+  const unsignedValue = value >= 0 ? value : value + 255;
   if (unsignedValue < 0 || unsignedValue > 255) {
     output.r = 0;
     output.g = 0;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -414,13 +414,20 @@ function createPickingMaterial(texture: THREE.DataTexture): THREE.ShaderMaterial
 }
 
 function occupancyGridHasTransparency(settings: LayerSettingsOccupancyGrid): boolean {
-  stringToRgba(tempMinColor, settings.minColor);
-  stringToRgba(tempMaxColor, settings.maxColor);
-  stringToRgba(tempUnknownColor, settings.unknownColor);
-  stringToRgba(tempInvalidColor, settings.invalidColor);
-  return (
-    tempMinColor.a < 1 || tempMaxColor.a < 1 || tempInvalidColor.a < 1 || tempUnknownColor.a < 1
-  );
+  if (settings.colorMode == "costmap")
+  {
+    return true;
+  }
+  else
+  {
+    stringToRgba(tempMinColor, settings.minColor);
+    stringToRgba(tempMaxColor, settings.maxColor);
+    stringToRgba(tempUnknownColor, settings.unknownColor);
+    stringToRgba(tempInvalidColor, settings.invalidColor);
+    return (
+      tempMinColor.a < 1 || tempMaxColor.a < 1 || tempInvalidColor.a < 1 || tempUnknownColor.a < 1
+    );
+  }
 }
 
 function srgbToLinearUint8(color: ColorRGBA): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -414,12 +414,9 @@ function createPickingMaterial(texture: THREE.DataTexture): THREE.ShaderMaterial
 }
 
 function occupancyGridHasTransparency(settings: LayerSettingsOccupancyGrid): boolean {
-  if (settings.colorMode == "costmap")
-  {
+  if (settings.colorMode === "costmap") {
     return true;
-  }
-  else
-  {
+  } else {
     stringToRgba(tempMinColor, settings.minColor);
     stringToRgba(tempMaxColor, settings.maxColor);
     stringToRgba(tempUnknownColor, settings.unknownColor);


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**

Cells of value 0 of the `nav_msgs/OccupancyGrid` type were not getting the transparency rendered at all.  See the image below.  The grey cells in the costmap should be fully transparent:

![transparency_before](https://user-images.githubusercontent.com/1470630/219169185-c1486e4b-fe77-4dba-a871-32c999f04a63.png)

Here's how it looks like in Rviz (at a different time point in the sample data):

![transparency_rviz](https://user-images.githubusercontent.com/1470630/219169399-a7fdf3c2-64f9-4fa4-85d6-7f3bc87b0178.png)

With this fix, this is how that same time point looks like in Foxglove.  Notice the grey cells are now transparent:

![transparency_fixed](https://user-images.githubusercontent.com/1470630/219169768-89f3e6de-54f6-4d7d-b1fb-1739c042c339.png)