### PR TITLE
Fix mismatched greys on dividers and restore hover color

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -4,6 +4,7 @@
 
 import { alpha } from "@mui/material";
 import { PropsWithChildren } from "react";
+import tinycolor from "tinycolor2";
 import { makeStyles } from "tss-react/mui";
 
 import "@foxglove/studio-base/styles/assets/inter.css";
@@ -161,10 +162,14 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
         zIndex: 99,
 
         ".mosaic-split-line": {
-          boxShadow: `0 0 0 1px ${palette.grey.A100}`,
+          boxShadow: `0 0 0 1px ${palette.divider}`,
         },
         "&:hover .mosaic-split-line": {
-          boxShadow: `0 0 0 1px ${palette.grey.A100}`,
+          boxShadow: `0 0 0 1px ${
+            palette.mode === "dark"
+              ? tinycolor(palette.divider).lighten().toHexString()
+              : tinycolor(palette.divider).darken().toHexString()
+          }`,
         },
       },
       "&.borderless": {


### PR DESCRIPTION
**User-Facing Changes**
Panel dividers now have a hover state

https://user-images.githubusercontent.com/924528/223888169-f151ff89-5b89-4488-a21a-f8bf86bc72bf.mov

