### PR TITLE
put URDF Viewer panel behind feature flag

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -22,6 +22,7 @@ export enum AppSetting {
   SHOW_DEBUG_PANELS = "showDebugPanels",
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
   ENABLE_NEW_TOPNAV = "enableNewTopNav",
+  ENABLE_URDF_VIEWER = "enableUrdfViewer",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -56,6 +56,11 @@ function useFeatures(): Feature[] {
       description: <>{t("legacyPlotPanelDescription")}</>,
     },
     {
+      key: AppSetting.ENABLE_URDF_VIEWER,
+      name: t("urdfPanel"),
+      description: <>{t("urdfPanelDescription")}</>,
+    },
+    {
       key: AppSetting.ENABLE_MEMORY_USE_INDICATOR,
       name: t("memoryUseIndicator"),
       description: <>{t("memoryUseIndicatorDescription")}</>,

--- a/packages/studio-base/src/i18n/en/preferences.ts
+++ b/packages/studio-base/src/i18n/en/preferences.ts
@@ -31,6 +31,8 @@ export default {
   studioDebugPanelsDescription: "Show Foxglove Studio debug panels in the “Add panel” list.",
   legacyPlotPanel: "Legacy Plot panel",
   legacyPlotPanelDescription: "Enable the Legacy Plot panel.",
+  urdfPanel: "URDF Viewer panel",
+  urdfPanelDescription: "Enable the deprecated URDF Viewer panel.",
   memoryUseIndicator: "Memory use indicator",
   memoryUseIndicatorDescription: "Show the app memory use in the sidebar.",
   newNavigation: "New navigation",

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -26,7 +26,7 @@ import variableSliderThumbnail from "./VariableSlider/thumbnail.png";
 import diagnosticStatusThumbnail from "./diagnostics/thumbnails/diagnostic-status.png";
 import diagnosticSummaryThumbnail from "./diagnostics/thumbnails/diagnostic-summary.png";
 
-const builtin: PanelInfo[] = [
+export const builtin: PanelInfo[] = [
   {
     title: "3D",
     type: "3D",
@@ -139,13 +139,6 @@ const builtin: PanelInfo[] = [
     hasCustomToolbar: true,
   },
   {
-    title: "URDF Viewer",
-    type: "URDFViewer",
-    description: "Visualize Unified Robot Description Format files.",
-    thumbnail: URDFViewerThumbnail,
-    module: async () => await import("./URDFViewer"),
-  },
-  {
     title: "Topic Graph",
     type: "TopicGraph",
     description: "Display a graph of active nodes, topics, and services.",
@@ -183,7 +176,7 @@ const builtin: PanelInfo[] = [
   },
 ];
 
-const debug: PanelInfo[] = [
+export const debug: PanelInfo[] = [
   {
     title: "Studio - Playback Performance",
     type: "PlaybackPerformance",
@@ -192,12 +185,16 @@ const debug: PanelInfo[] = [
   },
 ];
 
-const legacyPlot: PanelInfo[] = [
-  {
-    title: "Legacy Plot",
-    type: "LegacyPlot",
-    module: async () => await import("./LegacyPlot"),
-  },
-];
+export const legacyPlot: PanelInfo = {
+  title: "Legacy Plot",
+  type: "LegacyPlot",
+  module: async () => await import("./LegacyPlot"),
+};
 
-export default { builtin, debug, legacyPlot };
+export const urdfViewer: PanelInfo = {
+  title: "URDF Viewer",
+  type: "URDFViewer",
+  description: "Visualize Unified Robot Description Format files.",
+  thumbnail: URDFViewerThumbnail,
+  module: async () => await import("./URDFViewer"),
+};

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -13,7 +13,7 @@ import PanelCatalogContext, {
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
-import panels from "@foxglove/studio-base/panels";
+import * as panels from "@foxglove/studio-base/panels";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 type PanelProps = {
@@ -27,6 +27,9 @@ export default function PanelCatalogProvider(
   const [showDebugPanels = false] = useAppConfigurationValue<boolean>(AppSetting.SHOW_DEBUG_PANELS);
   const [enableLegacyPlotPanel = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_LEGACY_PLOT_PANEL,
+  );
+  const [enableUrdfViewerPanel = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_URDF_VIEWER,
   );
 
   const extensionPanels = useExtensionCatalog((state) => state.installedPanels);
@@ -58,16 +61,28 @@ export default function PanelCatalogProvider(
   }, [extensionPanels]);
 
   const allPanels = useMemo(() => {
-    return [...panels.builtin, ...panels.debug, ...panels.legacyPlot, ...wrappedExtensionPanels];
+    return [
+      ...panels.builtin,
+      ...panels.debug,
+      panels.legacyPlot,
+      panels.urdfViewer,
+      ...wrappedExtensionPanels,
+    ];
   }, [wrappedExtensionPanels]);
 
   const visiblePanels = useMemo(() => {
-    const legacyPlotPanels = enableLegacyPlotPanel ? panels.legacyPlot : [];
-
-    // debug panels are hidden by default, users can enable them within app settings
-    return showDebugPanels
-      ? [...panels.builtin, ...panels.debug, ...legacyPlotPanels, ...wrappedExtensionPanels]
-      : [...panels.builtin, ...legacyPlotPanels, ...wrappedExtensionPanels];
+    const panelList = [...panels.builtin];
+    if (showDebugPanels) {
+      panelList.push(...panels.debug);
+    }
+    if (enableLegacyPlotPanel) {
+      panelList.push(panels.legacyPlot);
+    }
+    if (enableUrdfViewerPanel) {
+      panelList.push(panels.urdfViewer);
+    }
+    panelList.push(...wrappedExtensionPanels);
+    return panelList;
   }, [enableLegacyPlotPanel, showDebugPanels, wrappedExtensionPanels]);
 
   const panelsByType = useMemo(() => {


### PR DESCRIPTION
**User-Facing Changes**
The URDF Viewer panel is now hidden from the list of panels by default.

**Description**
The panel will still work if it was already in the layout, but will be hidden from the "Add Panel" list unless the feature flag is enabled.

Closes FG-1117