### PR TITLE
Remove file info from top of DataSourceInfoPanel

### DIFF
--- a/packages/studio-base/src/panels/DataSourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.tsx
@@ -2,11 +2,9 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Divider } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
-import { DataSourceInfoView } from "@foxglove/studio-base/components/DataSourceInfoView";
 import { DirectTopicStatsUpdater } from "@foxglove/studio-base/components/DirectTopicStatsUpdater";
 import EmptyState from "@foxglove/studio-base/components/EmptyState";
 import {
@@ -129,12 +127,7 @@ function SourceInfo(): JSX.Element {
   return (
     <>
       <PanelToolbar />
-      <Divider />
       <Stack fullHeight overflowY="auto">
-        <Stack padding={1.5}>
-          <DataSourceInfoView />
-        </Stack>
-        <Divider />
         <table className={classes.table}>
           <thead>
             <tr>

--- a/packages/studio-base/src/panels/DataSourceInfo/index.tsx
+++ b/packages/studio-base/src/panels/DataSourceInfo/index.tsx
@@ -2,6 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Divider } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 import CopyButton from "@foxglove/studio-base/components/CopyButton";
@@ -33,6 +34,7 @@ const useStyles = makeStyles<void, "copyIcon">()((theme, _params, classes) => ({
       position: "sticky",
       textAlign: "left",
       top: 0,
+      zIndex: theme.zIndex.appBar - 1,
     },
 
     tr: {
@@ -127,6 +129,7 @@ function SourceInfo(): JSX.Element {
   return (
     <>
       <PanelToolbar />
+      <Divider />
       <Stack fullHeight overflowY="auto">
         <table className={classes.table}>
           <thead>


### PR DESCRIPTION
**User-Facing Changes**
Remove file info from top of DataSourceInfoPanel as it appears elsewhere in the app and takes up a significant amount of space.

| Before |. After |
| --- | --- |
|<img width="553" alt="Screen Shot 2023-03-08 at 8 40 12 am" src="https://user-images.githubusercontent.com/924528/223559183-d61f08f9-f92c-4671-9318-816c216c2e75.png"> | <img width="546" alt="Screen Shot 2023-03-08 at 8 37 16 am" src="https://user-images.githubusercontent.com/924528/223559193-246f0259-693a-462d-bd23-2690723cafcb.png"> |

Closes FG-1835