### PR TITLE
[3D Panel] Fix backfilled messages from disappearing when changing subscription

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -737,7 +737,7 @@ export function ThreeDeeRender(props: {
   // Keep the renderer currentTime up to date and handle seeking
   useEffect(() => {
     const newTimeNs = currentTime ? toNanoSec(currentTime) : undefined;
-    if (!renderer || newTimeNs == undefined || newTimeNs === renderer.currentTime) {
+    if (!renderer || newTimeNs == undefined) {
       return;
     }
     const oldTimeNs = renderer.currentTime;

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -737,6 +737,15 @@ export function ThreeDeeRender(props: {
   // Keep the renderer currentTime up to date and handle seeking
   useEffect(() => {
     const newTimeNs = currentTime ? toNanoSec(currentTime) : undefined;
+
+    /*
+     * NOTE AROUND SEEK HANDLING
+     * Seeking MUST be handled even if there is no change in current time.  When there is a subscription
+     * change while paused, the player goes into `seek-backfill` which sets didSeek to true.
+     *
+     * We cannot early return here when there is no change in current time due to that, otherwise it would
+     * handle seek next time the current time changes and clear the backfilled messages and transforms.
+     */
     if (!renderer || newTimeNs == undefined) {
       return;
     }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
 - Fix objects in 3D disappearing when playing after changing topic visibility

**Description**
Early return when the currentTime hasn't changed caused the seek to not be handled and set back to `false` in local state. This caused the behavior where the next time the current time change it would handle the seek, which clears renderables in the renderer. This would be after the backfill messages had been processed causing the previously backfilled messages to be cleared from the renderer. 

<!-- link relevant GitHub issues -->
FG-2779
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
