### PR TITLE
Bring back WssErrorModal

### DIFF
--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
@@ -22,6 +22,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { SidebarContent } from "@foxglove/studio-base/components/SidebarContent";
 import Stack from "@foxglove/studio-base/components/Stack";
+import WssErrorModal from "@foxglove/studio-base/components/WssErrorModal";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
@@ -107,6 +108,12 @@ export default function DataSourceSidebar(props: Props): JSX.Element {
     }
   }, [playerPresence, showEventsTab, selectedEventId]);
 
+  const [hasDismissedWssErrorModal, setHasDismissedWssErrorModal] = useState(false);
+  const hasWssConnectionProblem = playerProblems.find(
+    (problem) =>
+      problem.severity === "error" && problem.message === "Insecure WebSocket connection",
+  );
+
   return (
     <SidebarContent
       disablePadding
@@ -182,6 +189,9 @@ export default function DataSourceSidebar(props: Props): JSX.Element {
           </>
         )}
       </Stack>
+      {hasWssConnectionProblem && !hasDismissedWssErrorModal && (
+        <WssErrorModal onClose={() => setHasDismissedWssErrorModal(true)} />
+      )}
     </SidebarContent>
   );
 }

--- a/packages/studio-base/src/components/WssErrorModal.png
+++ b/packages/studio-base/src/components/WssErrorModal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:088f5cfbab8a287b872fa7def7b950d7d1176672cbcbe4b8147ebd1aa8ab5ec4
+size 98117

--- a/packages/studio-base/src/components/WssErrorModal.stories.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.stories.tsx
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import WssErrorModal from "./WssErrorModal";
+
+export default {
+  title: "components/WssErrorModal",
+  component: WssErrorModal,
+  parameters: {
+    colorScheme: "light",
+  },
+};
+
+export function Default(): JSX.Element {
+  return <WssErrorModal />;
+}

--- a/packages/studio-base/src/components/WssErrorModal.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.tsx
@@ -44,7 +44,9 @@ export default function WssErrorModal(props: { onClose?: () => void }): JSX.Elem
       </Stack>
       <Stack paddingX={3} paddingY={2} rowGap={2}>
         <Typography variant="body1" color="text.secondary">
-          By default, Chrome prevents a secure <code>https://</code> page from connecting to an insecure <code>ws://</code> WebSocket server. To allow the connection, enable "Unsafe Scripts" for this page.
+          By default, Chrome prevents a secure <code>https://</code> page from connecting to an
+          insecure <code>ws://</code> WebSocket server. To allow the connection, enable &quot;Unsafe
+          Scripts&quot; for this page.
         </Typography>
         <Typography variant="body1" color="text.secondary">
           Click the shield icon at the end of your address bar, and then click &quot;Load Unsafe

--- a/packages/studio-base/src/components/WssErrorModal.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.tsx
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import CloseIcon from "@mui/icons-material/Close";
+import { Dialog, IconButton, Stack, Typography } from "@mui/material";
+import { useState } from "react";
+import { makeStyles } from "tss-react/mui";
+
+import WssErrorModalScreenshot from "./WssErrorModal.png";
+
+const useStyles = makeStyles()({
+  image: {
+    maxWidth: "24rem",
+  },
+});
+
+export default function WssErrorModal(props: { onClose?: () => void }): JSX.Element {
+  const [open, setOpen] = useState(true);
+  const { onClose } = props;
+
+  const { classes } = useStyles();
+
+  const handleClose = () => {
+    setOpen(false);
+    onClose?.();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
+        paddingX={3}
+        paddingTop={2}
+      >
+        <Typography variant="h3" paddingTop={1}>
+          WebSocket SSL Error
+        </Typography>
+        <IconButton onClick={() => setOpen(false)} edge="end">
+          <CloseIcon />
+        </IconButton>
+      </Stack>
+      <Stack paddingX={3} paddingY={2} rowGap={2}>
+        <Typography variant="body1" color="text.secondary">
+          Chrome prevents connecting to a websocket which is not served over TLS/SSL. For now you
+          can circumvent this by enabling &quot;unsafe&quot; scripts for this page.
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Click the shield icon at the end of your address bar, and then click &quot;Load Unsafe
+          Scripts.&quot;
+        </Typography>
+        <img src={WssErrorModalScreenshot} alt="WSS screenshot" className={classes.image} />
+      </Stack>
+    </Dialog>
+  );
+}

--- a/packages/studio-base/src/components/WssErrorModal.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.tsx
@@ -44,8 +44,7 @@ export default function WssErrorModal(props: { onClose?: () => void }): JSX.Elem
       </Stack>
       <Stack paddingX={3} paddingY={2} rowGap={2}>
         <Typography variant="body1" color="text.secondary">
-          Chrome prevents connecting to a websocket which is not served over TLS/SSL. For now you
-          can circumvent this by enabling &quot;unsafe&quot; scripts for this page.
+          By default, Chrome prevents a secure <code>https://</code> page from connecting to an insecure <code>ws://</code> WebSocket server. To allow the connection, enable "Unsafe Scripts" for this page.
         </Typography>
         <Typography variant="body1" color="text.secondary">
           Click the shield icon at the end of your address bar, and then click &quot;Load Unsafe

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -195,6 +195,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     this._client.on("error", (err) => {
       log.error(err);
+
+      if (
+        (err as unknown as undefined | { message?: string })?.message != undefined &&
+        err.message.includes("insecure WebSocket connection")
+      ) {
+        this._problems.addProblem("ws:connection-failed", {
+          severity: "error",
+          message: "Insecure WebSocket connection",
+          tip: `Check that the WebSocket server at ${this._url} is reachable and supports protocol version ${FoxgloveClient.SUPPORTED_SUBPROTOCOL}.`,
+        });
+        this._emitState();
+      }
     });
 
     // Note: We've observed closed being called not only when an already open connection is closed


### PR DESCRIPTION
**User-Facing Changes**

Displays a useful modal when someone tries to connect to a `ws://non-localhost` over https:

<img width="1153" alt="modal" src="https://user-images.githubusercontent.com/349687/229573464-1dccd5f2-2c1a-4250-b20f-dc41009d33f8.png">

