### PR TITLE
Set minimum 3d Lidar PointSize to Zero

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/pointExtensionUtils.ts
@@ -98,6 +98,7 @@ export function pointSettingsNode(
       placeholder: "2",
       precision: 2,
       value: pointSize,
+      min: 0,
     },
     pointShape: {
       label: "Point shape",


### PR DESCRIPTION
**User-Facing Changes**
Fixes Lidar point size minimum




**Description**
Sets 3D Panel Lidar point size to have a minimum value of zero so that the value cannot go negative. Previously, when negative, the pointSize would default to ~50, which may seem confusing to users. 

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->


Before


https://user-images.githubusercontent.com/93497294/230643477-13c3621e-9499-428e-ad4e-6181801afe25.mov



After

https://user-images.githubusercontent.com/93497294/230643488-93be4e68-74e1-4e7f-ac0e-cc59d6388059.mov




