### PR TITLE
WssErrorModal to be displayed with the new top nav

### DIFF
--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -20,6 +20,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePipeline";
 import Stack from "@foxglove/studio-base/components/Stack";
 import TextMiddleTruncate from "@foxglove/studio-base/components/TextMiddleTruncate";
+import WssErrorModal from "@foxglove/studio-base/components/WssErrorModal";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 
 const LEFT_ICON_SIZE = 19;
@@ -118,6 +119,7 @@ export function DataSource({
     initializing && playerName == undefined ? "Initializing..." : playerName;
 
   const [problemModal, setProblemModal] = useState<JSX.Element | undefined>(undefined);
+  const [hasDismissedWssErrorModal, setHasDismissedWssErrorModal] = useState(false);
 
   if (playerPresence === PlayerPresence.NOT_PRESENT) {
     return (
@@ -127,9 +129,17 @@ export function DataSource({
     );
   }
 
+  const hasWssConnectionProblem = playerProblems.find(
+    (problem) =>
+      problem.severity === "error" && problem.message === "Insecure WebSocket connection",
+  );
+
   return (
     <>
       {problemModal}
+      {hasWssConnectionProblem && !hasDismissedWssErrorModal && (
+        <WssErrorModal onClose={() => setHasDismissedWssErrorModal(true)} />
+      )}
       <Stack direction="row" alignItems="center">
         <ButtonBase className={classes.button} onClick={onSelectDataSourceAction}>
           <div className={cx(classes.adornment, { [classes.adornmentError]: error })}>

--- a/packages/studio-base/src/components/AppBar/DataSource.tsx
+++ b/packages/studio-base/src/components/AppBar/DataSource.tsx
@@ -119,7 +119,6 @@ export function DataSource({
     initializing && playerName == undefined ? "Initializing..." : playerName;
 
   const [problemModal, setProblemModal] = useState<JSX.Element | undefined>(undefined);
-  const [hasDismissedWssErrorModal, setHasDismissedWssErrorModal] = useState(false);
 
   if (playerPresence === PlayerPresence.NOT_PRESENT) {
     return (
@@ -129,17 +128,10 @@ export function DataSource({
     );
   }
 
-  const hasWssConnectionProblem = playerProblems.find(
-    (problem) =>
-      problem.severity === "error" && problem.message === "Insecure WebSocket connection",
-  );
-
   return (
     <>
       {problemModal}
-      {hasWssConnectionProblem && !hasDismissedWssErrorModal && (
-        <WssErrorModal onClose={() => setHasDismissedWssErrorModal(true)} />
-      )}
+      <WssErrorModal playerProblems={playerProblems} />
       <Stack direction="row" alignItems="center">
         <ButtonBase className={classes.button} onClick={onSelectDataSourceAction}>
           <div className={cx(classes.adornment, { [classes.adornmentError]: error })}>

--- a/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
+++ b/packages/studio-base/src/components/DataSourceSidebar/DataSourceSidebar.tsx
@@ -110,12 +110,6 @@ export default function DataSourceSidebar(props: Props): JSX.Element {
     }
   }, [playerPresence, showEventsTab, selectedEventId]);
 
-  const [hasDismissedWssErrorModal, setHasDismissedWssErrorModal] = useState(false);
-  const hasWssConnectionProblem = playerProblems.find(
-    (problem) =>
-      problem.severity === "error" && problem.message === "Insecure WebSocket connection",
-  );
-
   return (
     <SidebarContent
       disablePadding
@@ -191,9 +185,7 @@ export default function DataSourceSidebar(props: Props): JSX.Element {
           </>
         )}
       </Stack>
-      {hasWssConnectionProblem && !hasDismissedWssErrorModal && (
-        <WssErrorModal onClose={() => setHasDismissedWssErrorModal(true)} />
-      )}
+      <WssErrorModal playerProblems={playerProblems} />
     </SidebarContent>
   );
 }

--- a/packages/studio-base/src/components/WssErrorModal.stories.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.stories.tsx
@@ -13,5 +13,9 @@ export default {
 };
 
 export function Default(): JSX.Element {
-  return <WssErrorModal />;
+  return (
+    <WssErrorModal
+      playerProblems={[{ severity: "error", message: "Insecure WebSocket connection" }]}
+    />
+  );
 }

--- a/packages/studio-base/src/components/WssErrorModal.tsx
+++ b/packages/studio-base/src/components/WssErrorModal.tsx
@@ -7,6 +7,8 @@ import { Dialog, IconButton, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
 
+import { PlayerProblem } from "@foxglove/studio-base/players/types";
+
 import WssErrorModalScreenshot from "./WssErrorModal.png";
 
 const useStyles = makeStyles()({
@@ -15,16 +17,26 @@ const useStyles = makeStyles()({
   },
 });
 
-export default function WssErrorModal(props: { onClose?: () => void }): JSX.Element {
-  const [open, setOpen] = useState(true);
-  const { onClose } = props;
-
+export default function WssErrorModal(props: { playerProblems?: PlayerProblem[] }): JSX.Element {
+  const { playerProblems } = props;
   const { classes } = useStyles();
+
+  const [open, setOpen] = useState(true);
+  const [hasDismissedWssErrorModal, setHasDismissedWssErrorModal] = useState(false);
 
   const handleClose = () => {
     setOpen(false);
-    onClose?.();
+    setHasDismissedWssErrorModal(true);
   };
+
+  const hasWssConnectionProblem = playerProblems?.find(
+    (problem) =>
+      problem.severity === "error" && problem.message === "Insecure WebSocket connection",
+  );
+
+  if (hasDismissedWssErrorModal || !hasWssConnectionProblem) {
+    return <></>;
+  }
 
   return (
     <Dialog open={open} onClose={handleClose}>


### PR DESCRIPTION
**User-Facing Changes**

Since the data source sidebar is removed when the new top nav bar is switched on, the WssErrorModal is never opened in this view. This PR adds the new `WssErrorModal` to `AppBar/DataSource`

<img width="1335" alt="demo" src="https://user-images.githubusercontent.com/349687/230309627-33ee8637-3ab3-43e1-bfc7-f6ab8a9333f3.png">
