### PR TITLE
Add support for showing enums names in arrays in raw message panel

### DIFF
--- a/packages/studio-base/src/panels/RawMessages/fixture.ts
+++ b/packages/studio-base/src/panels/RawMessages/fixture.ts
@@ -271,9 +271,11 @@ const exampleMessage = {
   state: 1,
   justField: 0,
   color: 2,
+  cmykColors: [0, 1, 2, 3],
   animal__foxglove_enum: {},
   animal: 10000,
   sentence: 'String with "quotes" and /slashes/.',
+  pets: [10000, 10001, 10001, 10000],
 };
 
 // ts-prune-ignore-next
@@ -290,8 +292,15 @@ export const enumAdvancedFixture: Fixture = {
           { type: "uint8", name: "YELLOW", isConstant: true, value: 1 },
           { type: "uint8", name: "GREEN", isConstant: true, value: 2 },
           { type: "uint8", name: "color", isArray: false },
+          { type: "uint8", name: "CYAN", isConstant: true, value: 0 },
+          { type: "uint8", name: "MAGENTA", isConstant: true, value: 1 },
+          { type: "uint8", name: "YELLOW", isConstant: true, value: 2 },
+          { type: "uint8", name: "BLACK", isConstant: true, value: 3 },
+          { type: "uint8", name: "cmykColors", isArray: true },
           { type: "baz/animals", name: "animal__foxglove_enum", isArray: false },
           { type: "uint32", name: "animal", isArray: false },
+          { type: "baz/animals", name: "pets__foxglove_enum", isArray: false },
+          { type: "uint32", name: "pets", isArray: true },
         ],
       },
       "baz/enum_advanced_array": {

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -341,7 +341,7 @@ function RawMessages(props: Props) {
               keyPath.slice(0, -1).reverse(),
             );
             if (childStructureItem) {
-              // if it's an array entry we need most root (first) array field name to get the enum annotation, not the element index
+              // if it's an array index (typeof number) then we want the nearest named array which will be typeof string 
 
               const keyPathIndex = keyPath.findIndex((key) => typeof key === "string");
               const field = keyPath[keyPathIndex];

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -348,7 +348,7 @@ function RawMessages(props: Props) {
               if (typeof field === "string") {
                 const enumMapping = enumValuesByDatatypeAndField(datatypes);
                 const datatype = childStructureItem.datatype;
-                constantName = enumMapping[datatype]?.[field]![String(itemValue)];
+                constantName = enumMapping[datatype]?.[field]?.[String(itemValue)];
               }
             }
           }

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -341,7 +341,7 @@ function RawMessages(props: Props) {
               keyPath.slice(0, -1).reverse(),
             );
             if (childStructureItem) {
-              // if it's an array index (typeof number) then we want the nearest named array which will be typeof string 
+              // if it's an array index (typeof number) then we want the nearest named array which will be typeof string
 
               const keyPathIndex = keyPath.findIndex((key) => typeof key === "string");
               const field = keyPath[keyPathIndex];

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -341,7 +341,8 @@ function RawMessages(props: Props) {
               keyPath.slice(0, -1).reverse(),
             );
             if (childStructureItem) {
-              const field = keyPath[0];
+              // if it's an array entry we need the array field name to get the enum annotation, not the element index
+              const field = typeof keyPath[0] === "number" ? keyPath[1] : keyPath[0];
               if (typeof field === "string") {
                 const enumMapping = enumValuesByDatatypeAndField(datatypes);
                 const datatype = childStructureItem.datatype;

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -348,7 +348,7 @@ function RawMessages(props: Props) {
               if (typeof field === "string") {
                 const enumMapping = enumValuesByDatatypeAndField(datatypes);
                 const datatype = childStructureItem.datatype;
-                constantName = enumMapping[datatype]?.[field][String(itemValue)];
+                constantName = enumMapping[datatype]?.[field]![String(itemValue)];
               }
             }
           }

--- a/packages/studio-base/src/panels/RawMessages/index.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.tsx
@@ -341,12 +341,14 @@ function RawMessages(props: Props) {
               keyPath.slice(0, -1).reverse(),
             );
             if (childStructureItem) {
-              // if it's an array entry we need the array field name to get the enum annotation, not the element index
-              const field = typeof keyPath[0] === "number" ? keyPath[1] : keyPath[0];
+              // if it's an array entry we need most root (first) array field name to get the enum annotation, not the element index
+
+              const keyPathIndex = keyPath.findIndex((key) => typeof key === "string");
+              const field = keyPath[keyPathIndex];
               if (typeof field === "string") {
                 const enumMapping = enumValuesByDatatypeAndField(datatypes);
                 const datatype = childStructureItem.datatype;
-                constantName = enumMapping[datatype]?.[field]?.[String(itemValue)];
+                constantName = enumMapping[datatype]?.[field][String(itemValue)];
               }
             }
           }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Add support for showing enums names in arrays in raw message panel

**Description**
Element indices weren't linking back to parent field names that the enums were stored under. This checks the field name for whether it's a number and if it is uses the parent to grab the constant name instead. 


<!-- link relevant GitHub issues -->
FG-2427 
Fixes: https://github.com/foxglove/studio/issues/5521 -- and confirmed that this is not specific to flatbuffers.
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
