### PR TITLE
Update signout text

### DIFF
--- a/packages/studio-base/src/components/AppBar/User.tsx
+++ b/packages/studio-base/src/components/AppBar/User.tsx
@@ -155,7 +155,7 @@ export function UserMenu({
         </MenuItem>
         <Divider variant="middle" />
         <MenuItem onClick={onSignoutClick}>
-          <ListItemText>Log out</ListItemText>
+          <ListItemText>Sign out</ListItemText>
         </MenuItem>
       </Menu>
       {confirmModal}


### PR DESCRIPTION
**User-Facing Changes**

Change the User menu "Log out" text to "Sign out".

**Description**

This updates the menu item to match the "Sign in" and "Sign out" terminology used elsewhere in the app.