### PR TITLE
foxglove-websocket: Add player problem for every status message

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -318,6 +318,17 @@ export default class FoxgloveWebSocketPlayer implements Player {
       } else {
         log.error(msg);
       }
+      
+      this._problems.addProblem(event.message, {
+        message: event.message,
+        severity:
+          event.level === StatusLevel.INFO
+            ? "info"
+            : event.level === StatusLevel.WARNING
+              ? "warn"
+              : "error",
+      });
+      this._emitState();
     });
 
     this._client.on("advertise", (newChannels) => {

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -23,6 +23,7 @@ import {
   PlayerCapabilities,
   PlayerMetricsCollectorInterface,
   PlayerPresence,
+  PlayerProblem,
   PlayerState,
   PublishPayload,
   SubscribePayload,
@@ -318,16 +319,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
       } else {
         log.error(msg);
       }
-      
-      this._problems.addProblem(event.message, {
+
+      const problem: PlayerProblem = {
         message: event.message,
-        severity:
-          event.level === StatusLevel.INFO
-            ? "info"
-            : event.level === StatusLevel.WARNING
-              ? "warn"
-              : "error",
-      });
+        severity: statusLevelToProblemSeverity(event.level),
+      };
+
+      if (event.message === "Send buffer limit reached") {
+        problem.tip =
+          "Server is dropping messages to the client. Check if you are subscribing to large or frequent topics or adjust your server send buffer limit.";
+      }
+
+      this._problems.addProblem(event.message, problem);
       this._emitState();
     });
 
@@ -981,4 +984,14 @@ function dataTypeToFullName(dataType: string): string {
     return `${parts[0]}/msg/${parts[1]}`;
   }
   return dataType;
+}
+
+function statusLevelToProblemSeverity(level: StatusLevel): PlayerProblem["severity"] {
+  if (level === StatusLevel.INFO) {
+    return "info";
+  } else if (level === StatusLevel.WARNING) {
+    return "warn";
+  } else {
+    return "error";
+  }
 }


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Add player problems for every incoming status message

**Description**
- Maps status messages to player problems (unresolvable for now)
- Adds a special tip if the player message is `"Send buffer limit reached"` (see https://github.com/foxglove/ros-foxglove-bridge/pull/201)

![Screenshot from 2023-03-27 15-26-46](https://user-images.githubusercontent.com/9250155/228033362-082fe28c-cfde-4b94-965e-dda68a6bb1ca.png)

Fixes: foxglove/ros-foxglove-bridge/issues/174
Fixes: FG-2202
