### PR TITLE
Output stable time values in extension panel renderState updates

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -34,6 +34,63 @@ describe("renderState", () => {
     });
   });
 
+  it("should provide stable time values", () => {
+    const buildRenderState = initRenderStateBuilder();
+    const initialState: Parameters<typeof buildRenderState>[0] = {
+      watchedFields: new Set(["currentTime", "endTime", "previewTime", "startTime"]),
+      appSettings: undefined,
+      currentFrame: [],
+      playerState: {
+        presence: PlayerPresence.PRESENT,
+        progress: {},
+        capabilities: [],
+        profile: "test",
+        playerId: "123",
+        activeData: {
+          datatypes: new Map(),
+          lastSeekTime: 1,
+          currentTime: { sec: 33, nsec: 1 },
+          endTime: { sec: 100, nsec: 1 },
+          startTime: { sec: 1, nsec: 1 },
+          isPlaying: true,
+          messages: [],
+          speed: 1,
+          topics: [],
+          topicStats: new Map(),
+          totalBytesReceived: 0,
+        },
+      },
+      colorScheme: undefined,
+      globalVariables: {},
+      hoverValue: {
+        value: 2.5,
+        componentId: "test",
+        type: "PLAYBACK_SECONDS",
+      },
+      sharedPanelState: {},
+      sortedTopics: [{ name: "test", schemaName: "schema" }],
+      subscriptions: [{ topic: "test", convertTo: "schema" }],
+    };
+    const firstRenderState = buildRenderState(initialState);
+    expect(firstRenderState).toEqual({
+      currentTime: { sec: 33, nsec: 1 },
+      endTime: { sec: 100, nsec: 1 },
+      previewTime: 3.500000001,
+      startTime: { sec: 1, nsec: 1 },
+    });
+
+    // need to change something to force a new, defined state
+    initialState.watchedFields = new Set(["currentTime", "endTime", "startTime", "topics"]);
+    const secondRenderState = buildRenderState(initialState);
+    expect(secondRenderState).toEqual({
+      currentTime: { sec: 33, nsec: 1 },
+      endTime: { sec: 100, nsec: 1 },
+      startTime: { sec: 1, nsec: 1 },
+      previewTime: 3.500000001,
+      topics: [{ datatype: "schema", name: "test", schemaName: "schema" }],
+    });
+  });
+
   it("should avoid conversion if the topic schema is already the desired convertTo schema", () => {
     const buildRenderState = initRenderStateBuilder();
     const state = buildRenderState({

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -329,44 +329,23 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     }
 
     if (watchedFields.has("currentTime")) {
-      const currentTime = activeData?.currentTime;
-
-      if (currentTime != undefined && currentTime !== renderState.currentTime) {
+      if (renderState.currentTime !== activeData?.currentTime) {
+        renderState.currentTime = activeData?.currentTime;
         shouldRender = true;
-        renderState.currentTime = currentTime;
-      } else {
-        if (renderState.currentTime != undefined) {
-          shouldRender = true;
-        }
-        renderState.currentTime = undefined;
       }
     }
 
     if (watchedFields.has("startTime")) {
-      const startTime = activeData?.startTime;
-
-      if (startTime != undefined && startTime !== renderState.startTime) {
+      if (renderState.startTime !== activeData?.startTime) {
+        renderState.startTime = activeData?.startTime;
         shouldRender = true;
-        renderState.startTime = startTime;
-      } else {
-        if (renderState.startTime != undefined) {
-          shouldRender = true;
-        }
-        renderState.startTime = undefined;
       }
     }
 
     if (watchedFields.has("endTime")) {
-      const endTime = activeData?.endTime;
-
-      if (endTime != undefined && endTime !== renderState.endTime) {
+      if (renderState.endTime !== activeData?.endTime) {
+        renderState.endTime = activeData?.endTime;
         shouldRender = true;
-        renderState.endTime = endTime;
-      } else {
-        if (renderState.endTime != undefined) {
-          shouldRender = true;
-        }
-        renderState.endTime = undefined;
       }
     }
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix logic in extension adapter renderState update function. Changes the semantics of currentTime, startTime and endTime in the render state to always contain a defined value if the value is available, instead of emitting alternating defined & undefined values to represent distinct snapshots of those values.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
