### PR TITLE
Add data source info in the playback bar

### DIFF
--- a/packages/studio-base/src/components/DataSourceInfoView.tsx
+++ b/packages/studio-base/src/components/DataSourceInfoView.tsx
@@ -40,6 +40,7 @@ const selectPlayerSourceId = ({ playerState }: MessagePipelineContext) =>
   playerState.urlState?.sourceId;
 
 function DataSourceInfoContent(props: {
+  disableSource?: boolean;
   durationRef: MutableRefObject<ReactNull | HTMLDivElement>;
   endTimeRef: MutableRefObject<ReactNull | HTMLDivElement>;
   playerName?: string;
@@ -47,7 +48,15 @@ function DataSourceInfoContent(props: {
   playerSourceId?: string;
   startTime?: Time;
 }): JSX.Element {
-  const { durationRef, endTimeRef, playerName, playerPresence, playerSourceId, startTime } = props;
+  const {
+    disableSource = false,
+    durationRef,
+    endTimeRef,
+    playerName,
+    playerPresence,
+    playerSourceId,
+    startTime,
+  } = props;
   const { classes } = useStyles();
   const { t } = useTranslation("dataSourceInfo");
 
@@ -58,26 +67,28 @@ function DataSourceInfoContent(props: {
 
   return (
     <Stack gap={1.5}>
-      <Stack>
-        <Typography className={classes.overline} display="block" variant="overline">
-          {t("currentSource")}
-        </Typography>
-        {playerPresence === PlayerPresence.INITIALIZING ? (
-          <Typography variant="inherit">
-            <Skeleton animation="wave" width="40%" />
+      {!disableSource && (
+        <Stack>
+          <Typography className={classes.overline} display="block" variant="overline">
+            {t("currentSource")}
           </Typography>
-        ) : playerPresence === PlayerPresence.RECONNECTING ? (
-          <Typography variant="inherit">{t("waitingForConnection")}</Typography>
-        ) : playerName ? (
-          <Typography variant="inherit" component="span">
-            <MultilineMiddleTruncate text={playerName} />
-          </Typography>
-        ) : (
-          <Typography className={classes.numericValue} variant="inherit">
-            &mdash;
-          </Typography>
-        )}
-      </Stack>
+          {playerPresence === PlayerPresence.INITIALIZING ? (
+            <Typography variant="inherit">
+              <Skeleton animation="wave" width="40%" />
+            </Typography>
+          ) : playerPresence === PlayerPresence.RECONNECTING ? (
+            <Typography variant="inherit">{t("waitingForConnection")}</Typography>
+          ) : playerName ? (
+            <Typography variant="inherit" component="span">
+              <MultilineMiddleTruncate text={playerName} />
+            </Typography>
+          ) : (
+            <Typography className={classes.numericValue} variant="inherit">
+              &mdash;
+            </Typography>
+          )}
+        </Stack>
+      )}
 
       <Stack>
         <Typography className={classes.overline} variant="overline">
@@ -129,7 +140,7 @@ const MemoDataSourceInfoContent = React.memo(DataSourceInfoContent);
 
 const EmDash = "\u2014";
 
-export function DataSourceInfoView(): JSX.Element {
+export function DataSourceInfoView({ disableSource }: { disableSource?: boolean }): JSX.Element {
   const startTime = useMessagePipeline(selectStartTime);
   const endTime = useMessagePipeline(selectEndTime);
   const playerName = useMessagePipeline(selectPlayerName);
@@ -164,6 +175,7 @@ export function DataSourceInfoView(): JSX.Element {
 
   return (
     <MemoDataSourceInfoContent
+      disableSource={disableSource}
       durationRef={durationRef}
       endTimeRef={endTimeRef}
       playerName={playerName}

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackTimeDisplayMethod.tsx
@@ -69,9 +69,15 @@ const StyledTextField = muiStyled(TextField)<{ error?: boolean }>(({ error, them
     borderLeft: `1px solid ${theme.palette.background.paper}`,
     visibility: "hidden",
     marginRight: theme.spacing(-1),
+
+    ...(error === true && {
+      color: theme.palette.error.main,
+      borderLeftColor: theme.palette.error.main,
+    }),
   },
   ...(error === true && {
     outline: `1px solid ${theme.palette.error.main}`,
+    outlineOffset: -1,
   }),
 }));
 

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -173,7 +173,7 @@ export default function PlaybackControls(props: {
               classes={{ popper: classes.popper }}
               title={
                 <Stack paddingY={1}>
-                  <DataSourceInfoView />
+                  <DataSourceInfoView disableSource />
                 </Stack>
               }
             >
@@ -182,7 +182,6 @@ export default function PlaybackControls(props: {
                 size="small"
                 icon={<Info24Regular />}
                 activeIcon={<Info24Filled />}
-                onClick={toggleCreateEventDialog}
               />
             </Tooltip>
             {currentUser && eventsSupported && (

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -60,6 +60,11 @@ const useStyles = makeStyles()((theme) => ({
     borderTop: `1px solid ${theme.palette.divider}`,
     zIndex: 100000,
   },
+  popper: {
+    "&[data-popper-placement*=top] .MuiTooltip-tooltip": {
+      margin: theme.spacing(0.5, 0.5, 0.75),
+    },
+  },
 }));
 
 const selectPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
@@ -165,7 +170,7 @@ export default function PlaybackControls(props: {
         <Stack direction="row" alignItems="center" flex={1} gap={1} overflowX="auto">
           <Stack direction="row" flex={1} gap={0.5}>
             <Tooltip
-              disableInteractive
+              classes={{ popper: classes.popper }}
               title={
                 <Stack paddingY={1}>
                   <DataSourceInfoView />
@@ -175,7 +180,6 @@ export default function PlaybackControls(props: {
               <HoverableIconButton
                 disabled={presence !== PlayerPresence.PRESENT}
                 size="small"
-                color="info"
                 icon={<Info24Regular />}
                 activeIcon={<Info24Filled />}
                 onClick={toggleCreateEventDialog}

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -177,7 +177,7 @@ export default function PlaybackControls(props: {
                 size="small"
                 title="Create event"
                 icon={<EventOutlinedIcon />}
-                activeIcon={<EventIcon />}
+                activeColor="info"
                 onClick={toggleCreateEventDialog}
               />
             )}

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -20,8 +20,8 @@ import {
   Next20Regular,
   Previous20Filled,
   Previous20Regular,
-  Clock24Regular,
-  Clock24Filled,
+  Info24Regular,
+  Info24Filled,
 } from "@fluentui/react-icons";
 import { Tooltip } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
@@ -193,8 +193,8 @@ export default function PlaybackControls(props: {
                 <HoverableIconButton
                   disabled={presence !== PlayerPresence.PRESENT}
                   size="small"
-                  icon={<Clock24Regular />}
-                  activeIcon={<Clock24Filled />}
+                  icon={<Info24Regular />}
+                  activeIcon={<Info24Filled />}
                 />
               </Tooltip>
             )}

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -21,7 +21,6 @@ import {
   Previous20Filled,
   Previous20Regular,
   Info24Regular,
-  Info24Filled,
 } from "@fluentui/react-icons";
 import { Tooltip } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
@@ -177,7 +176,7 @@ export default function PlaybackControls(props: {
                 size="small"
                 title="Create event"
                 icon={<EventOutlinedIcon />}
-                activeColor="info"
+                activeIcon={<EventIcon />}
                 onClick={toggleCreateEventDialog}
               />
             )}
@@ -194,7 +193,7 @@ export default function PlaybackControls(props: {
                   disabled={presence !== PlayerPresence.PRESENT}
                   size="small"
                   icon={<Info24Regular />}
-                  activeIcon={<Info24Filled />}
+                  activeColor="info"
                 />
               </Tooltip>
             )}

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -20,12 +20,16 @@ import {
   Next20Regular,
   Previous20Filled,
   Previous20Regular,
+  Info24Regular,
+  Info24Filled,
 } from "@fluentui/react-icons";
+import { Tooltip } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { compare, Time } from "@foxglove/rostime";
 import { CreateEventDialog } from "@foxglove/studio-base/components/CreateEventDialog";
+import { DataSourceInfoView } from "@foxglove/studio-base/components/DataSourceInfoView";
 import EventIcon from "@foxglove/studio-base/components/EventIcon";
 import EventOutlinedIcon from "@foxglove/studio-base/components/EventOutlinedIcon";
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
@@ -160,6 +164,23 @@ export default function PlaybackControls(props: {
         <Scrubber onSeek={seek} />
         <Stack direction="row" alignItems="center" flex={1} gap={1} overflowX="auto">
           <Stack direction="row" flex={1} gap={0.5}>
+            <Tooltip
+              disableInteractive
+              title={
+                <Stack paddingY={1}>
+                  <DataSourceInfoView />
+                </Stack>
+              }
+            >
+              <HoverableIconButton
+                disabled={presence !== PlayerPresence.PRESENT}
+                size="small"
+                color="info"
+                icon={<Info24Regular />}
+                activeIcon={<Info24Filled />}
+                onClick={toggleCreateEventDialog}
+              />
+            </Tooltip>
             {currentUser && eventsSupported && (
               <HoverableIconButton
                 size="small"

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -20,8 +20,8 @@ import {
   Next20Regular,
   Previous20Filled,
   Previous20Regular,
-  Info24Regular,
-  Info24Filled,
+  Clock24Regular,
+  Clock24Filled,
 } from "@fluentui/react-icons";
 import { Tooltip } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
@@ -169,21 +169,6 @@ export default function PlaybackControls(props: {
         <Scrubber onSeek={seek} />
         <Stack direction="row" alignItems="center" flex={1} gap={1} overflowX="auto">
           <Stack direction="row" flex={1} gap={0.5}>
-            <Tooltip
-              classes={{ popper: classes.popper }}
-              title={
-                <Stack paddingY={1}>
-                  <DataSourceInfoView disableSource />
-                </Stack>
-              }
-            >
-              <HoverableIconButton
-                disabled={presence !== PlayerPresence.PRESENT}
-                size="small"
-                icon={<Info24Regular />}
-                activeIcon={<Info24Filled />}
-              />
-            </Tooltip>
             {currentUser && eventsSupported && (
               <HoverableIconButton
                 size="small"
@@ -193,6 +178,21 @@ export default function PlaybackControls(props: {
                 onClick={toggleCreateEventDialog}
               />
             )}
+            <Tooltip
+              classes={{ popper: classes.popper }}
+              title={
+                <Stack paddingY={0.75}>
+                  <DataSourceInfoView disableSource />
+                </Stack>
+              }
+            >
+              <HoverableIconButton
+                disabled={presence !== PlayerPresence.PRESENT}
+                size="small"
+                icon={<Clock24Regular />}
+                activeIcon={<Clock24Filled />}
+              />
+            </Tooltip>
             <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
           </Stack>
           <Stack direction="row" alignItems="center" gap={1}>

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -28,6 +28,7 @@ import { useCallback, useMemo, useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
 import { compare, Time } from "@foxglove/rostime";
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
 import { CreateEventDialog } from "@foxglove/studio-base/components/CreateEventDialog";
 import { DataSourceInfoView } from "@foxglove/studio-base/components/DataSourceInfoView";
 import EventIcon from "@foxglove/studio-base/components/EventIcon";
@@ -43,6 +44,7 @@ import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpee
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
+import { useAppConfigurationValue } from "@foxglove/studio-base/hooks";
 import { Player, PlayerPresence } from "@foxglove/studio-base/players/types";
 
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
@@ -80,6 +82,7 @@ export default function PlaybackControls(props: {
 }): JSX.Element {
   const { play, pause, seek, isPlaying, getTimeInfo, playUntil } = props;
   const presence = useMessagePipeline(selectPresence);
+  const [enableNewTopNav = false] = useAppConfigurationValue<boolean>(AppSetting.ENABLE_NEW_TOPNAV);
 
   const { classes } = useStyles();
   const [repeat, setRepeat] = useState(false);
@@ -178,21 +181,23 @@ export default function PlaybackControls(props: {
                 onClick={toggleCreateEventDialog}
               />
             )}
-            <Tooltip
-              classes={{ popper: classes.popper }}
-              title={
-                <Stack paddingY={0.75}>
-                  <DataSourceInfoView disableSource />
-                </Stack>
-              }
-            >
-              <HoverableIconButton
-                disabled={presence !== PlayerPresence.PRESENT}
-                size="small"
-                icon={<Clock24Regular />}
-                activeIcon={<Clock24Filled />}
-              />
-            </Tooltip>
+            {enableNewTopNav && (
+              <Tooltip
+                classes={{ popper: classes.popper }}
+                title={
+                  <Stack paddingY={0.75}>
+                    <DataSourceInfoView disableSource />
+                  </Stack>
+                }
+              >
+                <HoverableIconButton
+                  disabled={presence !== PlayerPresence.PRESENT}
+                  size="small"
+                  icon={<Clock24Regular />}
+                  activeIcon={<Clock24Filled />}
+                />
+              </Tooltip>
+            )}
             <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
           </Stack>
           <Stack direction="row" alignItems="center" gap={1}>


### PR DESCRIPTION
**User-Facing Changes**
None (hidden behind feature flag)

**Description**
Adds icon that shows Data Source Info on hover in playback bar

<img width="253" alt="Screen Shot 2023-04-01 at 8 21 08 am" src="https://user-images.githubusercontent.com/924528/229233971-4b1adf63-8fd1-4cca-b89d-7c334b485c82.png">




<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
