### PR TITLE
Surface permission errors when loading local MCAP files

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -52,6 +52,11 @@ export class McapIterableSource implements IIterableSource {
 
     switch (source.type) {
       case "file": {
+        // Ensure the file is readable before proceeding (will throw in the event of a permission
+        // error). Workaround for the fact that `file.stream().getReader()` returns a generic
+        // "network error" in the event of a permission error.
+        await source.file.slice(0, 1).arrayBuffer();
+
         const readable = new FileReadable(source.file);
         const reader = await tryCreateIndexedReader(readable);
         if (reader) {


### PR DESCRIPTION
**User-Facing Changes**
Fixed misleading error message when attempting to load a local MCAP file with insufficient permission.

**Description**
Fixes #5471
Fixes FG-2257