### PR TITLE
[3D panel] Fix `foxglove.Grid` and `OccupancyGrid` crash

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -347,7 +347,7 @@ export class FoxgloveGridRenderable extends Renderable<FoxgloveGridUserData> {
             }
           }
         }
-      } else {
+      } else if (settings.colorMode === "flat") {
         // flat
         const colorConverter = getColorConverter(
           settings as typeof settings & { colorMode: typeof settings.colorMode },

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -520,6 +520,12 @@ function paletteColorCached(
       }
       palette = rawPalette;
       break;
+    default:
+      // Default to raw palette if unknown colormode, the user will have an error already in the settings
+      if (!rawPalette) {
+        rawPalette = createRawPalette();
+      }
+      palette = rawPalette;
   }
 
   const colorRaw = palette[Math.trunc(unsignedValue)]!;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -481,7 +481,11 @@ let costmapPalette: [number, number, number, number][] | undefined;
 let mapPalette: [number, number, number, number][] | undefined;
 let rawPalette: [number, number, number, number][] | undefined;
 
-function paletteColorCached(output: ColorRGBA, value: number, color_mode: ColorModes) {
+function paletteColorCached(
+  output: ColorRGBA,
+  value: number,
+  color_mode: "costmap" | "map" | "raw",
+) {
   const unsignedValue = value >= 0 ? value : value + 256;
   if (unsignedValue < 0 || unsignedValue > 255) {
     output.r = 0;
@@ -501,13 +505,12 @@ function paletteColorCached(output: ColorRGBA, value: number, color_mode: ColorM
       mapPalette = createMapPalette();
     }
     palette = mapPalette;
-  } else if (color_mode === "raw") {
+  } else {
+    // "raw"
     if (!rawPalette) {
       rawPalette = createRawPalette();
     }
     palette = rawPalette;
-  } else {
-    throw new Error(`Unsupported color mode ${color_mode}`);
   }
 
   const colorRaw = palette[Math.trunc(unsignedValue)]!;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/OccupancyGrids.ts
@@ -481,10 +481,16 @@ let costmapPalette: [number, number, number, number][] | undefined;
 let mapPalette: [number, number, number, number][] | undefined;
 let rawPalette: [number, number, number, number][] | undefined;
 
+/**
+ * Maps the value to a color using the given palette that is cached after initial use.
+ * @param output - RGBA color output of the given value using the palette in the colormode
+ * @param value - Int8 or Uint8 value to map to a color
+ * @param paletteColorMode - "costmap", "map", or "raw" these are the predefined palette colormodes. Their palette will be used to determine the output color
+ */
 function paletteColorCached(
   output: ColorRGBA,
   value: number,
-  color_mode: "costmap" | "map" | "raw",
+  paletteColorMode: "costmap" | "map" | "raw",
 ) {
   const unsignedValue = value >= 0 ? value : value + 256;
   if (unsignedValue < 0 || unsignedValue > 255) {
@@ -495,22 +501,25 @@ function paletteColorCached(
   }
 
   let palette: [number, number, number, number][] | undefined;
-  if (color_mode === "costmap") {
-    if (!costmapPalette) {
-      costmapPalette = createCostmapPalette();
-    }
-    palette = costmapPalette;
-  } else if (color_mode === "map") {
-    if (!mapPalette) {
-      mapPalette = createMapPalette();
-    }
-    palette = mapPalette;
-  } else {
-    // "raw"
-    if (!rawPalette) {
-      rawPalette = createRawPalette();
-    }
-    palette = rawPalette;
+  switch (paletteColorMode) {
+    case "costmap":
+      if (!costmapPalette) {
+        costmapPalette = createCostmapPalette();
+      }
+      palette = costmapPalette;
+      break;
+    case "map":
+      if (!mapPalette) {
+        mapPalette = createMapPalette();
+      }
+      palette = mapPalette;
+      break;
+    case "raw":
+      if (!rawPalette) {
+        rawPalette = createRawPalette();
+      }
+      palette = rawPalette;
+      break;
   }
 
   const colorRaw = palette[Math.trunc(unsignedValue)]!;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- [3D Panel] Fix `foxglove.Grid` and `OccupancyGrid` topics causing a crash on opening

**Description**
The crash happens because both OccupancyGrid and foxglove.Grid use `colorMode`. So when you switch from a layout that was initialized with an OccupancyGrid and have a colorMode for topic `/map` that is 'raw', to a source with a `foxglove.Grid` on topic `/map`, that foxglove.Grid will attempt to use `colorMode=raw` from the existing layout. Both of these panels happen to throw an Exception when something outside of their specified colorModes is used so it results in a crash. I've simply changed this behavior to not throw an exception. The foxglove.Grid will leave the grid blank, and the OccupancyGrid will simply use its raw palette. In either case, the Color mode input on both topics will show as invalid.
<img width="525" alt="image" src="https://user-images.githubusercontent.com/10187776/231922416-b90941c3-4841-4512-8699-1f27ba130dfd.png">



<!-- link relevant GitHub issues -->
FG-2774
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
