### PR TITLE
Reset player state when player changes

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/index.test.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.test.tsx
@@ -108,6 +108,30 @@ describe("MessagePipelineProvider/useMessagePipeline", () => {
         setParameter: expect.any(Function),
         pauseFrame: expect.any(Function),
       },
+      {
+        playerState: {
+          activeData: undefined,
+          capabilities: [],
+          presence: PlayerPresence.NOT_PRESENT,
+          playerId: "",
+          progress: {},
+        },
+        subscriptions: [],
+        publishers: [],
+        messageEventsBySubscriberId: new Map(),
+        sortedTopics: [],
+        datatypes: new Map(),
+        setSubscriptions: expect.any(Function),
+        setPublishers: expect.any(Function),
+        publish: expect.any(Function),
+        callService: expect.any(Function),
+        startPlayback: undefined,
+        pausePlayback: undefined,
+        setPlaybackSpeed: undefined,
+        seekPlayback: undefined,
+        setParameter: expect.any(Function),
+        pauseFrame: expect.any(Function),
+      },
     ]);
   });
 

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -126,6 +126,13 @@ export function MessagePipelineProvider({
   const dispatch = store.getState().dispatch;
   useEffect(() => {
     if (!player) {
+      // When there is no player, set the player state to the default to go back to a state where we
+      // indicate the player is not present.
+      dispatch({
+        type: "update-player-state",
+        playerState: defaultPlayerState(),
+        renderDone: undefined,
+      });
       return;
     }
 

--- a/packages/studio-base/src/components/OpenDialog/Connection.tsx
+++ b/packages/studio-base/src/components/OpenDialog/Connection.tsx
@@ -149,7 +149,8 @@ export default function Connection(props: ConnectionProps): JSX.Element {
       return;
     }
     selectSource(selectedSource.id, { type: "connection", params: fieldValues });
-  }, [selectedSource, fieldValues, selectSource]);
+    onCancel?.();
+  }, [onCancel, selectedSource, fieldValues, selectSource]);
 
   const disableOpen = selectedSource?.disabledReason != undefined || fieldErrors.size > 0;
 


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue that prevented the open dialog from closing after re-selecting a data source in certain situations.

**Description**
This change updates the message pipeline to re-set the player state to the default when there is no player (or when a player becomes undefined which happens when selecting a new player). Resetting the state ensures it moves back to not preset.

This change updates the Connection dialog `Open` action to explicitly close the dialog rather than relying on upstream guessing when a player becomes active to close the dialog.
