### PR TITLE
Fix 3D panel crash on selection

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interactions.tsx
@@ -42,6 +42,7 @@ type Props = {
   setInteractionsTabType: (arg0?: TabType) => void;
   addPanel: LayoutActions["addPanel"];
   selectedObject?: SelectionObject;
+  timezone: string | undefined;
 };
 
 const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseComponent({
@@ -49,6 +50,7 @@ const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseCom
   selectedObject,
   interactionsTabType,
   setInteractionsTabType,
+  timezone,
 }: Props) {
   const selectedInteractionData = selectedObject?.object.interactionData;
   const originalMessage = selectedInteractionData?.originalMessage;
@@ -68,10 +70,15 @@ const InteractionsBaseComponent = React.memo<Props>(function InteractionsBaseCom
               {selectedInteractionData.topic && (
                 <TopicLink addPanel={addPanel} topic={selectedInteractionData.topic} />
               )}
-              {instanceDetails ? <ObjectDetails selectedObject={instanceDetails} /> : <></>}
+              {instanceDetails ? (
+                <ObjectDetails selectedObject={instanceDetails} timezone={timezone} />
+              ) : (
+                <></>
+              )}
               <ObjectDetails
                 selectedObject={originalMessage}
                 interactionData={selectedInteractionData}
+                timezone={timezone}
               />
             </>
           ) : (

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/ObjectDetails.tsx
@@ -14,9 +14,7 @@
 import { first, omit } from "lodash";
 import Tree from "react-json-tree";
 
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
-import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { RosValue } from "@foxglove/studio-base/players/types";
 import { getItemString } from "@foxglove/studio-base/util/getItemString";
 import { useJsonTreeTheme } from "@foxglove/studio-base/util/globalConstants";
@@ -26,6 +24,7 @@ import { InteractionData } from "./types";
 type Props = {
   readonly interactionData?: InteractionData;
   readonly selectedObject?: RosValue;
+  readonly timezone: string | undefined;
 };
 
 function maybePlainObject(rawVal: unknown) {
@@ -35,7 +34,7 @@ function maybePlainObject(rawVal: unknown) {
   return rawVal;
 }
 
-function ObjectDetails({ interactionData, selectedObject }: Props): JSX.Element {
+function ObjectDetails({ interactionData, selectedObject, timezone }: Props): JSX.Element {
   const jsonTreeTheme = useJsonTreeTheme();
   const topic = interactionData?.topic ?? "";
 
@@ -43,8 +42,6 @@ function ObjectDetails({ interactionData, selectedObject }: Props): JSX.Element 
   // We need a plain object to sort the keys and omit interaction data
   const plainObject = maybePlainObject(selectedObject);
   const originalObject = omit(plainObject as Record<string, unknown>, "interactionData");
-
-  const [timezone] = useAppConfigurationValue<string>(AppSetting.TIMEZONE);
 
   if (topic.length === 0) {
     // show the original object directly if there is no interaction data

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -63,6 +63,7 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/CoreSettings";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 
 const log = Logger.getLogger(__filename);
 
@@ -103,6 +104,7 @@ function RendererOverlay(props: {
   publishClickType: PublishClickType;
   onChangePublishClickType: (_: PublishClickType) => void;
   onClickPublish: () => void;
+  timezone: string | undefined;
 }): JSX.Element {
   const [clickedPosition, setClickedPosition] = useState<{ clientX: number; clientY: number }>({
     clientX: 0,
@@ -226,6 +228,7 @@ function RendererOverlay(props: {
           selectedObject={selectedObject}
           interactionsTabType={interactionsTabType}
           setInteractionsTabType={setInteractionsTabType}
+          timezone={props.timezone}
         />
         <Paper square={false} elevation={4} style={{ display: "flex", flexDirection: "column" }}>
           <IconButton
@@ -410,6 +413,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   }, [canvas, configRef, config.scene.transforms?.enablePreloading]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
+  const [timezone, setTimezone] = useState<string | undefined>();
   const [topics, setTopics] = useState<ReadonlyArray<Topic> | undefined>();
   const [parameters, setParameters] = useState<ReadonlyMap<string, ParameterValue> | undefined>();
   const [variables, setVariables] = useState<ReadonlyMap<string, VariableValue> | undefined>();
@@ -574,6 +578,10 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
 
         // Keep UI elements and the renderer aware of the current color scheme
         setColorScheme(renderState.colorScheme);
+        if (renderState.appSettings) {
+          const tz = renderState.appSettings.get(AppSetting.TIMEZONE);
+          setTimezone(typeof tz === "string" ? tz : undefined);
+        }
 
         // We may have new topics - since we are also watching for messages in
         // the current frame, topics may not have changed
@@ -606,6 +614,8 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
     context.watch("sharedPanelState");
     context.watch("variables");
     context.watch("topics");
+    context.watch("appSettings");
+    context.subscribeAppSettings([AppSetting.TIMEZONE]);
   }, [context, renderer]);
 
   // Build a list of topics to subscribe to
@@ -1039,6 +1049,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
               renderer?.publishClickTool.setPublishClickType(type);
               renderer?.publishClickTool.start();
             }}
+            timezone={timezone}
           />
         </RendererContext.Provider>
       </div>

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -34,6 +34,7 @@ import {
   Topic,
   VariableValue,
 } from "@foxglove/studio";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import PublishGoalIcon from "@foxglove/studio-base/components/PublishGoalIcon";
 import PublishPointIcon from "@foxglove/studio-base/components/PublishPointIcon";
 import PublishPoseEstimateIcon from "@foxglove/studio-base/components/PublishPoseEstimateIcon";
@@ -63,7 +64,6 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/CoreSettings";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
-import { AppSetting } from "@foxglove/studio-base/AppSetting";
 
 const log = Logger.getLogger(__filename);
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash when selecting an object in the 3D panel.

**Description**
useAppConfigurationValue cannot be used in the 3D panel because it is not inside of an AppConfigurationContext provider. Instead use the subscribeAppSettings extension API to get the time zone.

Fixes #5426 (crash caused by #5045)
Fixes FG-2171