### PR TITLE
patch protobufjs to support native bigints

### DIFF
--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -37,6 +37,6 @@
     "@protobufjs/base64": "1.1.2",
     "flatbuffers": "23.3.3",
     "flatbuffers_reflection": "0.0.3",
-    "protobufjs": "7.2.2"
+    "protobufjs": "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
   }
 }

--- a/packages/mcap-support/src/parseChannel.test.ts
+++ b/packages/mcap-support/src/parseChannel.test.ts
@@ -77,6 +77,83 @@ describe("parseChannel", () => {
     expect(channel.deserialize(Buffer.from("0A0101", "hex"))).toEqual({ data: [1] });
   });
 
+  it("handles protobuf int64 values", () => {
+    /*
+    syntax = "proto3";
+
+    message Int64Test {
+      int64 int64 = 1;
+      uint64 uint64 = 2;
+      sint64 sint64 = 3;
+      fixed64 fixed64 = 4;
+      sfixed64 sfixed64 = 5;
+      map<int64, int64> int64map = 6;
+      map<uint64, uint64> uint64map = 7;
+      map<sint64, sint64> sint64map = 8;
+      map<fixed64, fixed64> fixed64map = 9;
+      map<sfixed64, sfixed64> sfixed64map = 10;
+      repeated Nested nested = 11;
+    }
+
+    message Nested {
+      int64 int64 = 1;
+      uint64 uint64 = 2;
+      sint64 sint64 = 3;
+      fixed64 fixed64 = 4;
+      sfixed64 sfixed64 = 5;
+      map<int64, int64> int64map = 6;
+      map<uint64, uint64> uint64map = 7;
+      map<sint64, sint64> sint64map = 8;
+      map<fixed64, fixed64> fixed64map = 9;
+      map<sfixed64, sfixed64> sfixed64map = 10;
+    }
+    */
+    const channel = parseChannel({
+      messageEncoding: "protobuf",
+      schema: {
+        name: "Int64Test",
+        encoding: "protobuf",
+        data: Buffer.from(
+          "CvILCg9JbnQ2NFRlc3QucHJvdG8igwYKCUludDY0VGVzdBIUCgVpbnQ2NBgBIAEoA1IFaW50NjQSFgoGdWludDY0GAIgASgEUgZ1aW50NjQSFgoGc2ludDY0GAMgASgSUgZzaW50NjQSGAoHZml4ZWQ2NBgEIAEoBlIHZml4ZWQ2NBIaCghzZml4ZWQ2NBgFIAEoEFIIc2ZpeGVkNjQSNAoIaW50NjRtYXAYBiADKAsyGC5JbnQ2NFRlc3QuSW50NjRtYXBFbnRyeVIIaW50NjRtYXASNwoJdWludDY0bWFwGAcgAygLMhkuSW50NjRUZXN0LlVpbnQ2NG1hcEVudHJ5Ugl1aW50NjRtYXASNwoJc2ludDY0bWFwGAggAygLMhkuSW50NjRUZXN0LlNpbnQ2NG1hcEVudHJ5UglzaW50NjRtYXASOgoKZml4ZWQ2NG1hcBgJIAMoCzIaLkludDY0VGVzdC5GaXhlZDY0bWFwRW50cnlSCmZpeGVkNjRtYXASPQoLc2ZpeGVkNjRtYXAYCiADKAsyGy5JbnQ2NFRlc3QuU2ZpeGVkNjRtYXBFbnRyeVILc2ZpeGVkNjRtYXASHwoGbmVzdGVkGAsgAygLMgcuTmVzdGVkUgZuZXN0ZWQaOwoNSW50NjRtYXBFbnRyeRIQCgNrZXkYASABKANSA2tleRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgBGjwKDlVpbnQ2NG1hcEVudHJ5EhAKA2tleRgBIAEoBFIDa2V5EhQKBXZhbHVlGAIgASgEUgV2YWx1ZToCOAEaPAoOU2ludDY0bWFwRW50cnkSEAoDa2V5GAEgASgSUgNrZXkSFAoFdmFsdWUYAiABKBJSBXZhbHVlOgI4ARo9Cg9GaXhlZDY0bWFwRW50cnkSEAoDa2V5GAEgASgGUgNrZXkSFAoFdmFsdWUYAiABKAZSBXZhbHVlOgI4ARo+ChBTZml4ZWQ2NG1hcEVudHJ5EhAKA2tleRgBIAEoEFIDa2V5EhQKBXZhbHVlGAIgASgQUgV2YWx1ZToCOAEi0AUKBk5lc3RlZBIUCgVpbnQ2NBgBIAEoA1IFaW50NjQSFgoGdWludDY0GAIgASgEUgZ1aW50NjQSFgoGc2ludDY0GAMgASgSUgZzaW50NjQSGAoHZml4ZWQ2NBgEIAEoBlIHZml4ZWQ2NBIaCghzZml4ZWQ2NBgFIAEoEFIIc2ZpeGVkNjQSMQoIaW50NjRtYXAYBiADKAsyFS5OZXN0ZWQuSW50NjRtYXBFbnRyeVIIaW50NjRtYXASNAoJdWludDY0bWFwGAcgAygLMhYuTmVzdGVkLlVpbnQ2NG1hcEVudHJ5Ugl1aW50NjRtYXASNAoJc2ludDY0bWFwGAggAygLMhYuTmVzdGVkLlNpbnQ2NG1hcEVudHJ5UglzaW50NjRtYXASNwoKZml4ZWQ2NG1hcBgJIAMoCzIXLk5lc3RlZC5GaXhlZDY0bWFwRW50cnlSCmZpeGVkNjRtYXASOgoLc2ZpeGVkNjRtYXAYCiADKAsyGC5OZXN0ZWQuU2ZpeGVkNjRtYXBFbnRyeVILc2ZpeGVkNjRtYXAaOwoNSW50NjRtYXBFbnRyeRIQCgNrZXkYASABKANSA2tleRIUCgV2YWx1ZRgCIAEoA1IFdmFsdWU6AjgBGjwKDlVpbnQ2NG1hcEVudHJ5EhAKA2tleRgBIAEoBFIDa2V5EhQKBXZhbHVlGAIgASgEUgV2YWx1ZToCOAEaPAoOU2ludDY0bWFwRW50cnkSEAoDa2V5GAEgASgSUgNrZXkSFAoFdmFsdWUYAiABKBJSBXZhbHVlOgI4ARo9Cg9GaXhlZDY0bWFwRW50cnkSEAoDa2V5GAEgASgGUgNrZXkSFAoFdmFsdWUYAiABKAZSBXZhbHVlOgI4ARo+ChBTZml4ZWQ2NG1hcEVudHJ5EhAKA2tleRgBIAEoEFIDa2V5EhQKBXZhbHVlGAIgASgQUgV2YWx1ZToCOAFiBnByb3RvMw==",
+          "base64",
+        ),
+      },
+    });
+    expect(
+      channel.deserialize(
+        Buffer.from(
+          "088c95f0c4c5a9d28ff20110bc85a0cfc8e0c8e38a0118e7d59ff6f4acdbe01b21bc02e8890423c78a298c0a9c584c491ff23216088c95f0c4c5a9d28ff201108c95f0c4c5a9d28ff2013a1608bc85a0cfc8e0c8e38a0110bc85a0cfc8e0c8e38a01421408e7d59ff6f4acdbe01b10e7d59ff6f4acdbe01b4a1209bc02e8890423c78a11bc02e8890423c78a5212098c0a9c584c491ff2118c0a9c584c491ff25aa001088c95f0c4c5a9d28ff20110bc85a0cfc8e0c8e38a0118e7d59ff6f4acdbe01b21bc02e8890423c78a298c0a9c584c491ff23216088c95f0c4c5a9d28ff201108c95f0c4c5a9d28ff2013a1608bc85a0cfc8e0c8e38a0110bc85a0cfc8e0c8e38a01421408e7d59ff6f4acdbe01b10e7d59ff6f4acdbe01b4a1209bc02e8890423c78a11bc02e8890423c78a5212098c0a9c584c491ff2118c0a9c584c491ff2",
+          "hex",
+        ),
+      ),
+    ).toEqual({
+      int64: -999999999999997300n,
+      uint64: 10000000000000000700n,
+      sint64: -999999999999997300n,
+      fixed64: 10000000000000000700n,
+      sfixed64: -999999999999997300n,
+      int64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+      uint64map: [{ key: 10000000000000000700n, value: 10000000000000000700n }],
+      sint64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+      fixed64map: [{ key: 10000000000000000700n, value: 10000000000000000700n }],
+      sfixed64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+      nested: [
+        {
+          int64: -999999999999997300n,
+          uint64: 10000000000000000700n,
+          sint64: -999999999999997300n,
+          fixed64: 10000000000000000700n,
+          sfixed64: -999999999999997300n,
+          int64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+          uint64map: [{ key: 10000000000000000700n, value: 10000000000000000700n }],
+          sint64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+          fixed64map: [{ key: 10000000000000000700n, value: 10000000000000000700n }],
+          sfixed64map: [{ key: -999999999999997300n, value: -999999999999997300n }],
+        },
+      ],
+    });
+  });
+
   it("works with ros1", () => {
     const channel = parseChannel({
       messageEncoding: "ros1",

--- a/patches/protobufjs.patch
+++ b/patches/protobufjs.patch
@@ -1,0 +1,150 @@
+diff --git a/src/converter.js b/src/converter.js
+index c9e68b5bee3ce7dd9a8190cd9c53d4d234d3eba0..14765609553fcd404b79ddd84b8d4a85ad2325db 100644
+--- a/src/converter.js
++++ b/src/converter.js
+@@ -67,14 +67,7 @@ function genValuePartial_fromObject(gen, field, fieldIndex, prop) {
+             case "sint64":
+             case "fixed64":
+             case "sfixed64": gen
+-                ("if(util.Long)")
+-                    ("(m%s=util.Long.fromValue(d%s)).unsigned=%j", prop, prop, isUnsigned)
+-                ("else if(typeof d%s===\"string\")", prop)
+-                    ("m%s=parseInt(d%s,10)", prop, prop)
+-                ("else if(typeof d%s===\"number\")", prop)
+-                    ("m%s=d%s", prop, prop)
+-                ("else if(typeof d%s===\"object\")", prop)
+-                    ("m%s=new util.LongBits(d%s.low>>>0,d%s.high>>>0).toNumber(%s)", prop, prop, prop, isUnsigned ? "true" : "");
++                ("(m%s=d%s)", prop, prop)
+                 break;
+             case "bytes": gen
+                 ("if(typeof d%s===\"string\")", prop)
+@@ -181,11 +174,7 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
+             case "sint64":
+             case "fixed64":
+             case "sfixed64": gen
+-            ("if(typeof m%s===\"number\")", prop)
+-                ("d%s=o.longs===String?String(m%s):m%s", prop, prop, prop)
+-            ("else") // Long-like
+-                ("d%s=o.longs===String?util.Long.prototype.toString.call(m%s):o.longs===Number?new util.LongBits(m%s.low>>>0,m%s.high>>>0).toNumber(%s):m%s", prop, prop, prop, prop, isUnsigned ? "true": "", prop);
+-                break;
++            ("d%s=m%s", prop, prop);
+             case "bytes": gen
+             ("d%s=o.bytes===String?util.base64.encode(m%s,0,m%s.length):o.bytes===Array?Array.prototype.slice.call(m%s):m%s", prop, prop, prop, prop, prop);
+                 break;
+@@ -247,11 +236,7 @@ converter.toObject = function toObject(mtype) {
+             if (field.resolvedType instanceof Enum) gen
+         ("d%s=o.enums===String?%j:%j", prop, field.resolvedType.valuesById[field.typeDefault], field.typeDefault);
+             else if (field.long) gen
+-        ("if(util.Long){")
+-            ("var n=new util.Long(%i,%i,%j)", field.typeDefault.low, field.typeDefault.high, field.typeDefault.unsigned)
+-            ("d%s=o.longs===String?n.toString():o.longs===Number?n.toNumber():n", prop)
+-        ("}else")
+-            ("d%s=o.longs===String?%j:%i", prop, field.typeDefault.toString(), field.typeDefault.toNumber());
++        ("d%s=%sn", prop, field.typeDefault);
+             else if (field.bytes) {
+                 var arrayDefault = "[" + Array.prototype.slice.call(field.typeDefault).join(",") + "]";
+                 gen
+diff --git a/src/decoder.js b/src/decoder.js
+index f55451f258d24bb5bffc5670c6bb13b8f5002c5a..3e78ee8329526ca469e0f36a47268b1638793d8e 100644
+--- a/src/decoder.js
++++ b/src/decoder.js
+@@ -72,7 +72,7 @@ function decoder(mtype) {
+                 ("}");
+ 
+             if (types.long[field.keyType] !== undefined) gen
+-                ("%s[typeof k===\"object\"?util.longToHash(k):k]=value", ref);
++                ("%s[k]=value", ref);
+             else gen
+                 ("%s[k]=value", ref);
+ 
+diff --git a/src/field.js b/src/field.js
+index e0feb8b4346a07970a0493dd724c0d4ea22c5c9c..e25512009eeadb6136c24a64e8bdb77ecd8212e5 100644
+--- a/src/field.js
++++ b/src/field.js
+@@ -157,7 +157,7 @@ function Field(name, id, type, rule, extend, options, comment) {
+      * Whether this field's value should be treated as a long.
+      * @type {boolean}
+      */
+-    this.long = util.Long ? types.long[type] !== undefined : /* istanbul ignore next */ false;
++    this.long = types.long[type] !== undefined;
+ 
+     /**
+      * Whether this field's value is a buffer.
+@@ -292,11 +292,7 @@ Field.prototype.resolve = function resolve() {
+ 
+     // convert to internal data type if necesssary
+     if (this.long) {
+-        this.typeDefault = util.Long.fromNumber(this.typeDefault, this.type.charAt(0) === "u");
+-
+-        /* istanbul ignore else */
+-        if (Object.freeze)
+-            Object.freeze(this.typeDefault); // long instances are meant to be immutable anyway (i.e. use small int cache that even requires it)
++        // nothing to do
+ 
+     } else if (this.bytes && typeof this.typeDefault === "string") {
+         var buf;
+diff --git a/src/reader.js b/src/reader.js
+index 1b6ae13f8805b616637dc81a96331a4646a64809..2b0a00fe2a22ea50dfb5bc7cbeab6c47734d9e78 100644
+--- a/src/reader.js
++++ b/src/reader.js
+@@ -384,7 +384,7 @@ Reader._configure = function(BufferReader_) {
+     Reader.create = create();
+     BufferReader._configure();
+ 
+-    var fn = util.Long ? "toLong" : /* istanbul ignore next */ "toNumber";
++    var fn = "toBigInt";
+     util.merge(Reader.prototype, {
+ 
+         int64: function read_int64() {
+diff --git a/src/types.js b/src/types.js
+index 5fda19a69a4f226ed0f4e4504ca0106fe0754a3d..19ba4eb101a4f35dd09183882daab14449033047 100644
+--- a/src/types.js
++++ b/src/types.js
+@@ -100,11 +100,11 @@ types.defaults = bake([
+     /* sint32   */ 0,
+     /* fixed32  */ 0,
+     /* sfixed32 */ 0,
+-    /* int64    */ 0,
+-    /* uint64   */ 0,
+-    /* sint64   */ 0,
+-    /* fixed64  */ 0,
+-    /* sfixed64 */ 0,
++    /* int64    */ 0n,
++    /* uint64   */ 0n,
++    /* sint64   */ 0n,
++    /* fixed64  */ 0n,
++    /* sfixed64 */ 0n,
+     /* bool     */ false,
+     /* string   */ "",
+     /* bytes    */ util.emptyArray,
+@@ -122,9 +122,9 @@ types.defaults = bake([
+  * @property {number} sfixed64=1 Fixed64 wire type
+  */
+ types.long = bake([
+-    /* int64    */ 0,
+-    /* uint64   */ 0,
+-    /* sint64   */ 0,
++    /* int64    */ 1,
++    /* uint64   */ 1,
++    /* sint64   */ 1,
+     /* fixed64  */ 1,
+     /* sfixed64 */ 1
+ ], 7);
+diff --git a/src/util/longbits.js b/src/util/longbits.js
+index 11bfb1c002e29d1e91c19ac5a3696d89fbaf419c..fd519d84abcdf92e290bb8d5b23846357940123d 100644
+--- a/src/util/longbits.js
++++ b/src/util/longbits.js
+@@ -106,6 +106,13 @@ LongBits.prototype.toNumber = function toNumber(unsigned) {
+     return this.lo + this.hi * 4294967296;
+ };
+ 
++const view = new DataView(new ArrayBuffer(8));
++LongBits.prototype.toBigInt = function toBigInt(unsigned) {
++    view.setUint32(0, this.lo, true);
++    view.setUint32(4, this.hi, true);
++    return unsigned ? view.getBigUint64(0, true) : view.getBigInt64(0, true);
++};
++
+ /**
+  * Converts this long bits to a long.
+  * @param {boolean} [unsigned=false] Whether unsigned or not

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,7 +2231,7 @@ __metadata:
     "@types/protobufjs": "workspace:*"
     flatbuffers: 23.3.3
     flatbuffers_reflection: 0.0.3
-    protobufjs: 7.2.2
+    protobufjs: "patch:protobufjs@7.2.3#../../patches/protobufjs.patch"
     typescript: 5.0.3
   languageName: unknown
   linkType: soft
@@ -19279,9 +19279,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:7.2.2":
-  version: 7.2.2
-  resolution: "protobufjs@npm:7.2.2"
+"protobufjs@npm:7.2.3":
+  version: 7.2.3
+  resolution: "protobufjs@npm:7.2.3"
   dependencies:
     "@protobufjs/aspromise": ^1.1.2
     "@protobufjs/base64": ^1.1.2
@@ -19295,7 +19295,27 @@ __metadata:
     "@protobufjs/utf8": ^1.1.0
     "@types/node": ">=13.7.0"
     long: ^5.0.0
-  checksum: 86166e8f3e46789fa4d117ae72c17356db36bf87c0e0710d224be32e543b1c378a94e66dc2b1de5af45edfc25f56acfc7e688c50c956426a3ae97bc474f4445c
+  checksum: 9afa6de5fced0139a5180c063718508fac3ea734a9f1aceb99712367b15473a83327f91193f16b63540f9112b09a40912f5f0441a9b0d3f3c6a1c7f707d78249
+  languageName: node
+  linkType: hard
+
+"protobufjs@patch:protobufjs@7.2.3#../../patches/protobufjs.patch::locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support":
+  version: 7.2.3
+  resolution: "protobufjs@patch:protobufjs@npm%3A7.2.3#../../patches/protobufjs.patch::version=7.2.3&hash=b342bd&locator=%40foxglove%2Fmcap-support%40workspace%3Apackages%2Fmcap-support"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 30f1cd2382edf301c0c5b05420fa0c7c5806dfc4ca336742d5638d6afcf89ec7ba2e0ededdb20ae5c8ca2810f7ba612dfa3866cf79c8038015b6b8f3366e23ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
Loading Protobuf data now preserves 64-bit integer values rather than rounding them to 53-bit integers.

**Description**

Since protobuf.js does not handle bigints natively (https://github.com/protobufjs/protobuf.js/issues/1838), I had to create a patch to use bigints instead of losing precision.

I tried switching to `@bufbuild/protobuf`, which does support bigints natively, but hit a roadblock because it modifies field names when parsing protobuf data into a message object (https://github.com/bufbuild/protobuf-es/issues/454).

Sample file: [int64.mcap.zip](https://github.com/foxglove/studio/files/11175108/int64.mcap.zip)

<img width="365" alt="image" src="https://user-images.githubusercontent.com/14237/230514607-e61350ad-73b4-4677-9da6-c057a2184615.png">

<details><summary>Script to produce sample data:</summary>

```proto
syntax = "proto3";

message Int64Test {
  int64 int64 = 1;
  uint64 uint64 = 2;
  sint64 sint64 = 3;
  fixed64 fixed64 = 4;
  sfixed64 sfixed64 = 5;
  map<int64, int64> int64map = 6;
  map<uint64, uint64> uint64map = 7;
  map<sint64, sint64> sint64map = 8;
  map<fixed64, fixed64> fixed64map = 9;
  map<sfixed64, sfixed64> sfixed64map = 10;
  repeated Nested nested = 11;
}

message Nested {
  int64 int64 = 1;
  uint64 uint64 = 2;
  sint64 sint64 = 3;
  fixed64 fixed64 = 4;
  sfixed64 sfixed64 = 5;
  map<int64, int64> int64map = 6;
  map<uint64, uint64> uint64map = 7;
  map<sint64, sint64> sint64map = 8;
  map<fixed64, fixed64> fixed64map = 9;
  map<sfixed64, sfixed64> sfixed64map = 10;
}
```

```py
from os import path
from tqdm import tqdm
from mcap_protobuf.writer import Writer
from Int64Test_pb2 import Int64Test
from google.protobuf.json_format import MessageToJson

with open(path.splitext(path.basename(__file__))[0] + ".mcap", "wb") as stream:
    writer = Writer(stream)

    frame_interval_ns = 1_000_000
    nframes = 10000
    for frame in tqdm(range(0, nframes)):
        t = frame * frame_interval_ns
        msg = Int64Test()
        msg.int64 = -999999999999999000 + frame
        msg.uint64 = 9999999999999999000 + frame
        msg.sint64 = -999999999999999000 + frame
        msg.fixed64 = 9999999999999999000 + frame
        msg.sfixed64 = -999999999999999000 + frame
        msg.int64map[-999999999999999000 + frame] = -999999999999999000 + frame
        msg.uint64map[9999999999999999000 + frame] = 9999999999999999000 + frame
        msg.sint64map[-999999999999999000 + frame] = -999999999999999000 + frame
        msg.fixed64map[9999999999999999000 + frame] = 9999999999999999000 + frame
        msg.sfixed64map[-999999999999999000 + frame] = -999999999999999000 + frame
        nested = msg.nested.add()
        nested.int64 = -999999999999999000 + frame
        nested.uint64 = 9999999999999999000 + frame
        nested.sint64 = -999999999999999000 + frame
        nested.fixed64 = 9999999999999999000 + frame
        nested.sfixed64 = -999999999999999000 + frame
        nested.int64map[-999999999999999000 + frame] = -999999999999999000 + frame
        nested.uint64map[9999999999999999000 + frame] = 9999999999999999000 + frame
        nested.sint64map[-999999999999999000 + frame] = -999999999999999000 + frame
        nested.fixed64map[9999999999999999000 + frame] = 9999999999999999000 + frame
        nested.sfixed64map[-999999999999999000 + frame] = -999999999999999000 + frame

        # print(msg.SerializeToString().hex())
        # print(MessageToJson(msg))

        writer.write_message("msg", msg, t)

    writer.finish()
    stream.close()
```
</details>

Fixes #5577
Fixes FG-2522

