### PR TITLE
Make top nav data source title clickable on desktop

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -102,6 +102,7 @@ const useStyles = makeStyles<{ leftInset?: number; debugDragRegion?: boolean }>(
         justifySelf: "center",
         overflow: "hidden",
         maxWidth: "100%",
+        ...NOT_DRAGGABLE_STYLE, // make buttons clickable for desktop app
       },
       end: {
         gridArea: "end",


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Fix drag region, data source name was not clickable on Linux desktop