### PR TITLE
Update StudioLogsChannel interval to 1 second

### DIFF
--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
@@ -35,7 +35,7 @@ function StudioLogsSettingsProvider(props: PropsWithChildren<unknown>): JSX.Elem
       if (storeChannelsCount !== Log.channels().length) {
         setStudioLogsSettingsStore(createStudioLogsSettingsStore(savedStateRef.current));
       }
-    }, 100);
+    }, 1000);
 
     return () => clearInterval(intervalHandle);
   }, [studioLogsSettingsStore, studioLogsSettingsSavedState]);

--- a/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
+++ b/packages/studio-base/src/providers/StudioLogsSettingsProvider/StudioLogsSettingsProvider.tsx
@@ -28,14 +28,14 @@ function StudioLogsSettingsProvider(props: PropsWithChildren<unknown>): JSX.Elem
   // Setup an interval to check for changes to the total number of logging channels
   //
   // When the total number of channels changes we re-initialize the settings store so we display any
-  // newly added log chnanels.
+  // newly added log channels.
   useEffect(() => {
     const storeChannelsCount = studioLogsSettingsStore.getState().channels.length;
     const intervalHandle = setInterval(() => {
       if (storeChannelsCount !== Log.channels().length) {
         setStudioLogsSettingsStore(createStudioLogsSettingsStore(savedStateRef.current));
       }
-    });
+    }, 100);
 
     return () => clearInterval(intervalHandle);
   }, [studioLogsSettingsStore, studioLogsSettingsSavedState]);


### PR DESCRIPTION


**User-Facing Changes**
None

**Description**
Rather than using a default interval, set the re-scan interval for internal studio logs to 100ms. This is sufficient for the desired functionality.

