### PR TITLE
Added a First Draft of a Custom Map Max Zoom Option

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -104,6 +104,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       layer: initialConfig.layer ?? "map",
       topicColors: initialConfig.topicColors ?? {},
       zoomLevel: initialConfig.zoomLevel,
+      maxNativeZoom: initialConfig.maxNativeZoom ?? 18,
     };
   });
 
@@ -259,6 +260,13 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       });
     }
 
+    if (path[1] === "maxNativeZoom" && input === "select") {
+      setConfig((oldConfig) => {
+        const zoom = parseInt(String(value));
+        return { ...oldConfig, maxNativeZoom: isNaN(zoom) ? oldConfig.maxNativeZoom : zoom };
+      });
+    }
+
     if (path[1] === "followTopic" && input === "select") {
       setConfig((oldConfig) => {
         return { ...oldConfig, followTopic: String(value) };
@@ -293,6 +301,12 @@ function MapPanel(props: MapPanelProps): JSX.Element {
       customLayer.setUrl(config.customTileUrl);
     }
   }, [config.layer, config.customTileUrl, customLayer]);
+
+  useEffect(() => {
+    if (config.layer === "custom") {
+      customLayer.options.maxNativeZoom = config.maxNativeZoom;
+    }
+  }, [config.layer, config.maxNativeZoom, customLayer]);
 
   // Subscribe to eligible and enabled topics
   useEffect(() => {

--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -263,7 +263,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
     if (path[1] === "maxNativeZoom" && input === "select") {
       setConfig((oldConfig) => {
         const zoom = parseInt(String(value));
-        return { ...oldConfig, maxNativeZoom: isNaN(zoom) ? oldConfig.maxNativeZoom : zoom };
+        return { ...oldConfig, maxNativeZoom: isFinite(zoom) ? zoom : oldConfig.maxNativeZoom };
       });
     }
 

--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -16,6 +16,7 @@ export type Config = {
   layer: string;
   topicColors: Record<string, string>;
   zoomLevel?: number;
+  maxNativeZoom?: number;
 };
 
 export function validateCustomUrl(url: string): Error | undefined {
@@ -110,6 +111,15 @@ export function buildSettingsTree(
       input: "string",
       value: config.customTileUrl,
       error,
+    };
+
+    generalSettings.maxNativeZoom = {
+      label: "Custom max zoom",
+      input: "select",
+      value: config.maxNativeZoom,
+      options: [18, 19, 20, 21, 22, 23, 24].map((num) => {
+        return { label: String(num), value: num };
+      }),
     };
   }
 

--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -114,12 +114,13 @@ export function buildSettingsTree(
     };
 
     generalSettings.maxNativeZoom = {
-      label: "Custom max zoom",
+      label: "Max source zoom",
       input: "select",
       value: config.maxNativeZoom,
       options: [18, 19, 20, 21, 22, 23, 24].map((num) => {
         return { label: String(num), value: num };
       }),
+      help: "Highest zoom supported by the custom map source. See https://leafletjs.com/examples/zoom-levels/ for more information.",
     };
   }
 

--- a/packages/studio-base/src/panels/Map/config.ts
+++ b/packages/studio-base/src/panels/Map/config.ts
@@ -114,7 +114,7 @@ export function buildSettingsTree(
     };
 
     generalSettings.maxNativeZoom = {
-      label: "Max source zoom",
+      label: "Max tile level",
       input: "select",
       value: config.maxNativeZoom,
       options: [18, 19, 20, 21, 22, 23, 24].map((num) => {


### PR DESCRIPTION
**User-Facing Changes**
Adds a drop-down box for custom map tile sources to choose the maximum tile level.

**Description**
This pull request is for a way for the 'maxNativeZoom' parameter to be user-configurable for custom tile layers.  This feature would benefit the application since some mapping sources provide more high-resolution tiles than the current hard-coded zoom limit of 18 that is applied to the leafletjs TileLayer map object.  In my particular use case of Foxglove, the data for the mapping server I am using goes up to a zoom of 22, so this change would greatly improve the mapping detail.  This issue seems to have been brought up in different ways by other users in the past, such as with the foxglove discussion 296 linked below [1] and a previous merged pull request [2] where the max native zoom level was first set to 18. 

However, I do acknowledge that this commit is likely in need of many improvements and changes, since I am both not particularly familiar with TypeScript or the project's standards of practice, and so I welcome any advice for how to proceed.

<!-- link relevant GitHub issues -->
1. https://github.com/orgs/foxglove/discussions/296
2. https://github.com/foxglove/studio/pull/610

<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->