### PR TITLE
fixed ROSLib and TypesLib generation race condition in `MemoizedLibGenerator`

### DIFF
--- a/packages/studio-base/src/players/UserNodePlayer/index.ts
+++ b/packages/studio-base/src/players/UserNodePlayer/index.ts
@@ -393,6 +393,8 @@ export default class UserNodePlayer implements Player {
     nodeId: string,
     userNode: UserNode,
     state: ProtectedState,
+    rosLib: string,
+    typesLib: string,
   ): Promise<NodeRegistration> {
     for (const cacheEntry of state.nodeRegistrationCache) {
       if (nodeId === cacheEntry.nodeId && isEqual(userNode, cacheEntry.userNode)) {
@@ -404,8 +406,6 @@ export default class UserNodePlayer implements Player {
     const { topics = [], datatypes = new Map() } = state.lastPlayerStateActiveData ?? {};
     const nodeDatatypes: RosDatatypes = new Map([...basicDatatypes, ...datatypes]);
 
-    const rosLib = await this._getRosLib(state);
-    const typesLib = await this._getTypesLib(state);
     const { name, sourceCode } = userNode;
     const transformMessage: TransformArgs = {
       name,
@@ -658,9 +658,13 @@ export default class UserNodePlayer implements Player {
       nodeRegistration.terminate();
     }
 
+    const rosLib = await this._getRosLib(state);
+    const typesLib = await this._getTypesLib(state);
+
     const allNodeRegistrations = await Promise.all(
       Object.entries(state.userNodes).map(
-        async ([nodeId, userNode]) => await this._createNodeRegistration(nodeId, userNode, state),
+        async ([nodeId, userNode]) =>
+          await this._createNodeRegistration(nodeId, userNode, state, rosLib, typesLib),
       ),
     );
 


### PR DESCRIPTION
**User-Facing Changes**

Better performance when using user script

**Description**

The `MemoizedLibGenerator` is used by both the `UserNodePlayer._getRosLib` and `UserNodePlayer._getTypesLib` calls. My understanding for this component is that the ROS and Types library can be efficiently cached if the topics and datatypes didn't change. However, there is a subtle race condition in the implementation where the underlying script compilation is called multiple times anyway, which can result in performance problems if a large number of user scripts is present in the layout, and if the compilation of the ROS lib and types lib takes a significant amount of time (assuming that you have a very large amount of types). The bug is explained as follows:

1. The [`MemoizedLibGenerator.update` code](https://github.com/foxglove/studio/blob/e7cad83/packages/studio-base/src/players/UserNodePlayer/MemoizedLibGenerator.ts#L37-L45) checks the input topics and datatypes are the same as the input to the last call and return the cached result if they match. Simplified, the code is effectively the same as this:

```
if (cached) {
  return {didUpdate: false, cachedLib}
}

lib = await actualUserScriptCompilation()
return {didUpdate: true, lib}
```

2. This code is [called via `await _getRosLib(...)` and `await _getTypesLib(...)`](https://github.com/foxglove/studio/blob/e7cad8306591e6b86e8fe12f1969152860463657/packages/studio-base/src/players/UserNodePlayer/index.ts#L382-L383), which is [invoked via a `Promise.all` for _N_ promises](https://github.com/foxglove/studio/blob/e7cad8306591e6b86e8fe12f1969152860463657/packages/studio-base/src/players/UserNodePlayer/index.ts#L637-L641) (_N_ == number of user scripts in the layout). This is effectively calling the `MemoizedLibGenerator.update` function in parallel (via async) _N_ times.

3. When `MemoizedLibGenerator.update` is called for the first script, `cached == false` and thus `await actualUserScriptCompilation()` is called. This yields which causes the `update` function to be called again for the second script. Since the `actualUserScriptCompilation` is still running, the cache won't be populated, which means the code will call `actualUserScriptCompilation` a second time, which yields again, and the loop repeats. In the worst case scenario (and I have observed this internally in production), all the types libs and ROS libs are generated for every single user script.

Empirically, we saw an approximate 2 second freeze when switching to a layout with 9 user scripts with our setup due to just this bug (and much worse if #5654 is not fixed). This occurs on every layout switch.

The solution is simple: since `_getRosLib` and `_getTypesLib` do not depend on the user script, they can be safely pulled out of `_createNodeRegistration`. The results of those two functions can be passed to `_createNodeRegistration` instead, which avoids the problem of them being called _N_ times in a Promise, which avoids the subtle race condition.