### PR TITLE
Fix multi-topic playback for unindexed local mcap files

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapIterableSource.ts
@@ -10,7 +10,7 @@ import { MessageEvent } from "@foxglove/studio-base/players/types";
 
 import { FileReadable } from "./FileReadable";
 import { McapIndexedIterableSource } from "./McapIndexedIterableSource";
-import { McapStreamingIterableSource } from "./McapStreamingIterableSource";
+import { McapUnindexedIterableSource } from "./McapUnindexedIterableSource";
 import { RemoteFileReadable } from "./RemoteFileReadable";
 import {
   IIterableSource,
@@ -62,7 +62,7 @@ export class McapIterableSource implements IIterableSource {
         if (reader) {
           this._sourceImpl = new McapIndexedIterableSource(reader);
         } else {
-          this._sourceImpl = new McapStreamingIterableSource({
+          this._sourceImpl = new McapUnindexedIterableSource({
             size: source.file.size,
             stream: source.file.stream(),
           });
@@ -85,7 +85,7 @@ export class McapIterableSource implements IIterableSource {
             throw new Error(`Remote file is missing Content-Length header. <${source.url}>`);
           }
 
-          this._sourceImpl = new McapStreamingIterableSource({
+          this._sourceImpl = new McapUnindexedIterableSource({
             size: parseInt(size),
             stream: response.body,
           });

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapStreamingIterableSource.ts
@@ -242,6 +242,7 @@ export class McapStreamingIterableSource implements IIterableSource {
     }
 
     const topicsSet = new Set(topics);
+    const messagesWithChannelId: { msgEvent: MessageEvent<unknown>; channelId: number }[] = [];
 
     for (const [channelId, msgEvents] of this.msgEventsByChannel) {
       for (const msgEvent of msgEvents) {
@@ -249,13 +250,23 @@ export class McapStreamingIterableSource implements IIterableSource {
           isTimeInRangeInclusive(msgEvent.receiveTime, start, end) &&
           topicsSet.has(msgEvent.topic)
         ) {
-          yield {
-            type: "message-event",
-            connectionId: channelId,
+          messagesWithChannelId.push({
             msgEvent,
-          };
+            channelId,
+          });
         }
       }
+    }
+
+    // Messages need to be yielded in receiveTime order
+    messagesWithChannelId.sort((a, b) => compare(a.msgEvent.receiveTime, b.msgEvent.receiveTime));
+
+    for (const { msgEvent, channelId } of messagesWithChannelId) {
+      yield {
+        type: "message-event",
+        connectionId: channelId,
+        msgEvent,
+      };
     }
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -32,7 +32,8 @@ const DURATION_YEAR_SEC = 365 * 24 * 60 * 60;
 
 type Options = { size: number; stream: ReadableStream<Uint8Array> };
 
-export class McapStreamingIterableSource implements IIterableSource {
+/** Only efficient for small files */
+export class McapUnindexedIterableSource implements IIterableSource {
   private options: Options;
   private msgEventsByChannel?: Map<number, MessageEvent<unknown>[]>;
   private start?: Time;

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -263,9 +263,7 @@ export class McapUnindexedIterableSource implements IIterableSource {
     // Messages need to be yielded in receiveTime order
     resultMessages.sort((a, b) => compare(a.msgEvent.receiveTime, b.msgEvent.receiveTime));
 
-    for (const resultMsg of resultMessages) {
-      yield resultMsg;
-    }
+    yield* resultMessages;
   }
 
   public async getBackfillMessages(

--- a/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mcap/McapUnindexedIterableSource.ts
@@ -243,7 +243,7 @@ export class McapUnindexedIterableSource implements IIterableSource {
     }
 
     const topicsSet = new Set(topics);
-    const messagesWithChannelId: { msgEvent: MessageEvent<unknown>; channelId: number }[] = [];
+    const resultMessages = [];
 
     for (const [channelId, msgEvents] of this.msgEventsByChannel) {
       for (const msgEvent of msgEvents) {
@@ -251,23 +251,20 @@ export class McapUnindexedIterableSource implements IIterableSource {
           isTimeInRangeInclusive(msgEvent.receiveTime, start, end) &&
           topicsSet.has(msgEvent.topic)
         ) {
-          messagesWithChannelId.push({
+          resultMessages.push({
+            type: "message-event" as const,
+            connectionId: channelId,
             msgEvent,
-            channelId,
           });
         }
       }
     }
 
     // Messages need to be yielded in receiveTime order
-    messagesWithChannelId.sort((a, b) => compare(a.msgEvent.receiveTime, b.msgEvent.receiveTime));
+    resultMessages.sort((a, b) => compare(a.msgEvent.receiveTime, b.msgEvent.receiveTime));
 
-    for (const { msgEvent, channelId } of messagesWithChannelId) {
-      yield {
-        type: "message-event",
-        connectionId: channelId,
-        msgEvent,
-      };
+    for (const resultMsg of resultMessages) {
+      yield resultMsg;
     }
   }
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->
- Fix multi-topic playback for unindexed local mcap files

**Description**

Unindexed MCAP files use the `McapStreamingIterableSource`. The message iterator returned from this source yields message values by channel first, then time-sorted within the channel. This cause messages to be iterated through by the player to also be in that order. So it would only read messages into the current frame from the first subscribed topic and no other ones because they were after all of the messages in that first topic



<!-- link relevant GitHub issues -->
FG-2863
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
