### PR TITLE
foxglove websocket: Add connection graph capability

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -57,7 +57,7 @@
     "@foxglove/velodyne-cloud": "1.0.1",
     "@foxglove/wasm-bz2": "0.1.1",
     "@foxglove/wasm-lz4": "1.0.2",
-    "@foxglove/ws-protocol": "0.4.1",
+    "@foxglove/ws-protocol": "0.5.0",
     "@foxglove/xmlrpc": "1.3.0",
     "@mcap/core": "1.1.0",
     "@mdi/svg": "7.1.96",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,7 +2430,7 @@ __metadata:
     "@foxglove/velodyne-cloud": 1.0.1
     "@foxglove/wasm-bz2": 0.1.1
     "@foxglove/wasm-lz4": 1.0.2
-    "@foxglove/ws-protocol": 0.4.1
+    "@foxglove/ws-protocol": 0.5.0
     "@foxglove/xmlrpc": 1.3.0
     "@mcap/core": 1.1.0
     "@mdi/svg": 7.1.96
@@ -2649,14 +2649,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/ws-protocol@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@foxglove/ws-protocol@npm:0.4.1"
+"@foxglove/ws-protocol@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@foxglove/ws-protocol@npm:0.5.0"
   dependencies:
     debug: ^4
     eventemitter3: ^5.0.0
-    tslib: ^2
-  checksum: 2aed1bbca50222d8e9c1419d7d1063fabac8ee47a87106d6120f92af0695efec26616d7fe469c4257d6318dbc9d896c2c03034064da6befc0422b6b5634f79ee
+    tslib: ^2.5.0
+  checksum: 7c06bc3683cc934fc0518beaa92eb9f0581ff9011ababa1a261450e18117960fca4da9aeff1955c2155a429cb8a38dc4a211e8de58f118ed9c093907137fc9db
   languageName: node
   linkType: hard
 
@@ -24058,7 +24058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.5.0, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
+"tslib@npm:2.5.0, tslib@npm:^2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0":
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
   checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1


### PR DESCRIPTION
**User-Facing Changes**
- foxglove websocket: Add connection graph capability (https://github.com/foxglove/ws-protocol/pull/368)
  - Enables the topic graph panel

**Description**
Depends on https://github.com/foxglove/ws-protocol/pull/368

If available, subscribes to connection graph updates to populate the topic graph panel

Fixes FG-1307
