### PR TITLE
Fix camera info topic subscription in image panel

### DIFF
--- a/packages/studio-base/src/panels/Image/ImageView.tsx
+++ b/packages/studio-base/src/panels/Image/ImageView.tsx
@@ -33,8 +33,10 @@ import { fonts } from "@foxglove/studio-base/util/sharedStyleConstants";
 import { formatTimeRaw } from "@foxglove/studio-base/util/time";
 
 import { ImageCanvas, ImageEmptyState, Toolbar } from "./components";
-import { ANNOTATION_DATATYPES, useImagePanelMessages } from "./hooks";
+import { useImagePanelMessages } from "./hooks";
+import { CALIBRATION_DATATYPES } from "./hooks/normalizeCameraInfo";
 import { downloadImage } from "./lib/downloadImage";
+import { ANNOTATION_DATATYPES } from "./lib/normalizeAnnotations";
 import { NORMALIZABLE_IMAGE_DATATYPES } from "./lib/normalizeMessage";
 import { getRelatedMarkerTopics, getMarkerOptions, getCameraInfoTopic } from "./lib/util";
 import { buildSettingsTree } from "./settings";
@@ -46,6 +48,7 @@ type Props = {
 
 const SUPPORTED_IMAGE_SCHEMAS = new Set(NORMALIZABLE_IMAGE_DATATYPES);
 const SUPPORTED_ANNOTATION_SCHEMAS = new Set(ANNOTATION_DATATYPES);
+const SUPPORTED_CALIBRATION_SCHEMAS = new Set(CALIBRATION_DATATYPES);
 
 function topicIsConvertibleToSchema(topic: Topic, supportedSchemaNames: Set<string>): boolean {
   return (
@@ -146,12 +149,12 @@ export function ImageView({ context }: Props): JSX.Element {
     }
     if (
       cameraInfoTopicFullObject &&
-      topicIsConvertibleToSchema(cameraInfoTopicFullObject, SUPPORTED_IMAGE_SCHEMAS)
+      topicIsConvertibleToSchema(cameraInfoTopicFullObject, SUPPORTED_CALIBRATION_SCHEMAS)
     ) {
       subs.push({
         topic: cameraInfoTopicFullObject.name,
         preload: false,
-        convertTo: pickConvertToSchema(cameraInfoTopicFullObject, SUPPORTED_IMAGE_SCHEMAS),
+        convertTo: pickConvertToSchema(cameraInfoTopicFullObject, SUPPORTED_CALIBRATION_SCHEMAS),
       });
     }
     for (const topic of enabledMarkerTopicsFullObjects) {

--- a/packages/studio-base/src/panels/Image/hooks/index.ts
+++ b/packages/studio-base/src/panels/Image/hooks/index.ts
@@ -2,4 +2,4 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-export { useImagePanelMessages, ANNOTATION_DATATYPES } from "./useImagePanelMessages";
+export { useImagePanelMessages } from "./useImagePanelMessages";

--- a/packages/studio-base/src/panels/Image/hooks/normalizeCameraInfo.ts
+++ b/packages/studio-base/src/panels/Image/hooks/normalizeCameraInfo.ts
@@ -16,7 +16,8 @@ export const CALIBRATION_DATATYPES = [
 ] as const;
 
 export function normalizeCameraInfo(message: unknown, datatype: string): CameraInfo | undefined {
-  switch (datatype) {
+  // Cast to the union of all supported datatypes to ensure we handle all cases
+  switch (datatype as (typeof CALIBRATION_DATATYPES)[number]) {
     case "sensor_msgs/CameraInfo":
     case "sensor_msgs/msg/CameraInfo":
       return message as CameraInfo;

--- a/packages/studio-base/src/panels/Image/hooks/normalizeCameraInfo.ts
+++ b/packages/studio-base/src/panels/Image/hooks/normalizeCameraInfo.ts
@@ -5,6 +5,16 @@
 import { FoxgloveMessages } from "@foxglove/studio-base/types/FoxgloveMessages";
 import { CameraInfo, DistortionModel } from "@foxglove/studio-base/types/Messages";
 
+export const CALIBRATION_DATATYPES = [
+  // ROS well-known
+  "sensor_msgs/CameraInfo",
+  "sensor_msgs/msg/CameraInfo",
+  // Foxglove schemas (ros and proto variants)
+  "foxglove_msgs/CameraCalibration",
+  "foxglove_msgs/msg/CameraCalibration",
+  "foxglove.CameraCalibration",
+] as const;
+
 export function normalizeCameraInfo(message: unknown, datatype: string): CameraInfo | undefined {
   switch (datatype) {
     case "sensor_msgs/CameraInfo":

--- a/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
+++ b/packages/studio-base/src/panels/Image/hooks/useImagePanelMessages.ts
@@ -57,27 +57,6 @@ export type SynchronizationItem = {
   annotationsByTopic: Map<string, Annotation[]>;
 };
 
-export const ANNOTATION_DATATYPES = [
-  // Single marker
-  "visualization_msgs/ImageMarker",
-  "visualization_msgs/msg/ImageMarker",
-  "ros.visualization_msgs.ImageMarker",
-  // Marker arrays
-  "foxglove_msgs/ImageMarkerArray",
-  "foxglove_msgs/msg/ImageMarkerArray",
-  "studio_msgs/ImageMarkerArray",
-  "studio_msgs/msg/ImageMarkerArray",
-  "visualization_msgs/ImageMarkerArray",
-  "visualization_msgs/msg/ImageMarkerArray",
-  "ros.visualization_msgs.ImageMarkerArray",
-  // backwards compat with webviz
-  "webviz_msgs/ImageMarkerArray",
-  // foxglove
-  "foxglove_msgs/ImageAnnotations",
-  "foxglove_msgs/msg/ImageAnnotations",
-  "foxglove.ImageAnnotations",
-] as const;
-
 function addMessages(
   state: ImagePanelState,
   messageEvents: readonly MessageEvent<unknown>[],

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -14,6 +14,28 @@ import { mightActuallyBePartial } from "@foxglove/studio-base/util/mightActually
 
 import type { Annotation, PointsAnnotation } from "../types";
 
+// Supported annotation schema names
+export const ANNOTATION_DATATYPES = [
+  // Single marker
+  "visualization_msgs/ImageMarker",
+  "visualization_msgs/msg/ImageMarker",
+  "ros.visualization_msgs.ImageMarker",
+  // Marker arrays
+  "foxglove_msgs/ImageMarkerArray",
+  "foxglove_msgs/msg/ImageMarkerArray",
+  "studio_msgs/ImageMarkerArray",
+  "studio_msgs/msg/ImageMarkerArray",
+  "visualization_msgs/ImageMarkerArray",
+  "visualization_msgs/msg/ImageMarkerArray",
+  "ros.visualization_msgs.ImageMarkerArray",
+  // backwards compat with webviz
+  "webviz_msgs/ImageMarkerArray",
+  // foxglove
+  "foxglove_msgs/ImageAnnotations",
+  "foxglove_msgs/msg/ImageAnnotations",
+  "foxglove.ImageAnnotations",
+] as const;
+
 function foxglovePointTypeToStyle(
   type: PointsAnnotationType,
 ): PointsAnnotation["style"] | undefined {

--- a/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeAnnotations.ts
@@ -191,7 +191,8 @@ function normalizeAnnotations(
   // The panel may send the annotations to a web worker, for this we need
   const message = toPOD(maybeLazyMessage);
 
-  switch (datatype) {
+  // Cast to the union of all supported datatypes to ensure we handle all cases
+  switch (datatype as (typeof ANNOTATION_DATATYPES)[number]) {
     // single marker
     case "visualization_msgs/ImageMarker":
     case "visualization_msgs/msg/ImageMarker":

--- a/packages/studio-base/src/panels/Image/lib/normalizeMessage.ts
+++ b/packages/studio-base/src/panels/Image/lib/normalizeMessage.ts
@@ -22,7 +22,7 @@ export const NORMALIZABLE_IMAGE_DATATYPES = [
   "foxglove_msgs/msg/RawImage",
   "foxglove_msgs/CompressedImage",
   "foxglove_msgs/msg/CompressedImage",
-];
+] as const;
 
 /**
  * Convert a message based on datatype to a NormalizedImageMessage
@@ -32,7 +32,8 @@ export function normalizeImageMessage(
   message: unknown,
   datatype: string,
 ): NormalizedImageMessage | undefined {
-  switch (datatype) {
+  // Cast to the union of all supported datatypes to ensure we handle all cases
+  switch (datatype as (typeof NORMALIZABLE_IMAGE_DATATYPES)[number]) {
     case "foxglove_msgs/RawImage":
     case "foxglove_msgs/msg/RawImage":
     case "foxglove.RawImage": {


### PR DESCRIPTION

**User-Facing Changes**
Image panel is able to subscribe to camera calibration (info) topics again.

**Description**

The image panel had incorrect logic for the camera info subscription. It was checking the topic against supported image schemas rather than calibration schemas.

This change fixes the logic by adding the list of supported calibration schemas.

Fixes: #5640