### PR TITLE
Rearrange sidebar items

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -571,7 +571,7 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
 
   const leftSidebarItems = useMemo(() => {
     const items = new Map<LeftSidebarItemKey, NewSidebarItem>([
-      ["panel-settings", { title: "Panel settings", component: PanelSettingsSidebar }],
+      ["panel-settings", { title: "Panel", component: PanelSettingsSidebar }],
       ["topics", { title: "Topics", component: TopicList }],
     ]);
     return items;

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -571,24 +571,24 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
 
   const leftSidebarItems = useMemo(() => {
     const items = new Map<LeftSidebarItemKey, NewSidebarItem>([
+      ["panel-settings", { title: "Panel settings", component: PanelSettingsSidebar }],
       ["topics", { title: "Topics", component: TopicList }],
+    ]);
+    return items;
+  }, [PanelSettingsSidebar]);
+
+  const rightSidebarItems = useMemo(() => {
+    const items = new Map<RightSidebarItemKey, NewSidebarItem>([
       ["variables", { title: "Variables", component: VariablesList }],
     ]);
     if (enableStudioLogsSidebar) {
       items.set("studio-logs-settings", { title: "Studio Logs", component: StudioLogsSettings });
     }
-    return items;
-  }, [enableStudioLogsSidebar]);
-
-  const rightSidebarItems = useMemo(() => {
-    const items = new Map<RightSidebarItemKey, NewSidebarItem>([
-      ["panel-settings", { title: "Panel settings", component: PanelSettingsSidebar }],
-    ]);
     if (showEventsTab) {
       items.set("events", { title: "Events", component: EventsList });
     }
     return items;
-  }, [PanelSettingsSidebar, showEventsTab]);
+  }, [enableStudioLogsSidebar, showEventsTab]);
 
   const keyDownHandlers = useMemo(() => {
     return {

--- a/packages/studio-base/src/components/Sidebars/index.tsx
+++ b/packages/studio-base/src/components/Sidebars/index.tsx
@@ -200,7 +200,7 @@ export default function Sidebars<
     enableNewTopNav && selectedRightKey != undefined && rightItems.has(selectedRightKey);
 
   useEffect(() => {
-    const leftTargetWidth = enableNewTopNav ? 280 : 384;
+    const leftTargetWidth = enableNewTopNav ? 320 : 384;
     const rightTargetWidth = 320;
     const defaultLeftPercentage = 100 * (leftTargetWidth / window.innerWidth);
     const defaultRightPercentage = 100 * (1 - rightTargetWidth / window.innerWidth);

--- a/packages/studio-base/src/context/WorkspaceContext.ts
+++ b/packages/studio-base/src/context/WorkspaceContext.ts
@@ -24,8 +24,11 @@ export type SidebarItemKey =
   | "studio-logs-settings"
   | "variables";
 
-export type LeftSidebarItemKey = "topics" | "variables" | "studio-logs-settings";
-export type RightSidebarItemKey = "panel-settings" | "events";
+const LeftSidebarItemKeys = ["panel-settings", "topics"] as const;
+export type LeftSidebarItemKey = (typeof LeftSidebarItemKeys)[number];
+
+const RightSidebarItemKeys = ["events", "variables", "studio-logs-settings"] as const;
+export type RightSidebarItemKey = (typeof RightSidebarItemKeys)[number];
 
 export type WorkspaceContextStore = DeepReadonly<{
   layoutMenuOpen: boolean;
@@ -46,7 +49,7 @@ WorkspaceContext.displayName = "WorkspaceContext";
 
 export const WorkspaceStoreSelectors = {
   selectPanelSettingsOpen: (store: WorkspaceContextStore): boolean =>
-    store.sidebarItem === "panel-settings" || store.rightSidebarItem === "panel-settings",
+    store.sidebarItem === "panel-settings" || store.leftSidebarItem === "panel-settings",
 };
 
 /**
@@ -101,7 +104,7 @@ export function useWorkspaceActions(): WorkspaceActions {
     return {
       openPanelSettings: () =>
         enableNewTopNav
-          ? set({ rightSidebarItem: "panel-settings", rightSidebarOpen: true })
+          ? set({ leftSidebarItem: "panel-settings", leftSidebarOpen: true })
           : set({ sidebarItem: "panel-settings" }),
 
       openAccountSettings: () => supportsAccountSettings && set({ sidebarItem: "account" }),
@@ -137,9 +140,10 @@ export function useWorkspaceActions(): WorkspaceActions {
         set((oldValue) => {
           const leftSidebarOpen = setterValue(setter, oldValue.leftSidebarOpen);
           if (leftSidebarOpen) {
+            const oldItem = LeftSidebarItemKeys.find((item) => item === oldValue.leftSidebarItem);
             return {
               leftSidebarOpen,
-              leftSidebarItem: oldValue.leftSidebarItem ?? "topics",
+              leftSidebarItem: oldItem ?? "panel-settings",
             };
           } else {
             return { leftSidebarOpen: false };
@@ -152,10 +156,11 @@ export function useWorkspaceActions(): WorkspaceActions {
       setRightSidebarOpen: (setter: SetStateAction<boolean>) => {
         set((oldValue) => {
           const rightSidebarOpen = setterValue(setter, oldValue.rightSidebarOpen);
+          const oldItem = RightSidebarItemKeys.find((item) => item === oldValue.rightSidebarItem);
           if (rightSidebarOpen) {
             return {
               rightSidebarOpen,
-              rightSidebarItem: oldValue.rightSidebarItem ?? "panel-settings",
+              rightSidebarItem: oldItem ?? "variables",
             };
           } else {
             return { rightSidebarOpen: false };

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -19,8 +19,8 @@ function createWorkspaceContextStore(
       () => {
         const store: WorkspaceContextStore = {
           layoutMenuOpen: false,
-          leftSidebarItem: undefined,
-          leftSidebarOpen: false,
+          leftSidebarItem: "panel-settings",
+          leftSidebarOpen: true,
           leftSidebarSize: undefined,
           rightSidebarItem: undefined,
           rightSidebarOpen: false,


### PR DESCRIPTION
**User-Facing Changes**
None (feature flagged)

**Description**
Rearranges the side bar items so that Settings & Topics are on the left and Events, Variables & Log Settings are on the right.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
