### PR TITLE
App bar tweaks

### DIFF
--- a/packages/studio-base/src/components/AppBar/AppBarIconButton.tsx
+++ b/packages/studio-base/src/components/AppBar/AppBarIconButton.tsx
@@ -37,23 +37,27 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export const AppBarIconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props, ref) => {
-  const { title, className, children, color = "inherit", ...rest } = props;
-  const { classes, cx } = useStyles();
+type AppBarIconButtonProps = Omit<IconButtonProps, "title"> & { title: React.ReactNode };
 
-  return (
-    <Tooltip
-      disableInteractive
-      classes={{ tooltip: classes.tooltip }}
-      title={title}
-      arrow={false}
-      enterDelay={200}
-    >
-      <IconButton color={color} ref={ref} className={cx(classes.iconButton, className)} {...rest}>
-        {children}
-      </IconButton>
-    </Tooltip>
-  );
-});
+export const AppBarIconButton = forwardRef<HTMLButtonElement, AppBarIconButtonProps>(
+  (props, ref) => {
+    const { title, className, children, color = "inherit", ...rest } = props;
+    const { classes, cx } = useStyles();
+
+    return (
+      <Tooltip
+        disableInteractive
+        classes={{ tooltip: classes.tooltip }}
+        title={title}
+        arrow={false}
+        enterDelay={200}
+      >
+        <IconButton color={color} ref={ref} className={cx(classes.iconButton, className)} {...rest}>
+          {children}
+        </IconButton>
+      </Tooltip>
+    );
+  },
+);
 
 AppBarIconButton.displayName = "AppBarIconButton";

--- a/packages/studio-base/src/components/AppBar/HelpMenu.tsx
+++ b/packages/studio-base/src/components/AppBar/HelpMenu.tsx
@@ -105,7 +105,7 @@ export function HelpMenu(props: HelpMenuProps): JSX.Element {
         <SlideLayout24Regular className={classes.icon} />
         <ListItemText
           primary="Studio"
-          secondary="Open source robotics visualization and debugging."
+          secondary="Open source robotics visualization and debugging"
           secondaryTypographyProps={{ className: classes.menuText }}
         />
       </MenuItem>
@@ -149,7 +149,7 @@ export function HelpMenu(props: HelpMenuProps): JSX.Element {
         <ChatBubblesQuestion24Regular className={classes.icon} />
         <ListItemText
           primary="Join us on Slack"
-          secondary="Give us feedback, ask questions, and collaborate with other users."
+          secondary="Give us feedback, ask questions, and collaborate with other users"
           secondaryTypographyProps={{ className: classes.menuText }}
         />
       </MenuItem>

--- a/packages/studio-base/src/components/AppBar/User.tsx
+++ b/packages/studio-base/src/components/AppBar/User.tsx
@@ -14,6 +14,7 @@ import {
   PopoverPosition,
   PopoverReference,
   Tooltip,
+  Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { forwardRef, useCallback } from "react";
@@ -69,7 +70,7 @@ export const UserIconButton = forwardRef<HTMLButtonElement, UserIconProps>((prop
   const { currentUser: me, ...otherProps } = props;
 
   return (
-    <Tooltip classes={{ tooltip: classes.tooltip }} title="My profile" arrow={false}>
+    <Tooltip classes={{ tooltip: classes.tooltip }} title={me?.email ?? "Profile"} arrow={false}>
       <IconButton {...otherProps} ref={ref} className={classes.iconButton}>
         <Avatar className={classes.avatar} variant="rounded">
           {me?.avatarImageUrl != undefined && (
@@ -150,12 +151,11 @@ export function UserMenu({
         <MenuItem onClick={onSettingsClick}>
           <ListItemText primary={currentUser.email} />
         </MenuItem>
-        <MenuItem onClick={onSettingsClick}>
-          <ListItemText>User settings</ListItemText>
-        </MenuItem>
         <Divider variant="middle" />
         <MenuItem onClick={onSignoutClick}>
-          <ListItemText>Sign out</ListItemText>
+          <ListItemText>
+            <Typography color="error">Sign out</Typography>
+          </ListItemText>
         </MenuItem>
       </Menu>
       {confirmModal}

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -38,6 +38,7 @@ import {
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { AddPanelMenu } from "./AddPanelMenu";
 import { DataSource } from "./DataSource";
@@ -125,6 +126,14 @@ const useStyles = makeStyles<{ leftInset?: number; debugDragRegion?: boolean }>(
             color: { main: APP_BAR_PRIMARY_COLOR },
           }).dark,
         },
+      },
+      keyEquivalent: {
+        fontFamily: fonts.MONOSPACE,
+        background: theme.palette.augmentColor({ color: { main: APP_BAR_FOREGROUND_COLOR } }).dark,
+        padding: theme.spacing(0, 0.5),
+        aspectRatio: 1,
+        borderRadius: theme.shape.borderRadius,
+        marginLeft: theme.spacing(1),
       },
     };
   },
@@ -220,8 +229,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
                 ref={layoutButtonRef}
                 color="inherit"
                 id="layout-button"
-                title="Layout browser"
-                aria-label="Layout button"
+                title="Layouts"
                 aria-controls={layoutMenuOpen ? "layout-menu" : undefined}
                 aria-haspopup="true"
                 aria-expanded={layoutMenuOpen ? "true" : undefined}
@@ -259,14 +267,24 @@ export function AppBar(props: AppBarProps): JSX.Element {
               {enableMemoryUseIndicator && <MemoryUseIndicator />}
               <Stack direction="row" alignItems="center" paddingX={1.5}>
                 <AppBarIconButton
-                  title={`${leftSidebarOpen ? "Hide" : "Show"} left sidebar - Shortcut: [`}
+                  title={
+                    <>
+                      {leftSidebarOpen ? "Hide" : "Show"} left sidebar{" "}
+                      <kbd className={classes.keyEquivalent}>[</kbd>
+                    </>
+                  }
                   aria-label={`${leftSidebarOpen ? "Hide" : "Show"} left sidebar`}
                   onClick={() => setLeftSidebarOpen(!leftSidebarOpen)}
                 >
                   {leftSidebarOpen ? <PanelLeft24Filled /> : <PanelLeft24Regular />}
                 </AppBarIconButton>
                 <AppBarIconButton
-                  title={`${rightSidebarOpen ? "Hide" : "Show"} right sidebar - Shortcut: ]`}
+                  title={
+                    <>
+                      {rightSidebarOpen ? "Hide" : "Show"} right sidebar{" "}
+                      <kbd className={classes.keyEquivalent}>]</kbd>
+                    </>
+                  }
                   aria-label={`${rightSidebarOpen ? "Hide" : "Show"} right sidebar`}
                   onClick={() => setRightSidebarOpen(!rightSidebarOpen)}
                 >
@@ -276,8 +294,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
               <AppBarIconButton
                 className={cx({ "Mui-selected": helpMenuOpen })}
                 id="help-button"
-                title="Help & Docs"
-                aria-label="Help menu button"
+                title="Help"
                 aria-controls={helpMenuOpen ? "help-menu" : undefined}
                 aria-haspopup="true"
                 aria-expanded={helpMenuOpen ? "true" : undefined}
@@ -293,8 +310,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
               </AppBarIconButton>
               <AppBarIconButton
                 id="preferences-button"
-                title="Studio preferences"
-                aria-label="Preferences dialog button"
+                title="Preferences"
                 aria-controls={prefsDialogOpen ? "preferences-dialog" : undefined}
                 aria-haspopup="true"
                 aria-expanded={prefsDialogOpen ? "true" : undefined}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
- Simplify titles & remove redundant aria-labels
-  Show keyboard shortcut as `<kbd>`  
   <img width="156" alt="image" src="https://user-images.githubusercontent.com/14237/224383247-3077f359-6efa-4596-a08d-2c9163495081.png">
- Remove extra menu item from user menu & make sign out red
   <img width="216" alt="image" src="https://user-images.githubusercontent.com/14237/224383541-349a3df0-5d8d-461c-8004-8b901fad190e.png">

