### PR TITLE
Show custom series labels in plot tooltips

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/TimeBasedChartTooltipContent.tsx
@@ -14,6 +14,7 @@
 import { Square24Filled } from "@fluentui/react-icons";
 import { sortBy, take } from "lodash";
 import { Fragment, PropsWithChildren, useMemo } from "react";
+import { DeepReadonly } from "ts-essentials";
 import { makeStyles } from "tss-react/mui";
 
 import Stack from "@foxglove/studio-base/components/Stack";
@@ -21,12 +22,13 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import { TimeBasedChartTooltipData } from "./index";
 
-type Props = {
+type Props = DeepReadonly<{
   colorsByDatasetIndex?: Record<string, undefined | string>;
   content: TimeBasedChartTooltipData[];
+  labelsByDatasetIndex?: Record<string, undefined | string>;
   // Flag indicating the containing chart has multiple datasets
   multiDataset: boolean;
-};
+}>;
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -78,7 +80,7 @@ function OverflowMessage(): JSX.Element {
 export default function TimeBasedChartTooltipContent(
   props: PropsWithChildren<Props>,
 ): React.ReactElement {
-  const { colorsByDatasetIndex, content, multiDataset } = props;
+  const { colorsByDatasetIndex, content, labelsByDatasetIndex, multiDataset } = props;
   const { classes, cx } = useStyles();
 
   const itemsByPath = useMemo(() => {
@@ -141,10 +143,14 @@ export default function TimeBasedChartTooltipContent(
           firstItem?.datasetIndex != undefined
             ? colorsByDatasetIndex?.[firstItem.datasetIndex]
             : "auto";
+        const label =
+          firstItem?.datasetIndex != undefined
+            ? labelsByDatasetIndex?.[firstItem.datasetIndex]
+            : undefined;
         return (
           <Fragment key={idx}>
             <Square24Filled className={classes.icon} primaryFill={color} />
-            <div className={classes.path}>{path}</div>
+            <div className={classes.path}>{label ?? path}</div>
             {take(items, 1).map((item, itemIdx) => {
               const value =
                 typeof item.value === "string"

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -11,17 +11,17 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 
-import { Tooltip, Button, useTheme, Fade } from "@mui/material";
+import { Button, Fade, Tooltip, useTheme } from "@mui/material";
 import { ChartOptions, ScaleOptions } from "chart.js";
 import { AnnotationOptions } from "chartjs-plugin-annotation";
 import React, {
-  useEffect,
-  useCallback,
-  useState,
-  useRef,
   ComponentProps,
-  useMemo,
   MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import { useMountedState, useThrottle } from "react-use";
 import { makeStyles } from "tss-react/mui";
@@ -39,15 +39,15 @@ import Stack from "@foxglove/studio-base/components/Stack";
 import {
   TimelineInteractionStateStore,
   useClearHoverValue,
-  useTimelineInteractionState,
   useSetHoverValue,
+  useTimelineInteractionState,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 
 import HoverBar from "./HoverBar";
 import TimeBasedChartTooltipContent from "./TimeBasedChartTooltipContent";
 import { VerticalBarWrapper } from "./VerticalBarWrapper";
-import { downsampleTimeseries, downsampleScatter } from "./downsample";
+import { downsampleScatter, downsampleTimeseries } from "./downsample";
 
 const log = Logger.getLogger(__filename);
 
@@ -755,6 +755,10 @@ export default function TimeBasedChart(props: Props): JSX.Element {
     );
   }, [data.datasets]);
 
+  const labelsByDatasetIndex = useMemo(() => {
+    return Object.fromEntries(data.datasets.map((dataset, index) => [index, dataset.label]));
+  }, [data.datasets]);
+
   const datasetsLength = datasets.length;
   const tooltipContent = useMemo(() => {
     return activeTooltip ? (
@@ -762,9 +766,10 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         content={activeTooltip.data}
         multiDataset={datasetsLength > 1}
         colorsByDatasetIndex={colorsByDatasetIndex}
+        labelsByDatasetIndex={labelsByDatasetIndex}
       />
     ) : undefined;
-  }, [activeTooltip, colorsByDatasetIndex, datasetsLength]);
+  }, [activeTooltip, colorsByDatasetIndex, datasetsLength, labelsByDatasetIndex]);
 
   // reset is shown if we have sync lock and there has been user interaction, or if we don't
   // have sync lock and the user has manually interacted with the plot

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -2,10 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { v4 as uuidv4 } from "uuid";
-
 import { filterMap } from "@foxglove/den/collection";
-import { isTime, Time, toSec, subtract } from "@foxglove/rostime";
+import { isTime, subtract, Time, toSec } from "@foxglove/rostime";
 import { format } from "@foxglove/studio-base/util/formatTime";
 import { darkColor, getLineColor, lightColor } from "@foxglove/studio-base/util/plotColors";
 import { formatTimeRaw, TimestampMethod } from "@foxglove/studio-base/util/time";
@@ -14,13 +12,13 @@ import { PlotXAxisVal } from "./index";
 import {
   BasePlotPath,
   DataSet,
+  Datum,
   isReferenceLinePlotPathType,
   PlotDataByPath,
   PlotDataItem,
   PlotPath,
-  Datum,
 } from "./internalTypes";
-import { derivative, applyToDatum, mathFunctions, MathFunction } from "./transformPlotRange";
+import { applyToDatum, derivative, MathFunction, mathFunctions } from "./transformPlotRange";
 
 const isCustomScale = (xAxisVal: PlotXAxisVal): boolean =>
   xAxisVal === "custom" || xAxisVal === "currentCustom";
@@ -218,7 +216,7 @@ function getDatasetsFromMessagePlotPath({
   const borderColor = getLineColor(path.color, index);
   const dataset: DataSet = {
     borderColor,
-    label: path.value ? path.value : uuidv4(),
+    label: path.label != undefined && path.label !== "" ? path.label : path.value,
     showLine,
     fill: false,
     borderWidth: 1,


### PR DESCRIPTION
**User-Facing Changes**
Show custom series labels in plot tooltips

**Description**
Use the custom label for each plot series, if any, in the plot tooltip.

<img width="500" alt="Screenshot 2023-03-27 at 8 19 42 AM" src="https://user-images.githubusercontent.com/93935560/227818793-c4d41e71-d033-4280-9b83-fd28fe000a8a.png">

We can do a followup for state transitions after https://github.com/foxglove/studio/pull/5604 merges.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
