### PR TITLE
Use both blocks and current frame data in plots

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/parseRosPath.ts
@@ -50,7 +50,7 @@ const parseRosPath = memoize((path: string): RosPath | undefined => {
 });
 export default parseRosPath;
 
-export function getTopicsFromPaths(paths: string[]): string[] {
+export function getTopicsFromPaths(paths: readonly string[]): string[] {
   return uniq(
     filterMap(paths, (path) => {
       const rosPath = parseRosPath(path);

--- a/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useCachedGetMessagePathDataItems.ts
@@ -45,11 +45,11 @@ export type MessagePathDataItem = {
 // and message to an array of `MessagePathDataItem` objects. The array+objects will be the same by
 // reference, as long as topics/datatypes/global variables haven't changed in the meantime.
 export function useCachedGetMessagePathDataItems(
-  paths: string[],
+  paths: readonly string[],
 ): (path: string, message: MessageEvent<unknown>) => MessagePathDataItem[] | undefined {
   const { topics: providerTopics, datatypes } = PanelAPI.useDataSourceInfo();
   const { globalVariables } = useGlobalVariables();
-  const memoizedPaths: string[] = useShallowMemo<string[]>(paths);
+  const memoizedPaths = useShallowMemo(paths);
 
   // We first fill in global variables in the paths, so we can later see which paths have really
   // changed when the global variables have changed.
@@ -376,11 +376,11 @@ export type MessageDataItemsByPath = {
 };
 
 export function useDecodeMessagePathsForMessagesByTopic(
-  paths: string[],
+  paths: readonly string[],
 ): (messagesByTopic: {
   [topicName: string]: readonly MessageEvent<unknown>[];
 }) => MessageDataItemsByPath {
-  const memoizedPaths = useShallowMemo<string[]>(paths);
+  const memoizedPaths = useShallowMemo(paths);
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(memoizedPaths);
   // Note: Let callers define their own memoization scheme for messagesByTopic. For regular playback
   // useMemo might be appropriate, but weakMemo will likely better for blocks.

--- a/packages/studio-base/src/panels/Plot/datasets.tsx
+++ b/packages/studio-base/src/panels/Plot/datasets.tsx
@@ -2,6 +2,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Immutable } from "immer";
+
 import { filterMap } from "@foxglove/den/collection";
 import { isTime, subtract, Time, toSec } from "@foxglove/rostime";
 import { format } from "@foxglove/studio-base/util/formatTime";
@@ -27,8 +29,8 @@ function getXForPoint(
   xAxisVal: PlotXAxisVal,
   timestamp: number,
   innerIdx: number,
-  xAxisRanges: readonly (readonly PlotDataItem[])[] | undefined,
-  xItem: PlotDataItem | undefined,
+  xAxisRanges: Immutable<PlotDataItem[][]> | undefined,
+  xItem: undefined | Immutable<PlotDataItem>,
   xAxisPath: BasePlotPath | undefined,
 ): number | bigint {
   if (isCustomScale(xAxisVal) && xAxisPath) {
@@ -47,13 +49,13 @@ function getXForPoint(
 }
 
 function getDatumsForMessagePathItem(
-  yItem: PlotDataItem,
-  xItem: PlotDataItem | undefined,
+  yItem: Immutable<PlotDataItem>,
+  xItem: undefined | Immutable<PlotDataItem>,
   startTime: Time,
   timestampMethod: TimestampMethod,
   xAxisVal: PlotXAxisVal,
   xAxisPath?: BasePlotPath,
-  xAxisRanges?: readonly (readonly PlotDataItem[])[],
+  xAxisRanges?: Immutable<PlotDataItem[][]>,
 ): { data: Datum[]; hasMismatchedData: boolean } {
   const timestamp = timestampMethod === "headerStamp" ? yItem.headerStamp : yItem.receiveTime;
   if (!timestamp) {
@@ -116,11 +118,11 @@ function getDatasetsFromMessagePlotPath({
   invertedTheme = false,
 }: {
   path: PlotPath;
-  yAxisRanges: readonly (readonly PlotDataItem[])[];
+  yAxisRanges: Immutable<PlotDataItem[][]>;
   index: number;
   startTime: Time;
   xAxisVal: PlotXAxisVal;
-  xAxisRanges: readonly (readonly PlotDataItem[])[] | undefined;
+  xAxisRanges: Immutable<PlotDataItem[][]> | undefined;
   xAxisPath?: BasePlotPath;
   invertedTheme?: boolean;
 }): {
@@ -147,10 +149,10 @@ function getDatasetsFromMessagePlotPath({
   }
 
   for (const [rangeIdx, range] of yAxisRanges.entries()) {
-    const xRange: readonly PlotDataItem[] | undefined = xAxisRanges?.[rangeIdx];
+    const xRange = xAxisRanges?.[rangeIdx];
     let rangeData: Datum[] = [];
     for (const [outerIdx, item] of range.entries()) {
-      const xItem: PlotDataItem | undefined = xRange?.[outerIdx];
+      const xItem = xRange?.[outerIdx];
       const { data: datums, hasMismatchedData: itemHasMistmatchedData } =
         getDatumsForMessagePathItem(
           item,
@@ -234,7 +236,7 @@ function getDatasetsFromMessagePlotPath({
 
 type Args = {
   paths: PlotPath[];
-  itemsByPath: PlotDataByPath;
+  itemsByPath: Immutable<PlotDataByPath>;
   startTime: Time;
   xAxisVal: PlotXAxisVal;
   xAxisPath?: BasePlotPath;

--- a/packages/studio-base/src/panels/Plot/index.tsx
+++ b/packages/studio-base/src/panels/Plot/index.tsx
@@ -14,29 +14,15 @@
 import DownloadIcon from "@mui/icons-material/Download";
 import { useTheme } from "@mui/material";
 import { compact, isNumber, uniq } from "lodash";
-import memoizeWeak from "memoize-weak";
 import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
 
-import { filterMap } from "@foxglove/den/collection";
-import { useShallowMemo } from "@foxglove/hooks";
 import {
+  Time,
   add as addTimes,
   fromSec,
   subtract as subtractTimes,
-  Time,
   toSec,
 } from "@foxglove/rostime";
-import { MessageEvent } from "@foxglove/studio";
-import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
-import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
-import parseRosPath, {
-  getTopicsFromPaths,
-} from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
-import {
-  MessageDataItemsByPath,
-  useCachedGetMessagePathDataItems,
-  useDecodeMessagePathsForMessagesByTopic,
-} from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -52,16 +38,16 @@ import {
   ChartDefaultView,
   TimeBasedChartTooltipData,
 } from "@foxglove/studio-base/components/TimeBasedChart";
+import { usePlotPanelMessageData } from "@foxglove/studio-base/panels/Plot/usePlotPanelMessageData";
 import { OnClickArg as OnChartClickArgs } from "@foxglove/studio-base/src/components/Chart";
 import { OpenSiblingPanel, PanelConfig, SaveConfig } from "@foxglove/studio-base/types/panels";
 import { PANEL_TITLE_CONFIG_KEY } from "@foxglove/studio-base/util/layout";
-import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
 
 import PlotChart from "./PlotChart";
 import { PlotLegend } from "./PlotLegend";
 import { downloadCSV } from "./csv";
 import { getDatasets } from "./datasets";
-import { DataSet, PlotDataByPath, PlotDataItem } from "./internalTypes";
+import { DataSet } from "./internalTypes";
 import { usePlotPanelSettings } from "./settings";
 import { PlotConfig } from "./types";
 
@@ -90,37 +76,7 @@ type Props = {
   saveConfig: SaveConfig<PlotConfig>;
 };
 
-// messagePathItems contains the whole parsed message, and we don't need to cache all of that.
-// Instead, throw away everything but what we need (the timestamps).
-const getPlotDataByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
-  const ret: PlotDataByPath = {};
-  Object.entries(itemsByPath).forEach(([path, items]) => {
-    ret[path] = [
-      items.map((messageAndData) => {
-        const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
-        return {
-          queriedData: messageAndData.queriedData,
-          receiveTime: messageAndData.messageEvent.receiveTime,
-          headerStamp,
-        };
-      }),
-    ];
-  });
-  return ret;
-};
-
-const getMessagePathItemsForBlock = memoizeWeak(
-  (
-    decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
-    block: MessageBlock,
-  ): PlotDataByPath => {
-    return Object.freeze(getPlotDataByPath(decodeMessagePathsForMessagesByTopic(block)));
-  },
-);
-
 const ZERO_TIME = { sec: 0, nsec: 0 };
-
-const performance = window.performance;
 
 /**
  * Builds a lookup map of a compound x:y:index key to a datum, used to map hovered positions
@@ -134,67 +90,6 @@ function buildTooltipLookupMap(datasets: DataSet[]): Map<string, TimeBasedChartT
     }
   }
   return lookup;
-}
-
-function getBlockItemsByPath(
-  decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
-  blocks: readonly MessageBlock[],
-) {
-  const ret: Record<string, PlotDataItem[][]> = {};
-  const lastBlockIndexForPath: Record<string, number> = {};
-  let count = 0;
-  let i = 0;
-  for (const block of blocks) {
-    const messagePathItemsForBlock: PlotDataByPath = getMessagePathItemsForBlock(
-      decodeMessagePathsForMessagesByTopic,
-      block,
-    );
-
-    // After 1 million data points we check if there is more memory to continue loading more
-    // data points. This helps prevent runaway memory use if the user tried to plot a binary topic.
-    //
-    // An example would be to try plotting `/map.data[:]` where map is an occupancy grid
-    // this can easily result in many millions of points.
-    if (count >= 1_000_000) {
-      // if we have memory stats we can let the user have more points as long as memory is not under pressure
-      if (performance.memory) {
-        const pct = performance.memory.usedJSHeapSize / performance.memory.jsHeapSizeLimit;
-        if (isNaN(pct) || pct > 0.6) {
-          return ret;
-        }
-      } else {
-        return ret;
-      }
-    }
-
-    for (const [path, messagePathItems] of Object.entries(messagePathItemsForBlock)) {
-      count += messagePathItems[0]?.[0]?.queriedData.length ?? 0;
-
-      const existingItems = ret[path] ?? [];
-      // getMessagePathItemsForBlock returns an array of exactly one range of items.
-      const [pathItems] = messagePathItems;
-      if (lastBlockIndexForPath[path] === i - 1) {
-        // If we are continuing directly from the previous block index (i - 1) then add to the
-        // existing range, otherwise start a new range
-        const currentRange = existingItems[existingItems.length - 1];
-        if (currentRange && pathItems) {
-          for (const item of pathItems) {
-            currentRange.push(item);
-          }
-        }
-      } else {
-        if (pathItems) {
-          // Start a new contiguous range. Make a copy so we can extend it.
-          existingItems.push(pathItems.slice());
-        }
-      }
-      ret[path] = existingItems;
-      lastBlockIndexForPath[path] = i;
-    }
-
-    i += 1;
-  }
-  return ret;
 }
 
 function selectStartTime(ctx: MessagePipelineContext) {
@@ -293,186 +188,31 @@ function Plot(props: Props) {
 
   // following view and fixed view are split to keep defaultView identity stable when possible
   const defaultView = useMemo<ChartDefaultView | undefined>(() => {
-    if (followingView) {
-      return followingView;
-    } else if (fixedView) {
-      return fixedView;
-    }
-    return undefined;
+    return followingView ?? fixedView ?? undefined;
   }, [fixedView, followingView]);
 
   const allPaths = useMemo(() => {
     return yAxisPaths.map(({ value }) => value).concat(compact([xAxisPath?.value]));
   }, [xAxisPath?.value, yAxisPaths]);
 
-  const subscribeTopics = useMemo(() => getTopicsFromPaths(allPaths), [allPaths]);
-
-  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(allPaths);
-  const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(allPaths);
-
-  // When iterating message events, we need a reverse lookup from topic to the paths that requested
-  // the topic.
-  const topicToPaths = useMemo<Map<string, string[]>>(() => {
-    const out = new Map<string, string[]>();
-    for (const path of allPaths) {
-      const rosPath = parseRosPath(path);
-      if (!rosPath) {
-        continue;
-      }
-      const existing = out.get(rosPath.topicName) ?? [];
-      existing.push(path);
-      out.set(rosPath.topicName, existing);
-    }
-    return out;
-  }, [allPaths]);
-
-  const blocks = useBlocksByTopic(subscribeTopics);
-
-  // This memoization isn't quite ideal: getDatasets is a bit expensive with lots of preloaded data,
-  // and when we preload a new block we re-generate the datasets for the whole timeline. We could
-  // try to use block memoization here.
-  const plotDataForBlocks = useMemo(() => {
-    if (showSingleCurrentMessage) {
-      return {};
-    }
-    return getBlockItemsByPath(decodeMessagePathsForMessagesByTopic, blocks);
-  }, [blocks, decodeMessagePathsForMessagesByTopic, showSingleCurrentMessage]);
-
-  // When restoring, keep only the paths that are present in allPaths.
-  // Without this, the reducer value will grow unbounded with new paths as users add/remove series.
-  const restore = useCallback(
-    (previous?: PlotDataByPath): PlotDataByPath => {
-      if (!previous) {
-        return {};
-      }
-
-      const updated: PlotDataByPath = {};
-      for (const path of allPaths) {
-        const plotData = previous[path];
-        if (plotData) {
-          updated[path] = plotData;
-        }
-      }
-
-      return updated;
-    },
-    [allPaths],
-  );
-
-  // The addMessages function below is passed to useMessageReducer to handle new messages during
-  // playback. If we have messages for a specific path in _blocks_ then we ignore the messages in
-  // the reducer.
-  //
-  // To keep the addMessages function "stable" when loading new blocks we grab only the paths from
-  // the blocks and make addMessages depend on the paths. To keep paths referentially stable when
-  // the paths values haven't changed we use a shallow memo.
-  const blockPaths = useMemo(() => Object.keys(plotDataForBlocks), [plotDataForBlocks]);
-  const blockPathsMemo = useShallowMemo(blockPaths);
-
-  const addMessages = useCallback(
-    (accumulated: PlotDataByPath, msgEvents: readonly MessageEvent<unknown>[]) => {
-      const lastEventTime = msgEvents[msgEvents.length - 1]?.receiveTime;
-      const isFollowing = followingView?.type === "following";
-
-      // If we don't change any accumulated data, avoid returning a new "accumulated" object so
-      // react hooks remain stable.
-      let newAccumulated: PlotDataByPath | undefined;
-
-      for (const msgEvent of msgEvents) {
-        const paths = topicToPaths.get(msgEvent.topic);
-        if (!paths) {
-          continue;
-        }
-
-        for (const path of paths) {
-          // Skip any paths we already service in plotDataForBlocks.
-          // We don't need to accumulate these because the block data takes precedence.
-          if (blockPathsMemo.includes(path)) {
-            continue;
-          }
-
-          const dataItem = cachedGetMessagePathDataItems(path, msgEvent);
-          if (!dataItem) {
-            continue;
-          }
-
-          const headerStamp = getTimestampForMessage(msgEvent.message);
-          const plotDataItem = {
-            queriedData: dataItem,
-            receiveTime: msgEvent.receiveTime,
-            headerStamp,
-          };
-
-          if (!newAccumulated) {
-            newAccumulated = { ...accumulated };
-          }
-
-          if (showSingleCurrentMessage) {
-            newAccumulated[path] = [[plotDataItem]];
-          } else {
-            const plotDataPath = newAccumulated[path]?.slice() ?? [[]];
-            // PlotDataPaths have 2d arrays of items to accommodate blocks which may have gaps so
-            // each continuous set of blocks forms one continuous line. For streaming messages we
-            // treat this as one continuous set of items and always add to the first "range"
-            const plotDataItems = plotDataPath[0]!;
-
-            // If we are using the _following_ view mode, truncate away any items older than the view window.
-            if (lastEventTime && isFollowing) {
-              const minStamp = toSec(lastEventTime) - followingView.width;
-              const newItems = filterMap(plotDataItems, (item) => {
-                if (toSec(item.receiveTime) < minStamp) {
-                  return undefined;
-                }
-                return item;
-              });
-              newItems.push(plotDataItem);
-              plotDataPath[0] = newItems;
-            } else {
-              plotDataPath[0] = plotDataItems.concat(plotDataItem);
-            }
-
-            newAccumulated[path] = plotDataPath;
-          }
-        }
-      }
-
-      return newAccumulated ?? accumulated;
-    },
-    [
-      blockPathsMemo,
-      cachedGetMessagePathDataItems,
-      followingView,
-      showSingleCurrentMessage,
-      topicToPaths,
-    ],
-  );
-
-  // The extra useShallowMemo is useful when seeking. Without it, the reduced value will be reset,
-  // and trigger the plot to re-render even if the old value and new value were both empty ({})
-  // which happens for fully pre-loaded data coming from blocks.
-  const plotDataByPath = useShallowMemo(
-    useMessageReducer<PlotDataByPath>({
-      topics: subscribeTopics,
-      preloadType: "full",
-      restore,
-      addMessages,
-    }),
-  );
+  const combinedPlotData = usePlotPanelMessageData({
+    allPaths,
+    followingView,
+    showSingleCurrentMessage,
+  });
 
   // Keep disabled paths when passing into getDatasets, because we still want
   // easy access to the history when turning the disabled paths back on.
   const { datasets, pathsWithMismatchedDataLengths } = useMemo(() => {
-    const allPlotData = { ...plotDataByPath, ...plotDataForBlocks };
-
     return getDatasets({
       paths: yAxisPaths,
-      itemsByPath: allPlotData,
+      itemsByPath: combinedPlotData,
       startTime: startTime ?? ZERO_TIME,
       xAxisVal,
       xAxisPath,
       invertedTheme: theme.palette.mode === "dark",
     });
-  }, [plotDataByPath, plotDataForBlocks, yAxisPaths, startTime, xAxisVal, xAxisPath, theme]);
+  }, [yAxisPaths, combinedPlotData, startTime, xAxisVal, xAxisPath, theme.palette.mode]);
 
   const tooltips = useMemo(() => {
     if (showLegend && showPlotValuesInLegend) {

--- a/packages/studio-base/src/panels/Plot/internalTypes.ts
+++ b/packages/studio-base/src/panels/Plot/internalTypes.ts
@@ -53,9 +53,7 @@ export type PlotDataItem = {
   headerStamp?: Time;
 };
 
-export type PlotDataByPath = {
-  [path: string]: PlotDataItem[][];
-};
+export type PlotDataByPath = Record<string, PlotDataItem[][]>;
 
 // A "reference line" plot path is a numeric value. It creates a horizontal line on the plot at the specified value.
 export function isReferenceLinePlotPathType(path: BasePlotPath): boolean {

--- a/packages/studio-base/src/panels/Plot/plotData.test.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.test.ts
@@ -1,0 +1,203 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { PlotDataByPath } from "./internalTypes";
+import * as PlotData from "./plotData";
+
+const dataA: PlotDataByPath = {
+  "/foo": [
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 1, nsec: 0 },
+        headerStamp: { sec: 1, nsec: 0 },
+      },
+    ],
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 3, nsec: 0 },
+        headerStamp: { sec: 3, nsec: 0 },
+      },
+    ],
+  ],
+  "/bar": [
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 1, nsec: 0 },
+        headerStamp: { sec: 1, nsec: 0 },
+      },
+    ],
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 4, nsec: 0 },
+        headerStamp: { sec: 4, nsec: 0 },
+      },
+    ],
+  ],
+};
+
+const dataB: PlotDataByPath = {
+  "/foo": [
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 4, nsec: 0 },
+        headerStamp: { sec: 4, nsec: 0 },
+      },
+    ],
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 5, nsec: 0 },
+        headerStamp: { sec: 5, nsec: 0 },
+      },
+    ],
+  ],
+  "/bar": [
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 3, nsec: 0 },
+        headerStamp: { sec: 3, nsec: 0 },
+      },
+    ],
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 5, nsec: 0 },
+        headerStamp: { sec: 5, nsec: 0 },
+      },
+    ],
+  ],
+  "/baz": [
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 1, nsec: 0 },
+        headerStamp: { sec: 1, nsec: 0 },
+      },
+    ],
+    [
+      {
+        queriedData: [],
+        receiveTime: { sec: 4, nsec: 0 },
+        headerStamp: { sec: 4, nsec: 0 },
+      },
+    ],
+  ],
+};
+
+describe("plotData", () => {
+  describe("findTimeRange", () => {
+    it("should find time range for plot data", () => {
+      expect(PlotData.findTimeRanges(dataA)).toEqual({
+        all: {
+          start: { sec: 1, nsec: 0 },
+          end: { sec: 4, nsec: 0 },
+        },
+        byPath: {
+          "/bar": {
+            end: {
+              nsec: 0,
+              sec: 4,
+            },
+            start: {
+              nsec: 0,
+              sec: 1,
+            },
+          },
+          "/foo": {
+            end: {
+              nsec: 0,
+              sec: 3,
+            },
+            start: {
+              nsec: 0,
+              sec: 1,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe("combine", () => {
+    it("should combine plot data", () => {
+      expect(PlotData.combine([dataA, dataB])).toEqual({
+        "/foo": [
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 1, nsec: 0 },
+              headerStamp: { sec: 1, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 3, nsec: 0 },
+              headerStamp: { sec: 3, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 4, nsec: 0 },
+              headerStamp: { sec: 4, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 5, nsec: 0 },
+              headerStamp: { sec: 5, nsec: 0 },
+            },
+          ],
+        ],
+        "/bar": [
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 1, nsec: 0 },
+              headerStamp: { sec: 1, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 4, nsec: 0 },
+              headerStamp: { sec: 4, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 5, nsec: 0 },
+              headerStamp: { sec: 5, nsec: 0 },
+            },
+          ],
+        ],
+        "/baz": [
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 1, nsec: 0 },
+              headerStamp: { sec: 1, nsec: 0 },
+            },
+          ],
+          [
+            {
+              queriedData: [],
+              receiveTime: { sec: 4, nsec: 0 },
+              headerStamp: { sec: 4, nsec: 0 },
+            },
+          ],
+        ],
+      });
+    });
+  });
+});

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -168,6 +168,8 @@ function mergeByPath(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): Im<PlotDataB
   );
 }
 
+// Sort by start time, then end time, so that folding from the left gives us the
+// right consolidated interval.
 function compare(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): number {
   const rangeA = findTimeRanges(a).all;
   const rangeB = findTimeRanges(b).all;

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -30,26 +30,27 @@ type TimeRange = { start: Time; end: Time };
  * Find the earliest and latest times of messages in data, for all messages and
  * per-path.
  */
-export const findTimeRanges = memoizeWeak(
-  (data: Im<PlotDataByPath>): { all: TimeRange; byPath: Record<string, TimeRange> } => {
-    const byPath: Record<string, TimeRange> = {};
-    let start: Time = MAX_TIME;
-    let end: Time = MIN_TIME;
-    for (const path of Object.keys(data)) {
-      const thisPath = (byPath[path] = { start: MAX_TIME, end: MIN_TIME });
-      for (const item of data[path] ?? []) {
-        for (const datum of item) {
-          start = minTime(start, datum.receiveTime);
-          end = maxTime(end, datum.receiveTime);
-          thisPath.start = minTime(thisPath.start, datum.receiveTime);
-          thisPath.end = maxTime(thisPath.end, datum.receiveTime);
-        }
+export function findTimeRanges(data: Im<PlotDataByPath>): {
+  all: TimeRange;
+  byPath: Record<string, TimeRange>;
+} {
+  const byPath: Record<string, TimeRange> = {};
+  let start: Time = MAX_TIME;
+  let end: Time = MIN_TIME;
+  for (const path of Object.keys(data)) {
+    const thisPath = (byPath[path] = { start: MAX_TIME, end: MIN_TIME });
+    for (const item of data[path] ?? []) {
+      for (const datum of item) {
+        start = minTime(start, datum.receiveTime);
+        end = maxTime(end, datum.receiveTime);
+        thisPath.start = minTime(thisPath.start, datum.receiveTime);
+        thisPath.end = maxTime(thisPath.end, datum.receiveTime);
       }
     }
+  }
 
-    return { all: { start, end }, byPath };
-  },
-);
+  return { all: { start, end }, byPath };
+}
 
 /**
  * Fetch the data we need from each item in itemsByPath and discard the rest of
@@ -168,11 +169,13 @@ function mergeByPath(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): Im<PlotDataB
   );
 }
 
+const memoFindTimeRanges = memoizeWeak(findTimeRanges);
+
 // Sort by start time, then end time, so that folding from the left gives us the
 // right consolidated interval.
 function compare(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): number {
-  const rangeA = findTimeRanges(a).all;
-  const rangeB = findTimeRanges(b).all;
+  const rangeA = memoFindTimeRanges(a).all;
+  const rangeB = memoFindTimeRanges(b).all;
   const startCompare = compareTimes(rangeA.start, rangeB.start);
   return startCompare !== 0 ? startCompare : compareTimes(rangeA.end, rangeB.end);
 }

--- a/packages/studio-base/src/panels/Plot/plotData.ts
+++ b/packages/studio-base/src/panels/Plot/plotData.ts
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable as Im } from "immer";
+import { assignWith, last, isEmpty } from "lodash";
+import memoizeWeak from "memoize-weak";
+
+import { filterMap } from "@foxglove/den/collection";
+import { Time, isLessThan, isGreaterThan, compare as compareTimes } from "@foxglove/rostime";
+import { MessageBlock } from "@foxglove/studio-base/PanelAPI/useBlocksByTopic";
+import { MessageDataItemsByPath } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { PlotDataByPath, PlotDataItem } from "@foxglove/studio-base/panels/Plot/internalTypes";
+import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
+
+const MAX_TIME = Object.freeze({ sec: Infinity, nsec: Infinity });
+const MIN_TIME = Object.freeze({ sec: -Infinity, nsec: -Infinity });
+
+function minTime(a: Time, b: Time): Time {
+  return isLessThan(a, b) ? a : b;
+}
+
+function maxTime(a: Time, b: Time): Time {
+  return isLessThan(a, b) ? b : a;
+}
+
+type TimeRange = { start: Time; end: Time };
+
+/**
+ * Find the earliest and latest times of messages in data, for all messages and
+ * per-path.
+ */
+export const findTimeRanges = memoizeWeak(
+  (data: Im<PlotDataByPath>): { all: TimeRange; byPath: Record<string, TimeRange> } => {
+    const byPath: Record<string, TimeRange> = {};
+    let start: Time = MAX_TIME;
+    let end: Time = MIN_TIME;
+    for (const path of Object.keys(data)) {
+      const thisPath = (byPath[path] = { start: MAX_TIME, end: MIN_TIME });
+      for (const item of data[path] ?? []) {
+        for (const datum of item) {
+          start = minTime(start, datum.receiveTime);
+          end = maxTime(end, datum.receiveTime);
+          thisPath.start = minTime(thisPath.start, datum.receiveTime);
+          thisPath.end = maxTime(thisPath.end, datum.receiveTime);
+        }
+      }
+    }
+
+    return { all: { start, end }, byPath };
+  },
+);
+
+/**
+ * Fetch the data we need from each item in itemsByPath and discard the rest of
+ * the message to save memory.
+ */
+const getByPath = (itemsByPath: MessageDataItemsByPath): PlotDataByPath => {
+  const ret: PlotDataByPath = {};
+  Object.entries(itemsByPath).forEach(([path, items]) => {
+    ret[path] = [
+      items.map((messageAndData) => {
+        const headerStamp = getTimestampForMessage(messageAndData.messageEvent.message);
+        return {
+          queriedData: messageAndData.queriedData,
+          receiveTime: messageAndData.messageEvent.receiveTime,
+          headerStamp,
+        };
+      }),
+    ];
+  });
+  return ret;
+};
+
+const getMessagePathItemsForBlock = memoizeWeak(
+  (
+    decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
+    block: MessageBlock,
+  ): PlotDataByPath => {
+    return Object.freeze(getByPath(decodeMessagePathsForMessagesByTopic(block)));
+  },
+);
+
+/**
+ * Fetch all the plot data we want for our current subscribed topics from blocks.
+ */
+export function getBlockItemsByPath(
+  decodeMessagePathsForMessagesByTopic: (_: MessageBlock) => MessageDataItemsByPath,
+  blocks: readonly MessageBlock[],
+): PlotDataByPath {
+  const ret: PlotDataByPath = {};
+  const lastBlockIndexForPath: Record<string, number> = {};
+  let count = 0;
+  let i = 0;
+  for (const block of blocks) {
+    const messagePathItemsForBlock: PlotDataByPath = getMessagePathItemsForBlock(
+      decodeMessagePathsForMessagesByTopic,
+      block,
+    );
+
+    // After 1 million data points we check if there is more memory to continue loading more
+    // data points. This helps prevent runaway memory use if the user tried to plot a binary topic.
+    //
+    // An example would be to try plotting `/map.data[:]` where map is an occupancy grid
+    // this can easily result in many millions of points.
+    if (count >= 1_000_000) {
+      // if we have memory stats we can let the user have more points as long as memory is not under pressure
+      if (performance.memory) {
+        const pct = performance.memory.usedJSHeapSize / performance.memory.jsHeapSizeLimit;
+        if (isNaN(pct) || pct > 0.6) {
+          return ret;
+        }
+      } else {
+        return ret;
+      }
+    }
+
+    for (const [path, messagePathItems] of Object.entries(messagePathItemsForBlock)) {
+      count += messagePathItems[0]?.[0]?.queriedData.length ?? 0;
+
+      const existingItems = ret[path] ?? [];
+      // getMessagePathItemsForBlock returns an array of exactly one range of items.
+      const [pathItems] = messagePathItems;
+      if (lastBlockIndexForPath[path] === i - 1) {
+        // If we are continuing directly from the previous block index (i - 1) then add to the
+        // existing range, otherwise start a new range
+        const currentRange = existingItems[existingItems.length - 1];
+        if (currentRange && pathItems) {
+          for (const item of pathItems) {
+            currentRange.push(item);
+          }
+        }
+      } else {
+        if (pathItems) {
+          // Start a new contiguous range. Make a copy so we can extend it.
+          existingItems.push(pathItems.slice());
+        }
+      }
+      ret[path] = existingItems;
+      lastBlockIndexForPath[path] = i;
+    }
+
+    i += 1;
+  }
+  return ret;
+}
+
+/**
+ * Merge two PlotDataByPath objects into a single PlotDataByPath object,
+ * discarding any overlapping messages between the two items.
+ */
+function mergeByPath(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): Im<PlotDataByPath> {
+  return assignWith(
+    {},
+    a,
+    b,
+    (objValue: undefined | PlotDataItem[][], srcValue: undefined | PlotDataItem[][]) => {
+      if (objValue == undefined) {
+        return srcValue;
+      }
+      const lastTime = last(last(objValue))?.receiveTime ?? MIN_TIME;
+      const newValues = filterMap(srcValue ?? [], (item) => {
+        const laterDatums = item.filter((datum) => isGreaterThan(datum.receiveTime, lastTime));
+        return laterDatums.length > 0 ? laterDatums : undefined;
+      });
+      return newValues.length > 0 ? objValue.concat(newValues) : objValue;
+    },
+  );
+}
+
+function compare(a: Im<PlotDataByPath>, b: Im<PlotDataByPath>): number {
+  const rangeA = findTimeRanges(a).all;
+  const rangeB = findTimeRanges(b).all;
+  const startCompare = compareTimes(rangeA.start, rangeB.start);
+  return startCompare !== 0 ? startCompare : compareTimes(rangeA.end, rangeB.end);
+}
+
+/**
+ * Reduce multiple PlotDataByPath objects into a single PlotDataByPath object,
+ * concatenating messages for each path after trimming messages that overlap
+ * between items.
+ */
+export function combine(data: Im<PlotDataByPath[]>): Im<PlotDataByPath> {
+  const sorted = data.slice().sort(compare);
+
+  const reduced = sorted.reduce((acc, item) => {
+    if (isEmpty(acc)) {
+      return item;
+    }
+    return mergeByPath(acc, item);
+  }, {} as PlotDataByPath);
+
+  return reduced;
+}

--- a/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
@@ -62,7 +62,10 @@ export function usePlotPanelMessageData(params: Params): Immutable<PlotDataByPat
 
   const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(allPaths);
 
-  const blocksTimeRange = PlotData.findTimeRanges(plotDataForBlocks);
+  const blocksTimeRange = useMemo(
+    () => PlotData.findTimeRanges(plotDataForBlocks),
+    [plotDataForBlocks],
+  );
 
   // When restoring, keep only the paths that are present in allPaths. Without
   // this, the reducer value will grow unbounded with new paths as users

--- a/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
+++ b/packages/studio-base/src/panels/Plot/usePlotPanelMessageData.ts
@@ -1,0 +1,194 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Immutable } from "immer";
+import { groupBy, isEmpty, pick } from "lodash";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { isLessThan, isTimeInRangeInclusive, subtract } from "@foxglove/rostime";
+import { useBlocksByTopic, useMessageReducer } from "@foxglove/studio-base/PanelAPI";
+import parseRosPath, {
+  getTopicsFromPaths,
+} from "@foxglove/studio-base/components/MessagePathSyntax/parseRosPath";
+import {
+  useCachedGetMessagePathDataItems,
+  useDecodeMessagePathsForMessagesByTopic,
+} from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
+import { ChartDefaultView } from "@foxglove/studio-base/components/TimeBasedChart";
+import { PlotDataByPath } from "@foxglove/studio-base/panels/Plot/internalTypes";
+import * as PlotData from "@foxglove/studio-base/panels/Plot/plotData";
+import { MessageEvent } from "@foxglove/studio-base/players/types";
+import { getTimestampForMessage } from "@foxglove/studio-base/util/time";
+
+type TaggedPlotDataByPath = { tag: string; data: PlotDataByPath };
+
+type Params = Immutable<{
+  allPaths: string[];
+  followingView: undefined | ChartDefaultView;
+  showSingleCurrentMessage: boolean;
+}>;
+
+/**
+ * Combines preloaded block data and messages accumulated during playback into a
+ * single PlotDataByPath object.
+ */
+export function usePlotPanelMessageData(params: Params): Immutable<PlotDataByPath> {
+  const { allPaths, followingView, showSingleCurrentMessage } = params;
+
+  // When iterating message events, we need a reverse lookup from topic to the
+  // paths that requested the topic.
+  const topicToPaths = useMemo(
+    () => groupBy(allPaths, (path) => parseRosPath(path)?.topicName),
+    [allPaths],
+  );
+
+  const subscribeTopics = useMemo(() => getTopicsFromPaths(allPaths), [allPaths]);
+
+  const blocks = useBlocksByTopic(subscribeTopics);
+
+  const decodeMessagePathsForMessagesByTopic = useDecodeMessagePathsForMessagesByTopic(allPaths);
+
+  // This memoization isn't quite ideal: getDatasets is a bit expensive with
+  // lots of preloaded data, and when we preload a new block we re-generate the
+  // datasets for the whole timeline. We could try to use block memoization
+  // here.
+  const plotDataForBlocks = useMemo(() => {
+    if (showSingleCurrentMessage) {
+      return {};
+    }
+    return PlotData.getBlockItemsByPath(decodeMessagePathsForMessagesByTopic, blocks);
+  }, [blocks, decodeMessagePathsForMessagesByTopic, showSingleCurrentMessage]);
+
+  const cachedGetMessagePathDataItems = useCachedGetMessagePathDataItems(allPaths);
+
+  const blocksTimeRange = PlotData.findTimeRanges(plotDataForBlocks);
+
+  // When restoring, keep only the paths that are present in allPaths. Without
+  // this, the reducer value will grow unbounded with new paths as users
+  // add/remove series. We use a timestamp tag so we can accumulate messages
+  // across multiple restore calls.
+  const restore = useCallback(
+    (previous?: TaggedPlotDataByPath): TaggedPlotDataByPath => {
+      if (!previous) {
+        return { tag: new Date().toISOString(), data: {} };
+      }
+
+      return { ...previous, data: pick(previous.data, allPaths) };
+    },
+    [allPaths],
+  );
+
+  const addMessages = useCallback(
+    (accumulated: TaggedPlotDataByPath, msgEvents: readonly MessageEvent<unknown>[]) => {
+      const lastEventTime = msgEvents[msgEvents.length - 1]?.receiveTime;
+      const isFollowing = followingView?.type === "following";
+
+      // If we don't change any accumulated data, avoid returning a new "accumulated" object so
+      // react hooks remain stable.
+      let newAccumulated: TaggedPlotDataByPath | undefined;
+
+      for (const msgEvent of msgEvents) {
+        const paths = topicToPaths[msgEvent.topic];
+        if (!paths) {
+          continue;
+        }
+
+        for (const path of paths) {
+          const dataItem = cachedGetMessagePathDataItems(path, msgEvent);
+          if (!dataItem) {
+            continue;
+          }
+
+          const headerStamp = getTimestampForMessage(msgEvent.message);
+          const existingBlockRange = blocksTimeRange.byPath[path];
+          if (
+            existingBlockRange &&
+            isTimeInRangeInclusive(
+              msgEvent.receiveTime,
+              existingBlockRange.start,
+              existingBlockRange.end,
+            )
+          ) {
+            // Skip messages that fall within the range of our block data since
+            // we would just filter them out later anyway. Note that this
+            // assumes blocks are loaded contiguously starting from the
+            // beginning of message data.
+            continue;
+          }
+          const plotDataItem = {
+            queriedData: dataItem,
+            receiveTime: msgEvent.receiveTime,
+            headerStamp,
+          };
+
+          newAccumulated ??= { ...accumulated };
+
+          if (showSingleCurrentMessage) {
+            newAccumulated.data[path] = [[plotDataItem]];
+          } else {
+            const plotDataPath = newAccumulated.data[path]?.slice() ?? [[]];
+            // PlotDataPaths have 2d arrays of items to accommodate blocks which
+            // may have gaps so each continuous set of blocks forms one
+            // continuous line. For streaming messages we treat this as one
+            // continuous set of items and always add to the first "range"
+            const plotDataItems = plotDataPath[0]!;
+
+            // If we are using the _following_ view mode, truncate away any
+            // items older than the view window.
+            if (lastEventTime && isFollowing) {
+              const minStamp = subtract(lastEventTime, { sec: followingView.width, nsec: 0 });
+              const newItems = plotDataItems.filter(
+                (item) => !isLessThan(item.receiveTime, minStamp),
+              );
+              newItems.push(plotDataItem);
+              plotDataPath[0] = newItems;
+            } else {
+              plotDataPath[0] = plotDataItems.concat(plotDataItem);
+            }
+
+            newAccumulated.data[path] = plotDataPath;
+          }
+        }
+      }
+
+      return newAccumulated ?? accumulated;
+    },
+    [
+      blocksTimeRange,
+      cachedGetMessagePathDataItems,
+      followingView,
+      showSingleCurrentMessage,
+      topicToPaths,
+    ],
+  );
+
+  const plotDataByPath = useMessageReducer<TaggedPlotDataByPath>({
+    topics: subscribeTopics,
+    preloadType: "full",
+    restore,
+    addMessages,
+  });
+
+  // Accumulate separate message playback sequences into distinct intervals we
+  // can later combine into a single combined set of message data.
+  const [accumulatedPathIntervals, setAccumulatedPathIntervals] = useState<
+    Record<string, PlotDataByPath>
+  >({});
+
+  useEffect(() => {
+    if (!isEmpty(plotDataByPath.data)) {
+      setAccumulatedPathIntervals((oldValue) => ({
+        ...oldValue,
+        [plotDataByPath.tag]: plotDataByPath.data,
+      }));
+    }
+  }, [plotDataByPath, plotDataForBlocks]);
+
+  const combinedPlotData = useMemo(
+    () => PlotData.combine([plotDataForBlocks, ...Object.values(accumulatedPathIntervals)]),
+    [accumulatedPathIntervals, plotDataForBlocks],
+  );
+
+  return combinedPlotData;
+}


### PR DESCRIPTION
**User-Facing Changes**
Improve behavior of the plot panel in low memory conditions.

**Description**
Combine block and current frame / playback messages in plots to give better user experience in low memory conditions.

This is an alternative to https://github.com/foxglove/studio/pull/5689 and a proposed fix for https://github.com/foxglove/studio/issues/5500.

The idea here is to allow data from blocks/allFrames and accumulated `currentFrame` to be merged and plotted together, so in cases where the block cache is full we can still plot something. This requires playback to accumulate `currentFrame` data.

Pros:
* If the user is willing to wait for playback we can in theory plot more data than in #5689.

Cons:
* Playback is required to see the currentFrame data. I'm not sure how we'd create an affordance for that in the UI.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
