### PR TITLE
Add support for remaining Rviz color modes to `nav_msgs/OccupancyGrid`

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -105,8 +105,8 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
           value: config.colorMode ?? "custom",
           options: [
             { label: "Custom", value: "custom" },
-            { label: "Costmap", value: "costmap" },
             { label: "Map", value: "map" },
+            { label: "Costmap", value: "costmap" },
             { label: "Raw", value: "raw" },
           ],
         },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -127,7 +127,15 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
         };
       } else {
         const paletteFields: SettingsTreeFields = {
-          alpha: { label: "Alpha", input: "number", value: config.alpha ?? DEFAULT_ALPHA, min: 0.0, max: 1.0, step: 0.1, placeholder: "auto"},
+          alpha: {
+            label: "Alpha",
+            input: "number",
+            value: config.alpha ?? DEFAULT_ALPHA,
+            min: 0.0,
+            max: 1.0,
+            step: 0.1,
+            placeholder: "auto",
+          },
         };
         fields = {
           ...fields,
@@ -493,16 +501,14 @@ function paletteColorCached(output: ColorRGBA, value: number, color_mode: ColorM
     }
     palette = rawPalette;
   } else {
-    throw new Error(`Unsupported palette name ${color_mode}`);
+    throw new Error(`Unsupported color mode ${color_mode}`);
   }
 
-  if (palette) {
-    const colorRaw = palette[Math.trunc(unsignedValue)]!;
-    output.r = colorRaw[0];
-    output.g = colorRaw[1];
-    output.b = colorRaw[2];
-    output.a = colorRaw[3];
-  }
+  const colorRaw = palette[Math.trunc(unsignedValue)]!;
+  output.r = colorRaw[0];
+  output.g = colorRaw[1];
+  output.b = colorRaw[2];
+  output.a = colorRaw[3];
 }
 
 // Based off of rviz map implementation

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -32,6 +32,7 @@ export type LayerSettingsOccupancyGrid = BaseSettings & {
   unknownColor: string;
   invalidColor: string;
   colorMode: ColorModes;
+  alpha: number;
 };
 
 const INVALID_OCCUPANCY_GRID = "INVALID_OCCUPANCY_GRID";
@@ -40,6 +41,7 @@ const DEFAULT_MIN_COLOR = { r: 1, g: 1, b: 1, a: 1 }; // white
 const DEFAULT_MAX_COLOR = { r: 0, g: 0, b: 0, a: 1 }; // black
 const DEFAULT_UNKNOWN_COLOR = { r: 0.5, g: 0.5, b: 0.5, a: 1 }; // gray
 const DEFAULT_INVALID_COLOR = { r: 1, g: 0, b: 1, a: 1 }; // magenta
+const DEFAULT_ALPHA = 1.0;
 
 const DEFAULT_MIN_COLOR_STR = rgbaToCssString(DEFAULT_MIN_COLOR);
 const DEFAULT_MAX_COLOR_STR = rgbaToCssString(DEFAULT_MAX_COLOR);
@@ -54,6 +56,7 @@ const DEFAULT_SETTINGS: LayerSettingsOccupancyGrid = {
   maxColor: DEFAULT_MAX_COLOR_STR,
   unknownColor: DEFAULT_UNKNOWN_COLOR_STR,
   invalidColor: DEFAULT_INVALID_COLOR_STR,
+  alpha: DEFAULT_ALPHA,
 };
 
 export type OccupancyGridUserData = BaseUserData & {
@@ -121,6 +124,14 @@ export class OccupancyGrids extends SceneExtension<OccupancyGridRenderable> {
         fields = {
           ...fields,
           ...customFields,
+        };
+      } else {
+        const paletteFields: SettingsTreeFields = {
+          alpha: { label: "Alpha", input: "number", value: config.alpha ?? DEFAULT_ALPHA, min: 0.0, max: 1.0, step: 0.1, placeholder: "auto"},
+        };
+        fields = {
+          ...fields,
+          ...paletteFields,
         };
       }
 
@@ -364,7 +375,7 @@ function updateTexture(
       rgba[offset + 0] = tempColor.r;
       rgba[offset + 1] = tempColor.g;
       rgba[offset + 2] = tempColor.b;
-      rgba[offset + 3] = tempColor.a;
+      rgba[offset + 3] = tempColor.a * settings.alpha;
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -471,7 +471,7 @@ function paletteColorCached(output: ColorRGBA, value: number, color_mode: ColorM
     palette = costmapPalette;
   } else if (color_mode === "raw") {
     if (!rawPalette) {
-      rawPalette == createRawPalette();
+      rawPalette = createRawPalette();
     }
     palette = rawPalette;
   } else {


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**

This PR adds support for the "Map" and "Raw" `nav_msgs/OccupancyGrid` color modes from Rviz.  It also fixes a bug with how the grid values were being converted that was producing slightly wrong colors.  It also adds support for an "Alpha" field that modifies the alpha color values when any non-custom color mode is selected.

Below is a screenshot showing a sample with the background map set to the "Map" color mode and the obstacle grid set to the "Costmap" color mode:

<img width="1312" alt="screenshot1" src="https://user-images.githubusercontent.com/1470630/219553658-6d34e7e8-3255-4cb3-a722-7a58d0574303.png">

Below is another screenshot showing a sample with the background map set to the default "Custom" color mode and the obstacle grid set to the "Raw" color mode:

<img width="1312" alt="screenshot2" src="https://user-images.githubusercontent.com/1470630/219553731-94a385fc-d05f-432e-86a1-ca68013bc666.png">
