### PR TITLE
Expose MCAP metadata and MCAP/rosbag attributes in the Parameters panel

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BagIterableSource.ts
@@ -7,6 +7,7 @@ import { BlobReader } from "@foxglove/rosbag/web";
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { compare } from "@foxglove/rostime";
+import { ParameterValue } from "@foxglove/studio";
 import {
   PlayerProblem,
   MessageEvent,
@@ -153,6 +154,12 @@ export class BagIterableSource implements IIterableSource {
       }
     }
 
+    const parameters = new Map<string, ParameterValue>();
+    if (this._bag.header) {
+      parameters.set("ROSBAG_CHUNK_COUNT", this._bag.header.chunkCount);
+      parameters.set("ROSBAG_CONNECTION_COUNT", this._bag.header.connectionCount);
+    }
+
     return {
       topics: Array.from(topics.values()),
       topicStats,
@@ -161,6 +168,7 @@ export class BagIterableSource implements IIterableSource {
       problems,
       profile: "ros1",
       datatypes,
+      parameters,
       publishersByTopic,
     };
   }

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Time } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio";
+import { MessageEvent, ParameterValue } from "@foxglove/studio";
 import { PlayerProblem, Topic, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
@@ -15,6 +15,7 @@ export type Initalization = {
   datatypes: RosDatatypes;
   profile: string | undefined;
   name?: string;
+  parameters?: Map<string, ParameterValue>;
 
   /** Publisher names by topic **/
   publishersByTopic: Map<string, Set<string>>;

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -126,6 +126,7 @@ export class IterablePlayer implements Player {
   private _providerTopics: Topic[] = [];
   private _providerTopicStats = new Map<string, TopicStats>();
   private _providerDatatypes: RosDatatypes = new Map();
+  private _providerParameters?: Map<string, ParameterValue>;
 
   private _capabilities: string[] = [
     PlayerCapabilities.setSpeed,
@@ -440,6 +441,7 @@ export class IterablePlayer implements Player {
         problems,
         publishersByTopic,
         datatypes,
+        parameters,
         name,
       } = await this._bufferedSource.initialize();
 
@@ -449,7 +451,12 @@ export class IterablePlayer implements Player {
       this._end = end;
       this._publishedTopics = publishersByTopic;
       this._providerDatatypes = datatypes;
+      this._providerParameters = parameters;
       this._name = name ?? this._name;
+
+      if (this._providerParameters) {
+        this._capabilities.push(PlayerCapabilities.getParameters);
+      }
 
       // Studio does not like duplicate topics or topics with different datatypes
       // Check for duplicates or for mismatched datatypes
@@ -741,6 +748,7 @@ export class IterablePlayer implements Player {
         topics: this._providerTopics,
         topicStats: this._providerTopicStats,
         datatypes: this._providerDatatypes,
+        parameters: this._providerParameters,
         publishedTopics: this._publishedTopics,
       };
     }


### PR DESCRIPTION
**User-Facing Changes**
- MCAP `Metadata` records can be viewed in the Parameters panel, along with `MCAP_LIBRARY`, `MCAP_PROFILE` parameters for MCAP files and `ROSBAG_CHUNK_COUNT`, `ROSBAG_CONNECTION_COUNT` parameters for rosbag files

**Description**
Pipe MCAP metadata through to `parameters` in the message pipeline and add the `getParameters` capability for MCAP and rosbag files. This also adds `MCAP_LIBRARY`, `MCAP_PROFILE`, `ROSBAG_CHUNK_COUNT`, and `ROSBAG_CONNECTION_COUNT` parameters

<img width="1015" alt="screenshot_2023-02-17_at_3 38 41_pm" src="https://user-images.githubusercontent.com/195374/219817671-cae40def-ea6d-4098-9fdb-8643b48b392a.png">
