### PR TITLE
fix PanelLayout re-mounting panels unnecessarily

### DIFF
--- a/packages/studio-base/jest.config.json
+++ b/packages/studio-base/jest.config.json
@@ -18,6 +18,7 @@
   "restoreMocks": true,
   "moduleNameMapper": {
     "\\.svg$": "<rootDir>/src/test/mocks/MockSvg.tsx",
+    "\\.css$": "<rootDir>/src/test/mocks/MockCss.ts",
     "react-monaco-editor": "<rootDir>/src/test/stubs/MonacoEditor.tsx",
     "\\.(glb|md|png)$": "<rootDir>/src/test/mocks/fileMock.ts",
     "@foxglove/studio-base/(.*)": "<rootDir>/src/$1"

--- a/packages/studio-base/src/components/PanelLayout.test.tsx
+++ b/packages/studio-base/src/components/PanelLayout.test.tsx
@@ -78,12 +78,13 @@ describe("UnconnectedPanelLayout", () => {
     );
 
     await waitFor(() => expect(renderA).toHaveBeenCalled());
-    expect(renderA).toHaveBeenCalledTimes(4);
-    expect(renderB).toHaveBeenCalledTimes(4);
-    expect(renderC).toHaveBeenCalledTimes(0);
+    // Each panel module should have only been loaded once
     expect(moduleA).toHaveBeenCalledTimes(1);
     expect(moduleB).toHaveBeenCalledTimes(1);
     expect(moduleC).toHaveBeenCalledTimes(0);
+    expect(renderA).toHaveBeenCalledTimes(4);
+    expect(renderB).toHaveBeenCalledTimes(4);
+    expect(renderC).toHaveBeenCalledTimes(0);
 
     rerender(
       <UnconnectedPanelLayout
@@ -92,6 +93,7 @@ describe("UnconnectedPanelLayout", () => {
       />,
     );
     await waitFor(() => expect(renderC).toHaveBeenCalledTimes(4));
+    // Each panel module should have only been loaded once; panels A and B should not render again
     expect(moduleA).toHaveBeenCalledTimes(1);
     expect(moduleB).toHaveBeenCalledTimes(1);
     expect(moduleC).toHaveBeenCalledTimes(1);

--- a/packages/studio-base/src/components/PanelLayout.test.tsx
+++ b/packages/studio-base/src/components/PanelLayout.test.tsx
@@ -1,0 +1,104 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, waitFor } from "@testing-library/react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+import Panel from "@foxglove/studio-base/components/Panel";
+import PanelCatalogContext, {
+  PanelCatalog,
+  PanelInfo,
+} from "@foxglove/studio-base/context/PanelCatalogContext";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+
+import { UnconnectedPanelLayout } from "./PanelLayout";
+
+class MockPanelCatalog implements PanelCatalog {
+  public constructor(private allPanels: PanelInfo[]) {}
+  public getPanels(): readonly PanelInfo[] {
+    return this.allPanels;
+  }
+  public getPanelByType(type: string): PanelInfo | undefined {
+    return this.allPanels.find((panel) => !panel.config && panel.type === type);
+  }
+}
+
+describe("UnconnectedPanelLayout", () => {
+  it("does not remount panels when changing split percentage", async () => {
+    const renderA = jest.fn().mockReturnValue(<>A</>);
+    const moduleA = jest.fn().mockResolvedValue({
+      default: Panel(Object.assign(renderA, { panelType: "a", defaultConfig: {} })),
+    });
+
+    const renderB = jest.fn().mockReturnValue(<>B</>);
+    const moduleB = jest.fn().mockResolvedValue({
+      default: Panel(Object.assign(renderB, { panelType: "b", defaultConfig: {} })),
+    });
+
+    const renderC = jest.fn().mockReturnValue(<>C</>);
+    const moduleC = jest.fn().mockResolvedValue({
+      default: Panel(Object.assign(renderC, { panelType: "c", defaultConfig: {} })),
+    });
+
+    const panels: PanelInfo[] = [
+      { title: "A", type: "a", module: moduleA },
+      { title: "B", type: "b", module: moduleB },
+      { title: "C", type: "c", module: moduleC },
+    ];
+
+    const panelCatalog = new MockPanelCatalog(panels);
+
+    const onChange = () => {
+      throw new Error("unexpected call to onChange");
+    };
+    const { rerender, unmount } = render(
+      <UnconnectedPanelLayout
+        layout={{ first: "a", second: "b", direction: "row", splitPercentage: 50 }}
+        onChange={onChange}
+      />,
+      {
+        wrapper: function Wrapper({ children }: React.PropsWithChildren<unknown>) {
+          return (
+            <DndProvider backend={HTML5Backend}>
+              <MockCurrentLayoutProvider>
+                <PanelStateContextProvider>
+                  <PanelCatalogContext.Provider value={panelCatalog}>
+                    {children}
+                  </PanelCatalogContext.Provider>
+                </PanelStateContextProvider>
+              </MockCurrentLayoutProvider>
+            </DndProvider>
+          );
+        },
+      },
+    );
+
+    await waitFor(() => expect(renderA).toHaveBeenCalled());
+    expect(renderA).toHaveBeenCalledTimes(4);
+    expect(renderB).toHaveBeenCalledTimes(4);
+    expect(renderC).toHaveBeenCalledTimes(0);
+    expect(moduleA).toHaveBeenCalledTimes(1);
+    expect(moduleB).toHaveBeenCalledTimes(1);
+    expect(moduleC).toHaveBeenCalledTimes(0);
+
+    rerender(
+      <UnconnectedPanelLayout
+        layout={{ first: "a", second: "c", direction: "row", splitPercentage: 40 }}
+        onChange={onChange}
+      />,
+    );
+    await waitFor(() => expect(renderC).toHaveBeenCalledTimes(4));
+    expect(moduleA).toHaveBeenCalledTimes(1);
+    expect(moduleB).toHaveBeenCalledTimes(1);
+    expect(moduleC).toHaveBeenCalledTimes(1);
+    expect(renderA).toHaveBeenCalledTimes(4);
+    expect(renderB).toHaveBeenCalledTimes(4);
+    expect(renderC).toHaveBeenCalledTimes(4);
+
+    unmount();
+  });
+});

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -12,15 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { CircularProgress, Link, styled as muiStyled, Typography } from "@mui/material";
-import React, {
-  LazyExoticComponent,
-  PropsWithChildren,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import React, { PropsWithChildren, Suspense, useCallback, useMemo } from "react";
 import { useDrop } from "react-dnd";
 import {
   MosaicDragType,
@@ -42,7 +34,7 @@ import {
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
-import { PanelComponent, usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
+import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
 import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
@@ -119,14 +111,13 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
 
   const panelCatalog = usePanelCatalog();
 
-  const panelComponentCache = useRef(
-    new Map<string, LazyExoticComponent<PanelComponent> | (() => JSX.Element)>(),
+  const panelComponents = useMemo(
+    () =>
+      new Map(
+        panelCatalog.getPanels().map((panelInfo) => [panelInfo.type, React.lazy(panelInfo.module)]),
+      ),
+    [panelCatalog],
   );
-
-  // Clear panel cache when panel catalog changes.
-  useEffect(() => {
-    panelComponentCache.current.clear();
-  }, [panelCatalog]);
 
   const renderTile = useCallback(
     (id: string | Record<string, never> | undefined, path: MosaicPath) => {
@@ -136,19 +127,13 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
       }
       const type = getPanelTypeFromId(id);
 
-      let Panel = panelComponentCache.current.get(type);
-
-      // cache the lazy created panel component to avoid making the component again
-      if (!Panel) {
-        const panelInfo = panelCatalog.getPanelByType(type);
+      let panel: JSX.Element;
+      const PanelComponent = panelComponents.get(type);
+      if (PanelComponent) {
+        panel = <PanelComponent childId={id} tabId={tabId} />;
+      } else {
         // If we haven't found a panel of the given type, render the panel selector
-        Panel = panelInfo
-          ? React.lazy(panelInfo.module)
-          : () => <UnknownPanel overrideConfig={{ type, id }} />;
-
-        if (panelInfo) {
-          panelComponentCache.current.set(type, Panel);
-        }
+        panel = <UnknownPanel childId={id} tabId={tabId} overrideConfig={{ type, id }} />;
       }
 
       const mosaicWindow = (
@@ -168,7 +153,7 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
           >
             <MosaicPathContext.Provider value={path}>
               <PanelRemounter id={id} tabId={tabId}>
-                <Panel childId={id} tabId={tabId} />
+                {panel}
               </PanelRemounter>
             </MosaicPathContext.Provider>
           </Suspense>
@@ -179,7 +164,7 @@ export function UnconnectedPanelLayout(props: Props): React.ReactElement {
       }
       return mosaicWindow;
     },
-    [createTile, tabId, panelCatalog],
+    [panelComponents, createTile, tabId],
   );
 
   const bodyToRender = useMemo(

--- a/packages/studio-base/src/test/mocks/MockCss.ts
+++ b/packages/studio-base/src/test/mocks/MockCss.ts
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export {};


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where panels would sometimes be reset when adjusting the layout.

**Description**
The ordering of react effects and render calls was causing `panelComponentCache.current.clear();` to happen after the mosaic tile had been rendered, meaning on the next render (e.g. when resizing a panel) the panel would be re-mounted (since the `React.lazy(panelInfo.module)` was called again). This fix switches to a `useMemo` for building the map of `React.lazy` components from the panel catalog.

Relates to #5551 / FG-2498