### PR TITLE
foxglove-websocket: Support byte array parameters

### DIFF
--- a/packages/studio-base/src/panels/Parameters/index.stories.tsx
+++ b/packages/studio-base/src/panels/Parameters/index.stories.tsx
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { StoryObj } from "@storybook/react";
+import { useState } from "react";
 
 import { ParameterValue } from "@foxglove/studio";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
@@ -10,12 +11,28 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import Parameters from "./index";
 
+const DEFAULT_PARAMS = new Map<string, ParameterValue>([
+  ["undefined", undefined],
+  ["boolean", false],
+  ["number", -42],
+  ["string", "Hello, world!"],
+  ["date", new Date(1618876820517)],
+  ["Uint8Array", new Uint8Array([0, 1])],
+  ["array", [1, 2]],
+  ["string array", ["one", "two", "three"]],
+  ["struct", { a: 1, b: [2, 3], c: "String value" }],
+]);
+
 const getFixture = ({
   getParameters,
   setParameters,
+  parameters,
+  setParameterValues,
 }: {
   getParameters: boolean;
   setParameters: boolean;
+  parameters?: Map<string, ParameterValue>;
+  setParameterValues?: (params: Map<string, ParameterValue>) => void;
 }) => {
   const capabilities: string[] = [];
   if (getParameters) {
@@ -30,20 +47,16 @@ const getFixture = ({
     frame: {},
     capabilities,
     activeData: {
-      parameters: getParameters
-        ? new Map<string, ParameterValue>([
-            ["undefined", undefined],
-            ["boolean", false],
-            ["number", -42],
-            ["string", "Hello, world!"],
-            ["date", new Date(1618876820517)],
-            ["Uint8Array", new Uint8Array([0, 1])],
-            ["array", [1, 2]],
-            ["string array", ["one", "two", "three"]],
-            ["struct", { a: 1, b: [2, 3], c: "String value" }],
-          ])
-        : undefined,
+      parameters: getParameters ? parameters : undefined,
     },
+    setParameter:
+      setParameters && setParameterValues
+        ? (key: string, value: ParameterValue) => {
+            const params = new Map<string, ParameterValue>(parameters);
+            params.set(key, value);
+            setParameterValues(params);
+          }
+        : undefined,
   };
 };
 
@@ -65,19 +78,36 @@ export const Default: StoryObj = {
 export const WithParameters: StoryObj = {
   render: () => {
     return (
-      <PanelSetup fixture={getFixture({ getParameters: true, setParameters: false })}>
+      <PanelSetup
+        fixture={getFixture({
+          getParameters: true,
+          setParameters: false,
+          parameters: DEFAULT_PARAMS,
+        })}
+      >
         <Parameters />
       </PanelSetup>
     );
   },
 };
 
+const EditableParameters = () => {
+  const [parameters, setParameterValues] = useState(DEFAULT_PARAMS);
+
+  return (
+    <PanelSetup
+      fixture={getFixture({
+        getParameters: true,
+        setParameters: true,
+        parameters,
+        setParameterValues,
+      })}
+    >
+      <Parameters />
+    </PanelSetup>
+  );
+};
+
 export const WithEditableParameters: StoryObj = {
-  render: () => {
-    return (
-      <PanelSetup fixture={getFixture({ getParameters: true, setParameters: true })}>
-        <Parameters />
-      </PanelSetup>
-    );
-  },
+  render: () => <EditableParameters />,
 };

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -21,7 +21,12 @@ import { useTranslation } from "react-i18next";
 import { Mosaic, MosaicNode, MosaicWindow } from "react-mosaic-component";
 
 import { useShallowMemo } from "@foxglove/hooks";
-import { MessageEvent, RegisterMessageConverterArgs, SettingsTree } from "@foxglove/studio";
+import {
+  MessageEvent,
+  ParameterValue,
+  RegisterMessageConverterArgs,
+  SettingsTree,
+} from "@foxglove/studio";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import SettingsTreeEditor from "@foxglove/studio-base/components/SettingsTreeEditor";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
@@ -89,6 +94,7 @@ export type Fixture = {
   publish?: (request: PublishPayload) => void;
   setPublishers?: (publisherId: string, advertisements: AdvertiseOptions[]) => void;
   setSubscriptions?: ComponentProps<typeof MockMessagePipelineProvider>["setSubscriptions"];
+  setParameter?: (key: string, value: ParameterValue) => void;
   messageConverters?: readonly RegisterMessageConverterArgs<unknown>[];
   panelState?: Partial<PanelStateStore>;
 };
@@ -286,6 +292,7 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
     publish,
     setPublishers,
     setSubscriptions,
+    setParameter,
   } = props.fixture ?? {};
   let dTypes = datatypes;
   if (!dTypes) {
@@ -329,6 +336,7 @@ function UnconnectedPanelSetup(props: UnconnectedProps): JSX.Element | ReactNull
         seekPlayback={noop}
         setPublishers={setPublishers}
         setSubscriptions={setSubscriptions}
+        setParameter={setParameter}
       >
         <PanelCatalogContext.Provider value={mockPanelCatalog}>
           <AppConfigurationContext.Provider value={mockAppConfiguration}>


### PR DESCRIPTION
**User-Facing Changes**
- foxglove websocket: Add support for byte array parameters

**Description**
Adds support for displaying byte array parameters which are communicated as base64 encoded string (see https://github.com/foxglove/ws-protocol/pull/396). These parameters are now displayed as number array and can also be modified in that format.

**Before**:

![Screenshot from 2023-05-08 17-21-50](https://user-images.githubusercontent.com/9250155/236930614-6952b3e3-220c-45d3-a5f7-1b3daddbba76.png)

**This PR**:

![Screenshot from 2023-05-08 17-23-19](https://user-images.githubusercontent.com/9250155/236930611-f7bf7c1b-5a3e-4a3a-b7d9-fc3e2c111d24.png)



Fixes FG-2949

