### PR TITLE
3D: compute vertex normals when overriding mesh color

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -39,6 +39,7 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
       disposeStandardMaterial(meshChild.material);
     }
     meshChild.material = material;
+    meshChild.geometry.computeVertexNormals();
   });
 }
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed color override functionality for certain mesh entities in the 3D panel.

**Description**
Meshes without normals (e.g. https://github.com/mrdoob/three.js/raw/dev/examples/models/gltf/Flamingo.glb) would appear black. Compute vertex normals when replacing the mesh's material.

Fixes FG-1935

<img width="181" alt="image" src="https://user-images.githubusercontent.com/14237/219252838-1c66bf85-640d-4f7e-9785-37e3efd16c8f.png">
