### PR TITLE
Respect opacity in model color override

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -289,6 +289,7 @@ export class RenderableModels extends RenderablePrimitive {
       }
       rgbToThreeColor(renderable.material.color, overrideColor);
       const transparent = overrideColor.a < 1;
+      renderable.material.opacity = overrideColor.a;
       renderable.material.transparent = transparent;
       renderable.material.depthWrite = !transparent;
       renderable.material.needsUpdate = true;


### PR DESCRIPTION
**User-Facing Changes**
Fixed a bug where the alpha component of the override color setting was not respected for ModelEntities.

**Description**
Fixes FG-2292

<img width="520" alt="image" src="https://user-images.githubusercontent.com/14237/223306130-77261a24-1188-46ed-a195-d6f4a5969074.png">
