### PR TITLE
Move plot series message path above label

### DIFF
--- a/packages/studio-base/src/panels/Plot/settings.ts
+++ b/packages/studio-base/src/panels/Plot/settings.ts
@@ -29,16 +29,16 @@ const makeSeriesNode = memoizeWeak((path: PlotPath, index: number): SettingsTree
     label: plotPathDisplayName(path, index),
     visible: path.enabled,
     fields: {
-      label: {
-        input: "string",
-        label: "Label",
-        value: path.label,
-      },
       value: {
         label: "Message path",
         input: "messagepath",
         value: path.value,
         validTypes: plotableRosTypes,
+      },
+      label: {
+        input: "string",
+        label: "Label",
+        value: path.label,
       },
       color: {
         input: "rgb",


### PR DESCRIPTION
**User-Facing Changes**
Move Plot panel series `Message path` text input above `Label`.

**Description**
Since we merged the new plot panel settings, I find myself constantly clicking the top text input of the series expecting to edit the series data. `Label` is an optional field so it feels weird having it above `Message path` - I propose moving it below.

After:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/637671/219844211-c316ddb4-dbaa-4e64-9f64-69787f784db5.png">