### PR TITLE
Fix Foxglove Websocket not reconnecting when server restarted

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -161,7 +161,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
     log.info(`Opening connection to ${this._url}`);
 
-    // Set a timeout to abort the connection if we are still not connected by then
+    // Set a timeout to abort the connection if we are still not connected by then.
+    // This will abort hanging connection attempts that can for whatever reason not
+    // establish a connection with the server.
     this._connectionAttemptTimeout = setTimeout(() => {
       this._client?.close();
     }, 10000);

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -117,6 +117,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _parameters = new Map<string, ParameterValue>();
   private _getParameterInterval?: ReturnType<typeof setInterval>;
   private _openTimeout?: ReturnType<typeof setInterval>;
+  private _connectionAttemptTimeout?: ReturnType<typeof setInterval>;
   private _unresolvedPublications: AdvertiseOptions[] = [];
   private _publicationsByTopic = new Map<string, Publication>();
   private _serviceCallEncoding?: string;
@@ -160,6 +161,11 @@ export default class FoxgloveWebSocketPlayer implements Player {
     }
     log.info(`Opening connection to ${this._url}`);
 
+    // Set a timeout to abort the connection if we are still not connected by then
+    this._connectionAttemptTimeout = setTimeout(() => {
+      this._client?.close();
+    }, 10000);
+
     this._client = new FoxgloveClient({
       ws:
         typeof Worker !== "undefined"
@@ -170,6 +176,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
     this._client.on("open", () => {
       if (this._closed) {
         return;
+      }
+      if (this._connectionAttemptTimeout != undefined) {
+        clearTimeout(this._connectionAttemptTimeout);
       }
       this._presence = PlayerPresence.PRESENT;
       this._problems.clear();
@@ -210,6 +219,9 @@ export default class FoxgloveWebSocketPlayer implements Player {
       if (this._getParameterInterval != undefined) {
         clearInterval(this._getParameterInterval);
         this._getParameterInterval = undefined;
+      }
+      if (this._connectionAttemptTimeout != undefined) {
+        clearTimeout(this._connectionAttemptTimeout);
       }
 
       this._client?.close();


### PR DESCRIPTION
**User-Facing Changes**
- Fix Foxglove Websocket not reconnecting when server restarted

**Description**
- Fixes that the websocket worker adapter does not receive the `close` signal from the websocket when `close()` is called
- Abort unsuccessful connection attempts after 10 seconds
