### PR TITLE
Change the app panel icon in the navbar

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import {
-  AddCircle24Regular,
+  SlideAdd24Regular,
   PanelLeft24Filled,
   PanelLeft24Regular,
   PanelRight24Filled,
@@ -259,7 +259,7 @@ export function AppBar(props: AppBarProps): JSX.Element {
                   setPanelAnchorEl(event.currentTarget);
                 }}
               >
-                <AddCircle24Regular />
+                <SlideAdd24Regular />
               </AppBarIconButton>
             </div>
           </div>


### PR DESCRIPTION
**User-Facing Changes**
None - the navbar is feature flagged

**Description**
Before:
<img width="121" alt="image" src="https://user-images.githubusercontent.com/84792/230218851-b75f41fe-179e-47a3-841e-6d53ca4ebd42.png">

After:
![image](https://user-images.githubusercontent.com/84792/230218742-0a46688d-ee03-4faa-94fc-ac2ec155cc48.png)

I find the _after_ less visually invasive than _before_.