### PR TITLE
Cancel promiseTimeout after completion

### DIFF
--- a/packages/studio-base/src/util/promiseTimeout.ts
+++ b/packages/studio-base/src/util/promiseTimeout.ts
@@ -16,11 +16,17 @@ async function promiseTimeout<T>(
   ms = 30000,
   reason = "unknown reason",
 ): Promise<T> {
+  let id: ReturnType<typeof setTimeout> | undefined;
   return await Promise.race([
-    promise,
-    new Promise<T>((_resolve, reject) =>
-      setTimeout(() => reject(new Error(`Promise timed out after ${ms}ms: ${reason} `)), ms),
-    ),
+    promise.then((result) => {
+      if (id != undefined) {
+        clearTimeout(id);
+      }
+      return result;
+    }),
+    new Promise<T>((_resolve, reject) => {
+      id = setTimeout(() => reject(new Error(`Promise timed out after ${ms}ms: ${reason} `)), ms);
+    }),
   ]);
 }
 


### PR DESCRIPTION
**User-Facing Changes**
- None

**Description**
When setting the Chrome dev console debugger to pause on exceptions, it would repeatedly pause in `promiseTimeout.ts`. It looks like this method was scheduling timers with `setTimeout()` but never canceling them, so they would eventually run the callback which unnecessarily allocated an `Error` object and called reject (which was ignored). After this change, I don't see this method coming up when pausing on exceptions in the debugger.