### PR TITLE
Improve error handling for invalid camera info

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -24,7 +24,7 @@ import {
 import Logger from "@foxglove/log";
 import { toNanoSec } from "@foxglove/rostime";
 import { CameraCalibration, CompressedImage, RawImage } from "@foxglove/schemas";
-import { SettingsTreeAction, SettingsTreeFields } from "@foxglove/studio";
+import { SettingsTreeAction, SettingsTreeFields, Topic } from "@foxglove/studio";
 import type { RosValue } from "@foxglove/studio-base/players/types";
 
 import { cameraInfosEqual, normalizeCameraInfo, projectPixel } from "./projections";
@@ -65,6 +65,7 @@ export type LayerSettingsImage = BaseSettings & {
 
 const NO_CAMERA_INFO_ERR = "NoCameraInfo";
 const CREATE_BITMAP_ERR = "CreateBitmap";
+const CAMERA_MODEL = "CameraModel";
 
 const DEFAULT_IMAGE_WIDTH = 512;
 const DEFAULT_DISTANCE = 1;
@@ -130,6 +131,36 @@ export class Images extends SceneExtension<ImageRenderable> {
       handler: this.handleCameraInfo,
       shouldSubscribe: this.cameraInfoShouldSubscribe,
     });
+
+    this._updateCameraInfoToImageTopicsIfNeeded();
+  }
+
+  private _lastTopics: readonly Topic[] | undefined = undefined;
+  /**
+   * Update cameraInfoToImageTopics based on the current config and list of available topics.
+   */
+  private _updateCameraInfoToImageTopicsIfNeeded() {
+    if (this.renderer.topics === this._lastTopics) {
+      return;
+    }
+    this._lastTopics = this.renderer.topics;
+    for (const topic of this.renderer.topics ?? []) {
+      if (
+        !(
+          topicIsConvertibleToSchema(topic, ROS_IMAGE_DATATYPES) ||
+          topicIsConvertibleToSchema(topic, ROS_COMPRESSED_IMAGE_DATATYPES) ||
+          topicIsConvertibleToSchema(topic, RAW_IMAGE_DATATYPES) ||
+          topicIsConvertibleToSchema(topic, COMPRESSED_IMAGE_DATATYPES)
+        )
+      ) {
+        continue;
+      }
+      const imageTopic = topic.name;
+      const config = (this.renderer.config.topics[imageTopic] ?? {}) as Partial<LayerSettingsImage>;
+      if (typeof config.cameraInfoTopic === "string") {
+        this.cameraInfoToImageTopics.set(config.cameraInfoTopic, imageTopic);
+      }
+    }
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
@@ -255,6 +286,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   };
 
   private handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
+    this._updateCameraInfoToImageTopicsIfNeeded();
     const imageTopic = messageEvent.topic;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;
@@ -331,11 +363,18 @@ export class Images extends SceneExtension<ImageRenderable> {
 
         const dataEqual = cameraInfosEqual(renderable.userData.cameraInfo, cameraInfo);
         if (!dataEqual) {
-          const cameraModel = new PinholeCameraModel(cameraInfo);
-          renderable.userData.cameraModel = cameraModel;
-          if (renderable.userData.image) {
-            const { image, settings } = renderable.userData;
-            this._updateImageRenderable(renderable, image, cameraModel, receiveTime, settings);
+          try {
+            const cameraModel = new PinholeCameraModel(cameraInfo);
+            renderable.userData.cameraModel = cameraModel;
+            if (renderable.userData.image) {
+              const { image, settings } = renderable.userData;
+              this._updateImageRenderable(renderable, image, cameraModel, receiveTime, settings);
+            }
+            this.renderer.settings.errors.removeFromTopic(imageTopic, CAMERA_MODEL);
+          } catch (errUnk) {
+            const err = errUnk as Error;
+            this.renderer.settings.errors.addToTopic(imageTopic, CAMERA_MODEL, err.message);
+            renderable.userData.cameraModel = undefined;
           }
         }
       }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -132,19 +132,29 @@ export class Images extends SceneExtension<ImageRenderable> {
       shouldSubscribe: this.cameraInfoShouldSubscribe,
     });
 
-    this._updateCameraInfoToImageTopicsIfNeeded();
+    this._updateTopicInfoIfNeeded();
   }
 
   private _lastTopics: readonly Topic[] | undefined = undefined;
   /**
    * Update cameraInfoToImageTopics based on the current config and list of available topics.
    */
-  private _updateCameraInfoToImageTopicsIfNeeded() {
+  private _updateTopicInfoIfNeeded() {
     if (this.renderer.topics === this._lastTopics) {
       return;
     }
+
     this._lastTopics = this.renderer.topics;
+
+    this.cameraInfoTopics = new Set();
     for (const topic of this.renderer.topics ?? []) {
+      if (
+        topicIsConvertibleToSchema(topic, CAMERA_INFO_DATATYPES) ||
+        topicIsConvertibleToSchema(topic, CAMERA_CALIBRATION_DATATYPES)
+      ) {
+        this.cameraInfoTopics.add(topic.name);
+      }
+
       if (
         !(
           topicIsConvertibleToSchema(topic, ROS_IMAGE_DATATYPES) ||
@@ -164,6 +174,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   }
 
   public override settingsNodes(): SettingsTreeEntry[] {
+    this._updateTopicInfoIfNeeded();
     const configTopics = this.renderer.config.topics;
     const handler = this.handleSettingsAction;
     const entries: SettingsTreeEntry[] = [];
@@ -286,7 +297,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   };
 
   private handleImage = (messageEvent: PartialMessageEvent<AnyImage>, image: AnyImage): void => {
-    this._updateCameraInfoToImageTopicsIfNeeded();
+    this._updateTopicInfoIfNeeded();
     const imageTopic = messageEvent.topic;
     const receiveTime = toNanoSec(messageEvent.receiveTime);
     const frameId = "header" in image ? image.header.frame_id : image.frame_id;


### PR DESCRIPTION
**User-Facing Changes**
Improved error-handling behavior in the 3D panel for image topics with invalid camera calibration.

**Description**
Also update the list of "Camera info" options in image topic settings when image topics change.

Example file:
[test_3d_image_0.mcap.zip](https://github.com/foxglove/studio/files/10845216/test_3d_image_0.mcap.zip)

### Before:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/14237/221715272-2e127221-652a-4943-aa7f-75c5c5f20243.png">
(3D panel crashes)
<img width="682" alt="image" src="https://user-images.githubusercontent.com/14237/221714253-95c49539-4628-4dcc-af30-7d0dc56121ec.png">


### After: 
<img width="385" alt="image" src="https://user-images.githubusercontent.com/14237/221715248-417f64b9-5e30-478b-8539-f1a0790e4d36.png">

<img width="472" alt="image" src="https://user-images.githubusercontent.com/14237/221714305-6df7f95e-25b7-4a1f-88fa-2e8a1885e9b4.png">
