### PR TITLE
SettingsTreeEditor: improve UX for no options or invalid selection

### DIFF
--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -26,8 +26,10 @@ import Stack from "@foxglove/studio-base/components/Stack";
 
 import { ColorPickerInput, ColorGradientInput, NumberInput, Vec3Input, Vec2Input } from "./inputs";
 
-// Used to both undefined and empty string in select inputs.
+/** Used to allow both undefined and empty string in select inputs. */
 const UNDEFINED_SENTINEL_VALUE = uuid();
+/** Used to avoid MUI errors when an invalid option is selected */
+const INVALID_SENTINEL_VALUE = uuid();
 
 const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
   const prefersDarkMode = theme.palette.mode === "dark";
@@ -46,11 +48,9 @@ const useStyles = makeStyles<void, "error">()((theme, _params, classes) => {
     fieldWrapper: {
       minWidth: theme.spacing(14),
       marginRight: theme.spacing(0.5),
-      [`&.${classes.error}`]: {
-        ".MuiInputBase-root": {
-          outline: `1px ${theme.palette.error.main} solid`,
-          outlineOffset: -1,
-        },
+      [`&.${classes.error} .MuiInputBase-root, .MuiInputBase-root.${classes.error}`]: {
+        outline: `1px ${theme.palette.error.main} solid`,
+        outlineOffset: -1,
       },
     },
     multiLabelWrapper: {
@@ -121,7 +121,7 @@ function FieldInput({
   field: DeepReadonly<SettingsTreeField>;
   path: readonly string[];
 }): JSX.Element {
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles();
 
   switch (field.input) {
     case "autocomplete":
@@ -297,23 +297,43 @@ function FieldInput({
           />
         </Stack>
       );
-    case "select":
+    case "select": {
+      const selectedOptionIndex = // use findIndex instead of find to avoid confusing TypeScript with union of arrays
+        field.options.findIndex((option) => option.value === field.value);
+      const selectedOption = field.options[selectedOptionIndex];
+
+      const isEmpty = field.options.length === 0;
+      let selectValue = field.value;
+      if (!selectedOption) {
+        selectValue = INVALID_SENTINEL_VALUE;
+      } else if (selectValue == undefined) {
+        // We can't pass value={undefined} or we get a React error "A component is changing an
+        // uncontrolled input to be controlled" when changing the value to be non-undefined.
+        selectValue = UNDEFINED_SENTINEL_VALUE;
+      }
+
+      const hasError = !selectedOption && (!isEmpty || field.value != undefined);
       return (
         <Select
+          data-testid="field-editor-select"
+          className={cx({ [classes.error]: hasError })}
           size="small"
           displayEmpty
           fullWidth
           disabled={field.disabled}
           readOnly={field.readonly}
           variant="filled"
-          value={field.value ?? UNDEFINED_SENTINEL_VALUE}
-          renderValue={(value) => {
+          value={selectValue}
+          renderValue={(_value) => {
+            // Use field.value rather than the passed-in value so we can render the value even when
+            // it was not present in the list of options.
+            const value = field.value;
             for (const option of field.options) {
               if (option.value === value) {
                 return option.label.trim();
               }
             }
-            return undefined;
+            return value;
           }}
           onChange={(event) =>
             actionHandler({
@@ -335,8 +355,13 @@ function FieldInput({
               {label}
             </MenuItem>
           ))}
+          {isEmpty && <MenuItem disabled>No options</MenuItem>}
+          {!selectedOption && (
+            <MenuItem style={{ display: "none" }} value={INVALID_SENTINEL_VALUE} />
+          )}
         </Select>
       );
+    }
     case "gradient":
       return (
         <ColorGradientInput

--- a/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/FieldEditor.tsx
@@ -315,7 +315,6 @@ function FieldInput({
       const hasError = !selectedOption && (!isEmpty || field.value != undefined);
       return (
         <Select
-          data-testid="field-editor-select"
           className={cx({ [classes.error]: hasError })}
           size="small"
           displayEmpty

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.stories.tsx
@@ -4,6 +4,7 @@
 
 import { Box } from "@mui/material";
 import { fireEvent } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import produce from "immer";
 import { last } from "lodash";
 import { useCallback, useMemo, useState, useEffect } from "react";
@@ -146,6 +147,94 @@ For ROS users, we also support package:// URLs
     },
   },
   empty: undefined,
+};
+
+const SelectValidWithUndefinedSettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      validSelectWithUndefined: {
+        label: "Valid Select w/ Undefined",
+        value: undefined,
+        input: "select",
+        options: [
+          { label: "Undefined", value: undefined },
+          { label: "Nothing", value: "" },
+          { label: "Something", value: "something" },
+        ],
+      },
+    },
+  },
+};
+const SelectValidWithEmptyStringSettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      validSelectWithEmptyString: {
+        label: 'Valid Select w/ ""',
+        value: "",
+        input: "select",
+        options: [
+          { label: "Undefined", value: undefined },
+          { label: "Nothing", value: "" },
+          { label: "Something", value: "something" },
+        ],
+      },
+    },
+  },
+};
+const SelectInvalidWithUndefinedSettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      invalidSelectWithUndefined: {
+        label: "Invalid Select w/ Undefined",
+        value: "foobar",
+        input: "select",
+        options: [
+          { label: "Undefined", value: undefined },
+          { label: "Nothing", value: "" },
+          { label: "Something", value: "something" },
+        ],
+      },
+    },
+  },
+};
+const SelectInvalidWithoutUndefinedSettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      invalidSelectWithoutUndefined: {
+        label: "Invalid Select w/o Undefined",
+        value: "foobar",
+        input: "select",
+        options: [
+          { label: "Nothing", value: "" },
+          { label: "Something", value: "something" },
+        ],
+      },
+    },
+  },
+};
+const SelectEmptySettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      emptySelect: {
+        label: "Empty Select",
+        value: undefined,
+        input: "select",
+        options: [],
+      },
+    },
+  },
+};
+const SelectEmptyInvalidSettings: SettingsTreeNodes = {
+  general: {
+    fields: {
+      invalidEmptySelect: {
+        label: "Invalid Empty Select",
+        value: "foobar",
+        input: "select",
+        options: [],
+      },
+    },
+  },
 };
 
 const DisabledSettings: SettingsTreeNodes = {
@@ -731,7 +820,7 @@ function Wrapper({ nodes }: { nodes: SettingsTreeNodes }): JSX.Element {
           const nodeCount = Object.keys(dynamicNodes).length;
           setDynamicNodes((oldNodes) => ({
             ...oldNodes,
-            [`background{nodeCount + 1}`]: makeBackgroundNode(nodeCount + 1),
+            [`background${nodeCount + 1}`]: makeBackgroundNode(nodeCount + 1),
           }));
         }
         if (action.payload.id === "remove-grid" || action.payload.id === "remove-background") {
@@ -919,3 +1008,38 @@ export function Vec3(): JSX.Element {
 
   return <Wrapper nodes={settings} />;
 }
+
+async function clickSelect() {
+  const user = userEvent.setup();
+  await user.click(document.querySelector(".MuiSelect-select")!);
+}
+
+export function SelectInvalidWithUndefined(): JSX.Element {
+  return <Wrapper nodes={SelectInvalidWithUndefinedSettings} />;
+}
+SelectInvalidWithUndefined.play = clickSelect;
+
+export function SelectInvalidWithoutUndefined(): JSX.Element {
+  return <Wrapper nodes={SelectInvalidWithoutUndefinedSettings} />;
+}
+SelectInvalidWithoutUndefined.play = clickSelect;
+
+export function SelectValidWithUndefined(): JSX.Element {
+  return <Wrapper nodes={SelectValidWithUndefinedSettings} />;
+}
+SelectValidWithUndefined.play = clickSelect;
+
+export function SelectValidWithEmptyString(): JSX.Element {
+  return <Wrapper nodes={SelectValidWithEmptyStringSettings} />;
+}
+SelectValidWithEmptyString.play = clickSelect;
+
+export function SelectEmpty(): JSX.Element {
+  return <Wrapper nodes={SelectEmptySettings} />;
+}
+SelectEmpty.play = clickSelect;
+
+export function SelectEmptyInvalid(): JSX.Element {
+  return <Wrapper nodes={SelectEmptyInvalidSettings} />;
+}
+SelectEmptyInvalid.play = clickSelect;


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
- Show currently selected value and red outline if the selected value is not present in the `options`:  <img width="606" alt="image" src="https://user-images.githubusercontent.com/14237/228922366-01b613ea-a517-4bb0-802a-6dce58969e25.png">
- Show "No options" if the options list is empty: <img width="566" alt="image" src="https://user-images.githubusercontent.com/14237/228922486-3d4b2de3-a3ff-46b8-a752-3a4fafc05d41.png">


Relates to FG-2682 / #5663 