### PR TITLE
studio-desktop: pass AppConfiguration in as argument to main()

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "@foxglove/log": "workspace:*",
+    "@foxglove/studio-base": "workspace:*",
     "@foxglove/studio-desktop": "workspace:*",
     "electron": "23.1.4",
     "playwright": "1.30.0",

--- a/desktop/renderer/index.ts
+++ b/desktop/renderer/index.ts
@@ -2,6 +2,24 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { main } from "@foxglove/studio-desktop/src/renderer/index";
+import { AppSetting } from "@foxglove/studio-base";
+import { Storage } from "@foxglove/studio-desktop/src/common/types";
+import { main as rendererMain } from "@foxglove/studio-desktop/src/renderer/index";
+import NativeStorageAppConfiguration from "@foxglove/studio-desktop/src/renderer/services/NativeStorageAppConfiguration";
+
+const isDevelopment = process.env.NODE_ENV === "development";
+
+async function main() {
+  const appConfiguration = await NativeStorageAppConfiguration.Initialize(
+    (global as { storageBridge?: Storage }).storageBridge!,
+    {
+      defaults: {
+        [AppSetting.SHOW_DEBUG_PANELS]: isDevelopment,
+      },
+    },
+  );
+
+  await rendererMain({ appConfiguration });
+}
 
 void main();

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -34,7 +34,7 @@
     "@foxglove/comlink-transfer-handlers": "workspace:*",
     "@foxglove/crc": "0.0.3",
     "@foxglove/den": "workspace:*",
-    "@foxglove/electron-socket": "2.1.0",
+    "@foxglove/electron-socket": "2.1.1",
     "@foxglove/hooks": "workspace:*",
     "@foxglove/log": "workspace:*",
     "@foxglove/mcap-support": "workspace:*",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -78,7 +78,11 @@ function useFeatures(): Feature[] {
     {
       key: AppSetting.ENABLE_ROS2_NATIVE_DATA_SOURCE,
       name: t("ros2NativeConnection"),
-      description: <>{t("ros2NativeConnectionDescription")}</>,
+      description: (
+        <>
+          {t("ros2NativeConnectionDescription")} {t("restartTheAppForChangesToTakeEffect")}
+        </>
+      ),
     },
   ];
 

--- a/packages/studio-desktop/package.json
+++ b/packages/studio-desktop/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@actions/exec": "1.1.1",
     "@actions/tool-cache": "2.0.1",
-    "@foxglove/electron-socket": "2.1.0",
+    "@foxglove/electron-socket": "2.1.1",
     "@foxglove/log": "workspace:*",
     "@foxglove/mcap-support": "workspace:*",
     "@foxglove/rosbag": "0.3.0",

--- a/packages/studio-desktop/src/main/getDevModeIcon.ts
+++ b/packages/studio-desktop/src/main/getDevModeIcon.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { NativeImage, nativeImage } from "electron";
+import path from "path";
 import tinycolor from "tinycolor2";
 
 const ROTATION_DEGREES = 270;
@@ -11,7 +12,14 @@ const ROTATION_DEGREES = 270;
 export default function getDevModeIcon(): NativeImage | undefined {
   try {
     // This can fail when opening the app from a packaged DMG.
-    const originalIcon = nativeImage.createFromPath("resources/icon/icon.png");
+    const originalIcon = nativeImage.createFromPath(
+      path.resolve(
+        __dirname,
+        "..",
+        require.resolve("@foxglove/studio-desktop/src/main"),
+        "../../../resources/icon/icon.png",
+      ),
+    );
 
     const buffer = originalIcon.toBitmap();
     for (let i = 0; i + 3 < buffer.length; i += 4) {

--- a/packages/studio-desktop/src/renderer/index.tsx
+++ b/packages/studio-desktop/src/renderer/index.tsx
@@ -11,21 +11,17 @@ import ReactDOM from "react-dom";
 import { Sockets } from "@foxglove/electron-socket/renderer";
 import Logger from "@foxglove/log";
 import {
-  AppSetting,
   installDevtoolsFormatters,
   overwriteFetch,
   waitForFonts,
   initI18n,
   IDataSourceFactory,
+  IAppConfiguration,
 } from "@foxglove/studio-base";
 
 import Root from "./Root";
-import NativeStorageAppConfiguration from "./services/NativeStorageAppConfiguration";
-import { Storage } from "../common/types";
 
 const log = Logger.getLogger(__filename);
-
-const isDevelopment = process.env.NODE_ENV === "development";
 
 function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
   useEffect(() => {
@@ -39,9 +35,10 @@ function LogAfterRender(props: React.PropsWithChildren<unknown>): JSX.Element {
 type MainParams = {
   dataSources?: IDataSourceFactory[];
   extraProviders?: JSX.Element[];
+  appConfiguration: IAppConfiguration;
 };
 
-export async function main(params: MainParams = {}): Promise<void> {
+export async function main(params: MainParams): Promise<void> {
   log.debug("initializing renderer");
 
   installDevtoolsFormatters();
@@ -61,20 +58,11 @@ export async function main(params: MainParams = {}): Promise<void> {
   await waitForFonts();
   await initI18n();
 
-  const appConfiguration = await NativeStorageAppConfiguration.Initialize(
-    (global as { storageBridge?: Storage }).storageBridge!,
-    {
-      defaults: {
-        [AppSetting.SHOW_DEBUG_PANELS]: isDevelopment,
-      },
-    },
-  );
-
   ReactDOM.render(
     <StrictMode>
       <LogAfterRender>
         <Root
-          appConfiguration={appConfiguration}
+          appConfiguration={params.appConfiguration}
           extraProviders={params.extraProviders}
           dataSources={params.dataSources}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11100,6 +11100,7 @@ __metadata:
   resolution: "desktop@workspace:desktop"
   dependencies:
     "@foxglove/log": "workspace:*"
+    "@foxglove/studio-base": "workspace:*"
     "@foxglove/studio-desktop": "workspace:*"
     electron: 23.1.4
     playwright: 1.30.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,15 +2147,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@foxglove/electron-socket@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@foxglove/electron-socket@npm:2.1.0"
+"@foxglove/electron-socket@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@foxglove/electron-socket@npm:2.1.1"
   dependencies:
     dns-packet: ^5.2.4
     eventemitter3: ^4.0.7
   peerDependencies:
     electron: ">=12"
-  checksum: 71cfb3160127e4499df876234b7134fb4740e7bdf141f55e8398762c316a4a64bc520a7aa927699be1a4cf76548ce78028764f3f4a895e341f1c83d7e7a9d128
+  checksum: dc9d34999d12002de20f39b4d516016303edfd8ea9f825f93ac12824f6443680585fa52f95319b3f1c9116df678adc15a011f313ee94eb76a021fe44d37dab20
   languageName: node
   linkType: hard
 
@@ -2423,7 +2423,7 @@ __metadata:
     "@foxglove/comlink-transfer-handlers": "workspace:*"
     "@foxglove/crc": 0.0.3
     "@foxglove/den": "workspace:*"
-    "@foxglove/electron-socket": 2.1.0
+    "@foxglove/electron-socket": 2.1.1
     "@foxglove/hooks": "workspace:*"
     "@foxglove/log": "workspace:*"
     "@foxglove/mcap-support": "workspace:*"
@@ -2599,7 +2599,7 @@ __metadata:
   dependencies:
     "@actions/exec": 1.1.1
     "@actions/tool-cache": 2.0.1
-    "@foxglove/electron-socket": 2.1.0
+    "@foxglove/electron-socket": 2.1.1
     "@foxglove/log": "workspace:*"
     "@foxglove/mcap-support": "workspace:*"
     "@foxglove/rosbag": 0.3.0


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
AppConfiguration is now passed in as an argument to main() instead of being created in main(). This allows the calling code to read the configuration before creating other parameters to main().

Relates to FG-2506 / https://github.com/foxglove/studio/pull/5070