### PR TITLE
Fix issue with "Fixed" follow mode when display frame is absent

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1472,7 +1472,12 @@ export class Renderer extends EventEmitter<RendererEvents> {
     }
 
     // Should only occur on reload when the saved followMode is not follow
-    if (this.followMode !== "follow-pose" && !this.unfollowPoseSnapshot) {
+    if (
+      this.followMode !== "follow-pose" &&
+      !this.unfollowPoseSnapshot &&
+      // only record snapshot if the frame has transforms, otherwise it will be identity pose
+      frame.transformsSize() > 0
+    ) {
       // Snapshot the current pose of the render frame in the fixed frame
       this.unfollowPoseSnapshot = makePose();
       fixedFrame.applyLocal(


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - fix fixed follow mode from centering on root frame when display frame does not exist.

**Description**
 - the unfollowPose Snapshot was being set to an identity pose because transforms would come in with the display frame as it's parent pose, which would create the frame, but it would have no transforms in it. This function only checked to see that the display frame exists and not that it has transforms in it before rendering. This was causing the camera to center on the root frame instead of the display frame. Checking for this before setting the unfollowPoseSnapshot corrects this behavior.


<!-- link relevant GitHub issues -->
FG-2308
#5484
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
