### PR TITLE
Check for missing properties in GeoJSON messages

### DIFF
--- a/packages/studio-base/src/panels/Map/MapPanel.tsx
+++ b/packages/studio-base/src/panels/Map/MapPanel.tsx
@@ -42,7 +42,7 @@ import { MapPanelMessage, NavSatFixMsg, NavSatFixStatus, Point } from "./types";
 type GeoJsonMessage = MessageEvent<FoxgloveMessages["foxglove.GeoJSON"]>;
 
 // Minimal definition to allow extracting properties from features.
-type GeoJSONFeature = { properties: Record<string, unknown> };
+type GeoJSONFeature = { properties?: Record<string, unknown> };
 
 type MapPanelProps = {
   context: PanelExtensionContext;
@@ -472,7 +472,7 @@ function MapPanel(props: MapPanelProps): JSX.Element {
 
   const addGeoFeatureEventHandlers = useCallback(
     (feature: GeoJSONFeature, message: MessageEvent<unknown>, layer: Layer) => {
-      const featureName = feature.properties.name;
+      const featureName = feature.properties?.name;
       if (typeof featureName === "string" && featureName.length > 0) {
         layer.bindTooltip(featureName);
       }

--- a/packages/studio-base/src/panels/Map/index.stories.tsx
+++ b/packages/studio-base/src/panels/Map/index.stories.tsx
@@ -38,9 +38,6 @@ function makeGeoJsonMessage(center: { lat: number; lon: number }) {
     features: [
       {
         type: "Feature",
-        properties: {
-          name: "Named Line",
-        },
         geometry: {
           type: "LineString",
           coordinates: [


### PR DESCRIPTION
**User-Facing Changes**
Fix an issue with reading GeoJSON messages in the map panel

**Description**
Check for missing properties field in GeoJSON messages before trying to read the name.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
