### PR TITLE
Add experimental Image panel

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -23,6 +23,7 @@ export enum AppSetting {
   ENABLE_LEGACY_PLOT_PANEL = "enableLegacyPlotPanel",
   ENABLE_NEW_TOPNAV = "enableNewTopNav",
   ENABLE_ROS2_NATIVE_DATA_SOURCE = "enableRos2NativeDataSource",
+  ENABLE_NEW_IMAGE_PANEL = "enableNewImagePanel",
 
   // Miscellaneous
   HIDE_SIGN_IN_PROMPT = "hideSignInPrompt",

--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -79,6 +79,11 @@ function useFeatures(): Feature[] {
         </>
       ),
     },
+    {
+      key: AppSetting.ENABLE_NEW_IMAGE_PANEL,
+      name: t("newImagePanel"),
+      description: <>{t("newImagePanelDescription")}</>,
+    },
   ];
 
   if (process.env.NODE_ENV === "development") {

--- a/packages/studio-base/src/i18n/en/preferences.ts
+++ b/packages/studio-base/src/i18n/en/preferences.ts
@@ -40,4 +40,6 @@ export default {
   ros2NativeConnectionDescription: "Enable the deprecated ROS 2 native connector.",
   layoutDebugging: "Layout debugging",
   layoutDebuggingDescription: "Show extra controls for developing and debugging layout storage.",
+  newImagePanel: "New Image panel",
+  newImagePanelDescription: "Enable the experimental Image panel.",
 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.test.ts
@@ -113,15 +113,19 @@ describe("Renderer", () => {
   });
 
   it("constructs a renderer without error", () => {
-    expect(() => new Renderer(canvas, defaultRendererConfig)).not.toThrow();
+    expect(() => new Renderer(canvas, defaultRendererConfig, "3d")).not.toThrow();
   });
   it("tfPreloading off:  when seeking to before currentTime, clears transform tree", () => {
     // This test is meant accurately represent the flow of seek through the react component
 
-    const renderer = new Renderer(canvas, {
-      ...defaultRendererConfig,
-      scene: { transforms: { enablePreloading: false } },
-    });
+    const renderer = new Renderer(
+      canvas,
+      {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+      "3d",
+    );
     let currentFrame = [];
 
     // initialize renderer with transforms
@@ -173,10 +177,14 @@ describe("Renderer", () => {
   it("tfPreloading off: when seeking to time after currentTime, does not clear transform tree", () => {
     // This test is meant accurately represent the flow of seek through the react component
 
-    const renderer = new Renderer(canvas, {
-      ...defaultRendererConfig,
-      scene: { transforms: { enablePreloading: false } },
-    });
+    const renderer = new Renderer(
+      canvas,
+      {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: false } },
+      },
+      "3d",
+    );
     let currentFrame = [];
 
     // initialize renderer with transforms
@@ -230,10 +238,14 @@ describe("Renderer", () => {
     expect(renderer.transformTree.frame("seekOn")).not.toBeUndefined();
   });
   it("tfPreloading on:  when seeking to before currentTime, clears transform tree and repopulates it up to receiveTime from allFrames", () => {
-    const renderer = new Renderer(canvas, {
-      ...defaultRendererConfig,
-      scene: { transforms: { enablePreloading: true } },
-    });
+    const renderer = new Renderer(
+      canvas,
+      {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: true } },
+      },
+      "3d",
+    );
     const allFrames = [
       createTFMessageEvent("root", "before4", 5n, [1n]),
       createTFMessageEvent("root", "before2", 6n, [4n]),
@@ -274,10 +286,14 @@ describe("Renderer", () => {
     expect(renderer.transformTree.frame("after4")).toBeUndefined();
   });
   it("tfPreloading on: does not clear transform tree when seeking to after", () => {
-    const renderer = new Renderer(canvas, {
-      ...defaultRendererConfig,
-      scene: { transforms: { enablePreloading: true } },
-    });
+    const renderer = new Renderer(
+      canvas,
+      {
+        ...defaultRendererConfig,
+        scene: { transforms: { enablePreloading: true } },
+      },
+      "3d",
+    );
     const allFrames = [
       createTFMessageEvent("root", "before4", 5n, [1n]),
       createTFMessageEvent("root", "before2", 6n, [4n]),
@@ -333,10 +349,10 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
   });
 
   it("constructs a renderer without error", () => {
-    expect(() => new Renderer(canvas, defaultRendererConfig)).not.toThrow();
+    expect(() => new Renderer(canvas, defaultRendererConfig, "3d")).not.toThrow();
   });
   it("does not add in allFramesMessages if no messages are before currentTime", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     for (let i = 0; i < 10; i++) {
@@ -349,7 +365,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).not.toHaveBeenCalled();
   });
   it("adds messages with receiveTime up to currentTime", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     for (let i = 0; i < 10; i++) {
@@ -363,7 +379,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).toHaveBeenCalledTimes(5);
   });
   it("adds later messages after currentTime is updated", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     for (let i = 0; i < 10; i++) {
@@ -379,7 +395,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).toHaveBeenCalledTimes(6);
   });
   it("reads all messages when last message receiveTime is before currentTime", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     for (let i = 0; i < 10; i++) {
@@ -392,7 +408,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).toHaveBeenCalledTimes(10);
   });
   it("reads reads new messages when allFrames array is added to", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     let i = 0;
@@ -412,7 +428,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).toHaveBeenCalledTimes(12);
   });
   it("doesn't read messages when currentTime is updated but no more receiveTimes are past it", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     let i = 0;
@@ -430,7 +446,7 @@ describe("Renderer.handleAllFramesMessages behavior", () => {
     expect(addMessageEventMock).toHaveBeenCalledTimes(10);
   });
   it("adds all messages again after cursor is cleared", () => {
-    const renderer = new Renderer(canvas, defaultRendererConfig);
+    const renderer = new Renderer(canvas, defaultRendererConfig, "3d");
 
     const msgs = [];
     let i = 0;

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -76,6 +76,7 @@ import {
 } from "./ros";
 import { BaseSettings, CustomLayerSettings, SelectEntry } from "./settings";
 import { AddTransformResult, makePose, Pose, Transform, TransformTree } from "./transforms";
+import { InterfaceMode } from "./types";
 
 const log = Logger.getLogger(__filename);
 
@@ -265,6 +266,7 @@ class InstancedLineMaterial extends THREE.LineBasicMaterial {
  * `WebGLRenderingContext`, and `SettingsTree`.
  */
 export class Renderer extends EventEmitter<RendererEvents> {
+  public readonly interfaceMode: InterfaceMode;
   private canvas: HTMLCanvasElement;
   public readonly gl: THREE.WebGLRenderer;
   public maxLod = DetailLevel.High;
@@ -336,11 +338,16 @@ export class Renderer extends EventEmitter<RendererEvents> {
   private _cameraSyncError: undefined | string;
   private _devicePixelRatioMediaQuery?: MediaQueryList;
 
-  public constructor(canvas: HTMLCanvasElement, config: RendererConfig) {
+  public constructor(
+    canvas: HTMLCanvasElement,
+    config: RendererConfig,
+    interfaceMode: InterfaceMode,
+  ) {
     super();
     // NOTE: Global side effect
     THREE.Object3D.DEFAULT_UP = new THREE.Vector3(0, 0, 1);
 
+    this.interfaceMode = interfaceMode;
     this.canvas = canvas;
     this.config = config;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -144,9 +144,6 @@ function RendererOverlay(props: {
   const [interactionsTabType, setInteractionsTabType] = useState<TabType | undefined>(undefined);
   const renderer = useRenderer();
 
-  // Publish control is only available if the canPublish prop is true and we have a fixed frame in the renderer
-  const showPublishControl: boolean = props.canPublish && renderer?.fixedFrameId != undefined;
-
   // Toggle object selection mode on/off in the renderer
   useEffect(() => {
     if (renderer) {
@@ -236,6 +233,76 @@ function RendererOverlay(props: {
 
   const theme = useTheme();
 
+  // Publish control is only available if the canPublish prop is true and we have a fixed frame in the renderer
+  const showPublishControl =
+    props.interfaceMode === "3d" && props.canPublish && renderer?.fixedFrameId != undefined;
+  const publishControls = showPublishControl && (
+    <>
+      <IconButton
+        {...longPressPublishEvent}
+        color={props.publishActive ? "info" : "inherit"}
+        title={props.publishActive ? "Click to cancel" : "Click to publish"}
+        ref={publickClickButtonRef}
+        onClick={props.onClickPublish}
+        data-testid="publish-button"
+        style={{ fontSize: "1rem", pointerEvents: "auto" }}
+      >
+        {selectedPublishClickIcon}
+        <div
+          style={{
+            borderBottom: "6px solid currentColor",
+            borderRight: "6px solid transparent",
+            bottom: 0,
+            left: 0,
+            height: 0,
+            width: 0,
+            margin: theme.spacing(0.25),
+            position: "absolute",
+          }}
+        />
+      </IconButton>
+      <Menu
+        id="publish-menu"
+        anchorEl={publickClickButtonRef.current}
+        anchorOrigin={{ vertical: "top", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        open={publishMenuExpanded}
+        onClose={() => setPublishMenuExpanded(false)}
+      >
+        <MenuItem
+          selected={props.publishClickType === "pose_estimate"}
+          onClick={() => {
+            props.onChangePublishClickType("pose_estimate");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
+          <ListItemText>Publish pose estimate</ListItemText>
+        </MenuItem>
+        <MenuItem
+          selected={props.publishClickType === "pose"}
+          onClick={() => {
+            props.onChangePublishClickType("pose");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
+          <ListItemText>Publish pose</ListItemText>
+        </MenuItem>
+        <MenuItem
+          selected={props.publishClickType === "point"}
+          onClick={() => {
+            props.onChangePublishClickType("point");
+            setPublishMenuExpanded(false);
+          }}
+        >
+          <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
+          <ListItemText>Publish point</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+
   return (
     <React.Fragment>
       <div
@@ -277,72 +344,7 @@ function RendererOverlay(props: {
               <Ruler24Filled className={classes.rulerIcon} />
             </IconButton>
 
-            {showPublishControl && (
-              <>
-                <IconButton
-                  {...longPressPublishEvent}
-                  color={props.publishActive ? "info" : "inherit"}
-                  title={props.publishActive ? "Click to cancel" : "Click to publish"}
-                  ref={publickClickButtonRef}
-                  onClick={props.onClickPublish}
-                  data-testid="publish-button"
-                  style={{ fontSize: "1rem", pointerEvents: "auto" }}
-                >
-                  {selectedPublishClickIcon}
-                  <div
-                    style={{
-                      borderBottom: "6px solid currentColor",
-                      borderRight: "6px solid transparent",
-                      bottom: 0,
-                      left: 0,
-                      height: 0,
-                      width: 0,
-                      margin: theme.spacing(0.25),
-                      position: "absolute",
-                    }}
-                  />
-                </IconButton>
-                <Menu
-                  id="publish-menu"
-                  anchorEl={publickClickButtonRef.current}
-                  anchorOrigin={{ vertical: "top", horizontal: "left" }}
-                  transformOrigin={{ vertical: "top", horizontal: "right" }}
-                  open={publishMenuExpanded}
-                  onClose={() => setPublishMenuExpanded(false)}
-                >
-                  <MenuItem
-                    selected={props.publishClickType === "pose_estimate"}
-                    onClick={() => {
-                      props.onChangePublishClickType("pose_estimate");
-                      setPublishMenuExpanded(false);
-                    }}
-                  >
-                    <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
-                    <ListItemText>Publish pose estimate</ListItemText>
-                  </MenuItem>
-                  <MenuItem
-                    selected={props.publishClickType === "pose"}
-                    onClick={() => {
-                      props.onChangePublishClickType("pose");
-                      setPublishMenuExpanded(false);
-                    }}
-                  >
-                    <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
-                    <ListItemText>Publish pose</ListItemText>
-                  </MenuItem>
-                  <MenuItem
-                    selected={props.publishClickType === "point"}
-                    onClick={() => {
-                      props.onChangePublishClickType("point");
-                      setPublishMenuExpanded(false);
-                    }}
-                  >
-                    <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
-                    <ListItemText>Publish point</ListItemText>
-                  </MenuItem>
-                </Menu>
-              </>
-            )}
+            {publishControls}
           </Paper>
         )}
       </div>

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -65,6 +65,7 @@ import {
 import { DEFAULT_PUBLISH_SETTINGS } from "./renderables/CoreSettings";
 import type { LayerSettingsTransform } from "./renderables/FrameAxes";
 import { PublishClickEvent, PublishClickType } from "./renderables/PublishClickTool";
+import { InterfaceMode } from "./types";
 
 const log = Logger.getLogger(__filename);
 
@@ -116,6 +117,7 @@ const useStyles = makeStyles()((theme) => ({
  * Provides DOM overlay elements on top of the 3D scene (e.g. stats, debug GUI).
  */
 function RendererOverlay(props: {
+  interfaceMode: InterfaceMode;
   canvas: HTMLCanvasElement | ReactNull;
   addPanel: LayoutActions["addPanel"];
   enableStats: boolean;
@@ -255,92 +257,94 @@ function RendererOverlay(props: {
           setInteractionsTabType={setInteractionsTabType}
           timezone={props.timezone}
         />
-        <Paper square={false} elevation={4} style={{ display: "flex", flexDirection: "column" }}>
-          <IconButton
-            className={classes.iconButton}
-            color={props.perspective ? "info" : "inherit"}
-            title={props.perspective ? "Switch to 2D camera" : "Switch to 3D camera"}
-            onClick={props.onTogglePerspective}
-          >
-            <span className={classes.threeDeeButton}>3D</span>
-          </IconButton>
-          <IconButton
-            data-testid="measure-button"
-            className={classes.iconButton}
-            color={props.measureActive ? "info" : "inherit"}
-            title={props.measureActive ? "Cancel measuring" : "Measure distance"}
-            onClick={props.onClickMeasure}
-          >
-            <Ruler24Filled className={classes.rulerIcon} />
-          </IconButton>
+        {props.interfaceMode === "3d" && (
+          <Paper square={false} elevation={4} style={{ display: "flex", flexDirection: "column" }}>
+            <IconButton
+              className={classes.iconButton}
+              color={props.perspective ? "info" : "inherit"}
+              title={props.perspective ? "Switch to 2D camera" : "Switch to 3D camera"}
+              onClick={props.onTogglePerspective}
+            >
+              <span className={classes.threeDeeButton}>3D</span>
+            </IconButton>
+            <IconButton
+              data-testid="measure-button"
+              className={classes.iconButton}
+              color={props.measureActive ? "info" : "inherit"}
+              title={props.measureActive ? "Cancel measuring" : "Measure distance"}
+              onClick={props.onClickMeasure}
+            >
+              <Ruler24Filled className={classes.rulerIcon} />
+            </IconButton>
 
-          {showPublishControl && (
-            <>
-              <IconButton
-                {...longPressPublishEvent}
-                color={props.publishActive ? "info" : "inherit"}
-                title={props.publishActive ? "Click to cancel" : "Click to publish"}
-                ref={publickClickButtonRef}
-                onClick={props.onClickPublish}
-                data-testid="publish-button"
-                style={{ fontSize: "1rem", pointerEvents: "auto" }}
-              >
-                {selectedPublishClickIcon}
-                <div
-                  style={{
-                    borderBottom: "6px solid currentColor",
-                    borderRight: "6px solid transparent",
-                    bottom: 0,
-                    left: 0,
-                    height: 0,
-                    width: 0,
-                    margin: theme.spacing(0.25),
-                    position: "absolute",
-                  }}
-                />
-              </IconButton>
-              <Menu
-                id="publish-menu"
-                anchorEl={publickClickButtonRef.current}
-                anchorOrigin={{ vertical: "top", horizontal: "left" }}
-                transformOrigin={{ vertical: "top", horizontal: "right" }}
-                open={publishMenuExpanded}
-                onClose={() => setPublishMenuExpanded(false)}
-              >
-                <MenuItem
-                  selected={props.publishClickType === "pose_estimate"}
-                  onClick={() => {
-                    props.onChangePublishClickType("pose_estimate");
-                    setPublishMenuExpanded(false);
-                  }}
+            {showPublishControl && (
+              <>
+                <IconButton
+                  {...longPressPublishEvent}
+                  color={props.publishActive ? "info" : "inherit"}
+                  title={props.publishActive ? "Click to cancel" : "Click to publish"}
+                  ref={publickClickButtonRef}
+                  onClick={props.onClickPublish}
+                  data-testid="publish-button"
+                  style={{ fontSize: "1rem", pointerEvents: "auto" }}
                 >
-                  <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
-                  <ListItemText>Publish pose estimate</ListItemText>
-                </MenuItem>
-                <MenuItem
-                  selected={props.publishClickType === "pose"}
-                  onClick={() => {
-                    props.onChangePublishClickType("pose");
-                    setPublishMenuExpanded(false);
-                  }}
+                  {selectedPublishClickIcon}
+                  <div
+                    style={{
+                      borderBottom: "6px solid currentColor",
+                      borderRight: "6px solid transparent",
+                      bottom: 0,
+                      left: 0,
+                      height: 0,
+                      width: 0,
+                      margin: theme.spacing(0.25),
+                      position: "absolute",
+                    }}
+                  />
+                </IconButton>
+                <Menu
+                  id="publish-menu"
+                  anchorEl={publickClickButtonRef.current}
+                  anchorOrigin={{ vertical: "top", horizontal: "left" }}
+                  transformOrigin={{ vertical: "top", horizontal: "right" }}
+                  open={publishMenuExpanded}
+                  onClose={() => setPublishMenuExpanded(false)}
                 >
-                  <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
-                  <ListItemText>Publish pose</ListItemText>
-                </MenuItem>
-                <MenuItem
-                  selected={props.publishClickType === "point"}
-                  onClick={() => {
-                    props.onChangePublishClickType("point");
-                    setPublishMenuExpanded(false);
-                  }}
-                >
-                  <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
-                  <ListItemText>Publish point</ListItemText>
-                </MenuItem>
-              </Menu>
-            </>
-          )}
-        </Paper>
+                  <MenuItem
+                    selected={props.publishClickType === "pose_estimate"}
+                    onClick={() => {
+                      props.onChangePublishClickType("pose_estimate");
+                      setPublishMenuExpanded(false);
+                    }}
+                  >
+                    <ListItemIcon>{PublishClickIcons.pose_estimate}</ListItemIcon>
+                    <ListItemText>Publish pose estimate</ListItemText>
+                  </MenuItem>
+                  <MenuItem
+                    selected={props.publishClickType === "pose"}
+                    onClick={() => {
+                      props.onChangePublishClickType("pose");
+                      setPublishMenuExpanded(false);
+                    }}
+                  >
+                    <ListItemIcon>{PublishClickIcons.pose}</ListItemIcon>
+                    <ListItemText>Publish pose</ListItemText>
+                  </MenuItem>
+                  <MenuItem
+                    selected={props.publishClickType === "point"}
+                    onClick={() => {
+                      props.onChangePublishClickType("point");
+                      setPublishMenuExpanded(false);
+                    }}
+                  >
+                    <ListItemIcon>{PublishClickIcons.point}</ListItemIcon>
+                    <ListItemText>Publish point</ListItemText>
+                  </MenuItem>
+                </Menu>
+              </>
+            )}
+          </Paper>
+        )}
       </div>
       {clickedObjects.length > 1 && !selectedObject && (
         <InteractionContextMenu
@@ -390,7 +394,11 @@ function useRendererProperty<K extends keyof Renderer>(
 /**
  * A panel that renders a 3D scene. This is a thin wrapper around a `Renderer` instance.
  */
-export function ThreeDeeRender({ context }: { context: PanelExtensionContext }): JSX.Element {
+export function ThreeDeeRender(props: {
+  context: PanelExtensionContext;
+  interfaceMode: InterfaceMode;
+}): JSX.Element {
+  const { context, interfaceMode } = props;
   const { initialState, saveState } = context;
 
   // Load and save the persisted panel configuration
@@ -428,14 +436,14 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
   const [renderer, setRenderer] = useState<Renderer | undefined>(undefined);
   const rendererRef = useRef<Renderer | undefined>(undefined);
   useEffect(() => {
-    const newRenderer = canvas ? new Renderer(canvas, configRef.current) : undefined;
+    const newRenderer = canvas ? new Renderer(canvas, configRef.current, interfaceMode) : undefined;
     setRenderer(newRenderer);
     rendererRef.current = newRenderer;
     return () => {
       rendererRef.current?.dispose();
       rendererRef.current = undefined;
     };
-  }, [canvas, configRef, config.scene.transforms?.enablePreloading]);
+  }, [canvas, configRef, config.scene.transforms?.enablePreloading, interfaceMode]);
 
   const [colorScheme, setColorScheme] = useState<"dark" | "light" | undefined>();
   const [timezone, setTimezone] = useState<string | undefined>();
@@ -985,6 +993,7 @@ export function ThreeDeeRender({ context }: { context: PanelExtensionContext }):
         />
         <RendererContext.Provider value={renderer}>
           <RendererOverlay
+            interfaceMode={interfaceMode}
             canvas={canvas}
             addPanel={addPanel}
             enableStats={config.scene.enableStats ?? false}

--- a/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/index.tsx
@@ -13,12 +13,17 @@ import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExt
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
 
 import { ThreeDeeRender } from "./ThreeDeeRender";
+import { InterfaceMode } from "./types";
 
-function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
+function initPanel(
+  crash: ReturnType<typeof useCrash>,
+  interfaceMode: InterfaceMode,
+  context: PanelExtensionContext,
+) {
   ReactDOM.render(
     <StrictMode>
       <CaptureErrorBoundary onError={crash}>
-        <ThreeDeeRender context={context} />
+        <ThreeDeeRender context={context} interfaceMode={interfaceMode} />
       </CaptureErrorBoundary>
     </StrictMode>,
     context.panelElement,
@@ -33,9 +38,12 @@ type Props = {
   saveConfig: SaveConfig<unknown>;
 };
 
-function ThreeDeeRenderAdapter(props: Props) {
+function ThreeDeeRenderAdapter(interfaceMode: InterfaceMode, props: Props) {
   const crash = useCrash();
-  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
+  const boundInitPanel = useMemo(
+    () => initPanel.bind(undefined, crash, interfaceMode),
+    [crash, interfaceMode],
+  );
 
   return (
     <PanelExtensionAdapter
@@ -46,7 +54,16 @@ function ThreeDeeRenderAdapter(props: Props) {
   );
 }
 
-ThreeDeeRenderAdapter.panelType = "3D";
-ThreeDeeRenderAdapter.defaultConfig = {};
+export const ThreeDeePanel = Panel(
+  Object.assign(ThreeDeeRenderAdapter.bind(undefined, "3d"), {
+    panelType: "3D",
+    defaultConfig: {},
+  }),
+);
 
-export default Panel(ThreeDeeRenderAdapter);
+export const ImagePanel = Panel(
+  Object.assign(ThreeDeeRenderAdapter.bind(undefined, "image"), {
+    panelType: "Image",
+    defaultConfig: {},
+  }),
+);

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ArrowMarkers.stories.tsx
@@ -15,12 +15,12 @@ import {
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 ArrowMarkers.parameters = { colorScheme: "dark" };
@@ -143,9 +143,9 @@ export function ArrowMarkers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           cameraState: {
             distance: 4,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/AutoSelectFrame.stories.tsx
@@ -15,12 +15,12 @@ import {
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 AutoSelectFrame.parameters = { colorScheme: "dark" };
@@ -95,9 +95,9 @@ export function AutoSelectFrame(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: undefined,
           cameraState: {
             distance: 4,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CameraInfoRender.stories.tsx
@@ -14,12 +14,12 @@ import {
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { CameraInfo, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 CameraInfoRender.parameters = { colorScheme: "dark" };
@@ -133,9 +133,9 @@ export function CameraInfoRender(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: SENSOR_FRAME_ID,
           scene: {
             labelScaleFactor: 0.1,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ColladaUpAxis.stories.tsx
@@ -9,12 +9,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { COLLADA_CONE_Y_UP_MESH_RESOURCE, COLLADA_CONE_Z_UP_MESH_RESOURCE } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 import { DEFAULT_CAMERA_STATE } from "../camera";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 const baseMeshMarker: MessageEvent<Marker> = {
@@ -132,7 +132,7 @@ export function ColladaUpAxisObserve(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           layers: {
             grid: { layerId: "foxglove.Grid" },
@@ -214,7 +214,7 @@ export function ColladaUpAxisIgnore(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/CustomBackgroundColor.stories.tsx
@@ -5,11 +5,11 @@
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 export function CustomBackgroundColor(): JSX.Element {
@@ -24,9 +24,9 @@ export function CustomBackgroundColor(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           scene: { backgroundColor: "#2d7566" },
         }}
       />

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/FramelessMarkers.stories.tsx
@@ -8,12 +8,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeColor, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Header, Marker } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 FramelessMarkers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
@@ -63,9 +63,9 @@ export function FramelessMarkers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           layers: {
             grid: { layerId: "foxglove.Grid" },
           },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_Polygon.stories.tsx
@@ -8,12 +8,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PolygonStamped, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 GeometryMsgs_Polygon.parameters = { colorScheme: "dark" };
@@ -82,9 +82,9 @@ export function GeometryMsgs_Polygon(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           cameraState: {
             distance: 8.25,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseArray.stories.tsx
@@ -10,12 +10,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PoseArray, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 type Vec4 = [number, number, number, number];
@@ -139,7 +139,7 @@ export function GeometryMsgs_PoseArray(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/GeometryMsgs_PoseStamped.stories.tsx
@@ -10,12 +10,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PoseStamped, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 type Vec4 = [number, number, number, number];
@@ -122,7 +122,7 @@ export function GeometryMsgs_PoseStamped(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/ImageRender.stories.tsx
@@ -13,12 +13,12 @@ import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
 import { PNG_TEST_IMAGE, rad2deg, SENSOR_FRAME_ID } from "./common";
 import { useFixtureQueue } from "./useFixtureQueue";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { CameraInfo, CompressedImage as RosCompressedImage, Image } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender/Images",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 export const ImageRender: Story = () => {
@@ -131,9 +131,9 @@ export const ImageRender: Story = () => {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: SENSOR_FRAME_ID,
           scene: {
             labelScaleFactor: 0,
@@ -291,9 +291,9 @@ export const FoxgloveImage: Story = () => {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: SENSOR_FRAME_ID,
           scene: {
             labelScaleFactor: 0,
@@ -413,9 +413,9 @@ export const ImageThenInfo: Story = () => {
 
   return (
     <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: SENSOR_FRAME_ID,
           scene: {
             labelScaleFactor: 0,
@@ -524,9 +524,9 @@ export const InfoThenImage: Story = () => {
 
   return (
     <PanelSetup fixture={activeFixture} pauseFrame={pauseFrame}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: SENSOR_FRAME_ID,
           scene: {
             labelScaleFactor: 0,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LabelMarkers.stories.tsx
@@ -8,12 +8,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeColor, QUAT_IDENTITY, rad2deg, SENSOR_FRAME_ID } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker, MarkerType, TransformStamped, Vector3 } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 export function LabelMarkers(): JSX.Element {
@@ -105,9 +105,9 @@ export function LabelMarkers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           cameraState: {
             distance: 5.5,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/LargeTransform.stories.tsx
@@ -9,12 +9,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 LargeTransform.parameters = { colorScheme: "dark" };
@@ -87,7 +87,7 @@ export function LargeTransform(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MarkerLifetimes.stories.tsx
@@ -9,12 +9,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeFail, makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 MarkerLifetimes.parameters = { colorScheme: "dark" };
@@ -156,9 +156,9 @@ export function MarkerLifetimes(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           cameraState: {
             distance: 3,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Marker_PointCloud2_Alignment.stories.tsx
@@ -8,12 +8,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeColor, QUAT_IDENTITY, rad2deg, packRvizRgba, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker, MarkerType, PointCloud2, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 Marker_PointCloud2_Alignment.parameters = { colorScheme: "dark" };
@@ -144,9 +144,9 @@ export function Marker_PointCloud2_Alignment(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           topics: {
             "/markers": { visible: true },
             "/pointcloud": {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Markers.stories.tsx
@@ -12,12 +12,12 @@ import { useReadySignal } from "@foxglove/studio-base/stories/ReadySignalContext
 
 import { makeColor, QUAT_IDENTITY, rad2deg, SENSOR_FRAME_ID } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { ColorRGBA, Marker, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 Markers.parameters = { colorScheme: "dark", chromatic: { delay: 100 } };
@@ -524,9 +524,9 @@ export function Markers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           layers: {
             grid: { layerId: "foxglove.Grid" },
@@ -657,9 +657,9 @@ export const EmptyLineStrip: Story = () => {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeasurementTool.stories.tsx
@@ -9,12 +9,12 @@ import delay from "@foxglove/studio-base/util/delay";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 MeasurementTool.parameters = { colorScheme: "dark", chromatic: { delay: 200 } };
@@ -62,9 +62,9 @@ export function MeasurementTool(): JSX.Element {
   });
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkerOrientation.stories.tsx
@@ -14,12 +14,12 @@ import {
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 import { DEFAULT_CAMERA_STATE } from "../camera";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 MeshMarkerOrientation.parameters = { colorScheme: "dark" };
@@ -177,7 +177,7 @@ export function MeshMarkerOrientation(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/MeshMarkers.stories.tsx
@@ -9,12 +9,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { makeColor, OBJ_CUBE_MESH_RESOURCE, STL_CUBE_MESH_RESOURCE } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
 import { DEFAULT_CAMERA_STATE } from "../camera";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { Marker } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 MeshMarkers.parameters = { colorScheme: "dark" };
@@ -96,7 +96,7 @@ export function MeshMarkers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/NavMsgs_Path.stories.tsx
@@ -10,12 +10,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { NavPath, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 NavMsgs_Path.parameters = { colorScheme: "dark" };
@@ -122,7 +122,7 @@ export function NavMsgs_Path(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/OccupancyGrid.stories.tsx
@@ -12,12 +12,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { OccupancyGrid, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: { colorScheme: "light" },
 };
 
@@ -120,7 +120,7 @@ function BaseStory({ includeSettings = false }: { includeSettings?: boolean }): 
 
   return (
     <PanelSetup fixture={fixture} includeSettings={includeSettings}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PoseMarkers.stories.tsx
@@ -14,12 +14,12 @@ import {
   SENSOR_FRAME_ID,
 } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PoseStamped, PoseWithCovarianceStamped, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 PoseMarkers.parameters = { colorScheme: "dark" };
@@ -167,9 +167,9 @@ export function PoseMarkers(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           cameraState: {
             distance: 4,

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/PublishClickTool.stories.tsx
@@ -11,13 +11,13 @@ import delay from "@foxglove/studio-base/util/delay";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PublishClickType } from "../renderables/PublishClickTool";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender/PublishClickTool",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 export const Point = Object.assign(PublishClickToolTemplate.bind({}), {
@@ -141,9 +141,9 @@ function PublishClickToolTemplate({ type }: { type: PublishClickType }): JSX.Ele
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "base_link",
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SceneEntities.stories.tsx
@@ -15,11 +15,11 @@ import { Topic } from "@foxglove/studio-base/players/types";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeColor, QUAT_IDENTITY, rad2deg } from "./common";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender/SceneEntities",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 const icospherePointsAndIndices = {
@@ -385,9 +385,9 @@ export function BasicEntities(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
-          ...ThreeDeeRender.defaultConfig,
+          ...ThreeDeePanel.defaultConfig,
           followTf: "root",
           layers: {
             grid: { layerId: "foxglove.Grid" },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_LaserScan.stories.tsx
@@ -11,12 +11,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { LaserScan, PointCloud2, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender/LaserScan",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: { colorScheme: "dark" },
 };
 
@@ -121,7 +121,7 @@ function SensorMsgs_LaserScan({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           scene: { enableStats: false },
@@ -315,7 +315,7 @@ export function ComparisonWithPointCloudColors(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           scene: { enableStats: false },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SensorMsgs_PointCloud2.stories.tsx
@@ -10,12 +10,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { packRvizRgba, QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { PointCloud2, TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 export const SensorMsgs_PointCloud2_RGBA = (): JSX.Element => (
@@ -125,7 +125,7 @@ function SensorMsgs_PointCloud2({ rgbaFieldName }: { rgbaFieldName: string }): J
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -301,7 +301,7 @@ export function SensorMsgs_PointCloud2_Intensity(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -387,7 +387,7 @@ export function SensorMsgs_PointCloud2_TwoDimensions(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "sensor",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/SphereListPointsTransform.stories.tsx
@@ -11,12 +11,12 @@ import { SphereListMarker } from "@foxglove/studio-base/types/Messages";
 
 import { makeColor, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 SphereListPointsTransform.parameters = { colorScheme: "dark" };
@@ -113,7 +113,7 @@ export function SphereListPointsTransform(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "camera_link",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/TransformInterpolation.stories.tsx
@@ -9,14 +9,14 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 const VEC3_ZERO = { x: 0, y: 0, z: 0 };
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 TransformInterpolation.parameters = { colorScheme: "dark" };
@@ -88,7 +88,7 @@ export function TransformInterpolation(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           layers: {
@@ -189,7 +189,7 @@ export function TransformOffsets(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "b",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/Urdfs.stories.tsx
@@ -8,7 +8,7 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makeColor, STL_CUBE_MESH_RESOURCE } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 const RED = makeColorAttribute("#f44336");
 const GREEN = makeColorAttribute("#4caf50");
@@ -97,7 +97,7 @@ const URDF2 = `<?xml version="1.0"?>
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 Urdfs.parameters = { colorScheme: "dark" };
@@ -126,7 +126,7 @@ export function Urdfs(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           scene: {
             transforms: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/VelodyneScan.stories.tsx
@@ -8,11 +8,11 @@ import { VelodyneScan } from "@foxglove/studio-base/types/Messages";
 
 import { rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: { colorScheme: "light" },
 };
 
@@ -1313,7 +1313,7 @@ export function VelodyneScan_Intensity(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: velodyneScan.header.frame_id,
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransform.stories.tsx
@@ -10,14 +10,14 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { LegacyFrameTransform } from "../normalizeMessages";
 
 const VEC3_ZERO = { x: 0, y: 0, z: 0 };
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 FoxgloveFrameTransform.parameters = { colorScheme: "dark" };
@@ -91,7 +91,7 @@ export function FoxgloveFrameTransform(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.FrameTransforms.stories.tsx
@@ -10,11 +10,11 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { makePass, QUAT_IDENTITY, rad2deg, TEST_COLORS } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 FoxgloveFrameTransforms.parameters = { colorScheme: "dark" };
@@ -91,7 +91,7 @@ export function FoxgloveFrameTransforms(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "sensor_1",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.Grid.stories.tsx
@@ -10,12 +10,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: { colorScheme: "light" },
 };
 
@@ -213,7 +213,7 @@ function Foxglove_Grid_Uint8({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -380,7 +380,7 @@ function Foxglove_Grid_RGBA(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -507,7 +507,7 @@ function Foxglove_Grid_Float({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -631,7 +631,7 @@ function Row_Stride_Grid(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.LaserScan.stories.tsx
@@ -14,11 +14,11 @@ import { emptyPose } from "@foxglove/studio-base/util/Pose";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender/foxglove.LaserScan",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: { colorScheme: "dark" },
 };
 
@@ -120,7 +120,7 @@ function Foxglove_LaserScan({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           scene: { enableStats: false },
@@ -307,7 +307,7 @@ export function ComparisonWithPointCloudColors(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           scene: { enableStats: false },

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PointCloud.stories.tsx
@@ -11,12 +11,12 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg, VEC3_ZERO } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 import { TransformStamped } from "../ros";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
   parameters: {
     colorScheme: "dark",
   },
@@ -150,7 +150,7 @@ function Foxglove_PointCloud({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -333,7 +333,7 @@ function Foxglove_PointCloud_Intensity_Base({
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {
@@ -427,7 +427,7 @@ export function Foxglove_PointCloud_TwoDimensions(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "sensor",
           layers: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PoseInFrame.stories.tsx
@@ -11,11 +11,11 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 type Vec4 = [number, number, number, number];
@@ -123,7 +123,7 @@ export function Foxglove_PoseInFrame(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/stories/foxglove.PosesInFrame.stories.tsx
@@ -11,11 +11,11 @@ import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
 import { QUAT_IDENTITY, rad2deg } from "./common";
 import useDelayedFixture from "./useDelayedFixture";
-import ThreeDeeRender from "../index";
+import { ThreeDeePanel } from "../index";
 
 export default {
   title: "panels/ThreeDeeRender",
-  component: ThreeDeeRender,
+  component: ThreeDeePanel,
 };
 
 type Vec4 = [number, number, number, number];
@@ -137,7 +137,7 @@ export function Foxglove_PosesInFrame(): JSX.Element {
 
   return (
     <PanelSetup fixture={fixture}>
-      <ThreeDeeRender
+      <ThreeDeePanel
         overrideConfig={{
           followTf: "base_link",
           topics: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/types.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/types.ts
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type InterfaceMode = "3d" | "image";

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -31,7 +31,7 @@ export const builtin: PanelInfo[] = [
     type: "3D",
     description: "Display markers, camera images, meshes, URDFs, and more in a 3D scene.",
     thumbnail: threeDeeRenderThumbnail,
-    module: async () => await import("./ThreeDeeRender"),
+    module: async () => ({ default: (await import("./ThreeDeeRender")).ThreeDeePanel }),
     settingsOnboardingTooltip: "Open settings to configure topics and layers.",
   },
   {
@@ -189,4 +189,10 @@ export const legacyPlot: PanelInfo = {
   title: "Legacy Plot",
   type: "LegacyPlot",
   module: async () => await import("./LegacyPlot"),
+};
+
+export const newImage: PanelInfo = {
+  title: "3D Image",
+  type: "Image",
+  module: async () => ({ default: (await import("./ThreeDeeRender")).ImagePanel }),
 };

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -28,6 +28,9 @@ export default function PanelCatalogProvider(
   const [enableLegacyPlotPanel = false] = useAppConfigurationValue<boolean>(
     AppSetting.ENABLE_LEGACY_PLOT_PANEL,
   );
+  const [enableNewImagePanel = false] = useAppConfigurationValue<boolean>(
+    AppSetting.ENABLE_NEW_IMAGE_PANEL,
+  );
 
   const extensionPanels = useExtensionCatalog((state) => state.installedPanels);
 
@@ -58,7 +61,13 @@ export default function PanelCatalogProvider(
   }, [extensionPanels]);
 
   const allPanels = useMemo(() => {
-    return [...panels.builtin, ...panels.debug, panels.legacyPlot, ...wrappedExtensionPanels];
+    return [
+      ...panels.builtin,
+      ...panels.debug,
+      panels.legacyPlot,
+      panels.newImage,
+      ...wrappedExtensionPanels,
+    ];
   }, [wrappedExtensionPanels]);
 
   const visiblePanels = useMemo(() => {
@@ -69,9 +78,12 @@ export default function PanelCatalogProvider(
     if (enableLegacyPlotPanel) {
       panelList.push(panels.legacyPlot);
     }
+    if (enableNewImagePanel) {
+      panelList.push(panels.newImage);
+    }
     panelList.push(...wrappedExtensionPanels);
     return panelList;
-  }, [enableLegacyPlotPanel, showDebugPanels, wrappedExtensionPanels]);
+  }, [enableLegacyPlotPanel, enableNewImagePanel, showDebugPanels, wrappedExtensionPanels]);
 
   const panelsByType = useMemo(() => {
     const byType = new Map<string, PanelInfo>();


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Adds `interfaceMode: "3d" | "image"` to ThreeDeeRender component, and a new "3D Image" panel under a feature flag.

For now the only difference is that the 3D/measure/publish tools are hidden:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/14237/228634853-72ff5b5b-6f05-42ab-b138-19f1d1265b46.png">
