### PR TITLE
Create a bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,18 @@
+---
+name: "🐞 Bug report"
+about: Report broken functionality or incorrect documentation
+labels: "bug"
+---
+
+**Description**
+
+
+- Version:
+- Platform:
+- Data source (e.g. bag file, mcap file, rosbridge, ROS 1/2 native):
+
+**Steps To Reproduce**
+<!--- Include the minimum possible code, example data, or screenshots to reproduce the problem. -->
+
+
+**Expected Behavior**


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Copy our generic bug issue template (https://github.com/foxglove/.github/blob/main/.github/ISSUE_TEMPLATE/bug.md) and add a line for "Data source".

For Studio issues it is helpful to know the data source; which is not relevant on other code repos.

Removed in: https://github.com/foxglove/studio/pull/4975