### PR TITLE
Apply background blur to tooltips

### DIFF
--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -517,11 +517,11 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
       styleOverrides: {
         arrow: {
           color: tinycolor(theme.palette.grey[700]).setAlpha(0.86).toRgbString(),
-          backdropFilter: "blur(10px)",
+          backdropFilter: "blur(3px)",
         },
         tooltip: {
           backgroundColor: tinycolor(theme.palette.grey[700]).setAlpha(0.86).toRgbString(),
-          backdropFilter: "blur(10px)",
+          backdropFilter: "blur(3px)",
           fontWeight: "normal",
           fontSize: "0.75rem",
         },

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -4,6 +4,7 @@
 
 import { alpha, Theme } from "@mui/material";
 import { CSSProperties } from "react";
+import tinycolor from "tinycolor2";
 
 type MuiLabComponents = {
   MuiFocusVisible?: {
@@ -515,10 +516,12 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
       },
       styleOverrides: {
         arrow: {
-          color: theme.palette.grey[700],
+          color: tinycolor(theme.palette.grey[700]).setAlpha(0.86).toRgbString(),
+          backdropFilter: "blur(10px)",
         },
         tooltip: {
-          backgroundColor: theme.palette.grey[700],
+          backgroundColor: tinycolor(theme.palette.grey[700]).setAlpha(0.86).toRgbString(),
+          backdropFilter: "blur(10px)",
           fontWeight: "normal",
           fontSize: "0.75rem",
         },


### PR DESCRIPTION
**User-Facing Changes**
Apply background blur to tooltips for browsers that support it.

**Description**
<img width="350" alt="Screen Shot 2023-03-07 at 9 52 13 am" src="https://user-images.githubusercontent.com/924528/223277143-3317106a-f0b1-4420-9d27-d3144d5db96e.png">
<img width="370" alt="Screen Shot 2023-03-07 at 9 53 35 am" src="https://user-images.githubusercontent.com/924528/223277225-a57e905e-fbcf-46b5-a9fa-944af557a84e.png">

<img width="456" alt="Screen Shot 2023-03-07 at 9 52 21 am" src="https://user-images.githubusercontent.com/924528/223277213-80b34f04-e20f-4b42-bbfb-31afc75b1d5d.png">


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
