### PR TITLE
Add "Example CameraInfo" dropdown option to image renderables that synthesizes a plausible CameraInfo

### DIFF
--- a/packages/den/image/decodings.ts
+++ b/packages/den/image/decodings.ts
@@ -11,6 +11,17 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+// The set of image formats that can natively be rendered in the browser
+export const BROWSER_IMAGE_FORMATS = new Set([
+  "apng",
+  "avif",
+  "gif",
+  "jpeg",
+  "png",
+  "svg+xml",
+  "webp",
+]);
+
 function yuvToRGBA8(
   y1: number,
   u: number,

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -20,6 +20,7 @@ import {
   decodeMono8,
   decodeMono16,
   decodeYUYV,
+  BROWSER_IMAGE_FORMATS,
 } from "@foxglove/den/image";
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
@@ -69,6 +70,11 @@ const CREATE_BITMAP_ERR = "CreateBitmap";
 const DEFAULT_IMAGE_WIDTH = 512;
 const DEFAULT_DISTANCE = 1;
 const DEFAULT_PLANAR_PROJECTION_FACTOR = 0;
+const DEFAULT_BITMAP_OPTIONS: ImageBitmapOptions = { resizeWidth: DEFAULT_IMAGE_WIDTH };
+
+const EXAMPLE_CAMERA_INFO_ID = "__EXAMPLE_CAMERA_INFO__";
+const EXAMPLE_FOCAL_LENGTH_MM = 1.88; // From the Intel RealSense D435 datasheet
+const EXAMPLE_SENSOR_WIDTH_MM = 3.855;
 
 const DEFAULT_SETTINGS: LayerSettingsImage = {
   visible: false,
@@ -161,6 +167,11 @@ export class Images extends SceneExtension<ImageRenderable> {
         }
       }
       const cameraInfoOptions = [...bestCameraInfoOptions, ...otherCameraInfoOptions];
+      if (cameraInfoOptions.length === 0) {
+        // Add a hardcoded option to allow *something* to be projected (opt-in), even if
+        // no CameraInfo is available
+        cameraInfoOptions.push({ label: "Example CameraInfo", value: EXAMPLE_CAMERA_INFO_ID });
+      }
 
       // prettier-ignore
       const fields: SettingsTreeFields = {
@@ -294,6 +305,18 @@ export class Images extends SceneExtension<ImageRenderable> {
       }
     }
 
+    if (settings.cameraInfoTopic === EXAMPLE_CAMERA_INFO_ID && !renderable.userData.cameraModel) {
+      // If the user has selected the example camera info, synthesize a CameraInfo message
+      // with available info. If width/height are not available, they will be updated later when
+      // an ImageBitmap is created
+      const width = "width" in image ? image.width : 1280;
+      const height = "height" in image ? image.height : 720;
+      renderable.userData.cameraInfo ??= createExampleCameraInfo(frameId, width, height);
+      renderable.userData.cameraModel = new PinholeCameraModel(renderable.userData.cameraInfo);
+
+      this.renderer.settings.errors.removeFromTopic(imageTopic, NO_CAMERA_INFO_ERR);
+    }
+
     const cameraModel = renderable.userData.cameraModel;
     if (cameraModel) {
       this._updateImageRenderable(renderable, image, cameraModel, receiveTime, settings);
@@ -400,29 +423,18 @@ export class Images extends SceneExtension<ImageRenderable> {
 
     // Create or update the bitmap texture
     if ("format" in image) {
-      const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
-      self
-        .createImageBitmap(bitmapData, { resizeWidth: DEFAULT_IMAGE_WIDTH })
-        .then((bitmap) => {
-          if (renderable.userData.texture == undefined) {
-            renderable.userData.texture = createCanvasTexture(bitmap);
-            rebuildMaterial(renderable);
-            tryCreateMesh(renderable, this.renderer);
-          } else {
-            renderable.userData.texture.image.close();
-            renderable.userData.texture.image = bitmap;
-            renderable.userData.texture.needsUpdate = true;
-          }
-
-          this.renderer.settings.errors.removeFromTopic(topic, CREATE_BITMAP_ERR);
-        })
-        .catch((err) => {
-          this.renderer.settings.errors.addToTopic(
-            topic,
-            CREATE_BITMAP_ERR,
-            `createBitmap failed: ${err.message}`,
-          );
-        });
+      if (BROWSER_IMAGE_FORMATS.has(image.format)) {
+        const bitmapData = new Blob([image.data], { type: `image/${image.format}` });
+        self
+          .createImageBitmap(bitmapData, DEFAULT_BITMAP_OPTIONS)
+          .then((bitmap) => this._updateImageBitmap(renderable, bitmap))
+          .catch((err) => this._handleTopicError(topic, err as Error));
+      } else {
+        this._handleTopicError(
+          topic,
+          new Error(`Unsupported compressed image format: ${image.format}`),
+        );
+      }
     } else {
       const { width, height } = image;
       const prevTexture = renderable.userData.texture as THREE.DataTexture | undefined;
@@ -451,6 +463,54 @@ export class Images extends SceneExtension<ImageRenderable> {
     tryCreateMesh(renderable, this.renderer);
   }
 
+  private _updateImageBitmap = (renderable: ImageRenderable, bitmap: ImageBitmap): void => {
+    const { texture, topic } = renderable.userData;
+    if (texture == undefined) {
+      if (renderable.userData.settings.cameraInfoTopic === EXAMPLE_CAMERA_INFO_ID) {
+        // Synthesize a new CameraInfo and update the camera model if image dimensions changed
+        const prevWidth = renderable.userData.cameraInfo?.width ?? 0;
+        const prevHeight = renderable.userData.cameraInfo?.height ?? 0;
+        const { width, height } = bitmap;
+        if (width !== prevWidth || height !== prevHeight) {
+          if (renderable.userData.geometry) {
+            renderable.userData.geometry.dispose();
+            renderable.userData.geometry = undefined;
+          }
+
+          const cameraInfo = createExampleCameraInfo(renderable.userData.frameId, width, height);
+          const cameraModel = new PinholeCameraModel(cameraInfo);
+          const geometry = createGeometry(cameraModel, renderable.userData.settings);
+
+          renderable.userData.cameraInfo = cameraInfo;
+          renderable.userData.cameraModel = cameraModel;
+          renderable.userData.geometry = geometry;
+          if (renderable.userData.mesh) {
+            renderable.remove(renderable.userData.mesh);
+            renderable.userData.mesh = undefined;
+          }
+        }
+      }
+
+      renderable.userData.texture = createCanvasTexture(bitmap);
+      rebuildMaterial(renderable);
+      tryCreateMesh(renderable, this.renderer);
+    } else {
+      texture.image.close();
+      texture.image = bitmap;
+      texture.needsUpdate = true;
+    }
+
+    this.renderer.settings.errors.removeFromTopic(topic, CREATE_BITMAP_ERR);
+  };
+
+  private _handleTopicError = (topic: string, err: Error): void => {
+    this.renderer.settings.errors.addToTopic(
+      topic,
+      CREATE_BITMAP_ERR,
+      `createBitmap failed: ${err.message}`,
+    );
+  };
+
   private _getImageRenderable(
     imageTopic: string,
     receiveTime: bigint,
@@ -463,9 +523,12 @@ export class Images extends SceneExtension<ImageRenderable> {
       return renderable;
     }
 
+    const messageTime = image
+      ? toNanoSec("header" in image ? image.header.stamp : image.timestamp)
+      : 0n;
     renderable = new ImageRenderable(imageTopic, this.renderer, {
       receiveTime,
-      messageTime: image ? toNanoSec("header" in image ? image.header.stamp : image.timestamp) : 0n,
+      messageTime,
       frameId: this.renderer.normalizeFrameId(frameId),
       pose: makePose(),
       settingsPath: ["topics", imageTopic],
@@ -765,5 +828,36 @@ function normalizeCompressedImage(message: PartialMessage<CompressedImage>): Com
     frame_id: message.frame_id ?? "",
     format: message.format ?? "",
     data: normalizeByteArray(message.data),
+  };
+}
+
+function createExampleCameraInfo(frame_id: string, width: number, height: number): CameraInfo {
+  const focal_length_mm = EXAMPLE_FOCAL_LENGTH_MM;
+  const sensor_width_mm = EXAMPLE_SENSOR_WIDTH_MM;
+  const sensor_height_mm = (sensor_width_mm * height) / width;
+
+  const fx = width * (focal_length_mm / sensor_width_mm);
+  const fy = height * (focal_length_mm / sensor_height_mm);
+  const cx = width / 2;
+  const cy = height / 2;
+
+  return {
+    header: { stamp: { sec: 0, nsec: 0 }, frame_id },
+    distortion_model: "plumb_bob",
+    width,
+    height,
+    D: [0, 0, 0, 0, 0],
+    K: [fx, 0, cx, 0, fy, cy, 0, 0, 1],
+    R: [1, 0, 0, 0, 1, 0, 0, 0, 1],
+    P: [fx, 0, cx, 0, 0, fy, cy, 0, 0, 0, 1, 0],
+    binning_x: 0,
+    binning_y: 0,
+    roi: {
+      x_offset: 0,
+      y_offset: 0,
+      height: 0,
+      width: 0,
+      do_rectify: false,
+    },
   };
 }


### PR DESCRIPTION
**User-Facing Changes**
- Add "Example CameraInfo" option to image topics in the 3D panel to project images into 3D without camera calibrations

**Description**
This adds a physically plausible (based on RealSense D435 sensor) CameraInfo option that can be selected when your 3D panel image topic does not have an associated CameraInfo topic.
