### PR TITLE
Always emit urlState in FoxgloveWebsocketPlayer

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -94,6 +94,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _problems = new PlayerProblemManager();
   private _numTimeSeeks = 0;
   private _profile?: string;
+  private _urlState: PlayerState["urlState"];
 
   /** Earliest time seen */
   private _startTime?: Time;
@@ -141,6 +142,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._name = url;
     this._metricsCollector.playerConstructed();
     this._sourceId = sourceId;
+    this._urlState = {
+      sourceId: this._sourceId,
+      parameters: { url: this._url },
+    };
     this._open();
   }
 
@@ -637,6 +642,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         playerId: this._id,
         activeData: undefined,
         problems: this._problems.problems(),
+        urlState: this._urlState,
       });
     }
 
@@ -658,10 +664,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       profile: this._profile,
       playerId: this._id,
       problems: this._problems.problems(),
-      urlState: {
-        sourceId: this._sourceId,
-        parameters: { url: this._url },
-      },
+      urlState: this._urlState,
 
       activeData: {
         messages,


### PR DESCRIPTION


**User-Facing Changes**
When using the web app and selecting the foxglove websocket data source, the URL bar updates immediately after selection with the data source type and user-specified hostname.

**Description**
FoxgloveWebsocketPlayer was not emitting urlState when it did not have a connection. This prevented downstream logic from updating the URL with the latest player information. This chagne updates the player to always emit urlState which causes the app to update the URL bar immediately once the data source is selected.
