### PR TITLE
Read the `callerid`  field from MCAP files defined in the MCAP ROS 1 spec

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -167,6 +167,7 @@ export class McapStreamingIterableSource implements IIterableSource {
     const topics: Topic[] = [];
     const topicStats = new Map<string, TopicStats>();
     const datatypes: RosDatatypes = new Map();
+    const publishersByTopic = new Map<string, Set<string>>();
 
     for (const { channel, parsedChannel, schemaName } of channelInfoById.values()) {
       topics.push({ name: channel.topic, schemaName });
@@ -174,6 +175,18 @@ export class McapStreamingIterableSource implements IIterableSource {
       if (numMessages != undefined) {
         topicStats.set(channel.topic, { numMessages });
       }
+
+      // Track the publisher for this topic. "callerid" is defined in the MCAP ROS 1 Well-known
+      // profile at <https://mcap.dev/specification/appendix.html>. We skip the profile check to
+      // allow non-ROS profiles to utilize this functionality as well
+      const publisherId = channel.metadata.get("callerid") ?? String(channel.id);
+      let publishers = publishersByTopic.get(channel.topic);
+      if (!publishers) {
+        publishers = new Set();
+        publishersByTopic.set(channel.topic, publishers);
+      }
+      publishers.add(publisherId);
+
       // Final datatypes is an unholy union of schemas across all channels
       for (const [name, datatype] of parsedChannel.datatypes) {
         datatypes.set(name, datatype);
@@ -208,7 +221,7 @@ export class McapStreamingIterableSource implements IIterableSource {
       datatypes,
       profile,
       problems,
-      publishersByTopic: new Map(),
+      publishersByTopic,
       topicStats,
     };
   }


### PR DESCRIPTION
**User-Facing Changes**
- Topic Graph panel correctly visualizes MCAP files with the `callerid` channel metadata field

**Description**
The MCAP Well-known profiles appendix specifies the `callerid` Channel metadata key for storing a string identifier for the publisher of a channel. The equivalent in rosbag1 v2 files is the same `callerid` metadata field for channels, which Studio correctly parses and visualizes in the Topic Graph panel. This brings Topic Graph support for MCAP files up to par with rosbag1 v2 files, and allows non-ROS users to have the same functionality.
