### PR TITLE
Add ISSUE_TEMPLATE config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "🙋‍♀️ Question"
+    url: https://github.com/orgs/foxglove/discussions/new/choose
+    about: Search discussions or ask our community for help
+  - name: "🚀 Feature request"
+    url: https://github.com/orgs/foxglove/discussions/new/choose
+    about: Search existing feature requests or share a new idea
+  - name: "📚 Stack Exchange"
+    url: https://robotics.stackexchange.com/questions/ask
+    about: Get help from the robotics community
+  - name: "💬 Live chat"
+    url: https://foxglove.dev/slack
+    about: Join the discussion in our Slack community


### PR DESCRIPTION

**User-Facing Changes**
None

**Description**
Guide users with questions or feature requests to our discussions.

We need this in the repo since the base one from `foxglove/.github` repo no longer appears after merging: https://github.com/foxglove/studio/pull/5626
