### PR TITLE
[3D Panel]  fix bad vertex normals for meshes after applying color

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/models.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/models.ts
@@ -39,7 +39,9 @@ export function replaceMaterials(model: LoadedModel, material: THREE.MeshStandar
       disposeStandardMaterial(meshChild.material);
     }
     meshChild.material = material;
-    meshChild.geometry.computeVertexNormals();
+    if (!meshChild.geometry.attributes.normal) {
+      meshChild.geometry.computeVertexNormals();
+    }
   });
 }
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - [3D Panel] fix bad vertex normals for meshes after applying color

**Description**
Just need to not override existing vertex normals on the mesh if they already exist. 

<!-- link relevant GitHub issues -->
FG-2295
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
