### PR TITLE
Replace Sentry.captureException with reportError()

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -66,7 +66,6 @@
     "@popperjs/core": "2.11.6",
     "@protobufjs/base64": "1.1.2",
     "@sentry/core": "7.43.0",
-    "@sentry/types": "7.30.0",
     "@storybook/addon-actions": "6.5.16",
     "@storybook/react": "6.5.16",
     "@testing-library/dom": "8.11.3",

--- a/packages/studio-base/src/components/ErrorBoundary.tsx
+++ b/packages/studio-base/src/components/ErrorBoundary.tsx
@@ -3,10 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Link, Button, Typography } from "@mui/material";
-import { captureException } from "@sentry/core";
 import { Component, ErrorInfo, PropsWithChildren, ReactNode } from "react";
 
 import Stack from "@foxglove/studio-base/components/Stack";
+import { reportError } from "@foxglove/studio-base/reportError";
 import { AppError } from "@foxglove/studio-base/util/errors";
 
 import ErrorDisplay from "./ErrorDisplay";
@@ -27,7 +27,7 @@ export default class ErrorBoundary extends Component<PropsWithChildren<Props>, S
   };
 
   public override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    captureException(new AppError(error, errorInfo));
+    reportError(new AppError(error, errorInfo));
     this.setState({ currentError: { error, errorInfo } });
   }
 

--- a/packages/studio-base/src/components/PanelErrorBoundary.tsx
+++ b/packages/studio-base/src/components/PanelErrorBoundary.tsx
@@ -3,9 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Box, Button, Link, Stack } from "@mui/material";
-import { captureException } from "@sentry/core";
 import { Component, ErrorInfo, PropsWithChildren, ReactNode } from "react";
 
+import { reportError } from "@foxglove/studio-base/reportError";
 import { AppError } from "@foxglove/studio-base/util/errors";
 
 import ErrorDisplay from "./ErrorDisplay";
@@ -27,7 +27,7 @@ export default class PanelErrorBoundary extends Component<PropsWithChildren<Prop
   };
 
   public override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    captureException(new AppError(error, errorInfo));
+    reportError(new AppError(error, errorInfo));
     this.setState({ currentError: { error, errorInfo } });
   }
 

--- a/packages/studio-base/src/components/Preferences.tsx
+++ b/packages/studio-base/src/components/Preferences.tsx
@@ -23,7 +23,6 @@ import {
   ToggleButtonGroupProps,
   SelectChangeEvent,
 } from "@mui/material";
-import { captureException } from "@sentry/core";
 import moment from "moment-timezone";
 import { MouseEvent, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,6 +37,7 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { Language } from "@foxglove/studio-base/i18n";
+import { reportError } from "@foxglove/studio-base/reportError";
 import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 import { TimeDisplayMethod } from "@foxglove/studio-base/types/panels";
 import { formatTime } from "@foxglove/studio-base/util/formatTime";
@@ -366,7 +366,7 @@ export function LanguageSettings(): React.ReactElement {
       void setSelectedLanguage(lang);
       i18n.changeLanguage(lang).catch((error) => {
         console.error("Failed to switch languages", error);
-        captureException(error);
+        reportError(error as Error);
       });
     },
     [i18n, setSelectedLanguage],

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -48,3 +48,4 @@ export { default as VelodyneDataSourceFactory } from "./dataSources/VelodyneData
 export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";
 export { default as SampleNuscenesDataSourceFactory } from "./dataSources/SampleNuscenesDataSourceFactory";
 export { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
+export { reportError, setReportErrorHandler } from "./reportError";

--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { captureException } from "@sentry/core";
 import { isEqual, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import shallowequal from "shallowequal";
@@ -50,6 +49,7 @@ import {
   PlayerProblem,
   MessageBlock,
 } from "@foxglove/studio-base/players/types";
+import { reportError } from "@foxglove/studio-base/reportError";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 import { UserNode, UserNodes } from "@foxglove/studio-base/types/panels";
 import Rpc from "@foxglove/studio-base/util/Rpc";
@@ -969,7 +969,7 @@ export default class UserNodePlayer implements Player {
       })
       .catch((err) => {
         log.error(err);
-        captureException(err);
+        reportError(err);
       });
   }
 

--- a/packages/studio-base/src/reportError.ts
+++ b/packages/studio-base/src/reportError.ts
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+type ReportErrorHandler = (error: Error) => void;
+let reportFn: ReportErrorHandler = (_err: Error) => {};
+
+/**
+ * Report an error that has escaped past normal error-handling flows in the app and should be
+ * triaged and diagnosed.
+ */
+export function reportError(error: Error): void {
+  reportFn(error);
+}
+
+/**
+ * Set the handler function which will be called when an error is passed to `reportError()`. The default is
+ * a no-op.
+ */
+export function setReportErrorHandler(fn: ReportErrorHandler): void {
+  reportFn = fn;
+}

--- a/packages/studio-base/src/util/layout.ts
+++ b/packages/studio-base/src/util/layout.ts
@@ -10,7 +10,6 @@
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
-import { captureException } from "@sentry/core";
 import { compact, flatMap, xor, uniq } from "lodash";
 import {
   createRemoveUpdate,
@@ -30,6 +29,7 @@ import {
   ConfigsPayload,
   SaveConfigsPayload,
 } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { reportError } from "@foxglove/studio-base/reportError";
 import { TabConfig, TabLocation, TabPanelConfig } from "@foxglove/studio-base/types/layouts";
 import {
   PanelConfig,
@@ -297,13 +297,13 @@ export const validateTabPanelConfig = (config?: PanelConfig): config is TabPanel
       "A non-Tab panel config is being operated on as if it were a Tab panel.",
     );
     log.info(`Invalid Tab panel config: ${error.message}`, config);
-    captureException(error);
+    reportError(error);
     return false;
   }
   if (config.activeTabIdx >= config.tabs.length) {
     const error = new Error("A Tab panel has an activeTabIdx for a nonexistent tab.");
     log.info(`Invalid Tab panel config: ${error.message}`, config);
-    captureException(error);
+    reportError(error);
     return false;
   }
   return true;

--- a/packages/studio-base/src/util/sendNotification.ts
+++ b/packages/studio-base/src/util/sendNotification.ts
@@ -16,10 +16,9 @@
 // etc). We should generally prevent users from making mistakes in the first place, but sometimes
 // its unavoidable to bail out with a generic error message (e.g. when dragging in a malformed
 // ROS bag).
-import { captureException } from "@sentry/core";
-import { SeverityLevel } from "@sentry/types";
 import { ReactNode } from "react";
 
+import { reportError } from "@foxglove/studio-base/reportError";
 import { AppError } from "@foxglove/studio-base/util/errors";
 import { inWebWorker } from "@foxglove/studio-base/util/workers";
 
@@ -90,10 +89,8 @@ export default function sendNotification(
 ): void {
   // We only want to send non-user errors and warnings to Sentry
   if (type === "app") {
-    const sentrySeverity: SeverityLevel | undefined =
-      severity === "error" ? "error" : severity === "warn" ? "warning" : undefined;
-    if (sentrySeverity != undefined) {
-      captureException(new AppError(details, message), { level: sentrySeverity });
+    if (severity === "warn" || severity === "error") {
+      reportError(new AppError(details, message));
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,6 @@ __metadata:
     "@popperjs/core": 2.11.6
     "@protobufjs/base64": 1.1.2
     "@sentry/core": 7.43.0
-    "@sentry/types": 7.30.0
     "@storybook/addon-actions": 6.5.16
     "@storybook/react": 6.5.16
     "@testing-library/dom": 8.11.3
@@ -3879,13 +3878,6 @@ __metadata:
     "@sentry/utils": 7.43.0
     tslib: ^1.9.3
   checksum: 54e6b8c0ae6830211ff94d99a6d5f31fa461a9de6c4baf1507945ba7225d61bac7d48b0c021e8a8cb109ce30c83165dcbef6aba9f6a205d69703eb99b95077d0
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:7.30.0":
-  version: 7.30.0
-  resolution: "@sentry/types@npm:7.30.0"
-  checksum: be228ae65f8750513371b6692821aa0d92d15354aa9fd7f1f1b497c2a53d20769fd56f89a1516d80e416ab73596609e805a6fae2b51510018338eedf5a0dd260
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Remove `Sentry.captureException()` calls and replace them with a new `reportError()` function that can be overridden.
When https://github.com/foxglove/studio/pull/5589 merges we will be able to completely remove the `@sentry/core` dependency.
Relates to FG-2454