### PR TITLE
perf: improve playback performance with the presence of Autocomplete

### DIFF
--- a/packages/studio-base/src/components/Autocomplete.tsx
+++ b/packages/studio-base/src/components/Autocomplete.tsx
@@ -412,6 +412,17 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
     [blur, items],
   );
 
+  const inputWidth = useMemo(
+    () =>
+      autoSize
+        ? Math.max(
+            measureText(value != undefined && value.length > 0 ? value : placeholder ?? ""),
+            minWidth,
+          )
+        : "100%",
+    [autoSize, value, placeholder, minWidth],
+  );
+
   return (
     <ReactAutocomplete
       open={open}
@@ -454,12 +465,7 @@ export default React.forwardRef(function Autocomplete<T = unknown>(
           fontSize,
           paddingLeft: 4,
           pointerEvents: readOnly === true ? "none" : "auto",
-          width: autoSize
-            ? Math.max(
-                measureText(value != undefined && value.length > 0 ? value : placeholder ?? ""),
-                minWidth,
-              )
-            : "100%",
+          width: inputWidth,
         },
         onFocus,
         onBlur,


### PR DESCRIPTION
**User-Facing Changes**

Improved playback performance with the presence of Autocomplete

**Description**

When there are many `Autocomplete` elements on screen, each of them needs their width measured. The `Autocomplete` element is being recreated on forward ref and this is happening for every frame during playback. Based on flamegraphs, this is taking about 8% CPU time in a layout with 5 autocomplete elements in a state transition panel, and a simple plot panel. This is enough to cause choppy rendering as the rest of the layout is already consistently taking up about 14-16ms of render time.

This change caches the width in a memo and improves playback performance such the playback is less choppy.

![image](https://user-images.githubusercontent.com/338100/228555558-98c64c27-52f3-46b7-af27-c75a947482d3.png)
