### PR TITLE
Fix double-click to open bag/mcap files

### DIFF
--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -417,6 +417,8 @@ function WorkspaceContent(props: WorkspaceProps): JSX.Element {
               variant: "error",
             });
           }
+        } else {
+          otherFiles.push(file);
         }
       }
 


### PR DESCRIPTION
**User-Facing Changes**
Fixed an issue with double-clicking to open files in the desktop app (bag, mcap, etc.).

**Description**
This regressed in https://github.com/foxglove/studio/pull/5634 since this line of code was accidentally deleted.
Fixes #5692