### PR TITLE
Fix handling of out of bounds urlState time values

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
@@ -4,6 +4,7 @@
 
 import { keyframes } from "@emotion/react";
 import { simplify } from "intervals-fn";
+import { clamp } from "lodash";
 import { useMemo } from "react";
 import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
@@ -56,11 +57,22 @@ export function ProgressPlot(props: ProgressProps): JSX.Element {
   const { availableRanges, loading } = props;
   const { classes } = useStyles();
 
-  const ranges = useMemo(() => {
+  const clampedRanges = useMemo(() => {
     if (!availableRanges) {
+      return undefined;
+    }
+
+    return availableRanges.map((range) => ({
+      start: clamp(range.start, 0, 1),
+      end: clamp(range.end, 0, 1),
+    }));
+  }, [availableRanges]);
+
+  const ranges = useMemo(() => {
+    if (!clampedRanges) {
       return <></>;
     }
-    const mergedRanges = simplify(availableRanges);
+    const mergedRanges = simplify(clampedRanges);
 
     return filterMap(mergedRanges, (range, idx) => {
       const width = range.end - range.start;
@@ -79,7 +91,7 @@ export function ProgressPlot(props: ProgressProps): JSX.Element {
         />
       );
     });
-  }, [availableRanges, classes.range]);
+  }, [clampedRanges, classes.range]);
 
   return (
     <Stack position="relative" fullHeight>

--- a/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.stories.tsx
@@ -169,6 +169,7 @@ export const DownloadProgressByRanges: Story = () => {
   player.progress = {
     ...player.progress,
     fullyLoadedFractionRanges: [
+      { start: -2, end: 0.1 },
       { start: 0.23, end: 0.6 },
       { start: 0.7, end: 1 },
     ],

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -252,10 +252,14 @@ export class IterablePlayer implements Player {
 
   public seekPlayback(time: Time): void {
     // Wait to perform seek until initialization is complete
-    if (this._state === "preinit" || this._state === "initialize" || !this._start || !this._end) {
+    if (this._state === "preinit" || this._state === "initialize") {
       log.debug(`Ignoring seek, state=${this._state}`);
-      this._seekTarget = this._start && this._end ? clampTime(time, this._start, this._end) : time;
+      this._seekTarget = time;
       return;
+    }
+
+    if (!this._start || !this._end) {
+      throw new Error("invariant: initialized but no start/end set");
     }
 
     // Limit seek to within the valid range
@@ -439,6 +443,12 @@ export class IterablePlayer implements Player {
         datatypes,
         name,
       } = await this._bufferedSource.initialize();
+
+      // Prior to initialization, the seekTarget may have been set to an out-of-bounds value
+      // This brings the value in bounds
+      if (this._seekTarget) {
+        this._seekTarget = clampTime(this._seekTarget, start, end);
+      }
 
       this._profile = profile;
       this._start = start;
@@ -643,10 +653,16 @@ export class IterablePlayer implements Player {
   // Process a seek request. The seek is performed by requesting a getBackfillMessages from the source.
   // This provides the last message on all subscribed topics.
   private async _stateSeekBackfill() {
-    const targetTime = this._seekTarget;
-    if (!targetTime) {
+    if (!this._start || !this._end) {
+      throw new Error("invariant: stateSeekBackfill prior to initialization");
+    }
+
+    if (!this._seekTarget) {
       return;
     }
+
+    // Ensure the seek time is always within the data source bounds
+    const targetTime = clampTime(this._seekTarget, this._start, this._end);
 
     this._lastMessageEvent = undefined;
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -254,7 +254,7 @@ export class IterablePlayer implements Player {
     // Wait to perform seek until initialization is complete
     if (this._state === "preinit" || this._state === "initialize" || !this._start || !this._end) {
       log.debug(`Ignoring seek, state=${this._state}`);
-      this._seekTarget = time;
+      this._seekTarget = this._start && this._end ? clampTime(time, this._start, this._end) : time;
       return;
     }
 


### PR DESCRIPTION
**User-Facing Changes**
Fix handling of out of bounds urlState time values.

**Description**
This makes two fixes:
1. Clamps the ranges supplied to the ProgressPlot component so it doesn't draw out of bounds.
2. Clamps the seek time in the `IterablePlayer` seekPlayback method within start & end time.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
