### PR TITLE
urdf: fix split() in pose parsing

### DIFF
--- a/packages/den/urdf/parser.test.ts
+++ b/packages/den/urdf/parser.test.ts
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { parseUrdf } from "./parser";
+
+describe("parseUrdf", () => {
+  it("parses pose with arbitrary whitespace", () => {
+    expect(
+      parseUrdf(/* xml */ `<?xml version="1.0" ?>
+    <robot name="X">
+      <link name="x">
+        <visual name="y">
+          <origin xyz="0     0    -0.135" rpy="0   0   1.57"/>
+          <geometry>
+            <box size="1 2 3"/>
+          </geometry>
+        </visual>
+      </link>
+    </robot>
+`),
+    ).toMatchInlineSnapshot(`
+      {
+        "joints": Map {},
+        "links": Map {
+          "x" => {
+            "colliders": [],
+            "name": "x",
+            "visuals": [
+              {
+                "geometry": {
+                  "geometryType": "box",
+                  "size": {
+                    "x": 1,
+                    "y": 2,
+                    "z": 3,
+                  },
+                },
+                "material": undefined,
+                "name": "y",
+                "origin": {
+                  "rpy": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 1.57,
+                  },
+                  "xyz": {
+                    "x": 0,
+                    "y": 0,
+                    "z": -0.135,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        "materials": Map {},
+        "name": "X",
+      }
+    `);
+  });
+});

--- a/packages/den/urdf/parser.ts
+++ b/packages/den/urdf/parser.ts
@@ -352,7 +352,7 @@ function parsePose(xml: Element): Pose {
 }
 
 function parseVec3Attribute(xml: Element, attribName: string): Vector3 | undefined {
-  const parts = xml.getAttribute(attribName)?.trim().split(" ");
+  const parts = xml.getAttribute(attribName)?.trim().split(/\s+/);
   if (parts?.length !== 3) {
     return undefined;
   }
@@ -362,7 +362,7 @@ function parseVec3Attribute(xml: Element, attribName: string): Vector3 | undefin
 }
 
 function parseColorAttribute(xml: Element, attribName: string): Color | undefined {
-  const parts = xml.getAttribute(attribName)?.trim().split(" ");
+  const parts = xml.getAttribute(attribName)?.trim().split(/\s+/);
   if (parts?.length !== 4) {
     return undefined;
   }


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue where certain `<origin>` elements in URDFs were parsed incorrectly.

**Description**
Fixes #5512 
Fixes FG-2392

After:
![image](https://user-images.githubusercontent.com/14237/226068647-5b94ffdd-23a4-4a5a-8f6d-95671b90395e.png)
