### PR TITLE
Only show ROS_PACKAGE_PATH when in desktop app

### DIFF
--- a/packages/studio-base/src/components/PreferencesDialog/PreferencesDialog.tsx
+++ b/packages/studio-base/src/components/PreferencesDialog/PreferencesDialog.tsx
@@ -268,7 +268,7 @@ export function PreferencesDialog(
               <LanguageSettings />
               {supportsAppUpdates && <AutoUpdate />}
               {!isDesktopApp() && <LaunchDefault />}
-              <RosPackagePath />
+              {isDesktopApp() && <RosPackagePath />}
             </Stack>
           </section>
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Only show ROS_PACKAGE_PATH in settings when in desktop app

**Description**


<!-- link relevant GitHub issues -->
FG-2499
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
