### PR TITLE
Fix some image panel state issues

### DIFF
--- a/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
+++ b/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
@@ -28,7 +28,7 @@ type UseImagePanelMessagesParams = {
 export type ImagePanelState = UseImagePanelMessagesParams & {
   image?: NormalizedImageMessage;
   cameraInfo?: CameraInfo;
-  annotationsByTopic: Map<string, Annotation[]>;
+  annotationsByTopic: ReadonlyMap<string, Annotation[]>;
   tree: AVLTree<Time, SynchronizationItem>;
 
   actions: {
@@ -86,8 +86,15 @@ function addMessages(
     return synchronizedAddMessages(state, messageEvents);
   }
 
-  let newState: Pick<ImagePanelState, "image" | "annotationsByTopic" | "cameraInfo"> | undefined;
+  let newState:
+    | (Pick<ImagePanelState, "image" | "cameraInfo"> & {
+        annotationsByTopic: Map<string, Annotation[]>;
+      })
+    | undefined;
   for (const event of messageEvents) {
+    // We have to check `event.topic` in all cases because we may occasionally receive messages on
+    // topics that we have already unsubscribed from with context.subscribe().
+    // <https://github.com/foxglove/studio/issues/5371>
     const normalizedCameraInfo =
       event.topic === state.cameraInfoTopic
         ? normalizeCameraInfo(event.message, event.schemaName)
@@ -96,7 +103,9 @@ function addMessages(
       event.topic === state.imageTopic
         ? normalizeImageMessage(event.message, event.schemaName)
         : undefined;
-    const normalizedAnnotations = normalizeAnnotations(event.message, event.schemaName);
+    const normalizedAnnotations = state.annotationTopics.includes(event.topic)
+      ? normalizeAnnotations(event.message, event.schemaName)
+      : undefined;
     if (!normalizedCameraInfo && !normalizedImage && !normalizedAnnotations) {
       continue;
     }
@@ -138,14 +147,45 @@ export function useImagePanelMessages(params: UseImagePanelMessagesParams): Publ
 
       actions: {
         setParams(newParams: UseImagePanelMessagesParams) {
-          // When changing params, clear the image and any annotations
-          set({
-            image: undefined,
-            cameraInfo: undefined,
-            annotationsByTopic: new Map(),
-            tree: new AVLTree(compareTime),
+          set((prevState) => {
+            // Optimize for the common case of toggling annotations on/off while the synchronize
+            // setting is disabled. As long as the image and camera info topics are the same, we can
+            // keep the existing image and need only rebuild the annotationsByTopic.
+            if (
+              !prevState.synchronize &&
+              !newParams.synchronize &&
+              prevState.imageTopic === newParams.imageTopic &&
+              prevState.cameraInfoTopic === newParams.cameraInfoTopic
+            ) {
+              let newAnnotationsByTopic: Map<string, Annotation[]> | undefined;
+              if (prevState.annotationTopics !== newParams.annotationTopics) {
+                newAnnotationsByTopic = new Map();
+                for (const topic of newParams.annotationTopics) {
+                  const annotation = prevState.annotationsByTopic.get(topic);
+                  if (annotation) {
+                    newAnnotationsByTopic.set(topic, annotation);
+                  }
+                }
+              }
+              return {
+                annotationsByTopic: newAnnotationsByTopic ?? prevState.annotationsByTopic,
+                ...newParams,
+              };
+            }
 
-            ...newParams,
+            // Otherwise, simply clear the image and any annotations when settings
+            // change. More precise/intelligent/complicated logic could be written to keep the image
+            // hidden if a new annotation is enabled but a synchronized set is not available, and
+            // similarly to show the image if an annotation being disabled results in a synchronized
+            // set being available. For now, we just clear everything.
+            return {
+              image: undefined,
+              cameraInfo: undefined,
+              annotationsByTopic: new Map(),
+              tree: new AVLTree(compareTime),
+
+              ...newParams,
+            };
           });
         },
         clear() {

--- a/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
+++ b/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
@@ -94,7 +94,7 @@ function addMessages(
   for (const event of messageEvents) {
     // We have to check `event.topic` in all cases because we may occasionally receive messages on
     // topics that we have already unsubscribed from with context.subscribe().
-    // <https://github.com/foxglove/studio/issues/5371>
+    // <https://github.com/foxglove/studio/issues/5479>
     const normalizedCameraInfo =
       event.topic === state.cameraInfoTopic
         ? normalizeCameraInfo(event.message, event.schemaName)

--- a/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
+++ b/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
@@ -151,24 +151,25 @@ export function useImagePanelMessages(params: UseImagePanelMessagesParams): Publ
             // Optimize for the common case of toggling annotations on/off while the synchronize
             // setting is disabled. As long as the image and camera info topics are the same, we can
             // keep the existing image and need only rebuild the annotationsByTopic.
+            const synchronizeDisabled = !prevState.synchronize && !newParams.synchronize;
             if (
-              !prevState.synchronize &&
-              !newParams.synchronize &&
+              synchronizeDisabled &&
               prevState.imageTopic === newParams.imageTopic &&
               prevState.cameraInfoTopic === newParams.cameraInfoTopic
             ) {
-              let newAnnotationsByTopic: Map<string, Annotation[]> | undefined;
-              if (prevState.annotationTopics !== newParams.annotationTopics) {
-                newAnnotationsByTopic = new Map();
-                for (const topic of newParams.annotationTopics) {
-                  const annotation = prevState.annotationsByTopic.get(topic);
-                  if (annotation) {
-                    newAnnotationsByTopic.set(topic, annotation);
-                  }
+              if (prevState.annotationTopics === newParams.annotationTopics) {
+                return newParams;
+              }
+
+              const newAnnotationsByTopic = new Map<string, Annotation[]>();
+              for (const topic of newParams.annotationTopics) {
+                const annotation = prevState.annotationsByTopic.get(topic);
+                if (annotation) {
+                  newAnnotationsByTopic.set(topic, annotation);
                 }
               }
               return {
-                annotationsByTopic: newAnnotationsByTopic ?? prevState.annotationsByTopic,
+                annotationsByTopic: newAnnotationsByTopic,
                 ...newParams,
               };
             }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where the Image panel would sometimes continue displaying annotations after they were disabled in the panel's settings.

**Description**
Addresses two issues:
1. As reported in #5371, the panel would sometimes display annotations after they were disabled. This happened because of a race condition around `context.subscribe()` (quite similar to #5473, but for subscribing rather than publishing), which causes the panel to occasionally receive a message in `currentFrame` after it has already unsubscribed. To work around this I added a check that the annotation's topic is in the list of `annotationTopics` the panel expects to receive. Also filed #5479 to follow up on the issue.

2. I also found that the panel would sometimes display an image and the "waiting for images" message at the same time. This was due to some logic that would display the `lastImageMessageRef.current` if no image is available. Reading `lastImageMessageRef.current` during render was wrong, since the modification of the ref does not always trigger the panel to re-render. Since the `useImagePanelMessages` hook now has responsibility for keeping the latest image message around, I removed uses of `lastImageMessageRef` other than for the "download image" feature.

Fixes https://github.com/foxglove/studio/issues/5371
Fixes FG-1924