### PR TITLE
Improve plot panel tooltip contrast

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -11,8 +11,9 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
+import { Square24Filled } from "@fluentui/react-icons";
 import { sortBy, take } from "lodash";
-import { PropsWithChildren, useMemo } from "react";
+import { Fragment, PropsWithChildren, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
@@ -35,17 +36,37 @@ const useStyles = makeStyles()((theme) => ({
     lineHeight: theme.typography.caption.lineHeight,
     overflowWrap: "break-word",
   },
-  overflow: {
-    opacity: theme.palette.action.disabledOpacity,
-    fontStyle: "italic",
+  grid: {
+    columnGap: theme.spacing(0.5),
+    display: "grid",
+    gridTemplateColumns: "auto minmax(0px, max-content) minmax(auto, max-content)",
+    alignItems: "center",
+  },
+  icon: {
+    gridColumn: "1",
+    height: 12,
+    width: 12,
   },
   path: {
     opacity: 0.9,
     whiteSpace: "nowrap",
   },
+  value: {
+    fontWeight: 600,
+    paddingLeft: theme.spacing(2),
+  },
+  overflow: {
+    gridColumn: "2/4",
+    opacity: theme.palette.action.disabledOpacity,
+    fontStyle: "italic",
+
+    ":not(:last-child)": {
+      marginBottom: theme.spacing(0.5),
+    },
+  },
 }));
 
-function OverflowMessage() {
+function OverflowMessage(): JSX.Element {
   const { classes } = useStyles();
 
   return <div className={classes.overflow}>&lt;multiple values under cursor&gt;</div>;
@@ -111,35 +132,36 @@ export default function TimeBasedChartTooltipContent(
 
   return (
     <div className={classes.root} data-testid="TimeBasedChartTooltipContent">
-      {sortedItems.map(([path, items], idx) => {
-        const firstItem = items[0];
-        const color =
-          firstItem?.datasetIndex != undefined
-            ? colorsByDatasetIndex?.[firstItem.datasetIndex]
-            : "auto";
-        return (
-          <div key={idx}>
-            <div className={classes.path} style={{ color: color ?? "auto" }}>
-              {path}
-            </div>
-            {take(items, 1).map((item, itemIdx) => {
-              const value =
-                typeof item.value === "string"
-                  ? item.value
-                  : typeof item.value === "bigint"
-                  ? item.value.toString()
-                  : JSON.stringify(item.value);
-              return (
-                <div key={itemIdx}>
-                  {value}
-                  {item.constantName != undefined ? ` (${item.constantName})` : ""}
-                </div>
-              );
-            })}
-            {itemsByPath.overflow.has(path) && <OverflowMessage />}
-          </div>
-        );
-      })}
+      <div className={classes.grid}>
+        {sortedItems.map(([path, items], idx) => {
+          const firstItem = items[0];
+          const color =
+            firstItem?.datasetIndex != undefined
+              ? colorsByDatasetIndex?.[firstItem.datasetIndex]
+              : "auto";
+          return (
+            <Fragment key={idx}>
+              <Square24Filled className={classes.icon} primaryFill={color} />
+              <div className={classes.path}>{path}</div>
+              {take(items, 1).map((item, itemIdx) => {
+                const value =
+                  typeof item.value === "string"
+                    ? item.value
+                    : typeof item.value === "bigint"
+                    ? item.value.toString()
+                    : JSON.stringify(item.value);
+                return (
+                  <div className={classes.value} key={itemIdx}>
+                    {value}
+                    {item.constantName != undefined ? ` (${item.constantName})` : ""}
+                  </div>
+                );
+              })}
+              {itemsByPath.overflow.has(path) && <OverflowMessage />}
+            </Fragment>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -16,6 +16,7 @@ import { sortBy, take } from "lodash";
 import { Fragment, PropsWithChildren, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import Stack from "@foxglove/studio-base/components/Stack";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { TimeBasedChartTooltipData } from "./index";
@@ -29,8 +30,6 @@ type Props = {
 
 const useStyles = makeStyles()((theme) => ({
   root: {
-    display: "flex",
-    flexDirection: "column",
     fontFamily: fonts.MONOSPACE,
     fontSize: theme.typography.caption.fontSize,
     lineHeight: theme.typography.caption.lineHeight,
@@ -41,6 +40,10 @@ const useStyles = makeStyles()((theme) => ({
     display: "grid",
     gridTemplateColumns: "auto minmax(0px, max-content) minmax(auto, max-content)",
     alignItems: "center",
+    fontFamily: fonts.MONOSPACE,
+    fontSize: theme.typography.caption.fontSize,
+    lineHeight: theme.typography.caption.lineHeight,
+    overflowWrap: "break-word",
   },
   icon: {
     gridColumn: "1",
@@ -76,7 +79,7 @@ export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
   const { colorsByDatasetIndex, content, multiDataset } = props;
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles();
 
   const itemsByPath = useMemo(() => {
     const out = new Map<string, TimeBasedChartTooltipData[]>();
@@ -104,7 +107,7 @@ export default function TimeBasedChartTooltipContent(
   // not include all datasets
   if (!multiDataset) {
     return (
-      <div className={classes.root} data-testid="TimeBasedChartTooltipContent">
+      <Stack className={classes.root} data-testid="TimeBasedChartTooltipContent">
         {take(content, 1).map((item, idx) => {
           const value =
             typeof item.value === "string"
@@ -120,7 +123,7 @@ export default function TimeBasedChartTooltipContent(
           );
         })}
         {content.length > 1 && <OverflowMessage />}
-      </div>
+      </Stack>
     );
   }
 
@@ -131,37 +134,35 @@ export default function TimeBasedChartTooltipContent(
   );
 
   return (
-    <div className={classes.root} data-testid="TimeBasedChartTooltipContent">
-      <div className={classes.grid}>
-        {sortedItems.map(([path, items], idx) => {
-          const firstItem = items[0];
-          const color =
-            firstItem?.datasetIndex != undefined
-              ? colorsByDatasetIndex?.[firstItem.datasetIndex]
-              : "auto";
-          return (
-            <Fragment key={idx}>
-              <Square24Filled className={classes.icon} primaryFill={color} />
-              <div className={classes.path}>{path}</div>
-              {take(items, 1).map((item, itemIdx) => {
-                const value =
-                  typeof item.value === "string"
-                    ? item.value
-                    : typeof item.value === "bigint"
-                    ? item.value.toString()
-                    : JSON.stringify(item.value);
-                return (
-                  <div className={classes.value} key={itemIdx}>
-                    {value}
-                    {item.constantName != undefined ? ` (${item.constantName})` : ""}
-                  </div>
-                );
-              })}
-              {itemsByPath.overflow.has(path) && <OverflowMessage />}
-            </Fragment>
-          );
-        })}
-      </div>
+    <div className={cx(classes.root, classes.grid)} data-testid="TimeBasedChartTooltipContent">
+      {sortedItems.map(([path, items], idx) => {
+        const firstItem = items[0];
+        const color =
+          firstItem?.datasetIndex != undefined
+            ? colorsByDatasetIndex?.[firstItem.datasetIndex]
+            : "auto";
+        return (
+          <Fragment key={idx}>
+            <Square24Filled className={classes.icon} primaryFill={color} />
+            <div className={classes.path}>{path}</div>
+            {take(items, 1).map((item, itemIdx) => {
+              const value =
+                typeof item.value === "string"
+                  ? item.value
+                  : typeof item.value === "bigint"
+                  ? item.value.toString()
+                  : JSON.stringify(item.value);
+              return (
+                <div className={classes.value} key={itemIdx}>
+                  {value}
+                  {item.constantName != undefined ? ` (${item.constantName})` : ""}
+                </div>
+              );
+            })}
+            {itemsByPath.overflow.has(path) && <OverflowMessage />}
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/packages/studio-base/src/util/plotColors.ts
+++ b/packages/studio-base/src/util/plotColors.ts
@@ -22,11 +22,10 @@ export const lineColors = [
   toolsColorScheme.blue.medium,
   toolsColorScheme.orange.medium,
   toolsColorScheme.yellow.medium,
-  toolsColorScheme.purple.dark,
-  toolsColorScheme.cyan.medium,
   toolsColorScheme.green.medium,
+  toolsColorScheme.cyan.medium,
+  toolsColorScheme.purple.medium,
   toolsColorScheme.paleGreen.medium,
-  "#DDDDDD",
 ];
 
 const colorExpansion = lineColors.map((color) => [

--- a/packages/studio-base/src/util/toolsColorScheme.ts
+++ b/packages/studio-base/src/util/toolsColorScheme.ts
@@ -57,7 +57,7 @@ export const toolsColorScheme = {
   yellow: {
     dark: "#EDCC28",
     medium: "#f7df71",
-    light: "#f1e4a",
+    light: "#f1e4aa",
   },
 };
 


### PR DESCRIPTION
**User-Facing Changes**
Restyled Chart tooltips

| Light theme | Dark theme |
|---|---|
| <img width="555" alt="Screen Shot 2023-03-23 at 12 42 51 pm" src="https://user-images.githubusercontent.com/924528/227077854-25d11db5-fbc0-47ef-ab2f-e12f18bad4ca.png"> | <img width="554" alt="Screen Shot 2023-03-23 at 12 43 22 pm" src="https://user-images.githubusercontent.com/924528/227077860-b874a0f2-f11a-4810-9f29-06f9b6aea2af.png"> |

**Description**
Abandon text color in favor of icon for better readability, drop light grey as default plot color and move purple down the list

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
