### PR TITLE
`ros2idl` schema encoding support

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@foxglove/message-definition": "0.2.0",
-    "@foxglove/rosmsg": "4.0.0",
+    "@foxglove/rosmsg": "4.2.0",
     "@foxglove/rosmsg-serialization": "2.0.0",
     "@foxglove/rosmsg2-serialization": "2.0.0",
     "@foxglove/schemas": "1.1.0",

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -104,4 +104,22 @@ describe("parseChannel", () => {
     const obj = channel.deserializer(new Uint8Array([0, 1, 0, 0, 5, 0, 0, 0, 65, 66, 67, 68, 0]));
     expect(obj).toEqual({ data: "ABCD" });
   });
+
+  it("works with ros2idl", () => {
+    const channel = parseChannel({
+      messageEncoding: "cdr",
+      schema: {
+        name: "foo_msgs/Bar",
+        encoding: "ros2idl",
+        data: new TextEncoder().encode(`
+        module foo_msgs {
+          struct Bar {string data;};
+        };
+        `),
+      },
+    });
+
+    const obj = channel.deserializer(new Uint8Array([0, 1, 0, 0, 5, 0, 0, 0, 65, 66, 67, 68, 0]));
+    expect(obj).toEqual({ data: "ABCD" });
+  });
 });

--- a/packages/mcap-support/src/parseChannel.ts
+++ b/packages/mcap-support/src/parseChannel.ts
@@ -6,7 +6,7 @@ import protobufjs from "protobufjs";
 import { FileDescriptorSet, IFileDescriptorSet } from "protobufjs/ext/descriptor";
 
 import { MessageDefinition } from "@foxglove/message-definition";
-import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
+import { parse as parseMessageDefinition, parseRos2idl } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { MessageReader as ROS2MessageReader } from "@foxglove/rosmsg2-serialization";
 
@@ -167,7 +167,7 @@ export function parseChannel(channel: Channel): ParsedChannel {
   }
 
   if (channel.messageEncoding === "cdr") {
-    if (channel.schema?.encoding !== "ros2msg") {
+    if (channel.schema?.encoding !== "ros2msg" && channel.schema?.encoding !== "ros2idl") {
       throw new Error(
         `Message encoding ${channel.messageEncoding} with ${
           channel.schema == undefined
@@ -177,7 +177,12 @@ export function parseChannel(channel: Channel): ParsedChannel {
       );
     }
     const schema = new TextDecoder().decode(channel.schema.data);
-    const parsedDefinitions = parseMessageDefinition(schema, { ros2: true });
+    const isIdl = channel.schema.encoding === "ros2idl";
+
+    const parsedDefinitions = isIdl
+      ? parseRos2idl(schema)
+      : parseMessageDefinition(schema, { ros2: true });
+
     const reader = new ROS2MessageReader(parsedDefinitions);
     return {
       datatypes: parsedDefinitionsToDatatypes(parsedDefinitions, channel.schema.name),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,7 +2233,7 @@ __metadata:
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
     "@foxglove/message-definition": 0.2.0
-    "@foxglove/rosmsg": 4.0.0
+    "@foxglove/rosmsg": 4.2.0
     "@foxglove/rosmsg-serialization": 2.0.0
     "@foxglove/rosmsg2-serialization": 2.0.0
     "@foxglove/schemas": 1.1.0
@@ -2385,6 +2385,18 @@ __metadata:
   bin:
     gendeps2: bin/gendeps2
   checksum: d3a685cdadb03e0be0bd906b99cbea1b31fe6e2129c54d1f4229f5f4f4198bebae93961fc2f77ecc96a7fd0da7de432018fc4bcbaee6e36f24e062f7c5f33672
+  languageName: node
+  linkType: hard
+
+"@foxglove/rosmsg@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@foxglove/rosmsg@npm:4.2.0"
+  dependencies:
+    "@foxglove/message-definition": ^0.2.0
+    md5-typescript: ^1.0.5
+  bin:
+    gendeps2: bin/gendeps2
+  checksum: 4d247a9157644702420dfc15aa29e9735f385dd5ab46c2ef88ca5a650e52658a57058f8d0532137adef5c62922496fca2769ee23555e17786f0366219476cd63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- foxglove studio can now parse `ros2idl` schema encodings

**Description**
Updated `parseChannel` to support `ros2idl` and added simple test case. 

<!-- link relevant GitHub issues -->
FG-1965
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
