### PR TITLE
Fix string/number confusion in getValueActionForValue

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -372,7 +372,7 @@ describe("getStructureItemForPath", () => {
       },
       datatype: "",
     };
-    expect(getStructureItemForPath(structureItem, [0])).toEqual({
+    expect(getStructureItemForPath(structureItem, ["0"])).toEqual({
       structureType: "primitive",
       primitiveType: "uint32",
       datatype: "",

--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -311,7 +311,7 @@ describe("getStructureItemForPath", () => {
       },
       datatype: "",
     };
-    expect(getStructureItemForPath(structureItem, "0")).toEqual({
+    expect(getStructureItemForPath(structureItem, [0])).toEqual({
       structureType: "primitive",
       primitiveType: "uint32",
       datatype: "",
@@ -330,7 +330,7 @@ describe("getStructureItemForPath", () => {
       },
       datatype: "",
     };
-    expect(getStructureItemForPath(structureItem, "some_id")).toEqual({
+    expect(getStructureItemForPath(structureItem, ["some_id"])).toEqual({
       structureType: "primitive",
       primitiveType: "uint32",
       datatype: "",
@@ -353,7 +353,26 @@ describe("getStructureItemForPath", () => {
       },
       datatype: "",
     };
-    expect(getStructureItemForPath(structureItem, "0,some_id")).toEqual({
+    expect(getStructureItemForPath(structureItem, [0, "some_id"])).toEqual({
+      structureType: "primitive",
+      primitiveType: "uint32",
+      datatype: "",
+    });
+  });
+
+  it("returns a key named '0'", () => {
+    const structureItem: MessagePathStructureItem = {
+      structureType: "message",
+      nextByName: {
+        0: {
+          structureType: "primitive",
+          primitiveType: "uint32",
+          datatype: "",
+        },
+      },
+      datatype: "",
+    };
+    expect(getStructureItemForPath(structureItem, [0])).toEqual({
       structureType: "primitive",
       primitiveType: "uint32",
       datatype: "",

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -338,7 +338,7 @@ function RawMessages(props: Props) {
           if (structureItem) {
             const childStructureItem = getStructureItemForPath(
               structureItem,
-              keyPath.slice(0, -1).reverse().join(","),
+              keyPath.slice(0, -1).reverse(),
             );
             if (childStructureItem) {
               const field = keyPath[0];


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash in the Raw Messages panel when message field names were numeric.

**Description**
`join()` + `split()` was losing information about `"0"` being a string.
Removes `memoizeWeak()` because it won't work as expected when the argument is an array rather than a plain string.

Fixes FG-2252