### PR TITLE
Remove excess padding on open connection input

### DIFF
--- a/packages/studio-base/src/components/OpenDialog/FormField.tsx
+++ b/packages/studio-base/src/components/OpenDialog/FormField.tsx
@@ -4,7 +4,6 @@
 
 import { FormHelperText, TextField } from "@mui/material";
 import { ChangeEvent, useState } from "react";
-import { makeStyles } from "tss-react/mui";
 
 import { Field } from "@foxglove/studio-base/context/PlayerSelectionContext";
 
@@ -15,18 +14,9 @@ type Props = {
   onError: (message: string) => void;
 };
 
-const useStyles = makeStyles()({
-  field: {
-    "& legend": {
-      display: "none",
-    },
-  },
-});
-
 export function FormField(props: Props): JSX.Element {
   const [error, setError] = useState<string | undefined>();
   const field = props.field;
-  const { classes } = useStyles();
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
     setError(undefined);
@@ -46,7 +36,6 @@ export function FormField(props: Props): JSX.Element {
     <div>
       <TextField
         fullWidth
-        className={classes.field}
         disabled={props.disabled}
         key={field.label}
         label={field.label}
@@ -58,6 +47,10 @@ export function FormField(props: Props): JSX.Element {
         placeholder={field.placeholder}
         defaultValue={field.defaultValue}
         onChange={onChange}
+        variant="outlined"
+        InputProps={{
+          notched: false,
+        }}
         InputLabelProps={{ shrink: true }}
       />
       <FormHelperText>{field.description}</FormHelperText>


### PR DESCRIPTION
**User-Facing Changes**
Minor cosmetic fix

**Description**
Remove the excess padding on the open connection dialog input.

Before:
<img width="653" alt="Screenshot 2023-02-27 at 1 03 23 PM" src="https://user-images.githubusercontent.com/93935560/221478748-3bfce6c7-1354-4b58-aed3-802c43cef204.png">

After:
<img width="633" alt="Screenshot 2023-02-27 at 1 03 41 PM" src="https://user-images.githubusercontent.com/93935560/221478763-8737b1a2-43f6-4627-abae-5037c21752a2.png">

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
