### PR TITLE
Added connection variable to PanelExtensionAdapter

### DIFF
--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -93,7 +93,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
   const { playerState, pauseFrame, setSubscriptions, seekPlayback, sortedTopics } =
     messagePipelineContext;
 
-  const { capabilities, profile: dataSourceProfile } = playerState;
+  const { capabilities, profile: dataSourceProfile, urlState: connection } = playerState;
 
   const { openSiblingPanel } = usePanelContext();
 
@@ -306,6 +306,8 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
         : undefined,
 
       dataSourceProfile,
+
+      connection,
 
       setParameter: (name: string, value: ParameterValue) => {
         if (!isMounted()) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -482,6 +482,7 @@ function PanelExtensionAdapter(props: PanelExtensionAdapterProps): JSX.Element {
     capabilities,
     clearHoverValue,
     dataSourceProfile,
+    connection,
     getMessagePipelineContext,
     initialState,
     isMounted,

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -256,6 +256,9 @@ export type PanelExtensionContext = {
    */
   readonly dataSourceProfile?: string;
 
+  /** Data about connection. */
+  readonly connection?: any;
+
   /**
    * Subscribe to updates on this field within the render state. Render will only be invoked when
    * this field changes.

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -257,7 +257,7 @@ export type PanelExtensionContext = {
   readonly dataSourceProfile?: string;
 
   /** Data about connection. */
-  readonly connection?: any;
+  readonly connection?: unknown;
 
   /**
    * Subscribe to updates on this field within the render state. Render will only be invoked when


### PR DESCRIPTION
**User-Facing Changes**
Added connection information to context in PanelExtensionContext (`context.connection`)

**Description**
This changes gives ability to access connection information from `PanelExtensionAdapter`. It is useful in custom extension development


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
