### PR TITLE
Support ZFP-compressed images in the Image and 3D panel

### DIFF
--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -19,7 +19,7 @@ import Zfp, { ZfpType, ZfpBuffer, ZfpResult } from "wasm-zfp";
 // https://github.com/ros-perception/image_pipeline/blob/42266892502427eb566a4dffa61b009346491ce7/image_view/src/nodes/image_view.cpp#L80-L88
 // https://github.com/ros-visualization/rqt_image_view/blob/fe076acd265a05c11c04f9d04392fda951878f54/src/rqt_image_view/image_view.cpp#L582
 // https://github.com/ros-visualization/rviz/blob/68b464fb6571b8760f91e8eca6fb933ba31190bf/src/rviz/image/ros_image_texture.cpp#L114
-const DEFAULT_MAX = 10000;
+const DEFAULT_INT_MAX = 10000;
 
 // The set of image formats that can natively be rendered in the browser
 export const BROWSER_IMAGE_FORMATS = new Set([
@@ -239,7 +239,7 @@ export function decodeMono16(
 
   // Use user-provided max/min values, or default to [0, DEFAULT_MAX]
   const minValue = options?.minValue ?? 0;
-  let maxValue = options?.maxValue ?? DEFAULT_MAX;
+  let maxValue = options?.maxValue ?? DEFAULT_INT_MAX;
   if (maxValue === minValue) {
     maxValue = minValue + 1;
   }
@@ -382,7 +382,7 @@ function expandZfpResult(
   size: number,
   options: { minValue?: number; maxValue?: number },
 ) {
-  const { minValue = 0, maxValue = DEFAULT_MAX } = options;
+  const { minValue = 0, maxValue = DEFAULT_INT_MAX } = options;
   const invDiff = 1 / (maxValue - minValue);
   const hasRange = options.maxValue != undefined;
 

--- a/packages/den/package.json
+++ b/packages/den/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://foxglove.dev/",
   "dependencies": {
     "async-mutex": "0.4.0",
+    "wasm-zfp": "3.0.0",
     "xacro-parser": "0.3.9"
   }
 }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -199,7 +199,6 @@
     "use-immer": "0.8.1",
     "use-pan-and-zoom": "0.6.5",
     "uuid": "9.0.0",
-    "wasm-zfp": "3.0.0",
     "webpack": "5.75.0",
     "xacro-parser": "0.3.9",
     "zustand": "4.3.2"

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -199,6 +199,7 @@
     "use-immer": "0.8.1",
     "use-pan-and-zoom": "0.6.5",
     "uuid": "9.0.0",
+    "wasm-zfp": "3.0.0",
     "webpack": "5.75.0",
     "xacro-parser": "0.3.9",
     "zustand": "4.3.2"

--- a/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
+++ b/packages/studio-base/src/panels/Image/components/ImageCanvas.stories.tsx
@@ -20,7 +20,7 @@ import { CameraInfo } from "@foxglove/studio-base/types/Messages";
 
 import { ImageCanvas } from "./ImageCanvas";
 import ImageView from "../index";
-import { useCompressedImage, annotations } from "../storySupport";
+import { useCompressedImage, annotations, useZfpCompressedImage } from "../storySupport";
 import { Config } from "../types";
 
 const cameraInfo: CameraInfo = {
@@ -308,6 +308,35 @@ MarkersImageSize.play = async (ctx) => {
   await ctx.parameters.storyReady;
 };
 MarkersImageSize.parameters = {
+  useReadySignal: true,
+};
+
+export const ZfpMarkersTransformed: Story = (_args) => {
+  const image = useZfpCompressedImage();
+  const readySignal = useReadySignal();
+
+  return (
+    <div style={{ height: "400px" }}>
+      <ImageCanvas
+        topic={topics[1]}
+        image={image}
+        rawMarkerData={{
+          markers: annotations,
+          cameraInfo,
+          transformMarkers: true,
+        }}
+        config={config}
+        saveConfig={noop}
+        setActivePixelData={noop}
+        onStartRenderImage={() => readySignal}
+      />
+    </div>
+  );
+};
+ZfpMarkersTransformed.play = async (ctx) => {
+  await ctx.parameters.storyReady;
+};
+ZfpMarkersTransformed.parameters = {
   useReadySignal: true,
 };
 

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -7,13 +7,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { normalizeAnnotations } from "./normalizeAnnotations";
 import { renderImage } from "./renderImage";
-import {
-  useCompressedImage,
-  cameraInfo,
-  annotations,
-  foxgloveAnnotations,
-  useZfpCompressedImage,
-} from "../storySupport";
+import { useCompressedImage, cameraInfo, annotations, foxgloveAnnotations } from "../storySupport";
 
 export default {
   title: "panels/Image/renderImage",
@@ -128,48 +122,6 @@ export const MarkersWithRotations: Story = (_args) => {
           style={{ width, height }}
         />
       ))}
-    </div>
-  );
-};
-
-export const ZfpImage: Story = (_args) => {
-  const imageMessage = useZfpCompressedImage();
-  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
-
-  const width = 480;
-  const height = 320;
-
-  useEffect(() => {
-    if (!canvasRef.current) {
-      return;
-    }
-
-    canvasRef.current.width = 2 * width;
-    canvasRef.current.height = 2 * height;
-
-    void renderImage({
-      canvas: canvasRef.current,
-      hitmapCanvas: undefined,
-      geometry: {
-        flipHorizontal: false,
-        flipVertical: false,
-        panZoom: { x: 0, y: 0, scale: 1 },
-        rotation: 0,
-        viewport: { width, height },
-        zoomMode: "fill",
-      },
-      imageMessage,
-      rawMarkerData: {
-        markers: annotations,
-        cameraInfo,
-        transformMarkers: true,
-      },
-    });
-  }, [imageMessage]);
-
-  return (
-    <div style={{ backgroundColor: "white", padding: "1rem" }}>
-      <canvas ref={canvasRef} style={{ width, height }} />
     </div>
   );
 };

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -7,7 +7,13 @@ import { useEffect, useMemo, useRef } from "react";
 
 import { normalizeAnnotations } from "./normalizeAnnotations";
 import { renderImage } from "./renderImage";
-import { useCompressedImage, cameraInfo, annotations, foxgloveAnnotations } from "../storySupport";
+import {
+  useCompressedImage,
+  cameraInfo,
+  annotations,
+  foxgloveAnnotations,
+  useZfpCompressedImage,
+} from "../storySupport";
 
 export default {
   title: "panels/Image/renderImage",
@@ -122,6 +128,48 @@ export const MarkersWithRotations: Story = (_args) => {
           style={{ width, height }}
         />
       ))}
+    </div>
+  );
+};
+
+export const ZfpImage: Story = (_args) => {
+  const imageMessage = useZfpCompressedImage();
+  const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+
+  const width = 400;
+  const height = 300;
+
+  useEffect(() => {
+    if (!canvasRef.current) {
+      return;
+    }
+
+    canvasRef.current.width = 2 * width;
+    canvasRef.current.height = 2 * height;
+
+    void renderImage({
+      canvas: canvasRef.current,
+      hitmapCanvas: undefined,
+      geometry: {
+        flipHorizontal: false,
+        flipVertical: false,
+        panZoom: { x: 0, y: 0, scale: 1 },
+        rotation: 0,
+        viewport: { width, height },
+        zoomMode: "fill",
+      },
+      imageMessage,
+      rawMarkerData: {
+        markers: annotations,
+        cameraInfo,
+        transformMarkers: true,
+      },
+    });
+  }, [imageMessage]);
+
+  return (
+    <div style={{ backgroundColor: "white", padding: "1rem" }}>
+      <canvas ref={canvasRef} style={{ width, height }} />
     </div>
   );
 };

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -19,7 +19,7 @@ export default {
   title: "panels/Image/renderImage",
   parameters: {
     chromatic: {
-      delay: 100,
+      delay: 3000,
     },
     colorScheme: "dark",
   },
@@ -136,8 +136,8 @@ export const ZfpImage: Story = (_args) => {
   const imageMessage = useZfpCompressedImage();
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
 
-  const width = 400;
-  const height = 300;
+  const width = 480;
+  const height = 320;
 
   useEffect(() => {
     if (!canvasRef.current) {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -24,7 +24,6 @@ export default {
       delay: 100,
     },
     colorScheme: "dark",
-    useReadySignal: true,
   },
 };
 
@@ -138,17 +137,10 @@ export const MarkersWithRotations: Story = (_args) => {
 export const ZfpImage: Story = (_args) => {
   const imageMessage = useZfpCompressedImage();
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
+  const readySignal = useReadySignal();
 
   const width = 400;
   const height = 300;
-
-  // When imageMessage becomes defined, signal that the story is ready
-  const readySignal = useReadySignal();
-  useEffect(() => {
-    if (imageMessage) {
-      readySignal();
-    }
-  }, [imageMessage, readySignal]);
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -175,14 +167,21 @@ export const ZfpImage: Story = (_args) => {
         cameraInfo,
         transformMarkers: true,
       },
+    }).then(() => {
+      if (imageMessage) {
+        readySignal();
+      }
     });
-  }, [imageMessage]);
+  }, [imageMessage, readySignal]);
 
   return (
     <div style={{ backgroundColor: "white", padding: "1rem" }}>
       <canvas ref={canvasRef} style={{ width, height }} />
     </div>
   );
+};
+ZfpImage.parameters = {
+  useReadySignal: true,
 };
 
 export function FoxgloveAnnotations(): JSX.Element {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -19,7 +19,7 @@ export default {
   title: "panels/Image/renderImage",
   parameters: {
     chromatic: {
-      delay: 1000,
+      delay: 3000,
     },
     colorScheme: "dark",
   },

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -19,7 +19,7 @@ export default {
   title: "panels/Image/renderImage",
   parameters: {
     chromatic: {
-      delay: 100,
+      delay: 1000,
     },
     colorScheme: "dark",
   },

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -180,6 +180,9 @@ export const ZfpImage: Story = (_args) => {
     </div>
   );
 };
+ZfpImage.play = async (ctx) => {
+  await ctx.parameters.storyReady;
+};
 ZfpImage.parameters = {
   useReadySignal: true,
 };

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -5,8 +5,6 @@
 import { Story } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
-
 import { normalizeAnnotations } from "./normalizeAnnotations";
 import { renderImage } from "./renderImage";
 import {
@@ -137,7 +135,6 @@ export const MarkersWithRotations: Story = (_args) => {
 export const ZfpImage: Story = (_args) => {
   const imageMessage = useZfpCompressedImage();
   const canvasRef = useRef<HTMLCanvasElement>(ReactNull);
-  const readySignal = useReadySignal();
 
   const width = 400;
   const height = 300;
@@ -167,24 +164,14 @@ export const ZfpImage: Story = (_args) => {
         cameraInfo,
         transformMarkers: true,
       },
-    }).then(() => {
-      if (imageMessage) {
-        readySignal();
-      }
     });
-  }, [imageMessage, readySignal]);
+  }, [imageMessage]);
 
   return (
     <div style={{ backgroundColor: "white", padding: "1rem" }}>
       <canvas ref={canvasRef} style={{ width, height }} />
     </div>
   );
-};
-ZfpImage.play = async (ctx) => {
-  await ctx.parameters.storyReady;
-};
-ZfpImage.parameters = {
-  useReadySignal: true,
 };
 
 export function FoxgloveAnnotations(): JSX.Element {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.stories.tsx
@@ -5,6 +5,8 @@
 import { Story } from "@storybook/react";
 import { useEffect, useMemo, useRef } from "react";
 
+import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext";
+
 import { normalizeAnnotations } from "./normalizeAnnotations";
 import { renderImage } from "./renderImage";
 import {
@@ -19,9 +21,10 @@ export default {
   title: "panels/Image/renderImage",
   parameters: {
     chromatic: {
-      delay: 3000,
+      delay: 100,
     },
     colorScheme: "dark",
+    useReadySignal: true,
   },
 };
 
@@ -138,6 +141,14 @@ export const ZfpImage: Story = (_args) => {
 
   const width = 400;
   const height = 300;
+
+  // When imageMessage becomes defined, signal that the story is ready
+  const readySignal = useReadySignal();
+  useEffect(() => {
+    if (imageMessage) {
+      readySignal();
+    }
+  }, [imageMessage, readySignal]);
 
   useEffect(() => {
     if (!canvasRef.current) {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -135,10 +135,14 @@ function decodeMessageToBitmap(
 
   switch (imageMessage.type) {
     case "compressed": {
-      if (BROWSER_IMAGE_FORMATS.has(imageMessage.format)) {
-        const image = new Blob([rawData], { type: `image/${imageMessage.format}` });
+      // Strip image/ prefix if present
+      const format = imageMessage.format.startsWith("image/")
+        ? imageMessage.format.slice(6)
+        : imageMessage.format;
+      if (BROWSER_IMAGE_FORMATS.has(format)) {
+        const image = new Blob([rawData], { type: `image/${format}` });
         return self.createImageBitmap(image);
-      } else if (imageMessage.format === "zfp") {
+      } else if (format === "zfp") {
         // Potentially performance-sensitive; await can be expensive
         // eslint-disable-next-line @typescript-eslint/promise-function-async
         return decodeZfp(imageMessage.data, imageDataCache, options).then((zfpResult) => {

--- a/packages/studio-base/src/panels/Image/lib/renderImage.ts
+++ b/packages/studio-base/src/panels/Image/lib/renderImage.ts
@@ -494,9 +494,12 @@ function paintPointsAnnotation(
       break;
     }
     case "line_list": {
-      const hasExactColors = annotation.outlineColors.length === annotation.points.length / 2;
+      // Round annotation.points.length down to the nearest even number
+      const pointsCount = annotation.points.length - (annotation.points.length % 2);
 
-      for (let i = 0; i < annotation.points.length; i += 2) {
+      const hasExactColors = annotation.outlineColors.length === pointsCount / 2;
+
+      for (let i = 0; i < pointsCount; i += 2) {
         // Support the case where outline_colors is half the length of points,
         // one color per line, and where outline_colors matches the length of
         // points (although we only use the first color in this case). Fall back

--- a/packages/studio-base/src/panels/Image/storySupport/useCompressedImage.ts
+++ b/packages/studio-base/src/panels/Image/storySupport/useCompressedImage.ts
@@ -60,15 +60,17 @@ function useZfpCompressedImage(): NormalizedImageMessage | undefined {
       }
     }
 
-    const zfpBuffer = Zfp.createBuffer();
-    const compressed = Zfp.compress(zfpBuffer, {
-      data: int32Data,
-      shape: [width, height, 0, 0],
-      dimensions: 2,
-    });
-    Zfp.freeBuffer(zfpBuffer);
+    void Zfp.isLoaded.then(() => {
+      const zfpBuffer = Zfp.createBuffer();
+      const compressed = Zfp.compress(zfpBuffer, {
+        data: int32Data,
+        shape: [width, height, 0, 0],
+        dimensions: 2,
+      });
+      Zfp.freeBuffer(zfpBuffer);
 
-    setImageData(compressed);
+      setImageData(compressed);
+    });
   }, []);
 
   return useMemo(() => {

--- a/packages/studio-base/src/panels/Image/storySupport/useCompressedImage.ts
+++ b/packages/studio-base/src/panels/Image/storySupport/useCompressedImage.ts
@@ -1,10 +1,13 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import * as base64 from "@protobufjs/base64";
 import { useMemo } from "react";
-import Zfp from "wasm-zfp";
 
 import { NormalizedImageMessage } from "../types";
+
+const ZFP_BASE64_DATA =
+  "emZwBfQCAPABAACIHwAA0BkAmIF9AACwPIMIO7APAACGZxBxBvYBALDIMwi4A/sAAFjgXUCYgX0AAKzyLgDswD4AAFZ4FwBnYB8AAIO8i4g7sA8AgAHeRYAZ2AcAwCjvAMIO7AMAYIR3AHEG9gEALCLvAOAO7AMAgOUZRNiBfQAAMDyDiDOwDwCARZ5BwB3YBwDAAu8CwgzsAwBglXcBYAf2AQCwwrsAOAP7AAAY5F1E3IF9AAAM8C4CzMA+AABGeQcQdmAfAAAjvAOIM7APAGAReQcAd2AfAMAi8A4izMA+AAAYnkHEGdgHAMAizyDgDuwDAGCBdwFhBvYBALDKuwCwA/sAAFjhXQCcgX0AAAzyLiLuwD4AAAZ4FwFmYB8AAKO8Awg7sA8AgBHeAcQZ2AcAsIi8A4A7sA8AYBF4BxFmYB8AwKLyDgLswD4AABZ5BgF3YB8AAAu8CwgzsA8AgFXeBYAd2AcAwArvAuAM7AMAYJB3EXEH9gEAMMC7CDAD+wAAGOUdQNiBfQAAjPAOIM7APgCAReQdANyBfQAAi8A7iDAD+wAAFpV3EGAH9gEALArvIOAM7AMAYIF3AWEG9gEAsMq7ALAD+wAAWOFdAJyBfQAADPIuIu7APgAABngXAWZgHwAAo7wDCDuwDwCAEd4BxBnYBwCwiLwDgDuwDwBgEXgHEWZgHwDAovIOAuzAPgCAReEdBJyBfQAAi+KzgLgD+wAAWOVdANiBfQAArPAuAM7APgAABnkXEXdgHwAAA7yLADOwDwCAUd4BhB3YBwDACO8A4gzsAwBYRN4BwB3YBwCwCLyDCDOwDwBgUXkHAXZgHwDAovAOAs7APgCARfFZQNyBfQAAC+izADAD+wAAWOFdAJyBfQAADPIuIu7APgAABngXAWZgHwAAo7wDCDuwDwCAEd4BxBnYBwCwiLwDgDuwDwBgEXgHEWZgHwDAovIOAuzAPgCAReEdBJyBfQAAi+KzgLgD+wAAFtBnAWAG9gEALIDPIsIO7AMAYJB3EXEH9gEAMMC7CDAD+wAAGOUdQNiBfQAAjPAOIM7APgCAReQdANyBfQAAi8A7iDAD+wAAFpV3EGAH9gEALArvIOAM7AMAWBSfBcQd2AcAsIA+CwAzsA8AYAF8FhF2YB8AwIL6LCLOwAA=";
 
 function useCompressedImage(): NormalizedImageMessage | undefined {
   const imageFormat = "image/png";
@@ -48,35 +51,9 @@ function useCompressedImage(): NormalizedImageMessage | undefined {
 }
 
 function useZfpCompressedImage(): NormalizedImageMessage | undefined {
-  const [imageData, setImageData] = React.useState<Uint8Array | undefined>();
-  React.useEffect(() => {
-    const width = 400;
-    const height = 300;
-    const int32Data = new Int32Array(width * height);
-    // Create a grayscale gradient from top-left to bottom-right
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        int32Data[y * width + x] = ((x + y) * 10000) / (width + height);
-      }
-    }
-
-    void Zfp.isLoaded.then(() => {
-      const zfpBuffer = Zfp.createBuffer();
-      const compressed = Zfp.compress(zfpBuffer, {
-        data: int32Data,
-        shape: [width, height, 0, 0],
-        dimensions: 2,
-      });
-      Zfp.freeBuffer(zfpBuffer);
-
-      setImageData(compressed);
-    });
-  }, []);
-
   return useMemo(() => {
-    if (!imageData) {
-      return;
-    }
+    const imageData = new Uint8Array(base64.length(ZFP_BASE64_DATA));
+    base64.decode(ZFP_BASE64_DATA, imageData, 0);
 
     return {
       type: "compressed",
@@ -84,7 +61,7 @@ function useZfpCompressedImage(): NormalizedImageMessage | undefined {
       format: "zfp",
       data: imageData,
     };
-  }, [imageData]);
+  }, []);
 }
 
 export { useCompressedImage, useZfpCompressedImage };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -406,13 +406,15 @@ export class Images extends SceneExtension<ImageRenderable> {
 
     // Create or update the bitmap texture
     if ("format" in image) {
-      if (BROWSER_IMAGE_FORMATS.has(image.format)) {
-        const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
+      // Strip image/ prefix if present
+      const format = image.format.startsWith("image/") ? image.format.slice(6) : image.format;
+      if (BROWSER_IMAGE_FORMATS.has(format)) {
+        const bitmapData = new Blob([image.data], { type: `image/${format}` });
         self
           .createImageBitmap(bitmapData, { resizeWidth: DEFAULT_IMAGE_WIDTH })
           .then((bitmap) => this._updateImageBitmap(renderable, bitmap))
           .catch((err) => this._handleTopicError(topic, err as Error));
-      } else if (image.format === "zfp") {
+      } else if (format === "zfp") {
         const cache = renderable.imageDataCache;
 
         decodeZfp(image.data, cache)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,6 +2141,7 @@ __metadata:
   resolution: "@foxglove/den@workspace:packages/den"
   dependencies:
     async-mutex: 0.4.0
+    wasm-zfp: 3.0.0
     xacro-parser: 0.3.9
   languageName: unknown
   linkType: soft
@@ -2572,6 +2573,7 @@ __metadata:
     use-immer: 0.8.1
     use-pan-and-zoom: 0.6.5
     uuid: 9.0.0
+    wasm-zfp: 3.0.0
     webpack: 5.75.0
     xacro-parser: 0.3.9
     zustand: 4.3.2
@@ -25101,6 +25103,13 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"wasm-zfp@npm:3.0.0":
+  version: 3.0.0
+  resolution: "wasm-zfp@npm:3.0.0"
+  checksum: ff527548985e240fee34e5cdea49bf49ba1ede9136908ff487c12830185854f63234b0e6dcff2720938146807cae37c50ee6da10fe724c4e703e78d18a851a5a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,7 +2573,6 @@ __metadata:
     use-immer: 0.8.1
     use-pan-and-zoom: 0.6.5
     uuid: 9.0.0
-    wasm-zfp: 3.0.0
     webpack: 5.75.0
     xacro-parser: 0.3.9
     zustand: 4.3.2


### PR DESCRIPTION
**User-Facing Changes**
- Adds support for [ZFP](https://computing.llnl.gov/projects/zfp)-compressed images to the Image and 3D panels

**Description**
ZFP image support is a generic solution for depth images or other two-dimensional data requiring >8-bit depth in situations that benefit from message-level compression, such as live streaming or lossy storage. Lossy and lossless modes are supported. The ZFP data must be packaged in a `foxglove.CompressedImage` or `sensor_msgs/CompressedImage` message with `format="zfp"`. Only two-dimensional data is supported, and the compressed stream must be prefixed with a full ZFP header (which describes the shape and format of the data).

Website documentation PR is at <https://github.com/foxglove/website/pull/997> and example code for creating ZFP CompressedImage messages is at <https://github.com/foxglove/mcap/blob/main/cpp/examples/protobuf/write_zfp_images.cpp>.

https://user-images.githubusercontent.com/195374/219933766-a984858a-5aaa-44a9-8af9-0c09469cfe01.mov
