### PR TITLE
Migrate all storiesOf to CSF

### DIFF
--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
 import { useState, useEffect } from "react";
 
 import AutoSizingCanvas from ".";
@@ -55,18 +60,18 @@ export default {
   title: "components/AutoSizingCanvas",
 };
 
-export const Static = () => <Example />;
+export const Static: StoryFn = () => <Example />;
 
 Static.storyName = "static";
 
-export const ChangingSize = () => <Example changeSize />;
+export const ChangingSize: StoryFn = () => <Example changeSize />;
 
 ChangingSize.storyName = "changing size";
 
-export const PixelRatio2 = () => <Example devicePixelRatio={2} />;
+export const PixelRatio2: StoryFn = () => <Example devicePixelRatio={2} />;
 
 PixelRatio2.storyName = "pixel ratio 2";
 
-export const ChangingPixelRatio = () => <Example changePixelRatio />;
+export const ChangingPixelRatio: StoryFn = () => <Example changePixelRatio />;
 
 ChangingPixelRatio.storyName = "changing pixel ratio";

--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 import { useState, useEffect } from "react";

--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -5,7 +5,7 @@
 // This file incorporates work covered by the following copyright and
 // permission notice:
 //
-//   Copyright 2019-2021 Cruise LLC
+//   Copyright 2018-2021 Cruise LLC
 //
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
+++ b/packages/studio-base/src/components/AutoSizingCanvas/index.stories.tsx
@@ -1,17 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
 import { useState, useEffect } from "react";
 
 import AutoSizingCanvas from ".";
@@ -65,8 +51,22 @@ function Example({
   );
 }
 
-storiesOf("components/AutoSizingCanvas", module)
-  .add("static", () => <Example />)
-  .add("changing size", () => <Example changeSize />)
-  .add("pixel ratio 2", () => <Example devicePixelRatio={2} />)
-  .add("changing pixel ratio", () => <Example changePixelRatio />);
+export default {
+  title: "components/AutoSizingCanvas",
+};
+
+export const Static = () => <Example />;
+
+Static.storyName = "static";
+
+export const ChangingSize = () => <Example changeSize />;
+
+ChangingSize.storyName = "changing size";
+
+export const PixelRatio2 = () => <Example devicePixelRatio={2} />;
+
+PixelRatio2.storyName = "pixel ratio 2";
+
+export const ChangingPixelRatio = () => <Example changePixelRatio />;
+
+ChangingPixelRatio.storyName = "changing pixel ratio";

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 import { range } from "lodash";

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
 import { range } from "lodash";
 import { Component } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -21,7 +26,7 @@ export default {
   },
 };
 
-export const FilteringToO = () => {
+export const FilteringToO: StoryFn = () => {
   class Example extends Component {
     public override render() {
       return (
@@ -42,7 +47,7 @@ export const FilteringToO = () => {
 
 FilteringToO.storyName = "filtering to 'o'";
 
-export const FilteringToOLight = () => {
+export const FilteringToOLight: StoryFn = () => {
   class Example extends Component {
     public override render() {
       return (
@@ -64,7 +69,7 @@ export const FilteringToOLight = () => {
 FilteringToOLight.storyName = "filtering to 'o' light";
 FilteringToOLight.parameters = { colorScheme: "light" };
 
-export const WithNonStringItemsAndLeadingWhitespace = () => {
+export const WithNonStringItemsAndLeadingWhitespace: StoryFn = () => {
   return (
     <div style={{ padding: 20 }} ref={focusInput}>
       <Autocomplete
@@ -84,7 +89,7 @@ export const WithNonStringItemsAndLeadingWhitespace = () => {
 
 WithNonStringItemsAndLeadingWhitespace.storyName = "with non-string items and leading whitespace";
 
-export const UncontrolledValue = () => {
+export const UncontrolledValue: StoryFn = () => {
   return (
     <div
       style={{ padding: 20 }}
@@ -110,7 +115,7 @@ export const UncontrolledValue = () => {
 
 UncontrolledValue.storyName = "uncontrolled value";
 
-export const UncontrolledValueLight = () => {
+export const UncontrolledValueLight: StoryFn = () => {
   return (
     <div
       style={{ padding: 20 }}
@@ -137,7 +142,7 @@ export const UncontrolledValueLight = () => {
 UncontrolledValueLight.storyName = "uncontrolled value light";
 UncontrolledValueLight.parameters = { colorScheme: "light" };
 
-export const UncontrolledValueWithSelectedItem = () => {
+export const UncontrolledValueWithSelectedItem: StoryFn = () => {
   return (
     <div style={{ padding: 20 }} ref={focusInput}>
       <Autocomplete
@@ -152,7 +157,7 @@ export const UncontrolledValueWithSelectedItem = () => {
 
 UncontrolledValueWithSelectedItem.storyName = "uncontrolled value with selected item";
 
-export const UncontrolledValueWithSelectedItemAndClearOnFocus = () => {
+export const UncontrolledValueWithSelectedItemAndClearOnFocus: StoryFn = () => {
   return (
     <div style={{ padding: 20 }} ref={focusInput}>
       <Autocomplete
@@ -166,9 +171,10 @@ export const UncontrolledValueWithSelectedItemAndClearOnFocus = () => {
   );
 };
 
-UncontrolledValueWithSelectedItemAndClearOnFocus.storyName = "uncontrolled value with selected item and clearOnFocus";
+UncontrolledValueWithSelectedItemAndClearOnFocus.storyName =
+  "uncontrolled value with selected item and clearOnFocus";
 
-export const SortWhenFilteringFalse = () => {
+export const SortWhenFilteringFalse: StoryFn = () => {
   return (
     <div style={{ padding: 20 }} ref={focusInput}>
       <Autocomplete
@@ -184,7 +190,7 @@ export const SortWhenFilteringFalse = () => {
 
 SortWhenFilteringFalse.storyName = "sortWhenFiltering=false";
 
-export const WithALongTruncatedPathAndAutoSize = () => {
+export const WithALongTruncatedPathAndAutoSize: StoryFn = () => {
   class Example extends Component {
     public override render() {
       return (
@@ -204,7 +210,7 @@ export const WithALongTruncatedPathAndAutoSize = () => {
 
 WithALongTruncatedPathAndAutoSize.storyName = "with a long truncated path (and autoSize)";
 
-export const ManyItems = () => {
+export const ManyItems: StoryFn = () => {
   const items = range(1, 1000).map((i) => `item_${i}`);
   class Example extends Component {
     public override render() {

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -1,17 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
 import { range } from "lodash";
 import { Component } from "react";
 import TestUtils from "react-dom/test-utils";
@@ -27,180 +13,209 @@ function focusInput(el: HTMLDivElement | ReactNull) {
   }
 }
 
-storiesOf("components/Autocomplete", module)
-  .addParameters({ colorScheme: "dark" })
-  .add("filtering to 'o'", () => {
-    class Example extends Component {
-      public override render() {
-        return (
-          <div style={{ padding: 20 }} ref={focusInput}>
-            <Autocomplete
-              items={["one", "two", "three"]}
-              filterText="o"
-              value="o"
-              onSelect={() => {}}
-              hasError
-            />
-          </div>
-        );
-      }
-    }
-    return <Example />;
-  })
-  .add(
-    "filtering to 'o' light",
-    () => {
-      class Example extends Component {
-        public override render() {
-          return (
-            <div style={{ padding: 20 }} ref={focusInput}>
-              <Autocomplete
-                items={["one", "two", "three"]}
-                filterText="o"
-                value="o"
-                onSelect={() => {}}
-                hasError
-              />
-            </div>
-          );
-        }
-      }
-      return <Example />;
-    },
-    { colorScheme: "light" },
-  )
-  .add("with non-string items and leading whitespace", () => {
-    return (
-      <div style={{ padding: 20 }} ref={focusInput}>
-        <Autocomplete
-          items={[
-            { value: "one", text: "ONE" },
-            { value: "two", text: "    TWO" },
-            { value: "three", text: "THREE" },
-          ]}
-          getItemText={({ text }: any) => text}
-          filterText="o"
-          value="o"
-          onSelect={() => {}}
-        />
-      </div>
-    );
-  })
-  .add("uncontrolled value", () => {
-    return (
-      <div
-        style={{ padding: 20 }}
-        ref={(el) => {
-          if (el) {
-            const input: HTMLInputElement | undefined = el.querySelector("input") as any;
-            if (input) {
-              input.focus();
-              input.value = "h";
-              TestUtils.Simulate.change(input);
-            }
-          }
-        }}
-      >
-        <Autocomplete
-          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-          onSelect={() => {}}
-        />
-      </div>
-    );
-  })
-  .add(
-    "uncontrolled value light",
-    () => {
+export default {
+  title: "components/Autocomplete",
+
+  parameters: {
+    colorScheme: "dark",
+  },
+};
+
+export const FilteringToO = () => {
+  class Example extends Component {
+    public override render() {
       return (
-        <div
-          style={{ padding: 20 }}
-          ref={(el) => {
-            if (el) {
-              const input: HTMLInputElement | undefined = el.querySelector("input") as any;
-              if (input) {
-                input.focus();
-                input.value = "h";
-                TestUtils.Simulate.change(input);
-              }
-            }
-          }}
-        >
+        <div style={{ padding: 20 }} ref={focusInput}>
           <Autocomplete
-            items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-            getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+            items={["one", "two", "three"]}
+            filterText="o"
+            value="o"
             onSelect={() => {}}
+            hasError
           />
         </div>
       );
-    },
-    { colorScheme: "light" },
-  )
-  .add("uncontrolled value with selected item", () => {
-    return (
-      <div style={{ padding: 20 }} ref={focusInput}>
-        <Autocomplete
-          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-          selectedItem={{ value: "two" }}
-          onSelect={() => {}}
-        />
-      </div>
-    );
-  })
-  .add("uncontrolled value with selected item and clearOnFocus", () => {
-    return (
-      <div style={{ padding: 20 }} ref={focusInput}>
-        <Autocomplete
-          items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
-          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-          selectedItem={{ value: "two" }}
-          onSelect={() => {}}
-          selectOnFocus
-        />
-      </div>
-    );
-  })
-  .add("sortWhenFiltering=false", () => {
-    return (
-      <div style={{ padding: 20 }} ref={focusInput}>
-        <Autocomplete
-          items={[{ value: "bab" }, { value: "bb" }, { value: "a2" }, { value: "a1" }]}
-          getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
-          value="b"
-          onSelect={() => {}}
-          sortWhenFiltering={false}
-        />
-      </div>
-    );
-  })
-  .add("with a long truncated path (and autoSize)", () => {
-    class Example extends Component {
-      public override render() {
-        return (
-          <div style={{ maxWidth: 200 }} ref={focusInput}>
-            <Autocomplete
-              items={[]}
-              value="/abcdefghi_jklmnop.abcdefghi_jklmnop[:]{some_id==1297193}.isSomething"
-              onSelect={() => {}}
-              autoSize
-            />
-          </div>
-        );
-      }
     }
-    return <Example />;
-  })
-  .add("many items", () => {
-    const items = range(1, 1000).map((i) => `item_${i}`);
-    class Example extends Component {
-      public override render() {
-        return (
-          <div style={{ maxWidth: 200 }} ref={focusInput}>
-            <Autocomplete items={items} onSelect={() => {}} autoSize />
-          </div>
-        );
-      }
+  }
+  return <Example />;
+};
+
+FilteringToO.storyName = "filtering to 'o'";
+
+export const FilteringToOLight = () => {
+  class Example extends Component {
+    public override render() {
+      return (
+        <div style={{ padding: 20 }} ref={focusInput}>
+          <Autocomplete
+            items={["one", "two", "three"]}
+            filterText="o"
+            value="o"
+            onSelect={() => {}}
+            hasError
+          />
+        </div>
+      );
     }
-    return <Example />;
-  });
+  }
+  return <Example />;
+};
+
+FilteringToOLight.storyName = "filtering to 'o' light";
+FilteringToOLight.parameters = { colorScheme: "light" };
+
+export const WithNonStringItemsAndLeadingWhitespace = () => {
+  return (
+    <div style={{ padding: 20 }} ref={focusInput}>
+      <Autocomplete
+        items={[
+          { value: "one", text: "ONE" },
+          { value: "two", text: "    TWO" },
+          { value: "three", text: "THREE" },
+        ]}
+        getItemText={({ text }: any) => text}
+        filterText="o"
+        value="o"
+        onSelect={() => {}}
+      />
+    </div>
+  );
+};
+
+WithNonStringItemsAndLeadingWhitespace.storyName = "with non-string items and leading whitespace";
+
+export const UncontrolledValue = () => {
+  return (
+    <div
+      style={{ padding: 20 }}
+      ref={(el) => {
+        if (el) {
+          const input: HTMLInputElement | undefined = el.querySelector("input") as any;
+          if (input) {
+            input.focus();
+            input.value = "h";
+            TestUtils.Simulate.change(input);
+          }
+        }
+      }}
+    >
+      <Autocomplete
+        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+        onSelect={() => {}}
+      />
+    </div>
+  );
+};
+
+UncontrolledValue.storyName = "uncontrolled value";
+
+export const UncontrolledValueLight = () => {
+  return (
+    <div
+      style={{ padding: 20 }}
+      ref={(el) => {
+        if (el) {
+          const input: HTMLInputElement | undefined = el.querySelector("input") as any;
+          if (input) {
+            input.focus();
+            input.value = "h";
+            TestUtils.Simulate.change(input);
+          }
+        }
+      }}
+    >
+      <Autocomplete
+        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+        onSelect={() => {}}
+      />
+    </div>
+  );
+};
+
+UncontrolledValueLight.storyName = "uncontrolled value light";
+UncontrolledValueLight.parameters = { colorScheme: "light" };
+
+export const UncontrolledValueWithSelectedItem = () => {
+  return (
+    <div style={{ padding: 20 }} ref={focusInput}>
+      <Autocomplete
+        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+        selectedItem={{ value: "two" }}
+        onSelect={() => {}}
+      />
+    </div>
+  );
+};
+
+UncontrolledValueWithSelectedItem.storyName = "uncontrolled value with selected item";
+
+export const UncontrolledValueWithSelectedItemAndClearOnFocus = () => {
+  return (
+    <div style={{ padding: 20 }} ref={focusInput}>
+      <Autocomplete
+        items={[{ value: "one" }, { value: "two" }, { value: "three" }]}
+        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+        selectedItem={{ value: "two" }}
+        onSelect={() => {}}
+        selectOnFocus
+      />
+    </div>
+  );
+};
+
+UncontrolledValueWithSelectedItemAndClearOnFocus.storyName = "uncontrolled value with selected item and clearOnFocus";
+
+export const SortWhenFilteringFalse = () => {
+  return (
+    <div style={{ padding: 20 }} ref={focusInput}>
+      <Autocomplete
+        items={[{ value: "bab" }, { value: "bb" }, { value: "a2" }, { value: "a1" }]}
+        getItemText={({ value }: any) => `item: ${value.toUpperCase()}`}
+        value="b"
+        onSelect={() => {}}
+        sortWhenFiltering={false}
+      />
+    </div>
+  );
+};
+
+SortWhenFilteringFalse.storyName = "sortWhenFiltering=false";
+
+export const WithALongTruncatedPathAndAutoSize = () => {
+  class Example extends Component {
+    public override render() {
+      return (
+        <div style={{ maxWidth: 200 }} ref={focusInput}>
+          <Autocomplete
+            items={[]}
+            value="/abcdefghi_jklmnop.abcdefghi_jklmnop[:]{some_id==1297193}.isSomething"
+            onSelect={() => {}}
+            autoSize
+          />
+        </div>
+      );
+    }
+  }
+  return <Example />;
+};
+
+WithALongTruncatedPathAndAutoSize.storyName = "with a long truncated path (and autoSize)";
+
+export const ManyItems = () => {
+  const items = range(1, 1000).map((i) => `item_${i}`);
+  class Example extends Component {
+    public override render() {
+      return (
+        <div style={{ maxWidth: 200 }} ref={focusInput}>
+          <Autocomplete items={items} onSelect={() => {}} autoSize />
+        </div>
+      );
+    }
+  }
+  return <Example />;
+};
+
+ManyItems.storyName = "many items";

--- a/packages/studio-base/src/components/Autocomplete.stories.tsx
+++ b/packages/studio-base/src/components/Autocomplete.stories.tsx
@@ -5,7 +5,7 @@
 // This file incorporates work covered by the following copyright and
 // permission notice:
 //
-//   Copyright 2019-2021 Cruise LLC
+//   Copyright 2018-2021 Cruise LLC
 //
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -173,28 +173,33 @@ PathWithInvalidGlobalVariablesVariable.storyName = "path with invalid globalVari
 export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
 };
-PathWithIncorrectlyPrefixedGlobalVariablesVariable.storyName = "path with incorrectly prefixed globalVariables variable";
+PathWithIncorrectlyPrefixedGlobalVariablesVariable.storyName =
+  "path with incorrectly prefixed globalVariables variable";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[$]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx.storyName = "autocomplete for path with globalVariables variable in slice (single idx)";
+AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx.storyName =
+  "autocomplete for path with globalVariables variable in slice (single idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx.storyName = "autocomplete for path with globalVariables variable in slice (start idx)";
+AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx.storyName =
+  "autocomplete for path with globalVariables variable in slice (start idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx.storyName = "autocomplete for path with globalVariables variable in slice (end idx)";
+AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx.storyName =
+  "autocomplete for path with globalVariables variable in slice (end idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx =
   (): JSX.Element => {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
   };
-AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx.storyName = "autocomplete for path with globalVariables variables in slice (start and end idx)";
+AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx.storyName =
+  "autocomplete for path with globalVariables variables in slice (start and end idx)";
 
 export const PathWithInvalidMathModifier = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
@@ -204,7 +209,8 @@ PathWithInvalidMathModifier.storyName = "path with invalid math modifier";
 export const AutocompleteWhenPrioritizedDatatypeIsAvailable = (): JSX.Element => {
   return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
 };
-AutocompleteWhenPrioritizedDatatypeIsAvailable.storyName = "autocomplete when prioritized datatype is available";
+AutocompleteWhenPrioritizedDatatypeIsAvailable.storyName =
+  "autocomplete when prioritized datatype is available";
 
 export const AutocompleteForMessageWithJsonField = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic." />;
@@ -219,7 +225,8 @@ AutocompleteForPathWithExistingFilter.storyName = "autocomplete for path with ex
 export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
 };
-AutocompleteForPathWithExistingFilterUsingAGlobalVariable.storyName = "autocomplete for path with existing filter using a global variable";
+AutocompleteForPathWithExistingFilterUsingAGlobalVariable.storyName =
+  "autocomplete for path with existing filter using a global variable";
 
 export const PathForFieldInsideJsonObject = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic.myJson" />;
@@ -229,7 +236,8 @@ PathForFieldInsideJsonObject.storyName = "path for field inside json object";
 export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
 };
-PathForMultipleLevelsOfNestedFieldsInsideJsonObject.storyName = "path for multiple levels of nested fields inside json object";
+PathForMultipleLevelsOfNestedFieldsInsideJsonObject.storyName =
+  "path for multiple levels of nested fields inside json object";
 
 export const PerformanceTesting = (): JSX.Element => {
   return <MessagePathPerformanceStory path="." />;

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.stories.tsx
@@ -108,180 +108,130 @@ function makePathAndSelectionAction(path: undefined | string, item: number) {
 export const PathWithHeaderFields = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.header.stamp.sec" />;
 };
-PathWithHeaderFields.story = {
-  name: "path with header fields",
-};
+PathWithHeaderFields.storyName = "path with header fields";
 
 export const AutocompleteTopics = (): JSX.Element => {
   return <MessagePathInputStory path="/" />;
 };
-AutocompleteTopics.story = {
-  name: "autocomplete topics",
-};
+AutocompleteTopics.storyName = "autocomplete topics";
 
 export const AutocompleteScalarFromTopicAndEmptyPath = (): JSX.Element => {
   return <MessagePathInputStory path="" validTypes={["int32"]} />;
 };
 AutocompleteScalarFromTopicAndEmptyPath.play = makePathAndSelectionAction(undefined, 2);
 
-AutocompleteScalarFromTopicAndEmptyPath.story = {
-  name: "autocomplete scalar from topic and empty path",
-};
+AutocompleteScalarFromTopicAndEmptyPath.storyName = "autocomplete scalar from topic and empty path";
 
 export const AutocompleteScalarFromTopic = (): JSX.Element => {
   return <MessagePathInputStory path="" validTypes={["int32"]} />;
 };
 AutocompleteScalarFromTopic.play = makePathAndSelectionAction("/some_logs_", 1);
-AutocompleteScalarFromTopic.story = {
-  name: "autocomplete scalar from topic",
-};
+AutocompleteScalarFromTopic.storyName = "autocomplete scalar from topic";
 
 export const AutocompleteScalarFromFullTopic = (): JSX.Element => {
   return <MessagePathInputStory path="" validTypes={["int32"]} />;
 };
 AutocompleteScalarFromFullTopic.play = makePathAndSelectionAction("/some_logs_topic", 0);
-AutocompleteScalarFromFullTopic.story = {
-  name: "autocomplete scalar from full topic",
-};
+AutocompleteScalarFromFullTopic.storyName = "autocomplete scalar from full topic";
 
 export const AutocompleteMessagePath = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/location.po" />;
 };
-AutocompleteMessagePath.story = {
-  name: "autocomplete messagePath",
-};
+AutocompleteMessagePath.storyName = "autocomplete messagePath";
 
 export const AutocompleteMessagePathLight = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/location.po" />;
 };
-AutocompleteMessagePathLight.story = {
-  name: "autocomplete messagePath light",
-  parameters: { colorScheme: "light" },
-};
+AutocompleteMessagePathLight.storyName = "autocomplete messagePath light";
+AutocompleteMessagePathLight.parameters = { colorScheme: "light" };
 
 export const AutocompleteFilter = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{}" />;
 };
-AutocompleteFilter.story = {
-  name: "autocomplete filter",
-};
+AutocompleteFilter.storyName = "autocomplete filter";
 
 export const AutocompleteTopLevelFilter = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state{}" />;
 };
-AutocompleteTopLevelFilter.story = {
-  name: "autocomplete top level filter",
-};
+AutocompleteTopLevelFilter.storyName = "autocomplete top level filter";
 
 export const AutocompleteForGlobalVariablesVariables = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state{foo_id==0}.items[:]{id==$}" />;
 };
-AutocompleteForGlobalVariablesVariables.story = {
-  name: "autocomplete for globalVariables variables",
-};
+AutocompleteForGlobalVariablesVariables.storyName = "autocomplete for globalVariables variables";
 
 export const PathWithValidGlobalVariablesVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}" />;
 };
-PathWithValidGlobalVariablesVariable.story = {
-  name: "path with valid globalVariables variable",
-};
+PathWithValidGlobalVariablesVariable.storyName = "path with valid globalVariables variable";
 
 export const PathWithInvalidGlobalVariablesVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_3}" />;
 };
-PathWithInvalidGlobalVariablesVariable.story = {
-  name: "path with invalid globalVariables variable",
-};
+PathWithInvalidGlobalVariablesVariable.storyName = "path with invalid globalVariables variable";
 
 export const PathWithIncorrectlyPrefixedGlobalVariablesVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==global_var_2}" />;
 };
-PathWithIncorrectlyPrefixedGlobalVariablesVariable.story = {
-  name: "path with incorrectly prefixed globalVariables variable",
-};
+PathWithIncorrectlyPrefixedGlobalVariablesVariable.storyName = "path with incorrectly prefixed globalVariables variable";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[$]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx.story = {
-  name: "autocomplete for path with globalVariables variable in slice (single idx)",
-};
+AutocompleteForPathWithGlobalVariablesVariableInSliceSingleIdx.storyName = "autocomplete for path with globalVariables variable in slice (single idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[$:]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx.story = {
-  name: "autocomplete for path with globalVariables variable in slice (start idx)",
-};
+AutocompleteForPathWithGlobalVariablesVariableInSliceStartIdx.storyName = "autocomplete for path with globalVariables variable in slice (start idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:$]" />;
 };
-AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx.story = {
-  name: "autocomplete for path with globalVariables variable in slice (end idx)",
-};
+AutocompleteForPathWithGlobalVariablesVariableInSliceEndIdx.storyName = "autocomplete for path with globalVariables variable in slice (end idx)";
 
 export const AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx =
   (): JSX.Element => {
     return <MessagePathInputStory path="/some_topic/state.items[$global_var_2:$]" />;
   };
-AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx.story = {
-  name: "autocomplete for path with globalVariables variables in slice (start and end idx)",
-};
+AutocompleteForPathWithGlobalVariablesVariablesInSliceStartAndEndIdx.storyName = "autocomplete for path with globalVariables variables in slice (start and end idx)";
 
 export const PathWithInvalidMathModifier = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/location.pose.x.@negative" />;
 };
-PathWithInvalidMathModifier.story = {
-  name: "path with invalid math modifier",
-};
+PathWithInvalidMathModifier.storyName = "path with invalid math modifier";
 
 export const AutocompleteWhenPrioritizedDatatypeIsAvailable = (): JSX.Element => {
   return <MessagePathInputStory path="/" prioritizedDatatype="msgs/State" />;
 };
-AutocompleteWhenPrioritizedDatatypeIsAvailable.story = {
-  name: "autocomplete when prioritized datatype is available",
-};
+AutocompleteWhenPrioritizedDatatypeIsAvailable.storyName = "autocomplete when prioritized datatype is available";
 
 export const AutocompleteForMessageWithJsonField = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic." />;
 };
-AutocompleteForMessageWithJsonField.story = {
-  name: "autocomplete for message with json field",
-};
+AutocompleteForMessageWithJsonField.storyName = "autocomplete for message with json field";
 
 export const AutocompleteForPathWithExistingFilter = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==1}." />;
 };
-AutocompleteForPathWithExistingFilter.story = {
-  name: "autocomplete for path with existing filter",
-};
+AutocompleteForPathWithExistingFilter.storyName = "autocomplete for path with existing filter";
 
 export const AutocompleteForPathWithExistingFilterUsingAGlobalVariable = (): JSX.Element => {
   return <MessagePathInputStory path="/some_topic/state.items[:]{id==$global_var_2}." />;
 };
-AutocompleteForPathWithExistingFilterUsingAGlobalVariable.story = {
-  name: "autocomplete for path with existing filter using a global variable",
-};
+AutocompleteForPathWithExistingFilterUsingAGlobalVariable.storyName = "autocomplete for path with existing filter using a global variable";
 
 export const PathForFieldInsideJsonObject = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic.myJson" />;
 };
-PathForFieldInsideJsonObject.story = {
-  name: "path for field inside json object",
-};
+PathForFieldInsideJsonObject.storyName = "path for field inside json object";
 
 export const PathForMultipleLevelsOfNestedFieldsInsideJsonObject = (): JSX.Element => {
   return <MessagePathInputStory path="/some_logs_topic.myJson.a.b.c" />;
 };
-PathForMultipleLevelsOfNestedFieldsInsideJsonObject.story = {
-  name: "path for multiple levels of nested fields inside json object",
-};
+PathForMultipleLevelsOfNestedFieldsInsideJsonObject.storyName = "path for multiple levels of nested fields inside json object";
 
 export const PerformanceTesting = (): JSX.Element => {
   return <MessagePathPerformanceStory path="." />;
 };
-PerformanceTesting.story = {
-  name: "performance testing",
-};
+PerformanceTesting.storyName = "performance testing";

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -13,7 +13,6 @@
 
 import { Database20Filled } from "@fluentui/react-icons";
 import { Box } from "@mui/material";
-import { storiesOf } from "@storybook/react";
 import { Mosaic, MosaicWindow } from "react-mosaic-component";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
@@ -89,139 +88,138 @@ class PanelToolbarWithOpenMenu extends React.PureComponent {
   }
 }
 
-storiesOf("components/PanelToolbar", module)
-  .addDecorator((childrenRenderFcn) => {
-    // Provide all stories with PanelContext and current layout
-    return (
-      <MockCurrentLayoutProvider>
-        <MockPanelContextProvider>{childrenRenderFcn()}</MockPanelContextProvider>
-      </MockCurrentLayoutProvider>
-    );
-  })
-  .add("non-floating (narrow)", () => {
-    return (
-      <MosaicWrapper width={268}>
-        <PanelToolbar>
-          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
-            Some controls here
-          </div>
-        </PanelToolbar>
-      </MosaicWrapper>
-    );
-  })
-  .add("non-floating (wide with panel name)", () => {
-    return (
-      <MosaicWrapper width={468}>
-        <PanelToolbar>
-          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
-            Some controls here
-          </div>
-        </PanelToolbar>
-      </MosaicWrapper>
-    );
-  })
-  .add("one additional icon", () => {
-    const additionalIcons = (
-      <ToolbarIconButton title="database icon">
-        <Database20Filled />
-      </ToolbarIconButton>
-    );
-    return (
-      <MosaicWrapper width={468}>
-        <PanelToolbar additionalIcons={additionalIcons}>
-          <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>
-            Some controls here
-          </div>
-        </PanelToolbar>
-      </MosaicWrapper>
-    );
-  })
-  .add(
-    "menu (only panel)",
-    () => {
-      class Story extends React.Component {
-        public override render() {
-          return (
-            <MosaicWrapper width={268}>
-              <PanelToolbarWithOpenMenu />
-            </MosaicWrapper>
-          );
-        }
-      }
-      return <Story />;
+export default {
+  title: "components/PanelToolbar",
+
+  decorators: [
+    (childrenRenderFcn) => {
+      // Provide all stories with PanelContext and current layout
+      return (
+        <MockCurrentLayoutProvider>
+          <MockPanelContextProvider>{childrenRenderFcn()}</MockPanelContextProvider>
+        </MockCurrentLayoutProvider>
+      );
     },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "menu light",
-    () => {
-      class Story extends React.Component {
-        public override render() {
-          return (
-            <MosaicWrapper width={268}>
-              <PanelToolbarWithOpenMenu />
-            </MosaicWrapper>
-          );
-        }
-      }
-      return <Story />;
-    },
-    { colorScheme: "light" },
-  )
-  .add(
-    "menu (with sibling panel)",
-    () => {
-      class Story extends React.Component {
-        public override render() {
-          return (
-            <MosaicWrapper
-              width={268}
-              layout={{ direction: "row", first: "dummy", second: "Sibling" }}
-            >
-              <PanelToolbarWithOpenMenu />
-            </MosaicWrapper>
-          );
-        }
-      }
-      return <Story />;
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "menu for Tab panel",
-    () => {
-      class Story extends React.Component {
-        public override render() {
-          return (
-            <MosaicWrapper
-              width={268}
-              layout={{ direction: "row", first: "Tab", second: "Sibling" }}
-            >
-              <PanelToolbarWithOpenMenu />
-            </MosaicWrapper>
-          );
-        }
-      }
-      return <Story />;
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "no toolbars",
-    () => {
-      class Story extends React.Component {
-        public override render() {
-          return (
-            <MosaicWrapper
-              width={268}
-              layout={{ direction: "row", first: "dummy", second: "Sibling" }}
-            >
-              <PanelToolbarWithOpenMenu />
-            </MosaicWrapper>
-          );
-        }
-      }
-      return <Story />;
-    },
-    { colorScheme: "dark" },
+  ],
+};
+
+export const NonFloatingNarrow = () => {
+  return (
+    <MosaicWrapper width={268}>
+      <PanelToolbar>
+        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
+      </PanelToolbar>
+    </MosaicWrapper>
   );
+};
+
+NonFloatingNarrow.storyName = "non-floating (narrow)";
+
+export const NonFloatingWideWithPanelName = () => {
+  return (
+    <MosaicWrapper width={468}>
+      <PanelToolbar>
+        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
+      </PanelToolbar>
+    </MosaicWrapper>
+  );
+};
+
+NonFloatingWideWithPanelName.storyName = "non-floating (wide with panel name)";
+
+export const OneAdditionalIcon = () => {
+  const additionalIcons = (
+    <ToolbarIconButton title="database icon">
+      <Database20Filled />
+    </ToolbarIconButton>
+  );
+  return (
+    <MosaicWrapper width={468}>
+      <PanelToolbar additionalIcons={additionalIcons}>
+        <div style={{ width: "100%", lineHeight: "22px", paddingLeft: 5 }}>Some controls here</div>
+      </PanelToolbar>
+    </MosaicWrapper>
+  );
+};
+
+OneAdditionalIcon.storyName = "one additional icon";
+
+export const MenuOnlyPanel = () => {
+  class Story extends React.Component {
+    public override render() {
+      return (
+        <MosaicWrapper width={268}>
+          <PanelToolbarWithOpenMenu />
+        </MosaicWrapper>
+      );
+    }
+  }
+  return <Story />;
+};
+
+MenuOnlyPanel.storyName = "menu (only panel)";
+MenuOnlyPanel.parameters = { colorScheme: "dark" };
+
+export const MenuLight = () => {
+  class Story extends React.Component {
+    public override render() {
+      return (
+        <MosaicWrapper width={268}>
+          <PanelToolbarWithOpenMenu />
+        </MosaicWrapper>
+      );
+    }
+  }
+  return <Story />;
+};
+
+MenuLight.storyName = "menu light";
+MenuLight.parameters = { colorScheme: "light" };
+
+export const MenuWithSiblingPanel = () => {
+  class Story extends React.Component {
+    public override render() {
+      return (
+        <MosaicWrapper width={268} layout={{ direction: "row", first: "dummy", second: "Sibling" }}>
+          <PanelToolbarWithOpenMenu />
+        </MosaicWrapper>
+      );
+    }
+  }
+  return <Story />;
+};
+
+MenuWithSiblingPanel.storyName = "menu (with sibling panel)";
+MenuWithSiblingPanel.parameters = { colorScheme: "dark" };
+
+export const MenuForTabPanel = () => {
+  class Story extends React.Component {
+    public override render() {
+      return (
+        <MosaicWrapper width={268} layout={{ direction: "row", first: "Tab", second: "Sibling" }}>
+          <PanelToolbarWithOpenMenu />
+        </MosaicWrapper>
+      );
+    }
+  }
+  return <Story />;
+};
+
+MenuForTabPanel.storyName = "menu for Tab panel";
+MenuForTabPanel.parameters = { colorScheme: "dark" };
+
+export const NoToolbars = () => {
+  class Story extends React.Component {
+    public override render() {
+      return (
+        <MosaicWrapper width={268} layout={{ direction: "row", first: "dummy", second: "Sibling" }}>
+          <PanelToolbarWithOpenMenu />
+        </MosaicWrapper>
+      );
+    }
+  }
+  return <Story />;
+};
+
+NoToolbars.storyName = "no toolbars";
+NoToolbars.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
+++ b/packages/studio-base/src/components/PanelToolbar/index.stories.tsx
@@ -13,6 +13,7 @@
 
 import { Database20Filled } from "@fluentui/react-icons";
 import { Box } from "@mui/material";
+import { DecoratorFn, StoryFn } from "@storybook/react";
 import { Mosaic, MosaicWindow } from "react-mosaic-component";
 
 import MockPanelContextProvider from "@foxglove/studio-base/components/MockPanelContextProvider";
@@ -92,18 +93,18 @@ export default {
   title: "components/PanelToolbar",
 
   decorators: [
-    (childrenRenderFcn) => {
+    ((childrenRenderFcn) => {
       // Provide all stories with PanelContext and current layout
       return (
         <MockCurrentLayoutProvider>
           <MockPanelContextProvider>{childrenRenderFcn()}</MockPanelContextProvider>
         </MockCurrentLayoutProvider>
       );
-    },
+    }) as DecoratorFn,
   ],
 };
 
-export const NonFloatingNarrow = () => {
+export const NonFloatingNarrow: StoryFn = () => {
   return (
     <MosaicWrapper width={268}>
       <PanelToolbar>
@@ -115,7 +116,7 @@ export const NonFloatingNarrow = () => {
 
 NonFloatingNarrow.storyName = "non-floating (narrow)";
 
-export const NonFloatingWideWithPanelName = () => {
+export const NonFloatingWideWithPanelName: StoryFn = () => {
   return (
     <MosaicWrapper width={468}>
       <PanelToolbar>
@@ -127,7 +128,7 @@ export const NonFloatingWideWithPanelName = () => {
 
 NonFloatingWideWithPanelName.storyName = "non-floating (wide with panel name)";
 
-export const OneAdditionalIcon = () => {
+export const OneAdditionalIcon: StoryFn = () => {
   const additionalIcons = (
     <ToolbarIconButton title="database icon">
       <Database20Filled />
@@ -144,7 +145,7 @@ export const OneAdditionalIcon = () => {
 
 OneAdditionalIcon.storyName = "one additional icon";
 
-export const MenuOnlyPanel = () => {
+export const MenuOnlyPanel: StoryFn = () => {
   class Story extends React.Component {
     public override render() {
       return (
@@ -160,7 +161,7 @@ export const MenuOnlyPanel = () => {
 MenuOnlyPanel.storyName = "menu (only panel)";
 MenuOnlyPanel.parameters = { colorScheme: "dark" };
 
-export const MenuLight = () => {
+export const MenuLight: StoryFn = () => {
   class Story extends React.Component {
     public override render() {
       return (
@@ -176,7 +177,7 @@ export const MenuLight = () => {
 MenuLight.storyName = "menu light";
 MenuLight.parameters = { colorScheme: "light" };
 
-export const MenuWithSiblingPanel = () => {
+export const MenuWithSiblingPanel: StoryFn = () => {
   class Story extends React.Component {
     public override render() {
       return (
@@ -192,7 +193,7 @@ export const MenuWithSiblingPanel = () => {
 MenuWithSiblingPanel.storyName = "menu (with sibling panel)";
 MenuWithSiblingPanel.parameters = { colorScheme: "dark" };
 
-export const MenuForTabPanel = () => {
+export const MenuForTabPanel: StoryFn = () => {
   class Story extends React.Component {
     public override render() {
       return (
@@ -208,7 +209,7 @@ export const MenuForTabPanel = () => {
 MenuForTabPanel.storyName = "menu for Tab panel";
 MenuForTabPanel.parameters = { colorScheme: "dark" };
 
-export const NoToolbars = () => {
+export const NoToolbars: StoryFn = () => {
   class Story extends React.Component {
     public override render() {
       return (

--- a/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 

--- a/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
+
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
@@ -25,7 +31,7 @@ export default {
   title: "components/PlaybackSpeedControls",
 };
 
-export const WithoutSpeedCapability = () => {
+export const WithoutSpeedCapability: StoryFn = () => {
   return (
     <MockCurrentLayoutProvider>
       <MockMessagePipelineProvider>
@@ -38,7 +44,7 @@ export const WithoutSpeedCapability = () => {
 WithoutSpeedCapability.storyName = "without speed capability";
 WithoutSpeedCapability.parameters = { colorScheme: "dark" };
 
-export const WithoutASpeedFromThePlayer = () => {
+export const WithoutASpeedFromThePlayer: StoryFn = () => {
   return (
     <MockCurrentLayoutProvider>
       <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: undefined }}>
@@ -51,7 +57,7 @@ export const WithoutASpeedFromThePlayer = () => {
 WithoutASpeedFromThePlayer.storyName = "without a speed from the player";
 WithoutASpeedFromThePlayer.parameters = { colorScheme: "dark" };
 
-export const WithASpeed = () => {
+export const WithASpeed: StoryFn = () => {
   return (
     <MockCurrentLayoutProvider>
       <MockMessagePipelineProvider capabilities={CAPABILITIES}>
@@ -64,7 +70,7 @@ export const WithASpeed = () => {
 WithASpeed.storyName = "with a speed";
 WithASpeed.parameters = { colorScheme: "dark" };
 
-export const WithAVerySmallSpeed = () => {
+export const WithAVerySmallSpeed: StoryFn = () => {
   return (
     <MockCurrentLayoutProvider>
       <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: 0.01 }}>

--- a/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.stories.tsx
@@ -1,17 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-import { storiesOf } from "@storybook/react";
-
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpeedControls";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
@@ -35,59 +21,58 @@ function ControlsStory() {
   );
 }
 
-storiesOf("components/PlaybackSpeedControls", module)
-  .add(
-    "without speed capability",
-    () => {
-      return (
-        <MockCurrentLayoutProvider>
-          <MockMessagePipelineProvider>
-            <ControlsStory />
-          </MockMessagePipelineProvider>
-        </MockCurrentLayoutProvider>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "without a speed from the player",
-    () => {
-      return (
-        <MockCurrentLayoutProvider>
-          <MockMessagePipelineProvider
-            capabilities={CAPABILITIES}
-            activeData={{ speed: undefined }}
-          >
-            <ControlsStory />
-          </MockMessagePipelineProvider>
-        </MockCurrentLayoutProvider>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "with a speed",
-    () => {
-      return (
-        <MockCurrentLayoutProvider>
-          <MockMessagePipelineProvider capabilities={CAPABILITIES}>
-            <ControlsStory />
-          </MockMessagePipelineProvider>
-        </MockCurrentLayoutProvider>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "with a very small speed",
-    () => {
-      return (
-        <MockCurrentLayoutProvider>
-          <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: 0.01 }}>
-            <ControlsStory />
-          </MockMessagePipelineProvider>
-        </MockCurrentLayoutProvider>
-      );
-    },
-    { colorScheme: "dark" },
+export default {
+  title: "components/PlaybackSpeedControls",
+};
+
+export const WithoutSpeedCapability = () => {
+  return (
+    <MockCurrentLayoutProvider>
+      <MockMessagePipelineProvider>
+        <ControlsStory />
+      </MockMessagePipelineProvider>
+    </MockCurrentLayoutProvider>
   );
+};
+
+WithoutSpeedCapability.storyName = "without speed capability";
+WithoutSpeedCapability.parameters = { colorScheme: "dark" };
+
+export const WithoutASpeedFromThePlayer = () => {
+  return (
+    <MockCurrentLayoutProvider>
+      <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: undefined }}>
+        <ControlsStory />
+      </MockMessagePipelineProvider>
+    </MockCurrentLayoutProvider>
+  );
+};
+
+WithoutASpeedFromThePlayer.storyName = "without a speed from the player";
+WithoutASpeedFromThePlayer.parameters = { colorScheme: "dark" };
+
+export const WithASpeed = () => {
+  return (
+    <MockCurrentLayoutProvider>
+      <MockMessagePipelineProvider capabilities={CAPABILITIES}>
+        <ControlsStory />
+      </MockMessagePipelineProvider>
+    </MockCurrentLayoutProvider>
+  );
+};
+
+WithASpeed.storyName = "with a speed";
+WithASpeed.parameters = { colorScheme: "dark" };
+
+export const WithAVerySmallSpeed = () => {
+  return (
+    <MockCurrentLayoutProvider>
+      <MockMessagePipelineProvider capabilities={CAPABILITIES} activeData={{ speed: 0.01 }}>
+        <ControlsStory />
+      </MockMessagePipelineProvider>
+    </MockCurrentLayoutProvider>
+  );
+};
+
+WithAVerySmallSpeed.storyName = "with a very small speed";
+WithAVerySmallSpeed.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -1,69 +1,52 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
 import { useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
 import ShareJsonModal from "@foxglove/studio-base/components/ShareJsonModal";
 
-storiesOf("components/ShareJsonModal", module)
-  .add(
-    "standard",
-    () => (
+export default {
+  title: "components/ShareJsonModal",
+};
+
+export const Standard = () => (
+  <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
+);
+
+Standard.storyName = "standard";
+Standard.parameters = { colorScheme: "dark" };
+
+export const StandardLight = () => (
+  <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
+);
+
+StandardLight.storyName = "standard light";
+StandardLight.parameters = { colorScheme: "light" };
+
+export const Json = () => (
+  <ShareJsonModal
+    title="Foo"
+    onRequestClose={() => {}}
+    initialValue={{ foo: "bar", baz: "qux" }}
+    onChange={() => {}}
+  />
+);
+
+Json.storyName = "JSON";
+Json.parameters = { colorScheme: "dark" };
+
+export const SubmittingInvalidLayout = () => {
+  useEffect(() => {
+    setTimeout(() => {
+      const textarea = document.querySelector("textarea")!;
+      textarea.value = "{";
+      TestUtils.Simulate.change(textarea);
+    }, 10);
+  }, []);
+  return (
+    <div data-modalcontainer="true">
       <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
-    ),
-    { colorScheme: "dark" },
-  )
-  .add(
-    "standard light",
-    () => (
-      <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
-    ),
-    { colorScheme: "light" },
-  )
-  .add(
-    "JSON",
-    () => (
-      <ShareJsonModal
-        title="Foo"
-        onRequestClose={() => {}}
-        initialValue={{ foo: "bar", baz: "qux" }}
-        onChange={() => {}}
-      />
-    ),
-    { colorScheme: "dark" },
-  )
-  .add(
-    "submitting invalid layout",
-    () => {
-      useEffect(() => {
-        setTimeout(() => {
-          const textarea = document.querySelector("textarea")!;
-          textarea.value = "{";
-          TestUtils.Simulate.change(textarea);
-        }, 10);
-      }, []);
-      return (
-        <div data-modalcontainer="true">
-          <ShareJsonModal
-            title="Foo"
-            onRequestClose={() => {}}
-            initialValue=""
-            onChange={() => {}}
-          />
-        </div>
-      );
-    },
-    { colorScheme: "dark" },
+    </div>
   );
+};
+
+SubmittingInvalidLayout.storyName = "submitting invalid layout";
+SubmittingInvalidLayout.parameters = { colorScheme: "dark" };

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
 import { useEffect } from "react";
 import TestUtils from "react-dom/test-utils";
 
@@ -7,21 +12,21 @@ export default {
   title: "components/ShareJsonModal",
 };
 
-export const Standard = () => (
+export const Standard: StoryFn = () => (
   <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
 );
 
 Standard.storyName = "standard";
 Standard.parameters = { colorScheme: "dark" };
 
-export const StandardLight = () => (
+export const StandardLight: StoryFn = () => (
   <ShareJsonModal title="Foo" onRequestClose={() => {}} initialValue="" onChange={() => {}} />
 );
 
 StandardLight.storyName = "standard light";
 StandardLight.parameters = { colorScheme: "light" };
 
-export const Json = () => (
+export const Json: StoryFn = () => (
   <ShareJsonModal
     title="Foo"
     onRequestClose={() => {}}
@@ -33,7 +38,7 @@ export const Json = () => (
 Json.storyName = "JSON";
 Json.parameters = { colorScheme: "dark" };
 
-export const SubmittingInvalidLayout = () => {
+export const SubmittingInvalidLayout: StoryFn = () => {
   useEffect(() => {
     setTimeout(() => {
       const textarea = document.querySelector("textarea")!;

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -5,7 +5,7 @@
 // This file incorporates work covered by the following copyright and
 // permission notice:
 //
-//   Copyright 2019-2021 Cruise LLC
+//   Copyright 2018-2021 Cruise LLC
 //
 //   This source code is licensed under the Apache License, Version 2.0,
 //   found at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/studio-base/src/components/ShareJsonModal.stories.tsx
+++ b/packages/studio-base/src/components/ShareJsonModal.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 import { useEffect } from "react";

--- a/packages/studio-base/src/components/Sparkline.stories.tsx
+++ b/packages/studio-base/src/components/Sparkline.stories.tsx
@@ -1,6 +1,17 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { StoryFn } from "@storybook/react";
 
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 

--- a/packages/studio-base/src/components/Sparkline.stories.tsx
+++ b/packages/studio-base/src/components/Sparkline.stories.tsx
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 
 const points: SparklinePoint[] = [
@@ -19,7 +23,7 @@ export default {
   title: "components/Sparkline",
 };
 
-export const Standard = () => {
+export const Standard: StoryFn = () => {
   return (
     <div style={{ padding: 8 }}>
       <Sparkline {...props} />
@@ -29,7 +33,7 @@ export const Standard = () => {
 
 Standard.storyName = "standard";
 
-export const WithExplicitMaximumOf200 = () => {
+export const WithExplicitMaximumOf200: StoryFn = () => {
   return (
     <div style={{ padding: 8 }}>
       <Sparkline {...props} maximum={200} />

--- a/packages/studio-base/src/components/Sparkline.stories.tsx
+++ b/packages/studio-base/src/components/Sparkline.stories.tsx
@@ -1,18 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
-
 import { Sparkline, SparklinePoint } from "@foxglove/studio-base/components/Sparkline";
 
 const points: SparklinePoint[] = [
@@ -30,18 +15,26 @@ const props = {
   nowStamp: 100,
 };
 
-storiesOf("components/Sparkline", module)
-  .add("standard", () => {
-    return (
-      <div style={{ padding: 8 }}>
-        <Sparkline {...props} />
-      </div>
-    );
-  })
-  .add("with explicit maximum of 200", () => {
-    return (
-      <div style={{ padding: 8 }}>
-        <Sparkline {...props} maximum={200} />
-      </div>
-    );
-  });
+export default {
+  title: "components/Sparkline",
+};
+
+export const Standard = () => {
+  return (
+    <div style={{ padding: 8 }}>
+      <Sparkline {...props} />
+    </div>
+  );
+};
+
+Standard.storyName = "standard";
+
+export const WithExplicitMaximumOf200 = () => {
+  return (
+    <div style={{ padding: 8 }}>
+      <Sparkline {...props} maximum={200} />
+    </div>
+  );
+};
+
+WithExplicitMaximumOf200.storyName = "with explicit maximum of 200";

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0///
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
 // This file incorporates work covered by the following copyright and
 // permission notice:
 //

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -1,6 +1,14 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
+// file, You can obtain one at http://mozilla.org/MPL/2.0///
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
+
 import NodePlayground from "@foxglove/studio-base/panels/NodePlayground";
 import rawUserUtils from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils";
 import { UserNodeLog } from "@foxglove/studio-base/players/UserNodePlayer/types";
@@ -109,7 +115,7 @@ export default {
   },
 };
 
-export const WelcomeScreen = () => {
+export const WelcomeScreen: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <NodePlayground />
@@ -119,7 +125,7 @@ export const WelcomeScreen = () => {
 
 WelcomeScreen.storyName = "welcome screen";
 
-export const RawUserUtils = () => {
+export const RawUserUtils: StoryFn = () => {
   return (
     <div style={{ margin: 12 }}>
       <p style={{ color: "lightgreen" }}>
@@ -133,7 +139,7 @@ export const RawUserUtils = () => {
 
 RawUserUtils.storyName = "rawUserUtils";
 
-export const UtilsUsageInNode = () => (
+export const UtilsUsageInNode: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -153,7 +159,7 @@ export const UtilsUsageInNode = () => (
 
 UtilsUsageInNode.storyName = "utils usage in node";
 
-export const EditorShowsNewCodeWhenUserNodesChange = () => (
+export const EditorShowsNewCodeWhenUserNodesChange: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -188,7 +194,7 @@ export const EditorShowsNewCodeWhenUserNodesChange = () => (
 
 EditorShowsNewCodeWhenUserNodesChange.storyName = "Editor shows new code when userNodes change";
 
-export const EditorGotoDefinition = () => (
+export const EditorGotoDefinition: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -219,7 +225,7 @@ export const EditorGotoDefinition = () => (
 
 EditorGotoDefinition.storyName = "editor goto definition";
 
-export const GoBackFromGotoDefinition = () => (
+export const GoBackFromGotoDefinition: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -255,7 +261,7 @@ export const GoBackFromGotoDefinition = () => (
 
 GoBackFromGotoDefinition.storyName = "go back from goto definition";
 
-export const SidebarOpenNodeExplorer = () => {
+export const SidebarOpenNodeExplorer: StoryFn = () => {
   return (
     <PanelSetup
       fixture={{ ...fixture, userNodes }}
@@ -272,7 +278,7 @@ export const SidebarOpenNodeExplorer = () => {
 
 SidebarOpenNodeExplorer.storyName = "sidebar open - node explorer";
 
-export const SidebarOpenNodeExplorerSelectedNode = () => {
+export const SidebarOpenNodeExplorerSelectedNode: StoryFn = () => {
   return (
     <PanelSetup
       fixture={{ ...fixture, userNodes }}
@@ -289,7 +295,7 @@ export const SidebarOpenNodeExplorerSelectedNode = () => {
 
 SidebarOpenNodeExplorerSelectedNode.storyName = "sidebar open - node explorer - selected node";
 
-export const SidebarOpenUtilsExplorerSelectedUtility = () => {
+export const SidebarOpenUtilsExplorerSelectedUtility: StoryFn = () => {
   return (
     <PanelSetup
       fixture={{ ...fixture, userNodes }}
@@ -304,9 +310,10 @@ export const SidebarOpenUtilsExplorerSelectedUtility = () => {
   );
 };
 
-SidebarOpenUtilsExplorerSelectedUtility.storyName = "sidebar open - utils explorer - selected utility";
+SidebarOpenUtilsExplorerSelectedUtility.storyName =
+  "sidebar open - utils explorer - selected utility";
 
-export const SidebarOpenTemplatesExplorer = () => {
+export const SidebarOpenTemplatesExplorer: StoryFn = () => {
   return (
     <PanelSetup
       fixture={{ ...fixture, userNodes }}
@@ -323,7 +330,7 @@ export const SidebarOpenTemplatesExplorer = () => {
 
 SidebarOpenTemplatesExplorer.storyName = "sidebar open - templates explorer";
 
-export const EditorLoadingState = () => {
+export const EditorLoadingState: StoryFn = () => {
   const NeverLoad = () => {
     throw new Promise(() => {
       // no-op
@@ -340,7 +347,7 @@ export const EditorLoadingState = () => {
 
 EditorLoadingState.storyName = "editor loading state";
 
-export const BottomBarNoErrorsOrLogsClosed = () => (
+export const BottomBarNoErrorsOrLogsClosed: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -354,7 +361,7 @@ export const BottomBarNoErrorsOrLogsClosed = () => (
 
 BottomBarNoErrorsOrLogsClosed.storyName = "BottomBar - no errors or logs - closed";
 
-export const BottomBarNoErrorsOpen = () => (
+export const BottomBarNoErrorsOpen: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -376,7 +383,7 @@ export const BottomBarNoErrorsOpen = () => (
 
 BottomBarNoErrorsOpen.storyName = "BottomBar - no errors - open";
 
-export const BottomBarNoLogsOpen = () => (
+export const BottomBarNoLogsOpen: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -398,7 +405,7 @@ export const BottomBarNoLogsOpen = () => (
 
 BottomBarNoLogsOpen.storyName = "BottomBar - no logs - open";
 
-export const BottomBarErrorsClosed = () => (
+export const BottomBarErrorsClosed: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -445,7 +452,7 @@ export const BottomBarErrorsClosed = () => (
 
 BottomBarErrorsClosed.storyName = "BottomBar - errors - closed";
 
-export const BottomBarErrorsOpen = () => (
+export const BottomBarErrorsOpen: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -500,7 +507,7 @@ export const BottomBarErrorsOpen = () => (
 
 BottomBarErrorsOpen.storyName = "BottomBar - errors - open";
 
-export const BottomBarLogsClosed = () => (
+export const BottomBarLogsClosed: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -520,7 +527,7 @@ export const BottomBarLogsClosed = () => (
 
 BottomBarLogsClosed.storyName = "BottomBar - logs - closed";
 
-export const BottomBarLogsOpen = () => (
+export const BottomBarLogsOpen: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,
@@ -548,7 +555,7 @@ export const BottomBarLogsOpen = () => (
 
 BottomBarLogsOpen.storyName = "BottomBar - logs - open";
 
-export const BottomBarClearedLogs = () => (
+export const BottomBarClearedLogs: StoryFn = () => (
   <PanelSetup
     fixture={{
       ...fixture,

--- a/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
+++ b/packages/studio-base/src/panels/NodePlayground/index.stories.tsx
@@ -1,18 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
-
 import NodePlayground from "@foxglove/studio-base/panels/NodePlayground";
 import rawUserUtils from "@foxglove/studio-base/players/UserNodePlayer/nodeTransformerWorker/typescript/rawUserUtils";
 import { UserNodeLog } from "@foxglove/studio-base/players/UserNodePlayer/types";
@@ -114,418 +99,478 @@ const utilsSourceCode = `
 const OPEN_BOTTOM_BAR_TIMEOUT = 500;
 const SIDEBAR_OPEN_CLICK_TIMEOUT = 500;
 
-storiesOf("panels/NodePlayground", module)
-  .addParameters({
+export default {
+  title: "panels/NodePlayground",
+
+  parameters: {
     chromatic: {
       delay: 2500,
     },
-  })
-  .add("welcome screen", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <NodePlayground />
-      </PanelSetup>
-    );
-  })
-  .add("rawUserUtils", () => {
-    return (
-      <div style={{ margin: 12 }}>
-        <p style={{ color: "lightgreen" }}>
-          This should be original TypeScript source code. This is a story rather than a unit test
-          because it’s effectively a test of our webpack config.
-        </p>
-        <pre>{rawUserUtils[0]?.sourceCode}</pre>;
-      </div>
-    );
-  })
-  .add("utils usage in node", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
-          nodeId1: {
-            name: "/studio_script/script",
-            sourceCode: sourceCodeWithUtils,
-          },
-        },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: [] },
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  },
+};
+
+export const WelcomeScreen = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <NodePlayground />
     </PanelSetup>
-  ))
-  .add("Editor shows new code when userNodes change", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
+  );
+};
+
+WelcomeScreen.storyName = "welcome screen";
+
+export const RawUserUtils = () => {
+  return (
+    <div style={{ margin: 12 }}>
+      <p style={{ color: "lightgreen" }}>
+        This should be original TypeScript source code. This is a story rather than a unit test
+        because it’s effectively a test of our webpack config.
+      </p>
+      <pre>{rawUserUtils[0]?.sourceCode}</pre>;
+    </div>
+  );
+};
+
+RawUserUtils.storyName = "rawUserUtils";
+
+export const UtilsUsageInNode = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithUtils,
+        },
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: [] },
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+UtilsUsageInNode.storyName = "utils usage in node";
+
+export const EditorShowsNewCodeWhenUserNodesChange = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithUtils,
+        },
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: [] },
+    }}
+    onMount={(el, actions) => {
+      setTimeout(() => {
+        // Change the userNodes to confirm the code in the Editor updates
+        actions.setUserNodes({
           nodeId1: {
             name: "/studio_script/script",
-            sourceCode: sourceCodeWithUtils,
+            sourceCode: utilsSourceCode,
           },
+        });
+        el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]?.click();
+      }, 500);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    <SExpectedResult style={{ left: "375px", top: "150px" }}>
+      Should show function norm() code
+    </SExpectedResult>
+  </PanelSetup>
+);
+
+EditorShowsNewCodeWhenUserNodesChange.storyName = "Editor shows new code when userNodes change";
+
+export const EditorGotoDefinition = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithUtils,
         },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: [] },
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: [] },
+    }}
+  >
+    <NodePlayground
+      overrideConfig={{
+        selectedNodeId: "nodeId1",
+        additionalBackStackItems: [
+          {
+            filePath: "/studio_script/pointClouds",
+            code: utilsSourceCode,
+            readOnly: true,
+          },
+        ],
       }}
-      onMount={(el, actions) => {
+    />
+  </PanelSetup>
+);
+
+EditorGotoDefinition.storyName = "editor goto definition";
+
+export const GoBackFromGotoDefinition = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithUtils,
+        },
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: [] },
+    }}
+    onMount={(el) => {
+      setTimeout(() => {
+        el.querySelectorAll<HTMLElement>("[data-testid=go-back]")[0]!.click();
+      }, 500);
+    }}
+  >
+    <NodePlayground
+      overrideConfig={{
+        selectedNodeId: "nodeId1",
+        additionalBackStackItems: [
+          {
+            filePath: "/studio_script/pointClouds",
+            code: utilsSourceCode,
+            readOnly: true,
+          },
+        ],
+      }}
+    />
+  </PanelSetup>
+);
+
+GoBackFromGotoDefinition.storyName = "go back from goto definition";
+
+export const SidebarOpenNodeExplorer = () => {
+  return (
+    <PanelSetup
+      fixture={{ ...fixture, userNodes }}
+      onMount={(el) => {
         setTimeout(() => {
-          // Change the userNodes to confirm the code in the Editor updates
-          actions.setUserNodes({
-            nodeId1: {
-              name: "/studio_script/script",
-              sourceCode: utilsSourceCode,
-            },
-          });
-          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]?.click();
-        }, 500);
+          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
+        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+      }}
+    >
+      <NodePlayground />
+    </PanelSetup>
+  );
+};
+
+SidebarOpenNodeExplorer.storyName = "sidebar open - node explorer";
+
+export const SidebarOpenNodeExplorerSelectedNode = () => {
+  return (
+    <PanelSetup
+      fixture={{ ...fixture, userNodes }}
+      onMount={(el) => {
+        setTimeout(() => {
+          el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
+        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
       }}
     >
       <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-      <SExpectedResult style={{ left: "375px", top: "150px" }}>
-        Should show function norm() code
-      </SExpectedResult>
     </PanelSetup>
-  ))
-  .add("editor goto definition", () => (
+  );
+};
+
+SidebarOpenNodeExplorerSelectedNode.storyName = "sidebar open - node explorer - selected node";
+
+export const SidebarOpenUtilsExplorerSelectedUtility = () => {
+  return (
     <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
-          nodeId1: {
-            name: "/studio_script/script",
-            sourceCode: sourceCodeWithUtils,
-          },
-        },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: [] },
+      fixture={{ ...fixture, userNodes }}
+      onMount={(el) => {
+        setTimeout(() => {
+          el.querySelectorAll<HTMLElement>("[data-testid=utils-explorer]")[0]!.click();
+        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
       }}
     >
+      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+    </PanelSetup>
+  );
+};
+
+SidebarOpenUtilsExplorerSelectedUtility.storyName = "sidebar open - utils explorer - selected utility";
+
+export const SidebarOpenTemplatesExplorer = () => {
+  return (
+    <PanelSetup
+      fixture={{ ...fixture, userNodes }}
+      onMount={(el) => {
+        setTimeout(() => {
+          el.querySelectorAll<HTMLElement>("[data-testid=templates-explorer]")[0]!.click();
+        }, SIDEBAR_OPEN_CLICK_TIMEOUT);
+      }}
+    >
+      <NodePlayground />
+    </PanelSetup>
+  );
+};
+
+SidebarOpenTemplatesExplorer.storyName = "sidebar open - templates explorer";
+
+export const EditorLoadingState = () => {
+  const NeverLoad = () => {
+    throw new Promise(() => {
+      // no-op
+    });
+  };
+  return (
+    <PanelSetup fixture={{ ...fixture, userNodes }}>
       <NodePlayground
-        overrideConfig={{
-          selectedNodeId: "nodeId1",
-          additionalBackStackItems: [
-            {
-              filePath: "/studio_script/pointClouds",
-              code: utilsSourceCode,
-              readOnly: true,
-            },
-          ],
-        }}
+        overrideConfig={{ selectedNodeId: "nodeId1", editorForStorybook: <NeverLoad /> }}
       />
     </PanelSetup>
-  ))
-  .add("go back from goto definition", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
-          nodeId1: {
-            name: "/studio_script/script",
-            sourceCode: sourceCodeWithUtils,
+  );
+};
+
+EditorLoadingState.storyName = "editor loading state";
+
+export const BottomBarNoErrorsOrLogsClosed = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: { nodeId1: [] },
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarNoErrorsOrLogsClosed.storyName = "BottomBar - no errors or logs - closed";
+
+export const BottomBarNoErrorsOpen = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: { nodeId1: [] },
+    }}
+    onMount={(el) => {
+      setTimeout(() => {
+        const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
+        if (diagnosticsErrorsLabel) {
+          diagnosticsErrorsLabel.click();
+        }
+      }, OPEN_BOTTOM_BAR_TIMEOUT);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarNoErrorsOpen.storyName = "BottomBar - no errors - open";
+
+export const BottomBarNoLogsOpen = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: { nodeId1: [] },
+    }}
+    onMount={(el) => {
+      setTimeout(() => {
+        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+        if (logsLabel) {
+          logsLabel.click();
+        }
+      }, OPEN_BOTTOM_BAR_TIMEOUT);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarNoLogsOpen.storyName = "BottomBar - no logs - open";
+
+export const BottomBarErrorsClosed = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: {
+        nodeId1: [
+          {
+            message: `Type '"bad number"' is not assignable to type 'number[]'.`,
+            severity: 8,
+            source: "Typescript",
+            startLineNumber: 0,
+            startColumn: 6,
+            endLineNumber: 72,
+            endColumn: 20,
+            code: 2304,
           },
-        },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: [] },
-      }}
-      onMount={(el) => {
-        setTimeout(() => {
-          el.querySelectorAll<HTMLElement>("[data-testid=go-back]")[0]!.click();
-        }, 500);
-      }}
-    >
-      <NodePlayground
-        overrideConfig={{
-          selectedNodeId: "nodeId1",
-          additionalBackStackItems: [
-            {
-              filePath: "/studio_script/pointClouds",
-              code: utilsSourceCode,
-              readOnly: true,
-            },
-          ],
-        }}
-      />
-    </PanelSetup>
-  ))
-  .add("sidebar open - node explorer", () => {
-    return (
-      <PanelSetup
-        fixture={{ ...fixture, userNodes }}
-        onMount={(el) => {
-          setTimeout(() => {
-            el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
-          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
-        }}
-      >
-        <NodePlayground />
-      </PanelSetup>
-    );
-  })
-  .add("sidebar open - node explorer - selected node", () => {
-    return (
-      <PanelSetup
-        fixture={{ ...fixture, userNodes }}
-        onMount={(el) => {
-          setTimeout(() => {
-            el.querySelectorAll<HTMLElement>("[data-testid=node-explorer]")[0]!.click();
-          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
-        }}
-      >
-        <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-      </PanelSetup>
-    );
-  })
-  .add("sidebar open - utils explorer - selected utility", () => {
-    return (
-      <PanelSetup
-        fixture={{ ...fixture, userNodes }}
-        onMount={(el) => {
-          setTimeout(() => {
-            el.querySelectorAll<HTMLElement>("[data-testid=utils-explorer]")[0]!.click();
-          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
-        }}
-      >
-        <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-      </PanelSetup>
-    );
-  })
-  .add("sidebar open - templates explorer", () => {
-    return (
-      <PanelSetup
-        fixture={{ ...fixture, userNodes }}
-        onMount={(el) => {
-          setTimeout(() => {
-            el.querySelectorAll<HTMLElement>("[data-testid=templates-explorer]")[0]!.click();
-          }, SIDEBAR_OPEN_CLICK_TIMEOUT);
-        }}
-      >
-        <NodePlayground />
-      </PanelSetup>
-    );
-  })
-  .add("editor loading state", () => {
-    const NeverLoad = () => {
-      throw new Promise(() => {
-        // no-op
-      });
-    };
-    return (
-      <PanelSetup fixture={{ ...fixture, userNodes }}>
-        <NodePlayground
-          overrideConfig={{ selectedNodeId: "nodeId1", editorForStorybook: <NeverLoad /> }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("BottomBar - no errors or logs - closed", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: { nodeId1: [] },
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - no errors - open", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: { nodeId1: [] },
-      }}
-      onMount={(el) => {
-        setTimeout(() => {
-          const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
-          if (diagnosticsErrorsLabel) {
-            diagnosticsErrorsLabel.click();
-          }
-        }, OPEN_BOTTOM_BAR_TIMEOUT);
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - no logs - open", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: { nodeId1: [] },
-      }}
-      onMount={(el) => {
-        setTimeout(() => {
-          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-          if (logsLabel) {
-            logsLabel.click();
-          }
-        }, OPEN_BOTTOM_BAR_TIMEOUT);
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - errors - closed", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: {
-          nodeId1: [
-            {
-              message: `Type '"bad number"' is not assignable to type 'number[]'.`,
-              severity: 8,
-              source: "Typescript",
-              startLineNumber: 0,
-              startColumn: 6,
-              endLineNumber: 72,
-              endColumn: 20,
-              code: 2304,
-            },
-            {
-              message: "This is a warning message (without line or column numbers).",
-              severity: 4,
-              source: "Source A",
-              endLineNumber: 72,
-              endColumn: 20,
-              code: 2304,
-            },
-            {
-              message: "This is an info message (without line or column numbers).",
-              severity: 2,
-              source: "Source B",
-              code: 2304,
-            },
-            {
-              message: "This is a hint message (without line or column numbers).",
-              severity: 1,
-              source: "Source C",
-              code: 2304,
-            },
-          ],
-        },
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - errors - open", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: {
-          nodeId1: [
-            {
-              message: `Type '"bad number"' is not assignable to type 'number[]'.`,
-              severity: 8,
-              source: "Typescript",
-              startLineNumber: 0,
-              startColumn: 6,
-              endLineNumber: 72,
-              endColumn: 20,
-              code: 2304,
-            },
-            {
-              message: "This is a warning message (without line or column numbers).",
-              severity: 4,
-              source: "Source A",
-              endLineNumber: 72,
-              endColumn: 20,
-              code: 2304,
-            },
-            {
-              message: "This is an info message (without line or column numbers).",
-              severity: 2,
-              source: "Source B",
-              code: 2304,
-            },
-            {
-              message: "This is a hint message (without line or column numbers).",
-              severity: 1,
-              source: "Source C",
-              code: 2304,
-            },
-          ],
-        },
-      }}
-      onMount={(el) => {
-        setTimeout(() => {
-          const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
-          if (diagnosticsErrorsLabel) {
-            diagnosticsErrorsLabel.click();
-          }
-        }, OPEN_BOTTOM_BAR_TIMEOUT);
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - logs - closed", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
-          nodeId1: {
-            name: "/studio_script/script",
-            sourceCode: sourceCodeWithLogs,
+          {
+            message: "This is a warning message (without line or column numbers).",
+            severity: 4,
+            source: "Source A",
+            endLineNumber: 72,
+            endColumn: 20,
+            code: 2304,
           },
-        },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: logs },
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - logs - open", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: {
-          nodeId1: {
-            name: "/studio_script/script",
-            sourceCode: sourceCodeWithLogs,
+          {
+            message: "This is an info message (without line or column numbers).",
+            severity: 2,
+            source: "Source B",
+            code: 2304,
           },
+          {
+            message: "This is a hint message (without line or column numbers).",
+            severity: 1,
+            source: "Source C",
+            code: 2304,
+          },
+        ],
+      },
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarErrorsClosed.storyName = "BottomBar - errors - closed";
+
+export const BottomBarErrorsOpen = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: {
+        nodeId1: [
+          {
+            message: `Type '"bad number"' is not assignable to type 'number[]'.`,
+            severity: 8,
+            source: "Typescript",
+            startLineNumber: 0,
+            startColumn: 6,
+            endLineNumber: 72,
+            endColumn: 20,
+            code: 2304,
+          },
+          {
+            message: "This is a warning message (without line or column numbers).",
+            severity: 4,
+            source: "Source A",
+            endLineNumber: 72,
+            endColumn: 20,
+            code: 2304,
+          },
+          {
+            message: "This is an info message (without line or column numbers).",
+            severity: 2,
+            source: "Source B",
+            code: 2304,
+          },
+          {
+            message: "This is a hint message (without line or column numbers).",
+            severity: 1,
+            source: "Source C",
+            code: 2304,
+          },
+        ],
+      },
+    }}
+    onMount={(el) => {
+      setTimeout(() => {
+        const diagnosticsErrorsLabel = el.querySelector<HTMLElement>("[data-testid=np-errors]");
+        if (diagnosticsErrorsLabel) {
+          diagnosticsErrorsLabel.click();
+        }
+      }, OPEN_BOTTOM_BAR_TIMEOUT);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarErrorsOpen.storyName = "BottomBar - errors - open";
+
+export const BottomBarLogsClosed = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithLogs,
         },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: logs },
-      }}
-      onMount={(el) => {
-        setTimeout(() => {
-          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-          if (logsLabel) {
-            logsLabel.click();
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: logs },
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarLogsClosed.storyName = "BottomBar - logs - closed";
+
+export const BottomBarLogsOpen = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: {
+        nodeId1: {
+          name: "/studio_script/script",
+          sourceCode: sourceCodeWithLogs,
+        },
+      },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: logs },
+    }}
+    onMount={(el) => {
+      setTimeout(() => {
+        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+        if (logsLabel) {
+          logsLabel.click();
+        }
+      }, OPEN_BOTTOM_BAR_TIMEOUT);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarLogsOpen.storyName = "BottomBar - logs - open";
+
+export const BottomBarClearedLogs = () => (
+  <PanelSetup
+    fixture={{
+      ...fixture,
+      userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
+      userNodeDiagnostics: { nodeId1: [] },
+      userNodeLogs: { nodeId1: logs },
+    }}
+    onFirstMount={(el) => {
+      setTimeout(() => {
+        const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
+        if (logsLabel) {
+          logsLabel.click();
+          const clearBtn = el.querySelector<HTMLElement>("button[data-testid=np-logs-clear]");
+          if (clearBtn) {
+            clearBtn.click();
           }
-        }, OPEN_BOTTOM_BAR_TIMEOUT);
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ))
-  .add("BottomBar - cleared logs", () => (
-    <PanelSetup
-      fixture={{
-        ...fixture,
-        userNodes: { nodeId1: { name: "/studio_script/script", sourceCode: "" } },
-        userNodeDiagnostics: { nodeId1: [] },
-        userNodeLogs: { nodeId1: logs },
-      }}
-      onFirstMount={(el) => {
-        setTimeout(() => {
-          const logsLabel = el.querySelector<HTMLElement>("[data-testid=np-logs]");
-          if (logsLabel) {
-            logsLabel.click();
-            const clearBtn = el.querySelector<HTMLElement>("button[data-testid=np-logs-clear]");
-            if (clearBtn) {
-              clearBtn.click();
-            }
-          }
-        }, OPEN_BOTTOM_BAR_TIMEOUT);
-      }}
-    >
-      <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
-    </PanelSetup>
-  ));
+        }
+      }, OPEN_BOTTOM_BAR_TIMEOUT);
+    }}
+  >
+    <NodePlayground overrideConfig={{ selectedNodeId: "nodeId1" }} />
+  </PanelSetup>
+);
+
+BottomBarClearedLogs.storyName = "BottomBar - cleared logs";

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -11,7 +11,6 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { action } from "@storybook/addon-actions";
-import { storiesOf } from "@storybook/react";
 
 import Publish from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
@@ -44,93 +43,116 @@ const publishConfig = (config: Partial<(typeof Publish)["defaultConfig"]>) => ({
   ...config,
 });
 
-storiesOf("panels/Publish", module)
-  .add("example can publish, advanced", () => {
-    const allowPublish = true;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
-  })
-  .add("custom button color", () => {
-    const allowPublish = true;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish
-          overrideConfig={publishConfig({
-            advancedView: true,
-            value: advancedJSON,
-            buttonColor: "#ffbf49",
-          })}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("example can't publish, advanced", () => {
-    const allowPublish = false;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
-  })
-  .add("example can't publish, not advanced", () => {
-    const allowPublish = false;
-    return (
-      <PanelSetup fixture={getFixture({ allowPublish })}>
-        <Publish overrideConfig={publishConfig({ advancedView: false, value: advancedJSON })} />
-      </PanelSetup>
-    );
-  })
-  .add("Example with datatype that no longer exists", () => {
-    return (
-      <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
-      </PanelSetup>
-    );
-  })
-  .add("example with valid preset JSON", () => {
-    const fixture = {
-      topics: [],
-      datatypes: new Map(
-        Object.entries({
-          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-        }),
-      ),
-      frame: {},
-      capabilities: [PlayerCapabilities.advertise],
-      setPublishers: action("setPublishers"),
-      publish: action("publish"),
-    };
+export default {
+  title: "panels/Publish",
+};
 
-    const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
+export const ExampleCanPublishAdvanced = () => {
+  const allowPublish = true;
+  return (
+    <PanelSetup fixture={getFixture({ allowPublish })}>
+      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+    </PanelSetup>
+  );
+};
 
-    return (
-      <PanelSetup fixture={fixture}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: validJSON })} />
-      </PanelSetup>
-    );
-  })
-  .add("example with invalid preset JSON", () => {
-    const fixture = {
-      topics: [],
-      datatypes: new Map(
-        Object.entries({
-          "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
-        }),
-      ),
-      frame: {},
-      capabilities: [PlayerCapabilities.advertise],
-      setPublishers: action("setPublishers"),
-      publish: action("publish"),
-    };
+ExampleCanPublishAdvanced.storyName = "example can publish, advanced";
 
-    const invalid = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
+export const CustomButtonColor = () => {
+  const allowPublish = true;
+  return (
+    <PanelSetup fixture={getFixture({ allowPublish })}>
+      <Publish
+        overrideConfig={publishConfig({
+          advancedView: true,
+          value: advancedJSON,
+          buttonColor: "#ffbf49",
+        })}
+      />
+    </PanelSetup>
+  );
+};
 
-    return (
-      <PanelSetup fixture={fixture}>
-        <Publish overrideConfig={publishConfig({ advancedView: true, value: invalid })} />
-      </PanelSetup>
-    );
-  });
+CustomButtonColor.storyName = "custom button color";
+
+export const ExampleCantPublishAdvanced = () => {
+  const allowPublish = false;
+  return (
+    <PanelSetup fixture={getFixture({ allowPublish })}>
+      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+    </PanelSetup>
+  );
+};
+
+ExampleCantPublishAdvanced.storyName = "example can't publish, advanced";
+
+export const ExampleCantPublishNotAdvanced = () => {
+  const allowPublish = false;
+  return (
+    <PanelSetup fixture={getFixture({ allowPublish })}>
+      <Publish overrideConfig={publishConfig({ advancedView: false, value: advancedJSON })} />
+    </PanelSetup>
+  );
+};
+
+ExampleCantPublishNotAdvanced.storyName = "example can't publish, not advanced";
+
+export const ExampleWithDatatypeThatNoLongerExists = () => {
+  return (
+    <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
+      <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
+    </PanelSetup>
+  );
+};
+
+ExampleWithDatatypeThatNoLongerExists.storyName = "Example with datatype that no longer exists";
+
+export const ExampleWithValidPresetJson = () => {
+  const fixture = {
+    topics: [],
+    datatypes: new Map(
+      Object.entries({
+        "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
+      }),
+    ),
+    frame: {},
+    capabilities: [PlayerCapabilities.advertise],
+    setPublishers: action("setPublishers"),
+    publish: action("publish"),
+  };
+
+  const validJSON = `{\n  "a": 1,\n  "b": 2,\n  "c": 3\n}`;
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <Publish overrideConfig={publishConfig({ advancedView: true, value: validJSON })} />
+    </PanelSetup>
+  );
+};
+
+ExampleWithValidPresetJson.storyName = "example with valid preset JSON";
+
+export const ExampleWithInvalidPresetJson = () => {
+  const fixture = {
+    topics: [],
+    datatypes: new Map(
+      Object.entries({
+        "std_msgs/String": { definitions: [{ name: "data", type: "string" }] },
+      }),
+    ),
+    frame: {},
+    capabilities: [PlayerCapabilities.advertise],
+    setPublishers: action("setPublishers"),
+    publish: action("publish"),
+  };
+
+  const invalid = `{\n  "a": 1,\n  'b: 2,\n  "c": 3\n}`;
+
+  return (
+    <PanelSetup fixture={fixture}>
+      <Publish overrideConfig={publishConfig({ advancedView: true, value: invalid })} />
+    </PanelSetup>
+  );
+};
+
+ExampleWithInvalidPresetJson.storyName = "example with invalid preset JSON";

--- a/packages/studio-base/src/panels/Publish/index.stories.tsx
+++ b/packages/studio-base/src/panels/Publish/index.stories.tsx
@@ -11,6 +11,7 @@
 //   found at http://www.apache.org/licenses/LICENSE-2.0
 //   You may not use this file except in compliance with the License.
 import { action } from "@storybook/addon-actions";
+import { StoryFn } from "@storybook/react";
 
 import Publish from "@foxglove/studio-base/panels/Publish";
 import { PlayerCapabilities } from "@foxglove/studio-base/players/types";
@@ -47,7 +48,7 @@ export default {
   title: "panels/Publish",
 };
 
-export const ExampleCanPublishAdvanced = () => {
+export const ExampleCanPublishAdvanced: StoryFn = () => {
   const allowPublish = true;
   return (
     <PanelSetup fixture={getFixture({ allowPublish })}>
@@ -58,7 +59,7 @@ export const ExampleCanPublishAdvanced = () => {
 
 ExampleCanPublishAdvanced.storyName = "example can publish, advanced";
 
-export const CustomButtonColor = () => {
+export const CustomButtonColor: StoryFn = () => {
   const allowPublish = true;
   return (
     <PanelSetup fixture={getFixture({ allowPublish })}>
@@ -75,7 +76,7 @@ export const CustomButtonColor = () => {
 
 CustomButtonColor.storyName = "custom button color";
 
-export const ExampleCantPublishAdvanced = () => {
+export const ExampleCantPublishAdvanced: StoryFn = () => {
   const allowPublish = false;
   return (
     <PanelSetup fixture={getFixture({ allowPublish })}>
@@ -86,7 +87,7 @@ export const ExampleCantPublishAdvanced = () => {
 
 ExampleCantPublishAdvanced.storyName = "example can't publish, advanced";
 
-export const ExampleCantPublishNotAdvanced = () => {
+export const ExampleCantPublishNotAdvanced: StoryFn = () => {
   const allowPublish = false;
   return (
     <PanelSetup fixture={getFixture({ allowPublish })}>
@@ -97,7 +98,7 @@ export const ExampleCantPublishNotAdvanced = () => {
 
 ExampleCantPublishNotAdvanced.storyName = "example can't publish, not advanced";
 
-export const ExampleWithDatatypeThatNoLongerExists = () => {
+export const ExampleWithDatatypeThatNoLongerExists: StoryFn = () => {
   return (
     <PanelSetup fixture={{ topics: [], datatypes: new Map(), frame: {}, capabilities: [] }}>
       <Publish overrideConfig={publishConfig({ advancedView: true, value: advancedJSON })} />
@@ -107,7 +108,7 @@ export const ExampleWithDatatypeThatNoLongerExists = () => {
 
 ExampleWithDatatypeThatNoLongerExists.storyName = "Example with datatype that no longer exists";
 
-export const ExampleWithValidPresetJson = () => {
+export const ExampleWithValidPresetJson: StoryFn = () => {
   const fixture = {
     topics: [],
     datatypes: new Map(
@@ -132,7 +133,7 @@ export const ExampleWithValidPresetJson = () => {
 
 ExampleWithValidPresetJson.storyName = "example with valid preset JSON";
 
-export const ExampleWithInvalidPresetJson = () => {
+export const ExampleWithInvalidPresetJson: StoryFn = () => {
   const fixture = {
     topics: [],
     datatypes: new Map(

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
+
 import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -35,7 +41,7 @@ export default {
   title: "panels/RawMessages",
 };
 
-export const Default = () => {
+export const Default: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig } as any} />
@@ -45,7 +51,7 @@ export const Default = () => {
 
 Default.storyName = "default";
 
-export const Schemaless = () => {
+export const Schemaless: StoryFn = () => {
   return (
     <PanelSetup
       fixture={{
@@ -71,7 +77,7 @@ export const Schemaless = () => {
 
 Schemaless.storyName = "schemaless";
 
-export const Collapsed = () => {
+export const Collapsed: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -83,7 +89,7 @@ export const Collapsed = () => {
 
 Collapsed.storyName = "collapsed";
 
-export const Expanded = () => {
+export const Expanded: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -95,7 +101,7 @@ export const Expanded = () => {
 
 Expanded.storyName = "expanded";
 
-export const Overridden = () => {
+export const Overridden: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture} includeSettings>
       <RawMessages
@@ -113,7 +119,7 @@ export const Overridden = () => {
 
 Overridden.storyName = "overridden";
 
-export const WithReceiveTime = () => {
+export const WithReceiveTime: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/foo", ...noDiffConfig } as any} />
@@ -123,7 +129,7 @@ export const WithReceiveTime = () => {
 
 WithReceiveTime.storyName = "with receiveTime";
 
-export const DisplayBigValueNum = () => {
+export const DisplayBigValueNum: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/num.value", ...noDiffConfig } as any} />
@@ -133,7 +139,7 @@ export const DisplayBigValueNum = () => {
 
 DisplayBigValueNum.storyName = "display big value - num";
 
-export const DisplayMessageWithBigintValue = () => {
+export const DisplayMessageWithBigintValue: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
@@ -143,7 +149,7 @@ export const DisplayMessageWithBigintValue = () => {
 
 DisplayMessageWithBigintValue.storyName = "display message with bigint value";
 
-export const DisplayBigintValue = () => {
+export const DisplayBigintValue: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
@@ -153,7 +159,7 @@ export const DisplayBigintValue = () => {
 
 DisplayBigintValue.storyName = "display bigint value";
 
-export const DisplayBigValueText = () => {
+export const DisplayBigValueText: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/text.value", ...noDiffConfig } as any} />
@@ -163,7 +169,7 @@ export const DisplayBigValueText = () => {
 
 DisplayBigValueText.storyName = "display big value - text";
 
-export const DisplayBigValueTextTruncated = () => {
+export const DisplayBigValueTextTruncated: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
       <RawMessages overrideConfig={{ topicPath: "/baz/text.value_long", ...noDiffConfig } as any} />
@@ -173,7 +179,7 @@ export const DisplayBigValueTextTruncated = () => {
 
 DisplayBigValueTextTruncated.storyName = "display big value - text truncated";
 
-export const DisplayBigValueTextWithNewlines = () => {
+export const DisplayBigValueTextWithNewlines: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
       <RawMessages
@@ -185,7 +191,7 @@ export const DisplayBigValueTextWithNewlines = () => {
 
 DisplayBigValueTextWithNewlines.storyName = "display big value - text with newlines";
 
-export const DisplayBigValueSingleElementArray = () => {
+export const DisplayBigValueSingleElementArray: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/array.value", ...noDiffConfig } as any} />
@@ -195,7 +201,7 @@ export const DisplayBigValueSingleElementArray = () => {
 
 DisplayBigValueSingleElementArray.storyName = "display big value - single element array";
 
-export const DisplaySingleObjectArray = () => {
+export const DisplaySingleObjectArray: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/array/obj.value", ...noDiffConfig } as any} />
@@ -205,7 +211,7 @@ export const DisplaySingleObjectArray = () => {
 
 DisplaySingleObjectArray.storyName = "display single object array";
 
-export const DisplayBasicEnum = () => {
+export const DisplayBasicEnum: StoryFn = () => {
   return (
     <PanelSetup fixture={enumFixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/enum", ...noDiffConfig } as any} />
@@ -215,7 +221,7 @@ export const DisplayBasicEnum = () => {
 
 DisplayBasicEnum.storyName = "display basic enum";
 
-export const DisplayAdvancedEnumUsage = () => {
+export const DisplayAdvancedEnumUsage: StoryFn = () => {
   return (
     <PanelSetup fixture={enumAdvancedFixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/enum_advanced", ...noDiffConfig } as any} />
@@ -225,7 +231,7 @@ export const DisplayAdvancedEnumUsage = () => {
 
 DisplayAdvancedEnumUsage.storyName = "display advanced enum usage";
 
-export const WithMissingData = () => {
+export const WithMissingData: StoryFn = () => {
   return (
     <PanelSetup fixture={withMissingData}>
       <RawMessages overrideConfig={{ topicPath: "/baz/missing_data", ...noDiffConfig } as any} />
@@ -235,7 +241,7 @@ export const WithMissingData = () => {
 
 WithMissingData.storyName = "with missing data";
 
-export const WithATruncatedLongString = () => {
+export const WithATruncatedLongString: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/baz/text", ...noDiffConfig } as any} />
@@ -245,7 +251,7 @@ export const WithATruncatedLongString = () => {
 
 WithATruncatedLongString.storyName = "with a truncated long string";
 
-export const DisplayGeometryTypesLength = () => {
+export const DisplayGeometryTypesLength: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages overrideConfig={{ topicPath: "/geometry/types", ...noDiffConfig } as any} />
@@ -255,7 +261,7 @@ export const DisplayGeometryTypesLength = () => {
 
 DisplayGeometryTypesLength.storyName = "display geometry types - length";
 
-export const DisplayDiff = () => {
+export const DisplayDiff: StoryFn = () => {
   return (
     <PanelSetup fixture={topicsToDiffFixture}>
       <RawMessages
@@ -267,7 +273,7 @@ export const DisplayDiff = () => {
 
 DisplayDiff.storyName = "display diff";
 
-export const DisplayFullDiff = () => {
+export const DisplayFullDiff: StoryFn = () => {
   return (
     <PanelSetup fixture={topicsToDiffFixture}>
       <RawMessages
@@ -279,7 +285,7 @@ export const DisplayFullDiff = () => {
 
 DisplayFullDiff.storyName = "display full diff";
 
-export const DisplayDiffWithIdFields = () => {
+export const DisplayDiffWithIdFields: StoryFn = () => {
   const config = {
     ...diffConfig,
     topicPath: "/baz/enum_advanced_array.value",
@@ -296,7 +302,7 @@ export const DisplayDiffWithIdFields = () => {
 
 DisplayDiffWithIdFields.storyName = "display diff with ID fields";
 
-export const EmptyDiffMessage = () => {
+export const EmptyDiffMessage: StoryFn = () => {
   return (
     <PanelSetup fixture={{ topics: [], frame: {} }}>
       <RawMessages overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any} />
@@ -306,7 +312,7 @@ export const EmptyDiffMessage = () => {
 
 EmptyDiffMessage.storyName = "empty diff message";
 
-export const DiffSameMessages = () => {
+export const DiffSameMessages: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -324,7 +330,7 @@ export const DiffSameMessages = () => {
 
 DiffSameMessages.storyName = "diff same messages";
 
-export const DiffConsecutiveMessages = () => {
+export const DiffConsecutiveMessages: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -343,7 +349,7 @@ export const DiffConsecutiveMessages = () => {
 
 DiffConsecutiveMessages.storyName = "diff consecutive messages";
 
-export const DiffConsecutiveMessagesWithFilter = () => {
+export const DiffConsecutiveMessagesWithFilter: StoryFn = () => {
   return (
     <PanelSetup fixture={multipleMessagesFilter}>
       <RawMessages
@@ -362,7 +368,7 @@ export const DiffConsecutiveMessagesWithFilter = () => {
 
 DiffConsecutiveMessagesWithFilter.storyName = "diff consecutive messages with filter";
 
-export const DiffConsecutiveMessagesWithBigint = () => {
+export const DiffConsecutiveMessagesWithBigint: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -381,7 +387,7 @@ export const DiffConsecutiveMessagesWithBigint = () => {
 
 DiffConsecutiveMessagesWithBigint.storyName = "diff consecutive messages with bigint";
 
-export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet = () => {
+export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <RawMessages
@@ -398,9 +404,10 @@ export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet =
   );
 };
 
-DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet.storyName = "display correct message when diff is disabled, even with diff method & topic set";
+DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet.storyName =
+  "display correct message when diff is disabled, even with diff method & topic set";
 
-export const MultipleMessagesWithTopLevelFilter = () => {
+export const MultipleMessagesWithTopLevelFilter: StoryFn = () => {
   return (
     <PanelSetup fixture={multipleNumberMessagesFixture}>
       <RawMessages

--- a/packages/studio-base/src/panels/RawMessages/index.stories.tsx
+++ b/packages/studio-base/src/panels/RawMessages/index.stories.tsx
@@ -1,18 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2018-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
-
 import RawMessages, { PREV_MSG_METHOD } from "@foxglove/studio-base/panels/RawMessages";
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -46,307 +31,388 @@ const scrollToBottom = () => {
   scrollContainer.scrollTop = scrollContainer.scrollHeight;
 };
 
-storiesOf("panels/RawMessages", module)
-  .add("default", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("schemaless", () => {
-    return (
-      <PanelSetup
-        fixture={{
-          topics: [{ name: "foo", schemaName: undefined }],
-          datatypes: new Map(),
-          frame: {
-            ["foo"]: [
-              {
-                topic: "foo",
-                schemaName: "",
-                message: { bar: 1 },
-                receiveTime: { sec: 0, nsec: 0 },
-                sizeInBytes: 0,
-              },
-            ],
-          },
+export default {
+  title: "panels/RawMessages",
+};
+
+export const Default = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+Default.storyName = "default";
+
+export const Schemaless = () => {
+  return (
+    <PanelSetup
+      fixture={{
+        topics: [{ name: "foo", schemaName: undefined }],
+        datatypes: new Map(),
+        frame: {
+          ["foo"]: [
+            {
+              topic: "foo",
+              schemaName: "",
+              message: { bar: 1 },
+              receiveTime: { sec: 0, nsec: 0 },
+              sizeInBytes: 0,
+            },
+          ],
+        },
+      }}
+    >
+      <RawMessages overrideConfig={{ topicPath: "foo", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+Schemaless.storyName = "schemaless";
+
+export const Collapsed = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "none" } as any}
+      />
+    </PanelSetup>
+  );
+};
+
+Collapsed.storyName = "collapsed";
+
+export const Expanded = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{ topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "all" } as any}
+      />
+    </PanelSetup>
+  );
+};
+
+Expanded.storyName = "expanded";
+
+export const Overridden = () => {
+  return (
+    <PanelSetup fixture={fixture} includeSettings>
+      <RawMessages
+        overrideConfig={
+          {
+            topicPath: "/msgs/big_topic",
+            ...noDiffConfig,
+            expansion: { LotsOfStuff: "c", timestamp_array: "e" },
+          } as any
+        }
+      />
+    </PanelSetup>
+  );
+};
+
+Overridden.storyName = "overridden";
+
+export const WithReceiveTime = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/foo", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+WithReceiveTime.storyName = "with receiveTime";
+
+export const DisplayBigValueNum = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/num.value", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBigValueNum.storyName = "display big value - num";
+
+export const DisplayMessageWithBigintValue = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayMessageWithBigintValue.storyName = "display message with bigint value";
+
+export const DisplayBigintValue = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBigintValue.storyName = "display bigint value";
+
+export const DisplayBigValueText = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/text.value", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBigValueText.storyName = "display big value - text";
+
+export const DisplayBigValueTextTruncated = () => {
+  return (
+    <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/text.value_long", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBigValueTextTruncated.storyName = "display big value - text truncated";
+
+export const DisplayBigValueTextWithNewlines = () => {
+  return (
+    <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
+      <RawMessages
+        overrideConfig={{ topicPath: "/baz/text.value_with_newlines", ...noDiffConfig } as any}
+      />
+    </PanelSetup>
+  );
+};
+
+DisplayBigValueTextWithNewlines.storyName = "display big value - text with newlines";
+
+export const DisplayBigValueSingleElementArray = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/array.value", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBigValueSingleElementArray.storyName = "display big value - single element array";
+
+export const DisplaySingleObjectArray = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/array/obj.value", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplaySingleObjectArray.storyName = "display single object array";
+
+export const DisplayBasicEnum = () => {
+  return (
+    <PanelSetup fixture={enumFixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/enum", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayBasicEnum.storyName = "display basic enum";
+
+export const DisplayAdvancedEnumUsage = () => {
+  return (
+    <PanelSetup fixture={enumAdvancedFixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/enum_advanced", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayAdvancedEnumUsage.storyName = "display advanced enum usage";
+
+export const WithMissingData = () => {
+  return (
+    <PanelSetup fixture={withMissingData}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/missing_data", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+WithMissingData.storyName = "with missing data";
+
+export const WithATruncatedLongString = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/baz/text", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+WithATruncatedLongString.storyName = "with a truncated long string";
+
+export const DisplayGeometryTypesLength = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages overrideConfig={{ topicPath: "/geometry/types", ...noDiffConfig } as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayGeometryTypesLength.storyName = "display geometry types - length";
+
+export const DisplayDiff = () => {
+  return (
+    <PanelSetup fixture={topicsToDiffFixture}>
+      <RawMessages
+        overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: false } as any}
+      />
+    </PanelSetup>
+  );
+};
+
+DisplayDiff.storyName = "display diff";
+
+export const DisplayFullDiff = () => {
+  return (
+    <PanelSetup fixture={topicsToDiffFixture}>
+      <RawMessages
+        overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: true } as any}
+      />
+    </PanelSetup>
+  );
+};
+
+DisplayFullDiff.storyName = "display full diff";
+
+export const DisplayDiffWithIdFields = () => {
+  const config = {
+    ...diffConfig,
+    topicPath: "/baz/enum_advanced_array.value",
+    diffTopicPath: "/another/baz/enum_advanced_array.value",
+    showFullMessageForDiff: false,
+    expansion: "all",
+  };
+  return (
+    <PanelSetup fixture={topicsWithIdsToDiffFixture}>
+      <RawMessages overrideConfig={config as any} />
+    </PanelSetup>
+  );
+};
+
+DisplayDiffWithIdFields.storyName = "display diff with ID fields";
+
+export const EmptyDiffMessage = () => {
+  return (
+    <PanelSetup fixture={{ topics: [], frame: {} }}>
+      <RawMessages overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any} />
+    </PanelSetup>
+  );
+};
+
+EmptyDiffMessage.storyName = "empty diff message";
+
+export const DiffSameMessages = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{
+          topicPath: "/foo",
+          diffMethod: "custom",
+          diffTopicPath: "/foo",
+          diffEnabled: true,
+          showFullMessageForDiff: false,
         }}
-      >
-        <RawMessages overrideConfig={{ topicPath: "foo", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("collapsed", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={
-            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "none" } as any
-          }
-        />
-      </PanelSetup>
-    );
-  })
-  .add("expanded", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={
-            { topicPath: "/msgs/big_topic", ...noDiffConfig, expansion: "all" } as any
-          }
-        />
-      </PanelSetup>
-    );
-  })
-  .add("overridden", () => {
-    return (
-      <PanelSetup fixture={fixture} includeSettings>
-        <RawMessages
-          overrideConfig={
-            {
-              topicPath: "/msgs/big_topic",
-              ...noDiffConfig,
-              expansion: { LotsOfStuff: "c", timestamp_array: "e" },
-            } as any
-          }
-        />
-      </PanelSetup>
-    );
-  })
-  .add("with receiveTime", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/foo", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display big value - num", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/num.value", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display message with bigint value", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/bigint", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display bigint value", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/bigint.value", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display big value - text", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/text.value", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display big value - text truncated", () => {
-    return (
-      <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
-        <RawMessages
-          overrideConfig={{ topicPath: "/baz/text.value_long", ...noDiffConfig } as any}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display big value - text with newlines", () => {
-    return (
-      <PanelSetup fixture={fixture} onMount={() => setImmediate(scrollToBottom)}>
-        <RawMessages
-          overrideConfig={{ topicPath: "/baz/text.value_with_newlines", ...noDiffConfig } as any}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display big value - single element array", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/array.value", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display single object array", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={{ topicPath: "/baz/array/obj.value", ...noDiffConfig } as any}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display basic enum", () => {
-    return (
-      <PanelSetup fixture={enumFixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/enum", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display advanced enum usage", () => {
-    return (
-      <PanelSetup fixture={enumAdvancedFixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/enum_advanced", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("with missing data", () => {
-    return (
-      <PanelSetup fixture={withMissingData}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/missing_data", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("with a truncated long string", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/baz/text", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display geometry types - length", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages overrideConfig={{ topicPath: "/geometry/types", ...noDiffConfig } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("display diff", () => {
-    return (
-      <PanelSetup fixture={topicsToDiffFixture}>
-        <RawMessages
-          overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: false } as any}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display full diff", () => {
-    return (
-      <PanelSetup fixture={topicsToDiffFixture}>
-        <RawMessages
-          overrideConfig={{ ...diffConfig, expansion: "all", showFullMessageForDiff: true } as any}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display diff with ID fields", () => {
-    const config = {
-      ...diffConfig,
-      topicPath: "/baz/enum_advanced_array.value",
-      diffTopicPath: "/another/baz/enum_advanced_array.value",
-      showFullMessageForDiff: false,
-      expansion: "all",
-    };
-    return (
-      <PanelSetup fixture={topicsWithIdsToDiffFixture}>
-        <RawMessages overrideConfig={config as any} />
-      </PanelSetup>
-    );
-  })
-  .add("empty diff message", () => {
-    return (
-      <PanelSetup fixture={{ topics: [], frame: {} }}>
-        <RawMessages overrideConfig={{ ...diffConfig, showFullMessageForDiff: false } as any} />
-      </PanelSetup>
-    );
-  })
-  .add("diff same messages", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/foo",
-            diffMethod: "custom",
-            diffTopicPath: "/foo",
-            diffEnabled: true,
-            showFullMessageForDiff: false,
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("diff consecutive messages", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/foo",
-            diffMethod: PREV_MSG_METHOD,
-            diffTopicPath: "",
-            diffEnabled: true,
-            showFullMessageForDiff: true,
-            expansion: "all",
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("diff consecutive messages with filter", () => {
-    return (
-      <PanelSetup fixture={multipleMessagesFilter}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/foo{type==2}",
-            diffMethod: PREV_MSG_METHOD,
-            diffTopicPath: "",
-            diffEnabled: true,
-            showFullMessageForDiff: true,
-            expansion: "all",
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("diff consecutive messages with bigint", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/baz/bigint",
-            diffMethod: PREV_MSG_METHOD,
-            diffTopicPath: "",
-            diffEnabled: true,
-            showFullMessageForDiff: true,
-            expansion: "all",
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("display correct message when diff is disabled, even with diff method & topic set", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <RawMessages
-          overrideConfig={{
-            topicPath: "/foo",
-            diffMethod: PREV_MSG_METHOD,
-            diffTopicPath: "/another/baz/enum_advanced",
-            diffEnabled: false,
-            showFullMessageForDiff: true,
-            expansion: "all",
-          }}
-        />
-      </PanelSetup>
-    );
-  })
-  .add("multiple messages with top-level filter", () => {
-    return (
-      <PanelSetup fixture={multipleNumberMessagesFixture}>
-        <RawMessages
-          overrideConfig={
-            {
-              topicPath: "/multiple_number_messages{value==2}",
-              ...noDiffConfig,
-            } as any
-          }
-        />
-      </PanelSetup>
-    );
-  });
+      />
+    </PanelSetup>
+  );
+};
+
+DiffSameMessages.storyName = "diff same messages";
+
+export const DiffConsecutiveMessages = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{
+          topicPath: "/foo",
+          diffMethod: PREV_MSG_METHOD,
+          diffTopicPath: "",
+          diffEnabled: true,
+          showFullMessageForDiff: true,
+          expansion: "all",
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+DiffConsecutiveMessages.storyName = "diff consecutive messages";
+
+export const DiffConsecutiveMessagesWithFilter = () => {
+  return (
+    <PanelSetup fixture={multipleMessagesFilter}>
+      <RawMessages
+        overrideConfig={{
+          topicPath: "/foo{type==2}",
+          diffMethod: PREV_MSG_METHOD,
+          diffTopicPath: "",
+          diffEnabled: true,
+          showFullMessageForDiff: true,
+          expansion: "all",
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+DiffConsecutiveMessagesWithFilter.storyName = "diff consecutive messages with filter";
+
+export const DiffConsecutiveMessagesWithBigint = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{
+          topicPath: "/baz/bigint",
+          diffMethod: PREV_MSG_METHOD,
+          diffTopicPath: "",
+          diffEnabled: true,
+          showFullMessageForDiff: true,
+          expansion: "all",
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+DiffConsecutiveMessagesWithBigint.storyName = "diff consecutive messages with bigint";
+
+export const DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <RawMessages
+        overrideConfig={{
+          topicPath: "/foo",
+          diffMethod: PREV_MSG_METHOD,
+          diffTopicPath: "/another/baz/enum_advanced",
+          diffEnabled: false,
+          showFullMessageForDiff: true,
+          expansion: "all",
+        }}
+      />
+    </PanelSetup>
+  );
+};
+
+DisplayCorrectMessageWhenDiffIsDisabledEvenWithDiffMethodTopicSet.storyName = "display correct message when diff is disabled, even with diff method & topic set";
+
+export const MultipleMessagesWithTopLevelFilter = () => {
+  return (
+    <PanelSetup fixture={multipleNumberMessagesFixture}>
+      <RawMessages
+        overrideConfig={
+          {
+            topicPath: "/multiple_number_messages{value==2}",
+            ...noDiffConfig,
+          } as any
+        }
+      />
+    </PanelSetup>
+  );
+};
+
+MultipleMessagesWithTopLevelFilter.storyName = "multiple messages with top-level filter";

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
 import { noop } from "lodash";
 import React, { ReactNode } from "react";
 
@@ -36,7 +41,7 @@ export default {
   title: "panels/Tab/ToolbarTab",
 };
 
-export const Default = () => (
+export const Default: StoryFn = () => (
   <Container>
     <ToolbarTab {...baseProps} />
   </Container>
@@ -44,7 +49,7 @@ export const Default = () => (
 
 Default.storyName = "default";
 
-export const ActiveWithCloseIcon = () => (
+export const ActiveWithCloseIcon: StoryFn = () => (
   <Container>
     <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 3 }} />
   </Container>
@@ -52,7 +57,7 @@ export const ActiveWithCloseIcon = () => (
 
 ActiveWithCloseIcon.storyName = "active with close icon";
 
-export const ActiveWithoutCloseIcon = () => (
+export const ActiveWithoutCloseIcon: StoryFn = () => (
   <Container>
     <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 1 }} />
   </Container>
@@ -60,7 +65,7 @@ export const ActiveWithoutCloseIcon = () => (
 
 ActiveWithoutCloseIcon.storyName = "active without close icon";
 
-export const Hidden = () => (
+export const Hidden: StoryFn = () => (
   <Container>
     <ToolbarTab {...{ ...baseProps, hidden: true }} />
   </Container>
@@ -68,7 +73,7 @@ export const Hidden = () => (
 
 Hidden.storyName = "hidden";
 
-export const Highlight = () => (
+export const Highlight: StoryFn = () => (
   <Container>
     <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
   </Container>
@@ -76,7 +81,7 @@ export const Highlight = () => (
 
 Highlight.storyName = "highlight";
 
-export const Dragging = () => (
+export const Dragging: StoryFn = () => (
   <Container>
     <ToolbarTab {...{ ...baseProps, isDragging: true }} />
   </Container>
@@ -84,7 +89,7 @@ export const Dragging = () => (
 
 Dragging.storyName = "dragging";
 
-export const Editing = () => (
+export const Editing: StoryFn = () => (
   <Container
     ref={async (el) => {
       await tick();

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -1,6 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2019-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
 
 import { StoryFn } from "@storybook/react";
 import { noop } from "lodash";

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.stories.tsx
@@ -1,17 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2019-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
 import { noop } from "lodash";
 import React, { ReactNode } from "react";
 
@@ -46,46 +32,69 @@ const Container = React.forwardRef<HTMLDivElement, { children?: ReactNode }>(fun
   );
 });
 
-storiesOf("panels/Tab/ToolbarTab", module)
-  .add("default", () => (
-    <Container>
-      <ToolbarTab {...baseProps} />
-    </Container>
-  ))
-  .add("active with close icon", () => (
-    <Container>
-      <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 3 }} />
-    </Container>
-  ))
-  .add("active without close icon", () => (
-    <Container>
-      <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 1 }} />
-    </Container>
-  ))
-  .add("hidden", () => (
-    <Container>
-      <ToolbarTab {...{ ...baseProps, hidden: true }} />
-    </Container>
-  ))
-  .add("highlight", () => (
-    <Container>
-      <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
-    </Container>
-  ))
-  .add("dragging", () => (
-    <Container>
-      <ToolbarTab {...{ ...baseProps, isDragging: true }} />
-    </Container>
-  ))
-  .add("editing", () => (
-    <Container
-      ref={async (el) => {
-        await tick();
-        if (el) {
-          el.querySelectorAll("input")[0]?.click();
-        }
-      }}
-    >
-      <ToolbarTab {...{ ...baseProps, isActive: true }} />
-    </Container>
-  ));
+export default {
+  title: "panels/Tab/ToolbarTab",
+};
+
+export const Default = () => (
+  <Container>
+    <ToolbarTab {...baseProps} />
+  </Container>
+);
+
+Default.storyName = "default";
+
+export const ActiveWithCloseIcon = () => (
+  <Container>
+    <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 3 }} />
+  </Container>
+);
+
+ActiveWithCloseIcon.storyName = "active with close icon";
+
+export const ActiveWithoutCloseIcon = () => (
+  <Container>
+    <ToolbarTab {...{ ...baseProps, isActive: true, tabCount: 1 }} />
+  </Container>
+);
+
+ActiveWithoutCloseIcon.storyName = "active without close icon";
+
+export const Hidden = () => (
+  <Container>
+    <ToolbarTab {...{ ...baseProps, hidden: true }} />
+  </Container>
+);
+
+Hidden.storyName = "hidden";
+
+export const Highlight = () => (
+  <Container>
+    <ToolbarTab {...{ ...baseProps, highlight: "before" }} />
+  </Container>
+);
+
+Highlight.storyName = "highlight";
+
+export const Dragging = () => (
+  <Container>
+    <ToolbarTab {...{ ...baseProps, isDragging: true }} />
+  </Container>
+);
+
+Dragging.storyName = "dragging";
+
+export const Editing = () => (
+  <Container
+    ref={async (el) => {
+      await tick();
+      if (el) {
+        el.querySelectorAll("input")[0]?.click();
+      }
+    }}
+  >
+    <ToolbarTab {...{ ...baseProps, isActive: true }} />
+  </Container>
+);
+
+Editing.storyName = "editing";

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -115,10 +115,8 @@ export const Default: Story = () => (
   </PanelSetup>
 );
 
-Default.story = {
-  name: "default",
-  parameters: { colorScheme: "both-row" },
-};
+Default.storyName = "default";
+Default.parameters = { colorScheme: "both-row" };
 
 export const ShowingPanelList: Story = () => (
   <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
@@ -126,9 +124,7 @@ export const ShowingPanelList: Story = () => (
   </PanelSetup>
 );
 
-ShowingPanelList.story = {
-  name: "showing panel list",
-};
+ShowingPanelList.storyName = "showing panel list";
 
 export const ShowingPanelListLight: Story = () => (
   <PanelSetup fixture={fixture} panelCatalog={new MockPanelCatalog()}>
@@ -136,10 +132,8 @@ export const ShowingPanelListLight: Story = () => (
   </PanelSetup>
 );
 
-ShowingPanelListLight.story = {
-  name: "showing panel list light",
-  parameters: { colorScheme: "light" },
-};
+ShowingPanelListLight.storyName = "showing panel list light";
+ShowingPanelListLight.parameters = { colorScheme: "light" };
 
 export const PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = () => {
   return (
@@ -168,9 +162,7 @@ export const PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = 
   );
 };
 
-PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone.story = {
-  name: "picking a panel from the panel list creates a new tab if there are none",
-};
+PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName = "picking a panel from the panel list creates a new tab if there are none";
 
 export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   return (
@@ -199,9 +191,7 @@ export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   );
 };
 
-PickingAPanelFromThePanelListUpdatesTheTabsLayout.story = {
-  name: "picking a panel from the panel list updates the tab's layout",
-};
+PickingAPanelFromThePanelListUpdatesTheTabsLayout.storyName = "picking a panel from the panel list updates the tab's layout";
 
 export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   return (
@@ -233,9 +223,7 @@ export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   );
 };
 
-DraggingAPanelFromThePanelListUpdatesTheTabsLayout.story = {
-  name: "dragging a panel from the panel list updates the tab's layout",
-};
+DraggingAPanelFromThePanelListUpdatesTheTabsLayout.storyName = "dragging a panel from the panel list updates the tab's layout";
 
 export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = () => {
   return (
@@ -267,9 +255,7 @@ export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story =
   );
 };
 
-DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone.story = {
-  name: "dragging a panel from the panel list creates a new tab if there are none",
-};
+DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName = "dragging a panel from the panel list creates a new tab if there are none";
 
 export const WithChosenActiveTab: Story = () => (
   <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture}>
@@ -309,10 +295,8 @@ export const WithChosenActiveTab: Story = () => (
   </PanelSetup>
 );
 
-WithChosenActiveTab.story = {
-  name: "with chosen active tab",
-  parameters: { colorScheme: "both-row" },
-};
+WithChosenActiveTab.storyName = "with chosen active tab";
+WithChosenActiveTab.parameters = { colorScheme: "both-row" };
 
 export const AddTab: Story = () => {
   return (
@@ -339,9 +323,7 @@ export const AddTab: Story = () => {
   );
 };
 
-AddTab.story = {
-  name: "add tab",
-};
+AddTab.storyName = "add tab";
 
 export const RemoveTab: Story = () => {
   return (
@@ -368,9 +350,7 @@ export const RemoveTab: Story = () => {
   );
 };
 
-RemoveTab.story = {
-  name: "remove tab",
-};
+RemoveTab.storyName = "remove tab";
 
 export const ReorderTabsWithinTabPanelByDroppingOnTab: Story = () => {
   return (
@@ -399,9 +379,7 @@ export const ReorderTabsWithinTabPanelByDroppingOnTab: Story = () => {
   );
 };
 
-ReorderTabsWithinTabPanelByDroppingOnTab.story = {
-  name: "reorder tabs within Tab panel by dropping on tab",
-};
+ReorderTabsWithinTabPanelByDroppingOnTab.storyName = "reorder tabs within Tab panel by dropping on tab";
 
 export const MoveTabToDifferentTabPanel: Story = () => {
   return (
@@ -436,9 +414,7 @@ export const MoveTabToDifferentTabPanel: Story = () => {
   );
 };
 
-MoveTabToDifferentTabPanel.story = {
-  name: "move tab to different Tab panel",
-};
+MoveTabToDifferentTabPanel.storyName = "move tab to different Tab panel";
 
 export const PreventDraggingSelectedParentTabIntoChildTabPanel: Story = () => {
   return (
@@ -474,9 +450,7 @@ export const PreventDraggingSelectedParentTabIntoChildTabPanel: Story = () => {
   );
 };
 
-PreventDraggingSelectedParentTabIntoChildTabPanel.story = {
-  name: "prevent dragging selected parent tab into child tab panel",
-};
+PreventDraggingSelectedParentTabIntoChildTabPanel.storyName = "prevent dragging selected parent tab into child tab panel";
 
 export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: Story = () => {
   return (
@@ -507,9 +481,7 @@ export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: Story = () 
   );
 };
 
-DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs.story = {
-  name: "dragging and dropping a nested tab panel does not remove any tabs",
-};
+DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs.storyName = "dragging and dropping a nested tab panel does not remove any tabs";
 
 export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
   return (
@@ -536,6 +508,4 @@ export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
   );
 };
 
-SupportsDraggingBetweenTabsAnywhereInTheLayout.story = {
-  name: "supports dragging between tabs anywhere in the layout",
-};
+SupportsDraggingBetweenTabsAnywhereInTheLayout.storyName = "supports dragging between tabs anywhere in the layout";

--- a/packages/studio-base/src/panels/Tab/index.stories.tsx
+++ b/packages/studio-base/src/panels/Tab/index.stories.tsx
@@ -162,7 +162,8 @@ export const PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = 
   );
 };
 
-PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName = "picking a panel from the panel list creates a new tab if there are none";
+PickingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName =
+  "picking a panel from the panel list creates a new tab if there are none";
 
 export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   return (
@@ -191,7 +192,8 @@ export const PickingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   );
 };
 
-PickingAPanelFromThePanelListUpdatesTheTabsLayout.storyName = "picking a panel from the panel list updates the tab's layout";
+PickingAPanelFromThePanelListUpdatesTheTabsLayout.storyName =
+  "picking a panel from the panel list updates the tab's layout";
 
 export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   return (
@@ -223,7 +225,8 @@ export const DraggingAPanelFromThePanelListUpdatesTheTabsLayout: Story = () => {
   );
 };
 
-DraggingAPanelFromThePanelListUpdatesTheTabsLayout.storyName = "dragging a panel from the panel list updates the tab's layout";
+DraggingAPanelFromThePanelListUpdatesTheTabsLayout.storyName =
+  "dragging a panel from the panel list updates the tab's layout";
 
 export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story = () => {
   return (
@@ -255,7 +258,8 @@ export const DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone: Story =
   );
 };
 
-DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName = "dragging a panel from the panel list creates a new tab if there are none";
+DraggingAPanelFromThePanelListCreatesANewTabIfThereAreNone.storyName =
+  "dragging a panel from the panel list creates a new tab if there are none";
 
 export const WithChosenActiveTab: Story = () => (
   <PanelSetup panelCatalog={new MockPanelCatalog()} fixture={fixture}>
@@ -379,7 +383,8 @@ export const ReorderTabsWithinTabPanelByDroppingOnTab: Story = () => {
   );
 };
 
-ReorderTabsWithinTabPanelByDroppingOnTab.storyName = "reorder tabs within Tab panel by dropping on tab";
+ReorderTabsWithinTabPanelByDroppingOnTab.storyName =
+  "reorder tabs within Tab panel by dropping on tab";
 
 export const MoveTabToDifferentTabPanel: Story = () => {
   return (
@@ -450,7 +455,8 @@ export const PreventDraggingSelectedParentTabIntoChildTabPanel: Story = () => {
   );
 };
 
-PreventDraggingSelectedParentTabIntoChildTabPanel.storyName = "prevent dragging selected parent tab into child tab panel";
+PreventDraggingSelectedParentTabIntoChildTabPanel.storyName =
+  "prevent dragging selected parent tab into child tab panel";
 
 export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: Story = () => {
   return (
@@ -481,7 +487,8 @@ export const DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs: Story = () 
   );
 };
 
-DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs.storyName = "dragging and dropping a nested tab panel does not remove any tabs";
+DraggingAndDroppingANestedTabPanelDoesNotRemoveAnyTabs.storyName =
+  "dragging and dropping a nested tab panel does not remove any tabs";
 
 export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
   return (
@@ -508,4 +515,5 @@ export const SupportsDraggingBetweenTabsAnywhereInTheLayout: Story = () => {
   );
 };
 
-SupportsDraggingBetweenTabsAnywhereInTheLayout.storyName = "supports dragging between tabs anywhere in the layout";
+SupportsDraggingBetweenTabsAnywhereInTheLayout.storyName =
+  "supports dragging between tabs anywhere in the layout";

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StoryFn } from "@storybook/react";
+
 import Table from "@foxglove/studio-base/panels/Table";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -47,7 +53,7 @@ export default {
   title: "panels/Table",
 };
 
-export const NoTopicPath = () => {
+export const NoTopicPath: StoryFn = () => {
   return (
     <PanelSetup fixture={{ frame: {}, topics: [] }}>
       <Table overrideConfig={{ topicPath: "" }} />
@@ -57,7 +63,7 @@ export const NoTopicPath = () => {
 
 NoTopicPath.storyName = "no topic path";
 
-export const NoData = () => {
+export const NoData: StoryFn = () => {
   return (
     <PanelSetup fixture={{ frame: {}, topics: [] }}>
       <Table overrideConfig={{ topicPath: "/unknown" }} />
@@ -67,7 +73,7 @@ export const NoData = () => {
 
 NoData.storyName = "no data";
 
-export const Arrays = () => {
+export const Arrays: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
@@ -77,7 +83,7 @@ export const Arrays = () => {
 
 Arrays.storyName = "arrays";
 
-export const ExpandRows = () => {
+export const ExpandRows: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -97,7 +103,7 @@ export const ExpandRows = () => {
 ExpandRows.storyName = "expand rows";
 ExpandRows.parameters = { colorScheme: "dark" };
 
-export const ExpandCellsWithNestedObjects = () => {
+export const ExpandCellsWithNestedObjects: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -117,7 +123,7 @@ export const ExpandCellsWithNestedObjects = () => {
 ExpandCellsWithNestedObjects.storyName = "expand cells with nested objects";
 ExpandCellsWithNestedObjects.parameters = { colorScheme: "dark" };
 
-export const ExpandCellsWithNestedArrays = () => {
+export const ExpandCellsWithNestedArrays: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -137,7 +143,7 @@ export const ExpandCellsWithNestedArrays = () => {
 ExpandCellsWithNestedArrays.storyName = "expand cells with nested arrays";
 ExpandCellsWithNestedArrays.parameters = { colorScheme: "dark" };
 
-export const ExpandNestedCells = () => {
+export const ExpandNestedCells: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -162,7 +168,7 @@ export const ExpandNestedCells = () => {
 ExpandNestedCells.storyName = "expand nested cells";
 ExpandNestedCells.parameters = { colorScheme: "dark" };
 
-export const ExpandMultipleRows = () => {
+export const ExpandMultipleRows: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -185,7 +191,7 @@ export const ExpandMultipleRows = () => {
 ExpandMultipleRows.storyName = "expand multiple rows";
 ExpandMultipleRows.parameters = { colorScheme: "dark" };
 
-export const Filtering = () => {
+export const Filtering: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
@@ -195,7 +201,7 @@ export const Filtering = () => {
 
 Filtering.storyName = "filtering";
 
-export const Sorting = () => {
+export const Sorting: StoryFn = () => {
   return (
     <PanelSetup
       fixture={fixture}
@@ -218,7 +224,7 @@ export const Sorting = () => {
 Sorting.storyName = "sorting";
 Sorting.parameters = { colorScheme: "dark" };
 
-export const HandlesPrimitives = () => {
+export const HandlesPrimitives: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <Table overrideConfig={{ topicPath: "/my_arr.array[:].val" }} />
@@ -228,7 +234,7 @@ export const HandlesPrimitives = () => {
 
 HandlesPrimitives.storyName = "handles primitives";
 
-export const HandlesArraysOfPrimitives = () => {
+export const HandlesArraysOfPrimitives: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <Table overrideConfig={{ topicPath: "/my_arr.array[:].primitiveArray" }} />
@@ -238,7 +244,7 @@ export const HandlesArraysOfPrimitives = () => {
 
 HandlesArraysOfPrimitives.storyName = "handles arrays of primitives";
 
-export const ConstrainedWidth = () => {
+export const ConstrainedWidth: StoryFn = () => {
   return (
     <PanelSetup fixture={fixture}>
       <div style={{ width: "100px" }}>

--- a/packages/studio-base/src/panels/Table/index.stories.tsx
+++ b/packages/studio-base/src/panels/Table/index.stories.tsx
@@ -1,18 +1,3 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-//
-// This file incorporates work covered by the following copyright and
-// permission notice:
-//
-//   Copyright 2020-2021 Cruise LLC
-//
-//   This source code is licensed under the Apache License, Version 2.0,
-//   found at http://www.apache.org/licenses/LICENSE-2.0
-//   You may not use this file except in compliance with the License.
-
-import { storiesOf } from "@storybook/react";
-
 import Table from "@foxglove/studio-base/panels/Table";
 import PanelSetup, { Fixture } from "@foxglove/studio-base/stories/PanelSetup";
 
@@ -58,194 +43,209 @@ const fixture: Fixture = {
   },
 };
 
-storiesOf("panels/Table", module)
-  .add("no topic path", () => {
-    return (
-      <PanelSetup fixture={{ frame: {}, topics: [] }}>
-        <Table overrideConfig={{ topicPath: "" }} />
-      </PanelSetup>
-    );
-  })
-  .add("no data", () => {
-    return (
-      <PanelSetup fixture={{ frame: {}, topics: [] }}>
-        <Table overrideConfig={{ topicPath: "/unknown" }} />
-      </PanelSetup>
-    );
-  })
-  .add("arrays", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-      </PanelSetup>
-    );
-  })
-  .add(
-    "expand rows",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "expand cells with nested objects",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll(
-                  "[data-testid=expand-cell-obj-0]",
-                )[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "expand cells with nested arrays",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll(
-                  "[data-testid=expand-cell-arr-0]",
-                )[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "expand nested cells",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-              ).click();
-              (
-                document.querySelectorAll(
-                  "[data-testid=expand-cell-arr-obj-0]",
-                )[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add(
-    "expand multiple rows",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
-              ).click();
-              (
-                document.querySelectorAll("[data-testid=expand-row-1]")[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add("filtering", () => {
-    return (
-      <PanelSetup fixture={fixture}>
+export default {
+  title: "panels/Table",
+};
+
+export const NoTopicPath = () => {
+  return (
+    <PanelSetup fixture={{ frame: {}, topics: [] }}>
+      <Table overrideConfig={{ topicPath: "" }} />
+    </PanelSetup>
+  );
+};
+
+NoTopicPath.storyName = "no topic path";
+
+export const NoData = () => {
+  return (
+    <PanelSetup fixture={{ frame: {}, topics: [] }}>
+      <Table overrideConfig={{ topicPath: "/unknown" }} />
+    </PanelSetup>
+  );
+};
+
+NoData.storyName = "no data";
+
+export const Arrays = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+Arrays.storyName = "arrays";
+
+export const ExpandRows = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+ExpandRows.storyName = "expand rows";
+ExpandRows.parameters = { colorScheme: "dark" };
+
+export const ExpandCellsWithNestedObjects = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=expand-cell-obj-0]")[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+ExpandCellsWithNestedObjects.storyName = "expand cells with nested objects";
+ExpandCellsWithNestedObjects.parameters = { colorScheme: "dark" };
+
+export const ExpandCellsWithNestedArrays = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=expand-cell-arr-0]")[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+ExpandCellsWithNestedArrays.storyName = "expand cells with nested arrays";
+ExpandCellsWithNestedArrays.parameters = { colorScheme: "dark" };
+
+export const ExpandNestedCells = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+          ).click();
+          (
+            document.querySelectorAll(
+              "[data-testid=expand-cell-arr-obj-0]",
+            )[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+ExpandNestedCells.storyName = "expand nested cells";
+ExpandNestedCells.parameters = { colorScheme: "dark" };
+
+export const ExpandMultipleRows = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=expand-row-0]")[0] as HTMLTableCellElement
+          ).click();
+          (
+            document.querySelectorAll("[data-testid=expand-row-1]")[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+ExpandMultipleRows.storyName = "expand multiple rows";
+ExpandMultipleRows.parameters = { colorScheme: "dark" };
+
+export const Filtering = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
+    </PanelSetup>
+  );
+};
+
+Filtering.storyName = "filtering";
+
+export const Sorting = () => {
+  return (
+    <PanelSetup
+      fixture={fixture}
+      onMount={() => {
+        setImmediate(() => {
+          (
+            document.querySelectorAll("[data-testid=column-header-val]")[0] as HTMLTableCellElement
+          ).click();
+          (
+            document.querySelectorAll("[data-testid=column-header-val]")[0] as HTMLTableCellElement
+          ).click();
+        });
+      }}
+    >
+      <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
+    </PanelSetup>
+  );
+};
+
+Sorting.storyName = "sorting";
+Sorting.parameters = { colorScheme: "dark" };
+
+export const HandlesPrimitives = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <Table overrideConfig={{ topicPath: "/my_arr.array[:].val" }} />
+    </PanelSetup>
+  );
+};
+
+HandlesPrimitives.storyName = "handles primitives";
+
+export const HandlesArraysOfPrimitives = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <Table overrideConfig={{ topicPath: "/my_arr.array[:].primitiveArray" }} />
+    </PanelSetup>
+  );
+};
+
+HandlesArraysOfPrimitives.storyName = "handles arrays of primitives";
+
+export const ConstrainedWidth = () => {
+  return (
+    <PanelSetup fixture={fixture}>
+      <div style={{ width: "100px" }}>
         <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
-      </PanelSetup>
-    );
-  })
-  .add(
-    "sorting",
-    () => {
-      return (
-        <PanelSetup
-          fixture={fixture}
-          onMount={() => {
-            setImmediate(() => {
-              (
-                document.querySelectorAll(
-                  "[data-testid=column-header-val]",
-                )[0] as HTMLTableCellElement
-              ).click();
-              (
-                document.querySelectorAll(
-                  "[data-testid=column-header-val]",
-                )[0] as HTMLTableCellElement
-              ).click();
-            });
-          }}
-        >
-          <Table overrideConfig={{ topicPath: "/my_arr.array" }} />
-        </PanelSetup>
-      );
-    },
-    { colorScheme: "dark" },
-  )
-  .add("handles primitives", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <Table overrideConfig={{ topicPath: "/my_arr.array[:].val" }} />
-      </PanelSetup>
-    );
-  })
-  .add("handles arrays of primitives", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <Table overrideConfig={{ topicPath: "/my_arr.array[:].primitiveArray" }} />
-      </PanelSetup>
-    );
-  })
-  .add("constrained width", () => {
-    return (
-      <PanelSetup fixture={fixture}>
-        <div style={{ width: "100px" }}>
-          <Table overrideConfig={{ topicPath: "/my_arr.array[:]{val==3}" }} />
-        </div>
-      </PanelSetup>
-    );
-  });
+      </div>
+    </PanelSetup>
+  );
+};
+
+ConstrainedWidth.storyName = "constrained width";

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -342,12 +342,12 @@ export default {
   excludeStories: ["POINT_CLOUD_MESSAGE", "POINT_CLOUD_WITH_ADDITIONAL_FIELDS"],
 };
 
-export const Default: StoryFn = DefaultStory;
+export const Default: StoryFn = DefaultStory.bind(undefined);
 
 Default.storyName = "default";
 Default.parameters = { colorScheme: "dark" };
 
-export const DefaultLight: StoryFn = DefaultStory;
+export const DefaultLight: StoryFn = DefaultStory.bind(undefined);
 
 DefaultLight.storyName = "default light";
 DefaultLight.parameters = { colorScheme: "light" };

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -12,6 +12,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { Stack } from "@mui/material";
+import { StoryFn } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
@@ -314,7 +315,7 @@ function PanelSetupWithData({
   );
 }
 
-function DefaultStory() {
+const DefaultStory: StoryFn = () => {
   return (
     <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
       <PanelSetupWithData title="Default without clicked object">
@@ -329,7 +330,7 @@ function DefaultStory() {
       </PanelSetupWithData>
     </Stack>
   );
-}
+};
 
 export default {
   title: "panels/ThreeDeeRender/Interactions/Interaction",
@@ -341,17 +342,17 @@ export default {
   excludeStories: ["POINT_CLOUD_MESSAGE", "POINT_CLOUD_WITH_ADDITIONAL_FIELDS"],
 };
 
-export const Default = DefaultStory;
+export const Default: StoryFn = DefaultStory;
 
 Default.storyName = "default";
 Default.parameters = { colorScheme: "dark" };
 
-export const DefaultLight = DefaultStory;
+export const DefaultLight: StoryFn = DefaultStory;
 
 DefaultLight.storyName = "default light";
 DefaultLight.parameters = { colorScheme: "light" };
 
-export const PointCloud = () => {
+export const PointCloud: StoryFn = () => {
   const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
   const cloud2 = {
     ...selectedObject.object,

--- a/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Interactions/Interaction.stories.tsx
@@ -12,7 +12,6 @@
 //   You may not use this file except in compliance with the License.
 
 import { Stack } from "@mui/material";
-import { storiesOf } from "@storybook/react";
 
 import PanelSetup from "@foxglove/studio-base/stories/PanelSetup";
 import { PointCloud2 } from "@foxglove/studio-base/types/Messages";
@@ -332,50 +331,66 @@ function DefaultStory() {
   );
 }
 
-storiesOf("panels/ThreeDeeRender/Interactions/Interaction", module)
-  .addParameters({
-    chromatic: { viewport: { width: 1001, height: 1101 } },
-  })
-  .add("default", DefaultStory, { colorScheme: "dark" })
-  .add("default light", DefaultStory, { colorScheme: "light" })
-  .add("PointCloud", () => {
-    const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
-    const cloud2 = {
-      ...selectedObject.object,
-      ...POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
-    };
+export default {
+  title: "panels/ThreeDeeRender/Interactions/Interaction",
 
-    return (
-      <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
-        <PanelSetupWithData title="default with point color">
-          <Interactions
-            {...(sharedProps as any)}
-            selectedObject={{
-              instanceIndex: 0,
-              object: {
-                ...cloud1,
-                type: 102,
-                interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
+  parameters: {
+    chromatic: { viewport: { width: 1001, height: 1101 } },
+  },
+
+  excludeStories: ["POINT_CLOUD_MESSAGE", "POINT_CLOUD_WITH_ADDITIONAL_FIELDS"],
+};
+
+export const Default = DefaultStory;
+
+Default.storyName = "default";
+Default.parameters = { colorScheme: "dark" };
+
+export const DefaultLight = DefaultStory;
+
+DefaultLight.storyName = "default light";
+DefaultLight.parameters = { colorScheme: "light" };
+
+export const PointCloud = () => {
+  const cloud1 = { ...selectedObject.object, ...POINT_CLOUD_MESSAGE };
+  const cloud2 = {
+    ...selectedObject.object,
+    ...POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
+  };
+
+  return (
+    <Stack direction="row" flexWrap="wrap" height="100%" bgcolor="background.paper">
+      <PanelSetupWithData title="default with point color">
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={{
+            instanceIndex: 0,
+            object: {
+              ...cloud1,
+              type: 102,
+              interactionData: { topic: "/foo/bar", originalMessage: POINT_CLOUD_MESSAGE },
+            },
+          }}
+        />
+      </PanelSetupWithData>
+      <PanelSetupWithData title="with additional fields">
+        <Interactions
+          {...(sharedProps as any)}
+          selectedObject={{
+            instanceIndex: 0,
+            object: {
+              ...cloud2,
+              type: 102,
+              interactionData: {
+                topic: "/foo/bar",
+                originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
               },
-            }}
-          />
-        </PanelSetupWithData>
-        <PanelSetupWithData title="with additional fields">
-          <Interactions
-            {...(sharedProps as any)}
-            selectedObject={{
-              instanceIndex: 0,
-              object: {
-                ...cloud2,
-                type: 102,
-                interactionData: {
-                  topic: "/foo/bar",
-                  originalMessage: POINT_CLOUD_WITH_ADDITIONAL_FIELDS,
-                },
-              },
-            }}
-          />
-        </PanelSetupWithData>
-      </Stack>
-    );
-  });
+            },
+          }}
+        />
+      </PanelSetupWithData>
+    </Stack>
+  );
+};
+
+PointCloud.storyName = "PointCloud";


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
- Ran the `storiesof-to-csf` and `csf-hoist-story-annotations` migrations from [`sb migrate`](https://github.com/storybookjs/storybook/tree/next/code/lib/codemod)
- Manually added missing type annotations

Note: a handful of stories show up as "new" because the unique ids changed, e.g. `panels-threedeerender-interactions-interaction--pointcloud` vs `panels-threedeerender-interactions-interaction--point-cloud`.

Prerequisite for FG-2861