### PR TITLE
Update PointCloud renderable visibility

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -318,6 +318,11 @@ export class PointCloudRenderable extends Renderable<PointCloudUserData> {
   }
 
   public startFrame(currentTime: bigint, renderFrameId: string, fixedFrameId: string): void {
+    // The PointCloud SceneExtension overrides startFrame which is responsible for setting the
+    // THREE.Object3D.visible flag on renderables so we set it here to synchronize the THREE
+    // visibility state with the settings state.
+    this.visible = this.userData.settings.visible;
+
     if (!this.userData.settings.visible) {
       this.renderer.settings.errors.clearPath(this.userData.settingsPath);
       this.pointsHistory.clearHistory();


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue where PointClouds would remain visibile during playback even when toggling the topic visibility off.

**Description**
The `PointCloud` scene extensions overrides the `startFrame` method of the base `SceneExtension` class. In its own implementation it does not call `super.startFrame()` and provides a comment on why. However, `super.startFrame` performs an important function which is to synchronize the THREE Object visible state with the visible state from the settings tree for the topic. Since this was not happening for the PointCloud scene extension, when a user would toggle a point cloud topic off, the cloud would continue to display on screen.

This bug did not occur when toggling the topic while paused. When paused, the underlying playback architecture would perform a backfill for any new subscription changes (toggling a topic off changes the subscriptions). This backfill would trigger a "didSeek" render state for the 3d panel which flushes rendering and disposes of renderables in anticipation of new renderables. However, when playing, the backfill is skipped and the renderables remain and without the visibility sync they remain on screen.

This change updates the PointCloud renderable implementation to sync the visibility setting into the THREE object visible field.

More generally I view the various overloads as fragile since the base implementation could be doing important work (as shown here). The original reason for overloading was to avoid the _pose_ updates for extensions which do not need that to happen. I believe extensions should have some way of indicating this or the pose update should move to those that need it to happen so the base start frame is called for all extensions and then an extension specific start frame. That is a larger change which I did not pursue here.