### PR TITLE
IterablePlayer: Fix setting of playback speed after playback has ended not working correctly

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -967,6 +967,10 @@ export class IterablePlayer implements Player {
     try {
       while (this._isPlaying && !this._hasError && !this._nextState) {
         if (compare(this._currentTime, this._end) >= 0) {
+          // Playback has ended
+          this._lastTickMillis = undefined;
+          this._lastRangeMillis = undefined;
+          this._lastStamp = undefined;
           this._setState("idle");
           return;
         }

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -967,7 +967,7 @@ export class IterablePlayer implements Player {
     try {
       while (this._isPlaying && !this._hasError && !this._nextState) {
         if (compare(this._currentTime, this._end) >= 0) {
-          // Playback has ended
+          // Playback has ended. Reset internal trackers for maintaining the playback speed.
           this._lastTickMillis = undefined;
           this._lastRangeMillis = undefined;
           this._lastStamp = undefined;


### PR DESCRIPTION

**User-Facing Changes**
- Fix setting of playback speed after playback has ended not working correctly

**Description**
When changing the playback speed after playing back an mcap/rosbag file, the new playback speed was not immediately taken into account as some internal state was not reseted. This PR fixes that.

Fixes FG-2170