### PR TITLE
Avoid setting seek state when buffering during seek backfill in IterablePlayer

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -666,13 +666,15 @@ export class IterablePlayer implements Player {
 
     this._lastMessageEvent = undefined;
 
-    // If the backfill does not complete within 100 milliseconds, we emit a seek event with no messages.
-    // This provides feedback to the user that we've acknowledged their seek request but haven't loaded the data.
+    // If the backfill does not complete within 100 milliseconds, we emit with no messages to
+    // indicate buffering. This provides feedback to the user that we've acknowledged their seek
+    // request but haven't loaded the data.
+    //
+    // Note: we explicitly avoid setting _lastSeekEmitTime so panels do not reset visualizations
     const seekAckTimeout = setTimeout(() => {
       this._presence = PlayerPresence.BUFFERING;
       this._messages = [];
       this._currentTime = targetTime;
-      this._lastSeekEmitTime = Date.now();
       this._queueEmitState();
     }, 100);
 


### PR DESCRIPTION
**User-Facing Changes**
Fixes an issue where some panels might lose visualization when changing topics in other panels.

**Description**

A seek backfill is triggered whenever the topic subscriptions change. In some cases this backfill can take some time to fetch the messages. When this happens, the player issues a state update to indicate it is buffering.

The previous logic would set the "_lastSeekEmitTime" for this update which indicates the update is a result of a seek and that downstream panels should clear clear any accumulated state (if relevant to the panel). When triggering this in the buffering call, the result is panels enter their "empty" state because they think a seek happened even tho there are no new messages in the update.

Instead, this change removes the setting of this field for updates due to _buffering_ so panels continue to display what they were previously displaying. When the backfilled messages are loaded the seek backfill triggers and panels are provided new messages on their subscribed topics alongside the seek indicator. Since they have these new messages they are able to setup their visualizations.
