### PR TITLE
Enable minify for EsbuildMinifyPlugin

### DIFF
--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -214,7 +214,7 @@ export function makeConfig(
       minimizer: [
         new ESBuildMinifyPlugin({
           target: "es2020",
-          minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+          minifyIdentifiers: true,
           minifySyntax: true,
           minifyWhitespace: true,
         }),

--- a/packages/studio-base/webpack.ts
+++ b/packages/studio-base/webpack.ts
@@ -211,12 +211,11 @@ export function makeConfig(
     },
     optimization: {
       removeAvailableModules: true,
+
       minimizer: [
         new ESBuildMinifyPlugin({
           target: "es2020",
-          minifyIdentifiers: true,
-          minifySyntax: true,
-          minifyWhitespace: true,
+          minify: true,
         }),
       ],
     },

--- a/packages/studio-desktop/src/webpackMainConfig.ts
+++ b/packages/studio-desktop/src/webpackMainConfig.ts
@@ -71,7 +71,7 @@ export const webpackMainConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+            minifyIdentifiers: true,
             minifySyntax: true,
             minifyWhitespace: true,
           }),

--- a/packages/studio-desktop/src/webpackMainConfig.ts
+++ b/packages/studio-desktop/src/webpackMainConfig.ts
@@ -71,9 +71,7 @@ export const webpackMainConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: true,
-            minifySyntax: true,
-            minifyWhitespace: true,
+            minify: true,
           }),
         ],
       },

--- a/packages/studio-desktop/src/webpackPreloadConfig.ts
+++ b/packages/studio-desktop/src/webpackPreloadConfig.ts
@@ -54,9 +54,7 @@ export const webpackPreloadConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: true,
-            minifySyntax: true,
-            minifyWhitespace: true,
+            minify: true,
           }),
         ],
       },

--- a/packages/studio-desktop/src/webpackPreloadConfig.ts
+++ b/packages/studio-desktop/src/webpackPreloadConfig.ts
@@ -54,7 +54,7 @@ export const webpackPreloadConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+            minifyIdentifiers: true,
             minifySyntax: true,
             minifyWhitespace: true,
           }),

--- a/packages/studio-desktop/src/webpackQuicklookConfig.ts
+++ b/packages/studio-desktop/src/webpackQuicklookConfig.ts
@@ -68,7 +68,7 @@ export const webpackQuicklookConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+            minifyIdentifiers: true,
             minifySyntax: true,
             minifyWhitespace: true,
           }),

--- a/packages/studio-desktop/src/webpackQuicklookConfig.ts
+++ b/packages/studio-desktop/src/webpackQuicklookConfig.ts
@@ -68,9 +68,7 @@ export const webpackQuicklookConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: true,
-            minifySyntax: true,
-            minifyWhitespace: true,
+            minify: true,
           }),
         ],
       },

--- a/packages/studio-desktop/src/webpackRendererConfig.ts
+++ b/packages/studio-desktop/src/webpackRendererConfig.ts
@@ -50,7 +50,7 @@ export const webpackRendererConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: false, // readable error stack traces are helpful for debugging
+            minifyIdentifiers: true,
             minifySyntax: true,
             minifyWhitespace: true,
           }),

--- a/packages/studio-desktop/src/webpackRendererConfig.ts
+++ b/packages/studio-desktop/src/webpackRendererConfig.ts
@@ -50,9 +50,7 @@ export const webpackRendererConfig =
         minimizer: [
           new ESBuildMinifyPlugin({
             target: "es2020",
-            minifyIdentifiers: true,
-            minifySyntax: true,
-            minifyWhitespace: true,
+            minify: true,
           }),
         ],
       },


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
We want to production builds to be small and we don't need identifier names in our production builds. These can be part of source builds for OSS users.