### PR TITLE
Make panel titles editable for panels without custom settings

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -167,6 +167,8 @@ export default function PanelSettings({
 
   const isSettingsTree = settingsTree != undefined;
 
+  const showTitleField = panelInfo.hasCustomToolbar !== true;
+
   return (
     <SidebarContent
       disablePadding={enableNewTopNav || isSettingsTree}
@@ -189,7 +191,7 @@ export default function PanelSettings({
               <Typography variant="subtitle2">{`${panelInfo.title} panel`}</Typography>
             </Stack>
           )}
-          {settingsTree ? (
+          {settingsTree || showTitleField ? (
             <SettingsTreeEditor key={selectedPanelId} settings={settingsTree} />
           ) : (
             <Stack

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -6,6 +6,7 @@ import { Link, Typography } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useUnmount } from "react-use";
 
+import { SettingsTree } from "@foxglove/studio";
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { ActionMenu } from "@foxglove/studio-base/components/PanelSettings/ActionMenu";
@@ -38,6 +39,11 @@ const singlePanelIdSelector = (state: LayoutState) =>
     : undefined;
 
 const selectIncrementSequenceNumber = (store: PanelStateStore) => store.incrementSequenceNumber;
+
+const EMPTY_SETTINGS_TREE: SettingsTree = Object.freeze({
+  actionHandler: () => undefined,
+  nodes: {},
+});
 
 export default function PanelSettings({
   disableToolbar = false,
@@ -192,7 +198,10 @@ export default function PanelSettings({
             </Stack>
           )}
           {settingsTree || showTitleField ? (
-            <SettingsTreeEditor key={selectedPanelId} settings={settingsTree} />
+            <SettingsTreeEditor
+              key={selectedPanelId}
+              settings={settingsTree ?? EMPTY_SETTINGS_TREE}
+            />
           ) : (
             <Stack
               flex="auto"

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -15,7 +15,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { IconButton, Tooltip } from "@mui/material";
 import produce from "immer";
-import { forwardRef, useCallback, useContext, useEffect } from "react";
+import { forwardRef, useCallback, useContext, useEffect, useMemo } from "react";
 import { useAsyncFn } from "react-use";
 import { makeStyles } from "tss-react/mui";
 
@@ -72,6 +72,11 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
       [panelId],
     );
 
+    const panelInfo = useMemo(
+      () => (panelType != undefined ? panelCatalog?.getPanelByType(panelType) : undefined),
+      [panelCatalog, panelType],
+    );
+
     const hasSettings = usePanelStateStore(hasSettingsSelector);
 
     const userProfileStorage = useContext(UserProfileStorageContext);
@@ -91,6 +96,7 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
         }
         return tooltip;
       }, [hasSettings, panelCatalog, panelType, userProfileStorage]);
+
     useEffect(() => {
       void loadOnboardingState();
     }, [loadOnboardingState]);
@@ -166,7 +172,7 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     return (
       <Stack direction="row" alignItems="center" paddingLeft={1} ref={ref}>
         {additionalIcons}
-        {hasSettings && settingsButton}
+        {panelInfo?.hasCustomToolbar !== true && settingsButton}
         <PanelActionsDropdown isUnknownPanel={isUnknownPanel} />
       </Stack>
     );

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -172,7 +172,7 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     return (
       <Stack direction="row" alignItems="center" paddingLeft={1} ref={ref}>
         {additionalIcons}
-        {panelInfo?.hasCustomToolbar !== true && settingsButton}
+        {(panelInfo?.hasCustomToolbar !== true || hasSettings) && settingsButton}
         <PanelActionsDropdown isUnknownPanel={isUnknownPanel} />
       </Stack>
     );

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -131,6 +131,9 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
         <SettingsIcon />
       </ToolbarIconButton>
     );
+
+    const showSettingsButton = panelInfo?.hasCustomToolbar !== true || hasSettings;
+
     if (settingsOnboardingTooltip) {
       settingsButton = (
         <Tooltip
@@ -172,7 +175,7 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     return (
       <Stack direction="row" alignItems="center" paddingLeft={1} ref={ref}>
         {additionalIcons}
-        {(panelInfo?.hasCustomToolbar !== true || hasSettings) && settingsButton}
+        {showSettingsButton && settingsButton}
         <PanelActionsDropdown isUnknownPanel={isUnknownPanel} />
       </Stack>
     );

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -132,6 +132,8 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
       </ToolbarIconButton>
     );
 
+    // Show the settings button so that panel title is editable, unless we have a custom
+    // toolbar in which case the title wouldn't be visible.
     const showSettingsButton = panelInfo?.hasCustomToolbar !== true || hasSettings;
 
     if (settingsOnboardingTooltip) {

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -10,7 +10,12 @@ import { useCallback, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
-import { SettingsTree, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
+import {
+  SettingsTree,
+  SettingsTreeAction,
+  SettingsTreeField,
+  SettingsTreeNodes,
+} from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -47,22 +52,25 @@ const useStyles = makeStyles()((theme) => ({
 
 const makeStablePath = memoizeWeak((key: string) => [key]);
 
+const EMPTY_NODES: SettingsTreeNodes = {};
+const NULL_ACTION_HANDLER: SettingsTree["actionHandler"] = () => undefined;
+
 export default function SettingsTreeEditor({
   settings,
 }: {
-  settings: DeepReadonly<SettingsTree>;
+  settings: undefined | DeepReadonly<SettingsTree>;
 }): JSX.Element {
   const { classes } = useStyles();
-  const { actionHandler, focusedPath } = settings;
+  const { actionHandler = NULL_ACTION_HANDLER, focusedPath } = settings ?? {};
   const [filterText, setFilterText] = useState<string>("");
 
   const filteredNodes = useMemo(() => {
     if (filterText.length > 0) {
-      return filterTreeNodes(settings.nodes, filterText);
+      return filterTreeNodes(settings?.nodes ?? EMPTY_NODES, filterText);
     } else {
-      return settings.nodes;
+      return settings?.nodes ?? EMPTY_NODES;
     }
-  }, [settings.nodes, filterText]);
+  }, [settings?.nodes, filterText]);
 
   const definedNodes = useMemo(() => prepareSettingsNodes(filteredNodes), [filteredNodes]);
 
@@ -110,7 +118,7 @@ export default function SettingsTreeEditor({
 
   return (
     <Stack fullHeight>
-      {settings.enableFilter === true && (
+      {settings?.enableFilter === true && (
         <header className={classes.appBar}>
           <TextField
             id="settings-filter"

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -10,12 +10,7 @@ import { useCallback, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
-import {
-  SettingsTree,
-  SettingsTreeAction,
-  SettingsTreeField,
-  SettingsTreeNodes,
-} from "@foxglove/studio";
+import { SettingsTree, SettingsTreeAction, SettingsTreeField } from "@foxglove/studio";
 import { useConfigById } from "@foxglove/studio-base/PanelAPI";
 import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor/FieldEditor";
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -52,25 +47,22 @@ const useStyles = makeStyles()((theme) => ({
 
 const makeStablePath = memoizeWeak((key: string) => [key]);
 
-const EMPTY_NODES: SettingsTreeNodes = {};
-const NULL_ACTION_HANDLER: SettingsTree["actionHandler"] = () => undefined;
-
 export default function SettingsTreeEditor({
   settings,
 }: {
-  settings: undefined | DeepReadonly<SettingsTree>;
+  settings: DeepReadonly<SettingsTree>;
 }): JSX.Element {
   const { classes } = useStyles();
-  const { actionHandler = NULL_ACTION_HANDLER, focusedPath } = settings ?? {};
+  const { actionHandler, focusedPath } = settings;
   const [filterText, setFilterText] = useState<string>("");
 
   const filteredNodes = useMemo(() => {
     if (filterText.length > 0) {
-      return filterTreeNodes(settings?.nodes ?? EMPTY_NODES, filterText);
+      return filterTreeNodes(settings.nodes, filterText);
     } else {
-      return settings?.nodes ?? EMPTY_NODES;
+      return settings.nodes;
     }
-  }, [settings?.nodes, filterText]);
+  }, [settings.nodes, filterText]);
 
   const definedNodes = useMemo(() => prepareSettingsNodes(filteredNodes), [filteredNodes]);
 
@@ -118,7 +110,7 @@ export default function SettingsTreeEditor({
 
   return (
     <Stack fullHeight>
-      {settings?.enableFilter === true && (
+      {settings.enableFilter === true && (
         <header className={classes.appBar}>
           <TextField
             id="settings-filter"

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -17,14 +17,14 @@ import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMe
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import {
-  fixture,
-  enumFixture,
   enumAdvancedFixture,
-  withMissingData,
+  enumFixture,
+  fixture,
+  multipleMessagesFilter,
+  multipleNumberMessagesFixture,
   topicsToDiffFixture,
   topicsWithIdsToDiffFixture,
-  multipleNumberMessagesFixture,
-  multipleMessagesFilter,
+  withMissingData,
 } from "./fixture";
 
 const noDiffConfig = {

--- a/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
+++ b/packages/studio-base/src/panels/TopicGraph/index.stories.tsx
@@ -23,6 +23,17 @@ export const Empty = (): JSX.Element => {
   );
 };
 
+export const WithSettings = (): JSX.Element => {
+  return (
+    <PanelSetup includeSettings>
+      <TopicGraph />
+    </PanelSetup>
+  );
+};
+WithSettings.parameters = {
+  colorScheme: "light",
+};
+
 function TopicsStory({
   topicVisibility: initialTopicVisibility,
 }: {

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -173,6 +173,7 @@ export const builtin: PanelInfo[] = [
     description: "Group related panels into tabs.",
     thumbnail: tabThumbnail,
     module: async () => await import("./Tab"),
+    hasCustomToolbar: true,
   },
 ];
 

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -174,7 +174,7 @@ function PanelWrapper({
 
   return (
     <>
-      {settings && includeSettings && <SettingsTreeEditor settings={settings} />}
+      {includeSettings && <SettingsTreeEditor settings={settings} />}
       {children}
     </>
   );

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -174,7 +174,7 @@ function PanelWrapper({
 
   return (
     <>
-      {includeSettings && <SettingsTreeEditor settings={settings} />}
+      {settings && includeSettings && <SettingsTreeEditor settings={settings} />}
       {children}
     </>
   );

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -32,7 +32,6 @@ import {
 import { PanelsActions } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import PanelCatalogContext, {
   PanelCatalog,
-  PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { usePanelStateStore } from "@foxglove/studio-base/context/PanelStateContext";
 import {
@@ -40,13 +39,14 @@ import {
   useUserNodeState,
 } from "@foxglove/studio-base/context/UserNodeStateContext";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
+import * as panels from "@foxglove/studio-base/panels";
 import { Diagnostic, UserNodeLog } from "@foxglove/studio-base/players/UserNodePlayer/types";
 import {
-  Topic,
+  AdvertiseOptions,
   PlayerStateActiveData,
   Progress,
   PublishPayload,
-  AdvertiseOptions,
+  Topic,
 } from "@foxglove/studio-base/players/types";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
@@ -112,6 +112,21 @@ function setNativeValue(element: unknown, value: unknown) {
   }
 }
 
+export function makeMockPanelCatalog(): PanelCatalog {
+  const allPanels = [...panels.builtin, ...panels.debug, panels.legacyPlot, panels.urdfViewer];
+
+  const visiblePanels = [...panels.builtin];
+
+  return {
+    getPanels() {
+      return visiblePanels;
+    },
+    getPanelByType(type: string) {
+      return allPanels.find((panel) => panel.type === type);
+    },
+  };
+}
+
 export function triggerInputChange(
   node: HTMLInputElement | HTMLTextAreaElement,
   value: string = "",
@@ -153,16 +168,6 @@ export const MosaicWrapper = ({ children }: { children: React.ReactNode }): JSX.
   );
 };
 
-// empty catalog if one is not provided via props
-class MockPanelCatalog implements PanelCatalog {
-  public getPanels(): readonly PanelInfo[] {
-    return [];
-  }
-  public getPanelByType(_type: string): PanelInfo | undefined {
-    return undefined;
-  }
-}
-
 function PanelWrapper({
   children,
   includeSettings = false,
@@ -174,14 +179,14 @@ function PanelWrapper({
 
   return (
     <>
-      {settings && includeSettings && <SettingsTreeEditor settings={settings} />}
+      {includeSettings && <SettingsTreeEditor settings={settings} />}
       {children}
     </>
   );
 }
 
 function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull {
-  const [mockPanelCatalog] = useState(() => props.panelCatalog ?? new MockPanelCatalog());
+  const [mockPanelCatalog] = useState(() => props.panelCatalog ?? makeMockPanelCatalog());
   const [mockAppConfiguration] = useState(() => ({
     get() {
       return undefined;

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -19,7 +19,7 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 import { Mosaic, MosaicNode, MosaicWindow } from "react-mosaic-component";
 
 import { useShallowMemo } from "@foxglove/hooks";
-import { MessageEvent } from "@foxglove/studio";
+import { MessageEvent, SettingsTree } from "@foxglove/studio";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
@@ -168,6 +168,11 @@ export const MosaicWrapper = ({ children }: { children: React.ReactNode }): JSX.
   );
 };
 
+const EmptyTree: SettingsTree = {
+  actionHandler: () => undefined,
+  nodes: {},
+};
+
 function PanelWrapper({
   children,
   includeSettings = false,
@@ -175,7 +180,8 @@ function PanelWrapper({
   children?: ReactNode;
   includeSettings?: boolean;
 }): JSX.Element {
-  const settings = usePanelStateStore((store) => Object.values(store.settingsTrees)[0]);
+  const settings =
+    usePanelStateStore((store) => Object.values(store.settingsTrees)[0]) ?? EmptyTree;
 
   return (
     <>


### PR DESCRIPTION
**User-Facing Changes**
Make panel titles editable for panels without custom settings

**Description**
This shows the panel settings & title field even if a panel doesn't have any custom settings. However, it retains the restriction that panels with a custom toolbar do not have editable titles because we have no way to display them.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
