### PR TITLE
Fix spurious error icon in app bar

### DIFF
--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -90,10 +90,11 @@ export function DataSource({
   const playerName = useMessagePipeline(selectPlayerName);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems) ?? [];
-
   const reconnecting = playerPresence === PlayerPresence.RECONNECTING;
   const initializing = playerPresence === PlayerPresence.INITIALIZING;
-  const error = playerPresence === PlayerPresence.ERROR || playerProblems.length > 0;
+  const error =
+    playerPresence === PlayerPresence.ERROR ||
+    playerProblems.some((problem) => problem.severity === "error");
   const loading = reconnecting || initializing;
 
   const playerDisplayName =


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
In certain cases switching from one layout to another can cause a transient player problem of `warn` severity to register:

```json
{
    "severity": "warn",
    "message": "Data went back in time",
    "error": {}
}
```

Since this is just a transient warning and not an error we don't need to flash the red error icon.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
