### PR TITLE
Show user menu on click (instead of Add Panel) 🐞

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -301,7 +301,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
                     aria-controls={userMenuOpen ? "user-profile-menu" : undefined}
                     aria-haspopup="true"
                     aria-expanded={userMenuOpen ? "true" : undefined}
-                    onClick={(event) => setPanelAnchorEl(event.currentTarget)}
+                    onClick={(event) => setUserAnchorEl(event.currentTarget)}
                     size="small"
                     currentUser={currentUser}
                   />


### PR DESCRIPTION
User menu shown instead of Add Panel bug introduced in #5405 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
