### PR TITLE
Fix plot Y axis scale jittering

### DIFF
--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -681,11 +681,15 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       }
 
       // If this is an update from the chart adjusting its own bounds and not a
-      // user interaction and no changes have been made to the X scale we can
+      // user interaction and the X scale is defined but hasn't changed we can
       // skip updating global bounds and downsampling. This avoids a feedback
       // loop on boundary conditions when the chart is adjusting its own Y axis
       // to fit the dataset.
-      if (isEqual(scales.x, currentScalesRef.current?.x) && !userInteraction) {
+      if (
+        scales.x != undefined &&
+        isEqual(scales.x, currentScalesRef.current?.x) &&
+        !userInteraction
+      ) {
         return;
       }
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -14,6 +14,7 @@
 import { Button, Fade, Tooltip, useTheme } from "@mui/material";
 import { ChartOptions, ScaleOptions } from "chart.js";
 import { AnnotationOptions } from "chartjs-plugin-annotation";
+import { isEqual } from "lodash";
 import React, {
   ComponentProps,
   MouseEvent,
@@ -677,6 +678,12 @@ export default function TimeBasedChart(props: Props): JSX.Element {
 
       if (userInteraction) {
         setHasUserPannedOrZoomed(true);
+      }
+
+      // We only need to update global bounds and datasets when the chart
+      // reports X scale changes. We let the chart handle Y on its own.
+      if (isEqual(scales.x, currentScalesRef.current?.x)) {
+        return;
       }
 
       currentScalesRef.current = scales;

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -680,8 +680,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         setHasUserPannedOrZoomed(true);
       }
 
-      currentScalesRef.current = scales;
-
       // If this is an update from the chart adjusting its own bounds and not a
       // user interaction and the X scale is defined but hasn't changed we can
       // skip updating global bounds and downsampling. This avoids a feedback
@@ -689,11 +687,13 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       // to fit the dataset.
       if (
         scales.x != undefined &&
-        isEqual(scales.x, currentScalesRef.current.x) &&
+        isEqual(scales.x, currentScalesRef.current?.x) &&
         !userInteraction
       ) {
         return;
       }
+
+      currentScalesRef.current = scales;
 
       queueDownsampleInvalidate();
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -676,10 +676,6 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         return;
       }
 
-      if (userInteraction) {
-        setHasUserPannedOrZoomed(true);
-      }
-
       // If this is an update from the chart adjusting its own bounds and not a
       // user interaction and the X scale is defined but hasn't changed we can
       // skip updating global bounds and downsampling. This avoids a feedback
@@ -691,6 +687,10 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         !userInteraction
       ) {
         return;
+      }
+
+      if (userInteraction) {
+        setHasUserPannedOrZoomed(true);
       }
 
       currentScalesRef.current = scales;

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -680,9 +680,12 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         setHasUserPannedOrZoomed(true);
       }
 
-      // We only need to update global bounds and datasets when the chart
-      // reports X scale changes. We let the chart handle Y on its own.
-      if (isEqual(scales.x, currentScalesRef.current?.x)) {
+      // If this is an update from the chart adjusting its own bounds and not a
+      // user interaction and no changes have been made to the X scale we can
+      // skip updating global bounds and downsampling. This avoids a feedback
+      // loop on boundary conditions when the chart is adjusting its own Y axis
+      // to fit the dataset.
+      if (isEqual(scales.x, currentScalesRef.current?.x) && !userInteraction) {
         return;
       }
 

--- a/packages/studio-base/src/components/TimeBasedChart/index.tsx
+++ b/packages/studio-base/src/components/TimeBasedChart/index.tsx
@@ -680,6 +680,8 @@ export default function TimeBasedChart(props: Props): JSX.Element {
         setHasUserPannedOrZoomed(true);
       }
 
+      currentScalesRef.current = scales;
+
       // If this is an update from the chart adjusting its own bounds and not a
       // user interaction and the X scale is defined but hasn't changed we can
       // skip updating global bounds and downsampling. This avoids a feedback
@@ -687,13 +689,11 @@ export default function TimeBasedChart(props: Props): JSX.Element {
       // to fit the dataset.
       if (
         scales.x != undefined &&
-        isEqual(scales.x, currentScalesRef.current?.x) &&
+        isEqual(scales.x, currentScalesRef.current.x) &&
         !userInteraction
       ) {
         return;
       }
-
-      currentScalesRef.current = scales;
 
       queueDownsampleInvalidate();
 


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue with plot panel Y scale jittering.

**Description**
Update global bounds and rebuild datasets only when the chart reports an update to the X scale. We can skip this process when it automatically adjusts its Y scale and avoid this boundary condition feedback loop.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
