### PR TITLE
Bump @foxglove/rosmsg to 4.2.1

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@foxglove/message-definition": "0.2.0",
-    "@foxglove/rosmsg": "4.2.0",
+    "@foxglove/rosmsg": "4.2.1",
     "@foxglove/rosmsg-serialization": "2.0.0",
     "@foxglove/rosmsg2-serialization": "2.0.0",
     "@foxglove/schemas": "1.1.2",

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -44,7 +44,7 @@
     "@foxglove/rosbag": "0.3.0",
     "@foxglove/rosbag2-web": "4.1.0",
     "@foxglove/roslibjs": "0.0.1",
-    "@foxglove/rosmsg": "4.0.0",
+    "@foxglove/rosmsg": "4.2.1",
     "@foxglove/rosmsg-msgs-common": "3.0.0",
     "@foxglove/rosmsg-serialization": "2.0.0",
     "@foxglove/rosmsg2-serialization": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,7 +2219,7 @@ __metadata:
   resolution: "@foxglove/mcap-support@workspace:packages/mcap-support"
   dependencies:
     "@foxglove/message-definition": 0.2.0
-    "@foxglove/rosmsg": 4.2.0
+    "@foxglove/rosmsg": 4.2.1
     "@foxglove/rosmsg-serialization": 2.0.0
     "@foxglove/rosmsg2-serialization": 2.0.0
     "@foxglove/schemas": 1.1.2
@@ -2362,19 +2362,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg@npm:4.0.0":
-  version: 4.0.0
-  resolution: "@foxglove/rosmsg@npm:4.0.0"
+"@foxglove/rosmsg@npm:4.2.1":
+  version: 4.2.1
+  resolution: "@foxglove/rosmsg@npm:4.2.1"
   dependencies:
     "@foxglove/message-definition": ^0.2.0
     md5-typescript: ^1.0.5
   bin:
     gendeps2: bin/gendeps2
-  checksum: d3a685cdadb03e0be0bd906b99cbea1b31fe6e2129c54d1f4229f5f4f4198bebae93961fc2f77ecc96a7fd0da7de432018fc4bcbaee6e36f24e062f7c5f33672
+  checksum: 68477e61f5a8aeb722465e2d89c09038a21ca848aa281224f67bce28d1a0328aa19fa3acbb2256bcdf54854abeffebfeefbac026ca0cd97b58318576f8409683
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg@npm:4.2.0, @foxglove/rosmsg@npm:^4.0.0":
+"@foxglove/rosmsg@npm:^4.0.0":
   version: 4.2.0
   resolution: "@foxglove/rosmsg@npm:4.2.0"
   dependencies:
@@ -2445,7 +2445,7 @@ __metadata:
     "@foxglove/rosbag": 0.3.0
     "@foxglove/rosbag2-web": 4.1.0
     "@foxglove/roslibjs": 0.0.1
-    "@foxglove/rosmsg": 4.0.0
+    "@foxglove/rosmsg": 4.2.1
     "@foxglove/rosmsg-msgs-common": 3.0.0
     "@foxglove/rosmsg-serialization": 2.0.0
     "@foxglove/rosmsg2-serialization": 2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2362,7 +2362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@foxglove/rosmsg@npm:4.2.1":
+"@foxglove/rosmsg@npm:4.2.1, @foxglove/rosmsg@npm:^4.0.0":
   version: 4.2.1
   resolution: "@foxglove/rosmsg@npm:4.2.1"
   dependencies:
@@ -2371,18 +2371,6 @@ __metadata:
   bin:
     gendeps2: bin/gendeps2
   checksum: 68477e61f5a8aeb722465e2d89c09038a21ca848aa281224f67bce28d1a0328aa19fa3acbb2256bcdf54854abeffebfeefbac026ca0cd97b58318576f8409683
-  languageName: node
-  linkType: hard
-
-"@foxglove/rosmsg@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "@foxglove/rosmsg@npm:4.2.0"
-  dependencies:
-    "@foxglove/message-definition": ^0.2.0
-    md5-typescript: ^1.0.5
-  bin:
-    gendeps2: bin/gendeps2
-  checksum: 4d247a9157644702420dfc15aa29e9735f385dd5ab46c2ef88ca5a650e52658a57058f8d0532137adef5c62922496fca2769ee23555e17786f0366219476cd63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix ros2idl schema `double` size

**Description**
- update rosmsg library to 4.2.1



<!-- link relevant GitHub issues -->
FG-2536
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
