### PR TITLE
Remove hover color on datasource info icon

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -194,7 +194,6 @@ export default function PlaybackControls(props: {
                   disabled={presence !== PlayerPresence.PRESENT}
                   size="small"
                   icon={<Info24Regular />}
-                  activeColor="info"
                 />
               </Tooltip>
             )}


### PR DESCRIPTION
**User-Facing Changes**
None

**Description**
Data source info button no longer highlights blue
