### PR TITLE
Add an error boundary to built-in panels

### DIFF
--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -7,3 +7,4 @@ export { default as useShallowMemo } from "./useShallowMemo";
 export { default as useVisibilityState } from "./useVisibilityState";
 export { default as useMustNotChange } from "./useMustNotChange";
 export { default as useValueChangedDebugLog } from "./useValueChangedDebugLog";
+export * from "./useCrash";

--- a/packages/hooks/src/useCrash.test.ts
+++ b/packages/hooks/src/useCrash.test.ts
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, renderHook } from "@testing-library/react-hooks";
+import * as React from "react";
+
+import { useCrash } from "./useCrash";
+
+describe("useCrash", () => {
+  it("should re-throw the error", () => {
+    let error: Error | undefined;
+    const { result } = renderHook(() => useCrash(), {
+      wrapper: class Wrapper extends React.Component<React.PropsWithChildren<unknown>> {
+        public override componentDidCatch(err: Error) {
+          error = err;
+        }
+        public override render() {
+          return this.props.children;
+        }
+      },
+    });
+
+    act(() => {
+      result.current(new Error("my error"));
+    });
+    expect(error?.message).toEqual("my error");
+  });
+});

--- a/packages/hooks/src/useCrash.ts
+++ b/packages/hooks/src/useCrash.ts
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useReducer } from "react";
+
+// Throwing in a reducer call will make the error catchable by an error boundary.
+function reducer(_: unknown, err: Error) {
+  throw err;
+}
+
+/**
+ * useCrash returns a function you can call with an Error instance and it will re-throw the instance
+ * within the react loop allowing a react error boundary to handle the error.
+ *
+ * See: https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers
+ */
+export function useCrash(): (err: Error) => void {
+  const [_, dispatch] = useReducer(reducer, undefined);
+  return dispatch;
+}

--- a/packages/studio-base/src/components/CaptureErrorBoundary.tsx
+++ b/packages/studio-base/src/components/CaptureErrorBoundary.tsx
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { Component, PropsWithChildren, ReactNode } from "react";
+
+type Props = {
+  onError: (err: Error) => void;
+};
+
+/** An error boundary that calls an onError function when it captures an error */
+export class CaptureErrorBoundary extends Component<PropsWithChildren<Props>, unknown> {
+  public override componentDidCatch(error: Error): void {
+    this.props.onError(error);
+  }
+
+  public override render(): ReactNode {
+    return this.props.children;
+  }
+}

--- a/packages/studio-base/src/components/CaptureErrorBoundary.tsx
+++ b/packages/studio-base/src/components/CaptureErrorBoundary.tsx
@@ -7,13 +7,27 @@ type Props = {
   onError: (err: Error) => void;
 };
 
+type State = {
+  hadError: boolean;
+};
+
 /** An error boundary that calls an onError function when it captures an error */
-export class CaptureErrorBoundary extends Component<PropsWithChildren<Props>, unknown> {
+export class CaptureErrorBoundary extends Component<PropsWithChildren<Props>, State> {
+  public override state: State = {
+    hadError: false,
+  };
+
   public override componentDidCatch(error: Error): void {
+    this.setState({ hadError: true });
     this.props.onError(error);
   }
 
   public override render(): ReactNode {
+    // Avoid rendering children since the children are what caused the error
+    if (this.state.hadError) {
+      return <></>;
+    }
+
     return this.props.children;
   }
 }

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -39,12 +39,13 @@ type Props = {
 
 function GaugePanelAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -39,7 +39,7 @@ type Props = {
 
 function GaugePanelAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/Gauge/index.tsx
+++ b/packages/studio-base/src/panels/Gauge/index.tsx
@@ -5,7 +5,9 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
@@ -14,12 +16,14 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { Gauge } from "./Gauge";
 import { Config } from "./types";
 
-function initPanel(context: PanelExtensionContext) {
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <ThemeProvider isDark>
-        <Gauge context={context} />
-      </ThemeProvider>
+      <CaptureErrorBoundary onError={crash}>
+        <ThemeProvider isDark>
+          <Gauge context={context} />
+        </ThemeProvider>
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );
@@ -34,11 +38,13 @@ type Props = {
 };
 
 function GaugePanelAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -5,7 +5,9 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -13,10 +15,12 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { defaultConfig, ImageView } from "./ImageView";
 import { Config } from "./types";
 
-function initPanel(context: PanelExtensionContext) {
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <ImageView context={context} />
+      <CaptureErrorBoundary onError={crash}>
+        <ImageView context={context} />
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );
@@ -31,11 +35,13 @@ type Props = {
 };
 
 function ImagePanelAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -36,7 +36,7 @@ type Props = {
 
 function ImagePanelAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/Image/index.tsx
+++ b/packages/studio-base/src/panels/Image/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -36,12 +36,13 @@ type Props = {
 
 function ImagePanelAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }

--- a/packages/studio-base/src/panels/Indicator/index.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -39,7 +39,7 @@ type Props = {
 
 function IndicatorLightPanelAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/Indicator/index.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.tsx
@@ -5,7 +5,9 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
@@ -14,12 +16,14 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 import { Indicator } from "./Indicator";
 import { Config } from "./types";
 
-function initPanel(context: PanelExtensionContext) {
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <ThemeProvider isDark>
-        <Indicator context={context} />
-      </ThemeProvider>
+      <CaptureErrorBoundary onError={crash}>
+        <ThemeProvider isDark>
+          <Indicator context={context} />
+        </ThemeProvider>
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );
@@ -34,11 +38,13 @@ type Props = {
 };
 
 function IndicatorLightPanelAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/Indicator/index.tsx
+++ b/packages/studio-base/src/panels/Indicator/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -39,12 +39,13 @@ type Props = {
 
 function IndicatorLightPanelAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }

--- a/packages/studio-base/src/panels/Map/index.tsx
+++ b/packages/studio-base/src/panels/Map/index.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useCrash } from "@foxglove/hooks";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
@@ -14,11 +15,13 @@ type Props = {
 };
 
 function MapPanelAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/Map/index.tsx
+++ b/packages/studio-base/src/panels/Map/index.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useState } from "react";
+
 import { useCrash } from "@foxglove/hooks";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
@@ -16,12 +18,13 @@ type Props = {
 
 function MapPanelAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }

--- a/packages/studio-base/src/panels/Map/index.tsx
+++ b/packages/studio-base/src/panels/Map/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useState } from "react";
+import { useMemo } from "react";
 
 import { useCrash } from "@foxglove/hooks";
 import Panel from "@foxglove/studio-base/components/Panel";
@@ -18,7 +18,7 @@ type Props = {
 
 function MapPanelAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/Map/initPanel.tsx
+++ b/packages/studio-base/src/panels/Map/initPanel.tsx
@@ -9,7 +9,9 @@ import LeafletShadowIconUrl from "leaflet/dist/images/marker-shadow.png";
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 
 import MapPanel from "./MapPanel";
 
@@ -28,10 +30,15 @@ L.Marker.prototype.options.icon = L.icon({
   shadowSize: [41, 41],
 });
 
-export function initPanel(context: PanelExtensionContext): () => void {
+export function initPanel(
+  crash: ReturnType<typeof useCrash>,
+  context: PanelExtensionContext,
+): () => void {
   ReactDOM.render(
     <StrictMode>
-      <MapPanel context={context} />
+      <CaptureErrorBoundary onError={crash}>
+        <MapPanel context={context} />
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );

--- a/packages/studio-base/src/panels/Teleop/index.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -35,12 +35,13 @@ type Props = {
 
 function TeleopPanelAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }

--- a/packages/studio-base/src/panels/Teleop/index.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.tsx
@@ -5,17 +5,21 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import TeleopPanel from "./TeleopPanel";
 
-function initPanel(context: PanelExtensionContext) {
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <TeleopPanel context={context} />
+      <CaptureErrorBoundary onError={crash}>
+        <TeleopPanel context={context} />
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );
@@ -30,11 +34,13 @@ type Props = {
 };
 
 function TeleopPanelAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/Teleop/index.tsx
+++ b/packages/studio-base/src/panels/Teleop/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -35,7 +35,7 @@ type Props = {
 
 function TeleopPanelAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -390,6 +390,8 @@ function useRendererProperty<K extends keyof Renderer>(
 export function ThreeDeeRender({ context }: { context: PanelExtensionContext }): JSX.Element {
   const { initialState, saveState } = context;
 
+  throw new Error("foob");
+
   // Load and save the persisted panel configuration
   const [config, setConfig] = useState<RendererConfig>(() => {
     const partialConfig = initialState as DeepPartial<RendererConfig> | undefined;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -393,8 +393,6 @@ function useRendererProperty<K extends keyof Renderer>(
 export function ThreeDeeRender({ context }: { context: PanelExtensionContext }): JSX.Element {
   const { initialState, saveState } = context;
 
-  throw new Error("foob");
-
   // Load and save the persisted panel configuration
   const [config, setConfig] = useState<RendererConfig>(() => {
     const partialConfig = initialState as DeepPartial<RendererConfig> | undefined;

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useState } from "react";
+import { StrictMode, useMemo } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -35,7 +35,7 @@ type Props = {
 
 function ThreeDeeRenderAdapter(props: Props) {
   const crash = useCrash();
-  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
 
   return (
     <PanelExtensionAdapter

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -2,59 +2,24 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode, useCallback, useState } from "react";
-import { Component, PropsWithChildren, ReactNode } from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 
+import { useCrash } from "@foxglove/hooks";
 import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
 import Panel from "@foxglove/studio-base/components/Panel";
 import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { ThreeDeeRender } from "./ThreeDeeRender";
 
-type RethrowErrorBoundaryProps = {
-  onError: (err: Error) => void;
-};
-
-/** An error boundary that calls an onError function when it captures an error */
-class RethrowErrorBoundary extends Component<
-  PropsWithChildren<RethrowErrorBoundaryProps>,
-  unknown
-> {
-  public override componentDidCatch(error: Error): void {
-    this.props.onError(error);
-  }
-
-  public override render(): ReactNode {
-    return this.props.children;
-  }
-}
-
-/**
- * useCrash returns a function you can call with an error that was thrown outside of react into the
- * react tree for an error boundary to handle it.
- *
- * See: https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers
- */
-function useCrash() {
-  const [, setError] = useState<Error | undefined>();
-  return useCallback(
-    (err: Error) =>
-      // Trick to throw in the set function will make the error catchable by an error boundary
-      setError(() => {
-        throw err;
-      }),
-    [],
-  );
-}
-
-function initPanel(crash: (err: Error) => void, context: PanelExtensionContext) {
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <RethrowErrorBoundary onError={crash}>
+      <CaptureErrorBoundary onError={crash}>
         <ThreeDeeRender context={context} />
-      </RethrowErrorBoundary>
+      </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -2,7 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useCallback, useState } from "react";
+import { Component, PropsWithChildren, ReactNode } from "react";
 import ReactDOM from "react-dom";
 
 import { PanelExtensionContext } from "@foxglove/studio";
@@ -12,10 +13,48 @@ import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { ThreeDeeRender } from "./ThreeDeeRender";
 
-function initPanel(context: PanelExtensionContext) {
+type RethrowErrorBoundaryProps = {
+  onError: (err: Error) => void;
+};
+
+/** An error boundary that calls an onError function when it captures an error */
+class RethrowErrorBoundary extends Component<
+  PropsWithChildren<RethrowErrorBoundaryProps>,
+  unknown
+> {
+  public override componentDidCatch(error: Error): void {
+    this.props.onError(error);
+  }
+
+  public override render(): ReactNode {
+    return this.props.children;
+  }
+}
+
+/**
+ * useCrash returns a function you can call with an error that was thrown outside of react into the
+ * react tree for an error boundary to handle it.
+ *
+ * See: https://reactjs.org/docs/error-boundaries.html#how-about-event-handlers
+ */
+function useCrash() {
+  const [, setError] = useState<Error | undefined>();
+  return useCallback(
+    (err: Error) =>
+      // Trick to throw in the set function will make the error catchable by an error boundary
+      setError(() => {
+        throw err;
+      }),
+    [],
+  );
+}
+
+function initPanel(crash: (err: Error) => void, context: PanelExtensionContext) {
   ReactDOM.render(
     <StrictMode>
-      <ThreeDeeRender context={context} />
+      <RethrowErrorBoundary onError={crash}>
+        <ThreeDeeRender context={context} />
+      </RethrowErrorBoundary>
     </StrictMode>,
     context.panelElement,
   );
@@ -30,11 +69,13 @@ type Props = {
 };
 
 function ThreeDeeRenderAdapter(props: Props) {
+  const crash = useCrash();
+
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel}
+      initPanel={initPanel.bind(undefined, crash)}
     />
   );
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { StrictMode } from "react";
+import { StrictMode, useState } from "react";
 import ReactDOM from "react-dom";
 
 import { useCrash } from "@foxglove/hooks";
@@ -35,12 +35,13 @@ type Props = {
 
 function ThreeDeeRenderAdapter(props: Props) {
   const crash = useCrash();
+  const [boundInitPanel] = useState(() => initPanel.bind(undefined, crash));
 
   return (
     <PanelExtensionAdapter
       config={props.config}
       saveConfig={props.saveConfig}
-      initPanel={initPanel.bind(undefined, crash)}
+      initPanel={boundInitPanel}
     />
   );
 }


### PR DESCRIPTION

**User-Facing Changes**
Catch more types of errors for built-in panels and surface them as panel errors with the existing panel error boundary.

**Description**
When a built-in panel has an error in the react tree this error would bubble up, log to the console, but never result in a panel error boundary to show. This change updates the built-in panels with a new error boundary which relays this error back to the main app react tree where it can be handled by the panel error boundary we already have.

This change does not address 3rd-party panels which cause unhandled error. The solution for those is to move extension panels into an iframe.

Related issue which surfaced the gap in error handling: https://github.com/foxglove/studio/issues/5426 https://github.com/foxglove/studio/pull/5427