### PR TITLE
Improve player state display while initializing a data platform datasource

### DIFF
--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -87,7 +87,7 @@ export function DataSource({
   onSelectDataSourceAction: () => void;
 }): JSX.Element {
   const { classes, cx } = useStyles();
-  const playerName = useMessagePipeline(selectPlayerName) ?? "<unknown>";
+  const playerName = useMessagePipeline(selectPlayerName);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems) ?? [];
 
@@ -95,6 +95,9 @@ export function DataSource({
   const initializing = playerPresence === PlayerPresence.INITIALIZING;
   const error = playerPresence === PlayerPresence.ERROR || playerProblems.length > 0;
   const loading = reconnecting || initializing;
+
+  const playerDisplayName =
+    initializing && playerName == undefined ? "Initializing..." : playerName;
 
   const [problemModal, setProblemModal] = useState<JSX.Element | undefined>(undefined);
 
@@ -148,7 +151,10 @@ export function DataSource({
           </div>
           <div className={classes.sourceInfo}>
             <Typography noWrap variant="inherit" component="span">
-              <TextMiddleTruncate className={classes.playerName} text={playerName} />
+              <TextMiddleTruncate
+                className={classes.playerName}
+                text={playerDisplayName ?? "<unknown>"}
+              />
             </Typography>
           </div>
           <ArrowDropDownIcon className={classes.arrow} />

--- a/packages/studio-base/src/components/AppBar/index.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/index.stories.tsx
@@ -136,6 +136,16 @@ export function PlayerStates(): JSX.Element {
         >
           <LabeledAppBar label="INITIALIZING + problems" {...actions} />
         </MockMessagePipelineProvider>
+        <MockMessagePipelineProvider
+          name={undefined}
+          presence={PlayerPresence.INITIALIZING}
+          problems={[
+            { severity: "error", message: "example error" },
+            { severity: "warn", message: "example warn" },
+          ]}
+        >
+          <LabeledAppBar label="INITIALIZING + no name" {...actions} />
+        </MockMessagePipelineProvider>
       </div>
     </Stack>
   );


### PR DESCRIPTION
**User-Facing Changes**
Improve player state display while initializing a data platform datasource

**Description**
While initializing a data platform datasource there is a point in time where the `playerName` is undefined and the player state is `INITIALIZING`. This changes the value we display in this case from `unknown` to `Initializing...`.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
