### PR TITLE
Fix subscribing to multiple converters in single panel

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -536,6 +536,164 @@ describe("renderState", () => {
       ],
     });
   });
+
+  it.only("should support multiple _from_ converters with different _to_", () => {
+    const buildRenderState = initRenderStateBuilder();
+    const state = buildRenderState({
+      watchedFields: new Set(["topics", "currentFrame", "allFrames"]),
+      playerState: {
+        presence: PlayerPresence.INITIALIZING,
+        capabilities: [],
+        profile: undefined,
+        playerId: "test",
+        progress: {
+          messageCache: {
+            startTime: { sec: 0, nsec: 0 },
+            blocks: [
+              {
+                sizeInBytes: 0,
+                messagesByTopic: {
+                  test: [
+                    {
+                      topic: "test",
+                      schemaName: "schema",
+                      receiveTime: { sec: 1, nsec: 0 },
+                      sizeInBytes: 1,
+                      message: { from: "allFrames" },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+      appSettings: undefined,
+      currentFrame: [
+        {
+          topic: "test",
+          schemaName: "schema",
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+          message: { from: "currentFrame" },
+        },
+      ],
+      colorScheme: undefined,
+      globalVariables: {},
+      hoverValue: undefined,
+      sharedPanelState: {},
+      sortedTopics: [{ name: "test", schemaName: "schema" }],
+      subscriptions: [
+        { topic: "test" },
+        { topic: "test", convertTo: "otherSchema", preload: false },
+        { topic: "test", convertTo: "anotherSchema", preload: false },
+      ],
+      messageConverters: [
+        {
+          fromSchemaName: "schema",
+          toSchemaName: "otherSchema",
+          converter: () => {
+            return 1;
+          },
+        },
+        {
+          fromSchemaName: "schema",
+          toSchemaName: "anotherSchema",
+          converter: () => {
+            return 2;
+          },
+        },
+      ],
+    });
+
+    expect(state).toEqual({
+      topics: [
+        {
+          name: "test",
+          schemaName: "schema",
+          datatype: "schema",
+          convertibleTo: ["otherSchema", "anotherSchema"],
+        },
+      ],
+      currentFrame: [
+        {
+          topic: "test",
+          schemaName: "schema",
+          message: { from: "currentFrame" },
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+        },
+        {
+          topic: "test",
+          schemaName: "otherSchema",
+          message: 1,
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+          originalMessageEvent: {
+            topic: "test",
+            schemaName: "schema",
+            message: { from: "currentFrame" },
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 1,
+          },
+        },
+        {
+          topic: "test",
+          schemaName: "anotherSchema",
+          message: 2,
+          receiveTime: { sec: 0, nsec: 0 },
+          sizeInBytes: 1,
+          originalMessageEvent: {
+            topic: "test",
+            schemaName: "schema",
+            message: { from: "currentFrame" },
+            receiveTime: { sec: 0, nsec: 0 },
+            sizeInBytes: 1,
+          },
+        },
+      ],
+      allFrames: [],
+      /* fixme
+      allFrames: [
+        {
+          message: { from: "allFrames" },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "schema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+        {
+          message: 1,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "otherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+        {
+          message: 2,
+          originalMessageEvent: {
+            message: { from: "allFrames" },
+            receiveTime: { nsec: 0, sec: 1 },
+            schemaName: "schema",
+            sizeInBytes: 1,
+            topic: "test",
+          },
+          receiveTime: { nsec: 0, sec: 1 },
+          schemaName: "anotherSchema",
+          sizeInBytes: 1,
+          topic: "test",
+        },
+      ],
+      */
+    });
+  });
 });
 
 describe("forEachSortedArrays", () => {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -537,7 +537,7 @@ describe("renderState", () => {
     });
   });
 
-  it.only("should support multiple _from_ converters with different _to_", () => {
+  it("should support multiple _from_ converters with different _to_", () => {
     const buildRenderState = initRenderStateBuilder();
     const state = buildRenderState({
       watchedFields: new Set(["topics", "currentFrame", "allFrames"]),

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -537,6 +537,8 @@ describe("renderState", () => {
     });
   });
 
+  // It is valid to register multiple converters all sharing the same _from_ schema and having
+  // different _to_ schemas.
   it("should support multiple _from_ converters with different _to_", () => {
     const buildRenderState = initRenderStateBuilder();
     const state = buildRenderState({

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.test.ts
@@ -585,8 +585,8 @@ describe("renderState", () => {
       sortedTopics: [{ name: "test", schemaName: "schema" }],
       subscriptions: [
         { topic: "test" },
-        { topic: "test", convertTo: "otherSchema", preload: false },
-        { topic: "test", convertTo: "anotherSchema", preload: false },
+        { topic: "test", convertTo: "otherSchema", preload: true },
+        { topic: "test", convertTo: "anotherSchema", preload: true },
       ],
       messageConverters: [
         {
@@ -652,8 +652,6 @@ describe("renderState", () => {
           },
         },
       ],
-      allFrames: [],
-      /* fixme
       allFrames: [
         {
           message: { from: "allFrames" },
@@ -691,7 +689,6 @@ describe("renderState", () => {
           topic: "test",
         },
       ],
-      */
     });
   });
 });

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -80,6 +80,15 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       watchedFields,
     } = input;
 
+    // Should render indicates whether any fields of render state are updated
+    let shouldRender = false;
+
+    // Hoisted active data to shorten some of the code below that repeatedly uses active data
+    const activeData = playerState?.activeData;
+
+    // The render state starts with the previous render state and changes are applied as detected
+    const renderState: RenderState = prevRenderState;
+
     // If the player has loaded all the blocks, the blocks reference won't change so our message
     // pipeline handler for allFrames won't create a new set of all frames for the newly
     // subscribed topic. To ensure a new set of allFrames with the newly subscribed topic is
@@ -88,11 +97,12 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       prevBlocks = undefined;
     }
 
-    // Re-calculate the topic converters that need to run for subscriptions
-    if (subscriptions !== prevSubscriptions) {
-      // fixme - update when message converters change
-      // fixme - update when topics change
-
+    // If topics, message converters, or subscriptions change, recalculate the
+    if (
+      subscriptions !== prevSubscriptions ||
+      prevSortedTopics !== sortedTopics ||
+      prevMessageConverters !== messageConverters
+    ) {
       // reset which topics need converting
       topicNoConversions.clear();
       topicConversions.clear();
@@ -149,16 +159,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         }
       }
     }
-
-    prevSubscriptions = subscriptions;
-
-    // Should render indicates whether any fields of render state are updated
-    let shouldRender = false;
-
-    const activeData = playerState?.activeData;
-
-    // The render state starts with the previous render state and changes are applied as detected
-    const renderState: RenderState = prevRenderState;
 
     if (watchedFields.has("didSeek")) {
       const didSeek = prevSeekTime !== activeData?.lastSeekTime;
@@ -229,10 +229,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         prevSortedTopics = sortedTopics;
       }
     }
-
-    // fixme - how to make this clearer?
-    // update this after watch handlers which need to check for reference equality
-    prevMessageConverters = messageConverters;
 
     if (watchedFields.has("currentFrame")) {
       // If there are new frames we render
@@ -383,6 +379,11 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         renderState.appSettings = appSettings;
       }
     }
+
+    // Update the prev fields with the latest values at the end of all the watch steps
+    // Several of the watch steps depend on the comparison against prev and new values
+    prevSubscriptions = subscriptions;
+    prevMessageConverters = messageConverters;
 
     if (!shouldRender) {
       return undefined;

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -118,7 +118,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
 
     // If topics, message converters, or subscriptions change, recalculate the
     if (
-      subscriptions !== prevSubscriptions ||
+      prevSubscriptions !== subscriptions ||
       prevSortedTopics !== sortedTopics ||
       prevMessageConverters !== messageConverters
     ) {
@@ -166,11 +166,14 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         }
 
         // Find a converter that can go from the original topic schema to the target schema
+        // Note: We only support one converter per unique from/to pair so this _find_ only needs to
+        //       find one converter rather than multiple converters.
         const converter = messageConverters?.find(
           (conv) =>
             conv.fromSchemaName === subscriberTopic.schemaName &&
             conv.toSchemaName === subscription.convertTo,
         );
+
         if (converter) {
           existingConverters ??= [];
           existingConverters.push(converter);
@@ -245,7 +248,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         });
 
         renderState.topics = topics;
-        prevSortedTopics = sortedTopics;
       }
     }
 
@@ -402,6 +404,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     // Update the prev fields with the latest values at the end of all the watch steps
     // Several of the watch steps depend on the comparison against prev and new values
     prevSubscriptions = subscriptions;
+    prevSortedTopics = sortedTopics;
     prevMessageConverters = messageConverters;
 
     if (!shouldRender) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -41,14 +41,6 @@ type BuilderRenderStateInput = {
 
 type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderState> | undefined;
 
-// Create a string lookup key using fromSchemaName and toSchemaName.
-//
-// The string key uses a newline delimeter to avoid producting the same key for from/to name values
-// that might concatenate to the same string. i.e. "fromName" "toName" and "fromNameto" "Name".
-function converterKey(fromSchemaName: string, toSchemaName: string): string {
-  return fromSchemaName + "\n" + toSchemaName;
-}
-
 /**
  * initRenderStateBuilder creates a function that transforms render state input into a new
  * RenderState
@@ -72,10 +64,10 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   const topicNoConversions: Set<string> = new Set();
 
   // Topic -> convertTo mapping. These are topics which we want to receive some converted data in the convertTo schema
-  const topicConversions: Map<string, string> = new Map();
+  const topicConversions: Map<string, RegisterMessageConverterArgs<unknown>[]> = new Map();
 
   // from + to -> converter mapping. Allows for quick lookup of a converter by its from and to schema names
-  const convertersByKey: Map<string, RegisterMessageConverterArgs<unknown>> = new Map();
+  //const convertersByKey: Map<string, RegisterMessageConverterArgs<unknown>> = new Map();
 
   const prevRenderState: RenderState = {};
 
@@ -100,27 +92,70 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     // created, we unset the blocks ref which will force re-creating allFrames.
     if (subscriptions !== prevSubscriptions) {
       prevBlocks = undefined;
+    }
+
+    // Re-calculate the topic converters that need to run for subscriptions
+    if (subscriptions !== prevSubscriptions) {
+      // fixme - update when message converters change
+      // fixme - update when topics change
+
+      // reset which topics need converting
+      topicNoConversions.clear();
+      topicConversions.clear();
 
       // Bin the subscriptions into two sets: those which want a conversion and those that do not.
       //
       // For the subscriptions that want a conversion, if the topic schemaName matches the requested
       // convertTo, then we don't need to do a conversion.
       for (const subscription of subscriptions) {
-        if (subscription.convertTo) {
-          const noConversion = sortedTopics.find(
-            (topic) =>
-              topic.name === subscription.topic && topic.schemaName === subscription.convertTo,
-          );
-          if (noConversion) {
-            topicNoConversions.add(noConversion.name);
-          } else {
-            topicConversions.set(subscription.topic, subscription.convertTo);
-          }
-        } else {
+        if (!subscription.convertTo) {
           topicNoConversions.add(subscription.topic);
+          continue;
+        }
+
+        // If the convertTo is the same as the original schema for the topic then we don't need to
+        // perform a conversion.
+        const noConversion = sortedTopics.find(
+          (topic) =>
+            topic.name === subscription.topic && topic.schemaName === subscription.convertTo,
+        );
+        if (noConversion) {
+          topicNoConversions.add(noConversion.name);
+          continue;
+        }
+
+        // Since we don't have an existing topic with out destination schema we need to find
+        // a converter that will convert from the topic to the desired schema
+        const subscriberTopic = sortedTopics.find((topic) => topic.name === subscription.topic);
+        if (!subscriberTopic) {
+          continue;
+        }
+
+        const key = subscription.topic + (subscriberTopic.schemaName ?? "<no-schema>");
+        let existingConverters = topicConversions.get(key);
+
+        // We've already stored a converter for this topic to convertTo
+        const haveConverter = existingConverters?.find(
+          (conv) => conv.toSchemaName === subscription.convertTo,
+        );
+        if (haveConverter) {
+          continue;
+        }
+
+        // Find a converter that can go from the original topic schema to the target schema
+        const converter = messageConverters?.find(
+          (conv) =>
+            conv.fromSchemaName === subscriberTopic.schemaName &&
+            conv.toSchemaName === subscription.convertTo,
+        );
+        if (converter) {
+          existingConverters ??= [];
+          existingConverters.push(converter);
+          topicConversions.set(key, existingConverters);
         }
       }
     }
+
     prevSubscriptions = subscriptions;
 
     // Should render indicates whether any fields of render state are updated
@@ -201,30 +236,8 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       }
     }
 
-    // Update the mapping of converters.
-    // This needs to happen _after_ the above topics processing which re-runs if the message converters have changed,
-    // and _before_ currentFrame and _allFrames_ processing which use this cache.
-    //
-    // If setting `prevMessageConverters` runs before the above topics handling then topics won't
-    // run again if the message converters have changed.
-    //
-    // And if this runs after the currentFrame and allFrames handling then convertersByKey will be
-    // from the previous converters.
-    if (messageConverters !== prevMessageConverters) {
-      convertersByKey.clear();
-
-      if (messageConverters) {
-        for (const converter of messageConverters) {
-          const key = converterKey(converter.fromSchemaName, converter.toSchemaName);
-          if (convertersByKey.has(key)) {
-            log.error(
-              `A message converter from (${converter.fromSchemaName}) to (${converter.toSchemaName}) already exists.`,
-            );
-          }
-          convertersByKey.set(key, converter);
-        }
-      }
-    }
+    // fixme - how to make this clearer?
+    // update this after watch handlers which need to check for reference equality
     prevMessageConverters = messageConverters;
 
     if (watchedFields.has("currentFrame")) {
@@ -243,16 +256,15 @@ function initRenderStateBuilder(): BuildRenderStateFn {
               postProcessedFrame.push(messageEvent);
             }
 
-            // When subscribing with a convertTo, we have a topic + destination schema
+            // fixme - comment
+            // When subscribing with a convertTo, we have a topic + set of destination schemas
             // to identify a potential converter to use we lookup a converter by the src schema + dest schema.
             // The src schema comes from the message event and the destination schema from the subscription
 
-            // Lookup any subscriptions for this topic which want a conversion
-            const subConvertTo = topicConversions.get(messageEvent.topic);
-            if (subConvertTo) {
-              const convertKey = converterKey(messageEvent.schemaName, subConvertTo);
-              const converter = convertersByKey.get(convertKey);
-              if (converter) {
+            // Get the converters available for this topic and schema
+            const converters = topicConversions.get(messageEvent.topic + messageEvent.schemaName);
+            if (converters) {
+              for (const converter of converters) {
                 const convertedMessage = converter.converter(messageEvent.message);
                 postProcessedFrame.push({
                   topic: messageEvent.topic,
@@ -304,12 +316,10 @@ function initRenderStateBuilder(): BuildRenderStateFn {
                 frames.push(messageEvent);
               }
 
-              // Lookup any subscriptions for this topic which want a conversion
-              const subConvertTo = topicConversions.get(messageEvent.topic);
-              if (subConvertTo) {
-                const convertKey = converterKey(messageEvent.schemaName, subConvertTo);
-                const converter = convertersByKey.get(convertKey);
-                if (converter) {
+              // Get the converters available for this topic and schema
+              const converters = topicConversions.get(messageEvent.topic + messageEvent.schemaName);
+              if (converters) {
+                for (const converter of converters) {
                   const convertedMessage = converter.converter(messageEvent.message);
                   frames.push({
                     topic: messageEvent.topic,

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -248,6 +248,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         });
 
         renderState.topics = topics;
+        prevSortedTopics = sortedTopics;
       }
     }
 
@@ -404,7 +405,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
     // Update the prev fields with the latest values at the end of all the watch steps
     // Several of the watch steps depend on the comparison against prev and new values
     prevSubscriptions = subscriptions;
-    prevSortedTopics = sortedTopics;
     prevMessageConverters = messageConverters;
 
     if (!shouldRender) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { filterMap } from "@foxglove/den/collection";
-import Log from "@foxglove/log";
 import { compare, toSec } from "@foxglove/rostime";
 import {
   AppSettingValue,
@@ -20,8 +19,6 @@ import {
 } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { PlayerState, Topic as PlayerTopic } from "@foxglove/studio-base/players/types";
 import { HoverValue } from "@foxglove/studio-base/types/hoverValue";
-
-const log = Log.getLogger(__filename);
 
 const EmptyParameters = new Map<string, ParameterValue>();
 
@@ -65,9 +62,6 @@ function initRenderStateBuilder(): BuildRenderStateFn {
 
   // Topic -> convertTo mapping. These are topics which we want to receive some converted data in the convertTo schema
   const topicConversions: Map<string, RegisterMessageConverterArgs<unknown>[]> = new Map();
-
-  // from + to -> converter mapping. Allows for quick lookup of a converter by its from and to schema names
-  //const convertersByKey: Map<string, RegisterMessageConverterArgs<unknown>> = new Map();
 
   const prevRenderState: RenderState = {};
 

--- a/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/renderState.ts
@@ -38,6 +38,17 @@ type BuilderRenderStateInput = {
 
 type BuildRenderStateFn = (input: BuilderRenderStateInput) => Readonly<RenderState> | undefined;
 
+// Branded string to ensure that users go through the `converterKey` function to compute a lookup key
+type ConverterKey = string & { __brand: "ConverterKey" };
+
+// Create a string lookup key from a message event
+//
+// The string key uses a newline delimeter to avoid producting the same key for topic/schema name
+// values that might concatenate to the same string. i.e. "topic" "schema" and "topics" "chema".
+function converterKey(topic: string, schema: string): ConverterKey {
+  return (topic + "\n" + schema) as ConverterKey;
+}
+
 /**
  * initRenderStateBuilder creates a function that transforms render state input into a new
  * RenderState
@@ -57,11 +68,19 @@ function initRenderStateBuilder(): BuildRenderStateFn {
   let prevMessageConverters: BuilderRenderStateInput["messageConverters"] | undefined;
   let prevSharedPanelState: BuilderRenderStateInput["sharedPanelState"];
 
-  // Topics which we are subscribed without a conversion, these are topics we want to receive the original message
-  const topicNoConversions: Set<string> = new Set();
+  // Topics which we are subscribed without a conversion, these are topics we want to receive the
+  // original message
+  const unconvertedSubscriptionTopics: Set<string> = new Set();
 
-  // Topic -> convertTo mapping. These are topics which we want to receive some converted data in the convertTo schema
-  const topicConversions: Map<string, RegisterMessageConverterArgs<unknown>[]> = new Map();
+  // When a subscription with a convertTo exists, we lookup a converter which can produce the
+  // desired output message schema and store it in this map. The keys for the map are `topic + input
+  // schema`.
+  //
+  // This allows the runtime message event handler logic which builds currentFrame and allFrames to
+  // lookup whether the incoming message event has converters to run by looking up the topic +
+  // schema of the message event in this map.
+  const topicSchemaConverters: Map<ConverterKey, RegisterMessageConverterArgs<unknown>[]> =
+    new Map();
 
   const prevRenderState: RenderState = {};
 
@@ -103,9 +122,9 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       prevSortedTopics !== sortedTopics ||
       prevMessageConverters !== messageConverters
     ) {
-      // reset which topics need converting
-      topicNoConversions.clear();
-      topicConversions.clear();
+      // reset which topics have subscriptions and which need converting
+      unconvertedSubscriptionTopics.clear();
+      topicSchemaConverters.clear();
 
       // Bin the subscriptions into two sets: those which want a conversion and those that do not.
       //
@@ -113,7 +132,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
       // convertTo, then we don't need to do a conversion.
       for (const subscription of subscriptions) {
         if (!subscription.convertTo) {
-          topicNoConversions.add(subscription.topic);
+          unconvertedSubscriptionTopics.add(subscription.topic);
           continue;
         }
 
@@ -124,7 +143,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
             topic.name === subscription.topic && topic.schemaName === subscription.convertTo,
         );
         if (noConversion) {
-          topicNoConversions.add(noConversion.name);
+          unconvertedSubscriptionTopics.add(noConversion.name);
           continue;
         }
 
@@ -135,8 +154,8 @@ function initRenderStateBuilder(): BuildRenderStateFn {
           continue;
         }
 
-        const key = subscription.topic + (subscriberTopic.schemaName ?? "<no-schema>");
-        let existingConverters = topicConversions.get(key);
+        const key = converterKey(subscription.topic, subscriberTopic.schemaName ?? "<no-schema>");
+        let existingConverters = topicSchemaConverters.get(key);
 
         // We've already stored a converter for this topic to convertTo
         const haveConverter = existingConverters?.find(
@@ -155,7 +174,7 @@ function initRenderStateBuilder(): BuildRenderStateFn {
         if (converter) {
           existingConverters ??= [];
           existingConverters.push(converter);
-          topicConversions.set(key, existingConverters);
+          topicSchemaConverters.set(key, existingConverters);
         }
       }
     }
@@ -242,17 +261,15 @@ function initRenderStateBuilder(): BuildRenderStateFn {
           const postProcessedFrame: MessageEvent<unknown>[] = [];
 
           for (const messageEvent of currentFrame) {
-            if (topicNoConversions.has(messageEvent.topic)) {
+            if (unconvertedSubscriptionTopics.has(messageEvent.topic)) {
               postProcessedFrame.push(messageEvent);
             }
 
-            // fixme - comment
-            // When subscribing with a convertTo, we have a topic + set of destination schemas
-            // to identify a potential converter to use we lookup a converter by the src schema + dest schema.
-            // The src schema comes from the message event and the destination schema from the subscription
-
-            // Get the converters available for this topic and schema
-            const converters = topicConversions.get(messageEvent.topic + messageEvent.schemaName);
+            // Get the converters that need to be run for this message event
+            // See the comment for topicSchemaConverters on the use of the key
+            const converters = topicSchemaConverters.get(
+              converterKey(messageEvent.topic, messageEvent.schemaName),
+            );
             if (converters) {
               for (const converter of converters) {
                 const convertedMessage = converter.converter(messageEvent.message);
@@ -302,12 +319,14 @@ function initRenderStateBuilder(): BuildRenderStateFn {
               // Message blocks may contain topics that we are not subscribed to so we need to filter those out.
               // We use the topicNoConversions and topicConversions to determine if we should include the message event
 
-              if (topicNoConversions.has(messageEvent.topic)) {
+              if (unconvertedSubscriptionTopics.has(messageEvent.topic)) {
                 frames.push(messageEvent);
               }
 
               // Get the converters available for this topic and schema
-              const converters = topicConversions.get(messageEvent.topic + messageEvent.schemaName);
+              const converters = topicSchemaConverters.get(
+                converterKey(messageEvent.topic, messageEvent.schemaName),
+              );
               if (converters) {
                 for (const converter of converters) {
                   const convertedMessage = converter.converter(messageEvent.message);


### PR DESCRIPTION
**User-Facing Changes**
Fix a bug which prevented extension panels from subscribing to multiple converters for the same topic.

**Description**
`renderState` is responsible for figuring out the `currentFrame` and `allFrames` fields for extension panels. Part of this logic tracks which subscriptions need to leverage message converters and runs the converters. It would track this information by storing a map from the topic name to the target schema.

Unfortunately, this architecture meant that the panel could only subscribe to one converter per topic. If the user installed an extension which registered two converters, each for the same _from_ schema but different _to_ schemas, the panel could not subscribe to both _to_ schemas as one converter subscription would override the other.

This change fixes this behavior by tracking all of the subscribed converters for a specific input topic and schema. Now if a panel subscribes to the same topic with different convertTo parameters, both of these subscriptions are honored and the panel will receive both converted messages.

Fixes: #5487
Fixes: FG-2321


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
