### PR TITLE
Persist sidebar state

### DIFF
--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -10,7 +10,6 @@ import GlobalCss from "@foxglove/studio-base/components/GlobalCss";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
-import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Workspace from "./Workspace";
 import { CustomWindowControlsProps } from "./components/AppBar/CustomWindowControls";
@@ -84,7 +83,6 @@ export function App(props: AppProps): JSX.Element {
 
   const providers = [
     /* eslint-disable react/jsx-key */
-    <WorkspaceContextProvider />,
     <StudioLogsSettingsProvider />,
     <StudioToastProvider />,
     <LayoutStorageContext.Provider value={layoutStorage} />,

--- a/packages/studio-base/src/App.tsx
+++ b/packages/studio-base/src/App.tsx
@@ -10,6 +10,7 @@ import GlobalCss from "@foxglove/studio-base/components/GlobalCss";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Workspace from "./Workspace";
 import { CustomWindowControlsProps } from "./components/AppBar/CustomWindowControls";
@@ -83,6 +84,7 @@ export function App(props: AppProps): JSX.Element {
 
   const providers = [
     /* eslint-disable react/jsx-key */
+    <WorkspaceContextProvider />,
     <StudioLogsSettingsProvider />,
     <StudioToastProvider />,
     <LayoutStorageContext.Provider value={layoutStorage} />,

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -83,6 +83,7 @@ import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialD
 import useNativeAppMenuEvent from "@foxglove/studio-base/hooks/useNativeAppMenuEvent";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 const log = Logger.getLogger(__filename);
@@ -163,7 +164,7 @@ const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId
 const selectEventsSupported = (store: EventsStore) => store.eventsSupported;
 const selectWorkspaceSidebarItem = (store: WorkspaceContextStore) => store.sidebarItem;
 
-export default function Workspace(props: WorkspaceProps): JSX.Element {
+function WorkspaceContent(props: WorkspaceProps): JSX.Element {
   const { classes } = useStyles();
   const containerRef = useRef<HTMLDivElement>(ReactNull);
   const { availableSources, selectSource } = usePlayerSelection();
@@ -687,5 +688,13 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         )}
       </div>
     </MultiProvider>
+  );
+}
+
+export default function Workspace(props: WorkspaceProps): JSX.Element {
+  return (
+    <WorkspaceContextProvider>
+      <WorkspaceContent {...props} />
+    </WorkspaceContextProvider>
   );
 }

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -163,6 +163,12 @@ const selectPlayUntil = (ctx: MessagePipelineContext) => ctx.playUntil;
 const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
 const selectEventsSupported = (store: EventsStore) => store.eventsSupported;
 const selectWorkspaceSidebarItem = (store: WorkspaceContextStore) => store.sidebarItem;
+const selectWorkspaceLeftSidebarItem = (store: WorkspaceContextStore) => store.leftSidebarItem;
+const selectWorkspaceLeftSidebarOpen = (store: WorkspaceContextStore) => store.leftSidebarOpen;
+const selectWorkspaceLeftSidebarSize = (store: WorkspaceContextStore) => store.leftSidebarSize;
+const selectWorkspaceRightSidebarItem = (store: WorkspaceContextStore) => store.rightSidebarItem;
+const selectWorkspaceRightSidebarOpen = (store: WorkspaceContextStore) => store.rightSidebarOpen;
+const selectWorkspaceRightSidebarSize = (store: WorkspaceContextStore) => store.rightSidebarSize;
 
 function WorkspaceContent(props: WorkspaceProps): JSX.Element {
   const { classes } = useStyles();
@@ -172,8 +178,22 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
   const playerProblems = useMessagePipeline(selectPlayerProblems);
 
   const sidebarItem = useWorkspaceStore(selectWorkspaceSidebarItem);
+  const leftSidebarItem = useWorkspaceStore(selectWorkspaceLeftSidebarItem);
+  const leftSidebarOpen = useWorkspaceStore(selectWorkspaceLeftSidebarOpen);
+  const leftSidebarSize = useWorkspaceStore(selectWorkspaceLeftSidebarSize);
+  const rightSidebarItem = useWorkspaceStore(selectWorkspaceRightSidebarItem);
+  const rightSidebarOpen = useWorkspaceStore(selectWorkspaceRightSidebarOpen);
+  const rightSidebarSize = useWorkspaceStore(selectWorkspaceRightSidebarSize);
 
-  const { setLeftSidebarOpen, setRightSidebarOpen, selectSidebarItem } = useWorkspaceActions();
+  const {
+    setLeftSidebarOpen,
+    setRightSidebarOpen,
+    selectLeftSidebarItem,
+    selectRightSidebarItem,
+    setLeftSidebarSize,
+    setRightSidebarSize,
+    selectSidebarItem,
+  } = useWorkspaceActions();
 
   const [prefsDialogOpen, setPrefsDialogOpen] = useState(false);
 
@@ -662,10 +682,20 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
           />
         )}
         <Sidebars
-          bottomItems={sidebarBottomItems}
           items={sidebarItems}
+          bottomItems={sidebarBottomItems}
+          selectedKey={sidebarItem}
+          onSelectKey={selectSidebarItem}
           leftItems={leftSidebarItems}
+          selectedLeftKey={leftSidebarOpen ? leftSidebarItem : undefined}
+          onSelectLeftKey={selectLeftSidebarItem}
+          leftSidebarSize={leftSidebarSize}
+          setLeftSidebarSize={setLeftSidebarSize}
           rightItems={rightSidebarItems}
+          selectedRightKey={rightSidebarOpen ? rightSidebarItem : undefined}
+          onSelectRightKey={selectRightSidebarItem}
+          rightSidebarSize={rightSidebarSize}
+          setRightSidebarSize={setRightSidebarSize}
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
           <RemountOnValueChange value={playerId}>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -70,9 +70,9 @@ import {
   LeftSidebarItemKey,
   RightSidebarItemKey,
   SidebarItemKey,
-  useWorkspaceStore,
   useWorkspaceActions,
-  WorkspaceStoreSelectors,
+  useWorkspaceStore,
+  WorkspaceContextStore,
 } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
@@ -161,6 +161,7 @@ const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
 const selectPlayUntil = (ctx: MessagePipelineContext) => ctx.playUntil;
 const selectPlayerId = (ctx: MessagePipelineContext) => ctx.playerState.playerId;
 const selectEventsSupported = (store: EventsStore) => store.eventsSupported;
+const selectWorkspaceSidebarItem = (store: WorkspaceContextStore) => store.sidebarItem;
 
 export default function Workspace(props: WorkspaceProps): JSX.Element {
   const { classes } = useStyles();
@@ -169,9 +170,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems);
 
-  const { leftSidebarOpen, rightSidebarOpen, sidebarItem } = useWorkspaceStore(
-    WorkspaceStoreSelectors.selectAll,
-  );
+  const sidebarItem = useWorkspaceStore(selectWorkspaceSidebarItem);
 
   const { setLeftSidebarOpen, setRightSidebarOpen, selectSidebarItem } = useWorkspaceActions();
 
@@ -608,17 +607,10 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
         ev.preventDefault();
         selectSidebarItem(undefined);
       },
-      "[": () => setLeftSidebarOpen(!leftSidebarOpen),
-      "]": () => setRightSidebarOpen(!rightSidebarOpen),
+      "[": () => setLeftSidebarOpen((oldValue) => !oldValue),
+      "]": () => setRightSidebarOpen((oldValue) => !oldValue),
     };
-  }, [
-    leftSidebarOpen,
-    rightSidebarOpen,
-    sidebarItem,
-    setLeftSidebarOpen,
-    setRightSidebarOpen,
-    selectSidebarItem,
-  ]);
+  }, [sidebarItem, setLeftSidebarOpen, setRightSidebarOpen, selectSidebarItem]);
 
   const play = useMessagePipeline(selectPlay);
   const playUntil = useMessagePipeline(selectPlayUntil);

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -13,7 +13,7 @@
 import { Link, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { extname } from "path";
-import { useState, useEffect, useRef, useCallback, useMemo, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import Logger from "@foxglove/log";
@@ -66,7 +66,14 @@ import {
   IDataSourceFactory,
   usePlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { useWorkspace, WorkspaceContext } from "@foxglove/studio-base/context/WorkspaceContext";
+import {
+  LeftSidebarItemKey,
+  RightSidebarItemKey,
+  SidebarItemKey,
+  useWorkspaceStore,
+  useWorkspaceActions,
+  WorkspaceStoreSelectors,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import useAddPanel from "@foxglove/studio-base/hooks/useAddPanel";
 import { useCalloutDismissalBlocker } from "@foxglove/studio-base/hooks/useCalloutDismissalBlocker";
@@ -93,21 +100,6 @@ const useStyles = makeStyles()({
   },
 });
 
-type SidebarItemKey =
-  | "connection"
-  | "add-panel"
-  | "panel-settings"
-  | "variables"
-  | "extensions"
-  | "account"
-  | "layouts"
-  | "preferences"
-  | "help"
-  | "studio-logs-settings";
-
-type LeftSidebarItemKey = "topics" | "variables" | "studio-logs-settings";
-type RightSidebarItemKey = "panel-settings" | "events";
-
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 
 function activeElementIsInput() {
@@ -127,7 +119,7 @@ function keyboardEventHasModifier(event: KeyboardEvent) {
 
 function AddPanel() {
   const addPanel = useAddPanel();
-  const { openLayoutBrowser } = useWorkspace();
+  const { openLayoutBrowser } = useWorkspaceActions();
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
 
   return (
@@ -177,8 +169,13 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   const playerPresence = useMessagePipeline(selectPlayerPresence);
   const playerProblems = useMessagePipeline(selectPlayerProblems);
 
+  const { leftSidebarOpen, rightSidebarOpen, sidebarItem } = useWorkspaceStore(
+    WorkspaceStoreSelectors.selectAll,
+  );
+
+  const { setLeftSidebarOpen, setRightSidebarOpen, selectSidebarItem } = useWorkspaceActions();
+
   const [prefsDialogOpen, setPrefsDialogOpen] = useState(false);
-  const [layoutMenuOpen, setLayoutMenuOpen] = useState(false);
 
   // file types we support for drag/drop
   const allowedDropExtensions = useMemo(() => {
@@ -225,26 +222,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     { view: OpenDialogViews; activeDataSource?: IDataSourceFactory } | undefined
   >(isPlayerPresent || !showOpenDialogOnStartup || showSignInForm ? undefined : { view: "start" });
 
-  const [selectedSidebarItem, setSelectedSidebarItem] = useState<SidebarItemKey | undefined>(
-    "connection",
-  );
-
-  const [selectedLeftSidebarItem, setSelectedLeftSidebarItem] = useState<
-    LeftSidebarItemKey | undefined
-  >("topics");
-  const [selectedRightSidebarItem, setSelectedRightSidebarItem] = useState<
-    RightSidebarItemKey | undefined
-  >(undefined);
-
-  // When a player is present we hide the connection sidebar. To prevent hiding the connection sidebar
-  // when the user wants to select a new connection we track whether the sidebar item opened
-  const userSelectSidebarItem = useRef(false);
-
-  const selectSidebarItem = useCallback((item: SidebarItemKey | undefined) => {
-    userSelectSidebarItem.current = true;
-    setSelectedSidebarItem(item);
-  }, []);
-
   // When a player is activated, hide the open dialog.
   useLayoutEffect(() => {
     if (
@@ -267,43 +244,43 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   useNativeAppMenuEvent(
     "open-layouts",
     useCallback(() => {
-      setSelectedSidebarItem("layouts");
-    }, []),
+      selectSidebarItem("layouts");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
     "open-add-panel",
     useCallback(() => {
-      setSelectedSidebarItem("add-panel");
-    }, []),
+      selectSidebarItem("add-panel");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
     "open-panel-settings",
     useCallback(() => {
-      setSelectedSidebarItem("panel-settings");
-    }, []),
+      selectSidebarItem("panel-settings");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
     "open-variables",
     useCallback(() => {
-      setSelectedSidebarItem("variables");
-    }, []),
+      selectSidebarItem("variables");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
     "open-extensions",
     useCallback(() => {
-      setSelectedSidebarItem("extensions");
-    }, []),
+      selectSidebarItem("extensions");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
     "open-account",
     useCallback(() => {
-      setSelectedSidebarItem("account");
-    }, []),
+      selectSidebarItem("account");
+    }, [selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
@@ -312,9 +289,9 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
       if (enableNewTopNav) {
         setPrefsDialogOpen(true);
       } else {
-        setSelectedSidebarItem("preferences");
+        selectSidebarItem("preferences");
       }
-    }, [enableNewTopNav]),
+    }, [enableNewTopNav, selectSidebarItem]),
   );
 
   useNativeAppMenuEvent(
@@ -490,36 +467,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     [openFiles, openHandle],
   );
 
-  const workspaceContextValue = useMemo(
-    () => ({
-      panelSettingsOpen:
-        selectedSidebarItem === "panel-settings" || selectedRightSidebarItem === "panel-settings",
-      openPanelSettings: () =>
-        enableNewTopNav
-          ? setSelectedRightSidebarItem("panel-settings")
-          : setSelectedSidebarItem("panel-settings"),
-      // ↓ ↓ ↓  just remove this one when deleting enableNewTopNav feature flag  ↓ ↓ ↓
-      openAccountSettings: () => supportsAccountSettings && setSelectedSidebarItem("account"),
-      openLayoutBrowser: () =>
-        enableNewTopNav ? setLayoutMenuOpen(true) : setSelectedSidebarItem("layouts"),
-      leftSidebarOpen: selectedLeftSidebarItem != undefined,
-      // eslint-disable-next-line @foxglove/no-boolean-parameters
-      setLeftSidebarOpen: (open: boolean) =>
-        setSelectedLeftSidebarItem(open ? "topics" : undefined),
-      rightSidebarOpen: selectedRightSidebarItem != undefined,
-      // eslint-disable-next-line @foxglove/no-boolean-parameters
-      setRightSidebarOpen: (open: boolean) =>
-        setSelectedRightSidebarItem(open ? "panel-settings" : undefined),
-    }),
-    [
-      selectedSidebarItem,
-      selectedLeftSidebarItem,
-      selectedRightSidebarItem,
-      enableNewTopNav,
-      supportsAccountSettings,
-    ],
-  );
-
   // Since the _component_ field of a sidebar item entry is a component and accepts no additional
   // props we need to wrap our DataSourceSidebar component to connect the open data source action to
   // open the data source dialog.
@@ -652,25 +599,26 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
   }, [PanelSettingsSidebar, showEventsTab]);
 
   const keyDownHandlers = useMemo(() => {
-    const { leftSidebarOpen, rightSidebarOpen, setLeftSidebarOpen, setRightSidebarOpen } =
-      workspaceContextValue;
     return {
       b: (ev: KeyboardEvent) => {
-        if (
-          !keyboardEventHasModifier(ev) ||
-          activeElementIsInput() ||
-          selectedSidebarItem == undefined
-        ) {
+        if (!keyboardEventHasModifier(ev) || activeElementIsInput() || sidebarItem == undefined) {
           return;
         }
 
         ev.preventDefault();
-        setSelectedSidebarItem(undefined);
+        selectSidebarItem(undefined);
       },
       "[": () => setLeftSidebarOpen(!leftSidebarOpen),
       "]": () => setRightSidebarOpen(!rightSidebarOpen),
     };
-  }, [selectedSidebarItem, workspaceContextValue]);
+  }, [
+    leftSidebarOpen,
+    rightSidebarOpen,
+    sidebarItem,
+    setLeftSidebarOpen,
+    setRightSidebarOpen,
+    selectSidebarItem,
+  ]);
 
   const play = useMessagePipeline(selectPlay);
   const playUntil = useMessagePipeline(selectPlayUntil);
@@ -687,7 +635,6 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
     <MultiProvider
       providers={[
         /* eslint-disable react/jsx-key */
-        <WorkspaceContext.Provider value={workspaceContextValue} />,
         <PanelStateContextProvider />,
         /* eslint-enable react/jsx-key */
       ]}
@@ -719,21 +666,15 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
             onSelectDataSourceAction={() => setShowOpenDialog({ view: "start" })}
             prefsDialogOpen={prefsDialogOpen}
             setPrefsDialogOpen={setPrefsDialogOpen}
-            layoutMenuOpen={layoutMenuOpen}
-            setLayoutMenuOpen={setLayoutMenuOpen}
           />
         )}
         <Sidebars
-          items={sidebarItems}
           bottomItems={sidebarBottomItems}
-          selectedKey={selectedSidebarItem}
-          onSelectKey={selectSidebarItem}
+          items={sidebarItems}
           leftItems={leftSidebarItems}
-          selectedLeftKey={selectedLeftSidebarItem}
-          onSelectLeftKey={setSelectedLeftSidebarItem}
+          onSelectKey={selectSidebarItem}
           rightItems={rightSidebarItems}
-          selectedRightKey={selectedRightSidebarItem}
-          onSelectRightKey={setSelectedRightSidebarItem}
+          selectedKey={sidebarItem}
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
           <RemountOnValueChange value={playerId}>

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -672,9 +672,7 @@ export default function Workspace(props: WorkspaceProps): JSX.Element {
           bottomItems={sidebarBottomItems}
           items={sidebarItems}
           leftItems={leftSidebarItems}
-          onSelectKey={selectSidebarItem}
           rightItems={rightSidebarItems}
-          selectedKey={sidebarItem}
         >
           {/* To ensure no stale player state remains, we unmount all panels when players change */}
           <RemountOnValueChange value={playerId}>

--- a/packages/studio-base/src/components/AppBar/StorybookDecorator.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/StorybookDecorator.stories.tsx
@@ -13,6 +13,7 @@ import PanelCatalogContext, {
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 const SamplePanel1 = function () {
   return <div></div>;
@@ -64,13 +65,15 @@ export default {
 export function StorybookDecorator(StoryFn: Story): JSX.Element {
   return (
     <DndProvider backend={HTML5Backend}>
-      <PanelCatalogContext.Provider value={new MockPanelCatalog()}>
-        <MockCurrentLayoutProvider>
-          <MockMessagePipelineProvider>
-            <StoryFn />
-          </MockMessagePipelineProvider>
-        </MockCurrentLayoutProvider>
-      </PanelCatalogContext.Provider>
+      <WorkspaceContextProvider>
+        <PanelCatalogContext.Provider value={new MockPanelCatalog()}>
+          <MockCurrentLayoutProvider>
+            <MockMessagePipelineProvider>
+              <StoryFn />
+            </MockMessagePipelineProvider>
+          </MockCurrentLayoutProvider>
+        </PanelCatalogContext.Provider>
+      </WorkspaceContextProvider>
     </DndProvider>
   );
 }

--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -12,6 +12,7 @@ import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurat
 import { UserNodeStateProvider } from "@foxglove/studio-base/context/UserNodeStateContext";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
 
 import { AppBar } from ".";
@@ -20,6 +21,7 @@ function Wrapper({ children }: React.PropsWithChildren<unknown>): JSX.Element {
   const appConfiguration = makeMockAppConfiguration();
   const providers = [
     /* eslint-disable react/jsx-key */
+    <WorkspaceContextProvider />,
     <AppConfigurationContext.Provider value={appConfiguration} />,
     <StudioToastProvider />,
     <TimelineInteractionStateProvider />,
@@ -49,8 +51,6 @@ describe("<AppBar />", () => {
           onSelectDataSourceAction={() => {}}
           prefsDialogOpen={false}
           setPrefsDialogOpen={() => {}}
-          layoutMenuOpen={false}
-          setLayoutMenuOpen={() => {}}
         />
       </Wrapper>,
     );
@@ -76,8 +76,6 @@ describe("<AppBar />", () => {
           onSelectDataSourceAction={() => {}}
           prefsDialogOpen={false}
           setPrefsDialogOpen={() => {}}
-          layoutMenuOpen={false}
-          setLayoutMenuOpen={() => {}}
         />
       </Wrapper>,
     );

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -35,7 +35,11 @@ import {
   useCurrentUserType,
   User,
 } from "@foxglove/studio-base/context/CurrentUserContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import {
+  useWorkspaceStore,
+  useWorkspaceActions,
+  WorkspaceContextStore,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -150,12 +154,11 @@ type AppBarProps = CustomWindowControlsProps & {
   prefsDialogOpen: boolean;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setPrefsDialogOpen: (open: boolean) => void;
-  layoutMenuOpen: boolean;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setLayoutMenuOpen: (open: boolean) => void;
 };
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+
+const selectWorkspace = (store: WorkspaceContextStore) => store;
 
 export function AppBar(props: AppBarProps): JSX.Element {
   const {
@@ -174,8 +177,6 @@ export function AppBar(props: AppBarProps): JSX.Element {
     debugDragRegion,
     prefsDialogOpen,
     setPrefsDialogOpen,
-    layoutMenuOpen,
-    setLayoutMenuOpen,
   } = props;
   const { classes, cx } = useStyles({ leftInset, debugDragRegion });
   const currentUserType = useCurrentUserType();
@@ -187,8 +188,8 @@ export function AppBar(props: AppBarProps): JSX.Element {
   const selectedLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
   const supportsAccountSettings = signIn != undefined;
 
-  const { leftSidebarOpen, setLeftSidebarOpen, rightSidebarOpen, setRightSidebarOpen } =
-    useWorkspace();
+  const { leftSidebarOpen, rightSidebarOpen, layoutMenuOpen } = useWorkspaceStore(selectWorkspace);
+  const { setLayoutMenuOpen, setRightSidebarOpen, setLeftSidebarOpen } = useWorkspaceActions();
 
   const [helpAnchorEl, setHelpAnchorEl] = useState<undefined | HTMLElement>(undefined);
   const [userAnchorEl, setUserAnchorEl] = useState<undefined | HTMLElement>(undefined);

--- a/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/SignInPrompt.tsx
@@ -3,12 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import CloseIcon from "@mui/icons-material/Close";
-import { Link, IconButton, ButtonBase, Typography } from "@mui/material";
+import { ButtonBase, IconButton, Link, Typography } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 
 type SignInPromptProps = {
@@ -38,7 +38,7 @@ export default function SignInPrompt(props: SignInPromptProps): JSX.Element {
   const { onDismiss } = props;
   const { signIn } = useCurrentUser();
   const { classes } = useStyles();
-  const { openAccountSettings } = useWorkspace();
+  const { openAccountSettings } = useWorkspaceActions();
   const [topNavEnabled = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   const action = topNavEnabled ? signIn : openAccountSettings;

--- a/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.stories.tsx
@@ -14,6 +14,7 @@ import { UserProfileStorageContext } from "@foxglove/studio-base/context/UserPro
 import CurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import LayoutManagerProvider from "@foxglove/studio-base/providers/LayoutManagerProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import { ISO8601Timestamp, Layout, LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import LayoutManager from "@foxglove/studio-base/services/LayoutManager/LayoutManager";
 import MockLayoutStorage from "@foxglove/studio-base/services/MockLayoutStorage";
@@ -382,7 +383,11 @@ DeleteLastLayout.parameters = {
 DeleteLastLayout.play = async () => await deleteLayoutInteraction(0);
 
 export function SignInPrompt(_args: unknown): JSX.Element {
-  return <LayoutBrowser supportsSignIn />;
+  return (
+    <WorkspaceContextProvider>
+      <LayoutBrowser supportsSignIn />
+    </WorkspaceContextProvider>
+  );
 }
 SignInPrompt.parameters = {
   colorScheme: "light",

--- a/packages/studio-base/src/components/Panel.tsx
+++ b/packages/studio-base/src/components/Panel.tsx
@@ -18,25 +18,25 @@ import TabIcon from "@mui/icons-material/Tab";
 import { Button, styled as muiStyled, useTheme } from "@mui/material";
 import { last } from "lodash";
 import React, {
-  useState,
+  ComponentType,
+  CSSProperties,
+  MouseEventHandler,
+  Profiler,
   useCallback,
+  useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
-  ComponentType,
-  Profiler,
-  MouseEventHandler,
-  useLayoutEffect,
-  CSSProperties,
-  useContext,
+  useState,
 } from "react";
 import {
-  MosaicContext,
-  MosaicWindowActions,
-  MosaicWindowContext,
   getNodeAtPath,
   getOtherBranch,
-  updateTree,
+  MosaicContext,
   MosaicNode,
+  MosaicWindowActions,
+  MosaicWindowContext,
+  updateTree,
 } from "react-mosaic-component";
 import { Transition } from "react-transition-group";
 import { useMountedState } from "react-use";
@@ -53,10 +53,13 @@ import {
   useSelectedPanels,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import {
+  useWorkspaceStore,
+  WorkspaceStoreSelectors,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import usePanelDrag from "@foxglove/studio-base/hooks/usePanelDrag";
 import { TabPanelConfig } from "@foxglove/studio-base/types/layouts";
-import { PanelConfig, SaveConfig, OpenSiblingPanel } from "@foxglove/studio-base/types/panels";
+import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 import {
   getPanelIdForType,
@@ -349,7 +352,7 @@ export default function Panel<
       [childId, mosaicActions, mosaicWindowActions, swapPanel, tabId],
     );
 
-    const { panelSettingsOpen } = useWorkspace();
+    const panelSettingsOpen = useWorkspaceStore(WorkspaceStoreSelectors.selectPanelSettingsOpen);
 
     const onPanelRootClick: MouseEventHandler<HTMLDivElement> = useCallback(
       (e) => {

--- a/packages/studio-base/src/components/PanelLayout.test.tsx
+++ b/packages/studio-base/src/components/PanelLayout.test.tsx
@@ -14,6 +14,7 @@ import PanelCatalogContext, {
 } from "@foxglove/studio-base/context/PanelCatalogContext";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import { UnconnectedPanelLayout } from "./PanelLayout";
 
@@ -64,13 +65,15 @@ describe("UnconnectedPanelLayout", () => {
         wrapper: function Wrapper({ children }: React.PropsWithChildren<unknown>) {
           return (
             <DndProvider backend={HTML5Backend}>
-              <MockCurrentLayoutProvider>
-                <PanelStateContextProvider>
-                  <PanelCatalogContext.Provider value={panelCatalog}>
-                    {children}
-                  </PanelCatalogContext.Provider>
-                </PanelStateContextProvider>
-              </MockCurrentLayoutProvider>
+              <WorkspaceContextProvider>
+                <MockCurrentLayoutProvider>
+                  <PanelStateContextProvider>
+                    <PanelCatalogContext.Provider value={panelCatalog}>
+                      {children}
+                    </PanelCatalogContext.Provider>
+                  </PanelStateContextProvider>
+                </MockCurrentLayoutProvider>
+              </WorkspaceContextProvider>
             </DndProvider>
           );
         },

--- a/packages/studio-base/src/components/PanelLayout.tsx
+++ b/packages/studio-base/src/components/PanelLayout.tsx
@@ -35,7 +35,7 @@ import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/a
 import { useExtensionCatalog } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { defaultPlaybackConfig } from "@foxglove/studio-base/providers/CurrentLayoutProvider/reducers";
 import { MosaicDropResult, PanelConfig } from "@foxglove/studio-base/types/panels";
@@ -202,7 +202,7 @@ const selectedLayoutMosaicSelector = (state: LayoutState) => state.selectedLayou
 
 export default function PanelLayout(): JSX.Element {
   const { changePanelLayout, setSelectedLayoutId } = useCurrentLayoutActions();
-  const { openLayoutBrowser } = useWorkspace();
+  const { openLayoutBrowser } = useWorkspaceActions();
   const layoutManager = useLayoutManager();
   const layoutExists = useCurrentLayoutSelector(selectedLayoutExistsSelector);
   const layoutLoading = useCurrentLayoutSelector(selectedLayoutLoadingSelector);

--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -24,7 +24,7 @@ import {
   PanelStateStore,
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { PanelConfig } from "@foxglove/studio-base/types/panels";
 import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
@@ -64,7 +64,7 @@ export default function PanelSettings({
     }
   }, [selectAllPanels, selectedPanelIds, singlePanelId]);
 
-  const { openLayoutBrowser } = useWorkspace();
+  const { openLayoutBrowser } = useWorkspaceActions();
   const selectedPanelId = useMemo(
     () => (selectedPanelIds.length === 1 ? selectedPanelIds[0] : undefined),
     [selectedPanelIds],

--- a/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/PanelToolbarControls.tsx
@@ -29,7 +29,7 @@ import {
   usePanelStateStore,
 } from "@foxglove/studio-base/context/PanelStateContext";
 import { UserProfileStorageContext } from "@foxglove/studio-base/context/UserProfileStorageContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/WorkspaceContext";
 
 import { PanelActionsDropdown } from "./PanelActionsDropdown";
 
@@ -64,7 +64,7 @@ const PanelToolbarControlsComponent = forwardRef<HTMLDivElement, PanelToolbarCon
     const { id: panelId, type: panelType } = useContext(PanelContext) ?? {};
     const panelCatalog = useContext(PanelCatalogContext);
     const { setSelectedPanelIds } = useSelectedPanels();
-    const { openPanelSettings } = useWorkspace();
+    const { openPanelSettings } = useWorkspaceActions();
     const { classes } = useStyles();
 
     const hasSettingsSelector = useCallback(

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -20,6 +20,7 @@ import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanel
 import ToolbarIconButton from "@foxglove/studio-base/components/PanelToolbar/ToolbarIconButton";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import PanelToolbar from "./index";
 
@@ -31,31 +32,35 @@ class MosaicWrapper extends React.Component<{
   public override render() {
     const { width } = this.props;
     return (
-      <Mosaic
-        onChange={() => undefined}
-        renderTile={(id, path) => (
-          <MosaicWindow
-            title="test"
-            path={path}
-            toolbarControls={<div />}
-            renderPreview={() => undefined as any}
-          >
-            <PanelStateContextProvider>
-              <Box
-                width="100%"
-                height="100%"
-                padding={3}
-                position="relative"
-                bgcolor="background.default"
-              >
-                <Box width={width}>{id === "Sibling" ? "Sibling Panel" : this.props.children}</Box>
-              </Box>
-            </PanelStateContextProvider>
-          </MosaicWindow>
-        )}
-        value={this.props.layout ?? "dummy"}
-        className="mosaic-foxglove-theme" // prevent the default mosaic theme from being applied
-      />
+      <WorkspaceContextProvider>
+        <Mosaic
+          onChange={() => undefined}
+          renderTile={(id, path) => (
+            <MosaicWindow
+              title="test"
+              path={path}
+              toolbarControls={<div />}
+              renderPreview={() => undefined as any}
+            >
+              <PanelStateContextProvider>
+                <Box
+                  width="100%"
+                  height="100%"
+                  padding={3}
+                  position="relative"
+                  bgcolor="background.default"
+                >
+                  <Box width={width}>
+                    {id === "Sibling" ? "Sibling Panel" : this.props.children}
+                  </Box>
+                </Box>
+              </PanelStateContextProvider>
+            </MosaicWindow>
+          )}
+          value={this.props.layout ?? "dummy"}
+          className="mosaic-foxglove-theme" // prevent the default mosaic theme from being applied
+        />
+      </WorkspaceContextProvider>
     );
   }
 }

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -2,18 +2,30 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { DecoratorFn } from "@storybook/react";
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
-import { PropsWithChildren, useEffect, useState } from "react";
+import { PropsWithChildren, useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
+import {
+  LeftSidebarItemKey,
+  RightSidebarItemKey,
+  SidebarItemKey,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Sidebars, { SidebarItem } from ".";
 import { NewSidebarItem } from "./NewSidebar";
+
+const localStorageResetDecorator: DecoratorFn = (Story) => {
+  window.localStorage.clear();
+  return <Story />;
+};
 
 export default {
   title: "components/NewSidebar",
@@ -21,6 +33,7 @@ export default {
   parameters: {
     colorScheme: "both-column",
   },
+  decorators: [localStorageResetDecorator],
 };
 
 const longText =
@@ -40,37 +53,30 @@ const C = () => <>{longText}</>;
 
 const X = () => <Wrapper>X</Wrapper>;
 const Y = () => <Wrapper>Y</Wrapper>;
-const Z = () => <>{longText}</>;
 
-type LeftKey = "a" | "b" | "c";
-type RightKey = "x" | "y" | "z";
+const ITEMS = new Map<SidebarItemKey, SidebarItem>([]);
+const BOTTOM_ITEMS = new Map<SidebarItemKey, SidebarItem>([]);
 
-const ITEMS = new Map<string, SidebarItem>([]);
-const BOTTOM_ITEMS = new Map<string, SidebarItem>([]);
-
-const LEFT_ITEMS = new Map<LeftKey, NewSidebarItem>([
-  ["a", { title: "A", component: A }],
-  ["b", { title: "B", component: B }],
-  ["c", { title: "C", component: C }],
+const LEFT_ITEMS = new Map<LeftSidebarItemKey, NewSidebarItem>([
+  ["topics", { title: "A", component: A }],
+  ["variables", { title: "B", component: B }],
+  ["studio-logs-settings", { title: "C", component: C }],
 ]);
 
-const RIGHT_ITEMS = new Map<RightKey, NewSidebarItem>([
-  ["x", { title: "X", component: X }],
-  ["y", { title: "Y", component: Y }],
-  ["z", { title: "Z", component: Z }],
+const RIGHT_ITEMS = new Map<RightSidebarItemKey, NewSidebarItem>([
+  ["events", { title: "X", component: X }],
+  ["panel-settings", { title: "Y", component: Y }],
 ]);
 
-function Story({
+function StoryWrapper({
   label,
   defaultLeftKey,
   defaultRightKey,
 }: {
   label?: string;
-  defaultLeftKey?: LeftKey | undefined;
-  defaultRightKey?: RightKey | undefined;
+  defaultLeftKey?: LeftSidebarItemKey | undefined;
+  defaultRightKey?: RightSidebarItemKey | undefined;
 }): JSX.Element {
-  const [selectedRightKey, setSelectedRightKey] = useState<RightKey | undefined>(defaultRightKey);
-  const [selectedLeftKey, setSelectedLeftKey] = useState<LeftKey | undefined>(defaultLeftKey);
   const [_, setAppBarEnabled] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   useEffect(() => {
@@ -80,45 +86,52 @@ function Story({
   return (
     <DndProvider backend={HTML5Backend}>
       <div style={{ height: "100%" }}>
-        <Sidebars
-          items={ITEMS}
-          bottomItems={BOTTOM_ITEMS}
-          rightItems={RIGHT_ITEMS}
-          leftItems={LEFT_ITEMS}
-          selectedKey={undefined}
-          onSelectKey={() => {
-            // no-op
+        <WorkspaceContextProvider
+          initialState={{
+            leftSidebarItem: defaultLeftKey,
+            leftSidebarOpen: defaultLeftKey != undefined,
+            rightSidebarItem: defaultRightKey,
+            rightSidebarOpen: defaultRightKey != undefined,
           }}
-          selectedRightKey={selectedRightKey}
-          onSelectRightKey={setSelectedRightKey}
-          selectedLeftKey={selectedLeftKey}
-          onSelectLeftKey={setSelectedLeftKey}
         >
-          {label ?? "Main content"}
-        </Sidebars>
+          <Sidebars
+            items={ITEMS}
+            bottomItems={BOTTOM_ITEMS}
+            rightItems={RIGHT_ITEMS}
+            leftItems={LEFT_ITEMS}
+          >
+            {label ?? "Main content"}
+          </Sidebars>
+        </WorkspaceContextProvider>
       </div>
     </DndProvider>
   );
 }
 
 // Left
-export const LeftOpen = (): JSX.Element => <Story defaultLeftKey="a" />;
+export const LeftOpen = (): JSX.Element => <StoryWrapper defaultLeftKey="topics" />;
 LeftOpen.storyName = "Left";
 
-export const LeftLongText = (): JSX.Element => <Story defaultLeftKey="c" />;
+export const LeftLongText = (): JSX.Element => <StoryWrapper defaultLeftKey="variables" />;
 LeftLongText.storyName = "Left (with text overflow)";
 
-export const LeftClicked = (): JSX.Element => <Story defaultLeftKey="a" />;
+export const LeftClicked = (): JSX.Element => (
+  <StoryWrapper defaultLeftKey="studio-logs-settings" />
+);
 LeftClicked.storyName = "Left (tab click interaction)";
 LeftClicked.parameters = { colorScheme: "dark" };
 LeftClicked.play = async () => {
   const user = userEvent.setup();
 
-  const leftTab = await screen.findByTestId("b-left");
+  const leftTab = await screen.findByTestId("variables-left");
   await user.click(leftTab);
 };
 export const LeftClosed = (): JSX.Element => (
-  <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
+  <StoryWrapper
+    defaultLeftKey="topics"
+    defaultRightKey="panel-settings"
+    label="Left sidebar should be closed"
+  />
 );
 LeftClosed.storyName = "Left (closed by interaction)";
 LeftClosed.parameters = { colorScheme: "dark" };
@@ -130,23 +143,27 @@ LeftClosed.play = async () => {
 };
 
 // Right
-export const RightOpen = (): JSX.Element => <Story defaultRightKey="x" />;
+export const RightOpen = (): JSX.Element => <StoryWrapper defaultRightKey="panel-settings" />;
 RightOpen.storyName = "Right";
 
-export const RightLongText = (): JSX.Element => <Story defaultRightKey="z" />;
+export const RightLongText = (): JSX.Element => <StoryWrapper defaultRightKey="events" />;
 RightLongText.storyName = "Right (with text overflow)";
 
-export const RightClicked = (): JSX.Element => <Story defaultRightKey="x" />;
+export const RightClicked = (): JSX.Element => <StoryWrapper defaultRightKey="panel-settings" />;
 RightClicked.storyName = "Right (tab click interaction)";
 RightClicked.parameters = { colorScheme: "dark" };
 RightClicked.play = async () => {
   const user = userEvent.setup();
 
-  const rightTab = await screen.findByTestId("y-right");
+  const rightTab = await screen.findByTestId("panel-settings-right");
   await user.click(rightTab);
 };
 export const RightClosed = (): JSX.Element => (
-  <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
+  <StoryWrapper
+    defaultLeftKey="topics"
+    defaultRightKey="panel-settings"
+    label="Right sidebar should be closed"
+  />
 );
 RightClosed.storyName = "Right (closed by interaction)";
 RightClosed.parameters = { colorScheme: "dark" };
@@ -158,19 +175,23 @@ RightClosed.play = async () => {
 };
 
 // Both
-export const Default = (): JSX.Element => <Story label="Both sidebars should be closed" />;
-export const BothOpen = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
+export const Default = (): JSX.Element => <StoryWrapper label="Both sidebars should be closed" />;
+export const BothOpen = (): JSX.Element => (
+  <StoryWrapper defaultLeftKey="topics" defaultRightKey="panel-settings" />
+);
 BothOpen.storyName = "Both (opened)";
 
-export const BothClicked = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
+export const BothClicked = (): JSX.Element => (
+  <StoryWrapper defaultLeftKey="topics" defaultRightKey="panel-settings" />
+);
 BothClicked.storyName = "Both (tab click interaction)";
 BothClicked.parameters = { colorScheme: "dark" };
 BothClicked.play = async () => {
   const user = userEvent.setup();
 
-  const leftTab = await screen.findByTestId("b-left");
+  const leftTab = await screen.findByTestId("topics-left");
   await user.click(leftTab);
 
-  const rightTab = await screen.findByTestId("y-right");
+  const rightTab = await screen.findByTestId("panel-settings-right");
   await user.click(rightTab);
 };

--- a/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/NewSidebar.stories.tsx
@@ -2,30 +2,18 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { DecoratorFn } from "@storybook/react";
 import { screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import Stack from "@foxglove/studio-base/components/Stack";
-import {
-  LeftSidebarItemKey,
-  RightSidebarItemKey,
-  SidebarItemKey,
-} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
-import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Sidebars, { SidebarItem } from ".";
 import { NewSidebarItem } from "./NewSidebar";
-
-const localStorageResetDecorator: DecoratorFn = (Story) => {
-  window.localStorage.clear();
-  return <Story />;
-};
 
 export default {
   title: "components/NewSidebar",
@@ -33,7 +21,6 @@ export default {
   parameters: {
     colorScheme: "both-column",
   },
-  decorators: [localStorageResetDecorator],
 };
 
 const longText =
@@ -53,31 +40,40 @@ const C = () => <>{longText}</>;
 
 const X = () => <Wrapper>X</Wrapper>;
 const Y = () => <Wrapper>Y</Wrapper>;
+const Z = () => <>{longText}</>;
 
-const ITEMS = new Map<SidebarItemKey, SidebarItem>([]);
-const BOTTOM_ITEMS = new Map<SidebarItemKey, SidebarItem>([]);
+type LeftKey = "a" | "b" | "c";
+type RightKey = "x" | "y" | "z";
 
-const LEFT_ITEMS = new Map<LeftSidebarItemKey, NewSidebarItem>([
-  ["topics", { title: "A", component: A }],
-  ["variables", { title: "B", component: B }],
-  ["studio-logs-settings", { title: "C", component: C }],
+const ITEMS = new Map<string, SidebarItem>([]);
+const BOTTOM_ITEMS = new Map<string, SidebarItem>([]);
+
+const LEFT_ITEMS = new Map<LeftKey, NewSidebarItem>([
+  ["a", { title: "A", component: A }],
+  ["b", { title: "B", component: B }],
+  ["c", { title: "C", component: C }],
 ]);
 
-const RIGHT_ITEMS = new Map<RightSidebarItemKey, NewSidebarItem>([
-  ["events", { title: "X", component: X }],
-  ["panel-settings", { title: "Y", component: Y }],
+const RIGHT_ITEMS = new Map<RightKey, NewSidebarItem>([
+  ["x", { title: "X", component: X }],
+  ["y", { title: "Y", component: Y }],
+  ["z", { title: "Z", component: Z }],
 ]);
 
-function StoryWrapper({
+function Story({
   label,
   defaultLeftKey,
   defaultRightKey,
 }: {
   label?: string;
-  defaultLeftKey?: LeftSidebarItemKey | undefined;
-  defaultRightKey?: RightSidebarItemKey | undefined;
+  defaultLeftKey?: LeftKey | undefined;
+  defaultRightKey?: RightKey | undefined;
 }): JSX.Element {
+  const [selectedRightKey, setSelectedRightKey] = useState<RightKey | undefined>(defaultRightKey);
+  const [selectedLeftKey, setSelectedLeftKey] = useState<LeftKey | undefined>(defaultLeftKey);
   const [_, setAppBarEnabled] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
+  const [leftSidebarSize, setLeftSidebarSize] = useState<number | undefined>();
+  const [rightSidebarSize, setRightSidebarSize] = useState<number | undefined>();
 
   useEffect(() => {
     void setAppBarEnabled(true);
@@ -86,52 +82,49 @@ function StoryWrapper({
   return (
     <DndProvider backend={HTML5Backend}>
       <div style={{ height: "100%" }}>
-        <WorkspaceContextProvider
-          initialState={{
-            leftSidebarItem: defaultLeftKey,
-            leftSidebarOpen: defaultLeftKey != undefined,
-            rightSidebarItem: defaultRightKey,
-            rightSidebarOpen: defaultRightKey != undefined,
+        <Sidebars
+          items={ITEMS}
+          bottomItems={BOTTOM_ITEMS}
+          rightItems={RIGHT_ITEMS}
+          leftItems={LEFT_ITEMS}
+          selectedKey={undefined}
+          onSelectKey={() => {
+            // no-op
           }}
+          selectedRightKey={selectedRightKey}
+          onSelectRightKey={setSelectedRightKey}
+          selectedLeftKey={selectedLeftKey}
+          onSelectLeftKey={setSelectedLeftKey}
+          leftSidebarSize={leftSidebarSize}
+          setLeftSidebarSize={setLeftSidebarSize}
+          rightSidebarSize={rightSidebarSize}
+          setRightSidebarSize={setRightSidebarSize}
         >
-          <Sidebars
-            items={ITEMS}
-            bottomItems={BOTTOM_ITEMS}
-            rightItems={RIGHT_ITEMS}
-            leftItems={LEFT_ITEMS}
-          >
-            {label ?? "Main content"}
-          </Sidebars>
-        </WorkspaceContextProvider>
+          {label ?? "Main content"}
+        </Sidebars>
       </div>
     </DndProvider>
   );
 }
 
 // Left
-export const LeftOpen = (): JSX.Element => <StoryWrapper defaultLeftKey="topics" />;
+export const LeftOpen = (): JSX.Element => <Story defaultLeftKey="a" />;
 LeftOpen.storyName = "Left";
 
-export const LeftLongText = (): JSX.Element => <StoryWrapper defaultLeftKey="variables" />;
+export const LeftLongText = (): JSX.Element => <Story defaultLeftKey="c" />;
 LeftLongText.storyName = "Left (with text overflow)";
 
-export const LeftClicked = (): JSX.Element => (
-  <StoryWrapper defaultLeftKey="studio-logs-settings" />
-);
+export const LeftClicked = (): JSX.Element => <Story defaultLeftKey="a" />;
 LeftClicked.storyName = "Left (tab click interaction)";
 LeftClicked.parameters = { colorScheme: "dark" };
 LeftClicked.play = async () => {
   const user = userEvent.setup();
 
-  const leftTab = await screen.findByTestId("variables-left");
+  const leftTab = await screen.findByTestId("b-left");
   await user.click(leftTab);
 };
 export const LeftClosed = (): JSX.Element => (
-  <StoryWrapper
-    defaultLeftKey="topics"
-    defaultRightKey="panel-settings"
-    label="Left sidebar should be closed"
-  />
+  <Story defaultLeftKey="b" defaultRightKey="y" label="Left sidebar should be closed" />
 );
 LeftClosed.storyName = "Left (closed by interaction)";
 LeftClosed.parameters = { colorScheme: "dark" };
@@ -143,27 +136,23 @@ LeftClosed.play = async () => {
 };
 
 // Right
-export const RightOpen = (): JSX.Element => <StoryWrapper defaultRightKey="panel-settings" />;
+export const RightOpen = (): JSX.Element => <Story defaultRightKey="x" />;
 RightOpen.storyName = "Right";
 
-export const RightLongText = (): JSX.Element => <StoryWrapper defaultRightKey="events" />;
+export const RightLongText = (): JSX.Element => <Story defaultRightKey="z" />;
 RightLongText.storyName = "Right (with text overflow)";
 
-export const RightClicked = (): JSX.Element => <StoryWrapper defaultRightKey="panel-settings" />;
+export const RightClicked = (): JSX.Element => <Story defaultRightKey="x" />;
 RightClicked.storyName = "Right (tab click interaction)";
 RightClicked.parameters = { colorScheme: "dark" };
 RightClicked.play = async () => {
   const user = userEvent.setup();
 
-  const rightTab = await screen.findByTestId("panel-settings-right");
+  const rightTab = await screen.findByTestId("y-right");
   await user.click(rightTab);
 };
 export const RightClosed = (): JSX.Element => (
-  <StoryWrapper
-    defaultLeftKey="topics"
-    defaultRightKey="panel-settings"
-    label="Right sidebar should be closed"
-  />
+  <Story defaultLeftKey="b" defaultRightKey="y" label="Right sidebar should be closed" />
 );
 RightClosed.storyName = "Right (closed by interaction)";
 RightClosed.parameters = { colorScheme: "dark" };
@@ -175,23 +164,19 @@ RightClosed.play = async () => {
 };
 
 // Both
-export const Default = (): JSX.Element => <StoryWrapper label="Both sidebars should be closed" />;
-export const BothOpen = (): JSX.Element => (
-  <StoryWrapper defaultLeftKey="topics" defaultRightKey="panel-settings" />
-);
+export const Default = (): JSX.Element => <Story label="Both sidebars should be closed" />;
+export const BothOpen = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
 BothOpen.storyName = "Both (opened)";
 
-export const BothClicked = (): JSX.Element => (
-  <StoryWrapper defaultLeftKey="topics" defaultRightKey="panel-settings" />
-);
+export const BothClicked = (): JSX.Element => <Story defaultLeftKey="a" defaultRightKey="x" />;
 BothClicked.storyName = "Both (tab click interaction)";
 BothClicked.parameters = { colorScheme: "dark" };
 BothClicked.play = async () => {
   const user = userEvent.setup();
 
-  const leftTab = await screen.findByTestId("topics-left");
+  const leftTab = await screen.findByTestId("b-left");
   await user.click(leftTab);
 
-  const rightTab = await screen.findByTestId("panel-settings-right");
+  const rightTab = await screen.findByTestId("y-right");
   await user.click(rightTab);
 };

--- a/packages/studio-base/src/components/Sidebars/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.stories.tsx
@@ -2,14 +2,12 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
-import { SidebarItemKey } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
-import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Sidebars, { SidebarItem } from ".";
 
@@ -24,15 +22,15 @@ const C = () => <>C</>;
 const D = () => <>D</>;
 const E = () => <>E</>;
 
-const ITEMS = new Map<SidebarItemKey, SidebarItem>([
-  ["account", { title: "A", component: A, iconName: "Add" }],
-  ["add-panel", { title: "C", component: C, iconName: "Cancel" }],
-  ["connection", { title: "D", component: D, iconName: "Delete" }],
-  ["extensions", { title: "E", component: E, badge: { count: 2 }, iconName: "Edit" }],
+const ITEMS = new Map<string, SidebarItem>([
+  ["a", { title: "A", component: A, iconName: "Add" }],
+  ["c", { title: "C", component: C, iconName: "Cancel" }],
+  ["d", { title: "D", component: D, iconName: "Delete" }],
+  ["e", { title: "E", component: E, badge: { count: 2 }, iconName: "Edit" }],
 ]);
 
-const BOTTOM_ITEMS = new Map<SidebarItemKey, SidebarItem>([
-  ["help", { title: "B", component: B, iconName: "ErrorBadge" }],
+const BOTTOM_ITEMS = new Map<string, SidebarItem>([
+  ["b", { title: "B", component: B, iconName: "ErrorBadge" }],
 ]);
 
 function Story({
@@ -42,10 +40,11 @@ function Story({
   height = 300,
 }: {
   clickKey?: string;
-  defaultSelectedKey?: SidebarItemKey | undefined;
+  defaultSelectedKey?: string | undefined;
   enableAppBar?: boolean;
   height?: number;
 }) {
+  const [selectedKey, setSelectedKey] = useState<string | undefined>(defaultSelectedKey);
   const [_, setAppBarEnabled] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   useEffect(() => {
@@ -64,6 +63,9 @@ function Story({
           button.click();
           return;
         }
+        setSelectedKey(() => {
+          throw new Error("Missing sidebar button");
+        });
       })();
     }
   }, [clickKey]);
@@ -71,36 +73,38 @@ function Story({
   return (
     <DndProvider backend={HTML5Backend}>
       <div style={{ height }}>
-        <WorkspaceContextProvider initialState={{ sidebarItem: defaultSelectedKey }}>
-          <Sidebars
-            items={ITEMS}
-            bottomItems={BOTTOM_ITEMS}
-            rightItems={new Map()}
-            leftItems={new Map()}
-          >
-            Main content
-          </Sidebars>
-        </WorkspaceContextProvider>
+        <Sidebars
+          items={ITEMS}
+          bottomItems={BOTTOM_ITEMS}
+          rightItems={new Map()}
+          leftItems={new Map()}
+          selectedKey={selectedKey}
+          onSelectKey={setSelectedKey}
+          selectedRightKey={undefined}
+          onSelectRightKey={() => {}}
+          selectedLeftKey={undefined}
+          onSelectLeftKey={() => {}}
+          leftSidebarSize={undefined}
+          rightSidebarSize={undefined}
+          setLeftSidebarSize={() => {}}
+          setRightSidebarSize={() => {}}
+        >
+          Main content
+        </Sidebars>
       </div>
     </DndProvider>
   );
 }
 
 export const Unselected = (): JSX.Element => <Story />;
-export const ASelected = (): JSX.Element => <Story defaultSelectedKey="account" />;
-export const BSelected = (): JSX.Element => <Story defaultSelectedKey="add-panel" />;
+export const ASelected = (): JSX.Element => <Story defaultSelectedKey="a" />;
+export const BSelected = (): JSX.Element => <Story defaultSelectedKey="b" />;
 
 export const ClickToSelect = (): JSX.Element => <Story clickKey="a" />;
 ClickToSelect.parameters = { colorScheme: "dark" };
-export const ClickToDeselect = (): JSX.Element => (
-  <Story defaultSelectedKey="connection" clickKey="a" />
-);
+export const ClickToDeselect = (): JSX.Element => <Story defaultSelectedKey="a" clickKey="a" />;
 ClickToDeselect.parameters = { colorScheme: "dark" };
 
 export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
-export const OverflowCSelected = (): JSX.Element => (
-  <Story height={200} defaultSelectedKey="extensions" />
-);
-export const OverflowBSelected = (): JSX.Element => (
-  <Story height={200} defaultSelectedKey="help" />
-);
+export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;
+export const OverflowBSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="b" />;

--- a/packages/studio-base/src/components/Sidebars/index.stories.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.stories.tsx
@@ -2,12 +2,14 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
 import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { SidebarItemKey } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 
 import Sidebars, { SidebarItem } from ".";
 
@@ -22,15 +24,15 @@ const C = () => <>C</>;
 const D = () => <>D</>;
 const E = () => <>E</>;
 
-const ITEMS = new Map<string, SidebarItem>([
-  ["a", { title: "A", component: A, iconName: "Add" }],
-  ["c", { title: "C", component: C, iconName: "Cancel" }],
-  ["d", { title: "D", component: D, iconName: "Delete" }],
-  ["e", { title: "E", component: E, badge: { count: 2 }, iconName: "Edit" }],
+const ITEMS = new Map<SidebarItemKey, SidebarItem>([
+  ["account", { title: "A", component: A, iconName: "Add" }],
+  ["add-panel", { title: "C", component: C, iconName: "Cancel" }],
+  ["connection", { title: "D", component: D, iconName: "Delete" }],
+  ["extensions", { title: "E", component: E, badge: { count: 2 }, iconName: "Edit" }],
 ]);
 
-const BOTTOM_ITEMS = new Map<string, SidebarItem>([
-  ["b", { title: "B", component: B, iconName: "ErrorBadge" }],
+const BOTTOM_ITEMS = new Map<SidebarItemKey, SidebarItem>([
+  ["help", { title: "B", component: B, iconName: "ErrorBadge" }],
 ]);
 
 function Story({
@@ -40,11 +42,10 @@ function Story({
   height = 300,
 }: {
   clickKey?: string;
-  defaultSelectedKey?: string | undefined;
+  defaultSelectedKey?: SidebarItemKey | undefined;
   enableAppBar?: boolean;
   height?: number;
 }) {
-  const [selectedKey, setSelectedKey] = useState<string | undefined>(defaultSelectedKey);
   const [_, setAppBarEnabled] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   useEffect(() => {
@@ -63,9 +64,6 @@ function Story({
           button.click();
           return;
         }
-        setSelectedKey(() => {
-          throw new Error("Missing sidebar button");
-        });
       })();
     }
   }, [clickKey]);
@@ -73,34 +71,36 @@ function Story({
   return (
     <DndProvider backend={HTML5Backend}>
       <div style={{ height }}>
-        <Sidebars
-          items={ITEMS}
-          bottomItems={BOTTOM_ITEMS}
-          rightItems={new Map()}
-          leftItems={new Map()}
-          selectedKey={selectedKey}
-          onSelectKey={setSelectedKey}
-          selectedRightKey={undefined}
-          onSelectRightKey={() => {}}
-          selectedLeftKey={undefined}
-          onSelectLeftKey={() => {}}
-        >
-          Main content
-        </Sidebars>
+        <WorkspaceContextProvider initialState={{ sidebarItem: defaultSelectedKey }}>
+          <Sidebars
+            items={ITEMS}
+            bottomItems={BOTTOM_ITEMS}
+            rightItems={new Map()}
+            leftItems={new Map()}
+          >
+            Main content
+          </Sidebars>
+        </WorkspaceContextProvider>
       </div>
     </DndProvider>
   );
 }
 
 export const Unselected = (): JSX.Element => <Story />;
-export const ASelected = (): JSX.Element => <Story defaultSelectedKey="a" />;
-export const BSelected = (): JSX.Element => <Story defaultSelectedKey="b" />;
+export const ASelected = (): JSX.Element => <Story defaultSelectedKey="account" />;
+export const BSelected = (): JSX.Element => <Story defaultSelectedKey="add-panel" />;
 
 export const ClickToSelect = (): JSX.Element => <Story clickKey="a" />;
 ClickToSelect.parameters = { colorScheme: "dark" };
-export const ClickToDeselect = (): JSX.Element => <Story defaultSelectedKey="a" clickKey="a" />;
+export const ClickToDeselect = (): JSX.Element => (
+  <Story defaultSelectedKey="connection" clickKey="a" />
+);
 ClickToDeselect.parameters = { colorScheme: "dark" };
 
 export const OverflowUnselected = (): JSX.Element => <Story height={200} />;
-export const OverflowCSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="c" />;
-export const OverflowBSelected = (): JSX.Element => <Story height={200} defaultSelectedKey="b" />;
+export const OverflowCSelected = (): JSX.Element => (
+  <Story height={200} defaultSelectedKey="extensions" />
+);
+export const OverflowBSelected = (): JSX.Element => (
+  <Story height={200} defaultSelectedKey="help" />
+);

--- a/packages/studio-base/src/components/Sidebars/index.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.tsx
@@ -22,6 +22,12 @@ import { BuiltinIcon } from "@foxglove/studio-base/components/BuiltinIcon";
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
 import { MemoryUseIndicator } from "@foxglove/studio-base/components/MemoryUseIndicator";
 import Stack from "@foxglove/studio-base/components/Stack";
+import {
+  LeftSidebarItemKey,
+  RightSidebarItemKey,
+  useWorkspaceStore,
+  useWorkspaceActions,
+} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -121,39 +127,20 @@ function mosiacRightSidebarSplitPercentage(node: MosaicNode<LayoutNode>): number
   }
 }
 
-type SidebarProps<OldLeftKey, LeftKey, RightKey> = PropsWithChildren<{
+type SidebarProps<OldLeftKey> = PropsWithChildren<{
   items: Map<OldLeftKey, SidebarItem>;
   bottomItems: Map<OldLeftKey, SidebarItem>;
   selectedKey: OldLeftKey | undefined;
   onSelectKey: (key: OldLeftKey | undefined) => void;
 
-  leftItems: Map<LeftKey, NewSidebarItem>;
-  selectedLeftKey: LeftKey | undefined;
-  onSelectLeftKey: (key: LeftKey | undefined) => void;
-
-  rightItems: Map<RightKey, NewSidebarItem>;
-  selectedRightKey: RightKey | undefined;
-  onSelectRightKey: (key: RightKey | undefined) => void;
+  leftItems: Map<LeftSidebarItemKey, NewSidebarItem>;
+  rightItems: Map<RightSidebarItemKey, NewSidebarItem>;
 }>;
 
-export default function Sidebars<
-  OldLeftKey extends string,
-  LeftKey extends string,
-  RightKey extends string,
->(props: SidebarProps<OldLeftKey, LeftKey, RightKey>): JSX.Element {
-  const {
-    children,
-    items,
-    bottomItems,
-    selectedKey,
-    onSelectKey,
-    leftItems,
-    selectedLeftKey,
-    onSelectLeftKey,
-    rightItems,
-    selectedRightKey,
-    onSelectRightKey,
-  } = props;
+export default function Sidebars<OldLeftKey extends string>(
+  props: SidebarProps<OldLeftKey>,
+): JSX.Element {
+  const { children, items, bottomItems, selectedKey, onSelectKey, leftItems, rightItems } = props;
   const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
@@ -164,6 +151,18 @@ export default function Sidebars<
   );
   const [initialEnableNewTopNav] = useState(currentEnableNewTopNav);
   const enableNewTopNav = isDesktopApp() ? initialEnableNewTopNav : currentEnableNewTopNav;
+
+  const {
+    leftSidebarItem,
+    leftSidebarOpen,
+    leftSidebarSize,
+    rightSidebarItem,
+    rightSidebarOpen,
+    rightSidebarSize,
+  } = useWorkspaceStore((store) => store);
+
+  const { selectLeftSidebarItem, selectRightSidebarItem, setLeftSidebarSize, setRightSidebarSize } =
+    useWorkspaceActions();
 
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<LayoutNode>>("children");
   const { classes } = useStyles();
@@ -186,10 +185,16 @@ export default function Sidebars<
   const oldLeftSidebarOpen = !enableNewTopNav
     ? selectedKey != undefined && allOldLeftItems.has(selectedKey)
     : false;
-  const leftSidebarOpen =
-    enableNewTopNav && selectedLeftKey != undefined && leftItems.has(selectedLeftKey);
-  const rightSidebarOpen =
-    enableNewTopNav && selectedRightKey != undefined && rightItems.has(selectedRightKey);
+  const showLeftSidebar =
+    enableNewTopNav &&
+    leftSidebarOpen &&
+    leftSidebarItem != undefined &&
+    leftItems.has(leftSidebarItem);
+  const showRightSidebar =
+    enableNewTopNav &&
+    rightSidebarOpen &&
+    rightSidebarItem != undefined &&
+    rightItems.has(rightSidebarItem);
 
   useEffect(() => {
     const leftTargetWidth = enableNewTopNav ? 280 : 384;
@@ -199,25 +204,36 @@ export default function Sidebars<
 
     setMosaicValue((oldValue) => {
       let node: MosaicNode<LayoutNode> = "children";
-      if (rightSidebarOpen) {
+      if (showRightSidebar) {
         node = {
           direction: "row",
           first: node,
           second: "rightbar",
-          splitPercentage: mosiacRightSidebarSplitPercentage(oldValue) ?? defaultRightPercentage,
+          splitPercentage:
+            rightSidebarSize ??
+            mosiacRightSidebarSplitPercentage(oldValue) ??
+            defaultRightPercentage,
         };
       }
-      if (oldLeftSidebarOpen || leftSidebarOpen) {
+      if (oldLeftSidebarOpen || showLeftSidebar) {
         node = {
           direction: "row",
           first: "leftbar",
           second: node,
-          splitPercentage: mosiacLeftSidebarSplitPercentage(oldValue) ?? defaultLeftPercentage,
+          splitPercentage:
+            leftSidebarSize ?? mosiacLeftSidebarSplitPercentage(oldValue) ?? defaultLeftPercentage,
         };
       }
       return node;
     });
-  }, [enableNewTopNav, leftSidebarOpen, oldLeftSidebarOpen, rightSidebarOpen]);
+  }, [
+    enableNewTopNav,
+    leftSidebarSize,
+    oldLeftSidebarOpen,
+    rightSidebarSize,
+    showLeftSidebar,
+    showRightSidebar,
+  ]);
 
   const SelectedLeftComponent =
     (selectedKey != undefined && allOldLeftItems.get(selectedKey)?.component) || Noop;
@@ -287,6 +303,17 @@ export default function Sidebars<
     ));
   }, [bottomItems, classes, onClickTabAction]);
 
+  const onChangeMosaicValue = useCallback(
+    (newValue: ReactNull | MosaicNode<LayoutNode>) => {
+      if (newValue != undefined) {
+        setMosaicValue(newValue);
+        setLeftSidebarSize(mosiacLeftSidebarSplitPercentage(newValue));
+        setRightSidebarSize(mosiacRightSidebarSplitPercentage(newValue));
+      }
+    },
+    [setLeftSidebarSize, setRightSidebarSize],
+  );
+
   return (
     <Stack direction="row" fullHeight overflow="hidden">
       {!enableNewTopNav && (
@@ -337,7 +364,7 @@ export default function Sidebars<
         <MosaicWithoutDragDropContext<LayoutNode>
           className=""
           value={mosaicValue}
-          onChange={(value) => value != undefined && setMosaicValue(value)}
+          onChange={onChangeMosaicValue}
           renderTile={(id) => {
             switch (id) {
               case "children":
@@ -346,12 +373,12 @@ export default function Sidebars<
                 return (
                   <ErrorBoundary>
                     {enableNewTopNav ? (
-                      <NewSidebar<LeftKey>
+                      <NewSidebar<LeftSidebarItemKey>
                         anchor="left"
-                        onClose={() => onSelectLeftKey(undefined)}
+                        onClose={() => selectLeftSidebarItem(undefined)}
                         items={leftItems}
-                        activeTab={selectedLeftKey}
-                        setActiveTab={onSelectLeftKey}
+                        activeTab={leftSidebarItem}
+                        setActiveTab={selectLeftSidebarItem}
                       />
                     ) : (
                       <Paper square elevation={0}>
@@ -363,12 +390,12 @@ export default function Sidebars<
               case "rightbar":
                 return (
                   <ErrorBoundary>
-                    <NewSidebar<RightKey>
+                    <NewSidebar<RightSidebarItemKey>
                       anchor="right"
-                      onClose={() => onSelectRightKey(undefined)}
+                      onClose={() => selectRightSidebarItem(undefined)}
                       items={rightItems}
-                      activeTab={selectedRightKey}
-                      setActiveTab={onSelectRightKey}
+                      activeTab={rightSidebarItem}
+                      setActiveTab={selectRightSidebarItem}
                     />
                   </ErrorBoundary>
                 );

--- a/packages/studio-base/src/components/Sidebars/index.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.tsx
@@ -22,13 +22,6 @@ import { BuiltinIcon } from "@foxglove/studio-base/components/BuiltinIcon";
 import ErrorBoundary from "@foxglove/studio-base/components/ErrorBoundary";
 import { MemoryUseIndicator } from "@foxglove/studio-base/components/MemoryUseIndicator";
 import Stack from "@foxglove/studio-base/components/Stack";
-import {
-  LeftSidebarItemKey,
-  RightSidebarItemKey,
-  useWorkspaceStore,
-  useWorkspaceActions,
-  SidebarItemKey,
-} from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -128,16 +121,47 @@ function mosiacRightSidebarSplitPercentage(node: MosaicNode<LayoutNode>): number
   }
 }
 
-type SidebarProps = PropsWithChildren<{
-  items: Map<SidebarItemKey, SidebarItem>;
-  bottomItems: Map<SidebarItemKey, SidebarItem>;
+type SidebarProps<OldLeftKey, LeftKey, RightKey> = PropsWithChildren<{
+  items: Map<OldLeftKey, SidebarItem>;
+  bottomItems: Map<OldLeftKey, SidebarItem>;
+  selectedKey: OldLeftKey | undefined;
+  onSelectKey: (key: OldLeftKey | undefined) => void;
 
-  leftItems: Map<LeftSidebarItemKey, NewSidebarItem>;
-  rightItems: Map<RightSidebarItemKey, NewSidebarItem>;
+  leftItems: Map<LeftKey, NewSidebarItem>;
+  selectedLeftKey: LeftKey | undefined;
+  onSelectLeftKey: (key: LeftKey | undefined) => void;
+  leftSidebarSize: number | undefined;
+  setLeftSidebarSize: (size: number | undefined) => void;
+
+  rightItems: Map<RightKey, NewSidebarItem>;
+  selectedRightKey: RightKey | undefined;
+  onSelectRightKey: (key: RightKey | undefined) => void;
+  rightSidebarSize: number | undefined;
+  setRightSidebarSize: (size: number | undefined) => void;
 }>;
 
-export default function Sidebars(props: SidebarProps): JSX.Element {
-  const { children, items, bottomItems, leftItems, rightItems } = props;
+export default function Sidebars<
+  OldLeftKey extends string,
+  LeftKey extends string,
+  RightKey extends string,
+>(props: SidebarProps<OldLeftKey, LeftKey, RightKey>): JSX.Element {
+  const {
+    children,
+    items,
+    bottomItems,
+    selectedKey,
+    onSelectKey,
+    leftItems,
+    selectedLeftKey,
+    onSelectLeftKey,
+    leftSidebarSize,
+    setLeftSidebarSize,
+    rightItems,
+    selectedRightKey,
+    onSelectRightKey,
+    rightSidebarSize,
+    setRightSidebarSize,
+  } = props;
   const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
@@ -148,24 +172,6 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
   );
   const [initialEnableNewTopNav] = useState(currentEnableNewTopNav);
   const enableNewTopNav = isDesktopApp() ? initialEnableNewTopNav : currentEnableNewTopNav;
-
-  const {
-    leftSidebarItem,
-    leftSidebarOpen,
-    leftSidebarSize,
-    rightSidebarItem,
-    rightSidebarOpen,
-    rightSidebarSize,
-    sidebarItem,
-  } = useWorkspaceStore((store) => store);
-
-  const {
-    selectLeftSidebarItem,
-    selectRightSidebarItem,
-    setLeftSidebarSize,
-    setRightSidebarSize,
-    selectSidebarItem,
-  } = useWorkspaceActions();
 
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<LayoutNode>>("children");
   const { classes } = useStyles();
@@ -186,18 +192,12 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
   };
 
   const oldLeftSidebarOpen = !enableNewTopNav
-    ? sidebarItem != undefined && allOldLeftItems.has(sidebarItem)
+    ? selectedKey != undefined && allOldLeftItems.has(selectedKey)
     : false;
-  const showLeftSidebar =
-    enableNewTopNav &&
-    leftSidebarOpen &&
-    leftSidebarItem != undefined &&
-    leftItems.has(leftSidebarItem);
-  const showRightSidebar =
-    enableNewTopNav &&
-    rightSidebarOpen &&
-    rightSidebarItem != undefined &&
-    rightItems.has(rightSidebarItem);
+  const leftSidebarOpen =
+    enableNewTopNav && selectedLeftKey != undefined && leftItems.has(selectedLeftKey);
+  const rightSidebarOpen =
+    enableNewTopNav && selectedRightKey != undefined && rightItems.has(selectedRightKey);
 
   useEffect(() => {
     const leftTargetWidth = enableNewTopNav ? 280 : 384;
@@ -207,7 +207,7 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
 
     setMosaicValue((oldValue) => {
       let node: MosaicNode<LayoutNode> = "children";
-      if (showRightSidebar) {
+      if (rightSidebarOpen) {
         node = {
           direction: "row",
           first: node,
@@ -218,7 +218,7 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
             defaultRightPercentage,
         };
       }
-      if (oldLeftSidebarOpen || showLeftSidebar) {
+      if (oldLeftSidebarOpen || leftSidebarOpen) {
         node = {
           direction: "row",
           first: "leftbar",
@@ -234,23 +234,23 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
     leftSidebarSize,
     oldLeftSidebarOpen,
     rightSidebarSize,
-    showLeftSidebar,
-    showRightSidebar,
+    leftSidebarOpen,
+    rightSidebarOpen,
   ]);
 
   const SelectedLeftComponent =
-    (sidebarItem != undefined && allOldLeftItems.get(sidebarItem)?.component) || Noop;
+    (selectedKey != undefined && allOldLeftItems.get(selectedKey)?.component) || Noop;
 
   const onClickTabAction = useCallback(
-    (key: SidebarItemKey) => {
+    (key: OldLeftKey) => {
       // toggle tab selected/unselected on click
-      if (sidebarItem === key) {
-        selectSidebarItem(undefined);
+      if (selectedKey === key) {
+        onSelectKey(undefined);
       } else {
-        selectSidebarItem(key);
+        onSelectKey(key);
       }
     },
-    [sidebarItem, selectSidebarItem],
+    [selectedKey, onSelectKey],
   );
 
   const topTabs = useMemo(() => {
@@ -325,7 +325,7 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
             className={classes.tabs}
             orientation="vertical"
             variant="scrollable"
-            value={sidebarItem ?? false}
+            value={selectedKey ?? false}
             scrollButtons={false}
           >
             {topTabs}
@@ -376,12 +376,12 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
                 return (
                   <ErrorBoundary>
                     {enableNewTopNav ? (
-                      <NewSidebar<LeftSidebarItemKey>
+                      <NewSidebar<LeftKey>
                         anchor="left"
-                        onClose={() => selectLeftSidebarItem(undefined)}
+                        onClose={() => onSelectLeftKey(undefined)}
                         items={leftItems}
-                        activeTab={leftSidebarItem}
-                        setActiveTab={selectLeftSidebarItem}
+                        activeTab={selectedLeftKey}
+                        setActiveTab={onSelectLeftKey}
                       />
                     ) : (
                       <Paper square elevation={0}>
@@ -393,12 +393,12 @@ export default function Sidebars(props: SidebarProps): JSX.Element {
               case "rightbar":
                 return (
                   <ErrorBoundary>
-                    <NewSidebar<RightSidebarItemKey>
+                    <NewSidebar<RightKey>
                       anchor="right"
-                      onClose={() => selectRightSidebarItem(undefined)}
+                      onClose={() => onSelectRightKey(undefined)}
                       items={rightItems}
-                      activeTab={rightSidebarItem}
-                      setActiveTab={selectRightSidebarItem}
+                      activeTab={selectedRightKey}
+                      setActiveTab={onSelectRightKey}
                     />
                   </ErrorBoundary>
                 );

--- a/packages/studio-base/src/components/Sidebars/index.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.tsx
@@ -27,6 +27,7 @@ import {
   RightSidebarItemKey,
   useWorkspaceStore,
   useWorkspaceActions,
+  SidebarItemKey,
 } from "@foxglove/studio-base/context/WorkspaceContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
@@ -127,20 +128,16 @@ function mosiacRightSidebarSplitPercentage(node: MosaicNode<LayoutNode>): number
   }
 }
 
-type SidebarProps<OldLeftKey> = PropsWithChildren<{
-  items: Map<OldLeftKey, SidebarItem>;
-  bottomItems: Map<OldLeftKey, SidebarItem>;
-  selectedKey: OldLeftKey | undefined;
-  onSelectKey: (key: OldLeftKey | undefined) => void;
+type SidebarProps = PropsWithChildren<{
+  items: Map<SidebarItemKey, SidebarItem>;
+  bottomItems: Map<SidebarItemKey, SidebarItem>;
 
   leftItems: Map<LeftSidebarItemKey, NewSidebarItem>;
   rightItems: Map<RightSidebarItemKey, NewSidebarItem>;
 }>;
 
-export default function Sidebars<OldLeftKey extends string>(
-  props: SidebarProps<OldLeftKey>,
-): JSX.Element {
-  const { children, items, bottomItems, selectedKey, onSelectKey, leftItems, rightItems } = props;
+export default function Sidebars(props: SidebarProps): JSX.Element {
+  const { children, items, bottomItems, leftItems, rightItems } = props;
   const [enableMemoryUseIndicator = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_MEMORY_USE_INDICATOR,
   );
@@ -159,10 +156,16 @@ export default function Sidebars<OldLeftKey extends string>(
     rightSidebarItem,
     rightSidebarOpen,
     rightSidebarSize,
+    sidebarItem,
   } = useWorkspaceStore((store) => store);
 
-  const { selectLeftSidebarItem, selectRightSidebarItem, setLeftSidebarSize, setRightSidebarSize } =
-    useWorkspaceActions();
+  const {
+    selectLeftSidebarItem,
+    selectRightSidebarItem,
+    setLeftSidebarSize,
+    setRightSidebarSize,
+    selectSidebarItem,
+  } = useWorkspaceActions();
 
   const [mosaicValue, setMosaicValue] = useState<MosaicNode<LayoutNode>>("children");
   const { classes } = useStyles();
@@ -183,7 +186,7 @@ export default function Sidebars<OldLeftKey extends string>(
   };
 
   const oldLeftSidebarOpen = !enableNewTopNav
-    ? selectedKey != undefined && allOldLeftItems.has(selectedKey)
+    ? sidebarItem != undefined && allOldLeftItems.has(sidebarItem)
     : false;
   const showLeftSidebar =
     enableNewTopNav &&
@@ -236,18 +239,18 @@ export default function Sidebars<OldLeftKey extends string>(
   ]);
 
   const SelectedLeftComponent =
-    (selectedKey != undefined && allOldLeftItems.get(selectedKey)?.component) || Noop;
+    (sidebarItem != undefined && allOldLeftItems.get(sidebarItem)?.component) || Noop;
 
   const onClickTabAction = useCallback(
-    (key: OldLeftKey) => {
+    (key: SidebarItemKey) => {
       // toggle tab selected/unselected on click
-      if (selectedKey === key) {
-        onSelectKey(undefined);
+      if (sidebarItem === key) {
+        selectSidebarItem(undefined);
       } else {
-        onSelectKey(key);
+        selectSidebarItem(key);
       }
     },
-    [selectedKey, onSelectKey],
+    [sidebarItem, selectSidebarItem],
   );
 
   const topTabs = useMemo(() => {
@@ -322,7 +325,7 @@ export default function Sidebars<OldLeftKey extends string>(
             className={classes.tabs}
             orientation="vertical"
             variant="scrollable"
-            value={selectedKey ?? false}
+            value={sidebarItem ?? false}
             scrollButtons={false}
           >
             {topTabs}

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -2,46 +2,156 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext, useContext } from "react";
+import { createContext, useMemo, useState } from "react";
+import { DeepReadonly } from "ts-essentials";
+import { StoreApi, useStore } from "zustand";
 
-type WorkspaceContextType = {
-  panelSettingsOpen: boolean;
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
+import useGuaranteedContext from "@foxglove/studio-base/hooks/useGuaranteedContext";
+import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+
+export type SidebarItemKey =
+  | "account"
+  | "add-panel"
+  | "connection"
+  | "extensions"
+  | "help"
+  | "layouts"
+  | "panel-settings"
+  | "preferences"
+  | "studio-logs-settings"
+  | "variables";
+
+export type LeftSidebarItemKey = "topics" | "variables" | "studio-logs-settings";
+export type RightSidebarItemKey = "panel-settings" | "events";
+
+export type WorkspaceContextStore = DeepReadonly<{
+  layoutMenuOpen: boolean;
+  leftSidebarOpen: boolean;
+  rightSidebarOpen: boolean;
+  leftSidebarItem: undefined | LeftSidebarItemKey;
+  leftSidebarSize: undefined | number;
+  rightSidebarItem: undefined | RightSidebarItemKey;
+  rightSidebarSize: undefined | number;
+  sidebarItem: undefined | SidebarItemKey;
+}>;
+
+export const WorkspaceContext = createContext<undefined | StoreApi<WorkspaceContextStore>>(
+  undefined,
+);
+
+WorkspaceContext.displayName = "WorkspaceContext";
+
+export const WorkspaceStoreSelectors = {
+  selectAll: (store: WorkspaceContextStore): WorkspaceContextStore => store,
+  selectPanelSettingsOpen: (store: WorkspaceContextStore): boolean =>
+    store.sidebarItem === "panel-settings" || store.rightSidebarItem === "panel-settings",
+};
+
+/**
+ * Fetches values from the workspace store.
+ */
+export function useWorkspaceStore<T>(
+  selector: (store: WorkspaceContextStore) => T,
+  equalityFn?: (a: T, b: T) => boolean,
+): T {
+  const context = useGuaranteedContext(WorkspaceContext);
+  return useStore(context, selector, equalityFn);
+}
+
+export type WorkspaceActions = {
   openPanelSettings: () => void;
   openAccountSettings: () => void;
   openLayoutBrowser: () => void;
-
-  leftSidebarOpen: boolean;
+  selectSidebarItem: (selectedSidebarItem: undefined | SidebarItemKey) => void;
+  selectLeftSidebarItem: (item: undefined | LeftSidebarItemKey) => void;
+  selectRightSidebarItem: (item: undefined | RightSidebarItemKey) => void;
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
+  setLayoutMenuOpen: (open: boolean) => void;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setLeftSidebarOpen: (open: boolean) => void;
-
-  rightSidebarOpen: boolean;
+  setLeftSidebarSize: (size: undefined | number) => void;
   // eslint-disable-next-line @foxglove/no-boolean-parameters
   setRightSidebarOpen: (open: boolean) => void;
+  setRightSidebarSize: (size: undefined | number) => void;
 };
 
-export const WorkspaceContext = createContext<WorkspaceContextType>({
-  panelSettingsOpen: false,
-  leftSidebarOpen: false,
-  rightSidebarOpen: false,
+/**
+ * Provides various actions to manipulate the workspace state.
+ */
+export function useWorkspaceActions(): WorkspaceActions {
+  const { setState: set } = useGuaranteedContext(WorkspaceContext);
 
-  openPanelSettings: (): void => {
-    throw new Error("Must be in a WorkspaceContext.Provider to open panel settings");
-  },
-  openAccountSettings: (): void => {
-    throw new Error("Must be in a WorkspaceContext.Provider to open account settings");
-  },
-  openLayoutBrowser: (): void => {
-    throw new Error("Must be in a WorkspaceContext.Provider to open layout browser");
-  },
-  setLeftSidebarOpen: (): void => {
-    throw new Error("Must be in a WorkspaceContext.Provider to open the left sidebar");
-  },
-  setRightSidebarOpen: (): void => {
-    throw new Error("Must be in a WorkspaceContext.Provider to open the right sidebar");
-  },
-});
-WorkspaceContext.displayName = "WorkspaceContext";
+  const { signIn } = useCurrentUser();
+  const supportsAccountSettings = signIn != undefined;
 
-export function useWorkspace(): WorkspaceContextType {
-  return useContext(WorkspaceContext);
+  const [currentEnableNewTopNav = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_NEW_TOPNAV,
+  );
+  const [initialEnableNewTopNav] = useState(currentEnableNewTopNav);
+  const enableNewTopNav = isDesktopApp() ? initialEnableNewTopNav : currentEnableNewTopNav;
+
+  return useMemo(() => {
+    return {
+      openPanelSettings: () =>
+        enableNewTopNav
+          ? set({ rightSidebarItem: "panel-settings", rightSidebarOpen: true })
+          : set({ sidebarItem: "panel-settings" }),
+
+      openAccountSettings: () => supportsAccountSettings && set({ sidebarItem: "account" }),
+
+      openLayoutBrowser: () =>
+        enableNewTopNav ? set({ layoutMenuOpen: true }) : set({ sidebarItem: "layouts" }),
+
+      // eslint-disable-next-line @foxglove/no-boolean-parameters
+      setLayoutMenuOpen: (layoutMenuOpen: boolean) => set({ layoutMenuOpen }),
+
+      selectSidebarItem: (selectedSidebarItem: undefined | SidebarItemKey) =>
+        set({ sidebarItem: selectedSidebarItem }),
+
+      selectLeftSidebarItem: (selectedLeftSidebarItem: undefined | LeftSidebarItemKey) => {
+        set({
+          leftSidebarItem: selectedLeftSidebarItem,
+          leftSidebarOpen: selectedLeftSidebarItem != undefined,
+        });
+      },
+
+      selectRightSidebarItem: (selectedRightSidebarItem: undefined | RightSidebarItemKey) => {
+        set({
+          rightSidebarItem: selectedRightSidebarItem,
+          rightSidebarOpen: selectedRightSidebarItem != undefined,
+        });
+      },
+
+      // eslint-disable-next-line @foxglove/no-boolean-parameters
+      setLeftSidebarOpen: (leftSidebarOpen: boolean) => {
+        if (leftSidebarOpen) {
+          set((oldValue) => ({
+            leftSidebarOpen,
+            leftSidebarItem: oldValue.leftSidebarItem ?? "topics",
+          }));
+        } else {
+          set({ leftSidebarOpen: false });
+        }
+      },
+
+      setLeftSidebarSize: (leftSidebarSize: undefined | number) => set({ leftSidebarSize }),
+
+      // eslint-disable-next-line @foxglove/no-boolean-parameters
+      setRightSidebarOpen: (rightSidebarOpen: boolean) => {
+        if (rightSidebarOpen) {
+          set((oldValue) => ({
+            rightSidebarOpen,
+            rightSidebarItem: oldValue.rightSidebarItem ?? "panel-settings",
+          }));
+        } else {
+          set({ rightSidebarOpen: false });
+        }
+      },
+
+      setRightSidebarSize: (rightSidebarSize: undefined | number) => set({ rightSidebarSize }),
+    };
+  }, [enableNewTopNav, set, supportsAccountSettings]);
 }

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { createContext, useMemo, useState } from "react";
+import { createContext, Dispatch, SetStateAction, useMemo, useState } from "react";
 import { DeepReadonly } from "ts-essentials";
 import { StoreApi, useStore } from "zustand";
 
@@ -45,7 +45,6 @@ export const WorkspaceContext = createContext<undefined | StoreApi<WorkspaceCont
 WorkspaceContext.displayName = "WorkspaceContext";
 
 export const WorkspaceStoreSelectors = {
-  selectAll: (store: WorkspaceContextStore): WorkspaceContextStore => store,
   selectPanelSettingsOpen: (store: WorkspaceContextStore): boolean =>
     store.sidebarItem === "panel-settings" || store.rightSidebarItem === "panel-settings",
 };
@@ -68,15 +67,20 @@ export type WorkspaceActions = {
   selectSidebarItem: (selectedSidebarItem: undefined | SidebarItemKey) => void;
   selectLeftSidebarItem: (item: undefined | LeftSidebarItemKey) => void;
   selectRightSidebarItem: (item: undefined | RightSidebarItemKey) => void;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setLayoutMenuOpen: (open: boolean) => void;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setLeftSidebarOpen: (open: boolean) => void;
+  setLayoutMenuOpen: Dispatch<SetStateAction<boolean>>;
+  setLeftSidebarOpen: Dispatch<SetStateAction<boolean>>;
   setLeftSidebarSize: (size: undefined | number) => void;
-  // eslint-disable-next-line @foxglove/no-boolean-parameters
-  setRightSidebarOpen: (open: boolean) => void;
+  setRightSidebarOpen: Dispatch<SetStateAction<boolean>>;
   setRightSidebarSize: (size: undefined | number) => void;
 };
+
+function setterValue<T>(action: SetStateAction<T>, value: T): T {
+  if (action instanceof Function) {
+    return action(value);
+  }
+
+  return action;
+}
 
 /**
  * Provides various actions to manipulate the workspace state.
@@ -105,8 +109,12 @@ export function useWorkspaceActions(): WorkspaceActions {
       openLayoutBrowser: () =>
         enableNewTopNav ? set({ layoutMenuOpen: true }) : set({ sidebarItem: "layouts" }),
 
-      // eslint-disable-next-line @foxglove/no-boolean-parameters
-      setLayoutMenuOpen: (layoutMenuOpen: boolean) => set({ layoutMenuOpen }),
+      setLayoutMenuOpen: (setter: SetStateAction<boolean>) => {
+        set((oldValue) => {
+          const layoutMenuOpen = setterValue(setter, oldValue.layoutMenuOpen);
+          return { layoutMenuOpen };
+        });
+      },
 
       selectSidebarItem: (selectedSidebarItem: undefined | SidebarItemKey) =>
         set({ sidebarItem: selectedSidebarItem }),
@@ -125,30 +133,34 @@ export function useWorkspaceActions(): WorkspaceActions {
         });
       },
 
-      // eslint-disable-next-line @foxglove/no-boolean-parameters
-      setLeftSidebarOpen: (leftSidebarOpen: boolean) => {
-        if (leftSidebarOpen) {
-          set((oldValue) => ({
-            leftSidebarOpen,
-            leftSidebarItem: oldValue.leftSidebarItem ?? "topics",
-          }));
-        } else {
-          set({ leftSidebarOpen: false });
-        }
+      setLeftSidebarOpen: (setter: SetStateAction<boolean>) => {
+        set((oldValue) => {
+          const leftSidebarOpen = setterValue(setter, oldValue.leftSidebarOpen);
+          if (leftSidebarOpen) {
+            return {
+              leftSidebarOpen,
+              leftSidebarItem: oldValue.leftSidebarItem ?? "topics",
+            };
+          } else {
+            return { leftSidebarOpen: false };
+          }
+        });
       },
 
       setLeftSidebarSize: (leftSidebarSize: undefined | number) => set({ leftSidebarSize }),
 
-      // eslint-disable-next-line @foxglove/no-boolean-parameters
-      setRightSidebarOpen: (rightSidebarOpen: boolean) => {
-        if (rightSidebarOpen) {
-          set((oldValue) => ({
-            rightSidebarOpen,
-            rightSidebarItem: oldValue.rightSidebarItem ?? "panel-settings",
-          }));
-        } else {
-          set({ rightSidebarOpen: false });
-        }
+      setRightSidebarOpen: (setter: SetStateAction<boolean>) => {
+        set((oldValue) => {
+          const rightSidebarOpen = setterValue(setter, oldValue.rightSidebarOpen);
+          if (rightSidebarOpen) {
+            return {
+              rightSidebarOpen,
+              rightSidebarItem: oldValue.rightSidebarItem ?? "panel-settings",
+            };
+          } else {
+            return { rightSidebarOpen: false };
+          }
+        });
       },
 
       setRightSidebarSize: (rightSidebarSize: undefined | number) => set({ rightSidebarSize }),

--- a/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
+++ b/packages/studio-base/src/panels/Plot/PlotLegendRow.tsx
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { Square24Filled, Square24Regular, ErrorCircle16Filled } from "@fluentui/react-icons";
+import { ErrorCircle16Filled, Square24Filled, Square24Regular } from "@fluentui/react-icons";
 import { Checkbox, Tooltip, Typography } from "@mui/material";
 import { ComponentProps, useMemo, useState } from "react";
 import { makeStyles } from "tss-react/mui";
@@ -12,7 +12,7 @@ import { usePanelContext } from "@foxglove/studio-base/components/PanelContext";
 import TimeBasedChart from "@foxglove/studio-base/components/TimeBasedChart";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useHoverValue } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
-import { useWorkspace } from "@foxglove/studio-base/context/WorkspaceContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/WorkspaceContext";
 import { plotPathDisplayName } from "@foxglove/studio-base/panels/Plot/types";
 import { getLineColor } from "@foxglove/studio-base/util/plotColors";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -110,7 +110,7 @@ export function PlotLegendRow({
   savePaths,
   showPlotValuesInLegend,
 }: PlotLegendRowProps): JSX.Element {
-  const { openPanelSettings } = useWorkspace();
+  const { openPanelSettings } = useWorkspaceActions();
   const { id: panelId } = usePanelContext();
   const { setSelectedPanelIds } = useSelectedPanels();
   const { classes, cx } = useStyles();

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ReactNode, useState } from "react";
+import { createStore, StoreApi } from "zustand";
+import { persist } from "zustand/middleware";
+
+import {
+  WorkspaceContext,
+  WorkspaceContextStore,
+} from "@foxglove/studio-base/context/WorkspaceContext";
+
+function createWorkspaceContextStore(): StoreApi<WorkspaceContextStore> {
+  return createStore<WorkspaceContextStore>()(
+    persist(
+      () => {
+        const store: WorkspaceContextStore = {
+          layoutMenuOpen: false,
+          leftSidebarItem: undefined,
+          leftSidebarOpen: false,
+          leftSidebarSize: undefined,
+          rightSidebarItem: undefined,
+          rightSidebarOpen: false,
+          rightSidebarSize: undefined,
+          sidebarItem: undefined,
+        };
+        return store;
+      },
+      {
+        name: "fox.workspace",
+        partialize: (value) => {
+          const { layoutMenuOpen: _, ...rest } = value;
+          return rest;
+        },
+      },
+    ),
+  );
+}
+
+export default function WorkspaceContextProvider({
+  children,
+}: {
+  children?: ReactNode;
+}): JSX.Element {
+  const [store] = useState(createWorkspaceContextStore());
+
+  return <WorkspaceContext.Provider value={store}>{children}</WorkspaceContext.Provider>;
+}

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -25,7 +25,7 @@ function createWorkspaceContextStore(
           rightSidebarItem: undefined,
           rightSidebarOpen: false,
           rightSidebarSize: undefined,
-          sidebarItem: undefined,
+          sidebarItem: "connection",
           ...initialState,
         };
         return store;

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -11,7 +11,9 @@ import {
   WorkspaceContextStore,
 } from "@foxglove/studio-base/context/WorkspaceContext";
 
-function createWorkspaceContextStore(): StoreApi<WorkspaceContextStore> {
+function createWorkspaceContextStore(
+  initialState?: Partial<WorkspaceContextStore>,
+): StoreApi<WorkspaceContextStore> {
   return createStore<WorkspaceContextStore>()(
     persist(
       () => {
@@ -24,6 +26,7 @@ function createWorkspaceContextStore(): StoreApi<WorkspaceContextStore> {
           rightSidebarOpen: false,
           rightSidebarSize: undefined,
           sidebarItem: undefined,
+          ...initialState,
         };
         return store;
       },
@@ -40,10 +43,12 @@ function createWorkspaceContextStore(): StoreApi<WorkspaceContextStore> {
 
 export default function WorkspaceContextProvider({
   children,
+  initialState,
 }: {
   children?: ReactNode;
+  initialState?: Partial<WorkspaceContextStore>;
 }): JSX.Element {
-  const [store] = useState(createWorkspaceContextStore());
+  const [store] = useState(() => createWorkspaceContextStore(initialState));
 
   return <WorkspaceContext.Provider value={store}>{children}</WorkspaceContext.Provider>;
 }

--- a/packages/studio-base/src/stories/PanelSetup.tsx
+++ b/packages/studio-base/src/stories/PanelSetup.tsx
@@ -52,6 +52,7 @@ import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLa
 import ExtensionCatalogProvider from "@foxglove/studio-base/providers/ExtensionCatalogProvider";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { SavedProps, UserNodes } from "@foxglove/studio-base/types/panels";
@@ -327,18 +328,20 @@ type Props = UnconnectedProps & {
 export default function PanelSetup(props: Props): JSX.Element {
   const theme = useTheme();
   return (
-    <UserNodeStateProvider>
-      <TimelineInteractionStateProvider>
-        <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
-          <PanelStateContextProvider>
-            <ExtensionCatalogProvider loaders={[]}>
-              <ThemeProvider isDark={theme.palette.mode === "dark"}>
-                <UnconnectedPanelSetup {...props} />
-              </ThemeProvider>
-            </ExtensionCatalogProvider>
-          </PanelStateContextProvider>
-        </MockCurrentLayoutProvider>
-      </TimelineInteractionStateProvider>
-    </UserNodeStateProvider>
+    <WorkspaceContextProvider>
+      <UserNodeStateProvider>
+        <TimelineInteractionStateProvider>
+          <MockCurrentLayoutProvider onAction={props.onLayoutAction}>
+            <PanelStateContextProvider>
+              <ExtensionCatalogProvider loaders={[]}>
+                <ThemeProvider isDark={theme.palette.mode === "dark"}>
+                  <UnconnectedPanelSetup {...props} />
+                </ThemeProvider>
+              </ExtensionCatalogProvider>
+            </PanelStateContextProvider>
+          </MockCurrentLayoutProvider>
+        </TimelineInteractionStateProvider>
+      </UserNodeStateProvider>
+    </WorkspaceContextProvider>
   );
 }


### PR DESCRIPTION
**User-Facing Changes**
Persist sidebar UI state.

**Description**
Persist sidebar UI state. To make this more manageable I've lifted all the sidebar related state up into a new Workspace zustand context. This should make it easier to expand the slice of workspace state we want to persist in the future.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
