### PR TITLE
Use readahead message buffer in plot panel

### DIFF
--- a/packages/den/collection/VecQueue.ts
+++ b/packages/den/collection/VecQueue.ts
@@ -11,7 +11,7 @@
 export class VecQueue<T> {
   private readPos = 0;
   private writePos = 0;
-  private buffer: Array<T | undefined> = new Array(4);
+  private readonly buffer: Array<T | undefined> = new Array(4);
 
   /**
    * Add an item at the end of the queue. If the queue is full the underlying buffer is grown.
@@ -87,6 +87,22 @@ export class VecQueue<T> {
     this.buffer.length = 0;
     this.writePos = 0;
     this.readPos = 0;
+  }
+
+  /**
+   * Export the contents of the queue.
+   * @returns a linear, in-order array of all enqueued items.
+   */
+  public export(): Array<undefined | T> {
+    const endPos =
+      this.writePos < this.readPos ? this.writePos + this.buffer.length : this.writePos;
+    let pos = this.readPos;
+    const result = Array(endPos - pos);
+    while (pos < endPos) {
+      result[pos] = this.buffer[pos % this.buffer.length];
+      pos++;
+    }
+    return result;
   }
 
   private addCapacity() {

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -13,17 +13,18 @@
 
 import DownloadIcon from "@mui/icons-material/Download";
 import { useTheme } from "@mui/material";
-import { compact, isNumber, uniq } from "lodash";
+import { compact, isNumber, last, transform, uniq } from "lodash";
 import memoizeWeak from "memoize-weak";
 import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
 
 import { filterMap } from "@foxglove/den/collection";
 import { useShallowMemo } from "@foxglove/hooks";
 import {
+  Time,
   add as addTimes,
   fromSec,
+  isGreaterThan,
   subtract as subtractTimes,
-  Time,
   toSec,
 } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
@@ -205,6 +206,11 @@ function selectCurrentTime(ctx: MessagePipelineContext) {
   return ctx.playerState.activeData?.currentTime;
 }
 
+const EMPTY_READAHEAD_MESSAGES: MessageEvent<unknown>[] = [];
+function selectReadAheadMessages(ctx: MessagePipelineContext) {
+  return ctx.playerState.activeData?.readAheadMessages ?? EMPTY_READAHEAD_MESSAGES;
+}
+
 function selectEndTime(ctx: MessagePipelineContext) {
   return ctx.playerState.activeData?.endTime;
 }
@@ -338,6 +344,47 @@ function Plot(props: Props) {
     return getBlockItemsByPath(decodeMessagePathsForMessagesByTopic, blocks);
   }, [blocks, decodeMessagePathsForMessagesByTopic, showSingleCurrentMessage]);
 
+  const readAheadMessages = useMessagePipeline(selectReadAheadMessages);
+  const readAheadPlotDataItems: Record<string, PlotDataItem[]> = useMemo(() => {
+    const data: Record<string, PlotDataItem[]> = {};
+    for (const msgEvent of readAheadMessages) {
+      const paths = topicToPaths.get(msgEvent.topic);
+      if (!paths) {
+        continue;
+      }
+
+      for (const path of paths) {
+        const dataItem = cachedGetMessagePathDataItems(path, msgEvent);
+        if (!dataItem) {
+          continue;
+        }
+
+        const headerStamp = getTimestampForMessage(msgEvent.message);
+        const plotDataItem = {
+          queriedData: dataItem,
+          receiveTime: msgEvent.receiveTime,
+          headerStamp,
+        };
+        (data[path] ?? (data[path] = [])).push(plotDataItem);
+      }
+    }
+    return data;
+  }, [cachedGetMessagePathDataItems, readAheadMessages, topicToPaths]);
+
+  const plotDataForBlocksIncludingReadahead = useMemo<Record<string, PlotDataItem[][]>>(() => {
+    return transform(plotDataForBlocks, (result, value, key) => {
+      const lastBlockEndTime = last(last(value))?.receiveTime;
+      if (lastBlockEndTime) {
+        const itemsAfterBlocks = (readAheadPlotDataItems[key] ?? []).filter((item) =>
+          isGreaterThan(item.receiveTime, lastBlockEndTime),
+        );
+        result[key] = value.concat([itemsAfterBlocks]);
+      } else {
+        result[key] = value;
+      }
+    });
+  }, [plotDataForBlocks, readAheadPlotDataItems]);
+
   // When restoring, keep only the paths that are present in allPaths.
   // Without this, the reducer value will grow unbounded with new paths as users add/remove series.
   const restore = useCallback(
@@ -366,7 +413,10 @@ function Plot(props: Props) {
   // To keep the addMessages function "stable" when loading new blocks we grab only the paths from
   // the blocks and make addMessages depend on the paths. To keep paths referentially stable when
   // the paths values haven't changed we use a shallow memo.
-  const blockPaths = useMemo(() => Object.keys(plotDataForBlocks), [plotDataForBlocks]);
+  const blockPaths = useMemo(
+    () => Object.keys(plotDataForBlocksIncludingReadahead),
+    [plotDataForBlocksIncludingReadahead],
+  );
   const blockPathsMemo = useShallowMemo(blockPaths);
 
   const addMessages = useCallback(
@@ -462,7 +512,7 @@ function Plot(props: Props) {
   // Keep disabled paths when passing into getDatasets, because we still want
   // easy access to the history when turning the disabled paths back on.
   const { datasets, pathsWithMismatchedDataLengths } = useMemo(() => {
-    const allPlotData = { ...plotDataByPath, ...plotDataForBlocks };
+    const allPlotData = { ...plotDataByPath, ...plotDataForBlocksIncludingReadahead };
 
     return getDatasets({
       paths: yAxisPaths,
@@ -472,7 +522,15 @@ function Plot(props: Props) {
       xAxisPath,
       invertedTheme: theme.palette.mode === "dark",
     });
-  }, [plotDataByPath, plotDataForBlocks, yAxisPaths, startTime, xAxisVal, xAxisPath, theme]);
+  }, [
+    plotDataByPath,
+    plotDataForBlocksIncludingReadahead,
+    yAxisPaths,
+    startTime,
+    xAxisVal,
+    xAxisPath,
+    theme.palette.mode,
+  ]);
 
   const tooltips = useMemo(() => {
     if (showLegend && showPlotValuesInLegend) {

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -3,10 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Condvar } from "@foxglove/den/async";
-import { VecQueue } from "@foxglove/den/collection";
+import { VecQueue, filterMap } from "@foxglove/den/collection";
 import Log from "@foxglove/log";
-import { add as addTime, compare, clampTime } from "@foxglove/rostime";
-import { Time, MessageEvent } from "@foxglove/studio";
+import { add as addTime, clampTime, compare } from "@foxglove/rostime";
+import { MessageEvent, Time } from "@foxglove/studio";
 import { Range } from "@foxglove/studio-base/util/ranges";
 
 import { CachingIterableSource } from "./CachingIterableSource";
@@ -36,19 +36,19 @@ type Options = {
  * reading from the underlying source and populating the cache.
  */
 class BufferedIterableSource implements IIterableSource {
-  private source: CachingIterableSource;
+  private readonly source: CachingIterableSource;
 
   private readDone = false;
   private aborted = false;
 
   // The producer uses this signal to notify a waiting consumer there is data to consume.
-  private readSignal = new Condvar();
+  private readonly readSignal = new Condvar();
 
   // The consumer uses this signal to notify a waiting producer that something has been consumed.
-  private writeSignal = new Condvar();
+  private readonly writeSignal = new Condvar();
 
   // The producer loads results into the cache and the consumer reads from the cache.
-  private cache = new VecQueue<IteratorResult>();
+  private readonly cache = new VecQueue<IteratorResult>();
 
   // The location of the consumer read head
   private readHead: Time = { sec: 0, nsec: 0 };
@@ -60,7 +60,7 @@ class BufferedIterableSource implements IIterableSource {
   private initResult?: Initalization;
 
   // How far ahead of the read head we should try to keep buffering
-  private readAheadDuration: Time;
+  private readonly readAheadDuration: Time;
 
   public constructor(source: IIterableSource, opt?: Options) {
     this.readAheadDuration = opt?.readAheadDuration ?? DEFAULT_READ_AHEAD_DURATION;
@@ -70,6 +70,11 @@ class BufferedIterableSource implements IIterableSource {
   public async initialize(): Promise<Initalization> {
     this.initResult = await this.source.initialize();
     return this.initResult;
+  }
+
+  public getReadAheadMessages(): MessageEvent<unknown>[] {
+    const data = this.cache.export();
+    return filterMap(data, (item) => (item?.type === "message-event" ? item.msgEvent : undefined));
   }
 
   private async startProducer(args: MessageIteratorArgs): Promise<void> {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -757,6 +757,7 @@ export class IterablePlayer implements Player {
         topicStats: this._providerTopicStats,
         datatypes: this._providerDatatypes,
         publishedTopics: this._publishedTopics,
+        readAheadMessages: this._bufferedSource.getReadAheadMessages(),
       };
     }
 

--- a/packages/studio-base/src/players/types.ts
+++ b/packages/studio-base/src/players/types.ts
@@ -195,6 +195,8 @@ export type PlayerStateActiveData = {
   // A map of parameter names to parameter values, used to describe remote parameters such as
   // rosparams.
   parameters?: Map<string, ParameterValue>;
+
+  readAheadMessages?: MessageEvent<unknown>[];
 };
 
 // Represents a ROS topic, though the actual data does not need to come from a ROS system.


### PR DESCRIPTION
**User-Facing Changes**
Improve behavior of plot panel in memory constrained conditions

**Description**
This is a proof of concept PR that passes through the readahead buffer in `BufferedIterableSource` to the player and the plot panel.

Pros:
1. We already have the messages in the readahead buffer so this doesn't change our actual data loading pattern.
2. It doesn't allocate any more memory than the existing implementation.
3. The messages in the readahead are in a separate field in the player state so other panels should be able to ignore this safely and it shouldn't break any other assumptions about message ordering.

Cons:
1. The readahead buffer is arguably an implementation detail we don't want to commit to in the player state API.
2. The Y scale on the plot panel can change quite markedly while seeking around in the data.

***Before***:
https://user-images.githubusercontent.com/93935560/229448259-011898c4-5a1e-4163-a785-326d89ed5058.mov

***After***:
https://user-images.githubusercontent.com/93935560/229448329-867e5d2f-dc5f-4d3b-b34a-fb99a21b9755.mov


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
