### PR TITLE
Batch user node state diagnostics and improve layout switching performance

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -13,6 +13,7 @@
 
 import { isEqual, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
+import ReactDOM from "react-dom";
 import shallowequal from "shallowequal";
 import { v4 as uuidv4 } from "uuid";
 
@@ -748,9 +749,23 @@ export default class UserNodePlayer implements Player {
       this._memoizedNodeDatatypes = nodeDatatypes;
     }
 
-    for (const nodeRegistration of state.nodeRegistrations) {
-      this._setUserNodeDiagnostics(nodeRegistration.nodeId, []);
-    }
+    // We need to set the user node diagnostics, which is a react set state
+    // function. This is called once per user script. Since this is in an async
+    // function, the state updates will not be batched below React 18 and React
+    // will update components synchronously during the set state. In a complex
+    // layout, each of the following _setUserNodeDiagnostics call result in
+    // ~100ms of latency. With many scripts, this can turn into a multi-second
+    // stall during layout switching.
+    //
+    // By batching the state update, unnecessary component updates are avoided
+    // and performance is improved for layout switching and initial loading.
+    //
+    // Moving to React 18 should remove the need for this call.
+    ReactDOM.unstable_batchedUpdates(() => {
+      for (const nodeRegistration of state.nodeRegistrations) {
+        this._setUserNodeDiagnostics(nodeRegistration.nodeId, []);
+      }
+    });
   }
 
   private async _getRosLib(state: ProtectedState): Promise<string> {


### PR DESCRIPTION
**User-Facing Changes**

Improved layout switching performance when user scripts are present


**Description**

After user nodes are created, the code runs through a loop of `_setUserNodeDiagnostics` for each user script. These in turn calls React set state functions. Since set state functions are not batched in an async function below React 18 (and I see the latest branch is using React 17), this results in synchronous component updates, which in a complex layout can result in a 100ms latency per call. In a complex layout with many scripts (I have 9), this can take about ~2 seconds of run time (see attached screenshot in PR). Note that I used a previous build which also had `_setNodeMetadata` in that loop. This means with the current code and my layout, that would cause a ~1s lag.

Moving this loop into a batched update makes the block only costs 200ms, see below. With the current code without `setNodeMetadata`, this will only be 100ms.

Moving to React 18 should remove the need for this, but it would need to be confirmed.

![image](https://user-images.githubusercontent.com/338100/228558291-5f5d7f77-388e-4641-bb42-64dee823c538.png)

![image](https://user-images.githubusercontent.com/338100/228558391-72b04019-c763-44f1-80ce-c092e5fff33a.png)
