### PR TITLE
Add `startTime` and `endTime` to panel extension API

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -342,6 +342,22 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       }
     }
 
+    if (watchedFields.has("timeRange")) {
+      const startTime = activeData?.startTime;
+      const endTime = activeData?.endTime;
+
+      if (!renderState.timeRange) {
+        shouldRender = true;
+        renderState.timeRange = [startTime, endTime];
+      } else {
+        if (startTime !== renderState.timeRange[0] || endTime !== renderState.timeRange[1]) {
+          shouldRender = true;
+          renderState.timeRange[0] = startTime;
+          renderState.timeRange[1] = endTime;
+        }
+      }
+    }
+
     if (watchedFields.has("previewTime")) {
       const startTime = activeData?.startTime;
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -342,19 +342,31 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       }
     }
 
-    if (watchedFields.has("timeRange")) {
+    if (watchedFields.has("startTime")) {
       const startTime = activeData?.startTime;
+
+      if (startTime != undefined && startTime !== renderState.startTime) {
+        shouldRender = true;
+        renderState.startTime = startTime;
+      } else {
+        if (renderState.startTime != undefined) {
+          shouldRender = true;
+        }
+        renderState.startTime = undefined;
+      }
+    }
+
+    if (watchedFields.has("endTime")) {
       const endTime = activeData?.endTime;
 
-      if (!renderState.timeRange) {
+      if (endTime != undefined && endTime !== renderState.endTime) {
         shouldRender = true;
-        renderState.timeRange = [startTime, endTime];
+        renderState.endTime = endTime;
       } else {
-        if (startTime !== renderState.timeRange[0] || endTime !== renderState.timeRange[1]) {
+        if (renderState.endTime != undefined) {
           shouldRender = true;
-          renderState.timeRange[0] = startTime;
-          renderState.timeRange[1] = endTime;
         }
+        renderState.endTime = undefined;
       }
     }
 

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -204,11 +204,17 @@ export interface RenderState {
   currentTime?: Time;
 
   /**
-   * The start and end timestamps of the playback range for the current data source. For offline
-   * files it is expected both values will be present. For live connections, the start time may
-   * or may not be present depending on the data source and the end time will be undefined.
+   * The start timestamp of the playback range for the current data source. For offline files it
+   * is expected to be present. For live connections, the start time may or may not be present
+   * depending on the data source.
    */
-  timeRange?: [Time | undefined, Time | undefined];
+  startTime?: Time;
+
+  /**
+   * The end timestamp of the playback range for the current data source. For offline files it
+   * is expected to be present. For live connections, the end time will be undefined.
+   */
+  endTime?: Time;
 
   /**
    * A seconds value indicating a preview time. The preview time is set when a user hovers

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -204,6 +204,13 @@ export interface RenderState {
   currentTime?: Time;
 
   /**
+   * The start and end timestamps of the playback range for the current data source. For offline
+   * files it is expected both values will be present. For live connections, the start time may
+   * or may not be present depending on the data source and the end time will be undefined.
+   */
+  timeRange?: [Time | undefined, Time | undefined];
+
+  /**
    * A seconds value indicating a preview time. The preview time is set when a user hovers
    * over the seek bar or when a panel sets the preview time explicitly. The preview time
    * is a seconds value within the playback range.

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -212,7 +212,8 @@ export interface RenderState {
 
   /**
    * The end timestamp of the playback range for the current data source. For offline files it
-   * is expected to be present. For live connections, the end time will be undefined.
+   * is expected to be present. For live connections, the end time may or may not be present
+   * depending on the data source.
    */
   endTime?: Time;
 


### PR DESCRIPTION
**User-Facing Changes**
- Adds `startTime: Time | undefined` and `endTime: Time | undefined` to the panel extension API for querying start/end time of the data source

**Description**
Generally useful thing to expose, and can potentially be useful for video playback
