### PR TITLE
Fix crash with "Do not know how to serialize a BigInt"

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.test.ts
@@ -75,6 +75,36 @@ describe("getValueActionForValue", () => {
     });
   });
 
+  it("does not crash with bigints nested inside arrays under isTypicalFilterName key (id)", () => {
+    const structureItem: MessagePathStructureItem = {
+      structureType: "array",
+      next: {
+        structureType: "message",
+        nextByName: {
+          some_id: {
+            structureType: "message",
+            datatype: "",
+            nextByName: {
+              x: {
+                structureType: "primitive",
+                primitiveType: "uint64",
+                datatype: "",
+              },
+            },
+          },
+        },
+        datatype: "",
+      },
+      datatype: "",
+    };
+    expect(
+      getValueActionForValue([{ some_id: { x: 18446744073709552000n } }], structureItem, [
+        0,
+        "some_id",
+      ]),
+    ).toEqual(undefined);
+  });
+
   it("returns paths with bigints inside object inside array", () => {
     const structureItem: MessagePathStructureItem = {
       structureType: "message",

--- a/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
+++ b/packages/studio-base/src/panels/RawMessages/getValueActionForValue.ts
@@ -86,9 +86,10 @@ export function getValueActionForValue(
       // back to `/topic.object[10]` if necessary.
       let typicalFilterName;
       if (structureItem.structureType === "message") {
-        typicalFilterName = Object.keys(structureItem.nextByName).find((key) =>
-          isTypicalFilterName(key),
-        );
+        typicalFilterName = Object.entries(structureItem.nextByName).find(
+          ([key, nextStructureItem]) =>
+            nextStructureItem.structureType === "primitive" && isTypicalFilterName(key),
+        )?.[0];
       }
       if (
         typeof value === "object" &&

--- a/packages/studio-base/src/util/getItemString.tsx
+++ b/packages/studio-base/src/util/getItemString.tsx
@@ -5,10 +5,10 @@
 import { ReactNode } from "react";
 import tinycolor from "tinycolor2";
 
+import { filterMap } from "@foxglove/den/collection";
 import { isTypicalFilterName } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
 import { format, formatDuration } from "@foxglove/studio-base/util/formatTime";
 import { quatToEuler } from "@foxglove/studio-base/util/quatToEuler";
-import { filterMap } from "@foxglove/den/collection";
 
 const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
 

--- a/packages/studio-base/src/util/getItemString.tsx
+++ b/packages/studio-base/src/util/getItemString.tsx
@@ -8,6 +8,7 @@ import tinycolor from "tinycolor2";
 import { isTypicalFilterName } from "@foxglove/studio-base/components/MessagePathSyntax/isTypicalFilterName";
 import { format, formatDuration } from "@foxglove/studio-base/util/formatTime";
 import { quatToEuler } from "@foxglove/studio-base/util/quatToEuler";
+import { filterMap } from "@foxglove/den/collection";
 
 const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
 
@@ -90,16 +91,16 @@ export function getItemString(
   }
 
   // Surface typically-used keys directly in the object summary so the user doesn't have to expand it.
-  const filterKeys = keys
-    .filter(
-      (key) =>
-        isTypicalFilterName(key) &&
-        ["string", "number", "bigint", "boolean"].includes(
-          typeof (data as Record<string, unknown>)[key],
-        ),
-    )
-    .map((key) => `${key}: ${(data as Record<string, unknown>)[key]}`)
-    .join(", ");
+  const filterKeys = filterMap(keys, (key) => {
+    const value = (data as Record<string, unknown>)[key];
+    if (
+      isTypicalFilterName(key) &&
+      (value == undefined || ["string", "number", "bigint", "boolean"].includes(typeof value))
+    ) {
+      return `${key}: ${value}`;
+    }
+    return undefined;
+  }).join(", ");
   return (
     <span>
       {itemType} {filterKeys.length > 0 ? filterKeys : itemString}

--- a/packages/studio-base/src/util/getItemString.tsx
+++ b/packages/studio-base/src/util/getItemString.tsx
@@ -91,8 +91,14 @@ export function getItemString(
 
   // Surface typically-used keys directly in the object summary so the user doesn't have to expand it.
   const filterKeys = keys
-    .filter(isTypicalFilterName)
-    .map((key) => `${key}: ${(data as { [key: string]: unknown })[key]}`)
+    .filter(
+      (key) =>
+        isTypicalFilterName(key) &&
+        ["string", "number", "bigint", "boolean"].includes(
+          typeof (data as Record<string, unknown>)[key],
+        ),
+    )
+    .map((key) => `${key}: ${(data as Record<string, unknown>)[key]}`)
     .join(", ");
   return (
     <span>

--- a/packages/studio-base/src/util/getItemString.tsx
+++ b/packages/studio-base/src/util/getItemString.tsx
@@ -12,6 +12,8 @@ import { quatToEuler } from "@foxglove/studio-base/util/quatToEuler";
 
 const DURATION_20_YEARS_SEC = 20 * 365 * 24 * 60 * 60;
 
+const PRIMITIVE_TYPES = ["string", "number", "bigint", "boolean"];
+
 export function getItemString(
   _nodeType: string,
   data: unknown,
@@ -95,7 +97,7 @@ export function getItemString(
     const value = (data as Record<string, unknown>)[key];
     if (
       isTypicalFilterName(key) &&
-      (value == undefined || ["string", "number", "bigint", "boolean"].includes(typeof value))
+      (value == undefined || PRIMITIVE_TYPES.includes(typeof value))
     ) {
       return `${key}: ${value}`;
     }


### PR DESCRIPTION
**User-Facing Changes**
Fixed a crash in the Raw Messages panel in certain cases involving 64-bit integers nested inside objects nested inside arrays.

**Description**
Check that the nested value is a primitive before suggesting it as a filter. This avoids a crash when there was a field named e.g. `id` which contained a nested object that had a bigint somewhere inside it.

Test data:
[test_int64_0.mcap.zip](https://github.com/foxglove/studio/files/11006052/test_int64_0.mcap.zip)

Fixes FG-2528