### PR TITLE
Hide ros2 native flag for web build

### DIFF
--- a/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
+++ b/packages/studio-base/src/components/ExperimentalFeatureSettings.tsx
@@ -71,6 +71,14 @@ function useFeatures(): Feature[] {
       ),
     },
     {
+      key: AppSetting.ENABLE_NEW_IMAGE_PANEL,
+      name: t("newImagePanel"),
+      description: <>{t("newImagePanelDescription")}</>,
+    },
+  ];
+
+  if (isDesktopApp()) {
+    features.push({
       key: AppSetting.ENABLE_ROS2_NATIVE_DATA_SOURCE,
       name: t("ros2NativeConnection"),
       description: (
@@ -78,13 +86,8 @@ function useFeatures(): Feature[] {
           {t("ros2NativeConnectionDescription")} {t("restartTheAppForChangesToTakeEffect")}
         </>
       ),
-    },
-    {
-      key: AppSetting.ENABLE_NEW_IMAGE_PANEL,
-      name: t("newImagePanel"),
-      description: <>{t("newImagePanelDescription")}</>,
-    },
-  ];
+    });
+  }
 
   if (process.env.NODE_ENV === "development") {
     features.push({


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Fix ROS 2 native connection flag being shown on web builds where the connection is not supported