### PR TITLE
Increase scrollbar width to 6px

### DIFF
--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     },
     div: {
       "::-webkit-scrollbar": {
-        width: "6px",
+        width: 6,
         height: 0,
       },
       "::-webkit-scrollbar-corner": {

--- a/packages/studio-base/src/components/CssBaseline.tsx
+++ b/packages/studio-base/src/components/CssBaseline.tsx
@@ -51,8 +51,8 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
     },
     div: {
       "::-webkit-scrollbar": {
-        width: 4,
-        height: 4,
+        width: "6px",
+        height: 0,
       },
       "::-webkit-scrollbar-corner": {
         background: "transparent",
@@ -62,7 +62,7 @@ const useStyles = makeStyles()(({ palette, typography }) => ({
       },
       "::-webkit-scrollbar-thumb": {
         background: palette.action.focus,
-        borderRadius: 2,
+        borderRadius: 0,
       },
     },
     "p:not([class^='Mui')": {


### PR DESCRIPTION
**User-Facing Changes**
Not worth calling out in release notes

**Description**
While working on https://github.com/foxglove/studio/pull/5678, I noticed that in some instances our highlighted panel border will protrude into the active panel.

<img width="73" alt="Screenshot 2023-03-31 at 4 21 06 PM" src="https://user-images.githubusercontent.com/84792/229249137-d0e70637-c327-4c7f-980e-c6e437a30889.png">

Making it harder to select the scrollbar to scroll. Changing this border behavior is challenging and has other gotchas with react mosaic. To ease the pain of using a scrollbar in an active panel I am increasing the width to 6px from 4px. I've also removed the border radius since our app has a more boxy design.