### PR TITLE
3D: remove conditional render during TF preloading

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -837,18 +837,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
   // Render a new frame if requested
   useEffect(() => {
-    const { cursorTimeReached } = allFramesCursorRef.current;
-    const cursorActive = cursorTimeReached != undefined;
-    const cursorTimeReachedCurrentTime =
-      cursorActive && currentTime != undefined && compare(cursorTimeReached, currentTime) === 0;
-
-    if (
-      renderer &&
-      renderRef.current.needsRender &&
-      // if the allFrames cursor is active (time is defined), and has a reached time equal to the current time, then render
-      // if the allFrames cursor is not active, then render on usual `needsRender` condition
-      (cursorActive ? cursorTimeReachedCurrentTime : true)
-    ) {
+    if (renderer && renderRef.current.needsRender) {
       renderer.animationFrame();
       renderRef.current.needsRender = false;
     }


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where the 3D panel would sometimes not respond to user input.

**Description**
Removes a condition that was causing some renders to be skipped
Filed FG-2143 for follow up.