### PR TITLE
Fix initial state in layout browser multiple selection

### DIFF
--- a/packages/studio-base/src/components/LayoutBrowser/index.tsx
+++ b/packages/studio-base/src/components/LayoutBrowser/index.tsx
@@ -102,6 +102,7 @@ export default function LayoutBrowser({
   const { setSelectedLayoutId } = useCurrentLayoutActions();
 
   const [state, dispatch] = useLayoutBrowserReducer({
+    lastSelectedId: currentLayoutId,
     busy: layoutManager.isBusy,
     error: layoutManager.error,
     online: layoutManager.isOnline,

--- a/packages/studio-base/src/components/LayoutBrowser/reducer.ts
+++ b/packages/studio-base/src/components/LayoutBrowser/reducer.ts
@@ -84,11 +84,10 @@ function reducer(draft: State, action: Action) {
 }
 
 export function useLayoutBrowserReducer(
-  props: Pick<State, "busy" | "error" | "online">,
+  props: Pick<State, "busy" | "error" | "online" | "lastSelectedId">,
 ): [State, Dispatch<Action>] {
   return useImmerReducer(reducer, {
     ...props,
-    lastSelectedId: undefined,
     selectedIds: [],
     multiAction: undefined,
   });


### PR DESCRIPTION
**User-Facing Changes**
Fix initial state in layout browser multiple selection

**Description**
Fix initial state in layout browser multiple selection. The multiple selection logic wasn't taking the currently selected layout as the initial state so it required two clicks to start multi selecting. 

This is an issue in both the existing layout browser and the new top nav layout menu.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
