### PR TITLE
Reduce Popover margins

### DIFF
--- a/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
+++ b/packages/studio-base/src/components/AppBar/UserMenu.stories.tsx
@@ -50,7 +50,7 @@ function SignInStates(): JSX.Element {
       <div style={{ width: 224, paddingLeft: 16 }}>sign in undefined</div>
       <div style={{ width: 224, paddingLeft: 16 }}>no user present</div>
       <div style={{ width: 240, paddingLeft: 16 }}>user present</div>
-      <MenuStory top={44} left={0} />
+      <MenuStory top={44} left={16} />
       <CurrentUserContext.Provider
         value={{
           currentUser: undefined,

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -461,7 +461,7 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
     },
     MuiPopover: {
       defaultProps: {
-        marginThreshold: 0,
+        marginThreshold: 8,
       },
     },
     MuiRadio: {

--- a/packages/studio-base/src/theme/muiComponents.ts
+++ b/packages/studio-base/src/theme/muiComponents.ts
@@ -459,6 +459,11 @@ export default function muiComponents(theme: Theme): Theme["components"] & MuiLa
         },
       },
     },
+    MuiPopover: {
+      defaultProps: {
+        marginThreshold: 0,
+      },
+    },
     MuiRadio: {
       defaultProps: {
         disableRipple: true,


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Allow MUI Popover elements to get closer to the edge of the viewport

| before | after |
|---|---|
| <img width="327" alt="Screen Shot 2023-04-06 at 10 48 59 am" src="https://user-images.githubusercontent.com/924528/230245353-c1b2a2ad-4733-4d2c-a4ab-9b27e4b2d4ac.png"> | <img width="327" alt="Screen Shot 2023-04-06 at 11 03 34 am" src="https://user-images.githubusercontent.com/924528/230247480-9c7993f0-91db-45d2-b8f6-e50beed45464.png"> |

Closes FG-2747
