### PR TITLE
Fix sign in prompt in layout browser when app bar is enabled

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
@@ -3,9 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import CloseIcon from "@mui/icons-material/Close";
-import { Link, CardHeader, IconButton, styled as muiStyled } from "@mui/material";
+import { CardHeader, IconButton, Link, styled as muiStyled } from "@mui/material";
 
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 
 type SignInPromptProps = {
   onDismiss?: () => void;
@@ -27,14 +30,18 @@ const StyledCardHeader = muiStyled(CardHeader)(({ theme }) => ({
 
 export default function SignInPrompt(props: SignInPromptProps): JSX.Element {
   const { onDismiss } = props;
+  const { signIn } = useCurrentUser();
   const { openAccountSettings } = useWorkspace();
+  const [topNavEnabled = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
+
+  const action = topNavEnabled ? signIn : openAccountSettings;
 
   return (
     <StyledCardHeader
-      onClick={openAccountSettings}
+      onClick={action}
       title={
         <>
-          <Link color="inherit" onClick={openAccountSettings} underline="always">
+          <Link color="inherit" onClick={action} underline="always">
             Sign in
           </Link>{" "}
           to sync layouts across multiple devices, and share them with your organization.

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -380,3 +380,10 @@ DeleteLastLayout.parameters = {
   colorScheme: "dark",
 };
 DeleteLastLayout.play = async () => await deleteLayoutInteraction(0);
+
+export function SignInPrompt(_args: unknown): JSX.Element {
+  return <LayoutBrowser supportsSignIn />;
+}
+SignInPrompt.parameters = {
+  colorScheme: "light",
+};


### PR DESCRIPTION
**User-Facing Changes**
Fix sign in prompt in layout browser when app bar is enabled

**Description**
Update logic to either show the sign in modal directly if app bar is enabled or show the sign in left sidebar item if not.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
