### PR TITLE
Foxglove websocket: Clear state when serverInfo's sessionId changed

### DIFF
--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -186,7 +186,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._problems.clear();
       this._channelsById.clear();
       this._channelsByTopic.clear();
-      this._setupPublishers();
       this._servicesByName.clear();
       this._serviceResponseCbs.clear();
       this._parameters.clear();
@@ -194,7 +193,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._publishedTopics = undefined;
       this._subscribedTopics = undefined;
       this._advertisedServices = undefined;
-
+      this._publicationsByTopic.clear();
       this._datatypes = new Map();
 
       for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
@@ -293,6 +292,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
       if (event.capabilities.includes(ServerCapability.clientPublish)) {
         this._playerCapabilities = this._playerCapabilities.concat(PlayerCapabilities.advertise);
+        this._setupPublishers();
       }
       if (event.capabilities.includes(ServerCapability.services)) {
         this._serviceCallEncoding = event.supportedEncodings?.find((e) =>

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -183,6 +183,24 @@ export default class FoxgloveWebSocketPlayer implements Player {
         clearTimeout(this._connectionAttemptTimeout);
       }
       this._presence = PlayerPresence.PRESENT;
+      this._problems.clear();
+      this._channelsById.clear();
+      this._channelsByTopic.clear();
+      this._servicesByName.clear();
+      this._serviceResponseCbs.clear();
+      this._parameters.clear();
+      this._profile = undefined;
+      this._publishedTopics = undefined;
+      this._subscribedTopics = undefined;
+      this._advertisedServices = undefined;
+      this._publicationsByTopic.clear();
+      this._datatypes = new Map();
+
+      for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
+        this._unresolvedSubscriptions.add(topic);
+      }
+      this._resolvedSubscriptionsById.clear();
+      this._resolvedSubscriptionsByTopic.clear();
     });
 
     this._client.on("error", (err) => {
@@ -244,24 +262,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._serverPublishesTime = this._serverCapabilities.includes(ServerCapability.time);
       this._supportedEncodings = event.supportedEncodings;
       this._datatypes = new Map();
-      this._problems.clear();
-      this._channelsById.clear();
-      this._channelsByTopic.clear();
-      this._servicesByName.clear();
-      this._serviceResponseCbs.clear();
-      this._parameters.clear();
-      this._publicationsByTopic.clear();
-      this._profile = undefined;
-      this._publishedTopics = undefined;
-      this._subscribedTopics = undefined;
-      this._advertisedServices = undefined;
-      this._datatypes = new Map();
-
-      for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
-        this._unresolvedSubscriptions.add(topic);
-      }
-      this._resolvedSubscriptionsById.clear();
-      this._resolvedSubscriptionsByTopic.clear();
 
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -79,7 +79,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
   private _url: string; // WebSocket URL.
   private _name: string;
   private _client?: FoxgloveClient; // The client when we're connected.
-  private _id: string = uuidv4(); // Unique ID for this player.
+  private _id: string = uuidv4(); // Unique ID for this player session.
   private _serverCapabilities: string[] = [];
   private _playerCapabilities: (typeof PlayerCapabilities)[keyof typeof PlayerCapabilities][] = [];
   private _supportedEncodings?: string[];
@@ -183,6 +183,7 @@ export default class FoxgloveWebSocketPlayer implements Player {
         clearTimeout(this._connectionAttemptTimeout);
       }
       this._presence = PlayerPresence.PRESENT;
+      this._resetSessionState();
       this._problems.clear();
       this._channelsById.clear();
       this._channelsByTopic.clear();
@@ -257,6 +258,13 @@ export default class FoxgloveWebSocketPlayer implements Player {
           message: `Server sent an invalid or missing capabilities field: '${event.capabilities}'`,
         });
       }
+
+      const newSessionId = event.sessionId ?? uuidv4();
+      if (this._id !== newSessionId) {
+        this._resetSessionState();
+      }
+
+      this._id = newSessionId;
       this._name = `${this._url}\n${event.name}`;
       this._serverCapabilities = Array.isArray(event.capabilities) ? event.capabilities : [];
       this._serverPublishesTime = this._serverCapabilities.includes(ServerCapability.time);
@@ -1007,6 +1015,18 @@ export default class FoxgloveWebSocketPlayer implements Player {
 
     this._unresolvedPublications = [];
     this._emitState();
+  }
+
+  private _resetSessionState(): void {
+    this._startTime = undefined;
+    this._endTime = undefined;
+    this._clockTime = undefined;
+    this._topicsStats = new Map();
+    this._parsedMessages = [];
+    this._receivedBytes = 0;
+    this._hasReceivedMessage = false;
+    this._problems.clear();
+    this._parameters.clear();
   }
 }
 

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.ts
@@ -183,24 +183,6 @@ export default class FoxgloveWebSocketPlayer implements Player {
         clearTimeout(this._connectionAttemptTimeout);
       }
       this._presence = PlayerPresence.PRESENT;
-      this._problems.clear();
-      this._channelsById.clear();
-      this._channelsByTopic.clear();
-      this._servicesByName.clear();
-      this._serviceResponseCbs.clear();
-      this._parameters.clear();
-      this._profile = undefined;
-      this._publishedTopics = undefined;
-      this._subscribedTopics = undefined;
-      this._advertisedServices = undefined;
-      this._publicationsByTopic.clear();
-      this._datatypes = new Map();
-
-      for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
-        this._unresolvedSubscriptions.add(topic);
-      }
-      this._resolvedSubscriptionsById.clear();
-      this._resolvedSubscriptionsByTopic.clear();
     });
 
     this._client.on("error", (err) => {
@@ -262,6 +244,24 @@ export default class FoxgloveWebSocketPlayer implements Player {
       this._serverPublishesTime = this._serverCapabilities.includes(ServerCapability.time);
       this._supportedEncodings = event.supportedEncodings;
       this._datatypes = new Map();
+      this._problems.clear();
+      this._channelsById.clear();
+      this._channelsByTopic.clear();
+      this._servicesByName.clear();
+      this._serviceResponseCbs.clear();
+      this._parameters.clear();
+      this._publicationsByTopic.clear();
+      this._profile = undefined;
+      this._publishedTopics = undefined;
+      this._subscribedTopics = undefined;
+      this._advertisedServices = undefined;
+      this._datatypes = new Map();
+
+      for (const topic of this._resolvedSubscriptionsByTopic.keys()) {
+        this._unresolvedSubscriptions.add(topic);
+      }
+      this._resolvedSubscriptionsById.clear();
+      this._resolvedSubscriptionsByTopic.clear();
 
       // If the server publishes the time we clear any existing clockTime we might have and let the
       // server override


### PR DESCRIPTION
**User-Facing Changes**
- Foxglove websocket: Clear state when `serverInfo`'s `sessionId` changed

**Description**
Allows the server to clear state by sending a new `serverInfo` message with a different (or undefined) sessionId. Note that this will not reset the client's registered subscribers / publishers.

Fixes FG-2791
