### PR TITLE
Remove TF frames when removing URDF layer

### DIFF
--- a/packages/den/collection/ArrayMap.test.ts
+++ b/packages/den/collection/ArrayMap.test.ts
@@ -112,6 +112,7 @@ describe("ArrayMap", () => {
     expect(list.binarySearch(8)).toBe(~5);
     expect(list.binarySearch(9)).toBe(~5);
   });
+
   it("removes elements before key", () => {
     const list = new ArrayMap<number, string>();
     const data = [...Array(10).keys()];
@@ -128,5 +129,23 @@ describe("ArrayMap", () => {
     expect(list.binarySearch(7)).toBe(2);
     expect(list.binarySearch(8)).toBe(3);
     expect(list.binarySearch(9)).toBe(4);
+  });
+
+  it("removes specific elements", () => {
+    const list = new ArrayMap<number, string>();
+    const data = [...Array(10).keys()];
+    data.forEach((val) => list.set(val, String(val)));
+    list.remove(3);
+    expect(list.size).toBe(9);
+    expect(list.binarySearch(0)).toBe(0);
+    expect(list.binarySearch(1)).toBe(1);
+    expect(list.binarySearch(2)).toBe(2);
+    expect(list.binarySearch(3)).toBe(~3);
+    expect(list.binarySearch(4)).toBe(3);
+    expect(list.binarySearch(5)).toBe(4);
+    expect(list.binarySearch(6)).toBe(5);
+    expect(list.binarySearch(7)).toBe(6);
+    expect(list.binarySearch(8)).toBe(7);
+    expect(list.binarySearch(9)).toBe(8);
   });
 });

--- a/packages/den/collection/ArrayMap.ts
+++ b/packages/den/collection/ArrayMap.ts
@@ -53,6 +53,14 @@ export class ArrayMap<K, V> {
     return this._list.pop();
   }
 
+  /** Removes the element with the given key, if it exists */
+  public remove(key: K): void {
+    const index = this.binarySearch(key);
+    if (index >= 0) {
+      this._list.splice(index, 1);
+    }
+  }
+
   /** Removes all elements with keys greater than the given key. */
   public removeAfter(key: K): void {
     const index = this.binarySearch(key);

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1003,6 +1003,12 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
   }
 
+  public removeTransform(childFrameId: string, parentFrameId: string, stamp: bigint): void {
+    this.transformTree.removeTransform(childFrameId, parentFrameId, stamp);
+    this.coordinateFrameList = this.transformTree.frameList();
+    this.emit("transformTreeUpdated", this);
+  }
+
   // Callback handlers
 
   public animationFrame = (): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/CoordinateFrame.ts
@@ -159,6 +159,11 @@ export class CoordinateFrame {
     this._transforms.removeAfter(time);
   }
 
+  /** Removes a transform with a specific timestamp */
+  public removeTransformAt(time: Time): void {
+    this._transforms.remove(time);
+  }
+
   /**
    * Find the closest transform(s) in the transform history to the given time.
    * Note that if an exact match is found, both `outLower` and `outUpper` will

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -7,32 +7,62 @@ import { Transform } from "@foxglove/studio-base/panels/ThreeDeeRender/transform
 import { AddTransformResult, TransformTree } from "./TransformTree";
 
 const tf = Transform.Identity();
-const bigint = BigInt("0");
 describe("TransformTree", () => {
   it("updates tree when adding a transform that would not create a cycle", () => {
     const tfTree = new TransformTree();
-    tfTree.addTransform("b", "a", bigint, tf);
-    tfTree.addTransform("c", "b", bigint, tf);
-    expect(tfTree.addTransform("d", "c", bigint, tf)).toEqual(AddTransformResult.UPDATED);
+    tfTree.addTransform("b", "a", 0n, tf);
+    tfTree.addTransform("c", "b", 0n, tf);
+    expect(tfTree.addTransform("d", "c", 0n, tf)).toEqual(AddTransformResult.UPDATED);
   });
   it("detects a cycle adding a transform that would create a cycle with 2 frames", () => {
     const tfTree = new TransformTree();
     // a <- b
-    tfTree.addTransform("b", "a", bigint, tf);
+    tfTree.addTransform("b", "a", 0n, tf);
     // b <- a <- b ERROR - cycle created
-    expect(tfTree.addTransform("a", "b", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
+    expect(tfTree.addTransform("a", "b", 0n, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
   });
   it("detects a cycle when adding a transform that would create a cycle with 3 frames", () => {
     const tfTree = new TransformTree();
     // a <- b
-    tfTree.addTransform("b", "a", bigint, tf);
+    tfTree.addTransform("b", "a", 0n, tf);
     // a <- b <- c
-    tfTree.addTransform("c", "b", bigint, tf);
+    tfTree.addTransform("c", "b", 0n, tf);
     // c <- a <- b <- c  ERROR - cycle created
-    expect(tfTree.addTransform("a", "c", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
+    expect(tfTree.addTransform("a", "c", 0n, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
   });
   it("detects a cycle when adding a transform with a parent as itself", () => {
     const tfTree = new TransformTree();
-    expect(tfTree.addTransform("a", "a", bigint, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
+    expect(tfTree.addTransform("a", "a", 0n, tf)).toEqual(AddTransformResult.CYCLE_DETECTED);
+  });
+
+  it("supports deleting frames", () => {
+    const tfTree = new TransformTree();
+    tfTree.addTransform("b", "a", 0n, tf);
+    tfTree.addTransform("c", "b", 0n, tf);
+    tfTree.addTransform("c", "b", 1n, tf);
+
+    // Remove non-existent transform is a no-op
+    tfTree.removeTransform("a", "c", 0n);
+    expect(tfTree.frame("a")).toBeDefined();
+    expect(tfTree.frame("b")).toBeDefined();
+    expect(tfTree.frame("c")).toBeDefined();
+
+    // Remove transform from a->b, a is not deleted because it still has children
+    tfTree.removeTransform("b", "a", 0n);
+    expect(tfTree.frame("a")).toBeDefined();
+    expect(tfTree.frame("b")).toBeDefined();
+    expect(tfTree.frame("c")).toBeDefined();
+
+    // Remove transform at 0 from b->c, nothing is deleted because there's still a transform at time 1
+    tfTree.removeTransform("c", "b", 0n);
+    expect(tfTree.frame("a")).toBeDefined();
+    expect(tfTree.frame("b")).toBeDefined();
+    expect(tfTree.frame("c")).toBeDefined();
+
+    // Remove transform at 1 from b->c, everything is now empty, all frames get deleted
+    tfTree.removeTransform("c", "b", 1n);
+    expect(tfTree.frame("a")).toBeUndefined();
+    expect(tfTree.frame("b")).toBeUndefined();
+    expect(tfTree.frame("c")).toBeUndefined();
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.test.ts
@@ -40,29 +40,40 @@ describe("TransformTree", () => {
     tfTree.addTransform("b", "a", 0n, tf);
     tfTree.addTransform("c", "b", 0n, tf);
     tfTree.addTransform("c", "b", 1n, tf);
+    tfTree.addTransform("d", "a", 0n, tf);
 
     // Remove non-existent transform is a no-op
-    tfTree.removeTransform("a", "c", 0n);
+    tfTree.removeTransform("c", "a", 0n);
     expect(tfTree.frame("a")).toBeDefined();
     expect(tfTree.frame("b")).toBeDefined();
     expect(tfTree.frame("c")).toBeDefined();
+    expect(tfTree.frame("d")).toBeDefined();
 
     // Remove transform from a->b, a is not deleted because it still has children
     tfTree.removeTransform("b", "a", 0n);
     expect(tfTree.frame("a")).toBeDefined();
     expect(tfTree.frame("b")).toBeDefined();
     expect(tfTree.frame("c")).toBeDefined();
+    expect(tfTree.frame("d")).toBeDefined();
 
     // Remove transform at 0 from b->c, nothing is deleted because there's still a transform at time 1
     tfTree.removeTransform("c", "b", 0n);
     expect(tfTree.frame("a")).toBeDefined();
     expect(tfTree.frame("b")).toBeDefined();
     expect(tfTree.frame("c")).toBeDefined();
+    expect(tfTree.frame("d")).toBeDefined();
 
-    // Remove transform at 1 from b->c, everything is now empty, all frames get deleted
+    // Remove transform at 1 from b->c, b and c can now be deleted, a->d still exists
     tfTree.removeTransform("c", "b", 1n);
+    expect(tfTree.frame("a")).toBeDefined();
+    expect(tfTree.frame("b")).toBeUndefined();
+    expect(tfTree.frame("c")).toBeUndefined();
+    expect(tfTree.frame("d")).toBeDefined();
+
+    tfTree.removeTransform("d", "a", 0n);
     expect(tfTree.frame("a")).toBeUndefined();
     expect(tfTree.frame("b")).toBeUndefined();
     expect(tfTree.frame("c")).toBeUndefined();
+    expect(tfTree.frame("d")).toBeUndefined();
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -62,6 +62,71 @@ export class TransformTree {
       : AddTransformResult.NOT_UPDATED;
   }
 
+  /**
+   * Removes transform data from a particular parent-child link at the given timestamp. Does nothing
+   * if the child does not exist or has a different parent.
+   */
+  public removeTransform(childFrameId: string, parentFrameId: string, stamp: bigint): void {
+    const child = this.frame(childFrameId);
+    if (!child) {
+      return;
+    }
+    if (child.parent()?.id !== parentFrameId) {
+      return;
+    }
+    child.removeTransformAt(stamp);
+    this._removeEmptyFrames();
+  }
+
+  /** Prune frames with no history entries and no children from the tree */
+  private _removeEmptyFrames() {
+    // Build a list of children for each frame in the tree
+    const childrenByParentId = new Map<string, Set<string>>();
+    for (const frame of this._frames.values()) {
+      childrenByParentId.set(frame.id, new Set());
+    }
+    for (const frame of this._frames.values()) {
+      const parentId = frame.parent()?.id;
+      if (parentId == undefined) {
+        continue;
+      }
+      const children = childrenByParentId.get(parentId);
+      if (!children) {
+        throw new Error("invariant: should have children array");
+      }
+      children.add(frame.id);
+    }
+
+    // Repeatedly delete any frames with no children until the tree doesn't change
+    for (;;) {
+      let deletedAnyFrames = false;
+      for (const [frameId, children] of childrenByParentId) {
+        const frame = this.frame(frameId);
+        if (!frame) {
+          throw new Error(`invariant: unknown parent frame id ${frameId}`);
+        }
+        if (frame.transformsSize() > 0) {
+          // don't want to delete this frame, it is not empty
+          continue;
+        }
+        if (children.size > 0) {
+          // can't delete this frame yet, it still has children
+          continue;
+        }
+        const parent = frame.parent();
+        if (parent) {
+          childrenByParentId.get(parent.id)?.delete(frameId);
+        }
+        this._frames.delete(frameId);
+        childrenByParentId.delete(frameId);
+        deletedAnyFrames = true;
+      }
+      if (!deletedAnyFrames) {
+        break;
+      }
+    }
+  }
+
   public clear(): void {
     this._frames.clear();
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/transforms/TransformTree.ts
@@ -75,54 +75,61 @@ export class TransformTree {
       return;
     }
     child.removeTransformAt(stamp);
-    this._removeEmptyFrames();
+    this._removeEmptyAncestors(child);
   }
 
-  /** Prune frames with no history entries and no children from the tree */
-  private _removeEmptyFrames() {
-    // Build a list of children for each frame in the tree
+  /**
+   * Walk up the tree starting from `candidate` and prune frames with no history entries and no
+   * children.
+   */
+  private _removeEmptyAncestors(candidate: CoordinateFrame): void {
+    if (candidate.transformsSize() > 0) {
+      // don't want to delete this frame, it is not empty
+      return;
+    }
+
+    // Build a list of children for each frame in the tree, used to check whether nodes are leaf
+    // nodes
     const childrenByParentId = new Map<string, Set<string>>();
     for (const frame of this._frames.values()) {
       childrenByParentId.set(frame.id, new Set());
     }
     for (const frame of this._frames.values()) {
-      const parentId = frame.parent()?.id;
-      if (parentId == undefined) {
+      const parent = frame.parent();
+      if (parent === candidate) {
+        // can't delete this frame or its ancestors, it still has children
+        return;
+      }
+      if (parent == undefined) {
         continue;
       }
-      const children = childrenByParentId.get(parentId);
+      const children = childrenByParentId.get(parent.id);
       if (!children) {
         throw new Error("invariant: should have children array");
       }
       children.add(frame.id);
     }
 
-    // Repeatedly delete any frames with no children until the tree doesn't change
-    for (;;) {
-      let deletedAnyFrames = false;
-      for (const [frameId, children] of childrenByParentId) {
-        const frame = this.frame(frameId);
-        if (!frame) {
-          throw new Error(`invariant: unknown parent frame id ${frameId}`);
-        }
-        if (frame.transformsSize() > 0) {
-          // don't want to delete this frame, it is not empty
-          continue;
-        }
-        if (children.size > 0) {
-          // can't delete this frame yet, it still has children
-          continue;
-        }
-        const parent = frame.parent();
-        if (parent) {
-          childrenByParentId.get(parent.id)?.delete(frameId);
-        }
-        this._frames.delete(frameId);
-        childrenByParentId.delete(frameId);
-        deletedAnyFrames = true;
+    // Walk upwards, deleting nodes with no history entries and no children
+    for (
+      let current: typeof candidate | undefined = candidate;
+      current;
+      current = current.parent()
+    ) {
+      if (current.transformsSize() > 0) {
+        // don't want to delete this frame, it is not empty
+        return;
       }
-      if (!deletedAnyFrames) {
-        break;
+      const children = childrenByParentId.get(current.id);
+      if (children && children.size > 0) {
+        // can't delete this frame or its ancestors, it still has children
+        return;
+      }
+      this._frames.delete(current.id);
+      childrenByParentId.delete(current.id);
+      const parentId = current.parent()?.id;
+      if (parentId) {
+        childrenByParentId.get(parentId)?.delete(current.id);
       }
     }
   }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where transform frame axes from a URDF file would remain visible when the URDF was removed from the 3D panel.

**Description**
The `Urdfs` scene extension adds "static" transforms for URDFs with a timestamp of 0. When deleting a custom URDF layer, we now delete those transform history entries with a timestamp of 0, and clear out any newly-empty frames from the TF tree (as long as they don't have non-empty descendants).

Fixes FG-1538